### PR TITLE
Add loading delay and after

### DIFF
--- a/tests/js/loading_states.spec.js
+++ b/tests/js/loading_states.spec.js
@@ -84,3 +84,13 @@ test('remove element attribute while loading', async () => {
         expect(document.querySelector('span').hasAttribute('disabled')).toBeFalsy()
     })
 })
+
+//todo
+test('long running request with minimum loading only stops loading state at end of request', async () => {
+    // fire long action > min delay
+})
+
+//todo
+test('short running request with minimum loading only stops loading state at end of minimum delay', async () => {
+    //fire short action < min delay 
+})


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yep #69 
2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Just a loading.min and a loading.after

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Not yet..

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
**This is a first draft.**
It splits up the functionality in setLoading() and needs a look at with a fresh pair of eyes.
They both work as it stands using just two additional timers.

loading.min - Will set the minimum time a loading state can be active for (defaults to 500ms if no duration is set)

loading.after - Will delay the loading state for a duration (default 500ms) once a request has been sent to Livewire.

5️⃣ Thanks for contributing! 🙌
