### PR TITLE
Use response()->make to work on Laravel 5.6

### DIFF
--- a/src/Controllers/CanPretendToBeAFile.php
+++ b/src/Controllers/CanPretendToBeAFile.php
@@ -11,7 +11,7 @@ trait CanPretendToBeAFile
         $cacheControl = 'public, max-age=31536000';
 
         if ($this->matchesCache($lastModified)) {
-            return response()->noContent(304, [
+            return response()->make('', 304, [
                 'Expires' => $this->httpDate($expires),
                 'Cache-Control' => $cacheControl,
             ]);


### PR DESCRIPTION
The `noContent` method was only added in Laravel 5.7 (see https://github.com/laravel/framework/pull/23744/files).
But since Livewire supports Laravel 5.6 as well, this was causing a MethodNotFoundException.

This PR simply uses the `response()->make` method with an empty content, as this method always exists.
