### PR TITLE
Fix DestroyCommandTest to be user system independent

### DIFF
--- a/tests/DestroyCommandTest.php
+++ b/tests/DestroyCommandTest.php
@@ -11,44 +11,56 @@ class DestroyCommandTest extends TestCase
     function component_is_removed_by_destory_command()
     {
         Artisan::call('make:livewire foo');
-        $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
-        $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
+
+        $classPath = $this->livewireClassesPath('Foo.php');
+        $viewPath = $this->livewireViewsPath('foo.blade.php');
+
+        $this->assertTrue(File::exists($classPath));
+        $this->assertTrue(File::exists($viewPath));
 
         $this->artisan('livewire:destroy foo')->expectsQuestion(
-            "Are you sure you want to delete the following files?\n\n/Users/calebporzio/Documents/Code/sites/livewire/vendor/orchestra/testbench-core/src/Concerns/../../laravel/app/Http/Livewire/Foo.php\n/Users/calebporzio/Documents/Code/sites/livewire/tests/views/livewire/foo.blade.php\n",
+            "Are you sure you want to delete the following files?\n\n{$classPath}\n{$viewPath}\n",
             true
         );
 
-        $this->assertFalse(File::exists($this->livewireClassesPath('Foo.php')));
-        $this->assertFalse(File::exists($this->livewireViewsPath('foo.blade.php')));
+        $this->assertFalse(File::exists($classPath));
+        $this->assertFalse(File::exists($viewPath));
     }
 
     /** @test */
     function component_is_not_removed_when_confirm_answer_is_no()
     {
         Artisan::call('make:livewire foo');
-        $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
-        $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
+
+        $classPath = $this->livewireClassesPath('Foo.php');
+        $viewPath = $this->livewireViewsPath('foo.blade.php');
+
+        $this->assertTrue(File::exists($classPath));
+        $this->assertTrue(File::exists($viewPath));
 
         $this->artisan('livewire:destroy foo')->expectsQuestion(
-            "Are you sure you want to delete the following files?\n\n/Users/calebporzio/Documents/Code/sites/livewire/vendor/orchestra/testbench-core/src/Concerns/../../laravel/app/Http/Livewire/Foo.php\n/Users/calebporzio/Documents/Code/sites/livewire/tests/views/livewire/foo.blade.php\n",
+            "Are you sure you want to delete the following files?\n\n{$classPath}\n{$viewPath}\n",
             false
         );
 
-        $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
-        $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
+        $this->assertTrue(File::exists($classPath));
+        $this->assertTrue(File::exists($viewPath));
     }
 
     /** @test */
     function component_is_removed_without_confirmation_if_forced()
     {
         Artisan::call('make:livewire foo');
-        $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
-        $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
+
+        $classPath = $this->livewireClassesPath('Foo.php');
+        $viewPath = $this->livewireViewsPath('foo.blade.php');
+
+        $this->assertTrue(File::exists($classPath));
+        $this->assertTrue(File::exists($viewPath));
 
         Artisan::call('livewire:destroy foo --force');
 
-        $this->assertFalse(File::exists($this->livewireClassesPath('Foo.php')));
-        $this->assertFalse(File::exists($this->livewireViewsPath('foo.blade.php')));
+        $this->assertFalse(File::exists($classPath));
+        $this->assertFalse(File::exists($viewPath));
     }
 }


### PR DESCRIPTION
Was previously hard coded with Caleb's system paths.
Fixes https://github.com/calebporzio/livewire/issues/76

1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
No, but this is necessary for contributors.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Single purpose, finely scoped changes.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Test only change.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
Necessary for contributors.
