### PR TITLE
Added new Livewire::components() method

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -35,6 +35,13 @@ class LivewireManager
         $this->componentAliases[$alias] = $viewClass;
     }
 
+    public function components($components)
+    {
+        foreach ($components as $alias => $viewClass) {
+            $this->component($alias, $viewClass);
+        }
+    }
+
     public function componentResolver($callback)
     {
         $this->customComponentResolver = $callback;


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?

No feature request issue, just a general improvement to the already existing `Livewire::component()` method.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)

No.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

This PR adds a new `Livewire::components()` method for registering multiple component aliases at once using an array.

```php
Livewire::components([
    'alias' => ViewClass::class,
]);
```

5️⃣ Thanks for contributing! 🙌
