### PR TITLE
Convert to string if possible before json

### DIFF
--- a/src/Concerns/DetectsDirtyProperties.php
+++ b/src/Concerns/DetectsDirtyProperties.php
@@ -31,7 +31,9 @@ trait DetectsDirtyProperties
         $value = $this->getPropertyValue($name);
 
         if (! is_null($value) && ! is_string($value) && ! is_numeric($value)) {
-            $value = json_encode($value);
+            $value = method_exists($value, '__toString')
+                ? (string) $value
+                : json_encode($value);
         }
 
         // Using crc32 because it's fast, and this doesn't have to be secure.


### PR DESCRIPTION
This PR fixes the issue https://github.com/calebporzio/livewire/issues/29 where the created_at and updated_at are detected as dirty inputs even though they are not.

The reason why it's happening is because on the re-render of the component, the `created_at` returns an instance of `Carbon`. When using `json_encode` on a Carbon instance, it's returning the following:

> "2019-05-02T13:52:33.000000Z"

Instead of the string value we got from the component's initial data:

> "2019-05-02T13:52:33"

So converting the object to a string when possible before converting it to JSON would be more accurate for the dirty detection.