### PR TITLE
fix error assertion check on undefined index

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Testing\Concerns;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\MessageBag;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -100,7 +101,7 @@ trait MakesAssertions
             if (is_int($key)) {
                 PHPUnit::assertTrue($errors->has($value), "Component missing error: $value");
             } else {
-                $rules = array_keys($this->lastValidator->failed()[$key]);
+                $rules = array_keys(Arr::get($this->lastValidator->failed(), $key, []));
                 $lowerCaseRules = array_map('strtolower', $rules);
 
                 foreach ((array) $value as $rule) {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes. No.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
No.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

Take the following code where `token` will not be present in the errors. You will receive an error saying `ErrorException: Undefined index: token` instead of the expected `Component has no [required] errors for [token] attribute. Failed asserting that an array contains 'required'.` from PHPUnit.

```php
/** @test */
public function fails_to_store(): void
{
    Livewire::test(Component::class)
        ->set('name', 'John Doe')
        ->call('store')
        ->assertHasErrors([
            'name'  => 'required',
            'token' => 'required',
        ]);
}
```

The tests will fail but only because of the way an undefined index tried to be accessed instead of an actual code error in your component.

5️⃣ Thanks for contributing! 🙌
