### PR TITLE
Make upload directory formatting consistent

### DIFF
--- a/src/Controllers/FilePreviewHandler.php
+++ b/src/Controllers/FilePreviewHandler.php
@@ -12,6 +12,6 @@ class FilePreviewHandler
     {
         abort_unless(request()->hasValidSignature(), 401);
 
-        return $this->pretendResponseIsFile(FileUploadConfiguration::storage()->path(FileUploadConfiguration::directory().'/'.$filename));
+        return $this->pretendResponseIsFile(FileUploadConfiguration::storage()->path(FileUploadConfiguration::directory('/').$filename));
     }
 }

--- a/src/Controllers/FilePreviewHandler.php
+++ b/src/Controllers/FilePreviewHandler.php
@@ -12,6 +12,6 @@ class FilePreviewHandler
     {
         abort_unless(request()->hasValidSignature(), 401);
 
-        return $this->pretendResponseIsFile(FileUploadConfiguration::storage()->path(FileUploadConfiguration::directory().$filename));
+        return $this->pretendResponseIsFile(FileUploadConfiguration::storage()->path(FileUploadConfiguration::directory().'/'.$filename));
     }
 }

--- a/src/Controllers/FileUploadHandler.php
+++ b/src/Controllers/FileUploadHandler.php
@@ -44,6 +44,6 @@ class FileUploadHandler
         });
 
         // Strip out the livewire-tmp directory from the paths.
-        return $fileHashPaths->map(function ($path) { return str_replace(FileUploadConfiguration::directory().'/', '', $path); });
+        return $fileHashPaths->map(function ($path) { return str_replace(FileUploadConfiguration::directory('/'), '', $path); });
     }
 }

--- a/src/Controllers/FileUploadHandler.php
+++ b/src/Controllers/FileUploadHandler.php
@@ -38,12 +38,12 @@ class FileUploadHandler
         $fileHashPaths = collect($files)->map(function ($file) use ($disk) {
             $filename = TemporaryUploadedFile::generateHashNameWithOriginalNameEmbedded($file);
 
-            return $file->storeAs('/'. rtrim(FileUploadConfiguration::directory(), '/'), $filename, [
+            return $file->storeAs('/'.FileUploadConfiguration::directory(), $filename, [
                 'disk' => $disk
             ]);
         });
 
         // Strip out the livewire-tmp directory from the paths.
-        return $fileHashPaths->map(function ($path) { return str_replace(FileUploadConfiguration::directory(), '', $path); });
+        return $fileHashPaths->map(function ($path) { return str_replace(FileUploadConfiguration::directory().'/', '', $path); });
     }
 }

--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -42,9 +42,9 @@ class FileUploadConfiguration
         return config('filesystems.disks.'.strtolower($diskBeforeTestFake).'.driver') === 's3';
     }
 
-    public static function directory()
+    public static function directory($suffix = '')
     {
-        return config('livewire.temporary_file_upload.directory') ?: 'livewire-tmp';
+        return (config('livewire.temporary_file_upload.directory') ?: 'livewire-tmp').$suffix;
     }
 
     public static function middleware()

--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -44,7 +44,7 @@ class FileUploadConfiguration
 
     public static function directory()
     {
-        return config('livewire.temporary_file_upload.directory') ?: 'livewire-tmp/';
+        return config('livewire.temporary_file_upload.directory') ?: 'livewire-tmp';
     }
 
     public static function middleware()

--- a/src/GenerateSignedUploadUrl.php
+++ b/src/GenerateSignedUploadUrl.php
@@ -27,10 +27,10 @@ class GenerateSignedUploadUrl
 
         $fileHashName = TemporaryUploadedFile::generateHashNameWithOriginalNameEmbedded($file);
 
-        $directory = FileUploadConfiguration::directory();
+        $directory = FileUploadConfiguration::directory('/');
 
         $signedRequest = $client->createPresignedRequest(
-            $this->createCommand($client, $bucket, ($directory.'/'.$fileHashName), $fileType, $visibility),
+            $this->createCommand($client, $bucket, ($directory.$fileHashName), $fileType, $visibility),
             '+5 minutes'
         );
 

--- a/src/GenerateSignedUploadUrl.php
+++ b/src/GenerateSignedUploadUrl.php
@@ -30,7 +30,7 @@ class GenerateSignedUploadUrl
         $directory = FileUploadConfiguration::directory();
 
         $signedRequest = $client->createPresignedRequest(
-            $this->createCommand($client, $bucket, ($directory.$fileHashName), $fileType, $visibility),
+            $this->createCommand($client, $bucket, ($directory.'/'.$fileHashName), $fileType, $visibility),
             '+5 minutes'
         );
 

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -19,7 +19,7 @@ class TemporaryUploadedFile extends UploadedFile
         $this->disk = $disk;
         $this->storage = Storage::disk($this->disk);
         // Strip out any directory seperators.
-        $this->path = FileUploadConfiguration::directory().'/'.Util::normalizeRelativePath($path);
+        $this->path = FileUploadConfiguration::directory('/').Util::normalizeRelativePath($path);
 
         $tmpFile = tmpfile();
 

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -19,7 +19,7 @@ class TemporaryUploadedFile extends UploadedFile
         $this->disk = $disk;
         $this->storage = Storage::disk($this->disk);
         // Strip out any directory seperators.
-        $this->path = FileUploadConfiguration::directory().Util::normalizeRelativePath($path);
+        $this->path = FileUploadConfiguration::directory().'/'.Util::normalizeRelativePath($path);
 
         $tmpFile = tmpfile();
 

--- a/src/Testing/Concerns/MakesCallsToComponent.php
+++ b/src/Testing/Concerns/MakesCallsToComponent.php
@@ -118,7 +118,7 @@ trait MakesCallsToComponent
         $directory = FileUploadConfiguration::directory();
 
         collect($fileHashes)->zip($newFileHashes)->mapSpread(function ($fileHash, $newFileHash) use ($storage, $directory) {
-            $storage->move('/'.$directory.$fileHash, '/'.$directory.$newFileHash);
+            $storage->move('/'.$directory.'/'.$fileHash, '/'.$directory.'/'.$newFileHash);
         });
 
         // Now we finish the upload with a final call to the Livewire component

--- a/src/Testing/Concerns/MakesCallsToComponent.php
+++ b/src/Testing/Concerns/MakesCallsToComponent.php
@@ -115,10 +115,10 @@ trait MakesCallsToComponent
             return Str::replaceFirst('.', "-size:{$file->getSize()}.", $fileHash);
         })->toArray();
 
-        $directory = FileUploadConfiguration::directory();
+        $directory = FileUploadConfiguration::directory('/');
 
         collect($fileHashes)->zip($newFileHashes)->mapSpread(function ($fileHash, $newFileHash) use ($storage, $directory) {
-            $storage->move('/'.$directory.'/'.$fileHash, '/'.$directory.'/'.$newFileHash);
+            $storage->move('/'.$directory.$fileHash, '/'.$directory.$newFileHash);
         });
 
         // Now we finish the upload with a final call to the Livewire component


### PR DESCRIPTION
Format is now consistently `directory` instead of `directory/`, as described [here](https://github.com/livewire/livewire/blob/master/config/livewire.php#L75).