### PR TITLE
add assertNotEmitted

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -100,7 +100,7 @@ trait MakesAssertions
 
             $test = $event && $params[0]($event['event'], $event['params']);
         } else {
-            $test = ! ! collect($this->payload['eventQueue'])->first(function ($item) use ($value, $params) {
+            $test = !! collect($this->payload['eventQueue'])->first(function ($item) use ($value, $params) {
                 return $item['event'] === $value
                     && $item['params'] === $params;
             });
@@ -127,7 +127,7 @@ trait MakesAssertions
 
             $test = $event && $data($event['event'], $event['data']);
         } else {
-            $test = ! ! collect($this->payload['dispatchQueue'])->first(function ($item) use ($name, $data) {
+            $test = !! collect($this->payload['dispatchQueue'])->first(function ($item) use ($name, $data) {
                 return $item['event'] === $name
                     && $item['data'] === $data;
             });
@@ -146,7 +146,7 @@ trait MakesAssertions
 
         PHPUnit::assertTrue($errors->isNotEmpty(), 'Component has no errors.');
 
-        $keys = (array)$keys;
+        $keys = (array) $keys;
 
         foreach ($keys as $key => $value) {
             if (is_int($key)) {
@@ -158,8 +158,7 @@ trait MakesAssertions
                 }, $rules);
 
                 foreach ((array)$value as $rule) {
-                    PHPUnit::assertContains($rule, $snakeCaseRules,
-                        "Component has no [{$rule}] errors for [{$key}] attribute.");
+                    PHPUnit::assertContains($rule, $snakeCaseRules, "Component has no [{$rule}] errors for [{$key}] attribute.");
                 }
             }
         }
@@ -177,7 +176,7 @@ trait MakesAssertions
             return $this;
         }
 
-        $keys = (array)$keys;
+        $keys = (array) $keys;
 
         foreach ($keys as $key => $value) {
             if (is_int($key)) {
@@ -188,9 +187,8 @@ trait MakesAssertions
                     return Str::snake($rule);
                 }, $rules);
 
-                foreach ((array)$value as $rule) {
-                    PHPUnit::assertNotContains($rule, $snakeCaseRules,
-                        "Component has [{$rule}] errors for [{$key}] attribute.");
+                foreach ((array) $value as $rule) {
+                    PHPUnit::assertNotContains($rule, $snakeCaseRules, "Component has [{$rule}] errors for [{$key}] attribute.");
                 }
             }
         }
@@ -205,7 +203,7 @@ trait MakesAssertions
             'Component did not perform a redirect.'
         );
 
-        if ( ! is_null($uri)) {
+        if (! is_null($uri)) {
             PHPUnit::assertSame(url($uri), url($this->payload['redirectTo']));
         }
 

--- a/tests/LivewireTestingTest.php
+++ b/tests/LivewireTestingTest.php
@@ -90,6 +90,27 @@ class LivewireTestingTest extends TestCase
     }
 
     /** @test */
+    public function assert_not_emitted()
+    {
+        app(LivewireManager::class)
+            ->test(EmitsEventsComponentStub::class)
+            ->call('emitFoo')
+            ->assertNotEmitted('bar')
+            ->call('emitFooWithParam', 'not-bar')
+            ->assertNotEmitted('foo', 'bar')
+            ->call('emitFooWithParam', 'foo')
+            ->assertNotEmitted('bar', 'foo')
+            ->call('emitFooWithParam', 'baz')
+            ->assertNotEmitted('bar', function ($event, $params) {
+                return $event !== 'bar' && $params === ['baz'];
+            })
+            ->call('emitFooWithParam', 'baz')
+            ->assertNotEmitted('foo', function ($event, $params) {
+                return $event !== 'foo' && $params !== ['bar'];
+            });
+    }
+
+    /** @test */
     public function assert_dispatched()
     {
         app(LivewireManager::class)


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
No

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
This PR adds a new assertion for testing your livewire components.  There is already an assertion available to test if a specific event is emitted.  I have added `assertNotEmitted()` so that if needed you can check that a specific event was not emitted during your test.

5️⃣ Thanks for contributing! 🙌
