### PR TITLE
Fix mount parameter resolving

### DIFF
--- a/src/DependencyResolverTrait.php
+++ b/src/DependencyResolverTrait.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Livewire;
+
+use Illuminate\Support\Arr;
+use ReflectionFunctionAbstract;
+use ReflectionMethod;
+use ReflectionParameter;
+
+trait DependencyResolverTrait
+{
+    /**
+     * Resolve the object method's type-hinted dependencies.
+     *
+     * @param  array  $parameters
+     * @param  object  $instance
+     * @param  string  $method
+     * @return array
+     */
+    protected function resolveClassMethodDependencies(array $parameters, $instance, $method)
+    {
+        if (! method_exists($instance, $method)) {
+            return $parameters;
+        }
+
+        return $this->resolveMethodDependencies(
+            $parameters, new ReflectionMethod($instance, $method)
+        );
+    }
+
+    /**
+     * Resolve the given method's type-hinted dependencies.
+     *
+     * @param  array  $parameters
+     * @param  \ReflectionFunctionAbstract  $reflector
+     * @return array
+     */
+    public function resolveMethodDependencies(array $parameters, ReflectionFunctionAbstract $reflector)
+    {
+        $instanceCount = 0;
+
+        $values = array_values($parameters);
+
+        foreach ($reflector->getParameters() as $key => $parameter) {
+            $instance = $this->transformDependency(
+                $parameter, $parameters
+            );
+
+            if (! is_null($instance)) {
+                $instanceCount++;
+
+                $this->spliceIntoParameters($parameters, $key, $instance);
+            } elseif (! array_key_exists($key - $instanceCount, $values) &&
+                      $parameter->isDefaultValueAvailable()) {
+                $this->spliceIntoParameters($parameters, $key, $parameter->getDefaultValue());
+            }
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * Attempt to transform the given parameter into a class instance.
+     *
+     * @param  \ReflectionParameter  $parameter
+     * @param  array  $parameters
+     * @return mixed
+     */
+    protected function transformDependency(ReflectionParameter $parameter, $parameters)
+    {
+        $class = $parameter->getClass();
+
+        // If the parameter has a type-hinted class, we will check to see if it is already in
+        // the list of parameters. If it is we will just skip it as it is probably a model
+        // binding and we do not want to mess with those; otherwise, we resolve it here.
+        if ($class && ! $this->alreadyInParameters($class->name, $parameters)) {
+            return $parameter->isDefaultValueAvailable()
+                ? $parameter->getDefaultValue()
+                : $this->container->make($class->name);
+        }
+    }
+
+    /**
+     * Determine if an object of the given class is in a list of parameters.
+     *
+     * @param  string  $class
+     * @param  array  $parameters
+     * @return bool
+     */
+    protected function alreadyInParameters($class, array $parameters)
+    {
+        return ! is_null(Arr::first($parameters, function ($value) use ($class) {
+            return $value instanceof $class;
+        }));
+    }
+
+    /**
+     * Splice the given value into the parameter list.
+     *
+     * @param  array  $parameters
+     * @param  string  $offset
+     * @param  mixed  $value
+     * @return void
+     */
+    protected function spliceIntoParameters(array &$parameters, $offset, $value)
+    {
+        array_splice(
+            $parameters, $offset, 0, [$value]
+        );
+    }
+}

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -3,7 +3,6 @@
 namespace Livewire;
 
 use Exception;
-use Illuminate\Routing\RouteDependencyResolverTrait;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use Livewire\Exceptions\ComponentNotFoundException;
@@ -12,7 +11,7 @@ use Livewire\Testing\TestableLivewire;
 
 class LivewireManager
 {
-    use RouteDependencyResolverTrait;
+    use DependencyResolverTrait;
 
     protected $prefix = 'wire';
     protected $componentAliases = [];

--- a/tests/MountComponentTest.php
+++ b/tests/MountComponentTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Component;
+use Livewire\LivewireManager;
+
+class MountComponentTest extends TestCase
+{
+    /** @test */
+    public function it_resolves_the_mount_parameters()
+    {
+        $component = app(LivewireManager::class)->test(ComponentWithOptionalParameters::class);
+        $this->assertSame(null, $component->foo);
+        $this->assertSame([], $component->bar);
+
+        $component = app(LivewireManager::class)->test(ComponentWithOptionalParameters::class, 'caleb');
+        $this->assertSame('caleb', $component->foo);
+        $this->assertSame([], $component->bar);
+
+        $component = app(LivewireManager::class)->test(ComponentWithOptionalParameters::class, null, 'porzio');
+        $this->assertSame(null, $component->foo);
+        $this->assertSame('porzio', $component->bar);
+
+        $component = app(LivewireManager::class)->test(ComponentWithOptionalParameters::class, 'caleb', 'porzio');
+        $this->assertSame('caleb', $component->foo);
+        $this->assertSame('porzio', $component->bar);
+
+        $component = app(LivewireManager::class)->test(ComponentWithOptionalParameters::class, null, null);
+        $this->assertSame(null, $component->foo);
+        $this->assertSame(null, $component->bar);
+    }
+}
+
+class ComponentWithOptionalParameters extends Component
+{
+    public $foo;
+    public $bar;
+
+    public function mount($foo = null, $bar = [])
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+    }
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
This fixes the resolving of the parameters of the component mount method, when passing null values.
For more details please check this issue https://github.com/livewire/livewire/issues/372

So the change that i made on the trait copied from laravel is using `array_key_exists()` instead of `isset()` to avoid returning false for null values