### PR TITLE
WIP: Move livewire router macro logic to controller to allow proper route caching

### DIFF
--- a/src/LivewireController.php
+++ b/src/LivewireController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Livewire;
+
+use Illuminate\Http\Request;
+use Livewire\Livewire;
+use Livewire\Macros\PretendClassMethodIsControllerMethod;
+
+class LivewireController
+{
+    public $request;
+
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    public function __call($component, $parameters)
+    {
+        $componentClass = app('livewire')->getComponentClass($component);
+        $reflected = new \ReflectionClass($componentClass);
+
+        $paramters = $reflected->hasMethod('mount')
+                ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $this))->retrieveBindings()
+                : [];
+
+        $lastRenderedLivewireView = null;
+        Livewire::listen('view:render', function ($view) use (&$lastRenderedLivewireView) {
+            $lastRenderedLivewireView = $view;
+        });
+
+        $response = Livewire::mount($component, $paramters);
+
+        $componentViewData = array_diff_key(
+            $lastRenderedLivewireView->getData(),
+            array_flip(['_instance', 'errors'])
+        );
+
+        return app('view')->file(__DIR__.'/Macros/livewire-shared-view.blade.php', [
+            'layout' => $this->request->route()->getAction('layout') ?? 'layouts.app',
+            'section' => $this->request->route()->getAction('section') ?? 'content',
+            'livewireRenderedContent' => $response->dom,
+        ])
+        ->with($this->request->route()->layoutParamsFromLivewire ?? [])
+        ->with(Livewire::componentViewDataIsShared() ? $componentViewData : []);
+    }
+}

--- a/src/Macros/RouterMacros.php
+++ b/src/Macros/RouterMacros.php
@@ -3,6 +3,7 @@
 namespace Livewire\Macros;
 
 use Livewire\Livewire;
+use Livewire\LivewireController;
 
 class RouterMacros
 {
@@ -29,34 +30,7 @@ class RouterMacros
         return function ($uri, $component = null) {
             $component = $component ?: $uri;
 
-            return $this->get($uri, function () use ($component) {
-                $componentClass = app('livewire')->getComponentClass($component);
-                $reflected = new \ReflectionClass($componentClass);
-
-                $paramters = $reflected->hasMethod('mount')
-                        ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $this))->retrieveBindings()
-                        : [];
-
-                $lastRenderedLivewireView = null;
-                Livewire::listen('view:render', function ($view) use (&$lastRenderedLivewireView) {
-                    $lastRenderedLivewireView = $view;
-                });
-
-                $response = Livewire::mount($component, $paramters);
-
-                $componentViewData = array_diff_key(
-                    $lastRenderedLivewireView->getData(),
-                    array_flip(['_instance', 'errors'])
-                );
-
-                return app('view')->file(__DIR__.'/livewire-shared-view.blade.php', [
-                    'layout' => $this->current()->getAction('layout') ?? 'layouts.app',
-                    'section' => $this->current()->getAction('section') ?? 'content',
-                    'livewireRenderedContent' => $response->dom,
-                ])
-                ->with($this->current()->layoutParamsFromLivewire ?? [])
-                ->with(Livewire::componentViewDataIsShared() ? $componentViewData : []);
-            });
+            return $this->get($uri, [LivewireController::class, $component]);
         };
     }
 }


### PR DESCRIPTION
1️⃣ **Is this something that is wanted/needed? Did you create a feature-request issue first?**
Yes

2️⃣ **Does it contain multiple, unrelated changes? Please separate the PRs out.**
No

3️⃣ **Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)**
No, sorry. I tested it locally as best I could and it seems to work as expected. I did have a really hard time getting the unit tests to run correctly. It seems there needs to be a specific setup in order to properly test this and I haven't figured it out.

4️⃣ **Please include a thorough description of the feature/fix and reasons why it's useful.**
This will allow us to use `php artisan route:cache`. We use the component name as magic method call on a new `LivewireController`. The original livewire macro logic is moved to the new controller.

5️⃣ Thanks for contributing! 🙌
