### PR TITLE
[WIP] Add view()->extends/section to specify livewire layouts in render() method

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -127,12 +127,14 @@ abstract class Component
             '_instance' => $this,
         ] + $this->getPublicPropertiesDefinedBySubClass());
 
+        Livewire::dispatch('view:rendering', $view);
+
         $output = $view->render();
 
         app('view')->share('errors', $previouslySharedErrors);
         app('view')->share('_instance', $previouslySharedInstance);
 
-        Livewire::dispatch('view:render', $view);
+        Livewire::dispatch('view:rendered', $view);
 
         $engine->endLivewireRendering();
 

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -108,6 +108,8 @@ class LivewireManager
 
         $instance->mount(...$resolvedParameters);
 
+        $this->dispatch('mounted', $instance);
+
         $dom = $instance->output();
 
         $response = new Fluent([
@@ -122,7 +124,7 @@ class LivewireManager
             'initial-data' => array_diff_key($response->toArray(), array_flip(['dom'])),
         ], $instance);
 
-        $this->dispatch('mounted', $response);
+        $this->dispatch('rendered', $response);
 
         return $response;
     }

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Route as RouteFacade;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Testing\TestResponse as Laravel7TestResponse;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+use Illuminate\View\View;
 use Livewire\Commands\{
     CpCommand,
     MvCommand,
@@ -187,6 +188,18 @@ class LivewireServiceProvider extends ServiceProvider
     {
         Route::mixin(new RouteMacros);
         Router::mixin(new RouterMacros);
+
+        View::macro('extends', function ($view, $params = []) {
+            $this->livewireExtends = ['view' => $view, 'params' => $params];
+
+            return $this;
+        });
+
+        View::macro('section', function ($name) {
+            $this->livewireSection = $name;
+
+            return $this;
+        });
     }
 
     protected function registerTagCompiler()

--- a/src/Macros/livewire-view.blade.php
+++ b/src/Macros/livewire-view.blade.php
@@ -1,5 +1,5 @@
-@extends($layout)
+@extends($layout, $layoutParams)
 
 @section($section)
-    @livewire($component, $componentParameters)
+    {!! $dom !!}
 @endsection

--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -26,7 +26,7 @@ class TestableLivewire
 
     public function __construct($name, $params = [])
     {
-        Livewire::listen('view:render', function ($view) {
+        Livewire::listen('view:rendered', function ($view) {
             $this->lastRenderedView = $view;
         });
 
@@ -34,7 +34,7 @@ class TestableLivewire
             $this->lastValidator = $validator;
         });
 
-        Livewire::listen('mounted', function ($response) {
+        Livewire::listen('rendered', function ($response) {
             $this->rawMountedResponse = $response;
         });
 

--- a/tests/RouteRegistrationTest.php
+++ b/tests/RouteRegistrationTest.php
@@ -19,6 +19,18 @@ class RouteRegistrationTest extends TestCase
 
         $this->get('/foo')->assertSee('baz');
     }
+
+    /** @test */
+    public function can_specify_layout_and_section_in_render_method()
+    {
+        Livewire::component('foo', ComponentForRouteRegistrationWithExtends::class);
+
+        Route::livewire('/foo', 'foo');
+
+        $this->get('/foo')
+            ->assertSee('bar')
+            ->assertSee('baz');
+    }
 }
 
 class ComponentForRouteRegistration extends Component
@@ -28,5 +40,18 @@ class ComponentForRouteRegistration extends Component
     public function render()
     {
         return view('show-name');
+    }
+}
+
+class ComponentForRouteRegistrationWithExtends extends Component
+{
+    public $name = 'bar';
+
+    public function render()
+    {
+        return view('show-name')
+            ->extends('layouts.app-with-bar-and-yield-body', [
+                'bar' => 'baz',
+            ])->section('body');
     }
 }

--- a/tests/views/layouts/app-with-bar-and-yield-body.blade.php
+++ b/tests/views/layouts/app-with-bar-and-yield-body.blade.php
@@ -1,0 +1,3 @@
+{{ $bar }}
+
+@yield('body')


### PR DESCRIPTION
Here is the proposed API:

```php
public function render()
{
    return view('livewire.some-view)
        ->extends('layouts.base', ['title' => 'foo'])->section('body');
}
```