### PR TITLE
Added ActionMethodNotFound exception

### DIFF
--- a/src/Concerns/HandlesActions.php
+++ b/src/Concerns/HandlesActions.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Concerns;
 
+use Livewire\Exceptions\ActionMethodNotFound;
 use Livewire\Exceptions\NonPublicComponentMethodCall;
 
 trait HandlesActions
@@ -42,7 +43,7 @@ trait HandlesActions
 
             case '$toggle':
                 $prop = array_shift($params);
-                $this->syncInput($prop, ! $this->{$prop});
+                $this->syncInput($prop, !$this->{$prop});
                 return;
                 break;
 
@@ -51,6 +52,7 @@ trait HandlesActions
                 break;
 
             default:
+                throw_if(!method_exists($this, $method), ActionMethodNotFound::class);
                 throw_unless($this->methodIsPublicAndNotDefinedOnBaseClass($method), NonPublicComponentMethodCall::class);
 
                 $this->{$method}(...$params);

--- a/src/Exceptions/ActionMethodNotFound.php
+++ b/src/Exceptions/ActionMethodNotFound.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Livewire\Exceptions;
+
+class ActionMethodNotFound extends \Exception
+{
+    //
+}

--- a/tests/ComponentsAreSecureTest.php
+++ b/tests/ComponentsAreSecureTest.php
@@ -2,14 +2,24 @@
 
 namespace Tests;
 
-use Livewire\Exceptions\ComponentMismatchException;
+use Livewire\Exceptions\ActionMethodNotFound;
 use Livewire\Exceptions\NonPublicComponentMethodCall;
 use Livewire\Exceptions\ProtectedPropertyBindingException;
 use Livewire\Component;
-use Mockery\Exception\BadMethodCallException;
 
 class ComponentsAreSecureTest extends TestCase
 {
+    /** @test */
+    function throws_method_not_found_exception_when_action_missing()
+    {
+        $this->expectException(ActionMethodNotFound::class);
+
+        app('livewire')->component('security-target', SecurityTargetStub::class);
+        $component = app('livewire')->test('security-target');
+
+        $component->runAction('missingMethod');
+    }
+
     /** @test */
     function can_only_call_public_methods()
     {
@@ -45,7 +55,8 @@ class ComponentsAreSecureTest extends TestCase
     }
 }
 
-class SecurityTargetStub extends Component {
+class SecurityTargetStub extends Component
+{
     protected $protectedProperty = 'foo';
 
     protected function protectedMethod()


### PR DESCRIPTION
Wanted to take a crack at this after our chat today. Let me know what you think! This adds a _slightly_ more descriptive exception called `ActionMethodNotFound` when the livewire component class is missing a method used in a click or other action.

A couple considerations:
- The `ComponentsAreSecureTest` class seemed like the best place to put this... but perhaps this should go elsewhere in its own test class?
- Looks like my editor's PSR-2 format-on-save stuff took out a space around the `!`, want me to add that back in (and also to the negated `throw_if` statement I added)? Also, it moved the curly brace for the `SecurityTargetStub` class to the next line.
- Format on save also nuked a couple unused imports -- are those needed? Happy to add them back.