### PR TITLE
feat: call 'updating' and 'updated' for $set and $toggle

### DIFF
--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -48,11 +48,19 @@ trait HandlesActions
         $beforeMethod = 'updating'.$propertyName;
         $afterMethod = 'updated'.$propertyName;
 
+        if (method_exists($this, 'updating')) {
+            $this->updating($name, $value);
+        }
+
         if (method_exists($this, $beforeMethod)) {
             $this->{$beforeMethod}($value, $keyAfterFirstDot);
         }
 
         $callback($name, $value);
+
+        if (method_exists($this, 'updated')) {
+            $this->updated($name, $value);
+        }
 
         if (method_exists($this, $afterMethod)) {
             $this->{$afterMethod}($value, $keyAfterFirstDot);

--- a/tests/LifecycleHooksTest.php
+++ b/tests/LifecycleHooksTest.php
@@ -78,6 +78,25 @@ class LifecycleHooksTest extends TestCase
 
         $component->updateProperty('bar.cocktail.soft', 'Shirley Ginger');
     }
+
+    /** @test */
+    public function set_magic_method()
+    {
+        $component = app(LivewireManager::class)->test(ForLifecycleHooks::class);
+
+        $component->runAction('$set', 'foo', 'bar');
+
+        $this->assertEquals([
+            'mount' => true,
+            'hydrate' => true,
+            'updating' => true,
+            'updated' => true,
+            'updatingFoo' => true,
+            'updatedFoo' => true,
+            'updatingBar' => false,
+            'updatedBar' => false,
+        ], $component->lifecycles);
+    }
 }
 
 class ForLifecycleHooks extends Component


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Asked on discord:

> Is there any reason why updating and updated isn't run when using $set and $toggle? Only the property specific methods are run e.g. updatingMyProp and updatedMyProp.
PerformPublicPropertyFromDataBindingUpdates calles updating and updated but it skips anything that is not syncing (as the name suggests).
I would expect set and toggle would call them as well.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No, just invokes updating and updated.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Works of existing tests, which passes. Doesn't add extra tests.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Currently `updatingMyProperty` and `updatedMyProperty` is called as expected, however, surprisingly `updating` and `updated` isn't.

This PR adds those calls.

This is useful in cases where `$set` and `$toggle` is called with dynamic input and you want to trigger something based on the affected property value change. Just as it would be when model binding is used.

5️⃣ Thanks for contributing! 🙌