### PR TITLE
Reset loading after error

### DIFF
--- a/src/js/Component/index.js
+++ b/src/js/Component/index.js
@@ -70,6 +70,9 @@ class Component {
     }
 
     messageSendFailed() {
+        //Reset all loading elements back to their original state
+        this.unsetLoading(this.messageInTransit.loadingEls)
+
         this.messageInTransit = null
     }
 
@@ -88,8 +91,6 @@ class Component {
         this.replaceDom(response.dom, response.dirtyInputs)
 
         this.forceRefreshDataBoundElementsMarkedAsDirty(response.dirtyInputs)
-
-        this.unsetLoading(this.messageInTransit.loadingEls)
 
         this.messageInTransit = null
 
@@ -316,7 +317,30 @@ class Component {
     }
 
     unsetLoading(loadingEls) {
-        // No need to "unset" loading because the dom-diffing will automatically reverse any changes.
+        loadingEls.forEach(el => {
+            const directive = el.el.directives.get('loading')
+            el = el.el.el // I'm so sorry @todo
+
+            if (directive.modifiers.includes('class')) {
+                const classes = directive.value.split(' ')
+
+                if (directive.modifiers.includes('remove')) {
+                    el.classList.add(...classes)
+                } else {
+                    el.classList.remove(...classes)
+                }
+            } else if (directive.modifiers.includes('attr')) {
+                if (directive.modifiers.includes('remove')) {
+                    el.setAttribute(directive.value)
+                } else {
+                    el.removeAttribute(directive.value, true)
+                }
+            } else {
+                el.style.display = 'none'
+            }
+        })
+
+        return loadingEls
     }
 
     modelSyncDebounce(callback, time) {

--- a/tests/js/loading_states.spec.js
+++ b/tests/js/loading_states.spec.js
@@ -1,5 +1,5 @@
 import { wait } from 'dom-testing-library'
-import { mount, mountAndReturn } from './utils'
+import { mount } from './utils'
 
 test('show element while loading', async () => {
     mount('<button wire:click="onClick"></button><span style="display: none" wire:loading></span>')

--- a/tests/js/loading_states.spec.js
+++ b/tests/js/loading_states.spec.js
@@ -85,31 +85,7 @@ test('remove element attribute while loading', async () => {
     })
 })
 
-// //TODO - need to know how to throw a 500 error return from Livewire in a test - maybe a new method in util instead of mount?
-// test('loading state is reset when an error is thrown', async () => {
+// //TODO - throw a 500 error return from Livewire in a test - maybe a new method in util instead of mount?
+test('loading state is reset when an error is thrown', async () => {
 
-//     //TODO Implement in utils.js
-//     //Return a 500 error back
-//     mountAndReturnError(
-//         '<button wire:click="onClick"></button><span wire:loading.class="foo"></span>',
-//         500 
-//     )
-
-//     //Fire button click
-//     // document.querySelector('button').click()
-
-//     //check that the loading state is showing during wait
-//     await wait(() => {
-//         expect(document.querySelector('span').classList.contains('foo')).toBeTruthy()
-//     })
-
-//     // throw error on onClick action
-
-//     //check 500 error is returned
-
-//     //check state of loading is reset to original
-
-//     await wait(() => {
-//         expect(document.querySelector('span').classList.contains('foo')).toBeFalsy()
-//     })
-// })
+})

--- a/tests/js/loading_states.spec.js
+++ b/tests/js/loading_states.spec.js
@@ -1,5 +1,5 @@
 import { wait } from 'dom-testing-library'
-import { mount } from './utils'
+import { mount, mountAndReturn } from './utils'
 
 test('show element while loading', async () => {
     mount('<button wire:click="onClick"></button><span style="display: none" wire:loading></span>')
@@ -84,3 +84,32 @@ test('remove element attribute while loading', async () => {
         expect(document.querySelector('span').hasAttribute('disabled')).toBeFalsy()
     })
 })
+
+// //TODO - need to know how to throw a 500 error return from Livewire in a test - maybe a new method in util instead of mount?
+// test('loading state is reset when an error is thrown', async () => {
+
+//     //TODO Implement in utils.js
+//     //Return a 500 error back
+//     mountAndReturnError(
+//         '<button wire:click="onClick"></button><span wire:loading.class="foo"></span>',
+//         500 
+//     )
+
+//     //Fire button click
+//     // document.querySelector('button').click()
+
+//     //check that the loading state is showing during wait
+//     await wait(() => {
+//         expect(document.querySelector('span').classList.contains('foo')).toBeTruthy()
+//     })
+
+//     // throw error on onClick action
+
+//     //check 500 error is returned
+
+//     //check state of loading is reset to original
+
+//     await wait(() => {
+//         expect(document.querySelector('span').classList.contains('foo')).toBeFalsy()
+//     })
+// })


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yep. Relates to #54  :)

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
I have sketched out a test but need some smart person to work out how to throw http errors when calling a Livewire component action

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
Add the automatic reset of any loading elements affected when a Livewire message returns with an error.

5️⃣ Thanks for contributing! 🙌
