### PR TITLE
Make public properties available to view again

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -96,13 +96,10 @@ abstract class Component
             $errorBag = $errors ?: ($view->errors ?: $this->getErrorBag())
         );
 
-        $uses = array_flip(class_uses_recursive(static::class));
-        $shouldPassPublicPropertiesToView = isset($uses[PassPublicPropertiesToView::class]);
-
         $view->with([
             'errors' => (new ViewErrorBag)->put('default', $errorBag),
             '_instance' => $this,
-        ] + ($shouldPassPublicPropertiesToView ? $this->getPublicPropertiesDefinedBySubClass() : []));
+        ] + $this->getPublicPropertiesDefinedBySubClass());
 
         $output = $view->render();
 

--- a/tests/PublicPropertiesAreAvailableInTheViewTest.php
+++ b/tests/PublicPropertiesAreAvailableInTheViewTest.php
@@ -13,7 +13,7 @@ class PublicPropertiesAreAvailableInTheViewTest extends TestCase
     /** @test */
     public function public_property_is_accessible_in_view_via_this()
     {
-        $component = app(LivewireManager::class)->test(PublicPropertiesInViewStub::class);
+        $component = app(LivewireManager::class)->test(PublicPropertiesInViewWithThisStub::class);
 
         $this->assertTrue(Str::contains(
             $component->payload['dom'],
@@ -22,31 +22,14 @@ class PublicPropertiesAreAvailableInTheViewTest extends TestCase
     }
 
     /** @test */
-    public function public_properties_are_not_accessible_in_view_without_this_by_default()
-    {
-        $this->expectException(ErrorException::class);
-
-        $component = app(LivewireManager::class)->test(PublicPropertiesInViewWithoutThisAndWithoutTraitStub::class);
-
-        $this->assertTrue(Str::contains(
-            $component->payload['dom'],
-            'Caleb'
-        ));
-    }
-
-    /** @test */
-    public function public_property_is_accessible_in_view()
+    public function public_properties_are_accessible_in_view_without_this()
     {
         $component = app(LivewireManager::class)->test(PublicPropertiesInViewWithoutThisStub::class);
-
-        $this->assertTrue(Str::contains(
-            $component->payload['dom'],
-            'Caleb'
-        ));
+        $component->assertSee('Caleb');
     }
 }
 
-class PublicPropertiesInViewStub extends Component
+class PublicPropertiesInViewWithThisStub extends Component
 {
     public $name = 'Caleb';
 
@@ -56,20 +39,8 @@ class PublicPropertiesInViewStub extends Component
     }
 }
 
-class PublicPropertiesInViewWithoutThisAndWithoutTraitStub extends Component
-{
-    public $name = 'Caleb';
-
-    public function render()
-    {
-        return app('view')->make('show-name');
-    }
-}
-
 class PublicPropertiesInViewWithoutThisStub extends Component
 {
-    use PassPublicPropertiesToView;
-
     public $name = 'Caleb';
 
     public function render()

--- a/tests/PublicPropertiesAreAvailableInTheViewTest.php
+++ b/tests/PublicPropertiesAreAvailableInTheViewTest.php
@@ -2,30 +2,23 @@
 
 namespace Tests;
 
-use ErrorException;
-use Illuminate\Support\Str;
 use Livewire\Component;
-use Livewire\LivewireManager;
-use Livewire\PassPublicPropertiesToView;
+use Livewire\Livewire;
 
 class PublicPropertiesAreAvailableInTheViewTest extends TestCase
 {
     /** @test */
     public function public_property_is_accessible_in_view_via_this()
     {
-        $component = app(LivewireManager::class)->test(PublicPropertiesInViewWithThisStub::class);
-
-        $this->assertTrue(Str::contains(
-            $component->payload['dom'],
-            'Caleb'
-        ));
+        Livewire::test(PublicPropertiesInViewWithThisStub::class)
+            ->assertSee('Caleb');
     }
 
     /** @test */
     public function public_properties_are_accessible_in_view_without_this()
     {
-        $component = app(LivewireManager::class)->test(PublicPropertiesInViewWithoutThisStub::class);
-        $component->assertSee('Caleb');
+        Livewire::test(PublicPropertiesInViewWithoutThisStub::class)
+            ->assertSee('Caleb');
     }
 }
 


### PR DESCRIPTION
Now that we aren't using computed properties as heavily, we can go back to passing public properties into the view automatically.