### PR TITLE
Allow an empty literal string value when using tag-syntax

### DIFF
--- a/src/LivewireTagCompiler.php
+++ b/src/LivewireTagCompiler.php
@@ -26,7 +26,7 @@ class LivewireTagCompiler extends ComponentTagCompiler
                         (
                             =
                             (?:
-                                \\\"[^\\\"]+\\\"
+                                \\\"[^\\\"]*\\\"
                                 |
                                 \'[^\']+\'
                                 |

--- a/tests/ComponentCanAcceptValuesTest.php
+++ b/tests/ComponentCanAcceptValuesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Support\Facades\Route;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class ComponentCanAcceptValuesTest extends TestCase
+{
+    /** @test */
+    public function can_pass_values_to_component()
+    {
+        app('livewire')->component('accepts-values', ComponentThatAcceptsAValue::class);
+        Route::get('path', function () {
+            return view('pass-values');
+        });
+
+        if (! Livewire::isLaravel7()) {
+            $this->expectException(\Exception::class);
+        }
+
+        $this->withoutExceptionHandling()->get('/path')
+            ->assertSeeText('tag-syntax-literal-empty: The value is ""', false)
+            ->assertSeeText('tag-syntax-literal-non-empty: The value is "abc"', false)
+            ->assertSeeText('tag-syntax-value-empty: The value is ""', false)
+            ->assertSeeText('tag-syntax-value-non-empty: The value is "abc"', false)
+            ->assertSeeText('old-syntax-empty: The value is ""', false)
+            ->assertSeeText('old-syntax-non-empty: The value is "abc"', false);
+    }
+}
+
+class ComponentThatAcceptsAValue extends Component
+{
+    public $value;
+
+    public function mount($value)
+    {
+        $this->value = $value;
+    }
+
+    public function render()
+    {
+        return '<div>The value is "{{ $this->value }}"</div>';
+    }
+}

--- a/tests/views/pass-values.blade.php
+++ b/tests/views/pass-values.blade.php
@@ -1,0 +1,9 @@
+@php( $empty = '' )
+@php( $nonEmpty = 'abc' )
+
+tag-syntax-literal-empty: <livewire:accepts-values value=""/>
+tag-syntax-literal-non-empty: <livewire:accepts-values value="abc"/>
+tag-syntax-value-empty: <livewire:accepts-values :value="$empty"/>
+tag-syntax-value-non-empty: <livewire:accepts-values :value="$nonEmpty"/>
+old-syntax-empty: @livewire('accepts-values', ['value' => ''])
+old-syntax-non-empty: @livewire('accepts-values', ['value' => 'abc'])


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes, I have just created bug-issue #708.  It seems like a small and straight-forward change,  I hope that's ok.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No. The change is simply one character.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes. I have added a new test.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
If I have a Livewire component that has a value passed to it, when the string is empty and I'm using the new tag-syntax, the component isn't applied and the original tag is left in the output.

<livewire:do-something value=""/>

This is tag is currently skipped by Livewire as the regex in LivewireTagCompiler doesn't pick it up when no characters exist within the attribute's quotes.

The syntax above looks valid so I think it should work accordingly.

5️⃣ Thanks for contributing! 🙌
