### PR TITLE
Support for domain prefixed multi-tenancy domains

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -72,5 +72,18 @@ return [
     */
 
     'manifest_path' => null,
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Routes
+    |--------------------------------------------------------------------------
+    |
+    | Setting this value to true allows for you to decide where to put the routes.
+    |
+    | Example: Wanting to use a prefix that uses Route Model Binding "http(s)://{tenant}.foo.com/{bar}/livewire..."
+    |
+    */
+
+    'use_custom_routes' => false,
 
 ];

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -80,7 +80,7 @@ return [
     |
     | Setting this value to true allows for you to decide where to put the routes.
     |
-    | Example: Wanting to use a prefix that uses Route Model Binding "http(s)://{tenant}.foo.com/{bar}/livewire..."
+    | Example: Wanting to use a prefix that uses Route Model Binding "http(s)://{tenant}.myurl.com/{bar}/livewire..."
     |
     */
 

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -5,6 +5,7 @@ namespace Livewire;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Facades\Route as RouteFacade;
 use Illuminate\Support\Str;
 use Livewire\Exceptions\ComponentNotFoundException;
 use Livewire\HydrationMiddleware\AddAttributesToRootTagOfHtml;
@@ -372,5 +373,14 @@ HTML;
     public function isLaravel7()
     {
         return Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, '7.0', '>=');
+    }
+    
+    public function routes()
+    {
+        RouteFacade::get('/livewire/livewire.js', '\\Livewire\\LivewireJavaScriptAssets@source');
+        RouteFacade::get('/livewire/livewire.js.map', '\\Livewire\\LivewireJavaScriptAssets@maps');
+
+        RouteFacade::post('/livewire/message/{name}', '\\Livewire\\Connection\\HttpConnectionHandler')
+            ->middleware(config('livewire.middleware_group', 'web'));
     }
 }

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -10,9 +10,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Livewire\LivewireViewCompilerEngine;
-use Livewire\Connection\HttpConnectionHandler;
 use Illuminate\Foundation\Testing\TestResponse;
-use Illuminate\Support\Facades\Route as RouteFacade;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Testing\TestResponse as Laravel7TestResponse;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
@@ -120,11 +118,9 @@ class LivewireServiceProvider extends ServiceProvider
 
     protected function registerRoutes()
     {
-        RouteFacade::get('/livewire/livewire.js', [LivewireJavaScriptAssets::class, 'source']);
-        RouteFacade::get('/livewire/livewire.js.map', [LivewireJavaScriptAssets::class, 'maps']);
-
-        RouteFacade::post('/livewire/message/{name}', HttpConnectionHandler::class)
-            ->middleware(config('livewire.middleware_group', 'web'));
+        if (! config('livewire.use_custom_routes')) {
+            Livewire::routes();
+        }
     }
 
     protected function registerCommands()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
This is something that is wanted for my current scenario (needed for domain prefixed multi-tenancy to work). I have raised an issue (feature-request) but has been left uncommented for 3 days, the reason my proposed solution. :)

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
All of the changes here are relating to the same issue.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
There are no tests included, if accepted as a PR tests can be made for this specific use-case?

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
As described in #802, the issue is around not being able to use this framework in areas of an application that use a domain structure that has any route model binding provided in the domain prefix.

Example: ```http(s)://{tenant}.myurl.com/livewire``` or any route model binding that is provided before the livewire routes.

This fix keeps the current functionality, whilst allowing for the user to optionally _use custom routes_, placing them where they feel needed within their routes.php files.

5️⃣ Thanks for contributing! 🙌
