### PR TITLE
Add StyleCI and TravisCI setting files

### DIFF
--- a/.gitattribues
+++ b/.gitattribues
@@ -1,0 +1,12 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml.dist   export-ignore
+/.scrutinizer.yml   export-ignore
+/tests              export-ignore
+/.editorconfig      export-ignore
+/github_banner.png  export-ignore

--- a/.styleci
+++ b/.styleci
@@ -1,4 +1,0 @@
-preset: laravel
-
-disabled:
-  - single_class_element_per_statement

--- a/.styleci
+++ b/.styleci
@@ -1,0 +1,4 @@
+preset: laravel
+
+disabled:
+  - single_class_element_per_statement

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: php
+
+php:
+  - 7.1
+  - 7.2
+  - 7.3
+
+env:
+  matrix:
+    - COMPOSER_FLAGS="--prefer-lowest"
+    - COMPOSER_FLAGS=""
+
+before_script:
+  - travis_retry composer self-update
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+
+script:
+  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+
+after_script:
+  - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/src/Commands/LivewireDestroyCommand.php
+++ b/src/Commands/LivewireDestroyCommand.php
@@ -27,7 +27,7 @@ class LivewireDestroyCommand extends Command
 
         if (! $force = $this->option('force')) {
             $shouldContinue = $this->confirm(
-                "Are you sure you want to delete the following files?\n\n{$this->parser->classPath()}\n{$this->parser->viewPath()}\n"
+                "Are you sure you want to delete the following files?"
             );
 
             if (! $shouldContinue) {

--- a/tests/DestroyCommandTest.php
+++ b/tests/DestroyCommandTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\File;
 class DestroyCommandTest extends TestCase
 {
     /** @test */
-    function component_is_removed_by_destory_command()
+    function component_is_removed_by_destroy_command()
     {
         Artisan::call('make:livewire foo');
         $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));

--- a/tests/DestroyCommandTest.php
+++ b/tests/DestroyCommandTest.php
@@ -15,7 +15,7 @@ class DestroyCommandTest extends TestCase
         $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
 
         $this->artisan('livewire:destroy foo')->expectsQuestion(
-            "Are you sure you want to delete the following files?\n\n/Users/calebporzio/Documents/Code/sites/livewire/vendor/orchestra/testbench-core/src/Concerns/../../laravel/app/Http/Livewire/Foo.php\n/Users/calebporzio/Documents/Code/sites/livewire/tests/views/livewire/foo.blade.php\n",
+            "Are you sure you want to delete the following files?",
             true
         );
 
@@ -31,7 +31,7 @@ class DestroyCommandTest extends TestCase
         $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
 
         $this->artisan('livewire:destroy foo')->expectsQuestion(
-            "Are you sure you want to delete the following files?\n\n/Users/calebporzio/Documents/Code/sites/livewire/vendor/orchestra/testbench-core/src/Concerns/../../laravel/app/Http/Livewire/Foo.php\n/Users/calebporzio/Documents/Code/sites/livewire/tests/views/livewire/foo.blade.php\n",
+            "Are you sure you want to delete the following files?",
             false
         );
 
@@ -46,7 +46,7 @@ class DestroyCommandTest extends TestCase
         $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
 
-        Artisan::call('livewire:destroy foo --force');
+        Artisan::call('livewire:destroy', ['name' => 'foo', '--force' => true]);
 
         $this->assertFalse(File::exists($this->livewireClassesPath('Foo.php')));
         $this->assertFalse(File::exists($this->livewireViewsPath('foo.blade.php')));


### PR DESCRIPTION
Hey @calebporzio (and @wotta),

I have opened a pull request, adding `.styleci`and `.travis.yml` files. This is the format that @mpociot also uses in his packages and recommends in his PHP Package Development course.

Two things:
1. @wotta is correct, the actual setup of those services needs to handled by @calebporzio.
2. Laravel uses StyleCI's multilanguage fixes, so the `laravel/framework`version of this file looks like this:

````yml
php:
  preset: laravel
js:
  finder:
    not-name:
      - webpack.mix.js
css: true

````

This is however not offered to open source repositories (yet) and requires their $10/month or $100/year plan.

Kind regards,
g



