### PR TITLE
Add macro support to TestableLivewire

### DIFF
--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -9,6 +9,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\View;
 use Livewire\GenerateSignedUploadUrl;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Traits\Macroable;
 use Facades\Livewire\GenerateSignedUploadUrl as GenerateSignedUploadUrlFacade;
 
 class TestableLivewire
@@ -19,6 +20,8 @@ class TestableLivewire
     public $lastRenderedView;
     public $lastResponse;
     public $rawMountedResponse;
+
+    use Macroable { __call as macroCall; }
 
     use Concerns\MakesAssertions,
         Concerns\MakesCallsToComponent,
@@ -179,6 +182,10 @@ class TestableLivewire
 
     public function __call($method, $params)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $params);
+        }
+
         return $this->lastResponse->$method(...$params);
     }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

No discussion or issue, though It seems like something people would find useful?

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Nope

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

All current tests pass, doesn't really require additional testing.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Adds the ability to add custom assertions to the `TestableLivewire` class. For example:

```php
        TestableLivewire::macro('assertComputed', function ($property, $value) {
            PHPUnit::assertEquals($value, $this->viewData('_instance')->$property ?? null);

            return $this;
        });

        Livewire::test(MyComponent::class)
            ->assertComputed('foobar', 42);
```

5️⃣ Thanks for contributing! 🙌

 

P.S. Fair warning that accepting this PR means this will no longer be true ☹️

<img src="https://user-images.githubusercontent.com/627060/86282192-6282ee80-bba4-11ea-85f3-67a3d6a425ac.png" width="130">