### PR TITLE
Fixed typo in isUsingS3 function

### DIFF
--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -37,7 +37,7 @@ class FileUploadConfiguration
 
     public static function isUsingS3()
     {
-        $diskBeforeTestFake = config('livewire.temporary_file_upload.disk') ?: config('filsystems.default');
+        $diskBeforeTestFake = config('livewire.temporary_file_upload.disk') ?: config('filesystems.default');
 
         return config('filesystems.disks.'.strtolower($diskBeforeTestFake).'.driver') === 's3';
     }


### PR DESCRIPTION
Before this PR, 
if `livewire.temporary_file_upload.disk` is null it will set `$diskBeforeTestFake` to null also due to the typo of `config('filsystems.default')` instead of `config('filesystems.default')`