### PR TITLE
test: avoid test contamination in lifecycle hooks

### DIFF
--- a/tests/LifecycleHooksTest.php
+++ b/tests/LifecycleHooksTest.php
@@ -23,6 +23,12 @@ class LifecycleHooksTest extends TestCase
             'updatingBar' => false,
             'updatedBar' => false,
         ], $component->lifecycles);
+    }
+
+    /** @test */
+    public function refresh_magic_method()
+    {
+        $component = app(LivewireManager::class)->test(ForLifecycleHooks::class);
 
         $component->runAction('$refresh');
 
@@ -36,6 +42,31 @@ class LifecycleHooksTest extends TestCase
             'updatingBar' => false,
             'updatedBar' => false,
         ], $component->lifecycles);
+    }
+
+    /** @test */
+    public function update_property()
+    {
+        $component = app(LivewireManager::class)->test(ForLifecycleHooks::class);
+
+        $component->updateProperty('foo', 'bar');
+
+        $this->assertEquals([
+            'mount' => true,
+            'hydrate' => true,
+            'updating' => true,
+            'updated' => true,
+            'updatingFoo' => true,
+            'updatedFoo' => true,
+            'updatingBar' => false,
+            'updatedBar' => false,
+        ], $component->lifecycles);
+    }
+
+    /** @test */
+    public function update_two_properties()
+    {
+        $component = app(LivewireManager::class)->test(ForLifecycleHooks::class);
 
         $component->updateProperty('baz', 'bing');
 
@@ -62,6 +93,12 @@ class LifecycleHooksTest extends TestCase
             'updatingBar' => false,
             'updatedBar' => false,
         ], $component->lifecycles);
+    }
+
+    /** @test */
+    public function update_nested_properties()
+    {
+        $component = app(LivewireManager::class)->test(ForLifecycleHooks::class);
 
         $component->updateProperty('bar.foo', 'baz');
 
@@ -70,13 +107,24 @@ class LifecycleHooksTest extends TestCase
             'hydrate' => true,
             'updating' => true,
             'updated' => true,
-            'updatingFoo' => true,
-            'updatedFoo' => true,
+            'updatingFoo' => false,
+            'updatedFoo' => false,
             'updatingBar' => true,
             'updatedBar' => true,
         ], $component->lifecycles);
 
         $component->updateProperty('bar.cocktail.soft', 'Shirley Ginger');
+
+        $this->assertEquals([
+            'mount' => true,
+            'hydrate' => true,
+            'updating' => true,
+            'updated' => true,
+            'updatingFoo' => false,
+            'updatedFoo' => false,
+            'updatingBar' => true,
+            'updatedBar' => true,
+        ], $component->lifecycles);
     }
 }
 


### PR DESCRIPTION
This PR splits out `mount_hook` test into multiple tests so that each concern is tested in isolation.

Ideally the hook calls should be tested with mocks, but after playing around with it a bit I realize that may be hard in the case of Livewire where reflection is used heavily.

It is really hard to extend and even understand the logic of the tests with all those `||` in the component hooks. 

**UPDATE**: refactored the tests so that each test defines they own assertions, effectively getting rid of the `||` issue. (in e1c4576)

> For reviewer. Check each of the two commits individually as the 'Files changes' makes the changes look more extensive than they are.