### PR TITLE
Adding dedicated controller for Route::livewire() to allow route caching

### DIFF
--- a/src/Macros/LivewireSPAController.php
+++ b/src/Macros/LivewireSPAController.php
@@ -41,14 +41,11 @@ class LivewireSPAController
             ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $this->router))->retrieveBindings()
             : [];
 
-        return view()->file(
-            __DIR__ . '/livewire-view.blade.php',
-            [
-                'layout' => $this->route->getAction('layout') ?? 'layouts.app',
-                'section' => $this->route->getAction('section') ?? 'content',
-                'component' => $componentName,
-                'componentParameters' => $componentParameters,
-            ]
-        )->with($this->route->layoutParamsFromLivewire ?? []);
+        return view()->file(__DIR__ . '/livewire-view.blade.php', [
+            'layout' => $this->route->getAction('layout') ?? 'layouts.app',
+            'section' => $this->route->getAction('section') ?? 'content',
+            'component' => $componentName,
+            'componentParameters' => $componentParameters,
+        ])->with($this->route->layoutParamsFromLivewire ?? []);
     }
 }

--- a/src/Macros/LivewireSPAController.php
+++ b/src/Macros/LivewireSPAController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Livewire\Macros;
+
+use Illuminate\Routing\Route;
+use Illuminate\Routing\Router;
+use ReflectionClass;
+
+class LivewireSPAController
+{
+    /**
+     * @param Route $route
+     * @param Router $router
+     * @param string $method
+     * @param array $parameters
+     * @return \Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\View\View|mixed
+     * @throws \ReflectionException
+     */
+    public function __call(Route $route, Router $router, $method, $parameters)
+    {
+        $componentName = $method;
+
+        $componentClass = app('livewire')->getComponentClass($componentName);
+        $reflected = new ReflectionClass($componentClass);
+
+        $componentParameters = $reflected->hasMethod('mount')
+            ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $router))->retrieveBindings()
+            : [];
+
+        return view(
+            __DIR__ . '/livewire-view.blade.php',
+            [
+                'layout' => $route->getAction('layout') ?? 'layouts.app',
+                'section' => $route->getAction('section') ?? 'content',
+                'component' => $componentName,
+                'componentParameters' => $componentParameters,
+            ]
+        )->with($route->layoutParamsFromLivewire ?? []);
+    }
+}

--- a/src/Macros/LivewireSPAController.php
+++ b/src/Macros/LivewireSPAController.php
@@ -9,14 +9,28 @@ use ReflectionClass;
 class LivewireSPAController
 {
     /**
-     * @param Route $route
-     * @param Router $router
+     * @var Route
+     */
+    private $route;
+
+    /**
+     * @var Router
+     */
+    private $router;
+
+    public function __construct(Route $route, Router $router)
+    {
+        $this->route = $route;
+        $this->router = $router;
+    }
+
+    /**
      * @param string $method
      * @param array $parameters
+     *
      * @return \Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\View\View|mixed
-     * @throws \ReflectionException
      */
-    public function __call(Route $route, Router $router, $method, $parameters)
+    public function __call($method, $parameters)
     {
         $componentName = $method;
 
@@ -24,17 +38,17 @@ class LivewireSPAController
         $reflected = new ReflectionClass($componentClass);
 
         $componentParameters = $reflected->hasMethod('mount')
-            ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $router))->retrieveBindings()
+            ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $this->router))->retrieveBindings()
             : [];
 
-        return view(
+        return view()->file(
             __DIR__ . '/livewire-view.blade.php',
             [
-                'layout' => $route->getAction('layout') ?? 'layouts.app',
-                'section' => $route->getAction('section') ?? 'content',
+                'layout' => $this->route->getAction('layout') ?? 'layouts.app',
+                'section' => $this->route->getAction('section') ?? 'content',
                 'component' => $componentName,
                 'componentParameters' => $componentParameters,
             ]
-        )->with($route->layoutParamsFromLivewire ?? []);
+        )->with($this->route->layoutParamsFromLivewire ?? []);
     }
 }

--- a/src/Macros/RouterMacros.php
+++ b/src/Macros/RouterMacros.php
@@ -35,25 +35,19 @@ class RouterMacros
         return function ($uri, $component = null) {
             $component = $component ?: $uri;
 
-            return $this->get(
-                $uri,
-                function () use ($component) {
-                    $componentClass = app('livewire')->getComponentClass($component);
-                    $reflected = new \ReflectionClass($componentClass);
+            return $this->get($uri, function () use ($component) {
+                $componentClass = app('livewire')->getComponentClass($component);
+                $reflected = new \ReflectionClass($componentClass);
 
-                    return app('view')->file(
-                        __DIR__ . '/livewire-view.blade.php',
-                        [
-                            'layout' => $this->current()->getAction('layout') ?? 'layouts.app',
-                            'section' => $this->current()->getAction('section') ?? 'content',
-                            'component' => $component,
-                            'componentParameters' => $reflected->hasMethod('mount')
-                                ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $this))->retrieveBindings()
-                                : [],
-                        ]
-                    )->with($this->current()->layoutParamsFromLivewire ?? []);
-                }
-            );
+                return view()->file(__DIR__ . '/livewire-view.blade.php', [
+                    'layout' => $this->current()->getAction('layout') ?? 'layouts.app',
+                    'section' => $this->current()->getAction('section') ?? 'content',
+                    'component' => $component,
+                    'componentParameters' => $reflected->hasMethod('mount')
+                        ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $this))->retrieveBindings()
+                        : [],
+                ])->with($this->current()->layoutParamsFromLivewire ?? []);
+            });
         };
     }
 }

--- a/src/Macros/RouterMacros.php
+++ b/src/Macros/RouterMacros.php
@@ -27,19 +27,7 @@ class RouterMacros
         return function ($uri, $component = null) {
             $component = $component ?: $uri;
 
-            return $this->get($uri, function () use ($component) {
-                $componentClass = app('livewire')->getComponentClass($component);
-                $reflected = new \ReflectionClass($componentClass);
-
-                return app('view')->file(__DIR__.'/livewire-view.blade.php', [
-                    'layout' => $this->current()->getAction('layout') ?? 'layouts.app',
-                    'section' => $this->current()->getAction('section') ?? 'content',
-                    'component' => $component,
-                    'componentParameters' => $reflected->hasMethod('mount')
-                        ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $this))->retrieveBindings()
-                        : [],
-                ])->with($this->current()->layoutParamsFromLivewire ?? []);
-            });
+            return $this->get($uri, [LivewireSPAController::class, $component]);
         };
     }
 }

--- a/src/Macros/RouterMacros.php
+++ b/src/Macros/RouterMacros.php
@@ -24,10 +24,36 @@ class RouterMacros
 
     public function livewire()
     {
+        if (version_compare(PHP_VERSION, '7.4') >= 0) {
+            return function ($uri, $component = null) {
+                $component = $component ?: $uri;
+
+                return $this->get($uri, [LivewireSPAController::class, $component]);
+            };
+        }
+
         return function ($uri, $component = null) {
             $component = $component ?: $uri;
 
-            return $this->get($uri, [LivewireSPAController::class, $component]);
+            return $this->get(
+                $uri,
+                function () use ($component) {
+                    $componentClass = app('livewire')->getComponentClass($component);
+                    $reflected = new \ReflectionClass($componentClass);
+
+                    return app('view')->file(
+                        __DIR__ . '/livewire-view.blade.php',
+                        [
+                            'layout' => $this->current()->getAction('layout') ?? 'layouts.app',
+                            'section' => $this->current()->getAction('section') ?? 'content',
+                            'component' => $component,
+                            'componentParameters' => $reflected->hasMethod('mount')
+                                ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $this))->retrieveBindings()
+                                : [],
+                        ]
+                    )->with($this->current()->layoutParamsFromLivewire ?? []);
+                }
+            );
         };
     }
 }


### PR DESCRIPTION
Fixes #746

This adds a separate `LivewireSPAController` class in favor of the old closure route that wasn't route cachable.