### PR TITLE
Prevent wrapping of exceptions when in debug mode

### DIFF
--- a/src/CompilerEngine.php
+++ b/src/CompilerEngine.php
@@ -29,6 +29,8 @@ if (Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, 
                 || $e instanceof NotFoundHttpException
                 // Don't wrap "abort(500)".
                 || $e instanceof HttpException
+                // Don't wrap in debug mode
+                || config('app.debug')
                 // Don't wrap most Livewire exceptions.
                 || isset($uses[BypassViewHandler::class])
             ) {


### PR DESCRIPTION
Errors thrown while a view is rendering are caught by the Blade compiler and obscured in an "ErrorException".  This change enables you to see where these exceptions originated while in debug mode.