### PR TITLE
Windows only fix for finding components

### DIFF
--- a/src/LivewireComponentsFinder.php
+++ b/src/LivewireComponentsFinder.php
@@ -68,7 +68,7 @@ class LivewireComponentsFinder
                 return app()->getNamespace().str_replace(
                         ['/', '.php'],
                         ['\\', ''],
-                        Str::after($file->getPathname(), app_path().DIRECTORY_SEPARATOR)
+                        Str::after($file->getPathname(), app_path().'/')
                     );
             })
             ->filter(function (string $class) {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?

Bug Fix for PHP on Windows

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)

Components can't be automatically found at all before this change

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

Component File Paths:
Path before change: `C:\neard\www\library\app\`
*even though this looks correct ^, win/php actually ends it with a forward slash, so this causes Str::after to fail*
Path after change: `C:\neard\www\library\app/`

The problem is that PHP/Windows doesn't actually use the directory separator at the end.

5️⃣ Thanks for contributing! 🙌
