### PR TITLE
Add ::hydrateProperty runtime middleware callbacks

### DIFF
--- a/src/HydrationMiddleware/HydratePropertiesWithCustomRuntimeHydrators.php
+++ b/src/HydrationMiddleware/HydratePropertiesWithCustomRuntimeHydrators.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Livewire\HydrationMiddleware;
+
+use Livewire\Livewire;
+
+class HydratePropertiesWithCustomRuntimeHydrators implements HydrationMiddleware
+{
+    public static function hydrate($unHydratedInstance, $request)
+    {
+        $publicProperties = $unHydratedInstance->getPublicPropertiesDefinedBySubClass();
+
+        foreach ($publicProperties as $property => $value) {
+            $newValue = Livewire::performHydrateProperty($value, $property, $unHydratedInstance);
+
+            if ($newValue !== $value) {
+                $unHydratedInstance->{$property} = $newValue;
+            }
+        }
+    }
+
+    public static function dehydrate($instance, $response)
+    {
+        $publicProperties = $instance->getPublicPropertiesDefinedBySubClass();
+
+        foreach ($publicProperties as $property => $value) {
+            $newValue = Livewire::performDehydrateProperty($value, $property, $instance);
+
+            if ($newValue !== $value) {
+                $instance->{$property} = $newValue;
+            }
+        }
+    }
+}

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -13,14 +13,12 @@ use Livewire\HydrationMiddleware\AddAttributesToRootTagOfHtml;
 
 class LivewireManager
 {
-    use DependencyResolverTrait;
+    use DependencyResolverTrait,
+        RegistersHydrationMiddleware;
 
     protected $container;
     protected $componentAliases = [];
     protected $customComponentResolver;
-    protected $hydrationMiddleware = [];
-    protected $initialHydrationMiddleware = [];
-    protected $initialDehydrationMiddleware = [];
     protected $listeners = [];
 
     public static $isLivewireRequestTestingOverride;
@@ -299,51 +297,6 @@ HTML;
         }
 
         return request()->hasHeader('X-Livewire');
-    }
-
-    public function registerHydrationMiddleware(array $classes)
-    {
-        $this->hydrationMiddleware += $classes;
-    }
-
-    public function registerInitialHydrationMiddleware(array $callables)
-    {
-        $this->initialHydrationMiddleware += $callables;
-    }
-
-    public function registerInitialDehydrationMiddleware(array $callables)
-    {
-        $this->initialDehydrationMiddleware += $callables;
-    }
-
-    public function hydrate($instance, $request)
-    {
-        foreach ($this->hydrationMiddleware as $class) {
-            $class::hydrate($instance, $request);
-        }
-    }
-
-    public function initialHydrate($instance, $request)
-    {
-        foreach ($this->initialHydrationMiddleware as $callable) {
-            $callable($instance, $request);
-        }
-    }
-
-    public function initialDehydrate($instance, $response)
-    {
-        foreach (array_reverse($this->initialDehydrationMiddleware) as $callable) {
-            $callable($instance, $response);
-        }
-    }
-
-    public function dehydrate($instance, $response)
-    {
-        // The array is being reversed here, so the middleware dehydrate phase order of execution is
-        // the inverse of hydrate. This makes the middlewares behave like layers in a shell.
-        foreach (array_reverse($this->hydrationMiddleware) as $class) {
-            $class::dehydrate($instance, $response);
-        }
     }
 
     public function getRootElementTagName($dom)

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -46,7 +46,8 @@ use Livewire\HydrationMiddleware\{
     ClearFlashMessagesIfNotRedirectingAway,
     PrioritizeDataUpdatesBeforeActionCalls,
     HydrateEloquentModelsAsPublicProperties,
-    PerformPublicPropertyFromDataBindingUpdates
+    PerformPublicPropertyFromDataBindingUpdates,
+    HydratePropertiesWithCustomRuntimeHydrators
 };
 
 class LivewireServiceProvider extends ServiceProvider
@@ -230,6 +231,7 @@ class LivewireServiceProvider extends ServiceProvider
         /* v */ HashPropertiesForDirtyDetection::class,             /* ^ */
         /* v */ HydrateEloquentModelsAsPublicProperties::class,     /* ^ */
         /* v */ PerformPublicPropertyFromDataBindingUpdates::class, /* ^ */
+        /* v */ HydratePropertiesWithCustomRuntimeHydrators::class, /* ^ */
         /* v */ CastPublicProperties::class,                        /* ^ */
         /* v */ HydratePreviouslyRenderedChildren::class,           /* ^ */
         /* v */ InterceptRedirects::class,                          /* ^ */
@@ -250,6 +252,7 @@ class LivewireServiceProvider extends ServiceProvider
         /* ^ */ [HydratePreviouslyRenderedChildren::class, 'dehydrate'],
         /* ^ */ [HydratePublicProperties::class, 'dehydrate'],
         /* ^ */ [HydrateEloquentModelsAsPublicProperties::class, 'dehydrate'],
+        /* ^ */ [HydratePropertiesWithCustomRuntimeHydrators::class, 'dehydrate'],
         /* ^ */ [CastPublicProperties::class, 'dehydrate'],
         /* ^ */ [RegisterEmittedEvents::class, 'dehydrate'],
         /* ^ */ [RegisterEventsBeingListenedFor::class, 'dehydrate'],

--- a/src/RegistersHydrationMiddleware.php
+++ b/src/RegistersHydrationMiddleware.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Livewire;
+
+trait RegistersHydrationMiddleware
+{
+    protected $hydrationMiddleware = [];
+    protected $initialHydrationMiddleware = [];
+    protected $initialDehydrationMiddleware = [];
+    protected $propertyHydrationMiddleware = [];
+    protected $propertyDehydrationMiddleware = [];
+
+    public function registerHydrationMiddleware(array $classes)
+    {
+        $this->hydrationMiddleware += $classes;
+    }
+
+    public function registerInitialHydrationMiddleware(array $callables)
+    {
+        $this->initialHydrationMiddleware += $callables;
+    }
+
+    public function registerInitialDehydrationMiddleware(array $callables)
+    {
+        $this->initialDehydrationMiddleware += $callables;
+    }
+
+    public function hydrate($instance, $request)
+    {
+        foreach ($this->hydrationMiddleware as $class) {
+            $class::hydrate($instance, $request);
+        }
+    }
+
+    public function initialHydrate($instance, $request)
+    {
+        foreach ($this->initialHydrationMiddleware as $callable) {
+            $callable($instance, $request);
+        }
+    }
+
+    public function initialDehydrate($instance, $response)
+    {
+        foreach (array_reverse($this->initialDehydrationMiddleware) as $callable) {
+            $callable($instance, $response);
+        }
+    }
+
+    public function dehydrate($instance, $response)
+    {
+        // The array is being reversed here, so the middleware dehydrate phase order of execution is
+        // the inverse of hydrate. This makes the middlewares behave like layers in a shell.
+        foreach (array_reverse($this->hydrationMiddleware) as $class) {
+            $class::dehydrate($instance, $response);
+        }
+    }
+
+    public function hydrateProperty($callback)
+    {
+        $this->propertyHydrationMiddleware[] = $callback;
+
+        return $this;
+    }
+
+    public function dehydrateProperty($callback)
+    {
+        $this->propertyDehydrationMiddleware[] = $callback;
+
+        return $this;
+    }
+
+    public function performHydrateProperty($value, $property, $instance)
+    {
+        $valueMemo = $value;
+        foreach ($this->propertyHydrationMiddleware as $callable) {
+            $valueMemo  = $callable($valueMemo, $property, $instance);
+        }
+        return $valueMemo;
+    }
+
+    public function performDehydrateProperty($value, $property, $instance)
+    {
+        $valueMemo = $value;
+        foreach ($this->propertyDehydrationMiddleware as $callable) {
+            $valueMemo  = $callable($valueMemo, $property, $instance);
+        }
+        return $valueMemo;
+    }
+}

--- a/tests/RuntimeHydrationMiddlewareTest.php
+++ b/tests/RuntimeHydrationMiddlewareTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Livewire;
+use Livewire\Component;
+
+use function PHPUnit\Framework\assertEquals;
+
+class RuntimeHydrationMiddlewareTest extends TestCase
+{
+    /** @test */
+    public function a_livewire_component_can_return_an_associative_array_of_only_the_specified_properties()
+    {
+        Livewire::hydrateProperty(function ($value, $property) {
+            if ($value === 'BAR') {
+                assertEquals('foo', $property);
+                return 'bar';
+            }
+
+            return $value;
+        })->dehydrateProperty(function ($value, $property) {
+            if ($value === 'bar') {
+                assertEquals('foo', $property);
+                return 'BAR';
+            }
+
+            return $value;
+        });
+
+        Livewire::test(ComponentForCustomRuntimeHydrationMiddleware::class)
+            ->assertSet('foo', 'BAR')
+            ->call('assertSlice')
+            ->assertSet('foo', 'BAR');
+    }
+}
+
+class ComponentForCustomRuntimeHydrationMiddleware extends Component
+{
+    public $foo = 'bar';
+
+    public function assertSlice()
+    {
+        assertEquals('bar', $this->foo);
+    }
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}

--- a/tests/RuntimeHydrationMiddlewareTest.php
+++ b/tests/RuntimeHydrationMiddlewareTest.php
@@ -5,8 +5,6 @@ namespace Tests;
 use Livewire\Livewire;
 use Livewire\Component;
 
-use function PHPUnit\Framework\assertEquals;
-
 class RuntimeHydrationMiddlewareTest extends TestCase
 {
     /** @test */
@@ -14,14 +12,14 @@ class RuntimeHydrationMiddlewareTest extends TestCase
     {
         Livewire::hydrateProperty(function ($value, $property) {
             if ($value === 'BAR') {
-                assertEquals('foo', $property);
+                assert('foo' === $property);
                 return 'bar';
             }
 
             return $value;
         })->dehydrateProperty(function ($value, $property) {
             if ($value === 'bar') {
-                assertEquals('foo', $property);
+                assert('foo' === $property);
                 return 'BAR';
             }
 
@@ -41,7 +39,7 @@ class ComponentForCustomRuntimeHydrationMiddleware extends Component
 
     public function assertSlice()
     {
-        assertEquals('bar', $this->foo);
+        assert('bar' === $this->foo);
     }
 
     public function render()


### PR DESCRIPTION
This PR allows devs to add their own, simple, "runtime property hydrators":

```php
        Livewire::hydrateProperty(function ($value, $property, $instance) {
           // Can manipulate property value on it's way in.
           return $value;
        })->dehydrateProperty(function ($value, $property, $instance) {
            // Can manipulate property value on it's way out.
            return $value;
        });
```