### PR TITLE
[Feature] Add new resetExcept()

### DIFF
--- a/src/ComponentConcerns/InteractsWithProperties.php
+++ b/src/ComponentConcerns/InteractsWithProperties.php
@@ -143,4 +143,15 @@ trait InteractsWithProperties
 
         return $results;
     }
+    
+    public function resetExcept(array $exceptProperties = [])
+    {
+
+        $properties = array_keys($this->getPublicPropertiesDefinedBySubClass());
+
+        $properties = array_diff($properties, $exceptProperties);
+
+        $this->reset(...$properties);
+
+    }
 }

--- a/tests/ResetExceptPropertiesTest.php
+++ b/tests/ResetExceptPropertiesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class ResetExceptPropertiesTest extends TestCase
+{
+    /** @test */
+    public function can_reset_except_properties()
+    {
+        Livewire::test(ResetPropertiesComponent::class)
+            ->assertSet('foo', 'bar')
+            ->assertSet('bob', 'lob')
+            ->assertSet('john', 'doe')
+            ->set('foo', 'baz')
+            ->set('bob', 'law')
+            ->set('john', 'poe')
+            ->assertSet('foo', 'baz')
+            ->assertSet('bob', 'law')
+            ->assertSet('john', 'poe')
+            // Reset except foo and bob.
+            ->call('resetExceptFooAndBob')
+            ->assertSet('foo', 'baz')
+            ->assertSet('bob', 'law')
+            ->assertSet('john', 'doe');            ;
+    }
+}
+
+class ResetPropertiesComponent extends Component
+{
+    public $foo  = 'bar';
+    public $bob  = 'lob';
+    public $john = 'doe';
+
+    public function resetExceptFooAndBob()
+    {
+        $this->resetExcept(['foo', 'bob']);
+    }
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}

--- a/tests/ResetExceptPropertiesTest.php
+++ b/tests/ResetExceptPropertiesTest.php
@@ -24,7 +24,7 @@ class ResetExceptPropertiesTest extends TestCase
             ->call('resetExceptFooAndBob')
             ->assertSet('foo', 'baz')
             ->assertSet('bob', 'law')
-            ->assertSet('john', 'doe');            ;
+            ->assertSet('john', 'doe');
     }
 }
 

--- a/tests/ResetExceptPropertiesTest.php
+++ b/tests/ResetExceptPropertiesTest.php
@@ -10,7 +10,7 @@ class ResetExceptPropertiesTest extends TestCase
     /** @test */
     public function can_reset_except_properties()
     {
-        Livewire::test(ResetPropertiesComponent::class)
+        Livewire::test(ResetExceptPropertiesComponent::class)
             ->assertSet('foo', 'bar')
             ->assertSet('bob', 'lob')
             ->assertSet('john', 'doe')
@@ -28,7 +28,7 @@ class ResetExceptPropertiesTest extends TestCase
     }
 }
 
-class ResetPropertiesComponent extends Component
+class ResetExceptPropertiesComponent extends Component
 {
     public $foo  = 'bar';
     public $bob  = 'lob';


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Yes it is needed. eg: `request()->except()` exists for laravel.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No it doesn't

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Yes it is attached in the test.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

`$this->reset()` exists. But there are no exclusions to be excluded. 

The usage for this is as follows;

`$this->resetExcept([ 'foo', 'bar']);`

In this way, external reset of the 'foo' and 'bar' is performed.

5️⃣ Thanks for contributing! 🙌