### PR TITLE
Support published assets on Laravel Vapor

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -207,7 +207,10 @@ HTML;
         if (file_exists(public_path('vendor/livewire'))) {
             $publishedManifest = json_decode(file_get_contents(public_path('vendor/livewire/mix-manifest.json')), true);
             $versionedFileName = $publishedManifest[$jsFileName];
-            $fullAssetPath = "{$appUrl}/vendor/livewire{$versionedFileName}";
+
+            $isHostedOnVapor = ($_ENV['SERVER_SOFTWARE'] ?? null) === 'vapor';
+
+            $fullAssetPath = ($isHostedOnVapor ? config('app.asset_url') : $appUrl).'/vendor/livewire'.$versionedFileName;
 
             if ($manifest !== $publishedManifest) {
                 $assetWarning = <<<'HTML'


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?

Sure is - https://github.com/livewire/livewire/pull/385 and https://github.com/livewire/livewire/pull/385#issuecomment-566725885

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

I would never!

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)

The dog ate my ~~homework~~ tests. However, I did manually test it on Vapor - works like a charm with zero-config.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

Currently, published Livewire assets cannot be used on Vapor because the app url and asset url are not the same (assets are hosted on a CDN). This PR sets the correct published asset path for apps hosted on Vapor by auto-detecting the environment.

![Screen Shot 2020-01-14 at 5 14 26 pm](https://user-images.githubusercontent.com/5051286/72318856-900cd600-36f1-11ea-9603-408a35bcf532.png) 

5️⃣ Thanks for contributing! 🙌

And thank you for hosting some comedy podcast that sometimes talks about programming and "tea drinking" 👀