### PR TITLE
Rename /livewire-tmp back to /tmp for Vapor

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -320,7 +320,7 @@ HTML;
 
     public function isOnVapor()
     {
-        return ($_ENV['SERVER_SOFTWARE'] ?? null) === 'vapor' || ($_SERVER['SERVER_SOFTWARE'] ?? null) === 'vapor';
+        return ($_ENV['SERVER_SOFTWARE'] ?? null) === 'vapor';
     }
 
     public function isLaravel7()

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -99,7 +99,7 @@ class LivewireServiceProvider extends ServiceProvider
 
         // We will generate a manifest file so we don't have to do the lookup every time.
         $defaultManifestPath = $this->app['livewire']->isOnVapor()
-            ? '/livewire-tmp/storage/bootstrap/cache/livewire-components.php'
+            ? '/tmp/storage/bootstrap/cache/livewire-components.php'
             : app()->bootstrapPath('cache/livewire-components.php');
 
         $this->app->singleton(LivewireComponentsFinder::class, function () use ($defaultManifestPath) {


### PR DESCRIPTION
This PR renames the manifest temp directory for Vapor users, back to `/tmp`, since that is the only writable directory.

This was changed in the recent file upload PR, specifically in commit 83a5a21.

This PR also reverts the changes made in #1051 since that was not the underlying issue. 
Appologies for that, jumpted too quickly to conclusions (and the `dd()` search thing bugs me every time).)