### PR TITLE
avoid property name conflicts in tests

### DIFF
--- a/src/Testing/Concerns/MakesCallsToComponent.php
+++ b/src/Testing/Concerns/MakesCallsToComponent.php
@@ -64,7 +64,7 @@ trait MakesCallsToComponent
 
         $result = $handler->handle([
             'id' => $this->id,
-            'name' => $this->name,
+            'name' => $this->componentName,
             'data' => $this->data,
             'children' => $this->children,
             'checksum' => $this->checksum,

--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -7,7 +7,7 @@ use Livewire\Livewire;
 
 class TestableLivewire
 {
-    public $name;
+    public $componentName;
     public $id;
     public $children;
     public $checksum;
@@ -36,7 +36,7 @@ class TestableLivewire
             app('livewire')->component($name = Str::random(20), $componentClass);
         }
 
-        $result = app('livewire')->mount($this->name = $name, ...$params);
+        $result = app('livewire')->mount($this->componentName = $name, ...$params);
 
         $this->initialUpdateComponent($result);
     }
@@ -72,7 +72,7 @@ class TestableLivewire
 
     public function instance()
     {
-        return Livewire::activate($this->name, $this->id);
+        return Livewire::activate($this->componentName, $this->id);
     }
 
     public function get($property)

--- a/tests/ComponentHasNameAsPublicPropertyTest.php
+++ b/tests/ComponentHasNameAsPublicPropertyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Component;
+use Livewire\LivewireManager;
+
+class ComponentHasNameAsPublicPropertyTest extends TestCase
+{
+    /** @test */
+    public function public_id_property_is_set()
+    {
+        $component = app(LivewireManager::class)->test(ComponentWithNameProperty::class);
+
+        $component->set('name', 'Caleb');
+
+        $this->assertEquals($component->name, 'Caleb');
+    }
+}
+
+class ComponentWithNameProperty extends Component
+{
+    public $name;
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}

--- a/tests/ComponentsAreSecureTest.php
+++ b/tests/ComponentsAreSecureTest.php
@@ -91,7 +91,7 @@ class ComponentsAreSecureTest extends TestCase
         $component = app('livewire')->test('safe');
 
         // Hijack the "safe" component, with "unsafe"
-        $component->name = 'unsafe';
+        $component->componentName = 'unsafe';
 
         // If the hijack was stopped, the expected exception will be thrown.
         // If it worked the, an execption will be thrown that will fail the test.

--- a/tests/RequestManipulatingMiddlewareAreDisabledForLivewireRequestsTest.php
+++ b/tests/RequestManipulatingMiddlewareAreDisabledForLivewireRequestsTest.php
@@ -17,9 +17,9 @@ class RequestManipulatingMiddlewareAreDisabledForLivewireRequestsTest extends Te
 
         $component = app(LivewireManager::class)->test(ComponentWithStringPropertiesStub::class);
 
-        $this->withHeader('X-Livewire', 'true')->post("/livewire/message/{$component->name}", [
+        $this->withHeader('X-Livewire', 'true')->post("/livewire/message/{$component->componentName}", [
             'actionQueue' => [],
-            'name' => $component->name,
+            'name' => $component->componentName,
             'children' => $component->children,
             'data' => $component->data,
             'id' => $component->id,
@@ -42,9 +42,9 @@ class RequestManipulatingMiddlewareAreDisabledForLivewireRequestsTest extends Te
 
         $component = app(LivewireManager::class)->test(ComponentWithStringPropertiesStub::class);
 
-        $this->post("/livewire/message/{$component->name}", [
+        $this->post("/livewire/message/{$component->componentName}", [
             'actionQueue' => [],
-            'name' => $component->name,
+            'name' => $component->componentName,
             'children' => $component->children,
             'data' => $component->data,
             'id' => $component->id,


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes. Fixes https://github.com/livewire/livewire/issues/381.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
Prefixes the randomly generated `name` property with `component` to avoid naming conflicts and false results in tests.

5️⃣ Thanks for contributing! 🙌