### PR TITLE
remove render from base class checks

### DIFF
--- a/src/Concerns/HandlesActions.php
+++ b/src/Concerns/HandlesActions.php
@@ -85,6 +85,11 @@ trait HandlesActions
     {
         return collect((new \ReflectionClass($this))->getMethods(\ReflectionMethod::IS_PUBLIC))
             ->reject(function ($method) {
+                // The "render" method is a special case. This method might be called by event listeners or other ways.
+                if ($method === 'render') {
+                    return false;
+                }
+
                 return $method->class === self::class;
             })
             ->pluck('name')


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes. No but fixes https://github.com/livewire/livewire/issues/393.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
No. Wasn't sure how to best test this without a mock to assert a method call.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
Excludes the `render` method from the base class checks as it is an exception to how the rest of the methods work and are used. If `render` is omitted it will be called by the method on the abstract that is extended which means that if you don't define it in your own class it will result in an error if an even listener tries to call it because it only exists on the abstract but not on your component itself.

5️⃣ Thanks for contributing! 🙌
