### PR TITLE
Flash errors to session again (@error and $errors are not working in nested blade components)

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -119,6 +119,8 @@ abstract class Component
             $previouslySharedErrors->getBag('default')
         );
 
+        session()->flash('errors', $errors);
+
         app('view')->share('errors', $errors);
         app('view')->share('_instance', $this);
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?

Flashing errors to session was removed in another PR and @error and $errors stopped working again inside nested blade components. Should fix #621.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)

The tests made on the other PR should cover this too.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

Flashing errors to session was removed in another PR and @error and $errors stopped working again inside nested blade components. This PR should fix #621. I tested before and after the change and I can confirm It was not working and started working after change.

Please, if this is not the best solution, please let's discuss another one that fixes this issue and is better then. I'm asking this because another PR reverted my PR #646 and the issues that were fixed started happening again.

5️⃣ Thanks for contributing! 🙌
