### PR TITLE
add redirectRoute and redirectAction helpers

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -13,12 +13,12 @@ abstract class Component
     use Concerns\ValidatesInput,
         Concerns\DetectsDirtyProperties,
         Concerns\HandlesActions,
+        Concerns\PerformsRedirects,
         Concerns\ReceivesEvents,
         Concerns\InteractsWithProperties,
         Concerns\TracksRenderedChildren;
 
     public $id;
-    public $redirectTo;
     protected $lifecycleHooks = [
         'mount', 'updating', 'updated',
     ];
@@ -50,11 +50,6 @@ abstract class Component
     public function render()
     {
         return view("livewire.{$this->getName()}");
-    }
-
-    public function redirect($url)
-    {
-        $this->redirectTo = $url;
     }
 
     public function output($errors = null)

--- a/src/Concerns/PerformsRedirects.php
+++ b/src/Concerns/PerformsRedirects.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Livewire\Concerns;
+
+trait PerformsRedirects
+{
+    public $redirectTo;
+
+    public function redirect($url)
+    {
+        $this->redirectTo = $url;
+    }
+
+    public function redirectRoute($name, $parameters = [], $absolute = true)
+    {
+        $this->redirectTo = route($name, $parameters, $absolute);
+    }
+
+    public function redirectAction($name, $parameters = [], $absolute = true)
+    {
+        $this->redirectTo = action($name, $parameters, $absolute);
+    }
+}

--- a/tests/RedirectTest.php
+++ b/tests/RedirectTest.php
@@ -20,6 +20,30 @@ class RedirectTest extends TestCase
     }
 
     /** @test */
+    public function route_redirect()
+    {
+        $this->registerNamedRoute();
+
+        $component = app(LivewireManager::class)->test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectRoute');
+
+        $this->assertEquals('http://localhost/foo', $component->redirectTo);
+    }
+
+    /** @test */
+    public function action_redirect()
+    {
+        $this->registerAction();
+
+        $component = app(LivewireManager::class)->test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectAction');
+
+        $this->assertEquals('http://localhost/foo', $component->redirectTo);
+    }
+
+    /** @test */
     public function redirect_helper()
     {
         $component = app(LivewireManager::class)->test(TriggersRedirectStub::class);
@@ -69,6 +93,11 @@ class RedirectTest extends TestCase
             return true;
         })->name('foo');
     }
+
+    protected function registerAction()
+    {
+        Route::get('foo', 'HomeController@index')->name('foo');
+    }
 }
 
 class TriggersRedirectStub extends Component
@@ -76,6 +105,16 @@ class TriggersRedirectStub extends Component
     public function triggerRedirect()
     {
         return $this->redirect('/local');
+    }
+
+    public function triggerRedirectRoute()
+    {
+        return $this->redirectRoute('foo');
+    }
+
+    public function triggerRedirectAction()
+    {
+        return $this->redirectAction('HomeController@index');
     }
 
     public function triggerRedirectHelper()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes https://github.com/calebporzio/livewire/issues/140

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
Adds the `redirectRoute` and `redirectAction` methods to provide a more convenient way of redirecting from inside components.

**Route**
```php
// Before
$this->redirect(route('home'));

// After
$this->redirectRoute('home');
```

**Action**
```php
// Before
$this->redirect(action('HomeController@index'));

// After
$this->redirectAction('HomeController@index');
```

Under the hood it supports the same arguments as the `route` and `action` functions.

5️⃣ Thanks for contributing! 🙌
