### PR TITLE
Change naming convention of computed properties to that of Eloquent f…

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -166,7 +166,9 @@ abstract class Component
 
     public function __get($property)
     {
-        if (method_exists($this, $computedMethodName = 'get'.ucfirst($property).'Property')) {
+        $studlyProperty = str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $property)));
+
+        if (method_exists($this, $computedMethodName = 'get'.$studlyProperty.'Property')) {
             if (isset($this->computedPropertyCache[$property])) {
                 return $this->computedPropertyCache[$property];
             } else {

--- a/tests/ComputedPropertiesTest.php
+++ b/tests/ComputedPropertiesTest.php
@@ -11,7 +11,7 @@ class ComputedPropertiesTest extends TestCase
     public function compute_property_is_accessable_within_blade_view()
     {
         Livewire::test(ComputedPropertyStub::class)
-            ->assertSee('foo');
+            ->assertSee('foo_bar');
     }
 
     /** @test */
@@ -24,16 +24,16 @@ class ComputedPropertiesTest extends TestCase
 
 class ComputedPropertyStub extends Component
 {
-    public $upperCasedFoo = 'FOO';
+    public $upperCasedFoo = 'FOO_BAR';
 
-    public function getFooProperty()
+    public function getFooBarProperty()
     {
         return strtolower($this->upperCasedFoo);
     }
 
     public function render()
     {
-        return view('var-dump-foo');
+        return view('var-dump-foo-bar');
     }
 }
 
@@ -41,7 +41,7 @@ class MemoizedComputedPropertyStub extends Component
 {
     public $count = 1;
 
-    public function getFooProperty()
+    public function getFooBarProperty()
     {
         return $this->count += 1;
     }
@@ -49,8 +49,8 @@ class MemoizedComputedPropertyStub extends Component
     public function render()
     {
         // Access foo once here to start the cache.
-        $this->foo;
+        $this->foo_bar;
 
-        return view('var-dump-foo');
+        return view('var-dump-foo-bar');
     }
 }

--- a/tests/views/var-dump-foo-bar.blade.php
+++ b/tests/views/var-dump-foo-bar.blade.php
@@ -1,0 +1,3 @@
+<div>
+    {{ var_dump($this->foo_bar) }}
+</div>


### PR DESCRIPTION
As per #684 we replace `ucfirst` with a studly property calculation.

This is a breaking change for properties with more than one word.

Given that Livewire is currently compatible with many Laravel versions, and built-in string helpers have changed between these versions, we compute the studly property explicitly rather than defer to helpers.