### PR TITLE
Fix checkbox custom value always boolean

### DIFF
--- a/js/dom/dom_element.js
+++ b/js/dom/dom_element.js
@@ -95,7 +95,7 @@ ${this.el.outerHTML}
                 return modelValue
             }
 
-            return this.el.getAttribute('value') ? this.el.value : this.el.checked;
+            return this.el.getAttribute('value') || this.el.checked;
         } else if (this.el.tagName === 'SELECT' && this.el.multiple) {
             return this.getSelectValues()
         }

--- a/js/dom/dom_element.js
+++ b/js/dom/dom_element.js
@@ -95,7 +95,7 @@ ${this.el.outerHTML}
                 return modelValue
             }
 
-            return this.el.checked
+            return this.el.getAttribute('value') ? this.el.value : this.el.checked;
         } else if (this.el.tagName === 'SELECT' && this.el.multiple) {
             return this.getSelectValues()
         }


### PR DESCRIPTION
This PR fixes an issue #965 with checkbox values. usually, the browser would send the text in the `value` attribute. the current behavior is boolean which is not what we expect.

We have to check if the attribute exists because `return this.el.value || this.el.checked` would return the value always. as default value on chrome is `on`