### PR TITLE
Fix #814 Allow injecting dependencies at render() method

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -80,11 +80,6 @@ abstract class Component
         return $this->casts;
     }
 
-    public function render()
-    {
-        return view("livewire.{$this->getName()}");
-    }
-
     public function output($errors = null)
     {
         // In the service provider, we hijack Laravel's Blade engine
@@ -95,7 +90,7 @@ abstract class Component
         $engine = app('view.engine.resolver')->resolve('blade');
         $engine->startLivewireRendering($this);
 
-        $view = $this->render();
+        $view = method_exists($this, 'render') ? app()->call([$this,'render']) : view("livewire.{$this->getName()}");
 
         if (is_string($view) && Livewire::isLaravel7()) {
             $view = app('view')->make((new CreateBladeViewFromString)($view));

--- a/tests/ComponentCanResolveRenderDependencies.php
+++ b/tests/ComponentCanResolveRenderDependencies.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Component;
+use Livewire\LivewireManager;
+
+class ComponentCanResolveRenderDependencies extends TestCase
+{
+    /** @test */
+    public function public_name_property_is_set()
+    {
+        $component = app(LivewireManager::class)->test(DummyComponent::class);
+
+        $component->assertSee('bar');
+    }
+
+}
+
+class Dummy
+{
+    public $foo = 'bar';
+}
+
+class DummyComponent extends Component
+{
+    public function render(Dummy $dummy)
+    {
+        return view('dummy-view', ['dummy' => $dummy]);
+    }
+}

--- a/tests/views/dummy-view.blade.php
+++ b/tests/views/dummy-view.blade.php
@@ -1,0 +1,3 @@
+<div>
+    {{ $dummy->foo }}
+</div>


### PR DESCRIPTION
this **PR** closes #814 and allows laravel container to **resolve render method** and inject any dependencies needed.


```php

class PostsComponent extends Component
{
       public function render(App\Post $post)
       {
             //some logic
       }
}