### PR TITLE
Add ->only() method to components

### DIFF
--- a/src/ComponentConcerns/InteractsWithProperties.php
+++ b/src/ComponentConcerns/InteractsWithProperties.php
@@ -126,4 +126,15 @@ trait InteractsWithProperties
             $this->{$property} = $freshInstance->{$property};
         }
     }
+
+    public function only($properties)
+    {
+        $results = [];
+
+        foreach ($properties as $property) {
+            $results[$property] = $this->hasProperty($property) ? $this->getPropertyValue($property) : null;
+        }
+
+        return $results;
+    }
 }

--- a/tests/ComponentCanReturnOnlySpecifiedPropertiesTest.php
+++ b/tests/ComponentCanReturnOnlySpecifiedPropertiesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Livewire;
+use Livewire\Component;
+
+class ComponentCanReturnOnlySpecifiedPropertiesTest extends TestCase
+{
+    /** @test */
+    public function a_livewire_component_can_return_an_associative_array_of_only_the_specified_properties()
+    {
+        Livewire::test(ComponentWithProperties::class)
+            ->call('setOnlyProperties', ['foo', 'bar'])
+            ->assertSet('onlyProperties', [
+                'foo' => 'Foo',
+                'bar' => 'Bar',
+            ]);
+    }
+}
+
+class ComponentWithProperties extends Component
+{
+    public $onlyProperties = [];
+
+    public $foo = 'Foo';
+
+    public $bar = 'Bar';
+
+    public $baz = 'Baz';
+
+    public function setOnlyProperties($properties)
+    {
+        $this->onlyProperties = $this->only($properties);
+    }
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}


### PR DESCRIPTION
This change adds a new `->only()` method to the base `Component` class that mimics the method of the same name in Laravel's own `Request` class.

This method takes an array of strings as an argument, the strings should each match the name of a property on the component. The method then returns an associative array the property names and values.

This is just a small convenience method that can be used for many things and I often find myself using in regular controllers, particularly when creating models, for example:

```php
User::create(request()->only(['name', 'email', 'password']));
```

Here's another example where such a method would help to clean up the code a little bit: https://github.com/laravel-frontend-presets/tall/blob/master/stubs/auth/app/Http/Livewire/Auth/Passwords/Reset.php#L41-L45