### PR TITLE
Fix Testing Livewire Route Conflict

### DIFF
--- a/tests/TestableLivewireTestingLivewireRouteTest.php
+++ b/tests/TestableLivewireTestingLivewireRouteTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Component;
+use Livewire\LivewireManager;
+use Illuminate\Support\Facades\Route;
+
+class TestableLivewireTestingLivewireRouteTest extends TestCase
+{
+    /** @test */
+    public function testing_livewire_route_works_with_user_route_with_the_same_signature()
+    {
+        $this->expectNotToPerformAssertions();
+
+        Route::get('/{param1}/{param2}', function() {
+            return 'Livewire is awesome!';
+        });
+
+        app(LivewireManager::class)->test(TestingLivewireRouteComponent::class);
+    }
+}
+
+class TestingLivewireRouteComponent extends Component
+{
+    public function render()
+    {
+        return view('null-view');
+    }
+}


### PR DESCRIPTION
# Problem
There is a conflict with Livewire's testing route in an edge case.

If a Laravel project has a route like the following
```php
Route::get('/{type}/{number}', [OrganizationController::class, 'show']);
```
it causes a conflict with Livewire's testing route making the route above get called instead of Livewire's. This makes all Livewire tests fail.
```php
$randomRoutePath = '/testing-livewire/'.Str::random(20);

Route::get($randomRoutePath, function () use ($name, $params) {
    return View::file(__DIR__.'/../views/mount-component.blade.php', [
        'name' => $name,
        'params' => $params,
    ]);
});
```

# Solution
This PR changes the code to put Livewire's testing route as the first route instead of the last.