### PR TITLE
Allow Livewire components to sit outside of \App namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": "^7.1.3",
+        "ext-json": "*",
         "symfony/http-kernel": "^4.0|^5.0",
         "illuminate/support": "~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0",
         "illuminate/database": "~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0",

--- a/src/Commands/ComponentParser.php
+++ b/src/Commands/ComponentParser.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Commands;
 
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\File;
@@ -149,8 +150,24 @@ class ComponentParser
 
     public static function generatePathFromNamespace($namespace)
     {
-        $name = Str::replaceFirst(app()->getNamespace(), '', $namespace);
+        return base_path().'/'.str_replace(
+            '\\',
+            '/',
+            static::psr4NamespaceToPath($namespace)
+        );
+    }
 
-        return app('path').'/'.str_replace('\\', '/', $name);
+    protected static function psr4NamespaceToPath(string $namespace)
+    {
+        $filesystem = new Filesystem;
+        $composer = json_decode($filesystem->get(base_path('composer.json')), true);
+        $psr4Base = (array) data_get($composer, 'autoload.psr-4');
+
+        foreach ($psr4Base as $psr4Namespace => $path) {
+            if (Str::startsWith($namespace, $psr4Namespace)) {
+                return $path.Str::after($namespace, $psr4Namespace);
+            }
+        }
+        return $namespace;
     }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?

This is potentially wanted, it adds extra flexibility without affecting existing usage - I created #672 to propose the change.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)

No, sorry.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

#672 explains it in more detail however the synopsis is:

Livewire currently expects its components to exist within the \App namespace, the _livewire.class_namespace_ config must start with "App\\".  This PR relaxes this restriction and allows components to exist in other namespaces,  such as "Modules\Xyz".

5️⃣ Thanks for contributing! 🙌
