### PR TITLE
Add $option for specifying a nonce for livewire's script tag

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -230,11 +230,13 @@ HTML;
             }
         }
 
+        $nonce = isset($options['nonce']) ? " nonce=\"{$options['nonce']}\"" : '';
+
         // Adding semicolons for this JavaScript is important,
         // because it will be minified in production.
         return <<<HTML
 {$assetWarning}
-<script src="{$fullAssetPath}" data-turbolinks-eval="false"></script>
+<script src="{$fullAssetPath}" data-turbolinks-eval="false"{$nonce}></script>
 <script data-turbolinks-eval="false">
     window.livewire = new Livewire({$jsonEncodedOptions});
     window.livewire_app_url = '{$appUrl}';

--- a/tests/LivewireAssetsDirectiveTest.php
+++ b/tests/LivewireAssetsDirectiveTest.php
@@ -5,7 +5,7 @@ namespace Tests;
 use Livewire\Livewire;
 use Illuminate\Support\Facades\View;
 
-class LivewireUsesProperAppAndAssetsPathTest extends TestCase
+class LivewireAssetsDirectiveTest extends TestCase
 {
     /** @test */
     public function livewire_js_is_unminified_when_app_is_in_debug_mode()
@@ -79,6 +79,19 @@ class LivewireUsesProperAppAndAssetsPathTest extends TestCase
 
         $this->assertStringContainsString(
             "window.livewire_app_url = 'https://foo.com/assets';",
+            $output
+        );
+    }
+
+    /** @test */
+    public function nonce_passed_into_directive_gets_added_as_script_tag_attribute()
+    {
+        $output = View::make('assets-directive', [
+            'options' => ['nonce' => 'foobarnonce'],
+        ])->render();
+
+        $this->assertStringContainsString(
+            'nonce="foobarnonce">',
             $output
         );
     }


### PR DESCRIPTION
For sites that use content security policies (CSPs), Livewire offers an API for specifying a "nonce" to be placed in Livewire's generated, inline `<script>` tag.

```php
// Without nonce:
@livewireScripts
// Produces:
<script ...>...</script>

// WITH nonce:
@livewireScripts(['nonce' => 'some-nonce-here'])
// Produces:
<script ... nonce="some-nonce-here">...</script>
```