### PR TITLE
Fix Issue #612

### DIFF
--- a/src/CompilerEngine.php
+++ b/src/CompilerEngine.php
@@ -44,25 +44,30 @@ if (Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, 
         // Errors thrown while a view is rendering are caught by the Blade
         // compiler and wrapped in an "ErrorException". This makes Livewire errors
         // harder to read, AND causes issues like `abort(404)` not actually working.
-        protected function handleViewException(Exception $e, $obLevel)
+        protected function handleViewException(Throwable $e, $obLevel)
         {
-            $uses = array_flip(class_uses_recursive($e));
+            if($e instanceof Exception){
+                $uses = array_flip(class_uses_recursive($e));
 
-            if (
-                // Don't wrap "abort(404)".
-                $e instanceof NotFoundHttpException
-                // Don't wrap "abort(500)".
-                || $e instanceof HttpException
-                // Don't wrap most Livewire exceptions.
-                || isset($uses[BypassViewHandler::class])
-            ) {
-                // This is because there is no "parent::parent::".
-                PhpEngine::handleViewException($e, $obLevel);
+                if (
+                    // Don't wrap "abort(404)".
+                    $e instanceof NotFoundHttpException
+                    // Don't wrap "abort(500)".
+                    || $e instanceof HttpException
+                    // Don't wrap most Livewire exceptions.
+                    || isset($uses[BypassViewHandler::class])
+                ) {
+                    // This is because there is no "parent::parent::".
+                    PhpEngine::handleViewException($e, $obLevel);
 
-                return;
+                    return;
+                }
+
+                parent::handleViewException($e, $obLevel);
+            }else{
+                throw($e);
             }
 
-            parent::handleViewException($e, $obLevel);
         }
     }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
This is an approach of solving the issue #612 that causes complicated and unrelated error messages when an error occurs on a view.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
It only includes one change

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
No

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
See the referenced issue #612 for in-depth details; the handleViewException Method in the CompilerEngine Class only accepts Throwables of the Type Exception, however other Throwables such as ErrorExceptions etc. might occur on a view. In this Pull-Request, I have changed the method to accept all Throwables. If a Throwable is instanceof Exception, it is being treated as before. However, if the Throwable is of a different type, it gets thrown. 

5️⃣ Thanks for contributing! 🙌
