### PR TITLE
Fixing classContents method in StubParser class

### DIFF
--- a/src/Commands/StubParser.php
+++ b/src/Commands/StubParser.php
@@ -33,7 +33,7 @@ class StubParser extends ComponentParser
         return $this->component.'.stub';
     }
 
-    public function classContents()
+    public function classContents($inline = false)
     {
         return file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'Component.stub');
     }


### PR DESCRIPTION
This fixes the error: `Declaration of Livewire\Commands\StubParser::classContents() should be compatible with Livewire\Commands\ComponentParser::classContents($inline = false)`