### PR TITLE
Resolve ComponentNotFoundException when Manifest is Out of Date

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -2,7 +2,6 @@
 
 namespace Livewire;
 
-use Exception;
 use Illuminate\Support\Str;
 use Illuminate\Support\Fluent;
 use Livewire\Testing\TestableLivewire;
@@ -59,6 +58,13 @@ class LivewireManager
             $this->componentAliases[$alias] ?? $finder->find($alias)
         );
 
+        if(!$class) {
+            $finder->build();
+            $class = $class ?: (
+                $this->componentAliases[$alias] ?? $finder->find($alias)
+            );
+        }
+
         throw_unless($class, new ComponentNotFoundException(
             "Unable to find component: [{$alias}]"
         ));
@@ -70,7 +76,12 @@ class LivewireManager
     {
         $componentClass = $this->getComponentClass($component);
 
-        throw_unless(class_exists($componentClass), new Exception(
+        if(!class_exists($componentClass)) {
+            app(LivewireComponentsFinder::class)->build();
+            $componentClass = $this->getComponentClass($component);
+        }
+
+        throw_unless(class_exists($componentClass), new ComponentNotFoundException(
             "Component [{$component}] class not found: [{$componentClass}]"
         ));
 

--- a/tests/DiscoverCommandTest.php
+++ b/tests/DiscoverCommandTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Artisan;
 class DiscoverCommandTest extends TestCase
 {
     /** @test */
-    public function components_that_are_created_manually_can_be_added_to_the_manifest()
+    public function components_that_are_created_manually_are_automatically_added_to_the_manifest()
     {
         // Make the class & view directories, because otherwise, the manifest file cannot be created.
         File::makeDirectory($this->livewireClassesPath());
@@ -40,16 +40,7 @@ EOT
 EOT
         );
 
-        // We will get an error when trying to find it because the manifest is stale.
-        try {
-            view('render-component', [
-                'component' => 'to-be-discovered',
-            ])->render();
-        } catch (\Exception $e) {
-            $this->assertStringContainsString('Unable to find component: [to-be-discovered]', $e->getMessage());
-        }
-
-        Artisan::call('livewire:discover');
+        // We will not get an error because we will regenerate the manifest for the user automatically
 
         $output = view('render-component', [
             'component' => 'to-be-discovered',


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes. There are open issues that this will solve: #389 #165 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
There was an existing test that required a manual command to rebuild the manifest. I changed that one to remove the command to rebuild it, and verified that it is rebuilt automatically with no user input necessary.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
There are many instances where the manifest can become out of date and throw an exception. Before any exception is thrown, I am rebuilding the manifest and double checking to see if the component can be found in the updated manifest.

I also saw a generic exception might be thrown for a component not found, and I changed it to the more specific exception class.

5️⃣ Thanks for contributing! 🙌
