### PR TITLE
Stop creation of livewire class and view if name is not allowed / reserved

### DIFF
--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -19,7 +19,9 @@ class MakeCommand extends FileManipulationCommand
             $this->option('stub')
         );
 
-        if(!$this->ensureClassNameIsNotReserved()) {
+        if($this->isReservedClassName($name = $this->parser->className())) {
+            $this->line("<options=bold,reverse;fg=red> WHOOPS! </> 😳 \n");
+            $this->line("<fg=red;options=bold>Class is reserved:</> {$name}");
             return;
         }
 
@@ -76,17 +78,8 @@ class MakeCommand extends FileManipulationCommand
         return $viewPath;
     }
 
-    public function ensureClassNameIsNotReserved()
+    public function isReservedClassName($name)
     {
-        $reservedClasses = collect(['Parent', 'Component', 'Interface']);
-
-        if($reservedClasses->contains($this->parser->className())) {
-            $this->line("<options=bold,reverse;fg=red> WHOOPS-IE-TOOTLES </> 😳 \n");
-            $this->line("<fg=red;options=bold>Class is reserved:</> {$this->parser->className()}");
-
-            return false;
-        }
-
-        return true;
+        return array_search($name, ['Parent', 'Component', 'Interface']) !== false;
     }
 }

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -19,6 +19,10 @@ class MakeCommand extends FileManipulationCommand
             $this->option('stub')
         );
 
+        if(!$this->ensureClassNameIsNotReserved()) {
+            return;
+        }
+
         $force = $this->option('force');
 
         $showWelcomeMessage = $this->isFirstTimeMakingAComponent();
@@ -70,5 +74,19 @@ class MakeCommand extends FileManipulationCommand
         File::put($viewPath, $this->parser->viewContents());
 
         return $viewPath;
+    }
+
+    public function ensureClassNameIsNotReserved()
+    {
+        $reservedClasses = collect(['Parent', 'Component', 'Interface']);
+
+        if($reservedClasses->contains($this->parser->className())) {
+            $this->line("<options=bold,reverse;fg=red> WHOOPS-IE-TOOTLES </> 😳 \n");
+            $this->line("<fg=red;options=bold>Class is reserved:</> {$this->parser->className()}");
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -75,4 +75,13 @@ class MakeCommandTest extends TestCase
         );
         $this->assertTrue(File::exists(resource_path('views/not-livewire/foo.blade.php')));
     }
+
+    /** @test */
+    public function a_component_is_not_created_with_a_reserved_class_name()
+    {
+        Artisan::call('make:livewire component');
+
+        $this->assertFalse(File::exists($this->livewireClassesPath('Component.php')));
+        $this->assertFalse(File::exists($this->livewireViewsPath('component.blade.php')));
+    }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
When you try to make a component with a reserved name, everything blows up. I think it's needed but there's no issue.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope, this is self contained.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
When you make:livewire parent or make:livewire component the classes are created and everything breaks. I have added a check to make sure those classes cannot be created. If there is a definitive list of what class names are reserved, it would be great to use that. Right now I've just captured three I've seen (Parent, Component, Interface)

5️⃣ Thanks for contributing! 🙌
👍 