### PR TITLE
Add nonce markup

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -92,4 +92,17 @@ return [
 
     'manifest_path' => null,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Nonce callback function
+    |--------------------------------------------------------------------------
+    |
+    | This value sets a callback to generate a nonce hash in assets markups
+    | If you use csp policy, you may need to add a nonce hash in markups
+    |
+    | Example : 'csp_nonce'
+    |
+    */
+
+    'csp_callback' => null,
 ];


### PR DESCRIPTION
Issue #650 suggests adding a csp_callback function to add a nonce hash in style and script Livewire assets markups.

I use the second approach suggested by @liepumartins