### PR TITLE
Set minimum Laravel version to ^5.8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "illuminate/support": "^5.7|^6.0",
-        "illuminate/validation": "^5.7|^6.0"
+        "illuminate/support": "^5.8|^6.0",
+        "illuminate/validation": "^5.8|^6.0"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
Addresses minimum version debate from Issue [#296](https://github.com/livewire/livewire/issues/296).
