### PR TITLE
Idea: initialize mount<Trait> like Eloquent/Model does

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -391,10 +391,10 @@ HTML;
         );
     }
 
-    private function invokeTraitInitializers($instance, $runtime, $params = [])
+    private function invokeTraitInitializers($instance, $lifecycle, $params = [])
     {
         foreach (class_uses($instance) as $trait) {
-            $method = $runtime.class_basename($trait);
+            $method = $lifecycle.class_basename($trait);
 
             if (method_exists($instance, $method)) {
                 app()->call([$instance, $method], $params);

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -110,6 +110,8 @@ class LivewireManager
 
         $instance->mount(...$resolvedParameters);
 
+        $this->invokeTraitInitializers($instance, 'mount', $params);
+
         $dom = $instance->output();
 
         $response = new Fluent([
@@ -387,5 +389,16 @@ HTML;
             method_exists($instance, 'mount'),
             new MountMethodMissingException($instance->getName())
         );
+    }
+
+    private function invokeTraitInitializers($instance, $runtime, $params = [])
+    {
+        foreach (class_uses($instance) as $trait) {
+            $method = $runtime.class_basename($trait);
+
+            if (method_exists($instance, $method)) {
+                app()->call([$instance, $method], $params);
+            }
+        }
     }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?

I wanted to be able to reuse Livewire component code with traits. I love how parts of Laravel, e.g. Eloquent/Model and Support/ServiceProvider lets you run boot and register methods automatically.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No!

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)

No, but I will add them when/if getting feedback.

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.

When including a trait on the component the LivewireManager will check for implemented traits and run mount<TraitName> if the method exist.

An example use case:

```html
    @section('tab')
        <livewire:employee.surveys.builder :model="$survey" />
    @endsection
```

The component: 

```php
use App\Http\Livewire\Concerns\HasModel;

class Builder extends Component
{
    use HasModel;

    public function mount($model)
    {
        //
    }

    public function render()
    {
        // getModel() is from trait
        $survey = $this->getModel();

        return view('livewire.employee.surveys.builder', [
            'survey' => $survey,
        ]);
    }
}
```

The trait:

```php
use Illuminate\Database\Eloquent\Model;

trait HasModel
{
    public $model_class;

    public $model_key;

    // invoked by Livewire
    public function mountHasModel($model)
    {
        $this->setModel($model);
    }

    protected function setModel(Model $model)
    {
        $this->model_class = get_class($model);
        $this->model_key = $model->getKey();
    }

    protected function getModelKey()
    {
        return $this->model_key;
    }

    protected function getModel()
    {
        return $this->model_class::find($this->model_key);
    }
}
```

Current issues: 

- You cannot type-hint for instance to `Model` as Laravel/Livewire as the type must be concrete.
- You cannot leave the component mount method parameterless if you have input. In the example above $model is left unused. **Update** personally I dislike the special error-handling of mount. E.g. if an argument is missing in the case of passing props to a component. It is similar to an action method on a controller.

5️⃣ Thanks for contributing! 🙌

Usage in Eloquent/Model https://github.com/laravel/framework/blob/f16d3256f93be71935ed86951e58f90b83912feb/src/Illuminate/Database/Eloquent/Model.php#L221-L246