### PR TITLE
add fill method for public properties

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -120,4 +120,15 @@ trait InteractsWithProperties
             ->pluck('name')
             ->search($propertyName) !== false;
     }
+
+    public function fill($values): void
+    {
+        $publicProperties = array_keys($this->getPublicPropertiesDefinedBySubClass());
+
+        foreach ($values as $key => $value) {
+            if (in_array($key, $publicProperties)) {
+                $this->{$key} = $value;
+            }
+        }
+    }
 }

--- a/tests/ComponentCanBeFilled.php
+++ b/tests/ComponentCanBeFilled.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Component;
+use Livewire\LivewireManager;
+
+class ComponentCanBeFilled extends TestCase
+{
+    /** @test */
+    public function can_fill_from_an_array()
+    {
+        $component = app(LivewireManager::class)->test(ComponentWithFillableProperties::class);
+
+        $component->assertSee('public');
+        $component->assertSee('protected');
+        $component->assertSee('private');
+
+        $component->fill([
+            'publicProperty' => 'Caleb',
+            'protectedProperty' => 'Caleb',
+            'privateProperty' => 'Caleb',
+        ]);
+
+        $component->assertSee('Caleb');
+        $component->assertSee('protected');
+        $component->assertSee('private');
+    }
+
+    /** @test */
+    public function can_fill_from_an_object()
+    {
+        $component = app(LivewireManager::class)->test(ComponentWithFillableProperties::class);
+
+        $component->assertSee('public');
+        $component->assertSee('protected');
+        $component->assertSee('private');
+
+        $component->fill(new User());
+
+        $component->assertSee('Caleb');
+        $component->assertSee('protected');
+        $component->assertSee('private');
+    }
+}
+
+class User {
+    public $publicProperty = 'Caleb';
+    public $protectedProperty = 'Caleb';
+    public $privateProperty = 'Caleb';
+}
+
+class ComponentWithFillableProperties extends Component
+{
+    public $publicProperty = 'public';
+    protected $protectedProperty = 'protected';
+    private $privateProperty = 'private';
+
+    public function render()
+    {
+        return view('fillable-view', [
+            'publicProperty' => $this->publicProperty,
+            'protectedProperty' => $this->protectedProperty,
+            'privateProperty' => $this->privateProperty,
+        ]);
+    }
+}

--- a/tests/views/fillable-view.blade.php
+++ b/tests/views/fillable-view.blade.php
@@ -1,0 +1,5 @@
+<div>
+    {{ $publicProperty }}
+    {{ $protectedProperty }}
+    {{ $privateProperty }}
+</div>


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Probably. No.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
If you have a component that is a large form with a lot of fields that need to be pre-filled (when for example editing a model) it can be helpful to have a method to quickly fill the public properties of the component with values that are present on the model.

The fill method works with arrays and objects so it doesn't really matter what is passed in as long as the keys in those match the names of public properties on the component.

5️⃣ Thanks for contributing! 🙌
