### PR TITLE
Missing root tag exception

### DIFF
--- a/src/Exceptions/RootTagMissingFromViewException.php
+++ b/src/Exceptions/RootTagMissingFromViewException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Livewire\Exceptions;
+
+class RootTagMissingFromViewException extends \Exception
+{
+    use BypassViewHandler;
+
+    public function __construct($component)
+    {
+        parent::__construct(
+            "Livewire encountered a missing root tag when trying to render the [{$component}] " .
+            "component. \n When rendering a Blade view, make sure it contains a root HTML tag."
+        );
+    }
+}

--- a/src/HydrationMiddleware/AddAttributesToRootTagOfHtml.php
+++ b/src/HydrationMiddleware/AddAttributesToRootTagOfHtml.php
@@ -2,9 +2,11 @@
 
 namespace Livewire\HydrationMiddleware;
 
+use Livewire\Exceptions\RootTagMissingFromViewException;
+
 class AddAttributesToRootTagOfHtml
 {
-    public function __invoke($dom, $data)
+    public function __invoke($dom, $data, $instance)
     {
         $attributesFormattedForHtmlElement = collect($data)
             ->mapWithKeys(function ($value, $key) {
@@ -14,6 +16,12 @@ class AddAttributesToRootTagOfHtml
             })->implode(' ');
 
         preg_match('/<([a-zA-Z0-9\-]*)/', $dom, $matches, PREG_OFFSET_CAPTURE);
+
+        throw_unless(
+            count($matches),
+            new RootTagMissingFromViewException($instance->getName())
+        );
+
         $tagName = $matches[1][0];
         $lengthOfTagName = strlen($tagName);
         $positionOfFirstCharacterInTagName = $matches[1][1];

--- a/src/HydrationMiddleware/IncludeIdAsRootTagAttribute.php
+++ b/src/HydrationMiddleware/IncludeIdAsRootTagAttribute.php
@@ -13,6 +13,6 @@ class IncludeIdAsRootTagAttribute implements HydrationMiddleware
     {
         $response->dom = (new AddAttributesToRootTagOfHtml)($response->dom, [
             'id' => $instance->id,
-        ]);
+        ], $instance);
     }
 }

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -123,7 +123,7 @@ class LivewireManager
 
         $response->dom = (new AddAttributesToRootTagOfHtml)($response->dom, [
             'initial-data' => array_diff_key($response->toArray(), array_flip(['dom'])),
-        ]);
+        ], $instance);
 
         $this->dispatch('mounted', $response);
 

--- a/tests/ComponentRootHasIdAndComponentDataTest.php
+++ b/tests/ComponentRootHasIdAndComponentDataTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Illuminate\Support\Str;
 use Livewire\Component;
+use Livewire\Exceptions\RootTagMissingFromViewException;
 use Livewire\LivewireManager;
 
 class ComponentRootHasIdAndComponentDataTest extends TestCase
@@ -17,6 +18,14 @@ class ComponentRootHasIdAndComponentDataTest extends TestCase
             $component->payload['dom'],
             [$component->id(), 'foo']
         ));
+    }
+
+    /** @test */
+    public function root_element_exists()
+    {
+        $this->expectException(RootTagMissingFromViewException::class);
+
+        $component = app(LivewireManager::class)->test(ComponentRootExists::class);
     }
 
     /** @test */
@@ -61,5 +70,13 @@ class ComponentRootHasIdAndDataStub extends Component
     public function render()
     {
         return app('view')->make('null-view');
+    }
+}
+
+class ComponentRootExists extends Component
+{
+    public function render()
+    {
+        return app('view')->make('rootless-view');
     }
 }

--- a/tests/views/rootless-view.blade.php
+++ b/tests/views/rootless-view.blade.php
@@ -1,0 +1,1 @@
+This all you got?!


### PR DESCRIPTION
Before, a component view without a root HTML tag would cause this exception, and it's kinda unclear what's wrong...

![Before](https://user-images.githubusercontent.com/41773797/81476511-341f0d80-920a-11ea-92cd-0aae30cf4e99.png)

This mistake is now caught and clearly presented:

![After](https://user-images.githubusercontent.com/41773797/81476589-8c560f80-920a-11ea-91e4-d9851e5f4b6d.png)

A simple component to demonstrate...

Test.php
```php
class Test extends Component
{
    public function render()
    {
        return render('test');
    }
}
```

test.blade.php
```
Test
```