### PR TITLE
Don't wrap authorization exceptions in 500

### DIFF
--- a/src/CompilerEngine.php
+++ b/src/CompilerEngine.php
@@ -22,8 +22,10 @@ if (Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, 
             $uses = array_flip(class_uses_recursive($e));
 
             if (
+                // Don't wrap "abort(403)".
+                $e instanceof AuthorizationException
                 // Don't wrap "abort(404)".
-                $e instanceof NotFoundHttpException
+                || $e instanceof NotFoundHttpException
                 // Don't wrap "abort(500)".
                 || $e instanceof HttpException
                 // Don't wrap most Livewire exceptions.
@@ -46,12 +48,14 @@ if (Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, 
         // harder to read, AND causes issues like `abort(404)` not actually working.
         protected function handleViewException(Exception $e, $obLevel)
         {
-            if($e instanceof Exception){
+            if ($e instanceof Exception){
                 $uses = array_flip(class_uses_recursive($e));
 
                 if (
+                    // Don't wrap "abort(403)".
+                    $e instanceof AuthorizationException
                     // Don't wrap "abort(404)".
-                    $e instanceof NotFoundHttpException
+                    || $e instanceof NotFoundHttpException
                     // Don't wrap "abort(500)".
                     || $e instanceof HttpException
                     // Don't wrap most Livewire exceptions.
@@ -64,10 +68,9 @@ if (Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, 
                 }
 
                 parent::handleViewException($e, $obLevel);
-            }else{
+            } else {
                 throw($e);
             }
-
         }
     }
 }

--- a/src/CompilerEngine.php
+++ b/src/CompilerEngine.php
@@ -12,14 +12,18 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
 
-if (Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, '7.0', '>=')) {
-    class CompilerEngine extends LaravelCompilerEngine
+class CompilerEngine extends LaravelCompilerEngine
+{
+    // Errors thrown while a view is rendering are caught by the Blade
+    // compiler and wrapped in an "ErrorException". This makes Livewire errors
+    // harder to read, AND causes issues like `abort(404)` not actually working.
+    protected function handleViewException(Throwable $e, $obLevel)
     {
-        // Errors thrown while a view is rendering are caught by the Blade
-        // compiler and wrapped in an "ErrorException". This makes Livewire errors
-        // harder to read, AND causes issues like `abort(404)` not actually working.
-        protected function handleViewException(Throwable $e, $obLevel)
-        {
+        if (
+            $e instanceof Exception
+            || Application::VERSION === '7.x-dev'
+            || version_compare(Application::VERSION, '7.0', '>=')
+        ) {
             $uses = array_flip(class_uses_recursive($e));
 
             if (
@@ -39,39 +43,8 @@ if (Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, 
             }
 
             parent::handleViewException($e, $obLevel);
-        }
-    }
-} else {
-    class CompilerEngine extends LaravelCompilerEngine
-    {
-        // Errors thrown while a view is rendering are caught by the Blade
-        // compiler and wrapped in an "ErrorException". This makes Livewire errors
-        // harder to read, AND causes issues like `abort(404)` not actually working.
-        protected function handleViewException(Exception $e, $obLevel)
-        {
-            if ($e instanceof Exception){
-                $uses = array_flip(class_uses_recursive($e));
-
-                if (
-                    // Don't wrap "abort(403)".
-                    $e instanceof AuthorizationException
-                    // Don't wrap "abort(404)".
-                    || $e instanceof NotFoundHttpException
-                    // Don't wrap "abort(500)".
-                    || $e instanceof HttpException
-                    // Don't wrap most Livewire exceptions.
-                    || isset($uses[BypassViewHandler::class])
-                ) {
-                    // This is because there is no "parent::parent::".
-                    PhpEngine::handleViewException($e, $obLevel);
-
-                    return;
-                }
-
-                parent::handleViewException($e, $obLevel);
-            } else {
-                throw($e);
-            }
+        } else {
+            throw($e);
         }
     }
 }

--- a/src/CompilerEngine.php
+++ b/src/CompilerEngine.php
@@ -3,6 +3,7 @@
 namespace Livewire;
 
 use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Application;
 use Illuminate\View\Engines\CompilerEngine as LaravelCompilerEngine;
 use Illuminate\View\Engines\PhpEngine;

--- a/src/CompilerEngine.php
+++ b/src/CompilerEngine.php
@@ -12,18 +12,14 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
 
-class CompilerEngine extends LaravelCompilerEngine
-{
-    // Errors thrown while a view is rendering are caught by the Blade
-    // compiler and wrapped in an "ErrorException". This makes Livewire errors
-    // harder to read, AND causes issues like `abort(404)` not actually working.
-    protected function handleViewException(Throwable $e, $obLevel)
+if (Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, '7.0', '>=')) {
+    class CompilerEngine extends LaravelCompilerEngine
     {
-        if (
-            $e instanceof Exception
-            || Application::VERSION === '7.x-dev'
-            || version_compare(Application::VERSION, '7.0', '>=')
-        ) {
+        // Errors thrown while a view is rendering are caught by the Blade
+        // compiler and wrapped in an "ErrorException". This makes Livewire errors
+        // harder to read, AND causes issues like `abort(404)` not actually working.
+        protected function handleViewException(Throwable $e, $obLevel)
+        {
             $uses = array_flip(class_uses_recursive($e));
 
             if (
@@ -43,8 +39,39 @@ class CompilerEngine extends LaravelCompilerEngine
             }
 
             parent::handleViewException($e, $obLevel);
-        } else {
-            throw($e);
+        }
+    }
+} else {
+    class CompilerEngine extends LaravelCompilerEngine
+    {
+        // Errors thrown while a view is rendering are caught by the Blade
+        // compiler and wrapped in an "ErrorException". This makes Livewire errors
+        // harder to read, AND causes issues like `abort(404)` not actually working.
+        protected function handleViewException(Exception $e, $obLevel)
+        {
+            if ($e instanceof Exception){
+                $uses = array_flip(class_uses_recursive($e));
+
+                if (
+                    // Don't wrap "abort(403)".
+                    $e instanceof AuthorizationException
+                    // Don't wrap "abort(404)".
+                    || $e instanceof NotFoundHttpException
+                    // Don't wrap "abort(500)".
+                    || $e instanceof HttpException
+                    // Don't wrap most Livewire exceptions.
+                    || isset($uses[BypassViewHandler::class])
+                ) {
+                    // This is because there is no "parent::parent::".
+                    PhpEngine::handleViewException($e, $obLevel);
+
+                    return;
+                }
+
+                parent::handleViewException($e, $obLevel);
+            } else {
+                throw($e);
+            }
         }
     }
 }

--- a/tests/ErrorsThrownInLivewireViewsAreConditionallyWrappedTest.php
+++ b/tests/ErrorsThrownInLivewireViewsAreConditionallyWrappedTest.php
@@ -6,6 +6,7 @@ use Exception;
 use ErrorException;
 use Livewire\Livewire;
 use Livewire\Component;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\View;
 use Livewire\Exceptions\BypassViewHandler;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -51,6 +52,16 @@ class ErrorsThrownInLivewireViewsAreConditionallyWrappedTest extends TestCase
         $this->expectException(HttpException::class);
 
         Livewire::component('foo', Abort500IsThrownInComponentMountStub::class);
+
+        View::make('render-component', ['component' => 'foo'])->render();
+    }
+
+    /** @test */
+    public function errors_thrown_by_authorization_exception_function_are_not_wrapped()
+    {
+        $this->expectException(AuthorizationException::class);
+
+        Livewire::component('foo', AuthorizationExceptionIsThrownInComponentMountStub::class);
 
         View::make('render-component', ['component' => 'foo'])->render();
     }
@@ -103,6 +114,19 @@ class Abort500IsThrownInComponentMountStub extends Component
     public function mount()
     {
         abort(500);
+    }
+
+    public function render()
+    {
+        return app('view')->make('null-view');
+    }
+}
+
+class AuthorizationExceptionIsThrownInComponentMountStub extends Component
+{
+    public function mount()
+    {
+        throw new AuthorizationException;
     }
 
     public function render()


### PR DESCRIPTION
This issue is present when authorization exceptions are thrown from a component class. Instead of a 403 being thrown and cleanly rendered, Livewire wraps it in a 500, which causes this eyesore...

![ew](https://user-images.githubusercontent.com/41773797/79950925-b6b87680-846f-11ea-8296-eef3398010e4.png)

You can see this behaviour in action simply by using `$this->authorize()` on an unauthorized model.

I've written a test that demonstrates this bug and asserts that the change fixes it.