### PR TITLE
Fix test function typo

### DIFF
--- a/tests/DestroyCommandTest.php
+++ b/tests/DestroyCommandTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\File;
 class DestroyCommandTest extends TestCase
 {
     /** @test */
-    function component_is_removed_by_destory_command()
+    function component_is_removed_by_destroy_command()
     {
         Artisan::call('make:livewire foo');
 


### PR DESCRIPTION
Fixed a typo in the DestroyCommand test name.
