### PR TITLE
add second parameter to setAttribute 

### DIFF
--- a/src/js/dom/morphdom/specialElHandlers.js
+++ b/src/js/dom/morphdom/specialElHandlers.js
@@ -2,7 +2,7 @@ function syncBooleanAttrProp(fromEl, toEl, name) {
     if (fromEl[name] !== toEl[name]) {
         fromEl[name] = toEl[name];
         if (fromEl[name]) {
-            fromEl.setAttribute(name, name);
+            fromEl.setAttribute(name, '');
         } else {
             fromEl.removeAttribute(name);
         }

--- a/src/js/dom/morphdom/specialElHandlers.js
+++ b/src/js/dom/morphdom/specialElHandlers.js
@@ -2,7 +2,7 @@ function syncBooleanAttrProp(fromEl, toEl, name) {
     if (fromEl[name] !== toEl[name]) {
         fromEl[name] = toEl[name];
         if (fromEl[name]) {
-            fromEl.setAttribute(name);
+            fromEl.setAttribute(name, name);
         } else {
             fromEl.removeAttribute(name);
         }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
This was raised in the issue #316 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
no
3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
no
4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
The [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute) for the method says that it needs 2 parameters and this removes the following error:
`TypeError: Element.setAttribute requires at least 2 arguments, but only 1 were passed`

5️⃣ Thanks for contributing! 🙌
