### PR TITLE
Fix #904 resolving laravel container aliases variables

### DIFF
--- a/tests/ComponentMethodBindingsTest.php
+++ b/tests/ComponentMethodBindingsTest.php
@@ -35,6 +35,28 @@ class ComponentMethodBindingsTest extends TestCase
         Livewire::test(ComponentWithBindings::class, ['param' => 'foo'])
             ->assertSee('from-injectionfoo');
     }
+
+    /** @test */
+    public function custom_method_recieves_bindings()
+    {
+        $component = Livewire::test(ComponentWithBindings::class);
+
+        $component->call('customMethod', '/path/to/some/file');
+
+        $this->assertEquals('/path/to/some/file', $component->path);
+        $this->assertEquals('from-injection', $component->stubValue);
+    }
+
+    /** @test */
+    public function custom_method_without_dependencies()
+    {
+        $component = Livewire::test(ComponentWithBindings::class);
+
+        $component->call('customMethodWithoutDependencies');
+
+        $this->assertEquals(null, $component->path);
+        $this->assertEquals(null, $component->stubValue);
+    }
 }
 
 class ModelToBeBoundStub
@@ -49,6 +71,10 @@ class ComponentWithBindings extends Component
 {
     public $name;
 
+    public $path;
+
+    public $stubValue;
+
     public function mount(ModelToBeBoundStub $stub, $param = '')
     {
         $this->name = $stub->value.$param;
@@ -57,5 +83,16 @@ class ComponentWithBindings extends Component
     public function render()
     {
         return app('view')->make('show-name-with-this');
+    }
+
+    public function customMethod($path, ModelToBeBoundStub $stub)
+    {
+        $this->path = $path;
+        $this->stubValue = $stub->value;
+    }
+
+    public function customMethodWithoutDependencies()
+    {
+        
     }
 }


### PR DESCRIPTION
this PR fix #904 . for example when using [**any laravel container aliases variables as a dependency**](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Foundation/Application.php#L1200-L1240) it will get resolved by laravel container which is not the desired behavior .


```php
<button wire:click="customMethod('someRandomValue')">Click</button>

class FooComponent extends Component
{
   public function customMethod($path) //or $session or any aliased variable
   {
       dd($path); //print out laravel app path not 'someRandomValue'
   }

}

```

so this PR fixes the above issue