### PR TITLE
Add assertCount() to testing options

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -23,6 +23,13 @@ trait MakesAssertions
 
         return $this;
     }
+    
+    public function assertCount($name, $value)
+    {
+        PHPUnit::assertCount($value, $this->get($name));
+
+        return $this;
+    }
 
     public function assertSee($value)
     {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

We need it in a lot of tests in our project.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Nope

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Not required

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

We have a lot of public properties on our components that are arrays. It is useful to be able to assert the count of these.

One problem we have come across though is if you have a property that contains an `EloquentCollection`.

If for example you had the following code...

```php
class ExampleComponent extends Component
{
    public $users;

    public function mount()
    {
        $this->users = Users:limit(5)->get();
	}
}
```

Then this test will not pass...

```php
Livewire::test(ExampleComponent::class)
    ->assertCount('users', 5);
```

To get it to pass you have to change the test slightly to the following (notice `users.id`)

```php
Livewire::test(ExampleComponent::class)
    ->assertCount('users.id', 5);
```

As you know, this is because internally, that `EloquentCollection` is stored like this...

```
"users" => array:4 [
    "class" => "App\Users"
    "id" => [1, 2, 3, 4, 5]
    "relations" => []
    "connection" => "mysql"
  ]
```

Not sure if there is a way around this?

There are a few other assertions that we could do with. Would you be open to adding more?

Thanks 👍 