### PR TITLE
[Tests] Both slashes are valid directory separators for Windows

### DIFF
--- a/tests/FileManipulationCommandParserTest.php
+++ b/tests/FileManipulationCommandParserTest.php
@@ -20,9 +20,9 @@ class FileManipulationCommandParserTest extends TestCase
 
         $this->assertEquals($component, $parser->component());
         $this->assertEquals($namespace, $parser->classNamespace());
-        $this->assertEquals(app_path($classPath), $parser->classPath());
+        $this->assertEquals($this->normalizeDirectories(app_path($classPath)), $this->normalizeDirectories($parser->classPath()));
         $this->assertEquals($viewName, $parser->viewName());
-        $this->assertEquals(resource_path('views/'.$viewPath), $parser->viewPath());
+        $this->assertEquals($this->normalizeDirectories(resource_path('views/'.$viewPath)), $this->normalizeDirectories($parser->viewPath()));
     }
 
     public function classPathProvider()
@@ -85,5 +85,10 @@ class FileManipulationCommandParserTest extends TestCase
                 'livewire/foo-bar.blade.php',
             ],
         ];
+    }
+
+    private function normalizeDirectories($subject)
+    {
+        return str_replace(DIRECTORY_SEPARATOR, '/', $subject);
     }
 }


### PR DESCRIPTION
Windows Only

The code for copying files is working fine. However the tests strictly compare slashes, but in Windows, both "\\" and  "/" are valid directory separators. Therefore, this adds a test helper that replaces all directory separators with a normal forward slash for these comparisons.

The following testing failures are resolved from this change:
![image](https://user-images.githubusercontent.com/1296882/76051146-ddf6cb00-5f37-11ea-8899-798cfab9144d.png)

