### PR TITLE
Typo: window.wire and not window.livewire

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Livewire uses semantic versioning and will use the following release schedule st
 
 ## V2 Roadmap
 * Change all in-code references of `livewire` to `wire`? `@wire('foo')`, `artisan wire:make`, `<wire:foo>`
-* Change `window.livewire` to `window.Livewire` (And update Alpine to adapt)
+* Change `window.livewire` to `window.wire` (And update Alpine to adapt)
 * Make `->getName()` in `src/Component.php` a static method
 * Use camel-cased accessors for snake-cased properties ($this->foo_bar -> $this->getFooBarProperty) (PR ready here: #690)
 * Maybe remove base `render()` method to allow for DI in method params (PR here: #893)


### PR DESCRIPTION
You must mean `window.wire` and not `window.livewire` under **V2 Roadmap** heading.

1️⃣ Is this something that is wanted/needed? Did you create a feature-request issue first?
Since it is related to documentation so, not Applicable. 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests if possible? (Not a deal-breaker, just a nice-to-have)
Not Applicable

4️⃣ Please include a thorough description of the feature/fix and reasons why it's useful.
As of the Roadmap for v2 the references for `livewire` will be replaced with `wire`, so this should be `window.wire` and not `window.livewire`
