### PR TITLE
Pass extras to custom casters similar to Laravel

### DIFF
--- a/src/DataCaster.php
+++ b/src/DataCaster.php
@@ -47,7 +47,7 @@ class DataCaster
             return $this->casters[$type]['cast']($value, $extras);
         }
 
-        return (new $type)->cast($value);
+        return (new $type)->cast($value, $extras);
     }
 
     protected function runCasterUncast($type, $extras, $value)
@@ -56,7 +56,7 @@ class DataCaster
             return $this->casters[$type]['uncast']($value, $extras);
         }
 
-        return (new $type)->uncast($value);
+        return (new $type)->uncast($value, $extras);
     }
 
     protected function getCasters()
@@ -108,6 +108,10 @@ class DataCaster
         if (Str::startsWith($rawType, 'date:')) {
             $type = 'date';
             $extras = ['format' => Str::after($rawType, 'date:')];
+        }
+        else if (Str::contains($rawType, ':')) {
+            [$type, $params] = explode(':', $rawType);
+            $extras = explode(',', $params);
         } else {
             $type = $rawType;
             $extras = [];


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Wanted. Did not create an issue first 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Yes

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Similar to [custom casts in Laravel](https://laravel.com/docs/7.x/eloquent-mutators#custom-casts), this PR allows you to pass additional arguments into a custom caster. This is useful for various use cases, as an example below for Spatie's Data Transfer Objects. 

```php
class Login extends DataTransferObject
{
    public $email;
}
```

```php
class FooComponent extends Component
{
    public $email;

    public function mount()
    {
        $this->email = new Login(['email' => 'caleb@porzio.com']);
    }

    protected $casts = [
        'email' => DataTransferObjectCaster::class.':Login'
    ];

    ...
```

```php
use Livewire\Castable;

class DataTransferObjectCaster implements Castable {
    public function cast($value, $extras = [])
    {
        $className = $extras[0];

        return new $className($value);
    }

    public function uncast($value, $extras = [])
    {
        return $value->toArray();
    }
}
```

5️⃣ Thanks for contributing! 🙌