### PR TITLE
Update the property not found exception message to include the component name

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -155,7 +155,9 @@ abstract class Component
             }
         }
 
-        throw new \Exception("Property [{$property}] does not exist on the Component instance.");
+        $className = class_basename($this);
+
+        throw new \Exception("Property [{$property}] does not exist on the {$className} component instance.");
     }
 
     public function __call($method, $params)


### PR DESCRIPTION
This PR updates the property not found exception message "Property [{$property}] does not exist on the Component instance." to include the component name in order to provide better context when troubleshooting.