### PR TITLE
chore: add prettier config that disables prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,11 @@
         "@rollup/plugin-node-resolve": "^7.0.0",
         "rollup-plugin-output-manifest": "^1.0.2"
     },
-    "dependencies": {}
+    "dependencies": {},
+    "prettier": {
+        "arrowParens": "avoid",
+        "requirePragma": true,
+        "semi": false,
+        "singleQuote": true
+    }
 }


### PR DESCRIPTION
For users of IDEs with a global prettier/formatting config it can be
difficult to work on projects that has no configuration.

This config adds `requirePragma` (which you can also set globally),
which require you to at a pragma to the top of the file before prettier
starts formatting.  So unless you add `// @format` or `// @prettier` to
the top of the file nothing is formatted.

This allows Livewire to start adapting formatted code little by little.

I've also added a few configs that makes prettier behave very close to
the way the code has been formatted already.

Ideally someone should just run prettier on all the code and get it done
with :rocket: 