### PR TITLE
Fix error assertions on rules that contain underscores

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -3,6 +3,7 @@
 namespace Livewire\Testing\Concerns;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Support\MessageBag;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -26,7 +27,7 @@ trait MakesAssertions
     public function assertSee($value)
     {
         PHPUnit::assertStringContainsString(
-            e($value),
+            e((string) $value),
             $this->stripOutInitialData($this->payload['dom'])
         );
 
@@ -36,7 +37,7 @@ trait MakesAssertions
     public function assertDontSee($value)
     {
         PHPUnit::assertStringNotContainsString(
-            e($value),
+            e((string) $value),
             $this->stripOutInitialData($this->payload['dom'])
         );
 
@@ -113,7 +114,10 @@ trait MakesAssertions
                 PHPUnit::assertTrue($errors->has($value), "Component missing error: $value");
             } else {
                 $rules = array_keys(Arr::get($this->lastValidator->failed(), $key, []));
-                $lowerCaseRules = array_map('strtolower', $rules);
+                $snakeCaseRules = array_map(function ($rule) {
+                    return Str::snake($rule);
+                }, $rules);
+                $lowerCaseRules = array_map('strtolower', $snakeCaseRules);
 
                 foreach ((array) $value as $rule) {
                     PHPUnit::assertContains($rule, $lowerCaseRules, "Component has no [{$rule}] errors for [{$key}] attribute.");
@@ -140,8 +144,11 @@ trait MakesAssertions
             if (is_int($key)) {
                 PHPUnit::assertFalse($errors->has($value), "Component has error: $value");
             } else {
-                $rules = array_keys($this->lastValidator->failed()[$key]);
-                $lowerCaseRules = array_map('strtolower', $rules);
+                $rules = array_keys(Arr::get($this->lastValidator->failed(), $key, []));
+                $snakeCaseRules = array_map(function ($rule) {
+                    return Str::snake($rule);
+                }, $rules);
+                $lowerCaseRules = array_map('strtolower', $snakeCaseRules);
 
                 foreach ((array) $value as $rule) {
                     PHPUnit::assertNotContains($rule, $lowerCaseRules, "Component has [{$rule}] errors for [{$key}] attribute.");

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -27,7 +27,7 @@ trait MakesAssertions
     public function assertSee($value)
     {
         PHPUnit::assertStringContainsString(
-            e((string) $value),
+            e($value),
             $this->stripOutInitialData($this->payload['dom'])
         );
 
@@ -37,7 +37,7 @@ trait MakesAssertions
     public function assertDontSee($value)
     {
         PHPUnit::assertStringNotContainsString(
-            e((string) $value),
+            e($value),
             $this->stripOutInitialData($this->payload['dom'])
         );
 

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -117,10 +117,9 @@ trait MakesAssertions
                 $snakeCaseRules = array_map(function ($rule) {
                     return Str::snake($rule);
                 }, $rules);
-                $lowerCaseRules = array_map('strtolower', $snakeCaseRules);
 
                 foreach ((array) $value as $rule) {
-                    PHPUnit::assertContains($rule, $lowerCaseRules, "Component has no [{$rule}] errors for [{$key}] attribute.");
+                    PHPUnit::assertContains($rule, $snakeCaseRules, "Component has no [{$rule}] errors for [{$key}] attribute.");
                 }
             }
         }
@@ -148,10 +147,9 @@ trait MakesAssertions
                 $snakeCaseRules = array_map(function ($rule) {
                     return Str::snake($rule);
                 }, $rules);
-                $lowerCaseRules = array_map('strtolower', $snakeCaseRules);
 
                 foreach ((array) $value as $rule) {
-                    PHPUnit::assertNotContains($rule, $lowerCaseRules, "Component has [{$rule}] errors for [{$key}] attribute.");
+                    PHPUnit::assertNotContains($rule, $snakeCaseRules, "Component has [{$rule}] errors for [{$key}] attribute.");
                 }
             }
         }

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -132,6 +132,17 @@ class ValidationTest extends TestCase
 
         $this->assertTrue(app('view')->shared('errors') === $errors);
     }
+
+    /** @test */
+    public function multi_word_validation_rules_are_assertable()
+    {
+        $component = app(LivewireManager::class)->test(ForValidation::class);
+
+        $component
+            ->set('foo', 'bar')
+            ->call('runValidationWithMultiWordRule')
+            ->assertHasErrors(['foo' => 'ends_with']);
+    }
 }
 
 class ForValidation extends Component
@@ -149,6 +160,13 @@ class ForValidation extends Component
         $this->validate([
             'foo' => 'required',
             'bar' => 'required',
+        ]);
+    }
+
+    public function runValidationWithMultiWordRule()
+    {
+        $this->validate([
+            'foo' => 'ends_with:baz',
         ]);
     }
 


### PR DESCRIPTION
Fixes #818.

The issue is with `$this->lastValidator->failed()` returning rule names in StudlyCase, which are then formatted in lower case before being asserted.

This results in a scenario whereby to test for an `alpha_dash` error, you'd need to check for `alphadash`.

This fix involves converting the StudlyCase rule names into snake_case, which also formats them in lower case as well, killing two birds with one stone.

You can check that this works using the example described in #818.