### PR TITLE
Fix closing button tag on pagination-links

### DIFF
--- a/src/views/pagination-links.blade.php
+++ b/src/views/pagination-links.blade.php
@@ -33,7 +33,7 @@
         {{-- Next Page Link --}}
         @if ($paginator->hasMorePages())
             <li class="page-item">
-                <button type="button" class="page-link" wire:click="nextPage" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                <button type="button" class="page-link" wire:click="nextPage" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</button>
             </li>
         @else
             <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">


### PR DESCRIPTION
Switches `</a>` for `</button>`