### PR TITLE
dump() support similar to error modal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     ],
     "require": {
         "illuminate/support": "^5.7",
-        "illuminate/validation": "^5.7"
+        "illuminate/validation": "^5.7",
+        "symfony/var-dumper": "^4.1"
     },
     "extra": {
         "laravel": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f12000c12a8232bff712f5f4ca86e6a8",
+    "content-hash": "be99998804e0aa4ad8ab5d852356b22b",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -75,20 +75,23 @@
         },
         {
             "name": "doctrine/lexer",
-            "version": "v1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
-                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/1febd6c3ef84253d7c815bed85fc622ad207a9f8",
+                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5"
             },
             "type": "library",
             "extra": {
@@ -97,8 +100,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Lexer\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -119,35 +122,43 @@
                     "email": "schmittjoh@gmail.com"
                 }
             ],
-            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
-            "homepage": "http://www.doctrine-project.org",
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
             "keywords": [
+                "annotations",
+                "docblock",
                 "lexer",
-                "parser"
+                "parser",
+                "php"
             ],
-            "time": "2014-09-09T13:34:57+00:00"
+            "time": "2019-06-08T11:03:04+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
-            "version": "v2.2.0",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dragonmantank/cron-expression.git",
-                "reference": "92a2c3768d50e21a1f26a53cb795ce72806266c5"
+                "reference": "72b6fbf76adb3cf5bc0db68559b33d41219aba27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/92a2c3768d50e21a1f26a53cb795ce72806266c5",
-                "reference": "92a2c3768d50e21a1f26a53cb795ce72806266c5",
+                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/72b6fbf76adb3cf5bc0db68559b33d41219aba27",
+                "reference": "72b6fbf76adb3cf5bc0db68559b33d41219aba27",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.4"
+                "phpunit/phpunit": "^6.4|^7.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Cron\\": "src/Cron/"
@@ -174,20 +185,20 @@
                 "cron",
                 "schedule"
             ],
-            "time": "2018-06-06T03:12:17+00:00"
+            "time": "2019-03-31T00:38:28+00:00"
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.7",
+            "version": "2.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "709f21f92707308cdf8f9bcfa1af4cb26586521e"
+                "reference": "a6c8d7101b19a451c1707b1b79bbbc56e4bdb7ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/709f21f92707308cdf8f9bcfa1af4cb26586521e",
-                "reference": "709f21f92707308cdf8f9bcfa1af4cb26586521e",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/a6c8d7101b19a451c1707b1b79bbbc56e4bdb7ec",
+                "reference": "a6c8d7101b19a451c1707b1b79bbbc56e4bdb7ec",
                 "shasum": ""
             },
             "require": {
@@ -197,7 +208,8 @@
             "require-dev": {
                 "dominicsayers/isemail": "dev-master",
                 "phpunit/phpunit": "^4.8.35||^5.7||^6.0",
-                "satooshi/php-coveralls": "^1.0.1"
+                "satooshi/php-coveralls": "^1.0.1",
+                "symfony/phpunit-bridge": "^4.4@dev"
             },
             "suggest": {
                 "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
@@ -231,7 +243,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2018-12-04T22:38:24+00:00"
+            "time": "2019-07-19T20:52:08+00:00"
         },
         {
             "name": "erusev/parsedown",
@@ -281,16 +293,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.8.3",
+            "version": "v5.8.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "d36d74acd3added5abbe7e7a84342b54bb0b0521"
+                "reference": "489ae2218c7eb138caac780de584d8df9fe8160b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/d36d74acd3added5abbe7e7a84342b54bb0b0521",
-                "reference": "d36d74acd3added5abbe7e7a84342b54bb0b0521",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/489ae2218c7eb138caac780de584d8df9fe8160b",
+                "reference": "489ae2218c7eb138caac780de584d8df9fe8160b",
                 "shasum": ""
             },
             "require": {
@@ -424,20 +436,20 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2019-03-05T13:51:19+00:00"
+            "time": "2019-07-16T14:05:28+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.50",
+            "version": "1.0.53",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "dab4e7624efa543a943be978008f439c333f2249"
+                "reference": "08e12b7628f035600634a5e76d95b5eb66cea674"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/dab4e7624efa543a943be978008f439c333f2249",
-                "reference": "dab4e7624efa543a943be978008f439c333f2249",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/08e12b7628f035600634a5e76d95b5eb66cea674",
+                "reference": "08e12b7628f035600634a5e76d95b5eb66cea674",
                 "shasum": ""
             },
             "require": {
@@ -508,7 +520,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2019-02-01T08:50:36+00:00"
+            "time": "2019-06-18T20:09:29+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -590,16 +602,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.14.2",
+            "version": "2.21.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "a1f4f9abcde8241ce33bf5090896e9c16d0b4232"
+                "reference": "58bdbbfab17ccd2ec7347b99e997f18232def4dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/a1f4f9abcde8241ce33bf5090896e9c16d0b4232",
-                "reference": "a1f4f9abcde8241ce33bf5090896e9c16d0b4232",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/58bdbbfab17ccd2ec7347b99e997f18232def4dc",
+                "reference": "58bdbbfab17ccd2ec7347b99e997f18232def4dc",
                 "shasum": ""
             },
             "require": {
@@ -609,12 +621,15 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.14 || ^3.0",
-                "kylekatarnls/multi-tester": "^0.1",
+                "kylekatarnls/multi-tester": "^1.1",
                 "phpmd/phpmd": "^2.6",
-                "phpstan/phpstan": "^0.10.8",
+                "phpstan/phpstan": "^0.11",
                 "phpunit/phpunit": "^7.5 || ^8.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
+            "bin": [
+                "bin/carbon"
+            ],
             "type": "library",
             "extra": {
                 "laravel": {
@@ -637,6 +652,10 @@
                     "name": "Brian Nesbitt",
                     "email": "brian@nesbot.com",
                     "homepage": "http://nesbot.com"
+                },
+                {
+                    "name": "kylekatarnls",
+                    "homepage": "http://github.com/kylekatarnls"
                 }
             ],
             "description": "A simple API extension for DateTime.",
@@ -646,20 +665,20 @@
                 "datetime",
                 "time"
             ],
-            "time": "2019-02-28T09:07:12+00:00"
+            "time": "2019-07-18T18:47:28+00:00"
         },
         {
             "name": "opis/closure",
-            "version": "3.1.6",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opis/closure.git",
-                "reference": "ccb8e3928c5c8181c76cdd0ed9366c5bcaafd91b"
+                "reference": "92927e26d7fc3f271efe1f55bdbb073fbb2f0722"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opis/closure/zipball/ccb8e3928c5c8181c76cdd0ed9366c5bcaafd91b",
-                "reference": "ccb8e3928c5c8181c76cdd0ed9366c5bcaafd91b",
+                "url": "https://api.github.com/repos/opis/closure/zipball/92927e26d7fc3f271efe1f55bdbb073fbb2f0722",
+                "reference": "92927e26d7fc3f271efe1f55bdbb073fbb2f0722",
                 "shasum": ""
             },
             "require": {
@@ -667,12 +686,12 @@
             },
             "require-dev": {
                 "jeremeamia/superclosure": "^2.0",
-                "phpunit/phpunit": "^4.0|^5.0|^6.0|^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "3.3.x-dev"
                 }
             },
             "autoload": {
@@ -707,7 +726,7 @@
                 "serialization",
                 "serialize"
             ],
-            "time": "2019-02-22T10:30:00+00:00"
+            "time": "2019-07-09T21:58:11+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -1032,25 +1051,28 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v6.1.3",
+            "version": "v6.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "8ddcb66ac10c392d3beb54829eef8ac1438595f4"
+                "reference": "5397cd05b0a0f7937c47b0adcb4c60e5ab936b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/8ddcb66ac10c392d3beb54829eef8ac1438595f4",
-                "reference": "8ddcb66ac10c392d3beb54829eef8ac1438595f4",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/5397cd05b0a0f7937c47b0adcb4c60e5ab936b6a",
+                "reference": "5397cd05b0a0f7937c47b0adcb4c60e5ab936b6a",
                 "shasum": ""
             },
             "require": {
                 "egulias/email-validator": "~2.0",
-                "php": ">=7.0.0"
+                "php": ">=7.0.0",
+                "symfony/polyfill-iconv": "^1.0",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "require-dev": {
                 "mockery/mockery": "~0.9.1",
-                "symfony/phpunit-bridge": "~3.3@dev"
+                "symfony/phpunit-bridge": "^3.4.19|^4.1.8"
             },
             "suggest": {
                 "ext-intl": "Needed to support internationalized email addresses",
@@ -1059,7 +1081,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1-dev"
+                    "dev-master": "6.2-dev"
                 }
             },
             "autoload": {
@@ -1087,29 +1109,31 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2018-09-11T07:12:52+00:00"
+            "time": "2019-04-21T09:21:45+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.2.4",
+            "version": "v4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "9dc2299a016497f9ee620be94524e6c0af0280a9"
+                "reference": "8b0ae5742ce9aaa8b0075665862c1ca397d1c1d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/9dc2299a016497f9ee620be94524e6c0af0280a9",
-                "reference": "9dc2299a016497f9ee620be94524e6c0af0280a9",
+                "url": "https://api.github.com/repos/symfony/console/zipball/8b0ae5742ce9aaa8b0075665862c1ca397d1c1d9",
+                "reference": "8b0ae5742ce9aaa8b0075665862c1ca397d1c1d9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/contracts": "^1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/service-contracts": "^1.1"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4",
+                "symfony/event-dispatcher": "<4.3",
                 "symfony/process": "<3.3"
             },
             "provide": {
@@ -1119,9 +1143,10 @@
                 "psr/log": "~1.0",
                 "symfony/config": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/event-dispatcher": "^4.3",
                 "symfony/lock": "~3.4|~4.0",
-                "symfony/process": "~3.4|~4.0"
+                "symfony/process": "~3.4|~4.0",
+                "symfony/var-dumper": "^4.3"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -1132,7 +1157,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1159,88 +1184,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23T15:17:42+00:00"
-        },
-        {
-            "name": "symfony/contracts",
-            "version": "v1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/contracts.git",
-                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/contracts/zipball/1aa7ab2429c3d594dd70689604b5cf7421254cdf",
-                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3"
-            },
-            "require-dev": {
-                "psr/cache": "^1.0",
-                "psr/container": "^1.0"
-            },
-            "suggest": {
-                "psr/cache": "When using the Cache contracts",
-                "psr/container": "When using the Service contracts",
-                "symfony/cache-contracts-implementation": "",
-                "symfony/service-contracts-implementation": "",
-                "symfony/translation-contracts-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\": ""
-                },
-                "exclude-from-classmap": [
-                    "**/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A set of abstractions extracted out of the Symfony components",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "time": "2018-12-05T08:06:11+00:00"
+            "time": "2019-07-24T17:13:59+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v4.2.4",
+            "version": "v4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "48eddf66950fa57996e1be4a55916d65c10c604a"
+                "reference": "105c98bb0c5d8635bea056135304bd8edcc42b4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/48eddf66950fa57996e1be4a55916d65c10c604a",
-                "reference": "48eddf66950fa57996e1be4a55916d65c10c604a",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/105c98bb0c5d8635bea056135304bd8edcc42b4d",
+                "reference": "105c98bb0c5d8635bea056135304bd8edcc42b4d",
                 "shasum": ""
             },
             "require": {
@@ -1249,7 +1206,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1266,12 +1223,12 @@
             ],
             "authors": [
                 {
-                    "name": "Jean-François Simon",
-                    "email": "jeanfrancois.simon@sensiolabs.com"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
                 },
                 {
                     "name": "Symfony Community",
@@ -1280,20 +1237,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T20:31:39+00:00"
+            "time": "2019-01-16T21:53:39+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v4.2.4",
+            "version": "v4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "de73f48977b8eaf7ce22814d66e43a1662cc864f"
+                "reference": "527887c3858a2462b0137662c74837288b998ee3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/de73f48977b8eaf7ce22814d66e43a1662cc864f",
-                "reference": "de73f48977b8eaf7ce22814d66e43a1662cc864f",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/527887c3858a2462b0137662c74837288b998ee3",
+                "reference": "527887c3858a2462b0137662c74837288b998ee3",
                 "shasum": ""
             },
             "require": {
@@ -1309,7 +1266,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1336,34 +1293,40 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-03T18:11:24+00:00"
+            "time": "2019-07-23T11:21:36+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.2.4",
+            "version": "v4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "3354d2e6af986dd71f68b4e5cf4a933ab58697fb"
+                "reference": "212b020949331b6531250584531363844b34a94e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/3354d2e6af986dd71f68b4e5cf4a933ab58697fb",
-                "reference": "3354d2e6af986dd71f68b4e5cf4a933ab58697fb",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/212b020949331b6531250584531363844b34a94e",
+                "reference": "212b020949331b6531250584531363844b34a94e",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/contracts": "^1.0"
+                "symfony/event-dispatcher-contracts": "^1.1"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "1.1"
             },
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
                 "symfony/expression-language": "~3.4|~4.0",
+                "symfony/http-foundation": "^3.4|^4.0",
+                "symfony/service-contracts": "^1.1",
                 "symfony/stopwatch": "~3.4|~4.0"
             },
             "suggest": {
@@ -1373,7 +1336,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1400,20 +1363,78 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23T15:17:42+00:00"
+            "time": "2019-06-27T06:42:14+00:00"
         },
         {
-            "name": "symfony/finder",
-            "version": "v4.2.8",
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v1.1.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "e45135658bd6c14b61850bf131c4f09a55133f69"
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "c61766f4440ca687de1084a5c00b08e167a2575c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e45135658bd6c14b61850bf131c4f09a55133f69",
-                "reference": "e45135658bd6c14b61850bf131c4f09a55133f69",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c61766f4440ca687de1084a5c00b08e167a2575c",
+                "reference": "c61766f4440ca687de1084a5c00b08e167a2575c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "psr/event-dispatcher": "",
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-06-20T06:46:26+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "9638d41e3729459860bb96f6247ccb61faaa45f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/9638d41e3729459860bb96f6247ccb61faaa45f2",
+                "reference": "9638d41e3729459860bb96f6247ccb61faaa45f2",
                 "shasum": ""
             },
             "require": {
@@ -1422,7 +1443,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1449,24 +1470,25 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-06T13:51:08+00:00"
+            "time": "2019-06-28T13:16:30+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v4.2.8",
+            "version": "v4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "1ea878bd3af18f934dedb8c0de60656a9a31a718"
+                "reference": "8b778ee0c27731105fbf1535f51793ad1ae0ba2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/1ea878bd3af18f934dedb8c0de60656a9a31a718",
-                "reference": "1ea878bd3af18f934dedb8c0de60656a9a31a718",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/8b778ee0c27731105fbf1535f51793ad1ae0ba2b",
+                "reference": "8b778ee0c27731105fbf1535f51793ad1ae0ba2b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
+                "symfony/mime": "^4.3",
                 "symfony/polyfill-mbstring": "~1.1"
             },
             "require-dev": {
@@ -1476,7 +1498,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1503,34 +1525,35 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-01T08:36:31+00:00"
+            "time": "2019-07-23T11:21:36+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v4.2.4",
+            "version": "v4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "895ceccaa8149f9343e6134e607c21da42d73b7a"
+                "reference": "a414548d236ddd8fa3df52367d583e82339c5e95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/895ceccaa8149f9343e6134e607c21da42d73b7a",
-                "reference": "895ceccaa8149f9343e6134e607c21da42d73b7a",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/a414548d236ddd8fa3df52367d583e82339c5e95",
+                "reference": "a414548d236ddd8fa3df52367d583e82339c5e95",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "psr/log": "~1.0",
-                "symfony/contracts": "^1.0.2",
                 "symfony/debug": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~4.1",
+                "symfony/event-dispatcher": "^4.3",
                 "symfony/http-foundation": "^4.1.1",
-                "symfony/polyfill-ctype": "~1.8"
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php73": "^1.9"
             },
             "conflict": {
+                "symfony/browser-kit": "<4.3",
                 "symfony/config": "<3.4",
-                "symfony/dependency-injection": "<4.2",
+                "symfony/dependency-injection": "<4.3",
                 "symfony/translation": "<4.2",
                 "symfony/var-dumper": "<4.1.1",
                 "twig/twig": "<1.34|<2.4,>=2"
@@ -1540,11 +1563,11 @@
             },
             "require-dev": {
                 "psr/cache": "~1.0",
-                "symfony/browser-kit": "~3.4|~4.0",
+                "symfony/browser-kit": "^4.3",
                 "symfony/config": "~3.4|~4.0",
                 "symfony/console": "~3.4|~4.0",
                 "symfony/css-selector": "~3.4|~4.0",
-                "symfony/dependency-injection": "^4.2",
+                "symfony/dependency-injection": "^4.3",
                 "symfony/dom-crawler": "~3.4|~4.0",
                 "symfony/expression-language": "~3.4|~4.0",
                 "symfony/finder": "~3.4|~4.0",
@@ -1553,7 +1576,9 @@
                 "symfony/stopwatch": "~3.4|~4.0",
                 "symfony/templating": "~3.4|~4.0",
                 "symfony/translation": "~4.2",
-                "symfony/var-dumper": "^4.1.1"
+                "symfony/translation-contracts": "^1.1",
+                "symfony/var-dumper": "^4.1.1",
+                "twig/twig": "^1.34|^2.4"
             },
             "suggest": {
                 "symfony/browser-kit": "",
@@ -1565,7 +1590,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1592,7 +1617,66 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-03T19:38:09+00:00"
+            "time": "2019-07-28T07:10:23+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "6b7148029b1dd5eda1502064f06d01357b7b2d8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/6b7148029b1dd5eda1502064f06d01357b7b2d8b",
+                "reference": "6b7148029b1dd5eda1502064f06d01357b7b2d8b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.0",
+                "symfony/dependency-injection": "~3.4|^4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A library to manipulate MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "time": "2019-07-19T16:21:19+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1651,6 +1735,127 @@
                 "portable"
             ],
             "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-iconv",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-iconv.git",
+                "reference": "f037ea22acfaee983e271dd9c3b8bb4150bd8ad7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/f037ea22acfaee983e271dd9c3b8bb4150bd8ad7",
+                "reference": "f037ea22acfaee983e271dd9c3b8bb4150bd8ad7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-iconv": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Iconv\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Iconv extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "iconv",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "c766e95bec706cdd89903b1eda8afab7d7a6b7af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/c766e95bec706cdd89903b1eda8afab7d7a6b7af",
+                "reference": "c766e95bec706cdd89903b1eda8afab7d7a6b7af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php72": "^1.9"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-03-04T13:44:35+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1767,17 +1972,75 @@
             "time": "2019-02-06T07:57:58+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v4.2.8",
+            "name": "symfony/polyfill-php73",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "8cf39fb4ccff793340c258ee7760fd40bfe745fe"
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "d1fb4abcc0c47be136208ad9d68bf59f1ee17abd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/8cf39fb4ccff793340c258ee7760fd40bfe745fe",
-                "reference": "8cf39fb4ccff793340c258ee7760fd40bfe745fe",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/d1fb4abcc0c47be136208ad9d68bf59f1ee17abd",
+                "reference": "d1fb4abcc0c47be136208ad9d68bf59f1ee17abd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "856d35814cf287480465bb7a6c413bb7f5f5e69c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/856d35814cf287480465bb7a6c413bb7f5f5e69c",
+                "reference": "856d35814cf287480465bb7a6c413bb7f5f5e69c",
                 "shasum": ""
             },
             "require": {
@@ -1786,7 +2049,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1813,20 +2076,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-10T16:20:36+00:00"
+            "time": "2019-05-30T16:10:05+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v4.2.8",
+            "version": "v4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "f4e43bb0dff56f0f62fa056c82d7eadcdb391bab"
+                "reference": "a88c47a5861549f5dc1197660818084c3b67d773"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/f4e43bb0dff56f0f62fa056c82d7eadcdb391bab",
-                "reference": "f4e43bb0dff56f0f62fa056c82d7eadcdb391bab",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/a88c47a5861549f5dc1197660818084c3b67d773",
+                "reference": "a88c47a5861549f5dc1197660818084c3b67d773",
                 "shasum": ""
             },
             "require": {
@@ -1838,7 +2101,7 @@
                 "symfony/yaml": "<3.4"
             },
             "require-dev": {
-                "doctrine/annotations": "~1.0",
+                "doctrine/annotations": "~1.2",
                 "psr/log": "~1.0",
                 "symfony/config": "~4.2",
                 "symfony/dependency-injection": "~3.4|~4.0",
@@ -1856,7 +2119,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1889,26 +2152,84 @@
                 "uri",
                 "url"
             ],
-            "time": "2019-04-27T09:38:08+00:00"
+            "time": "2019-07-23T14:43:56+00:00"
         },
         {
-            "name": "symfony/translation",
-            "version": "v4.2.4",
+            "name": "symfony/service-contracts",
+            "version": "v1.1.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/translation.git",
-                "reference": "748464177a77011f8f4cdd076773862ce4915f8f"
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "f391a00de78ec7ec8cf5cdcdae59ec7b883edb8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/748464177a77011f8f4cdd076773862ce4915f8f",
-                "reference": "748464177a77011f8f4cdd076773862ce4915f8f",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f391a00de78ec7ec8cf5cdcdae59ec7b883edb8d",
+                "reference": "f391a00de78ec7ec8cf5cdcdae59ec7b883edb8d",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/contracts": "^1.0.2",
-                "symfony/polyfill-mbstring": "~1.0"
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-06-13T11:15:36+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "4e3e39cc485304f807622bdc64938e4633396406"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/4e3e39cc485304f807622bdc64938e4633396406",
+                "reference": "4e3e39cc485304f807622bdc64938e4633396406",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^1.1.2"
             },
             "conflict": {
                 "symfony/config": "<3.4",
@@ -1916,7 +2237,7 @@
                 "symfony/yaml": "<3.4"
             },
             "provide": {
-                "symfony/translation-contracts-implementation": "1.0"
+                "symfony/translation-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
@@ -1924,7 +2245,10 @@
                 "symfony/console": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
                 "symfony/finder": "~2.8|~3.0|~4.0",
+                "symfony/http-kernel": "~3.4|~4.0",
                 "symfony/intl": "~3.4|~4.0",
+                "symfony/service-contracts": "^1.1.2",
+                "symfony/var-dumper": "~3.4|~4.0",
                 "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
@@ -1935,7 +2259,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1962,20 +2286,77 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-27T03:31:50+00:00"
+            "time": "2019-07-18T10:34:59+00:00"
         },
         {
-            "name": "symfony/var-dumper",
-            "version": "v4.2.8",
+            "name": "symfony/translation-contracts",
+            "version": "v1.1.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "3c4084cb1537c0e2ad41aad622bbf55a44a5c9ce"
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "cb4b18ad7b92a26e83b65dde940fab78339e6f3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/3c4084cb1537c0e2ad41aad622bbf55a44a5c9ce",
-                "reference": "3c4084cb1537c0e2ad41aad622bbf55a44a5c9ce",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/cb4b18ad7b92a26e83b65dde940fab78339e6f3c",
+                "reference": "cb4b18ad7b92a26e83b65dde940fab78339e6f3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "symfony/translation-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-06-13T11:15:36+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "e4110b992d2cbe198d7d3b244d079c1c58761d07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/e4110b992d2cbe198d7d3b244d079c1c58761d07",
+                "reference": "e4110b992d2cbe198d7d3b244d079c1c58761d07",
                 "shasum": ""
             },
             "require": {
@@ -2004,7 +2385,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -2038,7 +2419,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2019-05-01T12:55:36+00:00"
+            "time": "2019-07-27T06:42:46+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -2089,16 +2470,16 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v3.3.2",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "1ee9369cfbf26cfcf1f2515d98f15fab54e9647a"
+                "reference": "5084b23845c24dbff8ac6c204290c341e4776c92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/1ee9369cfbf26cfcf1f2515d98f15fab54e9647a",
-                "reference": "1ee9369cfbf26cfcf1f2515d98f15fab54e9647a",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/5084b23845c24dbff8ac6c204290c341e4776c92",
+                "reference": "5084b23845c24dbff8ac6c204290c341e4776c92",
                 "shasum": ""
             },
             "require": {
@@ -2112,7 +2493,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -2137,7 +2518,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2019-01-30T10:43:17+00:00"
+            "time": "2019-06-15T22:40:20+00:00"
         }
     ],
     "packages-dev": [
@@ -2176,27 +2557,29 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^6.2.3",
-                "squizlabs/php_codesniffer": "^3.0.2"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -2221,12 +2604,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-07-22T11:58:36+00:00"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -2481,16 +2864,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.8.1",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
-                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
                 "shasum": ""
             },
             "require": {
@@ -2525,7 +2908,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2018-06-11T23:09:50+00:00"
+            "time": "2019-04-07T13:18:21+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2580,22 +2963,22 @@
         },
         {
             "name": "orchestra/testbench",
-            "version": "v3.8.1",
+            "version": "v3.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench.git",
-                "reference": "2a79dc414c27457e2c7500c763eba2594b51f14c"
+                "reference": "171b29bb9dbd754dc1eb8d9ba0ff05b914b8db1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/2a79dc414c27457e2c7500c763eba2594b51f14c",
-                "reference": "2a79dc414c27457e2c7500c763eba2594b51f14c",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/171b29bb9dbd754dc1eb8d9ba0ff05b914b8db1d",
+                "reference": "171b29bb9dbd754dc1eb8d9ba0ff05b914b8db1d",
                 "shasum": ""
             },
             "require": {
-                "laravel/framework": "~5.8.2",
+                "laravel/framework": "~5.8.19",
                 "mockery/mockery": "^1.0",
-                "orchestra/testbench-core": "~3.8.1",
+                "orchestra/testbench-core": "~3.8.4",
                 "php": ">=7.1",
                 "phpunit/phpunit": "^7.5 || ^8.0"
             },
@@ -2626,20 +3009,20 @@
                 "orchestral",
                 "testing"
             ],
-            "time": "2019-02-28T01:19:16+00:00"
+            "time": "2019-05-29T23:14:15+00:00"
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "v3.8.1",
+            "version": "v3.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "51192972746beb3766327bb84838998d3a59e99c"
+                "reference": "b81c24ef1036cb1f8ff0ca711535cea3f0281848"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/51192972746beb3766327bb84838998d3a59e99c",
-                "reference": "51192972746beb3766327bb84838998d3a59e99c",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/b81c24ef1036cb1f8ff0ca711535cea3f0281848",
+                "reference": "b81c24ef1036cb1f8ff0ca711535cea3f0281848",
                 "shasum": ""
             },
             "require": {
@@ -2647,12 +3030,13 @@
                 "php": ">=7.1"
             },
             "require-dev": {
-                "laravel/framework": "~5.8.0",
+                "laravel/framework": "~5.8.3",
+                "laravel/laravel": "dev-master",
                 "mockery/mockery": "^1.0",
                 "phpunit/phpunit": "^7.5 || ^8.0"
             },
             "suggest": {
-                "laravel/framework": "Required for testing (~5.8.0).",
+                "laravel/framework": "Required for testing (~5.8.19).",
                 "mockery/mockery": "Allow to use Mockery for testing (^1.0).",
                 "orchestra/testbench-browser-kit": "Allow to use legacy Laravel BrowserKit for testing (^3.8).",
                 "orchestra/testbench-dusk": "Allow to use Laravel Dusk for testing (^3.8).",
@@ -2690,7 +3074,7 @@
                 "orchestral",
                 "testing"
             ],
-            "time": "2019-02-28T00:40:46+00:00"
+            "time": "2019-06-10T08:29:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2850,16 +3234,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
                 "shasum": ""
             },
             "require": {
@@ -2897,7 +3281,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
+            "time": "2019-04-30T17:48:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -2948,16 +3332,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
                 "shasum": ""
             },
             "require": {
@@ -2978,8 +3362,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3007,7 +3391,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2019-06-13T12:50:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3059,8 +3443,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -3165,16 +3549,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b389aebe1b8b0578430bda0c7c95a829608e059",
-                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
@@ -3210,20 +3594,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-02-20T10:12:59+00:00"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18"
+                "reference": "e899757bb3df5ff6e95089132f32cd59aac2220a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/c99e3be9d3e85f60646f152f9002d46ed7770d18",
-                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e899757bb3df5ff6e95089132f32cd59aac2220a",
+                "reference": "e899757bb3df5ff6e95089132f32cd59aac2220a",
                 "shasum": ""
             },
             "require": {
@@ -3236,7 +3620,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -3259,20 +3643,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2018-10-30T05:52:18+00:00"
+            "time": "2019-07-25T05:29:42+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.6",
+            "version": "7.5.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "09c85e14994df92e5ff1f5ec0b481bdb7d3d3df9"
+                "reference": "2834789aeb9ac182ad69bfdf9ae91856a59945ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/09c85e14994df92e5ff1f5ec0b481bdb7d3d3df9",
-                "reference": "09c85e14994df92e5ff1f5ec0b481bdb7d3d3df9",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2834789aeb9ac182ad69bfdf9ae91856a59945ff",
+                "reference": "2834789aeb9ac182ad69bfdf9ae91856a59945ff",
                 "shasum": ""
             },
             "require": {
@@ -3290,7 +3674,7 @@
                 "phpunit/php-code-coverage": "^6.0.7",
                 "phpunit/php-file-iterator": "^2.0.1",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.0",
+                "phpunit/php-timer": "^2.1",
                 "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0",
                 "sebastian/environment": "^4.0",
@@ -3332,8 +3716,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -3343,7 +3727,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-02-18T09:24:50+00:00"
+            "time": "2019-07-15T06:24:08+00:00"
         },
         {
             "name": "psy/psysh",
@@ -3586,16 +3970,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "4.1.0",
+            "version": "4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656"
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6fda8ce1974b62b14935adc02a9ed38252eca656",
-                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
                 "shasum": ""
             },
             "require": {
@@ -3610,7 +3994,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -3635,7 +4019,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-02-01T05:27:49+00:00"
+            "time": "2019-05-05T09:05:15+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -3987,16 +4371,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.0",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
                 "shasum": ""
             },
             "require": {
@@ -4023,7 +4407,7 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07T12:08:54+00:00"
+            "time": "2019-06-13T22:48:21+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/dist/livewire.js
+++ b/dist/livewire.js
@@ -1,1 +1,2948 @@
-!function(e,t){if("object"==typeof exports&&"object"==typeof module)module.exports=t();else if("function"==typeof define&&define.amd)define([],t);else{var n=t();for(var i in n)("object"==typeof exports?exports:e)[i]=n[i]}}(window,function(){return function(e){var t={};function n(i){if(t[i])return t[i].exports;var r=t[i]={i:i,l:!1,exports:{}};return e[i].call(r.exports,r,r.exports,n),r.l=!0,r.exports}return n.m=e,n.c=t,n.d=function(e,t,i){n.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:i})},n.r=function(e){"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},n.t=function(e,t){if(1&t&&(e=n(e)),8&t)return e;if(4&t&&"object"==typeof e&&e&&e.__esModule)return e;var i=Object.create(null);if(n.r(i),Object.defineProperty(i,"default",{enumerable:!0,value:e}),2&t&&"string"!=typeof e)for(var r in e)n.d(i,r,function(t){return e[t]}.bind(null,r));return i},n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,"a",t),t},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.p="/",n(n.s=0)}({"/Se7":function(e,t){var n=null;e.exports=function(){return null===n&&(n=(document.querySelector('meta[name="livewire-prefix"]')||{content:"wire"}).content),n}},0:function(e,t,n){e.exports=n("e6Wu")},CJJz:function(module,__webpack_exports__,__webpack_require__){"use strict";__webpack_require__.d(__webpack_exports__,"a",function(){return DOMElement});var _directive_manager__WEBPACK_IMPORTED_MODULE_0__=__webpack_require__("OgvX");function _classCallCheck(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function _defineProperties(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}function _createClass(e,t,n){return t&&_defineProperties(e.prototype,t),n&&_defineProperties(e,n),e}var prefix=__webpack_require__("/Se7")(),DOMElement=function(){function DOMElement(e){_classCallCheck(this,DOMElement),this.el=e,this.directives=new _directive_manager__WEBPACK_IMPORTED_MODULE_0__.a(e)}return _createClass(DOMElement,[{key:"nextFrame",value:function(e){var t=this;requestAnimationFrame(function(){requestAnimationFrame(e.bind(t))})}},{key:"rawNode",value:function(){return this.el}},{key:"transitionElementIn",value:function(){var e=this;if(this.directives.has("transition")){var t=this.directives.get("transition");if(t.modifiers.includes("out")&&!t.modifiers.includes("in"))return!0;if(t.modifiers.includes("fade"))this.fadeIn(t);else if(t.modifiers.includes("slide"))this.slideIn(t);else{var n=t.value;this.el.classList.add("".concat(n,"-enter")),this.el.classList.add("".concat(n,"-enter-active")),this.nextFrame(function(){e.el.classList.remove("".concat(n,"-enter"));var t=1e3*Number(getComputedStyle(e.el).transitionDuration.replace("s",""));setTimeout(function(){e.el.classList.remove("".concat(n,"-enter-active"))},t)})}}}},{key:"transitionElementOut",value:function(e){var t=this;if(!this.directives.has("transition"))return!0;var n=this.directives.get("transition");if(n.modifiers.includes("in")&&!n.modifiers.includes("out"))return!0;if(n.modifiers.includes("fade"))return this.fadeOut(n,e),!1;if(n.modifiers.includes("slide"))return this.slideOut(n,e),!1;var i=n.value;return this.el.classList.add("".concat(i,"-leave-active")),this.nextFrame(function(){t.el.classList.add("".concat(i,"-leave"));var n=1e3*Number(getComputedStyle(t.el).transitionDuration.replace("s",""));setTimeout(function(){e(t.el),t.el.remove()},n)}),!1}},{key:"fadeIn",value:function(e){var t=this;this.el.style.opacity=0,this.el.style.transition="opacity ".concat(e.durationOr(300)/1e3,"s ease"),this.nextFrame(function(){t.el.style.opacity=1})}},{key:"slideIn",value:function(e){var t=this;this.el.style.opacity=0,this.el.style.transform={up:"translateY(10px)",down:"translateY(-10px)",left:"translateX(-10px)",right:"translateX(10px)"}[e.cardinalDirectionOr("right")],this.el.style.transition="opacity ".concat(e.durationOr(300)/1e3,"s ease, transform ").concat(e.durationOr(300)/1e3,"s ease"),this.nextFrame(function(){t.el.style.opacity=1,t.el.style.transform=""})}},{key:"fadeOut",value:function(e,t){var n=this;this.nextFrame(function(){n.el.style.opacity=0,setTimeout(function(){t(n.el),n.el.remove()},e.durationOr(300))})}},{key:"slideOut",value:function(e,t){var n=this,i={up:"translateY(10px)",down:"translateY(-10px)",left:"translateX(-10px)",right:"translateX(10px)"};this.nextFrame(function(){n.el.style.opacity=0,n.el.style.transform=i[e.cardinalDirectionOr("right")],setTimeout(function(){t(n.el),n.el.remove()},e.durationOr(300))})}},{key:"closestRoot",value:function(){return this.closestByAttribute("id")}},{key:"closestByAttribute",value:function(e){return new DOMElement(this.el.closest("[".concat(prefix,"\\:").concat(e,"]")))}},{key:"isComponentRootEl",value:function(){return this.hasAttribute("id")}},{key:"isVueComponent",value:function(){return!!this.asVueComponent()}},{key:"asVueComponent",value:function(){return this.rawNode().__vue__}},{key:"hasAttribute",value:function(e){return this.el.hasAttribute("".concat(prefix,":").concat(e))}},{key:"getAttribute",value:function(e){return this.el.getAttribute("".concat(prefix,":").concat(e))}},{key:"setAttribute",value:function(e,t){return this.el.setAttribute("".concat(prefix,":").concat(e),t)}},{key:"isFocused",value:function(){return this.el===document.activeElement}},{key:"hasFocus",value:function(){return this.el===document.activeElement}},{key:"preserveValueAttributeIfNotDirty",value:function(e,t){this.directives.missing("model")||!Array.from(t).includes(this.directives.get("model").value)&&e.isFocused()&&this.setInputValue(e.valueFromInput())}},{key:"isInput",value:function(){return["INPUT","TEXTAREA","SELECT"].includes(this.el.tagName.toUpperCase())}},{key:"isTextInput",value:function(){return["INPUT","TEXTAREA"].includes(this.el.tagName.toUpperCase())&&!["checkbox","radio"].includes(this.el.type)}},{key:"valueFromInput",value:function(){return"checkbox"===this.el.type?this.el.checked:"SELECT"===this.el.tagName&&this.el.multiple?this.getSelectValues():this.el.value}},{key:"setInputValueFromModel",value:function setInputValueFromModel(component){var modelString=this.directives.get("model").value,modelStringWithArraySyntaxForNumericKeys=modelString.replace(/\.([0-9]+)/,function(e,t){return"[".concat(t,"]")}),modelValue=eval("component.data."+modelStringWithArraySyntaxForNumericKeys);void 0!==modelValue&&this.setInputValue(modelValue)}},{key:"setInputValue",value:function(e){if(this.rawNode().__vue__){var t=window.Vue.config.silent;window.Vue.config.silent=!0,this.rawNode().__vue__.$props.value=e,window.Vue.config.silent=t}else"radio"===this.el.type?this.el.checked=this.el.value==e:"checkbox"===this.el.type?this.el.checked=!!e:"SELECT"===this.el.tagName?this.updateSelect(e):this.el.value=e}},{key:"getSelectValues",value:function(){return Array.from(this.el.options).filter(function(e){return e.selected}).map(function(e){return e.value||e.text})}},{key:"updateSelect",value:function(e){var t=[].concat(e);Array.from(this.el.options).forEach(function(e){e.selected=t.includes(e.value)})}},{key:"isSameNode",value:function(e){return"function"==typeof e.rawNode?this.el.isSameNode(e.rawNode()):this.el.isSameNode(e)}},{key:"getAttributeNames",value:function(){var e;return(e=this.el).getAttributeNames.apply(e,arguments)}},{key:"addEventListener",value:function(){var e;return(e=this.el).addEventListener.apply(e,arguments)}},{key:"querySelector",value:function(){var e;return(e=this.el).querySelector.apply(e,arguments)}},{key:"querySelectorAll",value:function(){var e;return(e=this.el).querySelectorAll.apply(e,arguments)}},{key:"ref",get:function(){return this.directives.has("ref")?this.directives.get("ref").value:null}},{key:"classList",get:function(){return this.el.classList}}]),DOMElement}()},OgvX:function(e,t,n){"use strict";n.d(t,"a",function(){return u});var i=n("uXse");function r(e){return function(e){if(Array.isArray(e))return e}(e)||function(e){if(Symbol.iterator in Object(e)||"[object Arguments]"===Object.prototype.toString.call(e))return Array.from(e)}(e)||function(){throw new TypeError("Invalid attempt to destructure non-iterable instance")}()}function o(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}var a=n("/Se7")(),u=function(){function e(t){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),this.el=t,this.directives=this.extractTypeModifiersAndValue()}var t,n,u;return t=e,(n=[{key:"all",value:function(){return this.directives}},{key:"has",value:function(e){return this.directives.map(function(e){return e.type}).includes(e)}},{key:"missing",value:function(e){return!this.directives.map(function(e){return e.type}).includes(e)}},{key:"get",value:function(e){return this.directives.find(function(t){return t.type===e})}},{key:"extractTypeModifiersAndValue",value:function(){var e=this;return Array.from(this.el.getAttributeNames().filter(function(e){return e.match(new RegExp(a+":"))}).map(function(t){var n=r(t.replace(new RegExp(a+":"),"").split(".")),o=n[0],u=n.slice(1);return new i.a(o,u,t,e.el)}))}}])&&o(t.prototype,n),u&&o(t,u),e}()},e6Wu:function(e,t,n){"use strict";function i(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}n.r(t);var r=function(){function e(t){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),this.el=t}var t,n,r;return t=e,(n=[{key:"ref",get:function(){return this.el?this.el.ref:null}}])&&i(t.prototype,n),r&&i(t,r),e}();function o(e){return(o="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}function a(e,t){return!t||"object"!==o(t)&&"function"!=typeof t?function(e){if(void 0===e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return e}(e):t}function u(e){return(u=Object.setPrototypeOf?Object.getPrototypeOf:function(e){return e.__proto__||Object.getPrototypeOf(e)})(e)}function s(e,t){return(s=Object.setPrototypeOf||function(e,t){return e.__proto__=t,e})(e,t)}var l=function(e){function t(e,n,i){var r;return function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,t),(r=a(this,u(t).call(this,i))).type="fireEvent",r.payload={event:e,params:n},r}return function(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function");e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,writable:!0,configurable:!0}}),t&&s(e,t)}(t,e),t}(r),c={componentsById:{},listeners:{},addComponent:function(e){return this.componentsById[e.id]=e},findComponent:function(e){return this.componentsById[e]},wipeComponents:function(){this.componentsById={}},on:function(e,t){void 0!==this.listeners[e]?this.listeners[e].push(t):this.listeners[e]=[t]},emit:function(e){for(var t=arguments.length,n=new Array(t>1?t-1:0),i=1;i<t;i++)n[i-1]=arguments[i];void 0!==this.listeners[e]&&this.listeners[e].forEach(function(e){return e.apply(void 0,n)}),this.componentsListeningForEvent(e).forEach(function(t){return t.addAction(new l(e,n))})},componentsListeningForEvent:function(e){var t=this;return Object.keys(this.componentsById).map(function(e){return t.componentsById[e]}).filter(function(t){return t.events.includes(e)})}},f=n("CJJz");function d(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}var p=n("/Se7")(),h=function(){function e(){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e)}var t,n,i;return t=e,i=[{key:"rootComponentElements",value:function(){return Array.from(document.querySelectorAll("[".concat(p,"\\:id]"))).map(function(e){return new f.a(e)})}},{key:"rootComponentElementsWithNoParents",value:function(){var e=Array.from(document.querySelectorAll("[".concat(p,"\\:id]"))),t=Array.from(document.querySelectorAll("[".concat(p,"\\:id] [").concat(p,"\\:id]")));return e.filter(function(e){return!t.includes(e)}).map(function(e){return new f.a(e)})}},{key:"allModelElementsInside",value:function(e){return Array.from(e.querySelectorAll("[".concat(p,"\\:model]"))).map(function(e){return new f.a(e)})}},{key:"getByAttributeAndValue",value:function(e,t){return new f.a(document.querySelector("[".concat(p,"\\:").concat(e,'="').concat(t,'"]')))}},{key:"prefix",get:function(){return p}}],(n=null)&&d(t.prototype,n),i&&d(t,i),e}();function v(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}var m=function(){function e(t,n){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),this.component=t,this.actionQueue=n}var t,n,i;return t=e,(n=[{key:"prepareForSend",value:function(){this.loadingEls=this.component.setLoading(this.refs)}},{key:"payload",value:function(){return{id:this.component.id,data:this.component.data,name:this.component.name,children:this.component.children,middleware:this.component.middleware,checksum:this.component.checksum,actionQueue:this.actionQueue.map(function(e){return{type:e.type,payload:e.payload}})}}},{key:"storeResponse",value:function(e){return this.response={id:e.id,dom:e.dom,children:e.children,dirtyInputs:e.dirtyInputs,eventQueue:e.eventQueue,events:e.events,data:e.data,redirectTo:e.redirectTo}}},{key:"refs",get:function(){return this.actionQueue.map(function(e){return e.ref}).filter(function(e){return e})}}])&&v(t.prototype,n),i&&v(t,i),e}();function y(e,t,n){var i;return function(){var r=this,o=arguments,a=n&&!i;clearTimeout(i),i=setTimeout(function(){i=null,n||e.apply(r,o)},t),a&&e.apply(r,o)}}var b,g,w=((b=document.createEvent("Events")).initEvent("test",!0,!0),b.preventDefault(),b.defaultPrevented);var E="http://www.w3.org/1999/xhtml",k="undefined"==typeof document?void 0:document,A=k?k.body||k.createElement("div"):{},_=A.hasAttributeNS?function(e,t,n){return e.hasAttributeNS(t,n)}:A.hasAttribute?function(e,t,n){return e.hasAttribute(n)}:function(e,t,n){return null!=e.getAttributeNode(t,n)};function S(e,t){var n=e.nodeName,i=t.nodeName;return n===i||!!(t.actualize&&n.charCodeAt(0)<91&&i.charCodeAt(0)>90)&&n===i.toUpperCase()}function O(e,t,n){e[n]!==t[n]&&(e[n]=t[n],e[n]?e.setAttribute(n,""):e.removeAttribute(n))}var C={OPTION:function(e,t){O(e,t,"selected")},INPUT:function(e,t){O(e,t,"checked"),O(e,t,"disabled"),e.value!==t.value&&(e.value=t.value),_(t,null,"value")||e.removeAttribute("value")},TEXTAREA:function(e,t){var n=t.value;e.value!==n&&(e.value=n);var i=e.firstChild;if(i){var r=i.nodeValue;if(r==n||!n&&r==e.placeholder)return;i.nodeValue=n}},SELECT:function(e,t){if(!_(t,null,"multiple")){for(var n=0,i=t.firstChild;i;){var r=i.nodeName;if(r&&"OPTION"===r.toUpperCase()){if(_(i,null,"selected")){n;break}n++}i=i.nextSibling}e.selectedIndex=n}}},x=1,T=3,N=8;function I(){}function M(e){return e.id}function L(e){"getNodeKey"!==e.name&&e.name;for(var t=arguments.length,n=new Array(t>1?t-1:0),i=1;i<t;i++)n[i-1]=arguments[i];if("function"==typeof n[0].hasAttribute)return e.apply(void 0,n)}var P,j=(P=function(e,t){var n,i,r,o,a,u=t.attributes;for(n=u.length-1;n>=0;--n)r=(i=u[n]).name,o=i.namespaceURI,a=i.value,o?(r=i.localName||r,e.getAttributeNS(o,r)!==a&&e.setAttributeNS(o,r,a)):e.getAttribute(r)!==a&&e.setAttribute(r,a);for(n=(u=e.attributes).length-1;n>=0;--n)!1!==(i=u[n]).specified&&(r=i.name,(o=i.namespaceURI)?(r=i.localName||r,_(t,o,r)||e.removeAttributeNS(o,r)):_(t,null,r)||e.removeAttribute(r))},function(e,t,n){if(n||(n={}),"string"==typeof t)if("#document"===e.nodeName||"HTML"===e.nodeName){var i=t;(t=k.createElement("html")).innerHTML=i}else r=t,!g&&k.createRange&&(g=k.createRange()).selectNode(k.body),g&&g.createContextualFragment?o=g.createContextualFragment(r):(o=k.createElement("body")).innerHTML=r,t=o.childNodes[0];var r,o,a,u=n.getNodeKey||M,s=n.onBeforeNodeAdded||I,l=n.onNodeAdded||I,c=n.onBeforeElUpdated||I,f=n.onElUpdated||I,d=n.onBeforeNodeDiscarded||I,p=n.onNodeDiscarded||I,h=n.onBeforeElChildrenUpdated||I,v=!0===n.childrenOnly,m={};function y(e){a?a.push(e):a=[e]}function b(e,t,n){!1!==L(d,e)&&(t&&t.removeChild(e),L(p,e),function e(t,n){if(t.nodeType===x)for(var i=t.firstChild;i;){var r=void 0;n&&(r=L(u,i))?y(r):(L(p,i),i.firstChild&&e(i,n)),i=i.nextSibling}}(e,n))}function w(e){L(l,e);for(var t=e.firstChild;t;){var n=t.nextSibling,i=L(u,t);if(i){var r=m[i];r&&S(t,r)&&(t.parentNode.replaceChild(r,t),A(r,t))}w(t),t=n}}function A(e,t,n){var i,r=L(u,t);if(r&&delete m[r],!t.isEqualNode||!t.isEqualNode(e)){if(!n){if(!1===L(c,e,t))return;if(P(e,t),L(f,e),!1===L(h,e,t))return}if("TEXTAREA"!==e.nodeName){var o,a,l,d,p=t.firstChild,v=e.firstChild;e:for(;p;){for(l=p.nextSibling,o=L(u,p);v;){if(a=v.nextSibling,p.isEqualNode&&p.isEqualNode(v)){p=l,v=a;continue e}i=L(u,v);var g=v.nodeType,E=void 0;if(g===p.nodeType&&(g===x?(o?o!==i&&((d=m[o])?v.nextSibling===d?E=!1:(e.insertBefore(d,v),a=v.nextSibling,i?y(i):b(v,e,!0),v=d):E=!1):i&&(E=!1),(E=!1!==E&&S(v,p))&&A(v,p)):g!==T&&g!=N||(E=!0,v.nodeValue!==p.nodeValue&&(v.nodeValue=p.nodeValue))),E){p=l,v=a;continue e}i?y(i):b(v,e,!0),v=a}if(o&&(d=m[o])&&S(d,p))e.appendChild(d),A(d,p);else{var _=L(s,p);!1!==_&&(_&&(p=_),p.actualize&&(p=p.actualize(e.ownerDocument||k)),e.appendChild(p),w(p))}p=l,v=a}for(;v;)a=v.nextSibling,(i=L(u,v))?y(i):b(v,e,!0),v=a}var O=C[e.nodeName];O&&!e.hasAttribute("wire:model")&&O(e,t)}}!function e(t){if(t.nodeType===x)for(var n=t.firstChild;n;){var i=L(u,n);i&&(m[i]=n),e(n),n=n.nextSibling}}(e);var _,O,j=e,V=j.nodeType,D=t.nodeType;if(!v)if(V===x)D===x?S(e,t)||(L(p,e),j=function(e,t){for(var n=e.firstChild;n;){var i=n.nextSibling;t.appendChild(n),n=i}return t}(e,(_=t.nodeName,(O=t.namespaceURI)&&O!==E?k.createElementNS(O,_):k.createElement(_)))):j=t;else if(V===T||V===N){if(D===V)return j.nodeValue!==t.nodeValue&&(j.nodeValue=t.nodeValue),j;j=t}if(j===t)L(p,e);else if(A(j,t,v),a)for(var R=0,F=a.length;R<F;R++){var B=m[a[R]];B&&b(B,B.parentNode,!1)}return!v&&j!==e&&e.parentNode&&(j.actualize&&(j=j.actualize(e.ownerDocument||k)),e.parentNode.replaceChild(j,e)),j});function V(e){return(V="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}function D(e,t){return!t||"object"!==V(t)&&"function"!=typeof t?function(e){if(void 0===e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return e}(e):t}function R(e){return(R=Object.setPrototypeOf?Object.getPrototypeOf:function(e){return e.__proto__||Object.getPrototypeOf(e)})(e)}function F(e,t){return(F=Object.setPrototypeOf||function(e,t){return e.__proto__=t,e})(e,t)}var B=function(e){function t(e,n,i){var r;return function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,t),(r=D(this,R(t).call(this,i))).type="syncInput",r.payload={name:e,value:n},r}return function(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function");e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,writable:!0,configurable:!0}}),t&&F(e,t)}(t,e),t}(r);function q(e){return(q="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}function U(e,t){return!t||"object"!==q(t)&&"function"!=typeof t?function(e){if(void 0===e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return e}(e):t}function X(e){return(X=Object.setPrototypeOf?Object.getPrototypeOf:function(e){return e.__proto__||Object.getPrototypeOf(e)})(e)}function W(e,t){return(W=Object.setPrototypeOf||function(e,t){return e.__proto__=t,e})(e,t)}var z=function(e){function t(e,n,i){var r;return function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,t),(r=U(this,X(t).call(this,i))).type="callMethod",r.payload={method:e,params:n},r}return function(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function");e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,writable:!0,configurable:!0}}),t&&W(e,t)}(t,e),t}(r);function H(e){return function(e){if(Array.isArray(e)){for(var t=0,n=new Array(e.length);t<e.length;t++)n[t]=e[t];return n}}(e)||function(e){if(Symbol.iterator in Object(e)||"[object Arguments]"===Object.prototype.toString.call(e))return Array.from(e)}(e)||function(){throw new TypeError("Invalid attempt to spread non-iterable instance")}()}var Q={initialize:function(e,t){var n=this;e.directives.all().forEach(function(i){switch(i.type){case"loading":n.registerElementForLoading(e,i,t);break;case"poll":n.fireActionOnInterval(e,i,t);break;case"model":e.setInputValueFromModel(t),n.attachModelListener(e,i,t);break;default:n.attachDomListener(e,i,t)}})},registerElementForLoading:function(e,t,n){var i=e.directives.get("target")&&e.directives.get("target").value;n.addLoadingEl(e,t.value,i,t.modifiers.includes("remove"))},fireActionOnInterval:function(e,t,n){var i=t.method||"$refresh";setInterval(function(){n.addAction(new z(i,t.params,e))},t.durationOr(500))},attachModelListener:function(e,t,n){var i=t.modifiers.includes("lazy"),r=function(e,t,n){return e?y(t,n):t},o=t.modifiers.includes("debounce");if(e.isVueComponent())e.asVueComponent().$on("input",r(o,function(i){var r=t.value,o=i;n.addAction(new B(r,o,e))},t.durationOr(150)));else{var a=e.isTextInput()?"input":"change";e.addEventListener(i?"change":a,r(o||e.isTextInput()&&!i,function(e){var i=t.value,r=new f.a(e.target),o=r.valueFromInput();n.addAction(new B(i,o,r))},t.durationOr(150)))}},attachDomListener:function(e,t,n){switch(t.type){case"keydown":this.attachListener(e,t,n,function(e){return!(0===t.modifiers.length||t.modifiers.includes((n=e.key,n.split(/[_\s]/).join("-").toLowerCase())));var n});break;default:this.attachListener(e,t,n)}},attachListener:function(e,t,n,i){var r=this;e.addEventListener(t.type,function(e){if(!i||!1===i(e)){var o=new f.a(e.target);t.setEventContext(e),r.preventAndStop(e,t.modifiers);var a=t.method,u=t.params;"$emit"!==a?t.value&&n.addAction(new z(a,u,o)):c.emit.apply(c,H(u))}})},preventAndStop:function(e,t){t.includes("prevent")&&e.preventDefault(),t.includes("stop")&&e.stopPropagation()}};function K(e,t){return function(e){if(Array.isArray(e))return e}(e)||function(e,t){var n=[],i=!0,r=!1,o=void 0;try{for(var a,u=e[Symbol.iterator]();!(i=(a=u.next()).done)&&(n.push(a.value),!t||n.length!==t);i=!0);}catch(e){r=!0,o=e}finally{try{i||null==u.return||u.return()}finally{if(r)throw o}}return n}(e,t)||function(){throw new TypeError("Invalid attempt to destructure non-iterable instance")}()}function J(e){return function(e){if(Array.isArray(e)){for(var t=0,n=new Array(e.length);t<e.length;t++)n[t]=e[t];return n}}(e)||function(e){if(Symbol.iterator in Object(e)||"[object Arguments]"===Object.prototype.toString.call(e))return Array.from(e)}(e)||function(){throw new TypeError("Invalid attempt to spread non-iterable instance")}()}function $(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}var Y=function(){function e(t,n){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),this.id=t.getAttribute("id"),this.data=JSON.parse(t.getAttribute("data")),this.events=JSON.parse(t.getAttribute("events")),this.children=JSON.parse(t.getAttribute("children")),this.middleware=t.getAttribute("middleware"),this.checksum=t.getAttribute("checksum"),this.name=t.getAttribute("name"),this.connection=n,this.actionQueue=[],this.messageInTransit=null,this.loadingEls=[],this.loadingElsByRef={},this.initialize(),this.registerEchoListeners()}var t,n,i;return t=e,(n=[{key:"initialize",value:function(){var t=this;this.walk(function(e){Q.initialize(e,t)},function(n){c.addComponent(new e(n,t.connection))})}},{key:"addAction",value:function(e){this.actionQueue.push(e),y(this.fireMessage,5).apply(this)}},{key:"fireMessage",value:function(){this.messageInTransit||(this.messageInTransit=new m(this,this.actionQueue),this.connection.sendMessage(this.messageInTransit),this.actionQueue=[])}},{key:"messageSendFailed",value:function(){this.messageInTransit=null}},{key:"receiveMessage",value:function(e){var t=this.messageInTransit.storeResponse(e);this.data=t.data,this.children=t.children,t.redirectTo?window.location.href=t.redirectTo:(this.replaceDom(t.dom,t.dirtyInputs),this.forceRefreshDataBoundElementsMarkedAsDirty(t.dirtyInputs),this.unsetLoading(this.messageInTransit.loadingEls),this.messageInTransit=null,t.eventQueue&&t.eventQueue.length>0&&t.eventQueue.forEach(function(e){c.emit.apply(c,[e.event].concat(J(e.params)))}))}},{key:"forceRefreshDataBoundElementsMarkedAsDirty",value:function(e){var t=this;this.walk(function(n){if(!n.directives.missing("model")){var i=n.directives.get("model").value;n.isFocused()&&!e.includes(i)||n.setInputValueFromModel(t)}})}},{key:"replaceDom",value:function(e){this.handleMorph(this.formatDomBeforeDiffToAvoidConflictsWithVue(e.trim()))}},{key:"formatDomBeforeDiffToAvoidConflictsWithVue",value:function(e){if(!window.Vue)return e;var t=document.createElement("div");return t.innerHTML=e,(new window.Vue).$mount(t.firstElementChild),t.firstElementChild.outerHTML}},{key:"handleMorph",value:function(t){var n=this;j(this.el.rawNode(),t,{childrenOnly:!0,getNodeKey:function(e){return e.hasAttribute("".concat(h.prefix,":key"))?e.getAttribute("".concat(h.prefix,":key")):e.hasAttribute("".concat(h.prefix,":id"))?e.getAttribute("".concat(h.prefix,":id")):e.hasAttribute("".concat(h.prefix,":model"))?e.getAttribute("".concat(h.prefix,":model")):e.id},onBeforeNodeAdded:function(e){return new f.a(e).transitionElementIn()},onBeforeNodeDiscarded:function(e){return new f.a(e).transitionElementOut(function(e){n.removeLoadingEl(e)})},onBeforeElChildrenUpdated:function(e){},onBeforeElUpdated:function(e,t){var i=new f.a(e);return!i.hasAttribute("ignore")&&((!i.isComponentRootEl()||i.getAttribute("id")===n.id)&&(!i.isVueComponent()&&void 0))},onElUpdated:function(e){},onNodeDiscarded:function(e){n.removeLoadingEl(e)},onNodeAdded:function(t){var i=new f.a(t);i.closestRoot().getAttribute("id")===n.id?Q.initialize(i,n):i.isComponentRootEl()&&c.addComponent(new e(i,n.connection))}})}},{key:"walk",value:function(e){var t=this,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:function(e){};!function e(t,n){if(!1!==n(t))for(var i=t.firstElementChild;i;)e(i,n),i=i.nextElementSibling}(this.el.rawNode(),function(i){var r=new f.a(i);if(!r.isSameNode(t.el))return r.isComponentRootEl()?(n(r),!1):void e(r)})}},{key:"registerEchoListeners",value:function(){Array.isArray(this.events)&&this.events.forEach(function(e){if(e.startsWith("echo")){if("undefined"==typeof Echo)return void console.warn("Laravel Echo cannot be found");var t=e.split(/(echo:|echo-)|:|,/);"echo:"==t[1]&&t.splice(2,0,"channel",void 0),"notification"==t[2]&&t.push(void 0,void 0);var n=K(t,7),i=(n[0],n[1],n[2]),r=(n[3],n[4]),o=(n[5],n[6]);["channel","private"].includes(i)?Echo[i](r).listen(o,function(t){c.emit(e,t)}):"presence"==i?Echo.join(r)[o](function(t){c.emit(e,t)}):"notification"==i?Echo.private(r).notification(function(t){c.emit(e,t)}):console.warn("Echo channel type not yet supported")}})}},{key:"addLoadingEl",value:function(e,t,n,i){n?this.loadingElsByRef[n]?this.loadingElsByRef[n].push({el:e,value:t,remove:i}):this.loadingElsByRef[n]=[{el:e,value:t,remove:i}]:this.loadingEls.push({el:e,value:t,remove:i})}},{key:"removeLoadingEl",value:function(e){var t=new f.a(e);this.loadingEls=this.loadingEls.filter(function(t){return!t.el.isSameNode(e)}),t.ref in this.loadingElsByRef&&delete this.loadingElsByRef[t.ref]}},{key:"setLoading",value:function(e){var t=this,n=e.map(function(e){return t.loadingElsByRef[e]}).filter(function(e){return e}).flat(),i=this.loadingEls.concat(n);return i.forEach(function(e){var t=e.el.directives.get("loading");if(e=e.el.el,t.modifiers.includes("class")){var n,i,r=t.value.split(" ");if(t.modifiers.includes("remove"))(n=e.classList).remove.apply(n,J(r));else(i=e.classList).add.apply(i,J(r))}else t.modifiers.includes("attr")?t.modifiers.includes("remove")?e.removeAttribute(t.value):e.setAttribute(t.value,!0):e.style.display="inline-block"}),i}},{key:"unsetLoading",value:function(e){}},{key:"el",get:function(){return h.getByAttributeAndValue("id",this.id)}}])&&$(t.prototype,n),i&&$(t,i),e}();function G(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}var Z=function(){function e(t){var n=this;!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),this.driver=t,this.driver.onMessage=function(e){n.onMessage(e)},this.driver.onError=function(e){n.onError(e)},void 0!==this.driver.keepAlive&&setInterval(function(){n.driver.keepAlive()},6e5),this.driver.init()}var t,n,i;return t=e,(n=[{key:"onMessage",value:function(e){c.findComponent(e.id).receiveMessage(e),function(e){var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{},n=t.target,i=t.cancelable,r=t.data,o=document.createEvent("Events");if(o.initEvent(e,!0,1==i),o.data=r||{},o.cancelable&&!w){var a=o.preventDefault;o.preventDefault=function(){this.defaultPrevented||Object.defineProperty(this,"defaultPrevented",{get:function(){return!0}}),a.call(this)}}(n||document).dispatchEvent(o)}("livewire:update")}},{key:"onError",value:function(e){c.findComponent(e.id).messageSendFailed()}},{key:"sendMessage",value:function(e){e.prepareForSend(),this.driver.sendMessage(e.payload())}}])&&G(t.prototype,n),i&&G(t,i),e}(),ee={http:{onError:null,onMessage:null,init:function(){},keepAlive:function(){fetch("/livewire/keep-alive",{credentials:"same-origin",headers:{"X-CSRF-TOKEN":this.getCSRFToken(),"X-Livewire-Keep-Alive":!0}})},sendMessage:function(e){var t=this;fetch("/livewire/message"+window.location.search,{method:"POST",body:JSON.stringify(e),credentials:"same-origin",headers:{"Content-Type":"application/json",Accept:"text/html, application/xhtml+xml","X-CSRF-TOKEN":this.getCSRFToken(),"X-Livewire":!0}}).then(function(n){n.ok?n.text().then(function(e){t.onMessage.call(t,JSON.parse(e))}):n.text().then(function(n){t.onError(e),t.showHtmlModal(n)})}).catch(function(){t.onError(e)})},getCSRFToken:function(){var e,t=document.head.querySelector('meta[name="csrf-token"]');if(t)e=t.content;else{if(!window.livewire_token)throw new Error('Whoops, looks like you haven\'t added a "csrf-token" meta tag');e=window.livewire_token}return e},showHtmlModal:function(e){var t=this,n=document.createElement("html");n.innerHTML=e,n.querySelectorAll("a").forEach(function(e){return e.setAttribute("target","_top")});var i=document.createElement("div");i.id="burst-error",i.style.position="fixed",i.style.width="100vw",i.style.height="100vh",i.style.padding="50px",i.style.backgroundColor="rgba(0, 0, 0, .6)",i.style.zIndex=2e5;var r=document.createElement("iframe");r.style.backgroundColor="white",r.style.borderRadius="5px",r.style.width="100%",r.style.height="100%",i.appendChild(r),document.body.prepend(i),document.body.style.overflow="hidden",r.contentWindow.document.open(),r.contentWindow.document.write(n.outerHTML),r.contentWindow.document.close(),i.addEventListener("click",function(){return t.hideHtmlModal(i)}),i.setAttribute("tabindex",0),i.addEventListener("keydown",function(e){"Escape"===e.key&&t.hideHtmlModal(i)}),i.focus()},hideHtmlModal:function(e){e.outerHTML="",document.body.style.overflow="visible"}}};function te(e){return(te="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}function ne(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}var ie=function(){function e(){var t=(arguments.length>0&&void 0!==arguments[0]?arguments[0]:{driver:"http"}).driver;!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),"object"!==te(t)&&(t=ee[t]),this.connection=new Z(t),this.components=c,this.start()}var t,n,i;return t=e,(n=[{key:"emit",value:function(e){for(var t,n=arguments.length,i=new Array(n>1?n-1:0),r=1;r<n;r++)i[r-1]=arguments[r];(t=this.components).emit.apply(t,[e].concat(i))}},{key:"on",value:function(e,t){this.components.on(e,t)}},{key:"restart",value:function(){this.stop(),this.start()}},{key:"stop",value:function(){this.components.wipeComponents()}},{key:"start",value:function(){var e=this;h.rootComponentElementsWithNoParents().forEach(function(t){e.components.addComponent(new Y(t,e.connection))})}}])&&ne(t.prototype,n),i&&ne(t,i),e}();window.Livewire||(window.Livewire=ie);t.default=ie},uXse:function(module,__webpack_exports__,__webpack_require__){"use strict";function _classCallCheck(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function _defineProperties(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}function _createClass(e,t,n){return t&&_defineProperties(e.prototype,t),n&&_defineProperties(e,n),e}__webpack_require__.d(__webpack_exports__,"a",function(){return _default});var _default=function(){function _default(e,t,n,i){_classCallCheck(this,_default),this.type=e,this.modifiers=t,this.rawName=n,this.el=i,this.eventContext}return _createClass(_default,[{key:"setEventContext",value:function(e){this.eventContext=e}},{key:"durationOr",value:function(e){var t,n=this.modifiers.find(function(e){return e.match(/([0-9]+)ms/)}),i=this.modifiers.find(function(e){return e.match(/([0-9]+)s/)});return n?t=Number(n.replace("ms","")):i&&(t=1e3*Number(i.replace("s",""))),t||e}},{key:"parseOutMethodAndParams",value:function parseOutMethodAndParams(rawMethod){var method=rawMethod,params=[],methodAndParamString=method.match(/(.*?)\((.*)\)/);if(methodAndParamString){var $event=this.eventContext;method=methodAndParamString[1],params=methodAndParamString[2].split(", ").map(function(param){return eval(param)})}return{method:method,params:params}}},{key:"cardinalDirectionOr",value:function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"right";return this.modifiers.includes("up")?"up":this.modifiers.includes("down")?"down":this.modifiers.includes("left")?"left":this.modifiers.includes("right")?"right":e}},{key:"value",get:function(){return this.el.getAttribute(this.rawName)}},{key:"method",get:function(){return this.parseOutMethodAndParams(this.value).method}},{key:"params",get:function(){return this.parseOutMethodAndParams(this.value).params}}]),_default}()}})});
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else {
+		var a = factory();
+		for(var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];
+	}
+})(window, function() {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "/";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./src/js/action/event.js":
+/*!********************************!*\
+  !*** ./src/js/action/event.js ***!
+  \********************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "default", function() { return _default; });
+/* harmony import */ var ___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! . */ "./src/js/action/index.js");
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+
+
+var _default =
+/*#__PURE__*/
+function (_Action) {
+  _inherits(_default, _Action);
+
+  function _default(event, params, el) {
+    var _this;
+
+    _classCallCheck(this, _default);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(_default).call(this, el));
+    _this.type = 'fireEvent';
+    _this.payload = {
+      event: event,
+      params: params
+    };
+    return _this;
+  }
+
+  return _default;
+}(___WEBPACK_IMPORTED_MODULE_0__["default"]);
+
+
+
+/***/ }),
+
+/***/ "./src/js/action/index.js":
+/*!********************************!*\
+  !*** ./src/js/action/index.js ***!
+  \********************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "default", function() { return _default; });
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+var _default =
+/*#__PURE__*/
+function () {
+  function _default(el) {
+    _classCallCheck(this, _default);
+
+    this.el = el;
+  }
+
+  _createClass(_default, [{
+    key: "ref",
+    get: function get() {
+      return this.el ? this.el.ref : null;
+    }
+  }]);
+
+  return _default;
+}();
+
+
+
+/***/ }),
+
+/***/ "./src/js/action/method.js":
+/*!*********************************!*\
+  !*** ./src/js/action/method.js ***!
+  \*********************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "default", function() { return _default; });
+/* harmony import */ var ___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! . */ "./src/js/action/index.js");
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+
+
+var _default =
+/*#__PURE__*/
+function (_Action) {
+  _inherits(_default, _Action);
+
+  function _default(method, params, el) {
+    var _this;
+
+    _classCallCheck(this, _default);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(_default).call(this, el));
+    _this.type = 'callMethod';
+    _this.payload = {
+      method: method,
+      params: params
+    };
+    return _this;
+  }
+
+  return _default;
+}(___WEBPACK_IMPORTED_MODULE_0__["default"]);
+
+
+
+/***/ }),
+
+/***/ "./src/js/action/model.js":
+/*!********************************!*\
+  !*** ./src/js/action/model.js ***!
+  \********************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "default", function() { return _default; });
+/* harmony import */ var ___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! . */ "./src/js/action/index.js");
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+
+
+var _default =
+/*#__PURE__*/
+function (_Action) {
+  _inherits(_default, _Action);
+
+  function _default(name, value, el) {
+    var _this;
+
+    _classCallCheck(this, _default);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(_default).call(this, el));
+    _this.type = 'syncInput';
+    _this.payload = {
+      name: name,
+      value: value
+    };
+    return _this;
+  }
+
+  return _default;
+}(___WEBPACK_IMPORTED_MODULE_0__["default"]);
+
+
+
+/***/ }),
+
+/***/ "./src/js/component/index.js":
+/*!***********************************!*\
+  !*** ./src/js/component/index.js ***!
+  \***********************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _message__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../message */ "./src/js/message.js");
+/* harmony import */ var _util__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../util */ "./src/js/util/index.js");
+/* harmony import */ var _dom_morphdom__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../dom/morphdom */ "./src/js/dom/morphdom/index.js");
+/* harmony import */ var _dom_dom__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../dom/dom */ "./src/js/dom/dom.js");
+/* harmony import */ var _dom_dom_element__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../dom/dom_element */ "./src/js/dom/dom_element.js");
+/* harmony import */ var _node_initializer__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../node_initializer */ "./src/js/node_initializer.js");
+/* harmony import */ var _store__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ../store */ "./src/js/store.js");
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+
+function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance"); }
+
+function _iterableToArray(iter) { if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+
+
+
+
+
+
+
+
+var Component =
+/*#__PURE__*/
+function () {
+  function Component(el, connection) {
+    _classCallCheck(this, Component);
+
+    this.id = el.getAttribute('id');
+    this.data = JSON.parse(el.getAttribute('data'));
+    this.events = JSON.parse(el.getAttribute('events'));
+    this.children = JSON.parse(el.getAttribute('children'));
+    this.middleware = el.getAttribute('middleware');
+    this.checksum = el.getAttribute('checksum');
+    this.name = el.getAttribute('name');
+    this.connection = connection;
+    this.actionQueue = [];
+    this.messageInTransit = null;
+    this.loadingEls = [];
+    this.loadingElsByRef = {};
+    this.initialize();
+    this.registerEchoListeners();
+  }
+
+  _createClass(Component, [{
+    key: "initialize",
+    value: function initialize() {
+      var _this = this;
+
+      this.walk(function (el) {
+        // Will run for every node in the component tree (not child component nodes).
+        _node_initializer__WEBPACK_IMPORTED_MODULE_5__["default"].initialize(el, _this);
+      }, function (el) {
+        // When new component is encountered in the tree, add it.
+        _store__WEBPACK_IMPORTED_MODULE_6__["default"].addComponent(new Component(el, _this.connection));
+      });
+    }
+  }, {
+    key: "addAction",
+    value: function addAction(action) {
+      this.actionQueue.push(action); // This debounce is here in-case two events fire at the "same" time:
+      // For example: if you are listening for a click on element A,
+      // and a "blur" on element B. If element B has focus, and then,
+      // you click on element A, the blur event will fire before the "click"
+      // event. This debounce captures them both in the actionsQueue and sends
+      // them off at the same time.
+      // Note: currently, it's set to 5ms, that might not be the right amount, we'll see.
+
+      Object(_util__WEBPACK_IMPORTED_MODULE_1__["debounce"])(this.fireMessage, 5).apply(this);
+    }
+  }, {
+    key: "fireMessage",
+    value: function fireMessage() {
+      if (this.messageInTransit) return;
+      this.messageInTransit = new _message__WEBPACK_IMPORTED_MODULE_0__["default"](this, this.actionQueue);
+      this.connection.sendMessage(this.messageInTransit);
+      this.actionQueue = [];
+    }
+  }, {
+    key: "messageSendFailed",
+    value: function messageSendFailed() {
+      this.messageInTransit = null;
+    }
+  }, {
+    key: "receiveMessage",
+    value: function receiveMessage(payload) {
+      var response = this.messageInTransit.storeResponse(payload);
+      this.data = response.data;
+      this.children = response.children; // This means "$this->redirect()" was called in the component. let's just bail and redirect.
+
+      if (response.redirectTo) {
+        window.location.href = response.redirectTo;
+        return;
+      }
+
+      this.replaceDom(response.dom, response.dirtyInputs);
+      this.forceRefreshDataBoundElementsMarkedAsDirty(response.dirtyInputs);
+      this.unsetLoading(this.messageInTransit.loadingEls);
+      this.messageInTransit = null;
+
+      if (response.eventQueue && response.eventQueue.length > 0) {
+        response.eventQueue.forEach(function (event) {
+          _store__WEBPACK_IMPORTED_MODULE_6__["default"].emit.apply(_store__WEBPACK_IMPORTED_MODULE_6__["default"], [event.event].concat(_toConsumableArray(event.params)));
+        });
+      }
+    }
+  }, {
+    key: "forceRefreshDataBoundElementsMarkedAsDirty",
+    value: function forceRefreshDataBoundElementsMarkedAsDirty(dirtyInputs) {
+      var _this2 = this;
+
+      this.walk(function (el) {
+        if (el.directives.missing('model')) return;
+        var modelValue = el.directives.get('model').value;
+        if (el.isFocused() && !dirtyInputs.includes(modelValue)) return;
+        el.setInputValueFromModel(_this2);
+      });
+    }
+  }, {
+    key: "replaceDom",
+    value: function replaceDom(rawDom) {
+      this.handleMorph(this.formatDomBeforeDiffToAvoidConflictsWithVue(rawDom.trim()));
+    }
+  }, {
+    key: "formatDomBeforeDiffToAvoidConflictsWithVue",
+    value: function formatDomBeforeDiffToAvoidConflictsWithVue(inputDom) {
+      if (!window.Vue) return inputDom;
+      var div = document.createElement('div');
+      div.innerHTML = inputDom;
+      new window.Vue().$mount(div.firstElementChild);
+      return div.firstElementChild.outerHTML;
+    }
+  }, {
+    key: "handleMorph",
+    value: function handleMorph(dom) {
+      var _this3 = this;
+
+      Object(_dom_morphdom__WEBPACK_IMPORTED_MODULE_2__["default"])(this.el.rawNode(), dom, {
+        childrenOnly: true,
+        getNodeKey: function getNodeKey(node) {
+          // This allows the tracking of elements by the "key" attribute, like in VueJs.
+          return node.hasAttribute("".concat(_dom_dom__WEBPACK_IMPORTED_MODULE_3__["default"].prefix, ":key")) ? node.getAttribute("".concat(_dom_dom__WEBPACK_IMPORTED_MODULE_3__["default"].prefix, ":key")) // If no "key", then first check for "wire:id", then "wire:model", then "id"
+          : node.hasAttribute("".concat(_dom_dom__WEBPACK_IMPORTED_MODULE_3__["default"].prefix, ":id")) ? node.getAttribute("".concat(_dom_dom__WEBPACK_IMPORTED_MODULE_3__["default"].prefix, ":id")) : node.hasAttribute("".concat(_dom_dom__WEBPACK_IMPORTED_MODULE_3__["default"].prefix, ":model")) ? node.getAttribute("".concat(_dom_dom__WEBPACK_IMPORTED_MODULE_3__["default"].prefix, ":model")) : node.id;
+        },
+        onBeforeNodeAdded: function onBeforeNodeAdded(node) {
+          return new _dom_dom_element__WEBPACK_IMPORTED_MODULE_4__["default"](node).transitionElementIn();
+        },
+        onBeforeNodeDiscarded: function onBeforeNodeDiscarded(node) {
+          return new _dom_dom_element__WEBPACK_IMPORTED_MODULE_4__["default"](node).transitionElementOut(function (nodeDiscarded) {
+            // Cleanup after removed element.
+            _this3.removeLoadingEl(nodeDiscarded);
+          });
+        },
+        onBeforeElChildrenUpdated: function onBeforeElChildrenUpdated(node) {//
+        },
+        onBeforeElUpdated: function onBeforeElUpdated(from, to) {
+          var fromEl = new _dom_dom_element__WEBPACK_IMPORTED_MODULE_4__["default"](from); // Honor the "wire:ignore" attribute.
+
+          if (fromEl.hasAttribute('ignore')) return false; // Children will update themselves.
+
+          if (fromEl.isComponentRootEl() && fromEl.getAttribute('id') !== _this3.id) return false; // Don't touch Vue components
+
+          if (fromEl.isVueComponent()) return false;
+        },
+        onElUpdated: function onElUpdated(node) {//
+        },
+        onNodeDiscarded: function onNodeDiscarded(node) {
+          // Elements with loading directives are stored, release this
+          // element from storage because it no longer exists on the DOM.
+          _this3.removeLoadingEl(node);
+        },
+        onNodeAdded: function onNodeAdded(node) {
+          var el = new _dom_dom_element__WEBPACK_IMPORTED_MODULE_4__["default"](node);
+          var closestComponentId = el.closestRoot().getAttribute('id');
+
+          if (closestComponentId === _this3.id) {
+            _node_initializer__WEBPACK_IMPORTED_MODULE_5__["default"].initialize(el, _this3);
+          } else if (el.isComponentRootEl()) {
+            _store__WEBPACK_IMPORTED_MODULE_6__["default"].addComponent(new Component(el, _this3.connection));
+          } // Skip.
+
+        }
+      });
+    }
+  }, {
+    key: "walk",
+    value: function walk(callback) {
+      var _this4 = this;
+
+      var callbackWhenNewComponentIsEncountered = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function (el) {};
+
+      Object(_util__WEBPACK_IMPORTED_MODULE_1__["walk"])(this.el.rawNode(), function (node) {
+        var el = new _dom_dom_element__WEBPACK_IMPORTED_MODULE_4__["default"](node); // Skip the root component element.
+
+        if (el.isSameNode(_this4.el)) return; // If we encounter a nested component, skip walking that tree.
+
+        if (el.isComponentRootEl()) {
+          callbackWhenNewComponentIsEncountered(el);
+          return false;
+        }
+
+        callback(el);
+      });
+    }
+  }, {
+    key: "registerEchoListeners",
+    value: function registerEchoListeners() {
+      if (Array.isArray(this.events)) {
+        this.events.forEach(function (event) {
+          if (event.startsWith('echo')) {
+            if (typeof Echo === 'undefined') {
+              console.warn('Laravel Echo cannot be found');
+              return;
+            }
+
+            var event_parts = event.split(/(echo:|echo-)|:|,/);
+
+            if (event_parts[1] == 'echo:') {
+              event_parts.splice(2, 0, 'channel', undefined);
+            }
+
+            if (event_parts[2] == 'notification') {
+              event_parts.push(undefined, undefined);
+            }
+
+            var _event_parts = _slicedToArray(event_parts, 7),
+                s1 = _event_parts[0],
+                signature = _event_parts[1],
+                channel_type = _event_parts[2],
+                s2 = _event_parts[3],
+                channel = _event_parts[4],
+                s3 = _event_parts[5],
+                event_name = _event_parts[6];
+
+            if (['channel', 'private'].includes(channel_type)) {
+              Echo[channel_type](channel).listen(event_name, function (e) {
+                _store__WEBPACK_IMPORTED_MODULE_6__["default"].emit(event, e);
+              });
+            } else if (channel_type == 'presence') {
+              Echo.join(channel)[event_name](function (e) {
+                _store__WEBPACK_IMPORTED_MODULE_6__["default"].emit(event, e);
+              });
+            } else if (channel_type == 'notification') {
+              Echo.private(channel).notification(function (notification) {
+                _store__WEBPACK_IMPORTED_MODULE_6__["default"].emit(event, notification);
+              });
+            } else {
+              console.warn('Echo channel type not yet supported');
+            }
+          }
+        });
+      }
+    }
+  }, {
+    key: "addLoadingEl",
+    value: function addLoadingEl(el, value, targetRef, remove) {
+      if (targetRef) {
+        if (this.loadingElsByRef[targetRef]) {
+          this.loadingElsByRef[targetRef].push({
+            el: el,
+            value: value,
+            remove: remove
+          });
+        } else {
+          this.loadingElsByRef[targetRef] = [{
+            el: el,
+            value: value,
+            remove: remove
+          }];
+        }
+      } else {
+        this.loadingEls.push({
+          el: el,
+          value: value,
+          remove: remove
+        });
+      }
+    }
+  }, {
+    key: "removeLoadingEl",
+    value: function removeLoadingEl(node) {
+      var el = new _dom_dom_element__WEBPACK_IMPORTED_MODULE_4__["default"](node);
+      this.loadingEls = this.loadingEls.filter(function (_ref) {
+        var el = _ref.el;
+        return !el.isSameNode(node);
+      });
+
+      if (el.ref in this.loadingElsByRef) {
+        delete this.loadingElsByRef[el.ref];
+      }
+    }
+  }, {
+    key: "setLoading",
+    value: function setLoading(refs) {
+      var _this5 = this;
+
+      var refEls = refs.map(function (ref) {
+        return _this5.loadingElsByRef[ref];
+      }).filter(function (el) {
+        return el;
+      }).flat();
+      var allEls = this.loadingEls.concat(refEls);
+      allEls.forEach(function (el) {
+        var directive = el.el.directives.get('loading');
+        el = el.el.el; // I'm so sorry @todo
+
+        if (directive.modifiers.includes('class')) {
+          // This is because wire:loading.class="border border-red"
+          // wouldn't work with classList.add.
+          var classes = directive.value.split(' ');
+
+          if (directive.modifiers.includes('remove')) {
+            var _el$classList;
+
+            (_el$classList = el.classList).remove.apply(_el$classList, _toConsumableArray(classes));
+          } else {
+            var _el$classList2;
+
+            (_el$classList2 = el.classList).add.apply(_el$classList2, _toConsumableArray(classes));
+          }
+        } else if (directive.modifiers.includes('attr')) {
+          if (directive.modifiers.includes('remove')) {
+            el.removeAttribute(directive.value);
+          } else {
+            el.setAttribute(directive.value, true);
+          }
+        } else {
+          el.style.display = 'inline-block';
+        }
+      });
+      return allEls;
+    }
+  }, {
+    key: "unsetLoading",
+    value: function unsetLoading(loadingEls) {// No need to "unset" loading because the dom-diffing will automatically reverse any changes.
+    }
+  }, {
+    key: "el",
+    get: function get() {
+      return _dom_dom__WEBPACK_IMPORTED_MODULE_3__["default"].getByAttributeAndValue('id', this.id);
+    }
+  }]);
+
+  return Component;
+}();
+
+/* harmony default export */ __webpack_exports__["default"] = (Component);
+
+/***/ }),
+
+/***/ "./src/js/connection/drivers/http.js":
+/*!*******************************************!*\
+  !*** ./src/js/connection/drivers/http.js ***!
+  \*******************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony default export */ __webpack_exports__["default"] = ({
+  onError: null,
+  onMessage: null,
+  init: function init() {//
+  },
+  keepAlive: function keepAlive() {
+    fetch('/livewire/keep-alive', {
+      credentials: "same-origin",
+      headers: {
+        'X-CSRF-TOKEN': this.getCSRFToken(),
+        'X-Livewire-Keep-Alive': true
+      }
+    });
+  },
+  sendMessage: function sendMessage(payload) {
+    var _this = this;
+
+    // Forward the query string for the ajax requests.
+    fetch('/livewire/message' + window.location.search, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      // This enables "cookies".
+      credentials: "same-origin",
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'text/html, application/xhtml+xml',
+        'X-CSRF-TOKEN': this.getCSRFToken(),
+        'X-Livewire': true
+      }
+    }).then(function (response) {
+      if (response.ok) {
+        response.text().then(function (response) {
+          var parsed = JSON.parse(response);
+
+          _this.onMessage.call(_this, parsed); //if there are dumps in the array then
+          //show the modal with all the dumped data
+
+
+          if (parsed.dumps.length > 0) {
+            _this.showHtmlModal(parsed.dumps.join(''));
+          }
+        });
+      } else {
+        response.text().then(function (response) {
+          _this.onError(payload);
+
+          _this.showHtmlModal(response);
+        });
+      }
+    }).catch(function () {
+      _this.onError(payload);
+    });
+  },
+  getCSRFToken: function getCSRFToken() {
+    var tokenTag = document.head.querySelector('meta[name="csrf-token"]');
+    var token;
+
+    if (!tokenTag) {
+      if (!window.livewire_token) {
+        throw new Error('Whoops, looks like you haven\'t added a "csrf-token" meta tag');
+      }
+
+      token = window.livewire_token;
+    } else {
+      token = tokenTag.content;
+    }
+
+    return token;
+  },
+  // This code and concept is all Jonathan Reinink - thanks main!
+  showHtmlModal: function showHtmlModal(html) {
+    var _this2 = this;
+
+    var page = document.createElement('html');
+    page.innerHTML = html;
+    page.querySelectorAll('a').forEach(function (a) {
+      return a.setAttribute('target', '_top');
+    });
+    var modal = document.createElement('div');
+    modal.id = 'burst-error';
+    modal.style.position = 'fixed';
+    modal.style.width = '100vw';
+    modal.style.height = '100vh';
+    modal.style.padding = '50px';
+    modal.style.backgroundColor = 'rgba(0, 0, 0, .6)';
+    modal.style.zIndex = 200000;
+    var iframe = document.createElement('iframe');
+    iframe.style.backgroundColor = 'white';
+    iframe.style.borderRadius = '5px';
+    iframe.style.width = '100%';
+    iframe.style.height = '100%';
+    modal.appendChild(iframe);
+    document.body.prepend(modal);
+    document.body.style.overflow = 'hidden';
+    iframe.contentWindow.document.open();
+    iframe.contentWindow.document.write(page.outerHTML);
+    iframe.contentWindow.document.close(); // Close on click.
+
+    modal.addEventListener('click', function () {
+      return _this2.hideHtmlModal(modal);
+    }); // Close on escape key press.
+
+    modal.setAttribute('tabindex', 0);
+    modal.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') _this2.hideHtmlModal(modal);
+    });
+    modal.focus();
+  },
+  hideHtmlModal: function hideHtmlModal(modal) {
+    modal.outerHTML = '';
+    document.body.style.overflow = 'visible';
+  }
+});
+
+/***/ }),
+
+/***/ "./src/js/connection/drivers/index.js":
+/*!********************************************!*\
+  !*** ./src/js/connection/drivers/index.js ***!
+  \********************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _http__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./http */ "./src/js/connection/drivers/http.js");
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  http: _http__WEBPACK_IMPORTED_MODULE_0__["default"]
+});
+
+/***/ }),
+
+/***/ "./src/js/connection/index.js":
+/*!************************************!*\
+  !*** ./src/js/connection/index.js ***!
+  \************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "default", function() { return Connection; });
+/* harmony import */ var _util__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../util */ "./src/js/util/index.js");
+/* harmony import */ var _store__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../store */ "./src/js/store.js");
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+
+
+
+var Connection =
+/*#__PURE__*/
+function () {
+  function Connection(driver) {
+    var _this = this;
+
+    _classCallCheck(this, Connection);
+
+    this.driver = driver;
+
+    this.driver.onMessage = function (payload) {
+      _this.onMessage(payload);
+    };
+
+    this.driver.onError = function (payload) {
+      _this.onError(payload);
+    }; // This prevents those annoying CSRF 419's by keeping the cookie fresh.
+    // Yum! No one likes stale cookies...
+
+
+    if (typeof this.driver.keepAlive !== 'undefined') {
+      setInterval(function () {
+        _this.driver.keepAlive();
+      }, 600000); // Every ten minutes.
+    }
+
+    this.driver.init();
+  }
+
+  _createClass(Connection, [{
+    key: "onMessage",
+    value: function onMessage(payload) {
+      _store__WEBPACK_IMPORTED_MODULE_1__["default"].findComponent(payload.id).receiveMessage(payload);
+      Object(_util__WEBPACK_IMPORTED_MODULE_0__["dispatch"])('livewire:update');
+    }
+  }, {
+    key: "onError",
+    value: function onError(payloadThatFailedSending) {
+      _store__WEBPACK_IMPORTED_MODULE_1__["default"].findComponent(payloadThatFailedSending.id).messageSendFailed();
+    }
+  }, {
+    key: "sendMessage",
+    value: function sendMessage(message) {
+      message.prepareForSend();
+      this.driver.sendMessage(message.payload());
+    }
+  }]);
+
+  return Connection;
+}();
+
+
+
+/***/ }),
+
+/***/ "./src/js/dom/directive.js":
+/*!*********************************!*\
+  !*** ./src/js/dom/directive.js ***!
+  \*********************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "default", function() { return _default; });
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+var _default =
+/*#__PURE__*/
+function () {
+  function _default(type, modifiers, rawName, el) {
+    _classCallCheck(this, _default);
+
+    this.type = type;
+    this.modifiers = modifiers;
+    this.rawName = rawName;
+    this.el = el;
+    this.eventContext;
+  }
+
+  _createClass(_default, [{
+    key: "setEventContext",
+    value: function setEventContext(context) {
+      this.eventContext = context;
+    }
+  }, {
+    key: "durationOr",
+    value: function durationOr(defaultDuration) {
+      var durationInMilliSeconds;
+      var durationInMilliSecondsString = this.modifiers.find(function (mod) {
+        return mod.match(/([0-9]+)ms/);
+      });
+      var durationInSecondsString = this.modifiers.find(function (mod) {
+        return mod.match(/([0-9]+)s/);
+      });
+
+      if (durationInMilliSecondsString) {
+        durationInMilliSeconds = Number(durationInMilliSecondsString.replace('ms', ''));
+      } else if (durationInSecondsString) {
+        durationInMilliSeconds = Number(durationInSecondsString.replace('s', '')) * 1000;
+      }
+
+      return durationInMilliSeconds || defaultDuration;
+    }
+  }, {
+    key: "parseOutMethodAndParams",
+    value: function parseOutMethodAndParams(rawMethod) {
+      var method = rawMethod;
+      var params = [];
+      var methodAndParamString = method.match(/(.*?)\((.*)\)/);
+
+      if (methodAndParamString) {
+        // This "$event" is for use inside the livewire event handler.
+        var $event = this.eventContext;
+        method = methodAndParamString[1];
+        params = methodAndParamString[2].split(', ').map(function (param) {
+          return eval(param);
+        });
+      }
+
+      return {
+        method: method,
+        params: params
+      };
+    }
+  }, {
+    key: "cardinalDirectionOr",
+    value: function cardinalDirectionOr() {
+      var fallback = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 'right';
+      if (this.modifiers.includes('up')) return 'up';
+      if (this.modifiers.includes('down')) return 'down';
+      if (this.modifiers.includes('left')) return 'left';
+      if (this.modifiers.includes('right')) return 'right';
+      return fallback;
+    }
+  }, {
+    key: "value",
+    get: function get() {
+      return this.el.getAttribute(this.rawName);
+    }
+  }, {
+    key: "method",
+    get: function get() {
+      var _this$parseOutMethodA = this.parseOutMethodAndParams(this.value),
+          method = _this$parseOutMethodA.method;
+
+      return method;
+    }
+  }, {
+    key: "params",
+    get: function get() {
+      var _this$parseOutMethodA2 = this.parseOutMethodAndParams(this.value),
+          params = _this$parseOutMethodA2.params;
+
+      return params;
+    }
+  }]);
+
+  return _default;
+}();
+
+
+
+/***/ }),
+
+/***/ "./src/js/dom/directive_manager.js":
+/*!*****************************************!*\
+  !*** ./src/js/dom/directive_manager.js ***!
+  \*****************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "default", function() { return _default; });
+/* harmony import */ var _directive__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./directive */ "./src/js/dom/directive.js");
+function _toArray(arr) { return _arrayWithHoles(arr) || _iterableToArray(arr) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+
+function _iterableToArray(iter) { if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter); }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+
+
+var prefix = __webpack_require__(/*! ./prefix.js */ "./src/js/dom/prefix.js")();
+
+var _default =
+/*#__PURE__*/
+function () {
+  function _default(el) {
+    _classCallCheck(this, _default);
+
+    this.el = el;
+    this.directives = this.extractTypeModifiersAndValue();
+  }
+
+  _createClass(_default, [{
+    key: "all",
+    value: function all() {
+      return this.directives;
+    }
+  }, {
+    key: "has",
+    value: function has(type) {
+      return this.directives.map(function (directive) {
+        return directive.type;
+      }).includes(type);
+    }
+  }, {
+    key: "missing",
+    value: function missing(type) {
+      return !this.directives.map(function (directive) {
+        return directive.type;
+      }).includes(type);
+    }
+  }, {
+    key: "get",
+    value: function get(type) {
+      return this.directives.find(function (directive) {
+        return directive.type === type;
+      });
+    }
+  }, {
+    key: "extractTypeModifiersAndValue",
+    value: function extractTypeModifiersAndValue() {
+      var _this = this;
+
+      return Array.from(this.el.getAttributeNames() // Filter only the livewire directives.
+      .filter(function (name) {
+        return name.match(new RegExp(prefix + ':'));
+      }) // Parse out the type, modifiers, and value from it.
+      .map(function (name) {
+        var _name$replace$split = name.replace(new RegExp(prefix + ':'), '').split('.'),
+            _name$replace$split2 = _toArray(_name$replace$split),
+            type = _name$replace$split2[0],
+            modifiers = _name$replace$split2.slice(1);
+
+        return new _directive__WEBPACK_IMPORTED_MODULE_0__["default"](type, modifiers, name, _this.el);
+      }));
+    }
+  }]);
+
+  return _default;
+}();
+
+
+
+/***/ }),
+
+/***/ "./src/js/dom/dom.js":
+/*!***************************!*\
+  !*** ./src/js/dom/dom.js ***!
+  \***************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "default", function() { return DOM; });
+/* harmony import */ var _dom_element__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./dom_element */ "./src/js/dom/dom_element.js");
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+
+
+var prefix = __webpack_require__(/*! ./prefix.js */ "./src/js/dom/prefix.js")();
+/**
+ * This is intended to isolate all native DOM operations. The operations that happen
+ * one specific element will be instance methods, the operations you would normally
+ * perform on the "document" (like "document.querySelector") will be static methods.
+ */
+
+
+var DOM =
+/*#__PURE__*/
+function () {
+  function DOM() {
+    _classCallCheck(this, DOM);
+  }
+
+  _createClass(DOM, null, [{
+    key: "rootComponentElements",
+    value: function rootComponentElements() {
+      return Array.from(document.querySelectorAll("[".concat(prefix, "\\:id]"))).map(function (el) {
+        return new _dom_element__WEBPACK_IMPORTED_MODULE_0__["default"](el);
+      });
+    }
+  }, {
+    key: "rootComponentElementsWithNoParents",
+    value: function rootComponentElementsWithNoParents() {
+      // In CSS, it's simple to select all elements that DO have a certain ancestor.
+      // However, it's not simple (kinda impossible) to select elements that DONT have
+      // a certain ancestor. Therefore, we will flip the logic: select all roots that DO have
+      // have a root ancestor, then select all roots that DONT, then diff the two.
+      // Convert NodeLists to Arrays so we can use ".includes()". Ew.
+      var allEls = Array.from(document.querySelectorAll("[".concat(prefix, "\\:id]")));
+      var onlyChildEls = Array.from(document.querySelectorAll("[".concat(prefix, "\\:id] [").concat(prefix, "\\:id]")));
+      return allEls.filter(function (el) {
+        return !onlyChildEls.includes(el);
+      }).map(function (el) {
+        return new _dom_element__WEBPACK_IMPORTED_MODULE_0__["default"](el);
+      });
+    }
+  }, {
+    key: "allModelElementsInside",
+    value: function allModelElementsInside(root) {
+      return Array.from(root.querySelectorAll("[".concat(prefix, "\\:model]"))).map(function (el) {
+        return new _dom_element__WEBPACK_IMPORTED_MODULE_0__["default"](el);
+      });
+    }
+  }, {
+    key: "getByAttributeAndValue",
+    value: function getByAttributeAndValue(attribute, value) {
+      return new _dom_element__WEBPACK_IMPORTED_MODULE_0__["default"](document.querySelector("[".concat(prefix, "\\:").concat(attribute, "=\"").concat(value, "\"]")));
+    }
+  }, {
+    key: "prefix",
+    get: function get() {
+      return prefix;
+    }
+  }]);
+
+  return DOM;
+}();
+
+
+
+/***/ }),
+
+/***/ "./src/js/dom/dom_element.js":
+/*!***********************************!*\
+  !*** ./src/js/dom/dom_element.js ***!
+  \***********************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "default", function() { return DOMElement; });
+/* harmony import */ var _directive_manager__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./directive_manager */ "./src/js/dom/directive_manager.js");
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+
+
+var prefix = __webpack_require__(/*! ./prefix.js */ "./src/js/dom/prefix.js")();
+/**
+ * Consider this a decorator for the ElementNode JavaScript object. (Hence the
+ * method forwarding I have to do at the bottom)
+ */
+
+
+var DOMElement =
+/*#__PURE__*/
+function () {
+  function DOMElement(el) {
+    _classCallCheck(this, DOMElement);
+
+    this.el = el;
+    this.directives = new _directive_manager__WEBPACK_IMPORTED_MODULE_0__["default"](el);
+  }
+
+  _createClass(DOMElement, [{
+    key: "nextFrame",
+    value: function nextFrame(fn) {
+      var _this = this;
+
+      requestAnimationFrame(function () {
+        requestAnimationFrame(fn.bind(_this));
+      });
+    }
+  }, {
+    key: "rawNode",
+    value: function rawNode() {
+      return this.el;
+    }
+  }, {
+    key: "transitionElementIn",
+    value: function transitionElementIn() {
+      var _this2 = this;
+
+      if (!this.directives.has('transition')) return;
+      var directive = this.directives.get('transition'); // If ".out" modifier is passed, don't fade in.
+
+      if (directive.modifiers.includes('out') && !directive.modifiers.includes('in')) {
+        return true;
+      }
+
+      if (directive.modifiers.includes('fade')) {
+        this.fadeIn(directive);
+        return;
+      }
+
+      if (directive.modifiers.includes('slide')) {
+        this.slideIn(directive);
+        return;
+      }
+
+      var transitionName = directive.value;
+      this.el.classList.add("".concat(transitionName, "-enter"));
+      this.el.classList.add("".concat(transitionName, "-enter-active"));
+      this.nextFrame(function () {
+        _this2.el.classList.remove("".concat(transitionName, "-enter"));
+
+        var duration = Number(getComputedStyle(_this2.el).transitionDuration.replace('s', '')) * 1000;
+        setTimeout(function () {
+          _this2.el.classList.remove("".concat(transitionName, "-enter-active"));
+        }, duration);
+      });
+    }
+  }, {
+    key: "transitionElementOut",
+    value: function transitionElementOut(onDiscarded) {
+      var _this3 = this;
+
+      if (!this.directives.has('transition')) return true;
+      var directive = this.directives.get('transition'); // If ".in" modifier is passed, don't fade out.
+
+      if (directive.modifiers.includes('in') && !directive.modifiers.includes('out')) {
+        return true;
+      }
+
+      if (directive.modifiers.includes('fade')) {
+        this.fadeOut(directive, onDiscarded);
+        return false;
+      }
+
+      if (directive.modifiers.includes('slide')) {
+        this.slideOut(directive, onDiscarded);
+        return false;
+      }
+
+      var transitionName = directive.value;
+      this.el.classList.add("".concat(transitionName, "-leave-active"));
+      this.nextFrame(function () {
+        _this3.el.classList.add("".concat(transitionName, "-leave"));
+
+        var duration = Number(getComputedStyle(_this3.el).transitionDuration.replace('s', '')) * 1000;
+        setTimeout(function () {
+          onDiscarded(_this3.el);
+
+          _this3.el.remove();
+        }, duration);
+      });
+      return false;
+    }
+  }, {
+    key: "fadeIn",
+    value: function fadeIn(directive) {
+      var _this4 = this;
+
+      this.el.style.opacity = 0;
+      this.el.style.transition = "opacity ".concat(directive.durationOr(300) / 1000, "s ease");
+      this.nextFrame(function () {
+        _this4.el.style.opacity = 1;
+      });
+    }
+  }, {
+    key: "slideIn",
+    value: function slideIn(directive) {
+      var _this5 = this;
+
+      var directions = {
+        up: 'translateY(10px)',
+        down: 'translateY(-10px)',
+        left: 'translateX(-10px)',
+        right: 'translateX(10px)'
+      };
+      this.el.style.opacity = 0;
+      this.el.style.transform = directions[directive.cardinalDirectionOr('right')];
+      this.el.style.transition = "opacity ".concat(directive.durationOr(300) / 1000, "s ease, transform ").concat(directive.durationOr(300) / 1000, "s ease");
+      this.nextFrame(function () {
+        _this5.el.style.opacity = 1;
+        _this5.el.style.transform = "";
+      });
+    }
+  }, {
+    key: "fadeOut",
+    value: function fadeOut(directive, onDiscarded) {
+      var _this6 = this;
+
+      this.nextFrame(function () {
+        _this6.el.style.opacity = 0;
+        setTimeout(function () {
+          onDiscarded(_this6.el);
+
+          _this6.el.remove();
+        }, directive.durationOr(300));
+      });
+    }
+  }, {
+    key: "slideOut",
+    value: function slideOut(directive, onDiscarded) {
+      var _this7 = this;
+
+      var directions = {
+        up: 'translateY(10px)',
+        down: 'translateY(-10px)',
+        left: 'translateX(-10px)',
+        right: 'translateX(10px)'
+      };
+      this.nextFrame(function () {
+        _this7.el.style.opacity = 0;
+        _this7.el.style.transform = directions[directive.cardinalDirectionOr('right')];
+        setTimeout(function () {
+          onDiscarded(_this7.el);
+
+          _this7.el.remove();
+        }, directive.durationOr(300));
+      });
+    }
+  }, {
+    key: "closestRoot",
+    value: function closestRoot() {
+      return this.closestByAttribute('id');
+    }
+  }, {
+    key: "closestByAttribute",
+    value: function closestByAttribute(attribute) {
+      return new DOMElement(this.el.closest("[".concat(prefix, "\\:").concat(attribute, "]")));
+    }
+  }, {
+    key: "isComponentRootEl",
+    value: function isComponentRootEl() {
+      return this.hasAttribute('id');
+    }
+  }, {
+    key: "isVueComponent",
+    value: function isVueComponent() {
+      return !!this.asVueComponent();
+    }
+  }, {
+    key: "asVueComponent",
+    value: function asVueComponent() {
+      return this.rawNode().__vue__;
+    }
+  }, {
+    key: "hasAttribute",
+    value: function hasAttribute(attribute) {
+      return this.el.hasAttribute("".concat(prefix, ":").concat(attribute));
+    }
+  }, {
+    key: "getAttribute",
+    value: function getAttribute(attribute) {
+      return this.el.getAttribute("".concat(prefix, ":").concat(attribute));
+    }
+  }, {
+    key: "setAttribute",
+    value: function setAttribute(attribute, value) {
+      return this.el.setAttribute("".concat(prefix, ":").concat(attribute), value);
+    }
+  }, {
+    key: "isFocused",
+    value: function isFocused() {
+      return this.el === document.activeElement;
+    }
+  }, {
+    key: "hasFocus",
+    value: function hasFocus() {
+      return this.el === document.activeElement;
+    }
+  }, {
+    key: "preserveValueAttributeIfNotDirty",
+    value: function preserveValueAttributeIfNotDirty(fromEl, dirtyInputs) {
+      if (this.directives.missing('model')) return; // If the input is not dirty && the input element is focused, keep the
+      // value the same, but change other attributes.
+
+      if (!Array.from(dirtyInputs).includes(this.directives.get('model').value) && fromEl.isFocused()) {
+        // Transfer the current "fromEl" value (preserving / overriding it).
+        this.setInputValue(fromEl.valueFromInput());
+      }
+    }
+  }, {
+    key: "isInput",
+    value: function isInput() {
+      return ['INPUT', 'TEXTAREA', 'SELECT'].includes(this.el.tagName.toUpperCase());
+    }
+  }, {
+    key: "isTextInput",
+    value: function isTextInput() {
+      return ['INPUT', 'TEXTAREA'].includes(this.el.tagName.toUpperCase()) && !['checkbox', 'radio'].includes(this.el.type);
+    }
+  }, {
+    key: "valueFromInput",
+    value: function valueFromInput() {
+      if (this.el.type === 'checkbox') {
+        return this.el.checked;
+      } else if (this.el.tagName === 'SELECT' && this.el.multiple) {
+        return this.getSelectValues();
+      }
+
+      return this.el.value;
+    }
+  }, {
+    key: "setInputValueFromModel",
+    value: function setInputValueFromModel(component) {
+      var modelString = this.directives.get('model').value;
+      var modelStringWithArraySyntaxForNumericKeys = modelString.replace(/\.([0-9]+)/, function (match, num) {
+        return "[".concat(num, "]");
+      });
+      var modelValue = eval('component.data.' + modelStringWithArraySyntaxForNumericKeys);
+      if (modelValue === undefined) return;
+      this.setInputValue(modelValue);
+    }
+  }, {
+    key: "setInputValue",
+    value: function setInputValue(value) {
+      if (this.rawNode().__vue__) {
+        // If it's a vue component pass down the value prop.
+        // Also, Vue will throw a warning because we are programmaticallly
+        // setting a prop, we need to silence that.
+        var originalSilent = window.Vue.config.silent;
+        window.Vue.config.silent = true;
+        this.rawNode().__vue__.$props.value = value;
+        window.Vue.config.silent = originalSilent;
+      } else if (this.el.type === 'radio') {
+        this.el.checked = this.el.value == value;
+      } else if (this.el.type === 'checkbox') {
+        this.el.checked = !!value;
+      } else if (this.el.tagName === 'SELECT') {
+        this.updateSelect(value);
+      } else {
+        this.el.value = value;
+      }
+    }
+  }, {
+    key: "getSelectValues",
+    value: function getSelectValues() {
+      return Array.from(this.el.options).filter(function (option) {
+        return option.selected;
+      }).map(function (option) {
+        return option.value || option.text;
+      });
+    }
+  }, {
+    key: "updateSelect",
+    value: function updateSelect(value) {
+      var arrayWrappedValue = [].concat(value);
+      Array.from(this.el.options).forEach(function (option) {
+        option.selected = arrayWrappedValue.includes(option.value);
+      });
+    }
+  }, {
+    key: "isSameNode",
+    value: function isSameNode(el) {
+      // We need to drop down to the raw node if we are comparing
+      // to another "DOMElement" Instance.
+      if (typeof el.rawNode === 'function') {
+        return this.el.isSameNode(el.rawNode());
+      }
+
+      return this.el.isSameNode(el);
+    }
+  }, {
+    key: "getAttributeNames",
+    value: function getAttributeNames() {
+      var _this$el;
+
+      return (_this$el = this.el).getAttributeNames.apply(_this$el, arguments);
+    }
+  }, {
+    key: "addEventListener",
+    value: function addEventListener() {
+      var _this$el2;
+
+      return (_this$el2 = this.el).addEventListener.apply(_this$el2, arguments);
+    }
+  }, {
+    key: "querySelector",
+    value: function querySelector() {
+      var _this$el3;
+
+      return (_this$el3 = this.el).querySelector.apply(_this$el3, arguments);
+    }
+  }, {
+    key: "querySelectorAll",
+    value: function querySelectorAll() {
+      var _this$el4;
+
+      return (_this$el4 = this.el).querySelectorAll.apply(_this$el4, arguments);
+    }
+  }, {
+    key: "ref",
+    get: function get() {
+      return this.directives.has('ref') ? this.directives.get('ref').value : null;
+    }
+  }, {
+    key: "classList",
+    get: function get() {
+      return this.el.classList;
+    }
+  }]);
+
+  return DOMElement;
+}();
+
+
+
+/***/ }),
+
+/***/ "./src/js/dom/morphdom/index.js":
+/*!**************************************!*\
+  !*** ./src/js/dom/morphdom/index.js ***!
+  \**************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _morphAttrs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./morphAttrs */ "./src/js/dom/morphdom/morphAttrs.js");
+/* harmony import */ var _morphdom__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./morphdom */ "./src/js/dom/morphdom/morphdom.js");
+
+
+var morphdom = Object(_morphdom__WEBPACK_IMPORTED_MODULE_1__["default"])(_morphAttrs__WEBPACK_IMPORTED_MODULE_0__["default"]);
+/* harmony default export */ __webpack_exports__["default"] = (morphdom);
+
+/***/ }),
+
+/***/ "./src/js/dom/morphdom/morphAttrs.js":
+/*!*******************************************!*\
+  !*** ./src/js/dom/morphdom/morphAttrs.js ***!
+  \*******************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "default", function() { return morphAttrs; });
+/* harmony import */ var _util__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./util */ "./src/js/dom/morphdom/util.js");
+
+/**
+ * I don't want to look at "value" attributes when diffing.
+ * I commented out all the lines that compare "value"
+ *
+ */
+
+function morphAttrs(fromNode, toNode) {
+  var attrs = toNode.attributes;
+  var i;
+  var attr;
+  var attrName;
+  var attrNamespaceURI;
+  var attrValue;
+  var fromValue;
+
+  for (i = attrs.length - 1; i >= 0; --i) {
+    attr = attrs[i];
+    attrName = attr.name;
+    attrNamespaceURI = attr.namespaceURI;
+    attrValue = attr.value;
+
+    if (attrNamespaceURI) {
+      attrName = attr.localName || attrName;
+      fromValue = fromNode.getAttributeNS(attrNamespaceURI, attrName);
+
+      if (fromValue !== attrValue) {
+        fromNode.setAttributeNS(attrNamespaceURI, attrName, attrValue);
+      }
+    } else {
+      fromValue = fromNode.getAttribute(attrName);
+
+      if (fromValue !== attrValue) {
+        fromNode.setAttribute(attrName, attrValue);
+      }
+    }
+  } // Remove any extra attributes found on the original DOM element that
+  // weren't found on the target element.
+
+
+  attrs = fromNode.attributes;
+
+  for (i = attrs.length - 1; i >= 0; --i) {
+    attr = attrs[i];
+
+    if (attr.specified !== false) {
+      attrName = attr.name;
+      attrNamespaceURI = attr.namespaceURI;
+
+      if (attrNamespaceURI) {
+        attrName = attr.localName || attrName;
+
+        if (!Object(_util__WEBPACK_IMPORTED_MODULE_0__["hasAttributeNS"])(toNode, attrNamespaceURI, attrName)) {
+          fromNode.removeAttributeNS(attrNamespaceURI, attrName);
+        }
+      } else {
+        if (!Object(_util__WEBPACK_IMPORTED_MODULE_0__["hasAttributeNS"])(toNode, null, attrName)) {
+          fromNode.removeAttribute(attrName);
+        }
+      }
+    }
+  }
+}
+
+/***/ }),
+
+/***/ "./src/js/dom/morphdom/morphdom.js":
+/*!*****************************************!*\
+  !*** ./src/js/dom/morphdom/morphdom.js ***!
+  \*****************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "default", function() { return morphdomFactory; });
+/* harmony import */ var _util__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./util */ "./src/js/dom/morphdom/util.js");
+/* harmony import */ var _specialElHandlers__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./specialElHandlers */ "./src/js/dom/morphdom/specialElHandlers.js");
+// From Caleb: I had to change all the "isSameNode"s to "isEqualNode"s and now everything is working great!
+
+/**
+ * I pulled in my own version of morphdom, so I could tweak it as needed.
+ * Here are the tweaks I've made so far:
+ *
+ * 1) Changed all the "isSameNode"s to "isEqualNode"s so that morhing doesn't check by reference, only by equality.
+ * 2) Automatically filter out any non-"ElementNode"s from the lifecycle hooks.
+ */
+
+
+
+
+var ELEMENT_NODE = 1;
+var TEXT_NODE = 3;
+var COMMENT_NODE = 8;
+
+function noop() {}
+
+function defaultGetNodeKey(node) {
+  return node.id;
+}
+
+function callHook(hook) {
+  if (hook.name !== 'getNodeKey' && hook.name !== 'onBeforeElUpdated') {} // debugger
+  // console.log(hook.name, ...params)
+  // Don't call hook on non-"DOMElement" elements.
+
+
+  for (var _len = arguments.length, params = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    params[_key - 1] = arguments[_key];
+  }
+
+  if (typeof params[0].hasAttribute !== 'function') return;
+  return hook.apply(void 0, params);
+}
+
+function morphdomFactory(morphAttrs) {
+  return function morphdom(fromNode, toNode, options) {
+    if (!options) {
+      options = {};
+    }
+
+    if (typeof toNode === 'string') {
+      if (fromNode.nodeName === '#document' || fromNode.nodeName === 'HTML') {
+        var toNodeHtml = toNode;
+        toNode = _util__WEBPACK_IMPORTED_MODULE_0__["doc"].createElement('html');
+        toNode.innerHTML = toNodeHtml;
+      } else {
+        toNode = Object(_util__WEBPACK_IMPORTED_MODULE_0__["toElement"])(toNode);
+      }
+    }
+
+    var getNodeKey = options.getNodeKey || defaultGetNodeKey;
+    var onBeforeNodeAdded = options.onBeforeNodeAdded || noop;
+    var onNodeAdded = options.onNodeAdded || noop;
+    var onBeforeElUpdated = options.onBeforeElUpdated || noop;
+    var onElUpdated = options.onElUpdated || noop;
+    var onBeforeNodeDiscarded = options.onBeforeNodeDiscarded || noop;
+    var onNodeDiscarded = options.onNodeDiscarded || noop;
+    var onBeforeElChildrenUpdated = options.onBeforeElChildrenUpdated || noop;
+    var childrenOnly = options.childrenOnly === true; // This object is used as a lookup to quickly find all keyed elements in the original DOM tree.
+
+    var fromNodesLookup = {};
+    var keyedRemovalList;
+
+    function addKeyedRemoval(key) {
+      if (keyedRemovalList) {
+        keyedRemovalList.push(key);
+      } else {
+        keyedRemovalList = [key];
+      }
+    }
+
+    function walkDiscardedChildNodes(node, skipKeyedNodes) {
+      if (node.nodeType === ELEMENT_NODE) {
+        var curChild = node.firstChild;
+
+        while (curChild) {
+          var key = undefined;
+
+          if (skipKeyedNodes && (key = callHook(getNodeKey, curChild))) {
+            // If we are skipping keyed nodes then we add the key
+            // to a list so that it can be handled at the very end.
+            addKeyedRemoval(key);
+          } else {
+            // Only report the node as discarded if it is not keyed. We do this because
+            // at the end we loop through all keyed elements that were unmatched
+            // and then discard them in one final pass.
+            callHook(onNodeDiscarded, curChild);
+
+            if (curChild.firstChild) {
+              walkDiscardedChildNodes(curChild, skipKeyedNodes);
+            }
+          }
+
+          curChild = curChild.nextSibling;
+        }
+      }
+    }
+    /**
+     * Removes a DOM node out of the original DOM
+     *
+     * @param  {Node} node The node to remove
+     * @param  {Node} parentNode The nodes parent
+     * @param  {Boolean} skipKeyedNodes If true then elements with keys will be skipped and not discarded.
+     * @return {undefined}
+     */
+
+
+    function removeNode(node, parentNode, skipKeyedNodes) {
+      if (callHook(onBeforeNodeDiscarded, node) === false) {
+        return;
+      }
+
+      if (parentNode) {
+        parentNode.removeChild(node);
+      }
+
+      callHook(onNodeDiscarded, node);
+      walkDiscardedChildNodes(node, skipKeyedNodes);
+    } // // TreeWalker implementation is no faster, but keeping this around in case this changes in the future
+    // function indexTree(root) {
+    //     var treeWalker = document.createTreeWalker(
+    //         root,
+    //         NodeFilter.SHOW_ELEMENT);
+    //
+    //     var el;
+    //     while((el = treeWalker.nextNode())) {
+    //         var key = callHook(getNodeKey, el);
+    //         if (key) {
+    //             fromNodesLookup[key] = el;
+    //         }
+    //     }
+    // }
+    // // NodeIterator implementation is no faster, but keeping this around in case this changes in the future
+    //
+    // function indexTree(node) {
+    //     var nodeIterator = document.createNodeIterator(node, NodeFilter.SHOW_ELEMENT);
+    //     var el;
+    //     while((el = nodeIterator.nextNode())) {
+    //         var key = callHook(getNodeKey, el);
+    //         if (key) {
+    //             fromNodesLookup[key] = el;
+    //         }
+    //     }
+    // }
+
+
+    function indexTree(node) {
+      if (node.nodeType === ELEMENT_NODE) {
+        var curChild = node.firstChild;
+
+        while (curChild) {
+          var key = callHook(getNodeKey, curChild);
+
+          if (key) {
+            fromNodesLookup[key] = curChild;
+          } // Walk recursively
+
+
+          indexTree(curChild);
+          curChild = curChild.nextSibling;
+        }
+      }
+    }
+
+    indexTree(fromNode);
+
+    function handleNodeAdded(el) {
+      callHook(onNodeAdded, el);
+      var curChild = el.firstChild;
+
+      while (curChild) {
+        var nextSibling = curChild.nextSibling;
+        var key = callHook(getNodeKey, curChild);
+
+        if (key) {
+          var unmatchedFromEl = fromNodesLookup[key];
+
+          if (unmatchedFromEl && Object(_util__WEBPACK_IMPORTED_MODULE_0__["compareNodeNames"])(curChild, unmatchedFromEl)) {
+            curChild.parentNode.replaceChild(unmatchedFromEl, curChild);
+            morphEl(unmatchedFromEl, curChild);
+          }
+        }
+
+        handleNodeAdded(curChild);
+        curChild = nextSibling;
+      }
+    }
+
+    function morphEl(fromEl, toEl, childrenOnly) {
+      var toElKey = callHook(getNodeKey, toEl);
+      var curFromNodeKey;
+
+      if (toElKey) {
+        // If an element with an ID is being morphed then it is will be in the final
+        // DOM so clear it out of the saved elements collection
+        delete fromNodesLookup[toElKey];
+      }
+
+      if (toEl.isEqualNode && toEl.isEqualNode(fromEl)) {
+        return;
+      }
+
+      if (!childrenOnly) {
+        if (callHook(onBeforeElUpdated, fromEl, toEl) === false) {
+          return;
+        }
+
+        morphAttrs(fromEl, toEl);
+        callHook(onElUpdated, fromEl);
+
+        if (callHook(onBeforeElChildrenUpdated, fromEl, toEl) === false) {
+          return;
+        }
+      }
+
+      if (fromEl.nodeName !== 'TEXTAREA') {
+        var curToNodeChild = toEl.firstChild;
+        var curFromNodeChild = fromEl.firstChild;
+        var curToNodeKey;
+        var fromNextSibling;
+        var toNextSibling;
+        var matchingFromEl;
+
+        outer: while (curToNodeChild) {
+          toNextSibling = curToNodeChild.nextSibling;
+          curToNodeKey = callHook(getNodeKey, curToNodeChild);
+
+          while (curFromNodeChild) {
+            fromNextSibling = curFromNodeChild.nextSibling;
+
+            if (curToNodeChild.isEqualNode && curToNodeChild.isEqualNode(curFromNodeChild)) {
+              curToNodeChild = toNextSibling;
+              curFromNodeChild = fromNextSibling;
+              continue outer;
+            }
+
+            curFromNodeKey = callHook(getNodeKey, curFromNodeChild);
+            var curFromNodeType = curFromNodeChild.nodeType;
+            var isCompatible = undefined;
+
+            if (curFromNodeType === curToNodeChild.nodeType) {
+              if (curFromNodeType === ELEMENT_NODE) {
+                // Both nodes being compared are Element nodes
+                if (curToNodeKey) {
+                  // The target node has a key so we want to match it up with the correct element
+                  // in the original DOM tree
+                  if (curToNodeKey !== curFromNodeKey) {
+                    // The current element in the original DOM tree does not have a matching key so
+                    // let's check our lookup to see if there is a matching element in the original
+                    // DOM tree
+                    if (matchingFromEl = fromNodesLookup[curToNodeKey]) {
+                      if (curFromNodeChild.nextSibling === matchingFromEl) {
+                        // Special case for single element removals. To avoid removing the original
+                        // DOM node out of the tree (since that can break CSS transitions, etc.),
+                        // we will instead discard the current node and wait until the next
+                        // iteration to properly match up the keyed target element with its matching
+                        // element in the original tree
+                        isCompatible = false;
+                      } else {
+                        // We found a matching keyed element somewhere in the original DOM tree.
+                        // Let's moving the original DOM node into the current position and morph
+                        // it.
+                        // NOTE: We use insertBefore instead of replaceChild because we want to go through
+                        // the `removeNode()` function for the node that is being discarded so that
+                        // all lifecycle hooks are correctly invoked
+                        fromEl.insertBefore(matchingFromEl, curFromNodeChild);
+                        fromNextSibling = curFromNodeChild.nextSibling;
+
+                        if (curFromNodeKey) {
+                          // Since the node is keyed it might be matched up later so we defer
+                          // the actual removal to later
+                          addKeyedRemoval(curFromNodeKey);
+                        } else {
+                          // NOTE: we skip nested keyed nodes from being removed since there is
+                          //       still a chance they will be matched up later
+                          removeNode(curFromNodeChild, fromEl, true
+                          /* skip keyed nodes */
+                          );
+                        }
+
+                        curFromNodeChild = matchingFromEl;
+                      }
+                    } else {
+                      // The nodes are not compatible since the "to" node has a key and there
+                      // is no matching keyed node in the source tree
+                      isCompatible = false;
+                    }
+                  }
+                } else if (curFromNodeKey) {
+                  // The original has a key
+                  isCompatible = false;
+                }
+
+                isCompatible = isCompatible !== false && Object(_util__WEBPACK_IMPORTED_MODULE_0__["compareNodeNames"])(curFromNodeChild, curToNodeChild);
+
+                if (isCompatible) {
+                  // We found compatible DOM elements so transform
+                  // the current "from" node to match the current
+                  // target DOM node.
+                  morphEl(curFromNodeChild, curToNodeChild);
+                }
+              } else if (curFromNodeType === TEXT_NODE || curFromNodeType == COMMENT_NODE) {
+                // Both nodes being compared are Text or Comment nodes
+                isCompatible = true; // Simply update nodeValue on the original node to
+                // change the text value
+
+                if (curFromNodeChild.nodeValue !== curToNodeChild.nodeValue) {
+                  curFromNodeChild.nodeValue = curToNodeChild.nodeValue;
+                }
+              }
+            }
+
+            if (isCompatible) {
+              // Advance both the "to" child and the "from" child since we found a match
+              curToNodeChild = toNextSibling;
+              curFromNodeChild = fromNextSibling;
+              continue outer;
+            } // No compatible match so remove the old node from the DOM and continue trying to find a
+            // match in the original DOM. However, we only do this if the from node is not keyed
+            // since it is possible that a keyed node might match up with a node somewhere else in the
+            // target tree and we don't want to discard it just yet since it still might find a
+            // home in the final DOM tree. After everything is done we will remove any keyed nodes
+            // that didn't find a home
+
+
+            if (curFromNodeKey) {
+              // Since the node is keyed it might be matched up later so we defer
+              // the actual removal to later
+              addKeyedRemoval(curFromNodeKey);
+            } else {
+              // NOTE: we skip nested keyed nodes from being removed since there is
+              //       still a chance they will be matched up later
+              removeNode(curFromNodeChild, fromEl, true
+              /* skip keyed nodes */
+              );
+            }
+
+            curFromNodeChild = fromNextSibling;
+          } // If we got this far then we did not find a candidate match for
+          // our "to node" and we exhausted all of the children "from"
+          // nodes. Therefore, we will just append the current "to" node
+          // to the end
+
+
+          if (curToNodeKey && (matchingFromEl = fromNodesLookup[curToNodeKey]) && Object(_util__WEBPACK_IMPORTED_MODULE_0__["compareNodeNames"])(matchingFromEl, curToNodeChild)) {
+            fromEl.appendChild(matchingFromEl);
+            morphEl(matchingFromEl, curToNodeChild);
+          } else {
+            var onBeforeNodeAddedResult = callHook(onBeforeNodeAdded, curToNodeChild);
+
+            if (onBeforeNodeAddedResult !== false) {
+              if (onBeforeNodeAddedResult) {
+                curToNodeChild = onBeforeNodeAddedResult;
+              }
+
+              if (curToNodeChild.actualize) {
+                curToNodeChild = curToNodeChild.actualize(fromEl.ownerDocument || _util__WEBPACK_IMPORTED_MODULE_0__["doc"]);
+              }
+
+              fromEl.appendChild(curToNodeChild);
+              handleNodeAdded(curToNodeChild);
+            }
+          }
+
+          curToNodeChild = toNextSibling;
+          curFromNodeChild = fromNextSibling;
+        } // We have processed all of the "to nodes". If curFromNodeChild is
+        // non-null then we still have some from nodes left over that need
+        // to be removed
+
+
+        while (curFromNodeChild) {
+          fromNextSibling = curFromNodeChild.nextSibling;
+
+          if (curFromNodeKey = callHook(getNodeKey, curFromNodeChild)) {
+            // Since the node is keyed it might be matched up later so we defer
+            // the actual removal to later
+            addKeyedRemoval(curFromNodeKey);
+          } else {
+            // NOTE: we skip nested keyed nodes from being removed since there is
+            //       still a chance they will be matched up later
+            removeNode(curFromNodeChild, fromEl, true
+            /* skip keyed nodes */
+            );
+          }
+
+          curFromNodeChild = fromNextSibling;
+        }
+      }
+
+      var specialElHandler = _specialElHandlers__WEBPACK_IMPORTED_MODULE_1__["default"][fromEl.nodeName];
+
+      if (specialElHandler && !fromEl.hasAttribute('wire:model')) {
+        specialElHandler(fromEl, toEl);
+      }
+    } // END: morphEl(...)
+
+
+    var morphedNode = fromNode;
+    var morphedNodeType = morphedNode.nodeType;
+    var toNodeType = toNode.nodeType;
+
+    if (!childrenOnly) {
+      // Handle the case where we are given two DOM nodes that are not
+      // compatible (e.g. <div> --> <span> or <div> --> TEXT)
+      if (morphedNodeType === ELEMENT_NODE) {
+        if (toNodeType === ELEMENT_NODE) {
+          if (!Object(_util__WEBPACK_IMPORTED_MODULE_0__["compareNodeNames"])(fromNode, toNode)) {
+            callHook(onNodeDiscarded, fromNode);
+            morphedNode = Object(_util__WEBPACK_IMPORTED_MODULE_0__["moveChildren"])(fromNode, Object(_util__WEBPACK_IMPORTED_MODULE_0__["createElementNS"])(toNode.nodeName, toNode.namespaceURI));
+          }
+        } else {
+          // Going from an element node to a text node
+          morphedNode = toNode;
+        }
+      } else if (morphedNodeType === TEXT_NODE || morphedNodeType === COMMENT_NODE) {
+        // Text or comment node
+        if (toNodeType === morphedNodeType) {
+          if (morphedNode.nodeValue !== toNode.nodeValue) {
+            morphedNode.nodeValue = toNode.nodeValue;
+          }
+
+          return morphedNode;
+        } else {
+          // Text node to something else
+          morphedNode = toNode;
+        }
+      }
+    }
+
+    if (morphedNode === toNode) {
+      // The "to node" was not compatible with the "from node" so we had to
+      // toss out the "from node" and use the "to node"
+      callHook(onNodeDiscarded, fromNode);
+    } else {
+      morphEl(morphedNode, toNode, childrenOnly); // We now need to loop over any keyed nodes that might need to be
+      // removed. We only do the removal if we know that the keyed node
+      // never found a match. When a keyed node is matched up we remove
+      // it out of fromNodesLookup and we use fromNodesLookup to determine
+      // if a keyed node has been matched up or not
+
+      if (keyedRemovalList) {
+        for (var i = 0, len = keyedRemovalList.length; i < len; i++) {
+          var elToRemove = fromNodesLookup[keyedRemovalList[i]];
+
+          if (elToRemove) {
+            removeNode(elToRemove, elToRemove.parentNode, false);
+          }
+        }
+      }
+    }
+
+    if (!childrenOnly && morphedNode !== fromNode && fromNode.parentNode) {
+      if (morphedNode.actualize) {
+        morphedNode = morphedNode.actualize(fromNode.ownerDocument || _util__WEBPACK_IMPORTED_MODULE_0__["doc"]);
+      } // If we had to swap out the from node with a new node because the old
+      // node was not compatible with the target node then we need to
+      // replace the old DOM node in the original DOM tree. This is only
+      // possible if the original DOM node was part of a DOM tree which
+      // we know is the case if it has a parent node.
+
+
+      fromNode.parentNode.replaceChild(morphedNode, fromNode);
+    }
+
+    return morphedNode;
+  };
+}
+
+/***/ }),
+
+/***/ "./src/js/dom/morphdom/specialElHandlers.js":
+/*!**************************************************!*\
+  !*** ./src/js/dom/morphdom/specialElHandlers.js ***!
+  \**************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _util__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./util */ "./src/js/dom/morphdom/util.js");
+
+
+function syncBooleanAttrProp(fromEl, toEl, name) {
+  if (fromEl[name] !== toEl[name]) {
+    fromEl[name] = toEl[name];
+
+    if (fromEl[name]) {
+      fromEl.setAttribute(name, '');
+    } else {
+      fromEl.removeAttribute(name);
+    }
+  }
+}
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  /**
+   * Needed for IE. Apparently IE doesn't think that "selected" is an
+   * attribute when reading over the attributes using selectEl.attributes
+   */
+  OPTION: function OPTION(fromEl, toEl) {
+    syncBooleanAttrProp(fromEl, toEl, 'selected');
+  },
+
+  /**
+   * The "value" attribute is special for the <input> element since it sets
+   * the initial value. Changing the "value" attribute without changing the
+   * "value" property will have no effect since it is only used to the set the
+   * initial value.  Similar for the "checked" attribute, and "disabled".
+   */
+  INPUT: function INPUT(fromEl, toEl) {
+    syncBooleanAttrProp(fromEl, toEl, 'checked');
+    syncBooleanAttrProp(fromEl, toEl, 'disabled');
+
+    if (fromEl.value !== toEl.value) {
+      fromEl.value = toEl.value;
+    }
+
+    if (!Object(_util__WEBPACK_IMPORTED_MODULE_0__["hasAttributeNS"])(toEl, null, 'value')) {
+      fromEl.removeAttribute('value');
+    }
+  },
+  TEXTAREA: function TEXTAREA(fromEl, toEl) {
+    var newValue = toEl.value;
+
+    if (fromEl.value !== newValue) {
+      fromEl.value = newValue;
+    }
+
+    var firstChild = fromEl.firstChild;
+
+    if (firstChild) {
+      // Needed for IE. Apparently IE sets the placeholder as the
+      // node value and vise versa. This ignores an empty update.
+      var oldValue = firstChild.nodeValue;
+
+      if (oldValue == newValue || !newValue && oldValue == fromEl.placeholder) {
+        return;
+      }
+
+      firstChild.nodeValue = newValue;
+    }
+  },
+  SELECT: function SELECT(fromEl, toEl) {
+    if (!Object(_util__WEBPACK_IMPORTED_MODULE_0__["hasAttributeNS"])(toEl, null, 'multiple')) {
+      var selectedIndex = -1;
+      var i = 0;
+      var curChild = toEl.firstChild;
+
+      while (curChild) {
+        var nodeName = curChild.nodeName;
+
+        if (nodeName && nodeName.toUpperCase() === 'OPTION') {
+          if (Object(_util__WEBPACK_IMPORTED_MODULE_0__["hasAttributeNS"])(curChild, null, 'selected')) {
+            selectedIndex = i;
+            break;
+          }
+
+          i++;
+        }
+
+        curChild = curChild.nextSibling;
+      }
+
+      fromEl.selectedIndex = i;
+    }
+  }
+});
+
+/***/ }),
+
+/***/ "./src/js/dom/morphdom/util.js":
+/*!*************************************!*\
+  !*** ./src/js/dom/morphdom/util.js ***!
+  \*************************************/
+/*! exports provided: doc, hasAttributeNS, toElement, compareNodeNames, createElementNS, moveChildren */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "doc", function() { return doc; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "hasAttributeNS", function() { return hasAttributeNS; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "toElement", function() { return toElement; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "compareNodeNames", function() { return compareNodeNames; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "createElementNS", function() { return createElementNS; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "moveChildren", function() { return moveChildren; });
+var range; // Create a range object for efficently rendering strings to elements.
+
+var NS_XHTML = 'http://www.w3.org/1999/xhtml';
+var doc = typeof document === 'undefined' ? undefined : document;
+var testEl = doc ? doc.body || doc.createElement('div') : {}; // Fixes <https://github.com/patrick-steele-idem/morphdom/issues/32>
+// (IE7+ support) <=IE7 does not support el.hasAttribute(name)
+
+var actualHasAttributeNS;
+
+if (testEl.hasAttributeNS) {
+  actualHasAttributeNS = function actualHasAttributeNS(el, namespaceURI, name) {
+    return el.hasAttributeNS(namespaceURI, name);
+  };
+} else if (testEl.hasAttribute) {
+  actualHasAttributeNS = function actualHasAttributeNS(el, namespaceURI, name) {
+    return el.hasAttribute(name);
+  };
+} else {
+  actualHasAttributeNS = function actualHasAttributeNS(el, namespaceURI, name) {
+    return el.getAttributeNode(namespaceURI, name) != null;
+  };
+}
+
+var hasAttributeNS = actualHasAttributeNS;
+function toElement(str) {
+  if (!range && doc.createRange) {
+    range = doc.createRange();
+    range.selectNode(doc.body);
+  }
+
+  var fragment;
+
+  if (range && range.createContextualFragment) {
+    fragment = range.createContextualFragment(str);
+  } else {
+    fragment = doc.createElement('body');
+    fragment.innerHTML = str;
+  }
+
+  return fragment.childNodes[0];
+}
+/**
+ * Returns true if two node's names are the same.
+ *
+ * NOTE: We don't bother checking `namespaceURI` because you will never find two HTML elements with the same
+ *       nodeName and different namespace URIs.
+ *
+ * @param {Element} a
+ * @param {Element} b The target element
+ * @return {boolean}
+ */
+
+function compareNodeNames(fromEl, toEl) {
+  var fromNodeName = fromEl.nodeName;
+  var toNodeName = toEl.nodeName;
+
+  if (fromNodeName === toNodeName) {
+    return true;
+  }
+
+  if (toEl.actualize && fromNodeName.charCodeAt(0) < 91 &&
+  /* from tag name is upper case */
+  toNodeName.charCodeAt(0) > 90
+  /* target tag name is lower case */
+  ) {
+      // If the target element is a virtual DOM node then we may need to normalize the tag name
+      // before comparing. Normal HTML elements that are in the "http://www.w3.org/1999/xhtml"
+      // are converted to upper case
+      return fromNodeName === toNodeName.toUpperCase();
+    } else {
+    return false;
+  }
+}
+/**
+ * Create an element, optionally with a known namespace URI.
+ *
+ * @param {string} name the element name, e.g. 'div' or 'svg'
+ * @param {string} [namespaceURI] the element's namespace URI, i.e. the value of
+ * its `xmlns` attribute or its inferred namespace.
+ *
+ * @return {Element}
+ */
+
+function createElementNS(name, namespaceURI) {
+  return !namespaceURI || namespaceURI === NS_XHTML ? doc.createElement(name) : doc.createElementNS(namespaceURI, name);
+}
+/**
+ * Copies the children of one DOM element to another DOM element
+ */
+
+function moveChildren(fromEl, toEl) {
+  var curChild = fromEl.firstChild;
+
+  while (curChild) {
+    var nextChild = curChild.nextSibling;
+    toEl.appendChild(curChild);
+    curChild = nextChild;
+  }
+
+  return toEl;
+}
+
+/***/ }),
+
+/***/ "./src/js/dom/prefix.js":
+/*!******************************!*\
+  !*** ./src/js/dom/prefix.js ***!
+  \******************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+var prefix = null;
+
+module.exports = function () {
+  if (prefix === null) {
+    prefix = (document.querySelector('meta[name="livewire-prefix"]') || {
+      content: 'wire'
+    }).content;
+  }
+
+  return prefix;
+};
+
+/***/ }),
+
+/***/ "./src/js/index.js":
+/*!*************************!*\
+  !*** ./src/js/index.js ***!
+  \*************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _store__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./store */ "./src/js/store.js");
+/* harmony import */ var _dom_dom__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./dom/dom */ "./src/js/dom/dom.js");
+/* harmony import */ var _component__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./component */ "./src/js/component/index.js");
+/* harmony import */ var _connection__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./connection */ "./src/js/connection/index.js");
+/* harmony import */ var _connection_drivers__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./connection/drivers */ "./src/js/connection/drivers/index.js");
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+
+
+
+
+
+
+var Livewire =
+/*#__PURE__*/
+function () {
+  function Livewire() {
+    var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {
+      driver: 'http'
+    },
+        driver = _ref.driver;
+
+    _classCallCheck(this, Livewire);
+
+    if (_typeof(driver) !== 'object') {
+      driver = _connection_drivers__WEBPACK_IMPORTED_MODULE_4__["default"][driver];
+    }
+
+    this.connection = new _connection__WEBPACK_IMPORTED_MODULE_3__["default"](driver);
+    this.components = _store__WEBPACK_IMPORTED_MODULE_0__["default"];
+    this.start();
+  }
+
+  _createClass(Livewire, [{
+    key: "emit",
+    value: function emit(event) {
+      var _this$components;
+
+      for (var _len = arguments.length, params = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        params[_key - 1] = arguments[_key];
+      }
+
+      (_this$components = this.components).emit.apply(_this$components, [event].concat(params));
+    }
+  }, {
+    key: "on",
+    value: function on(event, callback) {
+      this.components.on(event, callback);
+    }
+  }, {
+    key: "restart",
+    value: function restart() {
+      this.stop();
+      this.start();
+    }
+  }, {
+    key: "stop",
+    value: function stop() {
+      this.components.wipeComponents();
+    }
+  }, {
+    key: "start",
+    value: function start() {
+      var _this = this;
+
+      _dom_dom__WEBPACK_IMPORTED_MODULE_1__["default"].rootComponentElementsWithNoParents().forEach(function (el) {
+        _this.components.addComponent(new _component__WEBPACK_IMPORTED_MODULE_2__["default"](el, _this.connection));
+      });
+    }
+  }]);
+
+  return Livewire;
+}();
+
+if (!window.Livewire) {
+  window.Livewire = Livewire;
+}
+
+/* harmony default export */ __webpack_exports__["default"] = (Livewire);
+
+/***/ }),
+
+/***/ "./src/js/message.js":
+/*!***************************!*\
+  !*** ./src/js/message.js ***!
+  \***************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "default", function() { return _default; });
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+var _default =
+/*#__PURE__*/
+function () {
+  function _default(component, actionQueue) {
+    _classCallCheck(this, _default);
+
+    this.component = component;
+    this.actionQueue = actionQueue;
+  }
+
+  _createClass(_default, [{
+    key: "prepareForSend",
+    value: function prepareForSend() {
+      this.loadingEls = this.component.setLoading(this.refs);
+    }
+  }, {
+    key: "payload",
+    value: function payload() {
+      return {
+        id: this.component.id,
+        data: this.component.data,
+        name: this.component.name,
+        children: this.component.children,
+        middleware: this.component.middleware,
+        checksum: this.component.checksum,
+        actionQueue: this.actionQueue.map(function (action) {
+          // This ensures only the type & payload properties only get sent over.
+          return {
+            type: action.type,
+            payload: action.payload
+          };
+        })
+      };
+    }
+  }, {
+    key: "storeResponse",
+    value: function storeResponse(payload) {
+      return this.response = {
+        id: payload.id,
+        dom: payload.dom,
+        children: payload.children,
+        dirtyInputs: payload.dirtyInputs,
+        eventQueue: payload.eventQueue,
+        events: payload.events,
+        data: payload.data,
+        redirectTo: payload.redirectTo
+      };
+    }
+  }, {
+    key: "refs",
+    get: function get() {
+      return this.actionQueue.map(function (action) {
+        return action.ref;
+      }).filter(function (ref) {
+        return ref;
+      });
+    }
+  }]);
+
+  return _default;
+}();
+
+
+
+/***/ }),
+
+/***/ "./src/js/node_initializer.js":
+/*!************************************!*\
+  !*** ./src/js/node_initializer.js ***!
+  \************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _util__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./util */ "./src/js/util/index.js");
+/* harmony import */ var _action_model__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./action/model */ "./src/js/action/model.js");
+/* harmony import */ var _action_method__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./action/method */ "./src/js/action/method.js");
+/* harmony import */ var _dom_dom_element__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./dom/dom_element */ "./src/js/dom/dom_element.js");
+/* harmony import */ var _store__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./store */ "./src/js/store.js");
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance"); }
+
+function _iterableToArray(iter) { if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } }
+
+
+
+
+
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  initialize: function initialize(el, component) {
+    var _this = this;
+
+    // Parse out "direcives", "modifiers", and "value" from livewire attributes.
+    el.directives.all().forEach(function (directive) {
+      switch (directive.type) {
+        case 'loading':
+          _this.registerElementForLoading(el, directive, component);
+
+          break;
+
+        case 'poll':
+          _this.fireActionOnInterval(el, directive, component);
+
+          break;
+
+        case 'model':
+          el.setInputValueFromModel(component);
+
+          _this.attachModelListener(el, directive, component);
+
+          break;
+
+        default:
+          _this.attachDomListener(el, directive, component);
+
+          break;
+      }
+    });
+  },
+  registerElementForLoading: function registerElementForLoading(el, directive, component) {
+    var refName = el.directives.get('target') && el.directives.get('target').value;
+    component.addLoadingEl(el, directive.value, refName, directive.modifiers.includes('remove'));
+  },
+  fireActionOnInterval: function fireActionOnInterval(el, directive, component) {
+    var method = directive.method || '$refresh';
+    setInterval(function () {
+      component.addAction(new _action_method__WEBPACK_IMPORTED_MODULE_2__["default"](method, directive.params, el));
+    }, directive.durationOr(500));
+  },
+  attachModelListener: function attachModelListener(el, directive, component) {
+    var isLazy = directive.modifiers.includes('lazy');
+
+    var debounceIf = function debounceIf(condition, callback, time) {
+      return condition ? Object(_util__WEBPACK_IMPORTED_MODULE_0__["debounce"])(callback, time) : callback;
+    };
+
+    var hasDebounceModifier = directive.modifiers.includes('debounce'); // If it's a Vue component, listen for Vue input event emission.
+
+    if (el.isVueComponent()) {
+      el.asVueComponent().$on('input', debounceIf(hasDebounceModifier, function (e) {
+        var model = directive.value;
+        var value = e;
+        component.addAction(new _action_model__WEBPACK_IMPORTED_MODULE_1__["default"](model, value, el));
+      }, directive.durationOr(150)));
+    } else {
+      var defaultEventType = el.isTextInput() ? 'input' : 'change'; // If it's a text input and not .lazy, debounce, otherwise fire immediately.
+
+      el.addEventListener(isLazy ? 'change' : defaultEventType, debounceIf(hasDebounceModifier || el.isTextInput() && !isLazy, function (e) {
+        var model = directive.value;
+        var el = new _dom_dom_element__WEBPACK_IMPORTED_MODULE_3__["default"](e.target);
+        var value = el.valueFromInput();
+        component.addAction(new _action_model__WEBPACK_IMPORTED_MODULE_1__["default"](model, value, el));
+      }, directive.durationOr(150)));
+    }
+  },
+  attachDomListener: function attachDomListener(el, directive, component) {
+    switch (directive.type) {
+      case 'keydown':
+        this.attachListener(el, directive, component, function (e) {
+          // Only handle listener if no, or matching key modifiers are passed.
+          return !(directive.modifiers.length === 0 || directive.modifiers.includes(Object(_util__WEBPACK_IMPORTED_MODULE_0__["kebabCase"])(e.key)));
+        });
+        break;
+
+      default:
+        this.attachListener(el, directive, component);
+        break;
+    }
+  },
+  attachListener: function attachListener(el, directive, component, callback) {
+    var _this2 = this;
+
+    el.addEventListener(directive.type, function (e) {
+      if (callback && callback(e) !== false) {
+        return;
+      }
+
+      var el = new _dom_dom_element__WEBPACK_IMPORTED_MODULE_3__["default"](e.target);
+      directive.setEventContext(e); // This is outside the conditional below so "wire:click.prevent" without
+      // a value still prevents default.
+
+      _this2.preventAndStop(e, directive.modifiers);
+
+      var method = directive.method;
+      var params = directive.params; // Check for global event emission.
+
+      if (method === '$emit') {
+        _store__WEBPACK_IMPORTED_MODULE_4__["default"].emit.apply(_store__WEBPACK_IMPORTED_MODULE_4__["default"], _toConsumableArray(params));
+        return;
+      }
+
+      if (directive.value) {
+        component.addAction(new _action_method__WEBPACK_IMPORTED_MODULE_2__["default"](method, params, el));
+      }
+    });
+  },
+  preventAndStop: function preventAndStop(event, modifiers) {
+    modifiers.includes('prevent') && event.preventDefault();
+    modifiers.includes('stop') && event.stopPropagation();
+  }
+});
+
+/***/ }),
+
+/***/ "./src/js/store.js":
+/*!*************************!*\
+  !*** ./src/js/store.js ***!
+  \*************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _action_event__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./action/event */ "./src/js/action/event.js");
+
+var store = {
+  componentsById: {},
+  listeners: {},
+  addComponent: function addComponent(component) {
+    return this.componentsById[component.id] = component;
+  },
+  findComponent: function findComponent(id) {
+    return this.componentsById[id];
+  },
+  wipeComponents: function wipeComponents() {
+    this.componentsById = {};
+  },
+  on: function on(event, callback) {
+    if (this.listeners[event] !== undefined) {
+      this.listeners[event].push(callback);
+    } else {
+      this.listeners[event] = [callback];
+    }
+  },
+  emit: function emit(event) {
+    for (var _len = arguments.length, params = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      params[_key - 1] = arguments[_key];
+    }
+
+    if (this.listeners[event] !== undefined) {
+      this.listeners[event].forEach(function (callback) {
+        return callback.apply(void 0, params);
+      });
+    }
+
+    this.componentsListeningForEvent(event).forEach(function (component) {
+      return component.addAction(new _action_event__WEBPACK_IMPORTED_MODULE_0__["default"](event, params));
+    });
+  },
+  componentsListeningForEvent: function componentsListeningForEvent(event) {
+    var _this = this;
+
+    return Object.keys(this.componentsById).map(function (key) {
+      return _this.componentsById[key];
+    }).filter(function (component) {
+      return component.events.includes(event);
+    });
+  }
+};
+/* harmony default export */ __webpack_exports__["default"] = (store);
+
+/***/ }),
+
+/***/ "./src/js/util/debounce.js":
+/*!*********************************!*\
+  !*** ./src/js/util/debounce.js ***!
+  \*********************************/
+/*! exports provided: debounceWithFiringOnBothEnds, debounce */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "debounceWithFiringOnBothEnds", function() { return debounceWithFiringOnBothEnds; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "debounce", function() { return debounce; });
+// This is kindof like a normal debouncer, except it behaves like both "immediate" and
+// "non-immediate" strategies. I'll try to visually demonstrate the differences:
+// [normal] =    .......|
+// [immediate] = |.......
+// [both] =      |......|
+// The reason I want it to fire on both ends of the debounce is for the following scenario:
+// - a user types a letter into an input
+// - the debouncer is waiting 200ms to send the ajax request
+// - in the meantime a user hits the enter key
+// - the debouncer is not up yet, so the "enter" request will get fired before the "key" request
+// Note: I also added a checker in here ("wasInterupted") for the the case of a user
+// only typing one key, but two ajax requests getting sent.
+function debounceWithFiringOnBothEnds(func, wait) {
+  var timeout;
+  var timesInterupted = 0;
+  return function () {
+    var context = this,
+        args = arguments;
+    var callNow = !timeout;
+
+    if (timeout) {
+      clearTimeout(timeout);
+      timesInterupted++;
+    }
+
+    timeout = setTimeout(function () {
+      timeout = null;
+
+      if (timesInterupted > 0) {
+        func.apply(context, args);
+        timesInterupted = 0;
+      }
+    }, wait);
+
+    if (callNow) {
+      func.apply(context, args);
+    }
+  };
+}
+;
+function debounce(func, wait, immediate) {
+  var timeout;
+  return function () {
+    var context = this,
+        args = arguments;
+
+    var later = function later() {
+      timeout = null;
+      if (!immediate) func.apply(context, args);
+    };
+
+    var callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) func.apply(context, args);
+  };
+}
+
+/***/ }),
+
+/***/ "./src/js/util/dispatch.js":
+/*!*********************************!*\
+  !*** ./src/js/util/dispatch.js ***!
+  \*********************************/
+/*! exports provided: dispatch */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "dispatch", function() { return dispatch; });
+// I grabbed this from Turbolink's codebase.
+function dispatch(eventName) {
+  var _ref = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+      target = _ref.target,
+      cancelable = _ref.cancelable,
+      data = _ref.data;
+
+  var event = document.createEvent("Events");
+  event.initEvent(eventName, true, cancelable == true);
+  event.data = data || {}; // Fix setting `defaultPrevented` when `preventDefault()` is called
+  // http://stackoverflow.com/questions/23349191/event-preventdefault-is-not-working-in-ie-11-for-custom-events
+
+  if (event.cancelable && !preventDefaultSupported) {
+    var preventDefault = event.preventDefault;
+
+    event.preventDefault = function () {
+      if (!this.defaultPrevented) {
+        Object.defineProperty(this, "defaultPrevented", {
+          get: function get() {
+            return true;
+          }
+        });
+      }
+
+      preventDefault.call(this);
+    };
+  }
+
+  (target || document).dispatchEvent(event);
+  return event;
+}
+
+var preventDefaultSupported = function () {
+  var event = document.createEvent("Events");
+  event.initEvent("test", true, true);
+  event.preventDefault();
+  return event.defaultPrevented;
+}();
+
+/***/ }),
+
+/***/ "./src/js/util/index.js":
+/*!******************************!*\
+  !*** ./src/js/util/index.js ***!
+  \******************************/
+/*! exports provided: kebabCase, tap, debounceWithFiringOnBothEnds, debounce, walk, dispatch */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "kebabCase", function() { return kebabCase; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "tap", function() { return tap; });
+/* harmony import */ var _debounce__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./debounce */ "./src/js/util/debounce.js");
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "debounceWithFiringOnBothEnds", function() { return _debounce__WEBPACK_IMPORTED_MODULE_0__["debounceWithFiringOnBothEnds"]; });
+
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "debounce", function() { return _debounce__WEBPACK_IMPORTED_MODULE_0__["debounce"]; });
+
+/* harmony import */ var _walk__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./walk */ "./src/js/util/walk.js");
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "walk", function() { return _walk__WEBPACK_IMPORTED_MODULE_1__["walk"]; });
+
+/* harmony import */ var _dispatch__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./dispatch */ "./src/js/util/dispatch.js");
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "dispatch", function() { return _dispatch__WEBPACK_IMPORTED_MODULE_2__["dispatch"]; });
+
+
+
+
+function kebabCase(subject) {
+  return subject.split(/[_\s]/).join("-").toLowerCase();
+}
+function tap(output, callback) {
+  callback(output);
+  return output;
+}
+
+/***/ }),
+
+/***/ "./src/js/util/walk.js":
+/*!*****************************!*\
+  !*** ./src/js/util/walk.js ***!
+  \*****************************/
+/*! exports provided: walk */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "walk", function() { return walk; });
+// A little DOM-tree walker.
+// (TreeWalker won't do because I need to conditionaly ignore sub-trees using the callback)
+function walk(root, callback) {
+  if (callback(root) === false) return;
+  var node = root.firstElementChild;
+
+  while (node) {
+    walk(node, callback);
+    node = node.nextElementSibling;
+  }
+}
+
+/***/ }),
+
+/***/ 0:
+/*!*******************************!*\
+  !*** multi ./src/js/index.js ***!
+  \*******************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(/*! /Users/angusallman/GitHub/opensource/livewire/src/js/index.js */"./src/js/index.js");
+
+
+/***/ })
+
+/******/ });
+});

--- a/dist/livewire.js
+++ b/dist/livewire.js
@@ -716,7 +716,7 @@ __webpack_require__.r(__webpack_exports__);
 
 
           if (parsed.dumps.length > 0) {
-            _this.showHtmlModal(parsed.dumps.join(''));
+            _this.appendToModal(parsed.dumps.join(''));
           }
         });
       } else {
@@ -788,6 +788,16 @@ __webpack_require__.r(__webpack_exports__);
   hideHtmlModal: function hideHtmlModal(modal) {
     modal.outerHTML = '';
     document.body.style.overflow = 'visible';
+  },
+  appendToModal: function appendToModal(html) {
+    var modal = document.querySelector('#burst-error');
+
+    if (modal) {
+      var doc = modal.querySelector('iframe').contentDocument.body;
+      doc.innerHTML = doc.innerHTML + html;
+    } else {
+      this.showHtmlModal(html);
+    }
   }
 });
 

--- a/dist/mix-manifest.json
+++ b/dist/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/livewire.js": "/livewire.js?id=99db0448b28c5c3f1e28"
+    "/livewire.js": "/livewire.js?id=8c777e7195784d33fa72"
 }

--- a/dist/mix-manifest.json
+++ b/dist/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/livewire.js": "/livewire.js?id=8c777e7195784d33fa72"
+    "/livewire.js": "/livewire.js?id=ce609e57e4b57843cf1e"
 }

--- a/src/Connection/ConnectionHandler.php
+++ b/src/Connection/ConnectionHandler.php
@@ -4,13 +4,14 @@ namespace Livewire\Connection;
 
 use Illuminate\Validation\ValidationException;
 use Livewire\ResponsePayload;
+use Livewire\Watchers\DumpWatcher;
 
 abstract class ConnectionHandler
 {
     public function handle($payload)
     {
         $instance = ComponentHydrator::hydrate($payload['name'], $payload['id'], $payload['data'], $payload['checksum']);
-
+        $dumper = app()->make(DumpWatcher::class);
         $instance->setPreviouslyRenderedChildren($payload['children']);
         $instance->hashPropertiesForDirtyDetection();
 
@@ -30,6 +31,7 @@ abstract class ConnectionHandler
         return new ResponsePayload([
             'id' => $payload['id'],
             'dom' => $dom,
+            'dumps' => $dumper->dumps,
             'dirtyInputs' => $instance->getDirtyProperties(),
             'children' => $instance->getRenderedChildren(),
             'eventQueue' => $eventQueue,

--- a/src/Connection/ConnectionHandler.php
+++ b/src/Connection/ConnectionHandler.php
@@ -11,7 +11,7 @@ abstract class ConnectionHandler
     public function handle($payload)
     {
         $instance = ComponentHydrator::hydrate($payload['name'], $payload['id'], $payload['data'], $payload['checksum']);
-        $dumper = app()->make(DumpWatcher::class);
+        $dumper = new DumpWatcher;
         $instance->setPreviouslyRenderedChildren($payload['children']);
         $instance->hashPropertiesForDirtyDetection();
 

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -35,7 +35,6 @@ class LivewireServiceProvider extends ServiceProvider
         $this->registerCommands();
         $this->registerRouterMacros();
         $this->registerBladeDirectives();
-        $this->registerWatchers();
     }
 
     public function registerRoutes()
@@ -100,10 +99,4 @@ class LivewireServiceProvider extends ServiceProvider
         return request()->headers->get('X-Livewire') == true;
     }
 
-    public function registerWatchers()
-    {
-        $this->app->singleton(DumpWatcher::class, function ($app) {
-            return new DumpWatcher();
-        });     
-    }
 }

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -13,6 +13,7 @@ use Livewire\Commands\LivewireDestroyCommand;
 use Livewire\Commands\LivewireMakeCommand;
 use Livewire\Connection\HttpConnectionHandler;
 use Livewire\LivewireComponentsFinder;
+use Livewire\Watchers\DumpWatcher;
 use Livewire\Macros\RouteMacros;
 use Livewire\Macros\RouterMacros;
 
@@ -34,6 +35,7 @@ class LivewireServiceProvider extends ServiceProvider
         $this->registerCommands();
         $this->registerRouterMacros();
         $this->registerBladeDirectives();
+        $this->registerWatchers();
     }
 
     public function registerRoutes()
@@ -96,5 +98,12 @@ class LivewireServiceProvider extends ServiceProvider
     public function isLivewireRequest()
     {
         return request()->headers->get('X-Livewire') == true;
+    }
+
+    public function registerWatchers()
+    {
+        $this->app->singleton(DumpWatcher::class, function ($app) {
+            return new DumpWatcher();
+        });     
     }
 }

--- a/src/ResponsePayload.php
+++ b/src/ResponsePayload.php
@@ -20,6 +20,7 @@ class ResponsePayload implements Arrayable, Jsonable
     {
         $this->id = $data['id'];
         $this->dom = $data['dom'];
+        $this->dumps = $data['dumps'];
         $this->data = $data['data'];
         $this->children = $data['children'];
         $this->eventQueue = $data['eventQueue'];
@@ -33,6 +34,7 @@ class ResponsePayload implements Arrayable, Jsonable
         return [
             'id' => $this->id,
             'dom' => $this->dom,
+            'dumps' => $this->dumps,
             'data' => $this->data,
             'children' => $this->children,
             'eventQueue' => $this->eventQueue,

--- a/src/Watchers/DumpWatcher.php
+++ b/src/Watchers/DumpWatcher.php
@@ -1,0 +1,27 @@
+<?php
+namespace Livewire\Watchers;
+
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+use Symfony\Component\VarDumper\VarDumper;
+
+class DumpWatcher
+{
+
+    public $dumps = [];
+
+    public function __construct()
+    {
+        VarDumper::setHandler(function ($var) {
+            $this->recordDump((new HtmlDumper)->dump(
+                (new VarCloner)->cloneVar($var), true
+            ));
+        });
+    }
+
+    public function recordDump($dump)
+    {
+        $this->dumps[] = $dump;
+        return $this;
+    }
+}

--- a/src/js/connection/drivers/http.js
+++ b/src/js/connection/drivers/http.js
@@ -32,7 +32,14 @@ export default {
         }).then(response => {
             if (response.ok) {
                 response.text().then(response => {
-                    this.onMessage.call(this, JSON.parse(response))
+                    const parsed = JSON.parse(response);
+
+                    this.onMessage.call(this, parsed)
+                    //if there are dumps in the array then
+                    //show the modal with all the dumped data
+                    if(parsed.dumps.length > 0){
+                        this.showHtmlModal(parsed.dumps.join(''))
+                    }
                 })
             } else {
                 response.text().then(response => {

--- a/src/js/connection/drivers/http.js
+++ b/src/js/connection/drivers/http.js
@@ -38,7 +38,7 @@ export default {
                     //if there are dumps in the array then
                     //show the modal with all the dumped data
                     if(parsed.dumps.length > 0){
-                        this.showHtmlModal(parsed.dumps.join(''))
+                        this.appendToModal(parsed.dumps.join(''))
                     }
                 })
             } else {
@@ -109,5 +109,15 @@ export default {
     hideHtmlModal(modal) {
         modal.outerHTML = ''
         document.body.style.overflow = 'visible'
+    },
+
+    appendToModal(html){
+        const modal = document.querySelector('#burst-error')
+        if(modal){
+            let doc = modal.querySelector('iframe').contentDocument.body
+            doc.innerHTML = doc.innerHTML + html
+        } else {
+            this.showHtmlModal(html)
+        }
     },
 }

--- a/tests/DumpWatcherTest.php
+++ b/tests/DumpWatcherTest.php
@@ -11,7 +11,7 @@ class DumpWatcherTest extends TestCase
     {
         $dumpString = 'Livewire is awesome!';
 
-        $watcher = app()->make(DumpWatcher::class);
+        $watcher = new DumpWatcher;
         $this->assertEquals(0, count($watcher->dumps));
         
         dump($dumpString);

--- a/tests/DumpWatcherTest.php
+++ b/tests/DumpWatcherTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Watchers\DumpWatcher;
+
+class DumpWatcherTest extends TestCase
+{
+    /** @test */
+    function dump_watcher_stores_dumps()
+    {
+        $dumpString = 'Livewire is awesome!';
+
+        $watcher = app()->make(DumpWatcher::class);
+        $this->assertEquals(0, count($watcher->dumps));
+        
+        dump($dumpString);
+        
+        $this->assertEquals(1, count($watcher->dumps));
+        $this->assertContains($dumpString, $watcher->dumps[0]);
+    }
+
+}
+


### PR DESCRIPTION
This pull request adds support for the `dump()` function in livewire components. It adds a dump watcher to the framework (similar to how Laravel Telescope works), stores the dumps made in the current request, and returns them from the request to the javascript where they're displayed in a modal similar to how the errors are displayed in Livewire.

This will enable the developer to follow data flow through the app easier and output values whenever they like! When multiple requests are made containing multiple `dump()` calls, they are each appended to the existing modal so as not to have lots of modals piled on top of each other.