### PR TITLE
Fixing the class name to comply with psr-4 autoloading standard

### DIFF
--- a/tests/ComponentLocaleIsPersistedTest.php
+++ b/tests/ComponentLocaleIsPersistedTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\App;
 use Livewire\Livewire;
 use Livewire\Component;
 
-class ComponentLocaleIsPersisted extends TestCase
+class ComponentLocaleIsPersistedTest extends TestCase
 {
     /** @test */
     public function a_livewire_component_can_persist_its_locale()


### PR DESCRIPTION
Fixing The Deprecation Notice: 
`Class Tests\ComponentLocaleIsPersisted does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0.`