### PR TITLE
fix NonPublicComponentMethodCall in ComponentCanBeFilledTest

### DIFF
--- a/tests/ComponentCanBeFilledTest.php
+++ b/tests/ComponentCanBeFilledTest.php
@@ -16,11 +16,7 @@ class ComponentCanBeFilledTest extends TestCase
         $component->assertSee('protected');
         $component->assertSee('private');
 
-        $component->fill([
-            'publicProperty' => 'Caleb',
-            'protectedProperty' => 'Caleb',
-            'privateProperty' => 'Caleb',
-        ]);
+        $component->fillFromArray();
 
         $component->assertSee('Caleb');
         $component->assertSee('protected');
@@ -36,7 +32,7 @@ class ComponentCanBeFilledTest extends TestCase
         $component->assertSee('protected');
         $component->assertSee('private');
 
-        $component->fill(new User());
+        $component->fillFromObject();
 
         $component->assertSee('Caleb');
         $component->assertSee('protected');
@@ -55,6 +51,20 @@ class ComponentWithFillableProperties extends Component
     public $publicProperty = 'public';
     protected $protectedProperty = 'protected';
     private $privateProperty = 'private';
+
+    public function fillFromArray()
+    {
+        $this->fill([
+            'publicProperty' => 'Caleb',
+            'protectedProperty' => 'Caleb',
+            'privateProperty' => 'Caleb',
+        ]);
+    }
+
+    public function fillFromObject()
+    {
+        $this->fill(new User());
+    }
 
     public function render()
     {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes. No.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
A small last minute change in https://github.com/livewire/livewire/commit/fc7ff476b7d29c450fadcb00cc5d443e3e65fd22 caused `NonPublicComponentMethodCall` to be thrown. To fix this the `fill` method is now called inside the component with some helpers for testing.

5️⃣ Thanks for contributing! 🙌
