### PR TITLE
Fix string representation display of directories

### DIFF
--- a/src/Commands/ComponentParser.php
+++ b/src/Commands/ComponentParser.php
@@ -41,12 +41,12 @@ class ComponentParser
         return $this->baseClassPath.collect()
             ->concat($this->directories)
             ->push($this->classFile())
-            ->implode(DIRECTORY_SEPARATOR);
+            ->implode('/');
     }
 
     public function relativeClassPath()
     {
-        return Str::replaceFirst(base_path().'/', '', $this->classPath());
+        return Str::replaceFirst(base_path().DIRECTORY_SEPARATOR, '', $this->classPath());
     }
 
     public function classFile()


### PR DESCRIPTION
Windows Only

There are two line changes here.

The second line change is a bug fix. Without it, on Windows, it returns the entire file path including C:\users\lance\app\... instead of just the regular relative path.

The first line changes the final path to use "/" as the directory separator. This is correct because the rest of the path already is using it. This is a visual change though because Windows treats "/" and "\" the same for directory separators. However, this lines it up with what the output is for Linux and makes the tests pass.

The following testing errors are resolved from this change:
![image](https://user-images.githubusercontent.com/1296882/76053697-13051c80-5f3c-11ea-94b1-9ea7485daf24.png)
