### PR TITLE
Adds assertDontSeeLivewire() test macro

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -181,6 +181,26 @@ class LivewireServiceProvider extends ServiceProvider
         } else {
             TestResponse::macro('assertSeeLivewire', $macro);
         }
+
+        // Usage: $this->assertDontSeeLivewire('counter');
+        $macro = function ($component) {
+            $escapedComponentName = trim(htmlspecialchars(json_encode(['name' => $component])), '{}');
+
+            \PHPUnit\Framework\Assert::assertStringNotContainsString(
+                (string) $escapedComponentName, $this->getContent(),
+                'Found Livewire component ['.$component.'] rendered on page.'
+            );
+
+            return $this;
+        };
+
+        if (class_exists(Laravel7TestResponse::class)) {
+            // TestResponse was moved from illuminate/foundation
+            // and moved to illuminate/testing for Laravel 7.
+            Laravel7TestResponse::macro('assertDontSeeLivewire', $macro);
+        } else {
+            TestResponse::macro('assertDontSeeLivewire', $macro);
+        }
     }
 
     protected function registerRouteMacros()

--- a/tests/LivewireDirectivesTest.php
+++ b/tests/LivewireDirectivesTest.php
@@ -47,6 +47,25 @@ class LivewireDirectivesTest extends TestCase
     }
 
     /** @test */
+    public function can_assert_dont_see_livewire_on_standard_blade_view()
+    {
+        $fakeClass = new class {
+            public function getContent()
+            {
+                return view('null-view')->render();
+            }
+        };
+
+        if (Application::VERSION === '7.x-dev' || version_compare(Application::VERSION, '7.0', '>=')) {
+            $testResponse = new Laravel7TestResponse($fakeClass);
+        } else {
+            $testResponse = new TestResponse($fakeClass);
+        }
+
+        $testResponse->assertDontSeeLivewire('foo');
+    }
+
+    /** @test */
     public function component_is_loaded_with_blade_directive_by_classname()
     {
         Artisan::call('make:livewire', ['name' => 'foo']);


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Small chat on discord

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
There is an existing `assertSeeLivewire()` test method available - but sometimes I want to check that I _don't_ see a component.  For instance, `an_admin_can_see_the_destroy_all_the_things_component` and `regular_users_cant_see_the_destroy_all_the_things_component`.  It's just nice to have a bit of symmetry in the tests with assertSee & assertDontSee.

5️⃣ Thanks for contributing! 🙌
Aw, shucks!

P.S There is a bit of duplication now in the `LivewireServiceProvider` but I didn't want to make the PR more invasive by altering too much.  Happy to change it though if you'd rather.