### PR TITLE
Route name

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -79,7 +79,7 @@ class LivewireServiceProvider extends ServiceProvider
         RouteFacade::get('/livewire/livewire.js', [LivewireJavaScriptAssets::class, 'unminified']);
         RouteFacade::get('/livewire/livewire.min.js', [LivewireJavaScriptAssets::class, 'minified']);
 
-        RouteFacade::post('/livewire/message', HttpConnectionHandler::class);
+        RouteFacade::post('/livewire/message/{name}', HttpConnectionHandler::class);
     }
 
     public function registerViews()

--- a/src/js/connection/drivers/http.js
+++ b/src/js/connection/drivers/http.js
@@ -8,7 +8,7 @@ export default {
 
     sendMessage(payload) {
         // Forward the query string for the ajax requests.
-        fetch(window.livewire_app_url+'/livewire/message'+window.location.search, {
+        fetch(`${window.livewire_app_url}/livewire/message/${payload.name}${window.location.search}`, {
             method: 'POST',
             body: JSON.stringify(payload),
             // This enables "cookies".


### PR DESCRIPTION
This PR adds the component name to the route for easier debugging.

Closes #248.

@calebporzio: I haven't tested this code, because of the asset compilation. Am I missing something?