### PR TITLE
Add support for action with spread operator

### DIFF
--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -104,7 +104,7 @@ trait HandlesActions
             }, function () use (&$params) {
                 return array_shift($params);
             }, false);
-        });
+        })->concat($params);
     }
 
     protected function methodIsPublicAndNotDefinedOnBaseClass($methodName)

--- a/tests/LivewireTestingTest.php
+++ b/tests/LivewireTestingTest.php
@@ -122,6 +122,24 @@ class LivewireTestingTest extends TestCase
             ->set('bar', '')
             ->assertHasErrors(['foo', 'bar']);
     }
+
+    /** @test */
+    public function assert_called_action_without_spread_operator()
+    {
+        app(LivewireManager::class)
+            ->test(ActionWithoutSpreadOperator::class)
+            ->call('merge', 'te', 'st')
+            ->assertSet('word', 'test');
+    }
+
+    /** @test */
+    public function assert_called_action_with_spread_operator()
+    {
+        app(LivewireManager::class)
+            ->test(ActionWithSpreadOperator::class)
+            ->call('merge', 't', 'e', 's', 't')
+            ->assertSet('word', 'test');
+    }
 }
 
 class HasMountArguments extends Component
@@ -220,6 +238,36 @@ class ValidatesDataWithRealTimeStub extends Component
             'foo' => 'required|min:6',
             'bar' => 'required',
         ]);
+    }
+
+    public function render()
+    {
+        return app('view')->make('null-view');
+    }
+}
+
+class ActionWithoutSpreadOperator extends Component
+{
+    public $word;
+
+    public function merge($first, $second)
+    {
+        $this->word = "{$first}{$second}";
+    }
+
+    public function render()
+    {
+        return app('view')->make('null-view');
+    }
+}
+
+class ActionWithSpreadOperator extends Component
+{
+    public $word;
+
+    public function merge(...$characters)
+    {
+        $this->word = implode('', $characters);
     }
 
     public function render()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
No.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
```
<button wire:click="merge('a', 'b', 'c')">Merge</button>

class Demo extends Component
{
    public function merge(...$characters)
    {
        $this->word = implode('', $characters);

        // $this->word is now "a" instead of "abc"
    }
}
```
Currently `$this->word` will be "a", because `resolveActionParameters` in `HandlesActions.php` will only pass first X parameters to action (which X equals to func_num_args() of that action)

In this commit I just concat the rest parameters to the collection.

5️⃣ Thanks for contributing! 🙌