### PR TITLE
Fix Error Sharing

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -125,8 +125,6 @@ abstract class Component
             '_instance' => $this,
         ] + $this->getPublicPropertiesDefinedBySubClass());
 
-        session()->flash('errors', $errors);
-
         $output = $view->render();
 
         app('view')->share('errors', $previouslySharedErrors);

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -119,22 +119,6 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
-    public function validation_errors_are_flashed_to_session()
-    {
-        $component = app(LivewireManager::class)->test(ForValidation::class);
-
-        $component
-            ->set('bar', '')
-            ->call('runValidation')
-            ->assertSee('The bar field is required')
-            ->assertSee('sessionError:The bar field is required')
-            ->set('bar', 'bar')
-            ->call('runValidation')
-            ->assertDontSee('The bar field is required')
-            ->assertDontSee('sessionError:The bar field is required');
-    }
-
-    /** @test */
     public function validation_errors_are_shared_for_all_views()
     {
         /** @var TestableLivewire $component */

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Support\ViewErrorBag;
 use Livewire\Component;
 use Livewire\LivewireManager;
 
@@ -131,6 +132,22 @@ class ValidationTest extends TestCase
             ->call('runValidation')
             ->assertDontSee('The bar field is required')
             ->assertDontSee('sessionError:The bar field is required');
+    }
+
+    /** @test */
+    public function validation_errors_are_shared_for_all_views()
+    {
+        /** @var TestableLivewire $component */
+        $component = app(LivewireManager::class)->test(ForValidation::class);
+
+        app('view')->share('errors', $errors = new ViewErrorBag);
+
+        $component
+            ->set('bar', '')
+            ->call('runValidation')
+            ->assertSee('sharedError:The bar field is required');
+
+        $this->assertTrue(app('view')->shared('errors') === $errors);
     }
 }
 

--- a/tests/views/dump-errors-nested-component.blade.php
+++ b/tests/views/dump-errors-nested-component.blade.php
@@ -1,0 +1,3 @@
+<div>
+    @if (isset($errors) && $errors->has('bar')) sharedError:{{ $errors->first('bar') }} @endif
+</div>

--- a/tests/views/dump-errors.blade.php
+++ b/tests/views/dump-errors.blade.php
@@ -1,8 +1,6 @@
 <div>
     @json($errors->toArray())
 
-    {{ session()->has('errors') && session()->get('errors')->has('bar') ? 'sessionError:'.session()->get('errors')->first('bar') : '' }}
-
     @error('test') @enderror
 
     @component('dump-errors-nested-component')@endcomponent

--- a/tests/views/dump-errors.blade.php
+++ b/tests/views/dump-errors.blade.php
@@ -4,4 +4,6 @@
     {{ session()->has('errors') && session()->get('errors')->has('bar') ? 'sessionError:'.session()->get('errors')->first('bar') : '' }}
 
     @error('test') @enderror
+
+    @component('dump-errors-nested-component')@endcomponent
 </div>


### PR DESCRIPTION
This PR fixes error sharing with Livewire components as well as nested Blade components within those Livewire components. It also addresses a few other related problems.

Validation errors should not be flashed to the session as previous PR attempted to do. This doesn't solve the root problem and also creates new problems of making validation errors eternally persistent on the screen even after refresh. IMO errors should not be accessed in this way - the Laravel documentation never demonstrates accessing errors in this fashion either. You should use the global `$errors` variable that available to you in your views (and which is also utilized by the `@error` Blade directive).

After sharing the Livewire component's errors globally during that render cycle we reset the shared error bag to its previous state to clean up after ourselves.

Added new test for this based on https://github.com/livewire/livewire/pull/704 and also an additional check to make sure the error bag is restored to its previous state.