### PR TITLE
Fix command descriptions not being in line with Laravel conventions

### DIFF
--- a/src/Commands/CopyCommand.php
+++ b/src/Commands/CopyCommand.php
@@ -8,7 +8,7 @@ class CopyCommand extends FileManipulationCommand
 {
     protected $signature = 'livewire:copy {name} {new-name} {--inline} {--force}';
 
-    protected $description = 'Copy a Livewire component.';
+    protected $description = 'Copy a Livewire component';
 
     public function handle()
     {

--- a/src/Commands/DeleteCommand.php
+++ b/src/Commands/DeleteCommand.php
@@ -8,7 +8,7 @@ class DeleteCommand extends FileManipulationCommand
 {
     protected $signature = 'livewire:delete {name} {--inline} {--force}';
 
-    protected $description = 'Delete a Livewire component.';
+    protected $description = 'Delete a Livewire component';
 
     public function handle()
     {

--- a/src/Commands/DiscoverCommand.php
+++ b/src/Commands/DiscoverCommand.php
@@ -9,7 +9,7 @@ class DiscoverCommand extends Command
 {
     protected $signature = 'livewire:discover';
 
-    protected $description = 'Regenerate Livewire component auto-discovery manifest.';
+    protected $description = 'Regenerate Livewire component auto-discovery manifest';
 
     public function handle()
     {

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -8,7 +8,7 @@ class MakeCommand extends FileManipulationCommand
 {
     protected $signature = 'livewire:make {name} {--force} {--inline}';
 
-    protected $description = 'Create a new Livewire component.';
+    protected $description = 'Create a new Livewire component';
 
     public function handle()
     {

--- a/src/Commands/MoveCommand.php
+++ b/src/Commands/MoveCommand.php
@@ -8,7 +8,7 @@ class MoveCommand extends FileManipulationCommand
 {
     protected $signature = 'livewire:move {name} {new-name} {--force} {--inline}';
 
-    protected $description = 'Move a Livewire component.';
+    protected $description = 'Move a Livewire component';
 
     public function handle()
     {

--- a/src/Commands/StubsCommand.php
+++ b/src/Commands/StubsCommand.php
@@ -10,7 +10,7 @@ class StubsCommand extends Command
 {
     protected $signature = 'livewire:stubs';
 
-    protected $description = 'Publish Livewire stubs.';
+    protected $description = 'Publish Livewire stubs';
 
     protected $parser;
 


### PR DESCRIPTION
### This has to be wanted, and is definitely needed, by the whole Livewire community.

Just look at this eyesore:

![2020-05-15_16-30-39](https://user-images.githubusercontent.com/1066486/82062838-01be5600-96cb-11ea-9e79-114ff302db90.png)

What kind of animal puts a dot at the end of a sentence?! Just leave it out, like Laravel intended us to do. 

### JUST LOOK AT IT!!!

![image](https://user-images.githubusercontent.com/1066486/82063345-a50f6b00-96cb-11ea-9e53-1eba306f75f7.png)

It hertz my i:s.

Fixes #all-problems