### PR TITLE
Add ability to clear computed properties

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -175,6 +175,22 @@ abstract class Component
         }, $normalizedData);
     }
 
+    public function forgetComputed($key = null)
+    {
+        if (is_null($key)) {
+           $this->computedPropertyCache = [];
+           return;
+        }
+
+        $keys = is_array($key) ? $key : func_get_args();
+
+        collect($keys)->each(function ($i) {
+            if (isset($this->computedPropertyCache[$i])) {
+                unset($this->computedPropertyCache[$i]);
+            }
+        });
+    }
+
     public function __get($property)
     {
         if (method_exists($this, $computedMethodName = 'get'.ucfirst($property).'Property')) {

--- a/tests/ComputedPropertiesTest.php
+++ b/tests/ComputedPropertiesTest.php
@@ -15,10 +15,27 @@ class ComputedPropertiesTest extends TestCase
     }
 
     /** @test */
-    public function compute_property_is_memoized_after_its_accessed()
+    public function computed_property_is_memoized_after_its_accessed()
     {
         Livewire::test(MemoizedComputedPropertyStub::class)
             ->assertSee('int(2)');
+    }
+
+    /** @test */
+    public function computed_property_cache_can_be_cleared()
+    {
+        Livewire::test(MemoizedComputedPropertyStub::class)
+            ->assertSee('int(2)')
+            ->call('callForgetComputed')
+            ->assertSee('int(4)')
+            ->call('callForgetComputed', 'foo')
+            ->assertSee('int(6)')
+            ->call('callForgetComputed', 'bar')
+            ->assertSee('int(7)')
+            ->call('callForgetComputed', ['foo', 'bar'])
+            ->assertSee('int(9)')
+            ->call('callForgetComputed', 'bar', 'foo')
+            ->assertSee('int(11)');
     }
 }
 
@@ -44,6 +61,33 @@ class MemoizedComputedPropertyStub extends Component
     public function getFooProperty()
     {
         return $this->count += 1;
+    }
+
+    public function callForgetComputed(...$args)
+    {
+        $this->foo;
+
+        $this->forgetComputed(...$args);
+
+        $this->foo;
+    }
+
+    public function callForgetComputedArray($args)
+    {
+        $this->foo;
+
+        $this->forgetComputed($args);
+
+        $this->foo;
+    }
+
+    public function callForgetComputedSpread(...$args)
+    {
+        $this->foo;
+
+        $this->forgetComputed(...$args);
+
+        $this->foo;
     }
 
     public function render()

--- a/tests/ComputedPropertiesTest.php
+++ b/tests/ComputedPropertiesTest.php
@@ -81,24 +81,6 @@ class MemoizedComputedPropertyStub extends Component
         $this->foo;
     }
 
-    public function callForgetComputedArray($args)
-    {
-        $this->foo;
-
-        $this->forgetComputed($args);
-
-        $this->foo;
-    }
-
-    public function callForgetComputedSpread(...$args)
-    {
-        $this->foo;
-
-        $this->forgetComputed(...$args);
-
-        $this->foo;
-    }
-
     public function render()
     {
         // Access foo once here to start the cache.

--- a/tests/ComputedPropertiesTest.php
+++ b/tests/ComputedPropertiesTest.php
@@ -34,7 +34,7 @@ class ComputedPropertiesTest extends TestCase
             ->assertSee('int(7)')
             ->call('callForgetComputed', ['foo', 'bar'])
             ->assertSee('int(9)')
-            ->call('callForgetComputed', 'bar', 'foo')
+            ->call('callForgetComputedWithTwoArgs', 'bar', 'foo')
             ->assertSee('int(11)');
     }
 }
@@ -63,11 +63,20 @@ class MemoizedComputedPropertyStub extends Component
         return $this->count += 1;
     }
 
-    public function callForgetComputed(...$args)
+    public function callForgetComputed($arg)
     {
         $this->foo;
 
-        $this->forgetComputed(...$args);
+        $this->forgetComputed($arg);
+
+        $this->foo;
+    }
+
+    public function callForgetComputedWithTwoArgs($argOne, $argTwo)
+    {
+        $this->foo;
+
+        $this->forgetComputed($argOne, $argTwo);
 
         $this->foo;
     }

--- a/tests/ComputedPropertiesTest.php
+++ b/tests/ComputedPropertiesTest.php
@@ -63,7 +63,7 @@ class MemoizedComputedPropertyStub extends Component
         return $this->count += 1;
     }
 
-    public function callForgetComputed($arg)
+    public function callForgetComputed($arg = null)
     {
         $this->foo;
 


### PR DESCRIPTION
Currently, computed properties are cached to the component instance for the request lifecycle.

This PR add a new method to clear that cache for all or just specific properties:

```php
$this->forgetComputed();
$this->forgetComputed('post');
$this->forgetComputed(['post', 'comment']);
$this->forgetComputed('post', 'comment');
```