### PR TITLE
Make base namespace removal less aggressive when getting the name of a Component

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -43,12 +43,15 @@ abstract class Component
 
     public function getName()
     {
-        $namespace = config('livewire.class_namespace', 'App\\Http\\Livewire');
-
-        return collect(explode('.', str_replace(['/', '\\'], '.', static::class)))
-            ->diff(explode('\\', $namespace))
+        $namespace = collect(explode('.', str_replace(['/', '\\'], '.', config('livewire.class_namespace', 'App\\Http\\Livewire'))))
             ->map([Str::class, 'kebab'])
             ->implode('.');
+
+        $name = collect(explode('.', str_replace(['/', '\\'], '.', static::class)))
+            ->map([Str::class, 'kebab'])
+            ->implode('.');
+
+        return Str::substr($name, strlen($namespace) + 1);
     }
 
     public function render()

--- a/src/Component.php
+++ b/src/Component.php
@@ -51,7 +51,11 @@ abstract class Component
             ->map([Str::class, 'kebab'])
             ->implode('.');
 
-        return Str::substr($name, strlen($namespace) + 1);
+        if (Str::startsWith($name, $namespace)) {
+            return Str::substr($name, strlen($namespace) + 1);
+        }
+
+        return $name;
     }
 
     public function render()

--- a/tests/ComponentNameAndNamespaceTest.php
+++ b/tests/ComponentNameAndNamespaceTest.php
@@ -64,7 +64,7 @@ EOT
 
         File::put(
             app_path('Custom/Controllers/Http') . '/CustomNamespace.php',
-            <<<EOT
+<<<EOT
 <?php
 
 namespace App\Custom\Controllers\Http;
@@ -77,7 +77,7 @@ EOT
 
         File::put(
             $this->livewireViewsPath('custom-namespace.blade.php'),
-            <<<'EOT'
+<<<EOT
 <div>I've been namespaced!</div>
 EOT
         );

--- a/tests/ComponentNameAndNamespaceTest.php
+++ b/tests/ComponentNameAndNamespaceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests;
+
+use Livewire\LivewireManager;
+use Illuminate\Support\Facades\File;
+use Illuminate\Filesystem\Filesystem;
+use Livewire\Commands\ComponentParser;
+use Livewire\LivewireComponentsFinder;
+
+class ComponentNameAndNamespaceTest extends TestCase
+{
+    public function makeACleanSlate()
+    {
+        parent::makeACleanSlate();
+
+        File::deleteDirectory(app_path('Custom'));
+    }
+
+    /** @test */
+    public function can_get_name_with_livewire_default_namespace()
+    {
+        File::makeDirectory($this->livewireClassesPath('App'), 0755, true);
+        File::makeDirectory($this->livewireViewsPath('app'), 0755, true);
+
+        File::put(
+            $this->livewireClassesPath('App/DefaultNamespace.php'),
+<<<EOT
+<?php
+
+namespace App\Http\Livewire\App;
+
+use Livewire\Component;
+
+class DefaultNamespace extends Component {}
+EOT
+        );
+
+        File::put(
+            $this->livewireViewsPath('app/default-namespace.blade.php'),
+<<<EOT
+<div>I've been namespaced!</div>
+EOT
+        );
+
+        $component = app(LivewireManager::class)->test('App\Http\Livewire\App\DefaultNamespace');
+
+        $this->assertEquals('app.default-namespace', $component->instance->getName());
+    }
+
+    /** @test */
+    public function can_get_name_with_custom_namespace()
+    {
+        config(['livewire.class_namespace' => 'App\\Custom\\Controllers\\Http']);
+
+        app()->instance(LivewireComponentsFinder::class, new LivewireComponentsFinder(
+            new Filesystem,
+            app()->bootstrapPath('cache/livewire-components.php'),
+            ComponentParser::generatePathFromNamespace(config('livewire.class_namespace'))
+        ));
+
+        File::makeDirectory(app_path('Custom/Controllers/Http'), 0755, true);
+        File::makeDirectory($this->livewireViewsPath());
+
+        File::put(
+            app_path('Custom/Controllers/Http') . '/CustomNamespace.php',
+            <<<EOT
+<?php
+
+namespace App\Custom\Controllers\Http;
+
+use Livewire\Component;
+
+class CustomNamespace extends Component {}
+EOT
+        );
+
+        File::put(
+            $this->livewireViewsPath('custom-namespace.blade.php'),
+            <<<'EOT'
+<div>I've been namespaced!</div>
+EOT
+        );
+
+        $component = app(LivewireManager::class)->test('App\Custom\Controllers\Http\CustomNamespace');
+
+        $this->assertEquals('custom-namespace', $component->instance->getName());
+    }
+}

--- a/tests/ComponentNameAndNamespaceTest.php
+++ b/tests/ComponentNameAndNamespaceTest.php
@@ -51,7 +51,7 @@ EOT
     /** @test */
     public function can_get_name_with_custom_namespace()
     {
-        config(['livewire.class_namespace' => 'App\\Custom\\Controllers\\Http']);
+        config(['livewire.class_namespace' => 'Custom\\Controllers\\Http']);
 
         app()->instance(LivewireComponentsFinder::class, new LivewireComponentsFinder(
             new Filesystem,
@@ -67,7 +67,7 @@ EOT
 <<<EOT
 <?php
 
-namespace App\Custom\Controllers\Http;
+namespace Custom\Controllers\Http;
 
 use Livewire\Component;
 
@@ -82,7 +82,8 @@ EOT
 EOT
         );
 
-        $component = app(LivewireManager::class)->test('App\Custom\Controllers\Http\CustomNamespace');
+        require(app_path('Custom/Controllers/Http') . '/CustomNamespace.php');
+        $component = app(LivewireManager::class)->test('Custom\Controllers\Http\CustomNamespace');
 
         $this->assertEquals('custom-namespace', $component->instance->getName());
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes, resolves #267 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Most definitely.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
This changes how the base namespace of Livewire Components is removed when getting the name for a Component. Before it was too aggressive removing all instances of a word from the entire path. 

This is needed to accommodate for example if `App` is in the namespace twice like `App\Http\Livewire\App\Test`. Before it would remove both instances of `App`. Now it just removes the first giving us `app.test` instead of just `test`.

5️⃣ Thanks for contributing! 🙌
