### PR TITLE
[WIP] Support .pushState instead of .replaceState for `$updatesQueryString`

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -69,12 +69,12 @@ return [
     |
     */
 
-    'temporary_file_upload' => [
-        'disk' => null,        // Example: 'local', 's3'              Default: 'default'
-        'rules' => null,       // Example: '['file', 'mimes:png,jpg'] Default: ['required', 'file', 'max:12288'] (12MB)
-        'directory' => null,   // Example: 'tmp'                      Default  'livewire-tmp'
-        'middleware' => null,  // Example: 'throttle:5,1'             Default: 'throttle:60,1'
-    ],
+'temporary_file_upload' => [
+    'disk' => null,        // Example: 'local', 's3'              Default: 'default'
+    'rules' => null,       // Example: ['file', 'mimes:png,jpg']  Default: ['required', 'file', 'max:12288'] (12MB)
+    'directory' => null,   // Example: 'tmp'                      Default  'livewire-tmp'
+    'middleware' => null,  // Example: 'throttle:5,1'             Default: 'throttle:60,1'
+],
 
     /*
     |--------------------------------------------------------------------------

--- a/js/component/UpdateQueryString.js
+++ b/js/component/UpdateQueryString.js
@@ -2,6 +2,28 @@ import store from '@/Store'
 import queryString from '@/util/query-string'
 
 export default function () {
+    window.addEventListener('onpopstate', (event) => {
+        if (event && event.state && event.state.livewire) {
+            Object.keys(event.state.livewire.updates).forEach(id => {
+                let component = window.livewire.find(id)
+
+                if (component) {
+                    let updates = event.state.livewire.updates[id]
+
+                    Object.keys(updates).forEach(dataKey => {
+                        component.set(dataKey, updates[dataKey])
+                    })
+
+                    // This is so that when component.set() triggers a roundtrip,
+                    // the response received from that roundtrip uses "replaceState"
+                    // to update the query string so that it doesn't wipe out future state
+                    // (disabling the "forward button") by using pushState.
+                    component.useReplaceState = true
+                }
+            })
+        }
+    })
+
     store.registerHook('responseReceived', (component, response) => {
         if (response.updatesQueryString === undefined) return
 
@@ -43,6 +65,20 @@ export default function () {
 
         var stringifiedQueryString = queryString.stringify(queryData)
 
-        history.replaceState({turbolinks: {}}, "", [window.location.pathname, stringifiedQueryString].filter(Boolean).join('?'))
+        // This makes it so that Turbolinks doesn't break Livewire on the back button.
+        let state = { turbolinks: {} }
+
+        // Store the current Livewire state in the history stack, so that
+        // when a user hits a back button, we can re-apply the state from this
+        // point in time to the Livewire components.
+        state.livewire = { updates: {} }
+        state.livewire.updates[component.id] = dataDestinedForQueryString
+
+        if (component.useReplaceState === true) {
+            component.useReplaceState = false
+            history.replaceState(state, "", [window.location.pathname, stringifiedQueryString].filter(Boolean).join('?'))
+        } else {
+            history.pushState(state, "", [window.location.pathname, stringifiedQueryString].filter(Boolean).join('?'))
+        }
     })
 }

--- a/tests/js/update_query_string.spec.js
+++ b/tests/js/update_query_string.spec.js
@@ -4,7 +4,7 @@ import Livewire from 'laravel-livewire'
 test('data can be added to the query string', async () => {
     var newUri
 
-    window.history.replaceState = (object, title, uri) => {
+    window.history.pushState = (object, title, uri) => {
         newUri = uri
     }
 
@@ -45,7 +45,7 @@ test('data can be added to the query string', async () => {
 test('data will be removed from the query string if "except" is present', async () => {
     var newUri
 
-    window.history.replaceState = (object, title, uri) => {
+    window.history.pushState = (object, title, uri) => {
         newUri = uri
     }
 
@@ -86,7 +86,7 @@ test('data will be removed from the query string if "except" is present', async 
 test('data can be an object and still be passed to the query string', async () => {
     var newUri
 
-    window.history.replaceState = (object, title, uri) => {
+    window.history.pushState = (object, title, uri) => {
         newUri = uri
     }
 


### PR DESCRIPTION
### Ideal Magic Behavior
This component is shown on the `/component` route:
```php
class Foo extends Component
{
  public $foo = 'bar';

  protected $queryStringBindings = ['foo'];

  public function render()
  {
    return view('livewire.foo');
  }
}
```
* When the page loads, the URL goes from `/component` to `/component?foo=bar`
* When the `foo` property is changed to "baz", the URL is also changed to `/component?foo=baz`
* When the user hits the back button, the `$foo` property is reverted back to "bar" and the component will update with a server roundtrip, the forward button would set it back to "baz" -> all without actually changing pages.
* When the page loads from scratch, with the URL `/component?foo=bob`, then the `$foo` property will be set to `"bob"` initially.

In addition, you could opt-out of the magic "sync" behavior, and utilize manual methods:

```php
class Foo extends Component
{
  public $foo = 'bar';

  public function mount()
  {
    $this->foo = request()->query('foo', $this->foo);
  }

  public function updatedFoo()
  {
    $this->pushState('foo', $this->foo);
    // or...
    $this->replaceState('foo', $this->foo);
  }
```