### PR TITLE
Allow livewire.js to be loaded from root or subfolder

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -60,7 +60,7 @@ class LivewireManager
         return <<<EOT
 <!-- Livewire Assets-->
 <style>[wire\:loading] { display: none; }</style>
-<script src="/livewire{$versionedFileName}"></script>
+<script src="livewire{$versionedFileName}"></script>
 <script>
     document.addEventListener("DOMContentLoaded", function() {
         window.livewire = new Livewire({$options});


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes. #84 
2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
No
4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

`livewire.js` had 404 error when the livewire app was not served by `php artisan serve` or from the root of a webserver

This change allows the `livewire.js` file to be loaded irrespective of whether the app is being served from a subfolder or the root folder of the web server or `php artisan serve`


