### PR TITLE
Add container instance to Component

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -23,6 +23,8 @@ abstract class Component
         ComponentConcerns\TracksRenderedChildren,
         ComponentConcerns\InteractsWithProperties;
 
+    use InteractsWithContainerTrait;
+
     public $id;
 
     protected $updatesQueryString = [];

--- a/src/InteractsWithContainerTrait.php
+++ b/src/InteractsWithContainerTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Livewire;
+
+use Illuminate\Contracts\Container\Container;
+
+trait InteractsWithContainerTrait
+{
+    /**
+     * The container instance.
+     *
+     * @var \Illuminate\Contracts\Container\Container
+     */
+    protected $container;
+
+    /**
+     * Set the container implementation.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return $this
+     */
+    public function setContainer(Container $container)
+    {
+        $this->container = $container;
+
+        return $this;
+    }
+}

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -88,7 +88,9 @@ class LivewireServiceProvider extends ServiceProvider
 
     protected function registerLivewireSingleton()
     {
-        $this->app->singleton('livewire', LivewireManager::class);
+        $this->app->singleton('livewire', function ($app) {
+            return (new LivewireManager)->setContainer($app);
+        });
     }
 
     protected function registerComponentAutoDiscovery()


### PR DESCRIPTION
This adds the container instance ($app) to the Component during hydration and activation of said component. It also slightly reworks how the LivewireManager receives its container instance.

**Why?!**
In various instances during the lifecycle of a component, primarily during the update or storage of an entity, it might be required to use some instance from the IOC container. Having the container directly available on the component class makes this process easier, and personally I don't like the use of `app()` this could break in situations where this function would be overloaded.

**Additional rambling**
In my case I need a `FormRequest` instance to fetch some validation rules I also use in an API. However, without the traditional dependency injection form requests don't really work due to the missing container and base request instance on the object.

Laravel injects those during 'resolving' and triggers the validation after it has been resolved. I don't actually need that validation trigger, only the rules. For my use-case I've created a small trait, used in my component, imitating the resolving part of a form request.

```PHP
public function formRequest(string $class): FormRequest
{
    if (! class_exists($class)) {
        throw new RuntimeException(sprintf('Class [%s] does not exist.', $class));
    }

    $app = Container::getInstance();

    $request = FormRequest::createFrom($app->make('request'), (new $class));
    $request->setContainer($app);

    return $request;
}
```
Laravel does this in the [FormRequestServiceProvider.php](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php).

Having the container directly available would make this process a tiny bit simpler. It might even be an entry to **form request authorization**. 