### PR TITLE
Reset properties from array

### DIFF
--- a/src/ComponentConcerns/InteractsWithProperties.php
+++ b/src/ComponentConcerns/InteractsWithProperties.php
@@ -116,6 +116,12 @@ trait InteractsWithProperties
     {
         $propertyKeys = array_keys($this->getPublicPropertiesDefinedBySubClass());
 
+        // Keys to reset from array
+        if (count($properties) && is_array($properties[0])) {
+            $properties = $properties[0];
+        }
+
+        // Reset all
         if (empty($properties)) {
             $properties = $propertyKeys;
         }

--- a/tests/ResetPropertiesTest.php
+++ b/tests/ResetPropertiesTest.php
@@ -13,20 +13,37 @@ class ResetPropertiesTest extends TestCase
         Livewire::test(ResetPropertiesComponent::class)
             ->assertSet('foo', 'bar')
             ->assertSet('bob', 'lob')
+            ->assertSet('mwa', 'hah')
             ->set('foo', 'baz')
             ->set('bob', 'law')
+            ->set('mwa', 'aha')
             ->assertSet('foo', 'baz')
             ->assertSet('bob', 'law')
+            ->assertSet('mwa', 'aha')
             // Reset all.
             ->call('resetAll')
             ->assertSet('foo', 'bar')
             ->assertSet('bob', 'lob')
+            ->assertSet('mwa', 'hah')
             ->set('foo', 'baz')
             ->set('bob', 'law')
+            ->set('mwa', 'aha')
             ->assertSet('foo', 'baz')
             ->assertSet('bob', 'law')
+            ->assertSet('mwa', 'aha')
+            // Reset foo and bob.
+            ->call('resetKeys', ['foo', 'bob'])
+            ->assertSet('foo', 'bar')
+            ->assertSet('bob', 'lob')
+            ->assertSet('mwa', 'aha')
+            ->set('foo', 'baz')
+            ->set('bob', 'law')
+            ->set('mwa', 'aha')
+            ->assertSet('foo', 'baz')
+            ->assertSet('bob', 'law')
+            ->assertSet('mwa', 'aha')
             // Reset only foo.
-            ->call('resetKey', 'foo')
+            ->call('resetKeys', 'foo')
             ->assertSet('foo', 'bar')
             ->assertSet('bob', 'law');
     }
@@ -36,13 +53,14 @@ class ResetPropertiesComponent extends Component
 {
     public $foo = 'bar';
     public $bob = 'lob';
+    public $mwa = 'hah';
 
     public function resetAll()
     {
         $this->reset();
     }
 
-    public function resetKey($keys)
+    public function resetKeys($keys)
     {
         $this->reset($keys);
     }


### PR DESCRIPTION
Currently, `$this->reset()` accepts a [variable-length argument list](https://www.php.net/manual/en/functions.arguments.php#functions.variable-arg-list) of properties.

This change also allows it to accept an array of properties to reset, for a more dynamic usage possibilities.

A simple component to demonstrate...

```php
class Test extends Component
{
    public $foo = 'bar';
    public $bob = 'lob';
    public $mwa = 'hah';

    public function mount()
    {
        $this->foo = 'baz';
        $this->bob = 'law';
        $this->mwa = 'aha';

        $this->reset(['foo', 'bob']);

        // $this->foo is bar
        // $this->bob is lob
        // $this->mwa is aha
    }
}
```