### PR TITLE
Laravel 5.6 and 5.7 eloquent collection hydration compatibility

### DIFF
--- a/src/HydrationMiddleware/HydrateEloquentModelsAsPublicProperties.php
+++ b/src/HydrationMiddleware/HydrateEloquentModelsAsPublicProperties.php
@@ -2,9 +2,11 @@
 
 namespace Livewire\HydrationMiddleware;
 
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Contracts\Database\ModelIdentifier;
-use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
+use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 class HydrateEloquentModelsAsPublicProperties implements HydrationMiddleware
 {
@@ -21,18 +23,6 @@ class HydrateEloquentModelsAsPublicProperties implements HydrationMiddleware
                 $unHydratedInstance->$property = (new static)->getRestoredPropertyValue(
                     new ModelIdentifier($value['class'], $value['id'], $value['relations'], $value['connection'])
                 );
-
-                // only needed in Laravel 5.6 and 5.7
-                if($unHydratedInstance -> $property instanceof EloquentCollection){
-                    $collection = $unHydratedInstance -> $property ->keyBy->getKey();
-                    $collectionClass = get_class($collection);
-
-                    $unHydratedInstance -> $property =  new $collectionClass(
-                        collect($value['id'])->map(function ($id) use ($collection) {
-                            return $collection[$id] ?? null;
-                        })->filter()
-                    );
-                }
             }
         }
     }
@@ -46,5 +36,37 @@ class HydrateEloquentModelsAsPublicProperties implements HydrationMiddleware
                 $instance->$property = (array) $serializedModel;
             }
         }
+    }
+
+    /**
+     * This method is here to overide the method includeded in the "SerializesAndRestoresModelIdentifiers" trait.
+     * This method contains a fix that exists in Laravel 5.8 and greater and brings it to Laravel 5.6-7
+     * because this version of Livewire supports down to those.
+     * https://github.com/laravel/framework/blob/7.x/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+     */
+    protected function restoreCollection($value)
+    {
+        if (! $value->class || count($value->id) === 0) {
+            return new EloquentCollection;
+        }
+
+        $collection = $this->getQueryForModelRestoration(
+            (new $value->class)->setConnection($value->connection), $value->id
+        )->useWritePdo()->get();
+
+        if (is_a($value->class, Pivot::class, true) ||
+            in_array(AsPivot::class, class_uses($value->class))) {
+            return $collection;
+        }
+
+        $collection = $collection->keyBy->getKey();
+
+        $collectionClass = get_class($collection);
+
+        return new $collectionClass(
+            collect($value->id)->map(function ($id) use ($collection) {
+                return $collection[$id] ?? null;
+            })->filter()
+        );
     }
 }


### PR DESCRIPTION
The original fix from #1099 was not working correctly for Laravel 5.6 and 5.7 because Laravel was restoring collections differently in those version.

This fix copies the behaviour (and some of the code) that was introduced in Laravel 5.8 in SerializesAndRestoresModelIdentifiers.php for the restoreCollection method.