### PR TITLE
Change to use `component` rather than `yo`

### DIFF
--- a/src/js/component/SupportVueJs.js
+++ b/src/js/component/SupportVueJs.js
@@ -10,7 +10,7 @@ export default function () {
 
         new window.Vue().$mount(div.firstElementChild)
 
-        yo.html = div.firstElementChild.outerHTML
+        component.html = div.firstElementChild.outerHTML
     })
 
     store.registerHook('elementInitialized', el => {


### PR DESCRIPTION
This threw a error since `yo` is undefined. Looking at the blame the first argument in this was function was previously named `yo`.