### PR TITLE
Extract page resolving to a method

### DIFF
--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -15,9 +15,7 @@ trait WithPagination
 
     public function initializeWithPagination()
     {
-        // The "page" query string item should only be available
-        // from within the original component mount run.
-        $this->page = request()->query('page', $this->page);
+        $this->resolvePage();
 
         Paginator::currentPageResolver(function () {
             return $this->page;
@@ -49,5 +47,12 @@ trait WithPagination
     public function resetPage()
     {
         $this->page = 1;
+    }
+    
+    public function resolvePage()
+    {
+        // The "page" query string item should only be available
+        // from within the original component mount run.
+        $this->page = request()->query('page', $this->page);
     }
 }


### PR DESCRIPTION
When trying to visit a page with an invalid page number (i.e. ?page=1invalid) an exception is thrown saying "A non well formed numeric value encountered". This PR simply allows the developer to override the page setter without having to duplicate the whole `initializeWithPagination` method.

I am not really sure if casting the page to `int` would be a breaking change here so I just extracted the page resolver to another method so we can easily override this if needed. 

Let me know if you prefer to check whether the page is numeric and default to 1 and I'll update my PR.