### PR TITLE
Fix #953 Emit function on the tests

### DIFF
--- a/src/Testing/Concerns/MakesCallsToComponent.php
+++ b/src/Testing/Concerns/MakesCallsToComponent.php
@@ -6,7 +6,7 @@ trait MakesCallsToComponent
 {
     public function emit($event, ...$parameters)
     {
-        return $this->fireEvent($event, $parameters);
+        return $this->fireEvent($event, ...$parameters);
     }
 
     public function fireEvent($event, ...$parameters)

--- a/tests/TestableLiveWireEmitEventsTest.php
+++ b/tests/TestableLiveWireEmitEventsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests;
+
+use Livewire\LivewireManager;
+use Livewire\Component;
+
+class TestableLiveWireEmitEventsTest extends TestCase
+{
+    /** @test */
+    public function receive_event_with_single_value()
+    {
+
+        $component = app(LivewireManager::class)->test(ReceivesEventsEmitWithSingleValueListener::class);
+
+        $component->emit('bar', 'baz');
+
+        $this->assertEquals($component->get('foo'), 'baz');
+    }
+}
+
+class ReceivesEventsEmitWithSingleValueListener extends Component
+{
+    public $foo;
+
+    protected $listeners = ['bar'];
+
+    public function bar($value)
+    {
+        $this->foo = $value;
+    }
+
+    public function render()
+    {
+        return app('view')->make('null-view');
+    }
+}


### PR DESCRIPTION
Creating tests for my project I found that the emit method was not sending the values as expected. Instead of the value I was receiving an array, after digging in the code I found that the emit was getting the parameters as spread but instead of sending in the same way to to fire event was just sending the array.

Note: I didn't find any test using the emit method, all the tests were using the "fireEvent" directly that's why I create a new test file for this.