### PR TITLE
Fix typo "Eloquen" to "Eloquent" in exception name

### DIFF
--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -3,7 +3,7 @@
 namespace Livewire\ComponentConcerns;
 
 use Illuminate\Support\Str;
-use Livewire\Exceptions\CannotBindDataToEloquenModelException;
+use Livewire\Exceptions\CannotBindDataToEloquentModelException;
 use Livewire\Exceptions\MissingComponentMethodReferencedByAction;
 use Livewire\Exceptions\NonPublicComponentMethodCall;
 use Livewire\Exceptions\ProtectedPropertyBindingException;
@@ -21,7 +21,7 @@ trait HandlesActions
     {
         $propertyName = $this->beforeFirstDot($name);
 
-        throw_if(in_array($propertyName, $this->lockedModelProperties), new CannotBindDataToEloquenModelException($name));
+        throw_if(in_array($propertyName, $this->lockedModelProperties), new CannotBindDataToEloquentModelException($name));
 
         $this->callBeforeAndAferSyncHooks($name, $value, function ($name, $value) use ($propertyName) {
             // @todo: this is fired even if a property isn't present at all which is confusing.

--- a/src/Exceptions/CannotBindDataToEloquentModelException.php
+++ b/src/Exceptions/CannotBindDataToEloquentModelException.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Exceptions;
 
-class CannotBindDataToEloquenModelException extends \Exception
+class CannotBindDataToEloquentModelException extends \Exception
 {
     use BypassViewHandler;
 


### PR DESCRIPTION
Just a small typo fix in a class name to add the "t" to "Eloquent"