### PR TITLE
support eloquent models for the fill method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "require": {
+        "illuminate/database": "^5.6|^6.0",
         "illuminate/support": "^5.6|^6.0",
         "illuminate/validation": "^5.6|^6.0"
     },

--- a/src/ComponentConcerns/InteractsWithProperties.php
+++ b/src/ComponentConcerns/InteractsWithProperties.php
@@ -2,8 +2,9 @@
 
 namespace Livewire\ComponentConcerns;
 
-use Illuminate\Support\Str;
 use Livewire\DataCaster;
+use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Exceptions\ProtectedPropertyBindingException;
 
 trait InteractsWithProperties
@@ -124,6 +125,10 @@ trait InteractsWithProperties
     public function fill($values)
     {
         $publicProperties = array_keys($this->getPublicPropertiesDefinedBySubClass());
+
+        if ($values instanceof Model) {
+            $values = $values->toArray();
+        }
 
         foreach ($values as $key => $value) {
             if (in_array($key, $publicProperties)) {

--- a/tests/ComponentCanBeFilledTest.php
+++ b/tests/ComponentCanBeFilledTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Livewire\Component;
 use Livewire\LivewireManager;
+use Illuminate\Database\Eloquent\Model;
 
 class ComponentCanBeFilledTest extends TestCase
 {
@@ -42,12 +43,48 @@ class ComponentCanBeFilledTest extends TestCase
         $component->assertSee('protected');
         $component->assertSee('private');
     }
+
+    /** @test */
+    public function can_fill_from_an_eloquent_model()
+    {
+        $component = app(LivewireManager::class)->test(ComponentWithFillableProperties::class);
+
+        $component->assertSee('public');
+        $component->assertSee('protected');
+        $component->assertSee('private');
+
+        $component->call('callFill', new UserModel());
+
+        $component->assertSee('Caleb');
+        $component->assertSee('protected');
+        $component->assertSee('private');
+    }
 }
 
 class User {
     public $publicProperty = 'Caleb';
     public $protectedProperty = 'Caleb';
     public $privateProperty = 'Caleb';
+}
+
+class UserModel extends Model {
+    public $appends = [
+        'publicProperty',
+        'protectedProperty',
+        'privateProperty'
+    ];
+
+    public function getPublicPropertyAttribute() {
+        return 'Caleb';
+    }
+
+    public function getProtectedPropertyAttribute() {
+        return 'protected';
+    }
+
+    public function getPrivatePropertyAttribute() {
+        return 'private';
+    }
 }
 
 class ComponentWithFillableProperties extends Component


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes. No but there is an open issue https://github.com/livewire/livewire/issues/409.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
Support filling of the component from eloquent models by calling `toArray` and setting the array as values to be used.

I'll work on another PR after this has been merged to fix the `[id, name, data]` issue mentioned in https://github.com/livewire/livewire/issues/409. Somehow I remember that this had already been fixed months ago @calebporzio, am I remembering wrong or is it a regression? At least the ID used to work in an older Livewire project I have.

5️⃣ Thanks for contributing! 🙌
