### PR TITLE
Ensure default manifest path is used when config is null

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -100,7 +100,7 @@ class LivewireServiceProvider extends ServiceProvider
         $this->app->singleton(LivewireComponentsFinder::class, function () use ($defaultManifestPath) {
             return new LivewireComponentsFinder(
                 new Filesystem,
-                config('livewire.manifest_path', $defaultManifestPath),
+                config('livewire.manifest_path') ?: $defaultManifestPath,
                 ComponentParser::generatePathFromNamespace(
                     config('livewire.class_namespace', 'App\\Http\\Livewire')
                 )


### PR DESCRIPTION
This fixes #597 

The problem here is that the default manifest path isn't used, because they config key is null and null is a valid value for the configuration. The default value would only be used if no key is available. With this change, the expected behavior is restored.