### PR TITLE
Update npm scripts for rollup build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2719,6 +2719,17 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4969,6 +4980,15 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6755,6 +6775,12 @@
           "dev": true
         }
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cross-spawn": "^6.0.5",
     "dom-testing-library": "^3.19.4",
     "false": "^0.0.4",
+    "fs-extra": "^8.1.0",
     "get-value": "^3.0.1",
     "jest": "^24.9.0",
     "jest-dom": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,8 @@
   "scripts": {
     "test": "jest",
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
-    "unminified": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "minified": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch": "npm run unminified -- --watch",
-    "build": "npm run unminified && npm run minified"
+    "watch": "npx rollup -c -w",
+    "build": "npx rollup -c"
   },
   "author": "Caleb Porzio",
   "license": "MIT",


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?

Semi-related to #541

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

- Fix missing rollup npm dependency (`fs-extra`)
- Update npm scripts for rollup build

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)

No

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

You may've already gotten around to this (and not yet pushed it), but if not `npm run build` and `npm run watch` now work for the rollup config.

5️⃣ Thanks for contributing! 🙌
