### PR TITLE
fix file download redirect: issue 483

### DIFF
--- a/src/js/Component/index.js
+++ b/src/js/Component/index.js
@@ -156,8 +156,6 @@ export default class Component {
         // This means "$this->redirect()" was called in the component. let's just bail and redirect.
         if (response.redirectTo) {
             this.redirect(response.redirectTo)
-
-            return
         }
 
         store.callHook('responseReceived', this, response)


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes https://github.com/livewire/livewire/issues/483

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
I don't know if this can be tested and I didn't go through the tests, but I did check if not `return`ing after a redirect to a file download will let the rest of the code to be executed, and I think this will fix the problem. That line seems redundant anyway. Isn't it?

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
Currently livewire's `handleResponse` `return`s after redirecting if `redirectTo` is set, which is unnecessary if there's an actual url change AND breaks the page if there isn't (eg. in case the redirect url is just a file to be downloaded). By getting rid of the `return` we keep the current functionality and fix the problem.

5️⃣ Thanks for contributing! 🙌
