### PR TITLE
Use config file class namespace to resolve Livewire folder path

### DIFF
--- a/src/Commands/FileManipulationCommand.php
+++ b/src/Commands/FileManipulationCommand.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Commands;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Livewire\LivewireComponentsFinder;
@@ -24,7 +25,9 @@ class FileManipulationCommand extends Command
 
     public function isFirstTimeMakingAComponent()
     {
-        $livewireFolder = app_path(collect(['Http', 'Livewire'])->implode(DIRECTORY_SEPARATOR));
+        $namespace = Str::replaceFirst(app()->getNamespace(), '', config('livewire.class_namespace', 'App\\Http\\Livewire'));
+
+        $livewireFolder = app_path(collect(explode('\\', $namespace))->implode(DIRECTORY_SEPARATOR));
 
         return ! File::isDirectory($livewireFolder);
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?

No.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)

No.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

After switching to a different namespace in the config file, Livewire keeps displaying welcome message when creating a new component. This PR aims to fix that issue by using class namespace to resolve Livewire folder.

5️⃣ Thanks for contributing! 🙌
