### PR TITLE
Validation not working with cast properties

### DIFF
--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -55,7 +55,7 @@ class ValidationTest extends TestCase
         $component
             ->set('date', 'tomorrow')
             ->runAction('runValidationWithDateCastAttribute')
-            ->assertHasErrors('date', 'before');
+            ->assertHasErrors(['date' => 'before']);
     }
 
     /** @test */
@@ -63,14 +63,14 @@ class ValidationTest extends TestCase
     {
         $component = app(LivewireManager::class)->test(ForValidation::class);
 
-        // array
+        // array|size:4
         $component
             ->set('collection', 'not an array')
             ->runAction('runValidationWithCollectionCastAttribute')
-            ->assertHasErrors('collection', 'array');
+            ->assertHasErrors(['collection' => 'size']);
 
         $component
-            ->set('collection', [1, 2, 3])
+            ->set('collection', [1, 2, 3, 4])
             ->runAction('runValidationWithCollectionCastAttribute')
             ->assertHasNoErrors('collection');
     }
@@ -81,10 +81,10 @@ class ValidationTest extends TestCase
         $component = app(LivewireManager::class)->test(ForValidation::class);
 
         // array
-        // $component
-        //     ->set('custom', 'not a uuid')
-        //     ->runAction('runValidationWithCustomCastAttribute')
-        //     ->assertHasErrors('custom', 'uuid');
+        $component
+            ->set('custom', 'not a uuid')
+            ->runAction('runValidationWithCustomCastAttribute')
+            ->assertHasErrors(['custom' => 'uuid']);
 
         $component
             ->set('custom', '26e72cac-9dcf-4b30-b7f9-78b14632cbe7')
@@ -327,7 +327,7 @@ class ForValidation extends Component
     public function runValidationWithCollectionCastAttribute()
     {
         $this->validate([
-            'collection' => 'required|array',
+            'collection' => 'required|array|size:4',
         ]);
     }
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Needed. This is an issue in the form of a PR with tests to help solve the issue. 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Yes, but only tests! I'm not sure on the solution

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Laravel's validation only works with primitive types with the exception of DateTimeInterface. However, the components properties are cast into collections / dates / custom objects BEFORE we have the chance to do validation, so Laravel's validation will not work properly (tests attached)

Validation should be performed on the uncast values rather than the cast values. 

As far as I can tell, the cast process completely overwrites the uncast values so I'm not sure on the best approach for this. 

5️⃣ Thanks for contributing! 🙌