### PR TITLE
avoid collision with component name property

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -19,7 +19,6 @@ abstract class Component
 
     public $id;
     public $redirectTo;
-    protected $name;
     protected $lifecycleHooks = [
         'mount', 'updating', 'updated',
     ];
@@ -42,7 +41,9 @@ abstract class Component
 
     public function name()
     {
-        return $this->name ?: collect(explode('.', str_replace(['/', '\\'], '.', static::class)))
+        $name = method_exists($this, 'getName') ? $this->getName() : static::class;
+
+        return collect(explode('.', str_replace(['/', '\\'], '.', $name)))
             ->diff(['App', 'Http', 'Livewire'])
             ->map([Str::class, 'kebab'])
             ->implode('.');

--- a/src/Component.php
+++ b/src/Component.php
@@ -39,11 +39,9 @@ abstract class Component
         }
     }
 
-    public function name()
+    public function getName()
     {
-        $name = method_exists($this, 'getName') ? $this->getName() : static::class;
-
-        return collect(explode('.', str_replace(['/', '\\'], '.', $name)))
+        return collect(explode('.', str_replace(['/', '\\'], '.', static::class)))
             ->diff(['App', 'Http', 'Livewire'])
             ->map([Str::class, 'kebab'])
             ->implode('.');
@@ -51,7 +49,7 @@ abstract class Component
 
     public function render()
     {
-        return view("livewire.{$this->name()}");
+        return view("livewire.{$this->getName()}");
     }
 
     public function redirect($url)

--- a/src/LivewireComponentsFinder.php
+++ b/src/LivewireComponentsFinder.php
@@ -44,7 +44,7 @@ class LivewireComponentsFinder
     {
         $this->manifest = $this->getClassNames()
             ->mapWithKeys(function ($class) {
-                return [(new $class)->name() => $class];
+                return [(new $class)->getName() => $class];
             })->toArray();
 
         $this->write($this->manifest);

--- a/tests/ComponentUsesCustomName.php
+++ b/tests/ComponentUsesCustomName.php
@@ -13,7 +13,6 @@ class ComponentUsesCustomName extends TestCase
         $component = app(LivewireManager::class)->test(PreservesNameProperty::class);
 
         $this->assertEquals('Hello World', $component->instance->name);
-        $this->assertEquals('uses-custom-name', $component->instance->name());
         $this->assertEquals('uses-custom-name', $component->instance->getName());
     }
 }

--- a/tests/ComponentUsesCustomName.php
+++ b/tests/ComponentUsesCustomName.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Component;
+use Livewire\LivewireManager;
+
+class ComponentUsesCustomName extends TestCase
+{
+    /** @test */
+    public function preserves_name_property()
+    {
+        $component = app(LivewireManager::class)->test(PreservesNameProperty::class);
+
+        $this->assertEquals('Hello World', $component->instance->name);
+        $this->assertEquals('uses-custom-name', $component->instance->name());
+        $this->assertEquals('uses-custom-name', $component->instance->getName());
+    }
+}
+
+class PreservesNameProperty extends Component
+{
+    public $name = 'Hello World';
+
+    public function render()
+    {
+        return app('view')->make('null-view');
+    }
+
+    public function getName()
+    {
+        return 'uses-custom-name';
+    }
+}

--- a/tests/ComponentUsesCustomName.php
+++ b/tests/ComponentUsesCustomName.php
@@ -8,12 +8,31 @@ use Livewire\LivewireManager;
 class ComponentUsesCustomName extends TestCase
 {
     /** @test */
+    public function uses_default_component_name()
+    {
+        $component = app(LivewireManager::class)->test(UsesDefaultComponentName::class);
+
+        $this->assertEquals('Hello World', $component->instance->name);
+        $this->assertEquals('tests.uses-default-component-name', $component->instance->getName());
+    }
+
+    /** @test */
     public function preserves_name_property()
     {
         $component = app(LivewireManager::class)->test(PreservesNameProperty::class);
 
         $this->assertEquals('Hello World', $component->instance->name);
         $this->assertEquals('uses-custom-name', $component->instance->getName());
+    }
+}
+
+class UsesDefaultComponentName extends Component
+{
+    public $name = 'Hello World';
+
+    public function render()
+    {
+        return app('view')->make('null-view');
     }
 }
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes https://github.com/calebporzio/livewire/issues/130

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
At the moment the base component has a very generic property called `$name` which can be used to modify the component name. This could easily be overwritten and hard to figure out why a wrong component name is now used to resolve the view name.

The newly introduced `getName()` method allows the use of a custom name that will be used by `name()` and apply all the same methods as perform like diffing and imploding. This should avoid issues with components that themselves use a `$name` property.

5️⃣ Thanks for contributing! 🙌
