### PR TITLE
Invalid character and Syntax error in IE11

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -264,7 +264,7 @@ HTML;
     });
 
     document.addEventListener("turbolinks:before-cache", function() {
-        document.querySelectorAll(`[wire\\\:id]`).forEach(function(el) {
+        document.querySelectorAll('[wire\\\:id]').forEach(function(el) {
             const component = el.__livewire;
 
             const dataObject = {

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -264,7 +264,7 @@ HTML;
     });
 
     document.addEventListener("turbolinks:before-cache", function() {
-        document.querySelectorAll(`[wire\\\:id]`).forEach(el => {
+        document.querySelectorAll(`[wire\\\:id]`).forEach(function(el) {
             const component = el.__livewire;
 
             const dataObject = {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
I want to use Livewire with IE11 for a specific project. This script that is outputted from `@livewireScripts` has a syntax error with the arrow function and invalid character with the backticks in IE11. 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Single change

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
No

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
Allows use of `@livewireScripts` with IE11

5️⃣ Thanks for contributing! 🙌
