### PR TITLE
Support sharing Livewire component view data with Livewire route layo…

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -22,6 +22,7 @@ class LivewireManager
     protected $initialHydrationMiddleware = [];
     protected $initialDehydrationMiddleware = [];
     protected $listeners = [];
+    protected $shareComponentViewData = false;
 
     public static $isLivewireRequestTestingOverride;
 
@@ -375,6 +376,16 @@ HTML;
     public function isLaravel7()
     {
         return Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, '7.0', '>=');
+    }
+
+    public function routesShareComponentViewData()
+    {
+        $this->shareComponentViewData = true;
+    }
+
+    public function componentViewDataIsShared()
+    {
+        return $this->shareComponentViewData;
     }
 
     private function ensureComponentHasMountMethod($instance, $resolvedParameters)

--- a/src/Macros/RouterMacros.php
+++ b/src/Macros/RouterMacros.php
@@ -2,6 +2,8 @@
 
 namespace Livewire\Macros;
 
+use Livewire\Livewire;
+
 class RouterMacros
 {
     public function layout()
@@ -31,14 +33,29 @@ class RouterMacros
                 $componentClass = app('livewire')->getComponentClass($component);
                 $reflected = new \ReflectionClass($componentClass);
 
-                return app('view')->file(__DIR__.'/livewire-view.blade.php', [
+                $paramters = $reflected->hasMethod('mount')
+                        ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $this))->retrieveBindings()
+                        : [];
+
+                $lastRenderedLivewireView = null;
+                Livewire::listen('view:render', function ($view) use (&$lastRenderedLivewireView) {
+                    $lastRenderedLivewireView = $view;
+                });
+
+                $response = Livewire::mount($component, $paramters);
+
+                $componentViewData = array_diff_key(
+                    $lastRenderedLivewireView->getData(),
+                    array_flip(['_instance', 'errors'])
+                );
+
+                return app('view')->file(__DIR__.'/livewire-shared-view.blade.php', [
                     'layout' => $this->current()->getAction('layout') ?? 'layouts.app',
                     'section' => $this->current()->getAction('section') ?? 'content',
-                    'component' => $component,
-                    'componentParameters' => $reflected->hasMethod('mount')
-                        ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $this))->retrieveBindings()
-                        : [],
-                ])->with($this->current()->layoutParamsFromLivewire ?? []);
+                    'livewireRenderedContent' => $response->dom,
+                ])
+                ->with($this->current()->layoutParamsFromLivewire ?? [])
+                ->with(Livewire::componentViewDataIsShared() ? $componentViewData : []);
             });
         };
     }

--- a/src/Macros/livewire-shared-view.blade.php
+++ b/src/Macros/livewire-shared-view.blade.php
@@ -1,0 +1,5 @@
+@extends($layout)
+
+@section($section)
+    {!! $livewireRenderedContent !!}
+@endsection

--- a/tests/RouteRegistrationTest.php
+++ b/tests/RouteRegistrationTest.php
@@ -23,7 +23,7 @@ class RouteRegistrationTest extends TestCase
     /** @test */
     public function by_default_livewire_component_view_data_is_not_shared_with_outer_view_scope()
     {
-        $this->expectErrorMessage('Undefined variable: title');
+        $this->expectExceptionMessage('Undefined variable: title');
 
         Livewire::component('foo', ComponentWithTitleViewDataShared::class);
 

--- a/tests/RouteRegistrationTest.php
+++ b/tests/RouteRegistrationTest.php
@@ -19,6 +19,32 @@ class RouteRegistrationTest extends TestCase
 
         $this->get('/foo')->assertSee('baz');
     }
+
+    /** @test */
+    public function by_default_livewire_component_view_data_is_not_shared_with_outer_view_scope()
+    {
+        $this->expectErrorMessage('Undefined variable: title');
+
+        Livewire::component('foo', ComponentWithTitleViewDataShared::class);
+
+        Route::livewire('/foo', 'foo')
+            ->layout('layouts.app-with-title');
+
+        $this->withoutExceptionHandling()->get('/foo')->assertSee('baz');
+    }
+
+    /** @test */
+    public function can_share_livewire_component_view_data_with_outer_view_scope()
+    {
+        Livewire::component('foo', ComponentWithTitleViewDataShared::class);
+
+        Livewire::routesShareComponentViewData();
+
+        Route::livewire('/foo', 'foo')
+            ->layout('layouts.app-with-title');
+
+        $this->withoutExceptionHandling()->get('/foo')->assertSee('baz');
+    }
 }
 
 class ComponentForRouteRegistration extends Component
@@ -28,5 +54,15 @@ class ComponentForRouteRegistration extends Component
     public function render()
     {
         return view('show-name');
+    }
+}
+
+class ComponentWithTitleViewDataShared extends Component
+{
+    public function render()
+    {
+        return view('null-view', [
+            'title' => 'baz',
+        ]);
     }
 }

--- a/tests/views/layouts/app-with-title.blade.php
+++ b/tests/views/layouts/app-with-title.blade.php
@@ -1,0 +1,3 @@
+{{  $title }}
+
+@yield('content')


### PR DESCRIPTION
Currently, there is no way to share Livewire component view data with outer layout files when using `Route::livewire()`. For example:

*Your Routes File*
```
Route::livewire('/foo', 'foo');
```

*The Livewire Component*
```
class Foo extends Component
{
    public function render()
    {
        return view('livewire.foo', [ 'pageTitle' => 'Foo Page!!']);
    }
}
```

*The Blade Layout File (layouts.app.blade.php)*
```html
<html>
<head>
    <title>{{ $pageTitle }}</title>
</head>
<body>
    @yield('content')
</body>
</html>
```

This will throw an error: "Undefined variable $pageTitle"

This PR adds a configuration method you can add to your service provider that will enable this behavior:

```php
public function boot()
{
    Livewire::routesShareComponentViewData();
}
```

Big thanks to @davidhemphill for pairing on this with me.