### PR TITLE
Move to key value pairs for component parameters

### DIFF
--- a/src/DependencyResolverTrait.php
+++ b/src/DependencyResolverTrait.php
@@ -2,11 +2,10 @@
 
 namespace Livewire;
 
-use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Support\Arr;
-use ReflectionFunctionAbstract;
 use ReflectionMethod;
 use ReflectionParameter;
+use ReflectionFunctionAbstract;
+use Illuminate\Contracts\Container\BindingResolutionException;
 
 trait DependencyResolverTrait
 {
@@ -80,56 +79,5 @@ trait DependencyResolverTrait
 
             throw $e;
         }
-    }
-
-    public function hey($parameters, $reflector) {
-        $instanceCount = 0;
-
-        $values = array_values($parameters);
-
-        foreach ($reflector->getParameters() as $key => $parameter) {
-            $instance = $this->transformDependency(
-                $parameter, $parameters
-            );
-
-            if (! is_null($instance)) {
-                $instanceCount++;
-
-                $this->spliceIntoParameters($parameters, $key, $instance);
-            } elseif (! array_key_exists($key - $instanceCount, $values) &&
-                      $parameter->isDefaultValueAvailable()) {
-                $this->spliceIntoParameters($parameters, $key, $parameter->getDefaultValue());
-            }
-        }
-
-        return $parameters;
-    }
-
-    protected function transformDependency(ReflectionParameter $parameter, $parameters)
-    {
-        $class = $parameter->getClass();
-
-        // If the parameter has a type-hinted class, we will check to see if it is already in
-        // the list of parameters. If it is we will just skip it as it is probably a model
-        // binding and we do not want to mess with those; otherwise, we resolve it here.
-        if ($class && ! $this->alreadyInParameters($class->name, $parameters)) {
-            return $parameter->isDefaultValueAvailable()
-                ? $parameter->getDefaultValue()
-                : $this->container->make($class->name);
-        }
-    }
-
-    protected function alreadyInParameters($class, array $parameters)
-    {
-        return ! is_null(Arr::first($parameters, function ($value) use ($class) {
-            return $value instanceof $class;
-        }));
-    }
-
-    protected function spliceIntoParameters(array &$parameters, $offset, $value)
-    {
-        array_splice(
-            $parameters, $offset, 0, [$value]
-        );
     }
 }

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -88,8 +88,11 @@ class LivewireManager
         return new $componentClass($id);
     }
 
-    public function mount($name, ...$options)
+    public function mount($name, $params = [])
     {
+        // This is if a user doesn't pass params, BUT passes key() as the second argument.
+        if (is_string($params)) $params = [];
+
         $id = Str::random(20);
 
         // Allow instantiating Livewire components directly from classes.
@@ -105,10 +108,10 @@ class LivewireManager
         $this->initialHydrate($instance, []);
 
         $parameters = $this->resolveClassMethodDependencies(
-            $options, $instance, 'mount'
+            $params, $instance, 'mount'
         );
 
-        $instance->mount(...array_values($parameters));
+        $instance->mount(...$parameters);
 
         $dom = $instance->output();
 
@@ -134,7 +137,7 @@ class LivewireManager
         return "<{$tagName} wire:id=\"{$id}\"></{$tagName}>";
     }
 
-    public function test($name, ...$params)
+    public function test($name, $params = [])
     {
         return new TestableLivewire($name, $this->prefix, $params);
     }

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -107,11 +107,11 @@ class LivewireManager
 
         $this->initialHydrate($instance, []);
 
-        $parameters = $this->resolveClassMethodDependencies(
+        $resolvedParameters = $this->resolveClassMethodDependencies(
             $params, $instance, 'mount'
         );
 
-        $instance->mount(...$parameters);
+        $instance->mount(...$resolvedParameters);
 
         $dom = $instance->output();
 

--- a/src/LivewireViewCompilerEngine.php
+++ b/src/LivewireViewCompilerEngine.php
@@ -3,6 +3,8 @@
 namespace Livewire;
 
 use Exception;
+use Illuminate\Foundation\Application;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Throwable;
 
 class LivewireViewCompilerEngine extends CompilerEngine
@@ -49,7 +51,11 @@ class LivewireViewCompilerEngine extends CompilerEngine
         } catch (Exception $e) {
             $this->handleViewException($e, $obLevel);
         } catch (Throwable $e) {
-            $this->handleViewException($e, $obLevel);
+            if (Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, '7.0', '>=')) {
+                $this->handleViewException($e, $obLevel);
+            } else {
+                $this->handleViewException(new FatalThrowableError($e), $obLevel);
+            }
         }
 
         return ltrim(ob_get_clean());

--- a/src/Macros/RouterMacros.php
+++ b/src/Macros/RouterMacros.php
@@ -35,7 +35,7 @@ class RouterMacros
                     'layout' => $this->current()->getAction('layout') ?? 'layouts.app',
                     'section' => $this->current()->getAction('section') ?? 'content',
                     'component' => $component,
-                    'componentOptions' => $reflected->hasMethod('mount')
+                    'componentParameters' => $reflected->hasMethod('mount')
                         ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $this))->retrieveBindings()
                         : [],
                 ]);

--- a/src/Macros/livewire-view.blade.php
+++ b/src/Macros/livewire-view.blade.php
@@ -1,5 +1,5 @@
 @extends($layout)
 
 @section($section)
-    @livewire($component, ...$componentOptions)
+    @livewire($component, $componentParameters)
 @endsection

--- a/src/views/mount-component.blade.php
+++ b/src/views/mount-component.blade.php
@@ -1,1 +1,1 @@
-@livewire($name, ...$params)
+@livewire($name, $params)

--- a/tests/ComponentEventsTest.php
+++ b/tests/ComponentEventsTest.php
@@ -79,7 +79,7 @@ class ComponentEventsTest extends TestCase
     /** @test */
     public function component_can_set_dynamic_listeners()
     {
-        $component = app(LivewireManager::class)->test(ReceivesEventsWithDynamicListeners::class, 'bob');
+        $component = app(LivewireManager::class)->test(ReceivesEventsWithDynamicListeners::class, ['listener' => 'bob']);
 
         $component->fireEvent('bob', 'lob');
         $component->assertSet('foo', 'lob');

--- a/tests/ComponentMethodBindingsTest.php
+++ b/tests/ComponentMethodBindingsTest.php
@@ -32,7 +32,7 @@ class ComponentMethodBindingsTest extends TestCase
     /** @test */
     public function mount_method_receives_bindings_with_subsequent_param()
     {
-        Livewire::test(ComponentWithBindings::class, 'foo')
+        Livewire::test(ComponentWithBindings::class, ['param' => 'foo'])
             ->assertSee('from-injectionfoo');
     }
 }

--- a/tests/LivewireTestingTest.php
+++ b/tests/LivewireTestingTest.php
@@ -11,7 +11,7 @@ class LivewireTestingTest extends TestCase
     public function method_accepts_arguments_to_pass_to_mount()
     {
         $component = app(LivewireManager::class)
-            ->test(HasMountArguments::class, 'foo');
+            ->test(HasMountArguments::class, ['name' => 'foo']);
 
         $this->assertStringContainsString('foo', $component->payload['dom']);
     }
@@ -20,7 +20,7 @@ class LivewireTestingTest extends TestCase
     public function set_multiple_with_array()
     {
         app(LivewireManager::class)
-            ->test(HasMountArguments::class, 'foo')
+            ->test(HasMountArguments::class, ['name' => 'foo'])
             ->set(['name' => 'bar'])
             ->assertSet('name', 'bar');
     }
@@ -29,7 +29,7 @@ class LivewireTestingTest extends TestCase
     public function assert_set()
     {
         app(LivewireManager::class)
-            ->test(HasMountArguments::class, 'foo')
+            ->test(HasMountArguments::class, ['name' => 'foo'])
             ->assertSet('name', 'foo');
     }
 
@@ -37,7 +37,7 @@ class LivewireTestingTest extends TestCase
     public function assert_not_set()
     {
         app(LivewireManager::class)
-            ->test(HasMountArguments::class, 'bar')
+            ->test(HasMountArguments::class, ['name' => 'bar'])
             ->assertNotSet('name', 'foo');
     }
 
@@ -45,7 +45,7 @@ class LivewireTestingTest extends TestCase
     public function assert_see()
     {
         app(LivewireManager::class)
-            ->test(HasMountArguments::class, 'should see me')
+            ->test(HasMountArguments::class, ['name' => 'should see me'])
             ->assertSee('should see me');
     }
 
@@ -54,7 +54,7 @@ class LivewireTestingTest extends TestCase
     {
         // See for more info: https://github.com/calebporzio/livewire/issues/62
         app(LivewireManager::class)
-            ->test(HasMountArgumentsButDoesntPassThemToBladeView::class, 'shouldnt see me')
+            ->test(HasMountArgumentsButDoesntPassThemToBladeView::class, ['name' => 'shouldnt see me'])
             ->assertDontSee('shouldnt see me');
     }
 

--- a/tests/ModelsCanBeSetAsPublicPropertiesTest.php
+++ b/tests/ModelsCanBeSetAsPublicPropertiesTest.php
@@ -27,7 +27,7 @@ class ModelsCanBeSetAsPublicPropertiesTest extends TestCase
     {
         $model = ModelForSerialization::create(['id' => 1, 'title' => 'foo']);
 
-        Livewire::test(ComponentWithModelPublicProperty::class, $model)
+        Livewire::test(ComponentWithModelPublicProperty::class, ['model' => $model])
             ->assertSee('foo')
             ->call('refresh')
             ->assertSee('foo');
@@ -41,7 +41,7 @@ class ModelsCanBeSetAsPublicPropertiesTest extends TestCase
         $model = ModelForSerialization::create(['id' => 1, 'title' => 'foo']);
         ModelForSerialization::create(['id' => 2, 'title' => 'bar']);
 
-        Livewire::test(ComponentWithModelPublicProperty::class, $model)
+        Livewire::test(ComponentWithModelPublicProperty::class, ['model' => $model])
             ->set('model.id', 2)
             ->call('refresh')
             ->assertSee('foo')
@@ -56,7 +56,7 @@ class ModelsCanBeSetAsPublicPropertiesTest extends TestCase
         $model = ModelForSerialization::create(['id' => 1, 'title' => 'foo']);
         ModelForSerialization::create(['id' => 2, 'title' => 'bar']);
 
-        $component = Livewire::test(ComponentWithModelPublicProperty::class, $model);
+        $component = Livewire::test(ComponentWithModelPublicProperty::class, ['model' => $model]);
 
         $component->payload['data']['model']['id'] = 2;
 
@@ -71,7 +71,7 @@ class ModelsCanBeSetAsPublicPropertiesTest extends TestCase
 
         $models = ModelForSerialization::all();
 
-        Livewire::test(ComponentWithModelsPublicProperty::class, $models)
+        Livewire::test(ComponentWithModelsPublicProperty::class, ['models' => $models])
             ->assertSee('foo')
             ->assertSee('bar')
             ->call('refresh')

--- a/tests/MountComponentTest.php
+++ b/tests/MountComponentTest.php
@@ -14,19 +14,19 @@ class MountComponentTest extends TestCase
         $this->assertSame(null, $component->foo);
         $this->assertSame([], $component->bar);
 
-        $component = app(LivewireManager::class)->test(ComponentWithOptionalParameters::class, 'caleb');
+        $component = app(LivewireManager::class)->test(ComponentWithOptionalParameters::class, ['foo' => 'caleb']);
         $this->assertSame('caleb', $component->foo);
         $this->assertSame([], $component->bar);
 
-        $component = app(LivewireManager::class)->test(ComponentWithOptionalParameters::class, null, 'porzio');
+        $component = app(LivewireManager::class)->test(ComponentWithOptionalParameters::class, ['bar' => 'porzio']);
         $this->assertSame(null, $component->foo);
         $this->assertSame('porzio', $component->bar);
 
-        $component = app(LivewireManager::class)->test(ComponentWithOptionalParameters::class, 'caleb', 'porzio');
+        $component = app(LivewireManager::class)->test(ComponentWithOptionalParameters::class, ['foo' => 'caleb', 'bar' => 'porzio']);
         $this->assertSame('caleb', $component->foo);
         $this->assertSame('porzio', $component->bar);
 
-        $component = app(LivewireManager::class)->test(ComponentWithOptionalParameters::class, null, null);
+        $component = app(LivewireManager::class)->test(ComponentWithOptionalParameters::class, ['foo' => null, 'bar' => null]);
         $this->assertSame(null, $component->foo);
         $this->assertSame(null, $component->bar);
     }

--- a/tests/NestingComponentsTest.php
+++ b/tests/NestingComponentsTest.php
@@ -84,7 +84,7 @@ class ParentComponentForNestingChildStub extends Component
     public function render()
     {
         return app('view')->make('show-child', [
-            'child' => 'foo',
+            'child' => ['name' => 'foo'],
         ]);
     }
 }

--- a/tests/PublicPropertiesAreCastToJavaScriptUsableTypesTest.php
+++ b/tests/PublicPropertiesAreCastToJavaScriptUsableTypesTest.php
@@ -16,7 +16,7 @@ class PublicPropertiesAreCastToJavaScriptUsableTypesTest extends TestCase
     {
         $this->expectException(PublicPropertyTypeNotAllowedException::class);
 
-        Livewire::test(ComponentWithPropertiesStub::class, collect(['foo' => 'bar']))
+        Livewire::test(ComponentWithPropertiesStub::class, ['foo' => collect(['foo' => 'bar'])])
             ->assertDontSee('class Illuminate\Support\Collection')
             ->assertSee('array(1)')
             ->assertSee('foo')
@@ -29,7 +29,7 @@ class PublicPropertiesAreCastToJavaScriptUsableTypesTest extends TestCase
         $this->expectException(PublicPropertyTypeNotAllowedException::class);
         Livewire::component('foo', ComponentWithPropertiesStub::class);
 
-        View::make('render-component', ['component' => 'foo', 'params' => [collect()]])->render();
+        View::make('render-component', ['component' => 'foo', 'params' => ['foo' => collect()]])->render();
     }
 
     /** @test */
@@ -40,7 +40,7 @@ class PublicPropertiesAreCastToJavaScriptUsableTypesTest extends TestCase
             0 => 'bar',
         ];
 
-        $foo = Livewire::test(ComponentWithPropertiesStub::class, $orderedNumericArray)->foo;
+        $foo = Livewire::test(ComponentWithPropertiesStub::class, ['foo' => $orderedNumericArray])->foo;
 
         $this->assertSame([
             0 => 'bar',
@@ -59,7 +59,7 @@ class PublicPropertiesAreCastToJavaScriptUsableTypesTest extends TestCase
             2 => 'baz',
         ];
 
-        $foo = Livewire::test(ComponentWithPropertiesStub::class, $orderedNumericArray)
+        $foo = Livewire::test(ComponentWithPropertiesStub::class, ['foo' => $orderedNumericArray])
             ->foo;
 
         $this->assertSame([
@@ -81,7 +81,7 @@ class PublicPropertiesAreCastToJavaScriptUsableTypesTest extends TestCase
             ],
         ];
 
-        Livewire::test(ComponentWithPropertiesStub::class, $orderedNumericArray)
+        Livewire::test(ComponentWithPropertiesStub::class, ['foo' => $orderedNumericArray])
             ->assertSet('foo', [[0 => 'bar', 1 => 'foo']]);
     }
 }

--- a/tests/views/render-component.blade.php
+++ b/tests/views/render-component.blade.php
@@ -1,6 +1,6 @@
 <div>
     @isset($params)
-        @livewire($component, ...$params)
+        @livewire($component, $params)
     @else
         @livewire($component)
     @endisset

--- a/tests/views/show-children.blade.php
+++ b/tests/views/show-children.blade.php
@@ -1,5 +1,5 @@
 <div>
     @foreach ($children as $child)
-        @livewire('child', $child, key($child))
+        @livewire('child', ['name' => $child], key($child))
     @endforeach
 </div>


### PR DESCRIPTION
In order to make Livewire components and Blade components feel more symmetrical, we're moving to a key->value array for parameters, instead of just values:

```html
// Given this mount method:
public function mount($foo, $bob)

// Before
@livewire('component-name', 'bar', 'lob')

// After
@livewire('component-name', ['foo' => 'bar', 'bob' => 'lob']);
```