### PR TITLE
Add default fallback for render function on Component

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -47,6 +47,11 @@ abstract class Component
             ->map([Str::class, 'kebab'])
             ->implode('.');
     }
+    
+    public function render()
+    {
+        return view("livewire.{$this->name()}");
+    }
 
     public function redirect($url)
     {


### PR DESCRIPTION
**Is this something that is wanted/needed? Did you create a feature-request issue first?**
This was such an easy thing, so I thought I'd PR it directly.

**Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)**
I did not write any tests for this.

If this gets pulled in, people who don't customize and just return the default view in `render()` can remove it. Maybe it could even be removed from the default stub if it's a common thing to do. 
One less method on your component.

I have just been playing with Livewire for a few hours, so I don't know if this is a dumb suggestion, but might as well throw it out there! 

Thanks! 