### PR TITLE
Allow custom base_url to be passed into @livewireAssets()

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -75,7 +75,16 @@ class LivewireManager
 
     public function assets($options = null)
     {
-        $appUrl = $this->appUrlOrRoot();
+        if(!is_null($options) && array_key_exists('base_url', $options)) {
+            $appUrl = $options['base_url'];
+            // I'm not sure what you're doing with this options variable, so if base_url is passed in...
+            // I set $appUrl to the passed in value, then remove it from $options so it doesn't get passed through on line 101
+            unset($options['base_url']);
+            if(empty($options)) $options = null;
+        } else {
+            $appUrl = $this->appUrlOrRoot();
+        }
+
         $options = $options ? json_encode($options) : '';
 
         $manifest = json_decode(file_get_contents(__DIR__.'/../dist/mix-manifest.json'), true);

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -75,12 +75,14 @@ class LivewireManager
 
     public function assets($options = null)
     {
-        if(!is_null($options) && array_key_exists('base_url', $options)) {
+        if (! is_null($options) && array_key_exists('base_url', $options)) {
             $appUrl = $options['base_url'];
             // I'm not sure what you're doing with this options variable, so if base_url is passed in...
             // I set $appUrl to the passed in value, then remove it from $options so it doesn't get passed through on line 101
             unset($options['base_url']);
-            if(empty($options)) $options = null;
+            if (empty($options)) {
+                $options = null;
+            }
         } else {
             $appUrl = $this->appUrlOrRoot();
         }

--- a/tests/LivewireUsesProperAppAndAssetsPathTest.php
+++ b/tests/LivewireUsesProperAppAndAssetsPathTest.php
@@ -81,4 +81,18 @@ class LivewireUsesProperAppAndAssetsPathTest extends TestCase
             $laravelAppConfigFileContents
         );
     }
+
+    /** @test */
+    public function livewires_base_app_url_can_be_passed_into_blade_component()
+    {
+        // I couldn't get your tests running on my machine, but this ***should*** work
+        config()->set('app.url', 'https://foo.com/app/');
+
+        $this->assertContains(
+            'window.livewire_app_url = "https://passedin.domain.com";',
+            Livewire::assets(['base_url' => 'https://passedin.domain.com'])
+        );
+
+        // It would be good to send the base_url through the @livewireAssets component as well, but I'm not sure how to test that
+    }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?

No, but there is an open issue #155 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Nope

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)

I added one test that I *think* will work but I couldn't actually get the tests to run. There's also probably at least one more test to write (comments in the test file) 

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

If you use subdomains in your app, there is a CORS issue that won't allow livewire to work unless the domain matches the config value. With this change, a user can send in their subdomain URL through the blade template and everything works.

5️⃣ Thanks for contributing! 🙌
:)