### PR TITLE
Allow use with Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "illuminate/support": "^5.7",
-        "illuminate/validation": "^5.7"
+        "illuminate/support": "^5.7|^6.0",
+        "illuminate/validation": "^5.7|^6.0"
     },
     "extra": {
         "laravel": {
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5",
-        "laravel/framework": "^5.7",
+        "laravel/framework": "^5.7|^6.0",
         "orchestra/testbench": "~3.0",
         "psy/psysh": "@stable"
     }

--- a/src/Concerns/HandlesActions.php
+++ b/src/Concerns/HandlesActions.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Concerns;
 
+use Illuminate\Support\Str;
 use Livewire\Exceptions\MissingComponentMethodReferencedByAction;
 use Livewire\Exceptions\NonPublicComponentMethodCall;
 
@@ -18,8 +19,8 @@ trait HandlesActions
 
     protected function callBeforeAndAferSyncHooks($name, $value, $callback)
     {
-        $beforeMethod = 'updating' . studly_case($name);
-        $afterMethod = 'updated' . studly_case($name);
+        $beforeMethod = 'updating' . Str::studly($name);
+        $afterMethod = 'updated' . Str::studly($name);
 
         if (method_exists($this, $beforeMethod)) {
             $this->{$beforeMethod}($value);

--- a/src/Concerns/ValidatesInput.php
+++ b/src/Concerns/ValidatesInput.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Concerns;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 
 trait ValidatesInput
@@ -21,7 +22,7 @@ trait ValidatesInput
             $result[$this->beforeFirstDot($field)] = $this->getPropertyValue($field);
         }
 
-        return Validator::make($result, array_only($rules, $fields), $messages, $attributes)
+        return Validator::make($result, Arr::only($rules, $fields), $messages, $attributes)
             ->validate();
     }
 }

--- a/src/LivewireBladeDirectives.php
+++ b/src/LivewireBladeDirectives.php
@@ -16,7 +16,7 @@ class LivewireBladeDirectives
             array_pop($args);
             $expression = implode(',', $args);
         } else {
-            $cachedKey = "'".str_random(7)."'";
+            $cachedKey = "'".Str::random(7)."'";
         }
 
         return <<<EOT

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -3,6 +3,7 @@
 namespace Livewire;
 
 use Exception;
+use Illuminate\Support\Str;
 use Livewire\Connection\ComponentHydrator;
 use Livewire\Exceptions\ComponentNotFoundException;
 use Livewire\Testing\TestableLivewire;
@@ -79,7 +80,7 @@ EOT;
         $instance = $this->activate($name);
         $instance->mount(...$options);
         $dom = $instance->output();
-        $id = str_random(20);
+        $id = Str::random(20);
         $properties = ComponentHydrator::dehydrate($instance);
         $events = $instance->getEventsBeingListenedFor();
         $children = $instance->getRenderedChildren();

--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Testing;
 
+use Illuminate\Support\Str;
 use Livewire\Connection\ComponentHydrator;
 
 class TestableLivewire
@@ -31,7 +32,7 @@ class TestableLivewire
         // and not have to register an alias.
         if (class_exists($name)) {
             $componentClass = $name;
-            app('livewire')->component($name = str_random(20), $componentClass);
+            app('livewire')->component($name = Str::random(20), $componentClass);
         }
 
         $result = app('livewire')->mount($this->name = $name, ...$params);


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes. No.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Well, kind of, but not really.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
No.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
This makes Livewire work with Laravel 6 / the dev-branch of laravel/laravel. I changed the version constraint on the illuminate/laravel -stuff and replaced calls to the helper functions that were deprecated in 5.8 and apparently removed in 6. 

5️⃣ Thanks for contributing! 🙌
