### PR TITLE
Allow requests to be made correctly

### DIFF
--- a/src/js/connection/drivers/http.js
+++ b/src/js/connection/drivers/http.js
@@ -7,7 +7,7 @@ export default {
     },
 
     keepAlive() {
-        fetch('/livewire/keep-alive', {
+        fetch('livewire/keep-alive', {
             credentials: "same-origin",
             headers: {
                 'X-CSRF-TOKEN': this.getCSRFToken(),
@@ -18,7 +18,7 @@ export default {
 
     sendMessage(payload) {
         // Forward the query string for the ajax requests.
-        fetch('/livewire/message'+window.location.search, {
+        fetch('livewire/message'+window.location.search, {
             method: 'POST',
             body: JSON.stringify(payload),
             // This enables "cookies".


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes. 
2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No. However this is linked to #86 
3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
No
4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

Currently requests made to `/livewire/` will 404 when the livewire app is not being served from the root folder of a webserver or being run with `php artisan serve`

This fix allows the request to be made to the correct root path of the app irrespective of the hosting path