### PR TITLE
Changed temporary file size delimiter to allow Windows rename during tests

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -31,9 +31,9 @@ class TemporaryUploadedFile extends UploadedFile
 
     public function getSize()
     {
-        if (app()->environment('testing') && str::contains($this->getfilename(), '-size:')) {
+        if (app()->environment('testing') && str::contains($this->getfilename(), '-size=')) {
             // This head/explode/last/explode nonsense is the equivelant of Str::between().
-            [$beginning, $end] = ['-size:', '.'];
+            [$beginning, $end] = ['-size=', '.'];
             return (int) head(explode($end, last(explode($beginning, $this->getFilename()))));
         }
 

--- a/src/Testing/Concerns/MakesCallsToComponent.php
+++ b/src/Testing/Concerns/MakesCallsToComponent.php
@@ -112,7 +112,7 @@ trait MakesCallsToComponent
         // We are going to encode the file size in the filename so that when we create
         // a new TemporaryUploadedFile instance we can fake a specific file size.
         $newFileHashes = collect($files)->zip($fileHashes)->mapSpread(function ($file, $fileHash) {
-            return Str::replaceFirst('.', "-size:{$file->getSize()}.", $fileHash);
+            return Str::replaceFirst('.', "-size={$file->getSize()}.", $fileHash);
         })->toArray();
 
         collect($fileHashes)->zip($newFileHashes)->mapSpread(function ($fileHash, $newFileHash) use ($storage) {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Yes, fixes #1189.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

A colon ":" is an invalid character for Windows filenames. The temporary files encode the file size in the filename by appending `-size:{$file->getSize()}` during tests. This causes all file upload tests to fail since it cannot rename the files.

**Before**: `Tz65CjkB3IFvFrGY6FKoyXt1E6EBiN-metaYGWedGFyLnBuZw==--size:159.png`

This pull request changes the `:` to a `=`, allowing tests to pass on Windows machines.

**After**: `Tz65CjkB3IFvFrGY6FKoyXt1E6EBiN-metaYGWedGFyLnBuZw==--size=159.png`


5️⃣ Thanks for contributing! 🙌