### PR TITLE
Add route parameter support for camel case

### DIFF
--- a/src/DependencyResolverTrait.php
+++ b/src/DependencyResolverTrait.php
@@ -2,6 +2,7 @@
 
 namespace Livewire;
 
+use Illuminate\Support\Str;
 use ReflectionMethod;
 use ReflectionParameter;
 use ReflectionFunctionAbstract;
@@ -37,9 +38,17 @@ trait DependencyResolverTrait
     {
         $results = [];
 
+        $parameter_keys = collect(array_keys($parameters))->map(function ($parameterKey) {
+            return Str::camel($parameterKey);
+        })->toArray();
+
+        $parameters = array_combine($parameter_keys, array_values($parameters));
+
         foreach ($dependencies as $dependency) {
-            if (array_key_exists($dependency->name, $parameters)) {
-                $results[] = $parameters[$dependency->name];
+            $dependencyName = Str::camel($dependency->name);
+
+            if (array_key_exists($dependencyName, $parameters)) {
+                $results[] = $parameters[$dependencyName];
 
                 continue;
             }

--- a/tests/RouteParameterTest.php
+++ b/tests/RouteParameterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests;
+
+use Exception;
+use Illuminate\Support\Facades\Route;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class RouteParameterTest extends TestCase
+{
+    /** @test */
+    public function can_pass_parameters_to_component_file()
+    {
+        Livewire::component('foo', ComponentForRouteParameter::class);
+
+        Route::livewire('/foo/{first_name}/{last_name}', 'foo');
+
+        try {
+            $this->withoutExceptionHandling()->get('/foo/John/Doe');
+        } catch (Exception $e) {
+            $this->assertEquals("JohnDoe", explode(' ', $e->getMessage())[0] . explode(' ', $e->getMessage())[1]);
+        }
+    }
+
+    /** @test */
+    public function can_use_camel_case_parameter_for_declaring_route()
+    {
+        Livewire::component('foo', ComponentForRouteParameter::class);
+
+        Route::livewire('/foo/{firstName}', 'foo');
+
+        try {
+            $this->withoutExceptionHandling()->get('/foo/John')->ass;
+        } catch (Exception $e) {
+            $this->assertEquals("John", explode(' ', $e->getMessage())[0]);
+        }
+    }
+
+    /** @test */
+    public function when_wrong_parameter_is_passed_get_error()
+    {
+        Livewire::component('foo', ComponentForRouteParameter::class);
+
+        Route::livewire('/foo/{wrong_parameter}', 'foo');
+
+        try {
+            $this->withoutExceptionHandling()->get('/foo/John')->ass;
+        } catch (Exception $e) {
+            $this->assertNotEquals("John", explode(' ', $e->getMessage())[0]);
+        }
+    }
+}
+
+class ComponentForRouteParameter extends Component
+{
+    public $name;
+    public $last_name;
+
+    public function mount($first_name, $last_name = null)
+    {
+        $this->name = $first_name;
+        $this->last_name = $last_name ?? null;
+    }
+
+    public function render()
+    {
+        throw new Exception($this->name . ' ' . $this->last_name);
+    }
+}


### PR DESCRIPTION
This PR solves #1000 issue.


This is a livewire component class called `Foo`:
```
use Livewire\Component;

class Foo extends Component
{
   public $name;

   public function mount($first_name)
   {
        $this->name = $first_name;
   }

   public function render()
   {
        return view('foo');
   }
```

Before:
```
// Only the first one works
Route::livewire('/foo/{first_name}', 'foo');
Route::livewire('/foo/{firstName}', 'foo');
Route::livewire('/foo/{FirstName}', 'foo');
Route::livewire('/foo/{first-name}', 'foo');
```

After:
```
// All of them work
Route::livewire('/foo/{first_name}', 'foo');
Route::livewire('/foo/{firstName}', 'foo');
Route::livewire('/foo/{FirstName}', 'foo');
Route::livewire('/foo/{first-name}', 'foo');
```