### PR TITLE
strip wire:key from params

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -83,8 +83,9 @@ class LivewireManager
 
     public function mount($name, $params = [])
     {
-        // This is if a user doesn't pass params, BUT passes key() as the second argument.
-        if (is_string($params)) $params = [];
+        $params = is_array($params) ?
+            $this->stripParams($params):
+            []; // This is if a user doesn't pass params, BUT passes key() as the second argument.
 
         $id = Str::random(20);
 
@@ -328,6 +329,14 @@ HTML;
     public function isLaravel7()
     {
         return Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, '7.0', '>=');
+    }
+
+    private function stripParams($params) {
+        if (isset($params['wire:key'])) {
+            unset($params['wire:key']);
+        }
+
+        return $params;
     }
 
     private function ensureComponentHasMountMethod($instance, $resolvedParameters)

--- a/tests/MountComponentTest.php
+++ b/tests/MountComponentTest.php
@@ -41,6 +41,16 @@ class MountComponentTest extends TestCase
     }
 
     /** @test */
+    public function it_does_not_call_mount_on_the_component_if_only_wire_key_is_given()
+    {
+        $component = app(LivewireManager::class)->test(ComponentWithoutMount::class, ['wire:key' => 10]);
+        $component->assertHasNoErrors();
+
+        $this->expectException(MountMethodMissingException::class);
+        app(LivewireManager::class)->test(ComponentWithoutMount::class, ['wire:key' => 10, 'foo' => 10]);
+    }
+
+    /** @test */
     public function it_sets_missing_dynamically_passed_in_parameters_to_null()
     {
         $fooBar = ['foo' => 10, 'bar' => 5];


### PR DESCRIPTION
Given a component without any parameters.

```blade
<livewire:app.product.import wire:key="import-products-{{Str::random(10)}}"/>
```
Would force the component to have a `mount` method defined.

As of my knowledge, we can safely remove `wire:key` before trying to `mount` the component, since its used only to help the dom finding the element again.

---
Closes #1042