### PR TITLE
Add middleware filtering feature

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -11,6 +11,7 @@ class LivewireManager
 {
     protected $prefix = 'wire';
     protected $componentAliases = [];
+    protected $middlewaresFilter;
 
     public function prefix($prefix = null)
     {
@@ -80,7 +81,11 @@ EOT;
         $children = $instance->getRenderedChildren();
         $checksum = md5($name.$id);
 
-        $middleware = encrypt($this->currentMiddlewareStack(), $serialize = true);
+        $middlewareStack = $this->currentMiddlewareStack();
+        if ($this->middlewaresFilter) {
+            $middlewareStack = array_filter($middlewareStack, $this->middlewaresFilter);
+        }
+        $middleware = encrypt($middlewareStack, $serialize = true);
 
         return new InitialResponsePayload([
             'id' => $id,
@@ -102,6 +107,11 @@ EOT;
         }
 
         return request()->route()->gatherMiddleware();
+    }
+
+    public function filterMiddleware($filter)
+    {
+        return $this->middlewaresFilter = $filter;
     }
 
     public function dummyMount($id, $tagName)

--- a/tests/LivewireTestingTest.php
+++ b/tests/LivewireTestingTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Support\Facades\Artisan;
 use Livewire\Component;
 use Livewire\LivewireManager;
 
@@ -22,6 +23,23 @@ class LivewireTestingTest extends TestCase
         app(LivewireManager::class)
             ->test(HasMountArguments::class, 'foo')
             ->assertSet('name', 'foo');
+    }
+
+    /** @test */
+    public function test_filter_middlewares()
+    {
+        Artisan::call('make:livewire foo');
+        $manager = \Mockery::mock(LivewireManager::class)->makePartial();
+        $manager->shouldReceive('currentMiddlewareStack')->andReturn(['MiddlewareA', 'MiddlewareB', 'MiddlewareC']);
+        
+        $manager->filterMiddleware(function($middleware) {
+            return $middleware != 'MiddlewareB';
+        });
+        
+        $this->assertEquals([
+            0 => 'MiddlewareA',
+            2 => 'MiddlewareC',
+        ], decrypt($manager->mount('foo')->middleware));
     }
 }
 


### PR DESCRIPTION
This adds the `Livewire::filterMiddleware()` to allow filtering middlewares as discussed in this issue
https://github.com/calebporzio/livewire/issues/32

I'm wanted to add a PR for the docs, but i didn't know what is the best section to add that in.
Should i open a new section like "middleware" or maybe an "extra" section where we mention all non categorized things ?