### PR TITLE
Fixed a typo which was causing filesystem default driver recognition …

### DIFF
--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -37,7 +37,7 @@ class FileUploadConfiguration
 
     public static function isUsingS3()
     {
-        $diskBeforeTestFake = config('livewire.temporary_file_upload.disk') ?: config('filsystems.default');
+        $diskBeforeTestFake = config('livewire.temporary_file_upload.disk') ?: config('filesystems.default');
 
         return config('filesystems.disks.'.strtolower($diskBeforeTestFake).'.driver') === 's3';
     }


### PR DESCRIPTION
…issues

1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

This is a must-have fix for file system driver recognition to work properly. Without this fix, S3 file previews are not working at all. I haven't created an issue because it's a very straightforward fix.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No, but really surprised the existing tests didn't catch this.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

The uploads with S3 driver is working but preview temporary url generation isn't working because of this issue. Due to this problem, Livewire can't detect that the app is using an S3 driver for its configured filesystem disk.

5️⃣ Thanks for contributing! 🙌

Thank you for building this beautiful thing 👍 