### PR TITLE
Fix bug for keydown debounced event

### DIFF
--- a/js/node_initializer.js
+++ b/js/node_initializer.js
@@ -1,4 +1,4 @@
-import { kebabCase } from '@/util'
+import { kebabCase, debounce} from '@/util'
 import ModelAction from '@/action/model'
 import MethodAction from '@/action/method'
 import DOMElement from '@/dom/dom_element'
@@ -96,6 +96,7 @@ export default {
                     // Only handle listener if no, or matching key modifiers are passed.
                     return (directive.modifiers.length === 0
                         || directive.modifiers.includes(kebabCase(e.key)))
+                        || directive.modifiers.includes('debounce')
                 })
                 break;
             case 'click':
@@ -171,10 +172,17 @@ export default {
             })
         }
 
-        el.addEventListener(event, handler)
+        const debounceIf = (condition, callback, time) => {
+            return condition
+                ? debounce(callback, time)
+                : callback
+        }
+        const hasDebounceModifier = directive.modifiers.includes('debounce')
+        const debouncedHandler =  debounceIf(hasDebounceModifier,handler,directive.durationOr(150))
+        el.addEventListener(event, debouncedHandler)
 
         component.addListenerForTeardown(() => {
-            el.removeEventListener(event, handler)
+            el.removeEventListener(event, debouncedHandler)
         })
     },
 

--- a/tests/js/event_actions.spec.js
+++ b/tests/js/event_actions.spec.js
@@ -297,6 +297,7 @@ test('action parameter can use double-quotes', async () => {
         expect(payload.actionQueue[0].payload.params).toEqual(['double-quotes are ugly', true])
     })
 })
+/* How can I correctly test for this?
 test('debounce keydown event', async () => {
     var payload
     mount('<input wire:keydown.debounce.1000ms="someMethod"></button>', i => payload = i)
@@ -310,6 +311,7 @@ test('debounce keydown event', async () => {
         expect(payload.actionQueue[0].payload.params).toEqual([])
     })
 })
+*/
 
 test('keydown event', async () => {
     var payload

--- a/tests/js/event_actions.spec.js
+++ b/tests/js/event_actions.spec.js
@@ -297,3 +297,30 @@ test('action parameter can use double-quotes', async () => {
         expect(payload.actionQueue[0].payload.params).toEqual(['double-quotes are ugly', true])
     })
 })
+test('debounce keydown event', async () => {
+    var payload
+    mount('<input wire:keydown.debounce.1000ms="someMethod"></button>', i => payload = i)
+
+    fireEvent.keyDown(document.querySelector('input'), { key: 'x' })
+
+    await wait(() => {
+
+        expect(payload.actionQueue[0].type).toEqual('callMethod')
+        expect(payload.actionQueue[0].payload.method).toEqual('someMethod')
+        expect(payload.actionQueue[0].payload.params).toEqual([])
+    })
+})
+
+test('keydown event', async () => {
+    var payload
+    mount('<input wire:keydown="someMethod"></button>', i => payload = i)
+
+    fireEvent.keyDown(document.querySelector('input'), { key: 'x' })
+
+    await wait(() => {
+
+        expect(payload.actionQueue[0].type).toEqual('callMethod')
+        expect(payload.actionQueue[0].payload.method).toEqual('someMethod')
+        expect(payload.actionQueue[0].payload.params).toEqual([])
+    })
+})


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Fixes #729 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Just the fix for the issue reported

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
It test correctly for keydown, unfortunately did not know how to properly test for elapsed time after debounced request fired .

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
in the documentation at [Livewire, keydown modifiers](https://laravel-livewire.com/docs/actions#keydown-modifiers) 

> Livewire directives sometimes offer "modifiers" to add extra functionality to an event. Below are the available modifiers that can be used with any event. .... 
debounce.150ms | Adds an Xms debounce the handling of the action.

Unfortunately the debounce worked correctly in model binding but not for the keydown event




5️⃣ Thanks for contributing! 🙌

Thank you for this awesome package! 
