### PR TITLE
Fix Echo check inside getSocketId

### DIFF
--- a/src/js/connection/drivers/http.js
+++ b/src/js/connection/drivers/http.js
@@ -63,7 +63,7 @@ export default {
     },
 
     getSocketId() {
-        if(Echo) {
+        if (typeof Echo !== 'undefined') {
             return Echo.socketId();
         }
     },


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes, bugfix

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
No

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
Right now and after the merge of #365 when interacting with anything that uses wire:model (at least in my case) this error would show up
```
livewire.js?id=b84d3195e21b1d164dd0:3210 Uncaught ReferenceError: Echo is not defined
    at Object.getSocketId (livewire.js?id=b84d3195e21b1d164dd0:3210)
    at Object.sendMessage (livewire.js?id=b84d3195e21b1d164dd0:3165)
    at Connection.sendMessage (livewire.js?id=b84d3195e21b1d164dd0:3338)
    at Component.fireMessage (livewire.js?id=b84d3195e21b1d164dd0:1846)
    at later (livewire.js?id=b84d3195e21b1d164dd0:5611)
```

This PR fixes that.
5️⃣ Thanks for contributing! 🙌
