### PR TITLE
add assertSeeHtml

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -54,6 +54,16 @@ trait MakesAssertions
         return $this;
     }
 
+    public function assertDontSeeHtml($value)
+    {
+        PHPUnit::assertStringNotContainsString(
+            $value,
+            $this->stripOutInitialData($this->payload['dom'])
+        );
+
+        return $this;
+    }
+
     protected function stripOutInitialData($subject)
     {
         return preg_replace('(wire:initial-data=\".+}")', '', $subject);

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -44,6 +44,16 @@ trait MakesAssertions
         return $this;
     }
 
+    public function assertSeeHtml($value)
+    {
+        PHPUnit::assertStringContainsString(
+            $value,
+            $this->stripOutInitialData($this->payload['dom'])
+        );
+
+        return $this;
+    }
+
     protected function stripOutInitialData($subject)
     {
         return preg_replace('(wire:initial-data=\".+}")', '', $subject);

--- a/tests/LivewireTestingTest.php
+++ b/tests/LivewireTestingTest.php
@@ -50,6 +50,14 @@ class LivewireTestingTest extends TestCase
     }
 
     /** @test */
+    public function assert_see_html()
+    {
+        app(LivewireManager::class)
+            ->test(HasHtml::class)
+            ->assertSeeHtml('<p style="display: none">Hello HTML</p>');
+    }
+
+    /** @test */
     public function assert_see_doesnt_include_json_encoded_data_put_in_wire_data_attribute()
     {
         // See for more info: https://github.com/calebporzio/livewire/issues/62
@@ -136,6 +144,14 @@ class HasMountArguments extends Component
     public function render()
     {
         return app('view')->make('show-name-with-this');
+    }
+}
+
+class HasHtml extends Component
+{
+    public function render()
+    {
+        return app('view')->make('show-html');
     }
 }
 

--- a/tests/LivewireTestingTest.php
+++ b/tests/LivewireTestingTest.php
@@ -58,6 +58,14 @@ class LivewireTestingTest extends TestCase
     }
 
     /** @test */
+    public function assert_dont_see_html()
+    {
+        app(LivewireManager::class)
+            ->test(HasHtml::class)
+            ->assertDontSeeHtml('<span style="display: none">Hello HTML</span>');
+    }
+
+    /** @test */
     public function assert_see_doesnt_include_json_encoded_data_put_in_wire_data_attribute()
     {
         // See for more info: https://github.com/calebporzio/livewire/issues/62

--- a/tests/views/show-html.blade.php
+++ b/tests/views/show-html.blade.php
@@ -1,0 +1,1 @@
+<div><p style="display: none">Hello HTML</p></div>


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
No

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
I've been using Livewire for a work project and find myself wanting to test that the correct SVG and other HTML tags are displayed to the user based on decisions made in my code.  However the current `assertSee()` method escapes HTML.  This PR adds `assertSeeHtml()` and `assertDontSeeHtml()` that allows tests that check that the correct HTML is presented or not.

5️⃣ Thanks for contributing! 🙌
