### PR TITLE
Adds forward slash nested component names to livewire:make command

### DIFF
--- a/src/Commands/ComponentParser.php
+++ b/src/Commands/ComponentParser.php
@@ -24,7 +24,7 @@ class ComponentParser
         $this->baseClassPath = rtrim($classPath, DIRECTORY_SEPARATOR).'/';
         $this->baseViewPath = rtrim($viewPath, DIRECTORY_SEPARATOR).'/';
 
-        $directories = preg_split('/[.]+/', $rawCommand);
+        $directories = preg_split('/[.\/]+/', $rawCommand);
 
 
         $camelCase = Str::camel(array_pop($directories));

--- a/src/Commands/StubParser.php
+++ b/src/Commands/StubParser.php
@@ -15,7 +15,7 @@ class StubParser extends ComponentParser
         $this->baseClassPath = rtrim($classPath, DIRECTORY_SEPARATOR).'/Stubs/';
         $this->baseViewPath = rtrim($viewPath, DIRECTORY_SEPARATOR).'/stubs/';
 
-        $directories = preg_split('/[.]+/', $rawCommand);
+        $directories = preg_split('/[.\/]+/', $rawCommand);
 
         $this->component = Str::kebab(array_pop($directories));
         $this->componentClass = Str::studly($this->component);

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -45,9 +45,18 @@ class MakeCommandTest extends TestCase
     }
 
     /** @test */
-    public function nested_component_is_created_by_make_command()
+    public function dot_nested_component_is_created_by_make_command()
     {
         Artisan::call('make:livewire', ['name' => 'foo.bar']);
+
+        $this->assertTrue(File::exists($this->livewireClassesPath('Foo/Bar.php')));
+        $this->assertTrue(File::exists($this->livewireViewsPath('foo/bar.blade.php')));
+    }
+
+    /** @test */
+    public function forward_slash_nested_component_is_created_by_make_command()
+    {
+        Artisan::call('make:livewire', ['name' => 'foo/bar']);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Foo/Bar.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('foo/bar.blade.php')));


### PR DESCRIPTION
> 1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?

Yes. Fixes #913

> 2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

> 3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)

Yes.

> 4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

`livewire:make` command will support `.` or `/` nested names when creating, which is a common thing in laravel ecosystem. 

Now we can use as : 

`php artisan livewire:make foo/bar/baz`
`@livewire('livewire/with/slashes')`
or 
`php artisan livewire:make foo.bar/baz`
`@livewire('livewire.with/slashes/and.dots')`

results will be the same `Foo/Bar/Baz`

