### PR TITLE
Format the file upload rules as an array

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -70,10 +70,10 @@ return [
     */
 
     'temporary_file_upload' => [
-        'disk' => null,        // Example: 'local', 's3'         Default: 'default'
-        'rules' => null,       // Example: 'file|mimes:png,jpg'  Default: 'file|max:12288' (12MB)
-        'directory' => null,   // Example: 'tmp'                 Default  'livewire-tmp'
-        'middleware' => null,  // Example: 'throttle:5,1'        Default: 'throttle:60,1'
+        'disk' => null,        // Example: 'local', 's3'              Default: 'default'
+        'rules' => [],         // Example: '['file','mimes:png,jpg']  Default: ['required', 'file', 'max:12288'] (12MB)
+        'directory' => null,   // Example: 'tmp'                      Default  'livewire-tmp'
+        'middleware' => null,  // Example: 'throttle:5,1'             Default: 'throttle:60,1'
     ],
 
     /*

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -63,7 +63,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | Livewire handles file uploads by storing uploads in a temporary directory
-    | before the file is validated and stored permentantly. All file uploads
+    | before the file is validated and stored permanently. All file uploads
     | are directed to a global endpoint for temporary storage. The config
     | items below are used for customizing the way the endpoint works.
     |
@@ -71,7 +71,7 @@ return [
 
     'temporary_file_upload' => [
         'disk' => null,        // Example: 'local', 's3'              Default: 'default'
-        'rules' => [],         // Example: '['file','mimes:png,jpg']  Default: ['required', 'file', 'max:12288'] (12MB)
+        'rules' => [],         // Example: '['file','mimes:png,jpg']  Default: ['required','file','max:12288'] (12MB)
         'directory' => null,   // Example: 'tmp'                      Default  'livewire-tmp'
         'middleware' => null,  // Example: 'throttle:5,1'             Default: 'throttle:60,1'
     ],

--- a/src/Controllers/FileUploadHandler.php
+++ b/src/Controllers/FileUploadHandler.php
@@ -32,7 +32,7 @@ class FileUploadHandler
     public function validateAndStore($files, $disk)
     {
         Validator::make(['files' => $files], [
-            'files.*' => 'required|'.FileUploadConfiguration::rules()
+            'files.*' => FileUploadConfiguration::rules()
         ])->validate();
 
         $fileHashPaths = collect($files)->map(function ($file) use ($disk) {

--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -52,8 +52,18 @@ class FileUploadConfiguration
         return config('livewire.temporary_file_upload.middleware') ?: 'throttle:60,1';
     }
 
-    public static function rules()
+    public static function rules(): array
     {
-        return config('livewire.temporary_file_upload.rules') ?: 'file|max:12288';
+        $rules = config('livewire.temporary_file_upload.rules');
+
+        if (! empty($rules)) {
+            if (is_array($rules)) {
+                return $rules;
+            }
+
+            return explode('|', $rules);
+        }
+
+        return ['required', 'file', 'max:12288'];
     }
 }


### PR DESCRIPTION
# Description
This PR changes Livewire so that file upload validation is formatted using the array format of rules, instead of a concatenated string. 

## Reasoning
Laravel offers two ways to forma validation rules.

 As pipe separated string:
- `'rules' => 'file|mimes:png,jpg', `

Or as an array:
- `'rules' => ['file' , 'mimes:png,jpg']`

Livewire's default configuration relies on it being a string as it prepends it with a `required` before using the validation. 

If you customise is to be an array, `FileUploadHandler::validateAndStore` throws an exception as it's attempting to merge the string of `required` with the array from the configuration.

In my use case, I need to add a custom rule which can only be added via the array format. This offers more flexibility when customising file validation, for example:

- `'rules' =>  ['required', 'file', new \App\Rules\ValidProductFile()]`, 

This PR changes Livewire to given the option of both - but defaults to array to imply more flexibility is available.