### PR TITLE
Improve performance by removing getClass()

### DIFF
--- a/src/Concerns/HandlesActions.php
+++ b/src/Concerns/HandlesActions.php
@@ -73,6 +73,7 @@ trait HandlesActions
                 if ($class = $parameter->getClass()) {
                     return app($class->name);
                 }
+
                 return app($parameter->name);
             }, function () use (&$params) {
                 return array_shift($params);

--- a/src/Concerns/HandlesActions.php
+++ b/src/Concerns/HandlesActions.php
@@ -70,7 +70,11 @@ trait HandlesActions
     {
         return collect((new \ReflectionMethod($this, $method))->getParameters())->map(function ($parameter) use (&$params) {
             return rescue(function () use ($parameter) {
-                return app($parameter->name);
+                if($parameter->getClass()) {  
+                    return app($parameter->getClass()->name);
+                } else {
+                    return app($parameter->name);
+                }
             }, function () use (&$params) {
                 return array_shift($params);
             }, false);

--- a/src/Concerns/HandlesActions.php
+++ b/src/Concerns/HandlesActions.php
@@ -70,7 +70,7 @@ trait HandlesActions
     {
         return collect((new \ReflectionMethod($this, $method))->getParameters())->map(function ($parameter) use (&$params) {
             return rescue(function () use ($parameter) {
-                if($parameter->getClass()) {  
+                if ($parameter->getClass()) {
                     return app($parameter->getClass()->name);
                 } else {
                     return app($parameter->name);

--- a/src/Concerns/HandlesActions.php
+++ b/src/Concerns/HandlesActions.php
@@ -70,7 +70,7 @@ trait HandlesActions
     {
         return collect((new \ReflectionMethod($this, $method))->getParameters())->map(function ($parameter) use (&$params) {
             return rescue(function () use ($parameter) {
-                return app($parameter->getClass()->name);
+                return app($parameter->name);
             }, function () use (&$params) {
                 return array_shift($params);
             }, false);

--- a/src/Concerns/HandlesActions.php
+++ b/src/Concerns/HandlesActions.php
@@ -73,7 +73,6 @@ trait HandlesActions
                 if ($class = $parameter->getClass()) {
                     return app($class->name);
                 }
-                
                 return app($parameter->name);
             }, function () use (&$params) {
                 return array_shift($params);

--- a/src/Concerns/HandlesActions.php
+++ b/src/Concerns/HandlesActions.php
@@ -70,11 +70,11 @@ trait HandlesActions
     {
         return collect((new \ReflectionMethod($this, $method))->getParameters())->map(function ($parameter) use (&$params) {
             return rescue(function () use ($parameter) {
-                if ($parameter->getClass()) {
-                    return app($parameter->getClass()->name);
-                } else {
-                    return app($parameter->name);
+                if ($class = $parameter->getClass()) {
+                    return app($class->name);
                 }
+                
+                return app($parameter->name);
             }, function () use (&$params) {
                 return array_shift($params);
             }, false);


### PR DESCRIPTION
Fixes #256 

Admittedly I don't really know what's going on here, but I do know that with `->getClass()` here, my delete function takes between 400ms and 800ms. When I remove it then it not only still works, but takes just about 50ms.