### PR TITLE
[PHP] added test to ensure livewire routes are cachable

### DIFF
--- a/tests/CacheRoutesTest.php
+++ b/tests/CacheRoutesTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests;
+
+use Closure;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Route as RouteFacade;
+
+class CacheRoutesTest extends TestCase
+{
+    /** @test */
+    public function livewire_routes_are_cacheable()
+    {
+        $routesWithClosure = collect(RouteFacade::getRoutes())->filter(function (Route $route) {
+            return $route->getAction('uses') instanceof Closure;
+        });
+
+        $this->assertTrue($routesWithClosure->isEmpty());
+    }
+}


### PR DESCRIPTION
Fixes #51 

Unfortunately ```Artisan::call('route:cache');``` doesn't work because there is no ```bootstrap/app.php``` file.

I just take all Routes and test if any route uses a ```Closure```, if so the test will fail.