### PR TITLE
$this keyword in blade references the component class

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -92,6 +92,8 @@ abstract class Component
             $errorBag = $errors ?: ($view->errors ?: $this->getErrorBag())
         );
 
+        app('view.engine.resolver')->resolve('blade')->setLivewireComponent($this);
+
         $view
             ->with([
                 'errors' => (new ViewErrorBag)->put('default', $errorBag),

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -109,6 +109,7 @@ class LivewireServiceProvider extends ServiceProvider
         $this->registerRouterMacros();
         $this->registerBladeDirectives();
         $this->registerPublishables();
+        $this->registerViewCompilerEngine();
     }
 
     public function registerHydrationMiddleware()
@@ -219,5 +220,12 @@ class LivewireServiceProvider extends ServiceProvider
         foreach ((array) $groups as $group) {
             $this->publishes($paths, $group);
         }
+    }
+
+    protected function registerViewCompilerEngine()
+    {
+        $this->app->make('view.engine.resolver')->register('blade', function () {
+            return new LivewireViewCompilerEngine($this->app['blade.compiler']);
+        });
     }
 }

--- a/src/LivewireViewCompilerEngine.php
+++ b/src/LivewireViewCompilerEngine.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Livewire;
+
+use Illuminate\View\Engines\CompilerEngine;
+
+class LivewireViewCompilerEngine extends CompilerEngine
+{
+    protected $livewireComponent;
+
+    public function setLivewireComponent($component)
+    {
+        $this->livewireComponent = $component;
+    }
+
+    protected function evaluatePath($__path, $__data)
+    {
+        $obLevel = ob_get_level();
+
+        ob_start();
+
+        // We'll evaluate the contents of the view inside a try/catch block so we can
+        // flush out any stray output that might get out before an error occurs or
+        // an exception is thrown. This prevents any partial views from leaking.
+        try {
+            \Closure::bind(function() use($__path, $__data) {
+                extract($__data, EXTR_SKIP);
+                include $__path;
+            }, $this->livewireComponent ? $this->livewireComponent : $this)();
+        } catch (Exception $e) {
+            $this->handleViewException($e, $obLevel);
+        } catch (Throwable $e) {
+            $this->handleViewException(new FatalThrowableError($e), $obLevel);
+        }
+
+        return ltrim(ob_get_clean());
+    }
+}

--- a/tests/LivewireThisKeywordInBladeTest.php
+++ b/tests/LivewireThisKeywordInBladeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Livewire;
+use Livewire\Component;
+use Illuminate\Support\Facades\Artisan;
+
+class LivewireThisKeywordInBladeTest extends TestCase
+{
+    /** @test */
+    public function this_keyword_will_reference_the_livewire_component_class()
+    {
+        Livewire::test(ComponentForTestingThisKeyword::class)
+            ->assertSee(ComponentForTestingThisKeyword::class);
+    }
+}
+
+class ComponentForTestingThisKeyword extends Component
+{
+    public function render()
+    {
+        return view('this-keyword');
+    }
+}

--- a/tests/views/this-keyword.blade.php
+++ b/tests/views/this-keyword.blade.php
@@ -1,0 +1,3 @@
+<div>
+    {{ get_class($this) }}
+</div>


### PR DESCRIPTION
This PR allows to bind the `$this` php keyword inside of the livewire blade file to the related component class.

Before the PR your template will have somethings like this

```php
class MyComponent
{
    public $selected_ids;
}
```

```php
@if(in_array($id, $selected_ids))
    Do something
@endif
```

After the PR

```php
class MyComponent
{
    private $selected_ids;

    public function isSelected($id)
    {
        return in_array($id, $this->selected_ids);
    }
}
```

```php
@if($this->isSelected($id))
    Do something
@endif
```

This has 2 advantages :

1- Move the logic of checking if the item is selected from your template to the class. In the provided example, it looks simple and that doesn't hurt to have it within the template, but when you work on large components, things can get ugly very fast.

2- The `$selected_ids` is now private (was public before the PR), you don't need to pass every variable to the template because now the work is handled by the method within the class. This will lead to a more readable and clean code. 