### PR TITLE
Add route model binding to actions

### DIFF
--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -93,10 +93,17 @@ trait HandlesActions
     protected function resolveActionParameters($method, $params)
     {
         return collect((new \ReflectionMethod($this, $method))->getParameters())->flatMap(function ($parameter) use (&$params) {
-            if(!$parameter->getClass()){
+            if (!$parameter->getClass()) {
                 return [$parameter->getName() => array_shift($params)];
             }
-        })->filter()->toArray();
+
+            $instance = rescue(function () use ($class) { return app($class->name); });
+            if ($instance instanceof UrlRoutable) {
+                if ($model = $instance->resolveRouteBinding(array_shift($params))) {
+                    return [$parameter->getName() => $model];
+                };
+            }
+        })->filter()->all();
     }
 
     protected function methodIsPublicAndNotDefinedOnBaseClass($methodName)

--- a/tests/ComponentMethodBindingsTest.php
+++ b/tests/ComponentMethodBindingsTest.php
@@ -35,6 +35,28 @@ class ComponentMethodBindingsTest extends TestCase
         Livewire::test(ComponentWithBindings::class, ['param' => 'foo'])
             ->assertSee('from-injectionfoo');
     }
+
+    /** @test */
+    public function custom_method_recieves_bindings()
+    {
+        $component = Livewire::test(ComponentWithBindings::class);
+
+        $component->call('customMethod', '/path/to/some/file');
+
+        $this->assertEquals('/path/to/some/file', $component->path);
+        $this->assertEquals('from-injection', $component->stubValue);
+    }
+
+    /** @test */
+    public function custom_method_without_dependencies()
+    {
+        $component = Livewire::test(ComponentWithBindings::class);
+
+        $component->call('customMethodWithoutDependencies');
+
+        $this->assertEquals(null, $component->path);
+        $this->assertEquals(null, $component->stubValue);
+    }
 }
 
 class ModelToBeBoundStub
@@ -49,6 +71,10 @@ class ComponentWithBindings extends Component
 {
     public $name;
 
+    public $path;
+
+    public $stubValue;
+
     public function mount(ModelToBeBoundStub $stub, $param = '')
     {
         $this->name = $stub->value.$param;
@@ -57,5 +83,16 @@ class ComponentWithBindings extends Component
     public function render()
     {
         return app('view')->make('show-name-with-this');
+    }
+
+    public function customMethod($path, ModelToBeBoundStub $stub)
+    {
+        $this->path = $path;
+        $this->stubValue = $stub->value;
+    }
+
+    public function customMethodWithoutDependencies()
+    {
+        
     }
 }


### PR DESCRIPTION
Allows you to pass the model's route key (value) into a component's public function and have it be auto resolved to your type hinted model's instance.

This is based on #910

I'm working on tests still.

Todo:

* [ ] Implement Tests
* [ ] Whether to base off current code or pull request above
* [ ] Consider security implications

Example Component Function:
```php
public function setUsername(User $user, $username)
{
    $user->username = $username;
    $user->save();
}
```

Example View Call:
```html
<a wire:click.prevent="setUsername(1, 'test')"></a>
```