### PR TITLE
Replace ES6 code with traditional js for parsing action expressions

### DIFF
--- a/js/dom/directive.js
+++ b/js/dom/directive.js
@@ -52,7 +52,13 @@ export default class {
             const $event = this.eventContext
             method = methodAndParamString[1]
             // use a function that returns it's arguments to parse and eval all params
-            params = eval('((...params) => [...params])(' + methodAndParamString[2] + ')')
+            getParams = `function (${methodAndParamString[2]}) {
+                for (var l=arguments.length, p=new Array(l), k=0; k<l; k++) {
+                    p[k] = arguments[k];
+                }
+                return [].concat(p);
+            }`
+            params = eval(getParams)
         }
 
         return { method, params }


### PR DESCRIPTION
This addresses #1112 by replacing the ES6 code with traditional javascript.

Will admit to not doing extensive browser testing, but this should resolve the issue.