### PR TITLE
Laravel 7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.2, 7.3, 7.4]
-        laravel: [5.6.*, 5.7.*, 5.8.*, 6.*]
+        laravel: [5.6.*, 5.7.*, 5.8.*, 6.*, 7.*]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}(${{ matrix.dependency-version }})

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         }
     ],
     "require": {
-        "illuminate/database": "^5.6|^6.0",
-        "illuminate/support": "^5.6|^6.0",
-        "illuminate/validation": "^5.6|^6.0",
+        "illuminate/database": "^5.6|^6.0|^7.0",
+        "illuminate/support": "^5.6|^6.0|^7.0",
+        "illuminate/validation": "^5.6|^6.0|^7.0",
         "symfony/http-kernel": "^4.0|^5.0"
     },
     "extra": {
@@ -37,8 +37,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.3",
-        "laravel/framework": "^5.6|^6.0",
-        "orchestra/testbench": "~4.0",
+        "laravel/framework": "^5.6|^6.0|^7.0",
+        "orchestra/testbench": "^4.0|^5.0",
         "psy/psysh": "@stable"
     }
 }


### PR DESCRIPTION
This contains the bare minimum to get Livewire installed for Laravel 7. This was we can already start testing out Livewire for the upcoming Laravel 7 release. Tests seem to be passing. I don't know of any breaking changes by hand that could affect Livewire. I'll try it out on the Eventy codebase once this is merged and see if I stumble upon anything.