### PR TITLE
set-runs-hooks

### DIFF
--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -48,6 +48,10 @@ trait HandlesActions
         $beforeMethod = 'updating'.$propertyName;
         $afterMethod = 'updated'.$propertyName;
 
+        if (method_exists($this, 'updating')) {
+            $this->updating($name, $value);
+        }
+
         if (method_exists($this, $beforeMethod)) {
             $this->{$beforeMethod}($value, $keyAfterFirstDot);
         }
@@ -56,6 +60,10 @@ trait HandlesActions
 
         if (method_exists($this, $afterMethod)) {
             $this->{$afterMethod}($value, $keyAfterFirstDot);
+        }
+
+        if (method_exists($this, 'updated')) {
+            $this->updated($name, $value);
         }
     }
 


### PR DESCRIPTION
When we call wire:click.prevent="$set('amount', 1)" in the browser it do not run updated($key) hook on server side.

Fixes #1024