### PR TITLE
Use stubs in livewire:make command

### DIFF
--- a/src/Commands/ComponentParser.php
+++ b/src/Commands/ComponentParser.php
@@ -3,6 +3,7 @@
 namespace Livewire\Commands;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Illuminate\Console\DetectsApplicationNamespace;
 
@@ -15,8 +16,10 @@ class ComponentParser
     protected $component;
     protected $componentClass;
     protected $directories;
+    protected $stubClassPath = null;
+    protected $stubViewPath = null;
 
-    public function __construct($classNamespace, $viewPath, $rawCommand)
+    public function __construct($classNamespace, $viewPath, $rawCommand, $stub = null)
     {
         $this->baseClassNamespace = $classNamespace;
 
@@ -29,6 +32,9 @@ class ComponentParser
 
         $this->component = Str::kebab(array_pop($directories));
         $this->componentClass = Str::studly($this->component);
+
+        $this->stubViewPath = $this->baseViewPath.'stubs/'.Str::kebab($stub).'.stub';
+        $this->stubClassPath = $this->baseClassPath.'Stubs/'.Str::studly(Str::kebab($stub)).'.stub';
 
         $this->directories = array_map([Str::class, 'studly'], $directories);
     }
@@ -73,7 +79,11 @@ class ComponentParser
 
     public function classContents()
     {
-        $template = file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'Component.stub');
+        if(File::exists($this->stubClassPath)) {
+            $template = file_get_contents($this->stubClassPath);
+        } else {
+            $template = file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'Component.stub');
+        }
 
         return preg_replace_array(
             ['/\[namespace\]/', '/\[class\]/', '/\[view\]/'],
@@ -113,7 +123,11 @@ class ComponentParser
 
     public function viewContents()
     {
-        $template = file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'view.stub');
+        if(File::exists($this->stubViewPath)) {
+            $template = file_get_contents($this->stubViewPath);
+        } else {
+            $template = file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'view.stub');
+        }
 
         return preg_replace(
             '/\[quote\]/',

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\File;
 
 class MakeCommand extends FileManipulationCommand
 {
-    protected $signature = 'livewire:make {name} {--force}';
+    protected $signature = 'livewire:make {name} {--force} {--stub=default}';
 
     protected $description = 'Create a new Livewire component.';
 
@@ -15,7 +15,8 @@ class MakeCommand extends FileManipulationCommand
         $this->parser = new ComponentParser(
             config('livewire.class_namespace', 'App\\Http\\Livewire'),
             config('livewire.view_path', resource_path('views/livewire')),
-            $this->argument('name')
+            $this->argument('name'),
+            $this->option('stub')
         );
 
         $force = $this->option('force');

--- a/src/Commands/MakeLivewireCommand.php
+++ b/src/Commands/MakeLivewireCommand.php
@@ -4,5 +4,5 @@ namespace Livewire\Commands;
 
 class MakeLivewireCommand extends MakeCommand
 {
-    protected $signature = 'make:livewire {name} {--force}';
+    protected $signature = 'make:livewire {name} {--force} {--stub=default}';
 }

--- a/src/Commands/StubCommand.php
+++ b/src/Commands/StubCommand.php
@@ -4,6 +4,7 @@ namespace Livewire\Commands;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 
 class StubCommand extends Command
 {
@@ -13,13 +14,30 @@ class StubCommand extends Command
 
     public function handle()
     {
-        $this->info('you ran the command');
+        $input = preg_split('/[.]+/', $this->argument('name'));
+        $component = Str::kebab(array_pop($input));
+        $componentClass = Str::studly($component);
+        $this->ensureDirectoryExists('app/Http/Livewire/Stubs');
+        $this->ensureDirectoryExists('resources/views/livewire/stubs');
+        $this->createViewStub($component);
+        $this->createClassStub($componentClass);
+        $this->info('you ran the command with name: ' . $this->argument('name'));
     }
 
     protected function ensureDirectoryExists($path)
     {
-        if (! File::isDirectory(dirname($path))) {
-            File::makeDirectory(dirname($path), 0777, $recursive = true, $force = true);
+        if (! File::isDirectory($path)) {
+            File::makeDirectory($path, 0777, $recursive = true, $force = true);
         }
+    }
+
+    protected function createClassStub($name)
+    {
+        File::put('app/Http/Livewire/Stubs/'.$name.'.stub', file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'Component.stub'));
+    }
+
+    protected function createViewStub($name)
+    {
+        File::put('resources/views/livewire/stubs/'.$name.'.stub', file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'view.stub'));
     }
 }

--- a/src/Commands/StubCommand.php
+++ b/src/Commands/StubCommand.php
@@ -26,7 +26,6 @@ class StubCommand extends Command
         $classCreated = $this->createViewStubIfDoesNotExist();
         $viewCreated = $this->createClassStubIfDoesNotExist();
         if ($classCreated) {
-//            $this->info('Class '.$componentClass.'.stub created');
             $this->line("<options=bold;fg=green>CLASS STUB:</> {$this->parser->relativeClassPath()}");
         }
         if ($viewCreated) {

--- a/src/Commands/StubCommand.php
+++ b/src/Commands/StubCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Livewire\Commands;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Console\Command;
+
+class StubCommand extends Command
+{
+    protected $signature = 'livewire:stub {name}';
+
+    protected $description = 'Create Livewire stubs.';
+
+    public function handle()
+    {
+        $this->info('you ran the command');
+    }
+
+    protected function ensureDirectoryExists($path)
+    {
+        if (! File::isDirectory(dirname($path))) {
+            File::makeDirectory(dirname($path), 0777, $recursive = true, $force = true);
+        }
+    }
+}

--- a/src/Commands/StubCommand.php
+++ b/src/Commands/StubCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 
 class StubCommand extends Command
 {
+
     protected $signature = 'livewire:stub {name}';
 
     protected $description = 'Create Livewire stubs.';
@@ -17,27 +18,50 @@ class StubCommand extends Command
         $input = preg_split('/[.]+/', $this->argument('name'));
         $component = Str::kebab(array_pop($input));
         $componentClass = Str::studly($component);
-        $this->ensureDirectoryExists('app/Http/Livewire/Stubs');
+        $this->ensureDirectoryExists(app_path('Http/Livewire/Stubs'));
         $this->ensureDirectoryExists('resources/views/livewire/stubs');
-        $this->createViewStub($component);
-        $this->createClassStub($componentClass);
-        $this->info('you ran the command with name: ' . $this->argument('name'));
+        $classCreated = $this->createViewStubIfDoesNotExist($component);
+        $viewCreated = $this->createClassStubIfDoesNotExist($componentClass);
+        if ($classCreated) {
+            $this->info('Class '.$componentClass.'.stub created');
+        }
+        if ($viewCreated) {
+            $this->info('View '.$component.'.stub created');
+        }
     }
 
     protected function ensureDirectoryExists($path)
     {
-        if (! File::isDirectory($path)) {
+        if ( !File::isDirectory($path)) {
             File::makeDirectory($path, 0777, $recursive = true, $force = true);
         }
     }
 
-    protected function createClassStub($name)
+    protected function createClassStubIfDoesNotExist($name)
     {
-        File::put('app/Http/Livewire/Stubs/'.$name.'.stub', file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'Component.stub'));
+        if ( !File::exists('app/Http/Livewire/Stubs/'.$name.'.stub')) {
+            File::put('app/Http/Livewire/Stubs/'.$name.'.stub',
+                file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'Component.stub'));
+
+            return true;
+        } else {
+            $this->error('Class stub already exists');
+
+            return false;
+        }
     }
 
-    protected function createViewStub($name)
+    protected function createViewStubIfDoesNotExist($name)
     {
-        File::put('resources/views/livewire/stubs/'.$name.'.stub', file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'view.stub'));
+        if ( !File::exists('resources/views/livewire/stubs/'.$name.'.stub')) {
+            File::put('resources/views/livewire/stubs/'.$name.'.stub',
+                file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'view.stub'));
+
+            return true;
+        } else {
+            $this->error('View stub already exists');
+
+            return false;
+        }
     }
 }

--- a/src/Commands/StubParser.php
+++ b/src/Commands/StubParser.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Livewire\Commands;
+
+use Illuminate\Support\Str;
+
+class StubParser extends ComponentParser
+{
+
+    public function __construct($classNamespace, $viewPath, $rawCommand)
+    {
+        $this->baseClassNamespace = $classNamespace;
+
+        $classPath = static::generatePathFromNamespace($classNamespace);
+
+        $this->baseClassPath = rtrim($classPath, DIRECTORY_SEPARATOR).'/Stubs/';
+        $this->baseViewPath = rtrim($viewPath, DIRECTORY_SEPARATOR).'/stubs/';
+
+        $directories = preg_split('/[.]+/', $rawCommand);
+
+        $this->component = Str::kebab(array_pop($directories));
+        $this->componentClass = Str::studly($this->component);
+
+        $this->directories = array_map([Str::class, 'studly'], $directories);
+    }
+
+    public function classFile()
+    {
+        return $this->componentClass.'.stub';
+    }
+
+    public function viewFile()
+    {
+        return $this->component.'.stub';
+    }
+
+    public function classContents()
+    {
+        return file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'Component.stub');
+    }
+}

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -24,6 +24,7 @@ use Livewire\Commands\MoveCommand;
 use Livewire\Commands\MvCommand;
 use Livewire\Commands\RmCommand;
 use Livewire\Commands\TouchCommand;
+use Livewire\Commands\StubCommand;
 use Livewire\Connection\HttpConnectionHandler;
 use Livewire\Exceptions\BypassViewHandler;
 use Livewire\HydrationMiddleware\ClearFlashMessagesIfNotRedirectingAway;
@@ -147,6 +148,7 @@ class LivewireServiceProvider extends ServiceProvider
                 MvCommand::class,
                 RmCommand::class,
                 TouchCommand::class,
+                StubCommand::class,
             ]);
         }
     }

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -67,11 +67,25 @@ class MakeCommandTest extends TestCase
         Artisan::call('livewire:stub modal');
         File::replace($this->livewireViewsPath('stubs/modal.stub'), '<div>Modal Test</div>');
         File::append($this->livewireClassesPath('Stubs/Modal.stub'), '// comment');
-        Artisan::call('livewire:make foo --stub=modal');
+        Artisan::call('make:livewire foo --stub=modal');
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
         $this->assertContains('// comment', File::get($this->livewireClassesPath('Foo.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
         $this->assertContains('Modal Test', File::get($this->livewireViewsPath('foo.blade.php')));
+    }
+
+    /** @test */
+    public function component_is_created_with_view_and_class_custom_default_stubs()
+    {
+        Artisan::call('livewire:stub default');
+        File::replace($this->livewireViewsPath('stubs/default.stub'), '<div>Default Test</div>');
+        File::append($this->livewireClassesPath('Stubs/Default.stub'), '// comment default');
+        Artisan::call('make:livewire foo');
+
+        $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
+        $this->assertContains('// comment default', File::get($this->livewireClassesPath('Foo.php')));
+        $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
+        $this->assertContains('Default Test', File::get($this->livewireViewsPath('foo.blade.php')));
     }
 }

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -60,4 +60,18 @@ class MakeCommandTest extends TestCase
         $this->assertTrue(File::exists($this->livewireClassesPath('FooBar/FooBar.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('foo-bar/foo-bar.blade.php')));
     }
+
+    /** @test */
+    public function component_is_created_with_view_and_class_stubs()
+    {
+        Artisan::call('livewire:stub modal');
+        File::replace($this->livewireViewsPath('stubs/modal.stub'), '<div>Modal Test</div>');
+        File::append($this->livewireClassesPath('Stubs/Modal.stub'), '// comment');
+        Artisan::call('livewire:make foo --stub=modal');
+
+        $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
+        $this->assertContains('// comment', File::get($this->livewireClassesPath('Foo.php')));
+        $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
+        $this->assertContains('Modal Test', File::get($this->livewireViewsPath('foo.blade.php')));
+    }
 }

--- a/tests/StubCommandTest.php
+++ b/tests/StubCommandTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Artisan;
+
+class StubCommandTest extends TestCase
+{
+    /** @test */
+    public function view_stub_is_created_by_stub_command()
+    {
+        Artisan::call('livewire:stub Pizza');
+
+        $this->assertTrue(File::exists($this->livewireViewStubsPath('pizza.stub')));
+    }
+
+    /** @test */
+    public function class_stub_is_created_by_stub_command()
+    {
+        Artisan::call('livewire:stub Pizza');
+
+        $this->assertTrue(File::exists($this->livewireClassStubsPath('Pizza.stub')));
+    }
+
+    protected function livewireClassStubsPath($path = '')
+    {
+        return app_path('Http/Livewire/Stubs'.($path ? '/'.$path : ''));
+    }
+
+    protected function livewireViewStubsPath($path = '')
+    {
+        return resource_path('views').'/livewire/stubs'.($path ? '/'.$path : '');
+    }
+}


### PR DESCRIPTION
Resolves #355 

### Use Custom Stub in Make Command
Run `php artisan livewire:stub modal`
Customize the views/livewire/stubs/modal.stub and Http/Livewire/Stubs/Modal.stub files
Run `php artisan make:livewire success-model --stub=modal`
See that the customized stubs are used to create this modal

### Customize Default Stubs in Make Command
Run `php artisan livewire:stub default`
Customize the views/livewire/stubs/default.stub and Http/Livewire/Stubs/Default.stub files
Run `php artisan make:livewire success-model`
See that the customized stubs are used to create this modal

### Regression Testing
Run `php artisan make:livewire success-modal`
See that no custom stubs are being used, and the default stubs from the vendor package are used.

I have added a basic test here as well.
