### PR TITLE
Remove wire data from assert see

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -23,7 +23,7 @@ trait MakesAssertions
 
     public function assertDontSee($value)
     {
-        PHPUnit::assertStringNotContainsString((string) $value, $this->dom);
+        PHPUnit::assertStringNotContainsString((string) $value, preg_replace('(wire:data=\".+}")', '', $this->dom));
 
         return $this;
     }

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -2,7 +2,6 @@
 
 namespace Livewire\Testing\Concerns;
 
-use DOMDocument;
 use Illuminate\Foundation\Testing\Assert as PHPUnit;
 
 trait MakesAssertions

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Testing\Concerns;
 
+use DOMDocument;
 use Illuminate\Foundation\Testing\Assert as PHPUnit;
 
 trait MakesAssertions
@@ -15,7 +16,7 @@ trait MakesAssertions
 
     public function assertSee($value)
     {
-        PHPUnit::assertStringContainsString((string) $value, $this->dom);
+        PHPUnit::assertStringContainsString((string) $value, preg_replace('(wire:data=\".+}")', '', $this->dom));
 
         return $this;
     }

--- a/tests/LivewireTestingTest.php
+++ b/tests/LivewireTestingTest.php
@@ -26,16 +26,33 @@ class LivewireTestingTest extends TestCase
     }
 
     /** @test */
+    function test_assert_see()
+    {
+        app(LivewireManager::class)
+            ->test(HasMountArguments::class, 'should see me')
+            ->assertSee('should see me');
+    }
+
+    /** @test */
+    function test_assert_see_doesnt_include_json_encoded_data_put_in_wire_data_attribute()
+    {
+        // See for more info: https://github.com/calebporzio/livewire/issues/62
+        app(LivewireManager::class)
+            ->test(HasMountArgumentsButDoesntPassThemToBladeView::class, 'shouldnt see me')
+            ->assertDontSee('shouldnt see me');
+    }
+
+    /** @test */
     public function test_filter_middlewares()
     {
         Artisan::call('make:livewire foo');
         $manager = \Mockery::mock(LivewireManager::class)->makePartial();
         $manager->shouldReceive('currentMiddlewareStack')->andReturn(['MiddlewareA', 'MiddlewareB', 'MiddlewareC']);
-        
+
         $manager->filterMiddleware(function($middleware) {
             return $middleware != 'MiddlewareB';
         });
-        
+
         $this->assertEquals([
             0 => 'MiddlewareA',
             2 => 'MiddlewareC',
@@ -55,5 +72,20 @@ class HasMountArguments extends Component
     public function render()
     {
         return app('view')->make('show-name');
+    }
+}
+
+class HasMountArgumentsButDoesntPassThemToBladeView extends Component
+{
+    public $name;
+
+    public function mount($name)
+    {
+        $this->name = $name;
+    }
+
+    public function render()
+    {
+        return app('view')->make('null-view');
     }
 }


### PR DESCRIPTION
Performing a basic `preg_replace` on the html to remove the `wire:data` attribute. Since many of the values within the data attribute are likely to be printed on the page, it's possible over the course of testing to receive a false positive that some text is visible on the page because it exists in this attribute in the dom. 

Should resolve [Issue 62](https://github.com/calebporzio/livewire/issues/62)