### PR TITLE
Fixing unordered collection cause CorruptComponentPayloadException

### DIFF
--- a/src/ComponentChecksumManager.php
+++ b/src/ComponentChecksumManager.php
@@ -2,13 +2,15 @@
 
 namespace Livewire;
 
+use Illuminate\Support\Arr;
+
 class ComponentChecksumManager
 {
     public function generate($name, $id, $data)
     {
         $hashKey = app('encrypter')->getKey();
 
-        $stringForHashing = $name.$id.json_encode($data);
+        $stringForHashing = $name.$id.json_encode(Arr::sortRecursive($data));
 
         return hash_hmac('sha256', $stringForHashing, $hashKey);
     }


### PR DESCRIPTION
Coused by JSON.parse auto sorting

1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
This pr fix issues of #371  #354 #283 
2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No it does not.
3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Nope, this is one line fix that will not effect any behavior except fixing issue.
4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

Ok I think this will be a long text to explain.

Issue was when you start your component with unordered collection at livewire, on any event you were getting CorruptComponentPayloadException .

Here is how you can reproduce bug ;
app/Http/Livewire/TestComponent.php
```
<?php

namespace App\Http\Livewire;

use Livewire\Component;

class TestComponent extends Component
{
    public $data;

    public function mount($data) {
        $this->data = $data;
    }

    // just for test any event
    public function test() {
        
    }

    public function render()
    {
        return view('livewire.test-component');
    }
}

```
resources/views/livewire/test-component.blade.php

```
<div>
    <button wire:click="test">test</button>
</div>
```
resources/views/test.blade.php

```
<!doctype html>
<head>
    <meta charset="utf-8">
    @livewireStyles
    <meta name="viewport" content="width=device-width, initial-scale=1.0">

</head>
<body>

    @livewire('test-component',[collect([2 => "test",1=>"test2"])])
    @livewireScripts
</body>
</html>
```
When you click button you will get CorruptComponentPayloadException 

This is mostly can happen at elequent models that not returns with ordered id lets say you have a table users and have a column named external_id,
User 
id | external_id
1  | 3
2  | 2

when you sended 
```
$usersByExternalId = App\User::all()->keyBy('external_id');
@livewire('test-component',[$usersByExternalId])

```
you will face with this bug

Couse of this problem actually pretty nasty. 

Livewire at first request sets a initial-data as json.
After this whenever livewire js sends a request to livewire php, php checks this sum againist data comes from js to check is data corrapted. 

Unfortunately on ui side Chrome browser thinks that whenever a JSON.parse request comes i have to return an ORDERED list, you can test via :

```
JSON.parse(JSON.stringify({2:"test",1:"test"}))
```

its returns 

```
{1: "test", 2: "test"}
```

actually expected return is 
```
{2: "test", 1: "test"}
```

So what happens 
initial-data sended by livewirephp is :
```{2: "test", 1: "test"} ```
and sum is created by ComponentChecksumManager is lets say "X"

so Ui takes this data via json decode and Whoolaa array order is changed, at next event sended to server data is 
{1: "test", 2: "test"} and sum of this data ComponentChecksumManager  this time "y"

after generated 2 differnt data when ComponentChecksumManager  ->check compares this two data sees diffrence and thinks that, data modified at ui (actually works as expected data modified by chrome) and throws CorruptComponentPayloadException 

So as solution there is few ways can follow, maybe work around at JSON.parse to create not sorted array or adding ids as string (very dirty)

My solution is just sort values when create hash (dont worry its not manipulate original data just uses to generate sum). With this way even if chrome sorts data and returns back sum wont change.

I just realize i write 100 lines to explain 1 line of code :) 

5️⃣ Thanks for contributing! 🙌

Thank you guys for this awesome tool, its such a game changer.