### PR TITLE
Added Layout Config on component Layer

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -341,4 +341,15 @@ HTML;
             new MountMethodMissingException($instance->getName())
         );
     }
+
+    public function getLayoutParams($component)
+    {
+        $element = $this->activate($component, Str::random(20));
+        return method_exists($element, 'layoutParams') ? $element->layoutParams() : null;
+    }
+
+    public function getLayout($component) {
+        $element = $this->activate($component, Str::random(20));
+        return method_exists($element, 'layout') ? $element->layout() : null;
+    }
 }

--- a/src/Macros/RouterMacros.php
+++ b/src/Macros/RouterMacros.php
@@ -31,9 +31,14 @@ class RouterMacros
                 $componentClass = app('livewire')->getComponentClass($component);
                 $reflected = new \ReflectionClass($componentClass);
 
+                // the default is catched by the route action "layout" or the fallback.
+                // This can be overwritten from the layout function of a component.
+                $layout = $this->current()->getAction('layout') ?? 'layouts.app';
+
                 return app('view')->file(__DIR__.'/livewire-view.blade.php', [
-                    'layout' => $this->current()->getAction('layout') ?? 'layouts.app',
+                    'layout' => app('livewire')->getLayout($component) ?? $layout,
                     'section' => $this->current()->getAction('section') ?? 'content',
+                    'layout_params' => app('livewire')->getLayoutParams($component),
                     'component' => $component,
                     'componentParameters' => $reflected->hasMethod('mount')
                         ? (new PretendClassMethodIsControllerMethod($reflected->getMethod('mount'), $this))->retrieveBindings()

--- a/src/Macros/livewire-view.blade.php
+++ b/src/Macros/livewire-view.blade.php
@@ -1,4 +1,4 @@
-@extends($layout)
+@extends($layout, $layout_params ?: [])
 
 @section($section)
     @livewire($component, $componentParameters)

--- a/tests/ComponentCanDefineLayoutTest.php
+++ b/tests/ComponentCanDefineLayoutTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Support\Facades\Route;
+use Livewire\Component;
+use Livewire\Livewire;
+use Livewire\LivewireManager;
+
+class ComponentCanDefineLayoutTest extends TestCase
+{
+    /** @test */
+    public function livewire_components_can_configure_layouts()
+    {
+
+        // $component = app(LivewireManager::class)->test(ComponentWithLayout::class);
+
+        // $component->assertSee('baz');
+
+        Livewire::component('foobar', ComponentWithLayout::class);
+
+        Route::livewire('/foobar', 'foobar');
+
+        $this->get('/foobar')->assertSee('baz');
+    }
+}
+
+
+class ComponentWithLayout extends Component
+{
+
+    public function layout()
+    {
+        return 'layouts.app-with-bar';
+    }
+
+    public function layoutParams()
+    {
+        return [
+            'bar' => 'baz'
+        ];
+    }
+
+    public function render()
+    {
+        return app('view')->make('null-view');
+    }
+}


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yes, it's needed. But regarding the need for others: I'm not sure but I think this should be available. There is no other easy way to do things like Metadata or strings in layouts when they're computed.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope, just one.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes 😎 

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
If you want to give computed layouts or layout params on a component layer to your layout file while using `Route::livewire()` you can now use two new functions directly in the livewire component instead of using the `->layout()` function: `layout()` and `layoutParams()` like this:

```

class ComponentWithLayout extends Component
{

    public function layout()
    {
        return 'layouts.app-with-bar';
    }

    public function layoutParams()
    {
        return [
            'bar' => 'baz'
        ];
    }

    public function render()
    {
        return app('view')->make('null-view');
    }
}

```

5️⃣ Thanks for contributing! 🙌
You're welcome 😎 Thanks back, for building livewire. 😉  