### PR TITLE
allow page composition through Route::livewire

### DIFF
--- a/src/Macros/livewire-view.blade.php
+++ b/src/Macros/livewire-view.blade.php
@@ -1,5 +1,7 @@
 @extends($layout)
 
 @section($section)
-    @livewire($component, ...$componentOptions)
+    @foreach($components as $component => $componentOptions)
+        @livewire($component, ...$componentOptions)
+    @endforeach
 @endsection

--- a/tests/PageCompositionTest.php
+++ b/tests/PageCompositionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Livewire;
+use Livewire\Component;
+use Illuminate\Support\Facades\Route;
+
+class PageCompositionTest extends TestCase
+{
+    /** @test */
+    public function composes_page_with_a_single_component()
+    {
+        Livewire::component('foo', ComposableComponent::class);
+
+        Route::livewire('/test/{name}', 'foo')->middleware('web');
+
+        $this
+            ->get('/test/name-from-route')
+            ->assertSee('wire:name="foo"')
+            ->assertSeeText('name-from-route');
+    }
+
+    /** @test */
+    public function composes_page_with_multiple_components()
+    {
+        Livewire::component('foo', ComposableComponent::class);
+        Livewire::component('bar', ComposableComponent::class);
+
+        Route::livewire('/test/{name}', ['foo', 'bar'])->middleware('web');
+
+        $this
+            ->get('/test/name-from-route')
+            ->assertSeeInOrder(['wire:name="foo"', 'wire:name="bar"'])
+            ->assertSeeText('name-from-route');
+    }
+}
+
+class ComposableComponent extends Component
+{
+    public function mount(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function render()
+    {
+        return app('view')->make('show-name')->with('name', $this->name);
+    }
+}


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Probably. No.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
I find myself quite frequently in a situation where I end up composing pages with multiple components that are just a list of chained `@livewire(...)` calls in a blade template. This PR allows to pass in components as either a string or an array and will loop over them to include them.

**Old**
```blade
@extends('layouts.dashboard')

@section('content')
    @livewire('update-contact-information')

    @livewire('update-profile-information')
@endsection
```

**New**
```php
Route::livewire('profile', [
    'update-contact-information',
    'update-profile-information',
])->name('settings.profile');
```

This new syntax makes it very easy to compose pages that consist purely of Livewire components without the need of having an extra blade template for it.

5️⃣ Thanks for contributing! 🙌
