### PR TITLE
Register macros early

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -58,6 +58,8 @@ class LivewireServiceProvider extends ServiceProvider
 {
     public function register()
     {
+        $this->registerTestMacros();
+        $this->registerRouteMacros();
         $this->registerLivewireSingleton();
         $this->registerComponentAutoDiscovery();
     }
@@ -67,8 +69,6 @@ class LivewireServiceProvider extends ServiceProvider
         $this->registerViews();
         $this->registerRoutes();
         $this->registerCommands();
-        $this->registerTestMacros();
-        $this->registerRouteMacros();
         $this->registerTagCompiler();
         $this->registerPublishables();
         $this->registerBladeDirectives();


### PR DESCRIPTION
This moves the registration of (route) macros to the register method in the Livewire Service Provider.

Registering it here makes sure the macros are available in the boot method of other (Package) Service Providers wanting to use "Route::livewire" for route registration for example.