### PR TITLE
Wrap pagination view's root conditional in an element to prevent DOM diffing issues

### DIFF
--- a/src/views/pagination-links.blade.php
+++ b/src/views/pagination-links.blade.php
@@ -1,56 +1,58 @@
-@if ($paginator->hasPages())
-    <ul class="pagination" role="navigation">
-        {{-- Previous Page Link --}}
-        @if ($paginator->onFirstPage())
-            <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
-                <span class="page-link" aria-hidden="true">
-                    <span class="d-none d-md-block">&lsaquo;</span>
-                    <span class="d-block d-md-none">@lang('pagination.previous')</span>
-                </span>
-            </li>
-        @else
-            <li class="page-item">
-                <button type="button" class="page-link" wire:click="previousPage" rel="prev" aria-label="@lang('pagination.previous')">
-                    <span class="d-none d-md-block">&lsaquo;</span>
-                    <span class="d-block d-md-none">@lang('pagination.previous')</span>
-                </button>
-            </li>
-        @endif
-
-        {{-- Pagination Elements --}}
-        @foreach ($elements as $element)
-            {{-- "Three Dots" Separator --}}
-            @if (is_string($element))
-                <li class="page-item disabled d-none d-md-block" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+<div>
+    @if ($paginator->hasPages())
+        <ul class="pagination" role="navigation">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                    <span class="page-link" aria-hidden="true">
+                        <span class="d-none d-md-block">&lsaquo;</span>
+                        <span class="d-block d-md-none">@lang('pagination.previous')</span>
+                    </span>
+                </li>
+            @else
+                <li class="page-item">
+                    <button type="button" class="page-link" wire:click="previousPage" rel="prev" aria-label="@lang('pagination.previous')">
+                        <span class="d-none d-md-block">&lsaquo;</span>
+                        <span class="d-block d-md-none">@lang('pagination.previous')</span>
+                    </button>
+                </li>
             @endif
 
-            {{-- Array Of Links --}}
-            @if (is_array($element))
-                @foreach ($element as $page => $url)
-                    @if ($page == $paginator->currentPage())
-                        <li class="page-item active d-none d-md-block" aria-current="page"><span class="page-link">{{ $page }}</span></li>
-                    @else
-                        <li class="page-item d-none d-md-block"><button type="button" class="page-link" wire:click="gotoPage({{ $page }})">{{ $page }}</button></li>
-                    @endif
-                @endforeach
-            @endif
-        @endforeach
+            {{-- Pagination Elements --}}
+            @foreach ($elements as $element)
+                {{-- "Three Dots" Separator --}}
+                @if (is_string($element))
+                    <li class="page-item disabled d-none d-md-block" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+                @endif
 
-        {{-- Next Page Link --}}
-        @if ($paginator->hasMorePages())
-            <li class="page-item">
-                <button type="button" class="page-link" wire:click="nextPage" rel="next" aria-label="@lang('pagination.next')">
-                    <span class="d-block d-md-none">@lang('pagination.next')</span>
-                    <span class="d-none d-md-block">&rsaquo;</span>
-                </button>
-            </li>
-        @else
-            <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
-                <span class="page-link" aria-hidden="true">
-                    <span class="d-block d-md-none">@lang('pagination.next')</span>
-                    <span class="d-none d-md-block">&rsaquo;</span>
-                </span>
-            </li>
-        @endif
-    </ul>
-@endif
+                {{-- Array Of Links --}}
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <li class="page-item active d-none d-md-block" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                        @else
+                            <li class="page-item d-none d-md-block"><button type="button" class="page-link" wire:click="gotoPage({{ $page }})">{{ $page }}</button></li>
+                        @endif
+                    @endforeach
+                @endif
+            @endforeach
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <button type="button" class="page-link" wire:click="nextPage" rel="next" aria-label="@lang('pagination.next')">
+                        <span class="d-block d-md-none">@lang('pagination.next')</span>
+                        <span class="d-none d-md-block">&rsaquo;</span>
+                    </button>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                    <span class="page-link" aria-hidden="true">
+                        <span class="d-block d-md-none">@lang('pagination.next')</span>
+                        <span class="d-none d-md-block">&rsaquo;</span>
+                    </span>
+                </li>
+            @endif
+        </ul>
+    @endif
+</div>


### PR DESCRIPTION
Issue #420 started this.

Because the pagination view for Livewire contains a root-level blade conditional, depending on where it's included in a component's Blade view, it MAY create DOM-Diffing issues for morphdom.

The fix is to ALWAYS have a wrapping <div> for this view's inclusion.