### PR TITLE
Search for component aliases in kebab-case

### DIFF
--- a/src/LivewireComponentsFinder.php
+++ b/src/LivewireComponentsFinder.php
@@ -24,7 +24,7 @@ class LivewireComponentsFinder
 
     public function find($alias)
     {
-        return $this->getManifest()[$alias] ?? null;
+        return $this->getManifest()[Str::kebab($alias)] ?? null;
     }
 
     public function getManifest()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
I found this problem when using multi word components, like "EndpointUrl" and "EndpointRequest".

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
__

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Nope 👀

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
The `livewire-components.php` manifest already uses kebab-case for it's keys, as that is the way [a Component's name is retrieved](https://github.com/calebporzio/livewire/blob/master/src/Component.php#L47). So it makes sense to have this be consistent.

5️⃣ Thanks for contributing! 🙌
🙌