### PR TITLE
Allow empty value (using single quotes) to be passed

### DIFF
--- a/src/LivewireTagCompiler.php
+++ b/src/LivewireTagCompiler.php
@@ -28,7 +28,7 @@ class LivewireTagCompiler extends ComponentTagCompiler
                             (?:
                                 \\\"[^\\\"]*\\\"
                                 |
-                                \'[^\']+\'
+                                \'[^\']*\'
                                 |
                                 [^\'\\\"=<>]+
                             )


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?

This change is almost the same as one of my previous PRs.  I wasn't thorough enough and only made the fix for double quotes (sorry about that).  This one is for single quotes.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No,  only one fix.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)

I noticed the test I wrote for my previous PR (for almost the same thing) was removed. So I haven't added any for this one.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

This change allows Livewire components to be used when passing an empty string value with single quotes.

<livewire:do-something value=''>

5️⃣ Thanks for contributing! 🙌
