### PR TITLE
Share `$_instance` with nested blade components

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -111,6 +111,7 @@ abstract class Component
         );
 
         $previouslySharedErrors = app('view')->getShared()['errors'] ?? new ViewErrorBag;
+        $previouslySharedInstance = app('view')->getShared()['_instance'] ?? null;
 
         $errors = (new ViewErrorBag)->put('default', $errorBag);
 
@@ -119,6 +120,7 @@ abstract class Component
         );
 
         app('view')->share('errors', $errors);
+        app('view')->share('_instance', $this);
 
         $view->with([
             'errors' => $errors,
@@ -128,6 +130,7 @@ abstract class Component
         $output = $view->render();
 
         app('view')->share('errors', $previouslySharedErrors);
+        app('view')->share('_instance', $previouslySharedInstance);
 
         Livewire::dispatch('view:render', $view);
 

--- a/tests/LivewireDirectivesTest.php
+++ b/tests/LivewireDirectivesTest.php
@@ -67,6 +67,14 @@ class LivewireDirectivesTest extends TestCase
     }
 
     /** @test */
+    public function this_directive_can_be_used_in_nested_blade_component()
+    {
+        Livewire::test(ComponentForTestingNestedThisDirective::class)
+            ->assertDontSee('@this')
+            ->assertSee('window.livewire.find(');
+    }
+
+    /** @test */
     public function this_directive_isnt_registered_outside_of_livewire_component()
     {
         $output = view('this-directive')->render();
@@ -80,5 +88,13 @@ class ComponentForTestingDirectives extends Component
     public function render()
     {
         return view('this-directive');
+    }
+}
+
+class ComponentForTestingNestedThisDirective extends Component
+{
+    public function render()
+    {
+        return view('nested-this-directive');
     }
 }

--- a/tests/views/nested-this-directive.blade.php
+++ b/tests/views/nested-this-directive.blade.php
@@ -1,0 +1,3 @@
+<div>
+    @component('this-directive')@endcomponent
+</div>


### PR DESCRIPTION
Accessing `@this` from nested blade components in Livewire component is now possible:
// Livewire view
```html
<div>
  @component('foo')
  @endcomponent
</div>
```
// Blade component ('foo')
```html
<button onclick="@this.call('...')">...</button>
```
