### PR TITLE
Add support to Laravel version 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "illuminate/support": "^5.7|^6.0",
-        "illuminate/validation": "^5.7|^6.0"
+        "illuminate/support": "^5.6|^6.0",
+        "illuminate/validation": "^5.6|^6.0"
     },
     "extra": {
         "laravel": {
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5",
-        "laravel/framework": "^5.7|^6.0",
+        "laravel/framework": "^5.6|^6.0",
         "orchestra/testbench": "~3.0",
         "psy/psysh": "@stable"
     }

--- a/src/LivewireComponentsFinder.php
+++ b/src/LivewireComponentsFinder.php
@@ -56,9 +56,7 @@ class LivewireComponentsFinder
             throw new Exception('The '.dirname($this->manifestPath).' directory must be present and writable.');
         }
 
-        $this->files->replace(
-            $this->manifestPath, '<?php return '.var_export($manifest, true).';'
-        );
+        $this->files->put($this->manifestPath, '<?php return '.var_export($manifest, true).';', true);
     }
 
     public function getClassNames()

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -151,12 +151,25 @@ class LivewireServiceProvider extends ServiceProvider
 
     protected function registerPublishables()
     {
-        $this->publishes([
+        $this->publishesToGroups([
             __DIR__.'/../config/livewire.php' => base_path('config/livewire.php'),
         ], ['livewire', 'livewire:config']);
 
-        $this->publishes([
+        $this->publishesToGroups([
             __DIR__.'/../dist' => public_path('vendor/livewire'),
         ], ['livewire', 'livewire:assets']);
+    }
+
+    protected function publishesToGroups(array $paths, $groups = null)
+    {
+        if (is_null($groups)) {
+            $this->publishes($paths);
+
+            return;
+        }
+
+        foreach ((array) $groups as $group) {
+            $this->publishes($paths, $group);
+        }
     }
 }


### PR DESCRIPTION
Related to #315 

See #317 

This pull request goes one step further and downgrades the laravel version requirement to 5.6. I think we shouldn't encourage people to use version older than 5.6 because it is the oldest Laravel version with a PHP requirement including security fixes.

In addition to the changes in #317 in this case we need the `Filesystem::replace` method was introduced in 5.7 (See https://github.com/laravel/framework/pull/26010). I replaced it with the [5.6 code](https://github.com/laravel/framework/blob/d1be6e43207ed1bacd183f11b87c152dffd08a7c/src/Illuminate/Foundation/PackageManifest.php#L171)