### PR TITLE
Add support for action with ... operator

### DIFF
--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -94,17 +94,19 @@ trait HandlesActions
 
     protected function resolveActionParameters($method, $params)
     {
-        return collect((new \ReflectionMethod($this, $method))->getParameters())->map(function ($parameter) use (&$params) {
-            return rescue(function () use ($parameter) {
-                if ($class = $parameter->getClass()) {
-                    return app($class->name);
-                }
+        return collect((new \ReflectionMethod($this, $method))->getParameters())
+            ->map(function ($parameter) use (&$params) {
+                return rescue(function () use ($parameter) {
+                    if ($class = $parameter->getClass()) {
+                        return app($class->name);
+                    }
 
-                return app($parameter->name);
-            }, function () use (&$params) {
-                return array_shift($params);
-            }, false);
-        });
+                    return app($parameter->name);
+                }, function () use (&$params) {
+                    return array_shift($params);
+                }, false);
+            })
+            ->concat($params);
     }
 
     protected function methodIsPublicAndNotDefinedOnBaseClass($methodName)


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Yes.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
No.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
```
<button wire:click="merge('a', 'b', 'c')">Merge</button>

class Demo extends Component
{
    public function merge(...$characters)
    {
        $this->word = implode('', $characters);

        // $this->word is now "a" instead of "abc"
    }
}
```
Currently `$this->word` will be "a", because `resolveActionParameters` in `HandlesActions.php` will only pass first X parameters to action (which X equals to func_num_args() of that action)

In this commit I just concat the rest parameters to the collection.

5️⃣ Thanks for contributing! 🙌
