### PR TITLE
Add support for Laravel version 5.7

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -151,12 +151,25 @@ class LivewireServiceProvider extends ServiceProvider
 
     protected function registerPublishables()
     {
-        $this->publishes([
+        $this->publishesToGroups([
             __DIR__.'/../config/livewire.php' => base_path('config/livewire.php'),
         ], ['livewire', 'livewire:config']);
 
-        $this->publishes([
+        $this->publishesToGroups([
             __DIR__.'/../dist' => public_path('vendor/livewire'),
         ], ['livewire', 'livewire:assets']);
+    }
+
+    protected function publishesToGroups(array $paths, $groups = null)
+    {
+        if (is_null($groups)) {
+            $this->publishes($paths);
+
+            return;
+        }
+
+        foreach ((array) $groups as $group) {
+            $this->publishes($paths, $group);
+        }
     }
 }


### PR DESCRIPTION
Related to #315 

The only obstacle for using Liveware in a laravel 5.7 project was the way the package publishes it resources. Using multiple groups as an array was introduced in 5.8 (see https://github.com/laravel/framework/pull/26115)

For convenience I have created a method in the `LivewireServiceProvider` that provides the same behaviour.
