### PR TITLE
Better cache headers

### DIFF
--- a/src/LivewireJavaScriptAssets.php
+++ b/src/LivewireJavaScriptAssets.php
@@ -19,17 +19,22 @@ class LivewireJavaScriptAssets
         $lastModified = filemtime($file);
         $expires = strtotime('+1 year');
 
-        $manifest = json_decode(file_get_contents(__DIR__.'/../dist/mix-manifest.json'), true);
-        $versionedFileName = $manifest['/' . basename($file)];
-
-        parse_str(parse_url($versionedFileName, PHP_URL_QUERY), $query);
-
         return response()->file($file, [
             'Content-Type' => 'application/javascript; charset=utf-8',
-            'ETag' => $query['id'],
+            'ETag' => $this->etag($file),
             'Cache-Control' => 'public, max-age=31536000',
             'Expires' => sprintf('%s GMT', gmdate('D, d M Y H:i:s', $expires)),
             'Last-Modified' => sprintf('%s GMT', gmdate('D, d M Y H:i:s', $lastModified)),
         ]);
+    }
+
+    protected function etag($file)
+    {
+        $manifest = json_decode(file_get_contents(__DIR__.'/../dist/mix-manifest.json'), true);
+        $versioned = $manifest['/' . basename($file)];
+
+        parse_str(parse_url($versioned, PHP_URL_QUERY), $query);
+
+        return $query['id'];
     }
 }

--- a/src/LivewireJavaScriptAssets.php
+++ b/src/LivewireJavaScriptAssets.php
@@ -17,10 +17,12 @@ class LivewireJavaScriptAssets
     public function pretendResponseIsFile($file)
     {
         $lastModified = filemtime($file);
+        $expires = strtotime('+1 year');
 
         return response()->file($file, [
             'Content-Type' => 'application/javascript; charset=utf-8',
             'Cache-Control' => 'public, max-age=31536000',
+            'Expires' => sprintf('%s GMT', gmdate('D, d M Y H:i:s', $expires)),
             'Last-Modified' => sprintf('%s GMT', gmdate('D, d M Y H:i:s', $lastModified)),
         ]);
     }

--- a/src/LivewireJavaScriptAssets.php
+++ b/src/LivewireJavaScriptAssets.php
@@ -23,8 +23,8 @@ class LivewireJavaScriptAssets
             'Content-Type' => 'application/javascript; charset=utf-8',
             'ETag' => $this->etag($file),
             'Cache-Control' => 'public, max-age=31536000',
-            'Expires' => sprintf('%s GMT', gmdate('D, d M Y H:i:s', $expires)),
-            'Last-Modified' => sprintf('%s GMT', gmdate('D, d M Y H:i:s', $lastModified)),
+            'Expires' => $this->httpDate($expires),
+            'Last-Modified' => $this->httpDate($lastModified),
         ]);
     }
 
@@ -36,5 +36,10 @@ class LivewireJavaScriptAssets
         parse_str(parse_url($versioned, PHP_URL_QUERY), $query);
 
         return $query['id'];
+    }
+
+    protected function httpDate($timestamp)
+    {
+        return sprintf('%s GMT', gmdate('D, d M Y H:i:s', $timestamp));
     }
 }

--- a/src/LivewireJavaScriptAssets.php
+++ b/src/LivewireJavaScriptAssets.php
@@ -19,8 +19,14 @@ class LivewireJavaScriptAssets
         $lastModified = filemtime($file);
         $expires = strtotime('+1 year');
 
+        $manifest = json_decode(file_get_contents(__DIR__.'/../dist/mix-manifest.json'), true);
+        $versionedFileName = $manifest['/' . basename($file)];
+
+        parse_str(parse_url($versionedFileName, PHP_URL_QUERY), $query);
+
         return response()->file($file, [
             'Content-Type' => 'application/javascript; charset=utf-8',
+            'ETag' => $query['id'],
             'Cache-Control' => 'public, max-age=31536000',
             'Expires' => sprintf('%s GMT', gmdate('D, d M Y H:i:s', $expires)),
             'Last-Modified' => sprintf('%s GMT', gmdate('D, d M Y H:i:s', $lastModified)),

--- a/src/LivewireJavaScriptAssets.php
+++ b/src/LivewireJavaScriptAssets.php
@@ -20,7 +20,7 @@ class LivewireJavaScriptAssets
         return response()
             ->file($file, [
                 'Content-Type' => 'application/javascript; charset=utf-8',
-                'Cache-Control' => 'public, max-age=3600',
+                'Cache-Control' => 'public, max-age=31536000',
             ]);
     }
 }

--- a/src/LivewireJavaScriptAssets.php
+++ b/src/LivewireJavaScriptAssets.php
@@ -16,10 +16,12 @@ class LivewireJavaScriptAssets
 
     public function pretendResponseIsFile($file)
     {
-        // These headers will enable browsers to cache this asset.
+        $lastModified = filemtime($file);
+
         return response()->file($file, [
             'Content-Type' => 'application/javascript; charset=utf-8',
             'Cache-Control' => 'public, max-age=31536000',
+            'Last-Modified' => sprintf('%s GMT', gmdate('D, d M Y H:i:s', $lastModified)),
         ]);
     }
 }

--- a/src/LivewireJavaScriptAssets.php
+++ b/src/LivewireJavaScriptAssets.php
@@ -17,10 +17,9 @@ class LivewireJavaScriptAssets
     public function pretendResponseIsFile($file)
     {
         // These headers will enable browsers to cache this asset.
-        return response()
-            ->file($file, [
-                'Content-Type' => 'application/javascript; charset=utf-8',
-                'Cache-Control' => 'public, max-age=31536000',
-            ]);
+        return response()->file($file, [
+            'Content-Type' => 'application/javascript; charset=utf-8',
+            'Cache-Control' => 'public, max-age=31536000',
+        ]);
     }
 }


### PR DESCRIPTION
- Changed `Cache-Control` from 1 hour to 1 year
- Added `Last-Modified` / `Expires` header for browsers to use
- Return `304` response when cache matches