### PR TITLE
forget flashed session content if we are not redirecting

### DIFF
--- a/src/Connection/ConnectionHandler.php
+++ b/src/Connection/ConnectionHandler.php
@@ -30,7 +30,7 @@ abstract class ConnectionHandler
         $events = $instance->getEventsBeingListenedFor();
         $eventQueue = $instance->getEventQueue();
 
-        return new ResponsePayload([
+        $response = new ResponsePayload([
             'id' => $payload['id'],
             'dom' => $dom,
             'dirtyInputs' => $instance->getDirtyProperties(),
@@ -40,6 +40,12 @@ abstract class ConnectionHandler
             'data' => $data,
             'redirectTo' => $instance->redirectTo ?? false,
         ]);
+
+        if (empty($instance->redirectTo)) {
+            session()->forget(session()->get('_flash.new'));
+        }
+
+        return $response;
     }
 
     public function processMessage($type, $data, $instance)

--- a/tests/ComponentHandlesSessions.php
+++ b/tests/ComponentHandlesSessions.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Component;
+use Livewire\LivewireManager;
+
+class ComponentHandlesSessions extends TestCase
+{
+    /** @test */
+    public function removes_flashed_message_without_redirect()
+    {
+        $component = app(LivewireManager::class)->test(RemovesFlashedMessageWithoutRedirect::class);
+
+        $component->call('flashMessage');
+        $component->assertSee('Task was successfull!');
+        $component->set('foo', 'bar'); // Modify some property to force a refresh
+        $component->assertDontSee('Task was successfull!');
+    }
+
+    /** @test */
+    public function keeps_flashed_message_with_redirect()
+    {
+        $component = app(LivewireManager::class)->test(KeepsFlashedMessageWithRedirect::class);
+
+        $component->call('flashMessage');
+        $component->assertSee('Task was successfull!');
+        $component->set('foo', 'bar'); // Modify some property to force a refresh
+        $component->assertSee('Task was successfull!');
+    }
+}
+
+class RemovesFlashedMessageWithoutRedirect extends Component
+{
+    public $foo;
+
+    public function render()
+    {
+        return app('view')->make('show-session-flash');
+    }
+
+    public function flashMessage()
+    {
+        session()->flash('status', 'Task was successfull!');
+    }
+}
+
+class KeepsFlashedMessageWithRedirect extends Component
+{
+    public $foo;
+
+    public function render()
+    {
+        return app('view')->make('show-session-flash');
+    }
+
+    public function flashMessage()
+    {
+        session()->flash('status', 'Task was successfull!');
+
+        $this->redirect('/foo');
+    }
+}

--- a/tests/views/show-session-flash.blade.php
+++ b/tests/views/show-session-flash.blade.php
@@ -1,0 +1,7 @@
+<div>
+    @if (session('status'))
+        <div class="alert-success mb-" role="alert">
+            {{ session('status') }}
+        </div>
+    @endif
+</div>


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes https://github.com/calebporzio/livewire/issues/132

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
As described in https://github.com/calebporzio/livewire/issues/132 all flashed contents of a session is persisted for 1 in-browser page reload even though Livewire already rendered the contents.

This PR changes the connection handler to assume that if there is no redirect it means that the contents was already rendered by the component itself. This change results in 2 scenarios now.

1. We call `session()->flash()` inside our component but don't call `$this->redirect()` so the flashed content is removed after it has been added to the AJAX response.
2. We call `session()->flash()` inside our component and call `$this->redirect()` so we are redirected, the content is flashed and removed by Laravel and its session handler.

5️⃣ Thanks for contributing! 🙌
