### PR TITLE
Add wire:append directive

### DIFF
--- a/js/component/index.js
+++ b/js/component/index.js
@@ -305,6 +305,10 @@ export default class Component {
                     }
                 }
 
+                if(fromEl.directives.has('append')){
+                    to.insertAdjacentHTML('afterbegin', from.innerHTML)
+                }
+
                 // Children will update themselves.
                 if (fromEl.isComponentRootEl() && fromEl.getAttribute('id') !== this.id) return false
 


### PR DESCRIPTION
this **PR** adds **wire:append** directive

```html
<div>
   <h1> {{$foo}} <h2>
    
    <div wire:append> <!-- any changes to $bar will be happened to this div -->
       {{$bar}}
   </div>
</div>
```
two notes regarding testing

- first one if we tried to remove [this part of code](https://github.com/livewire/livewire/blob/master/js/component/index.js#L299-L306) that is responsible for **wire:ignore** and runner js test we will find it will pass

- for the above reason i felt that the **ignore.spec.js** isn't testing the actual behavior so i tried to that for testing **wire:append** . but it didn't work . hope someone could shade some light on that

```js
test("wire:append appends to the declared element", async () => {
    mount("<div wire:append>foo </div>");
    let root = window.livewire.find("123");

    root.handleMorph('<div wire:id="123"><div wire:append>bar </div></div>');
    await timeout(20);
    console.log(root.el.rawNode().innerHTML); //this outputed <div wire:append>bar </div> which is not the expected result

//expected result <div wire:append>bar foo </div>
});
```