### PR TITLE
Make assertHas[No]Errors work for class based rules

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -154,12 +154,9 @@ trait MakesAssertions
             } else {
                 $failed = optional($this->lastValidator)->failed() ?: [];
                 $rules = array_keys(Arr::get($failed, $key, []));
-                $snakeCaseRules = array_map(function ($rule) {
-                    return Str::snake($rule);
-                }, $rules);
 
                 foreach ((array)$value as $rule) {
-                    PHPUnit::assertContains($rule, $snakeCaseRules, "Component has no [{$rule}] errors for [{$key}] attribute.");
+                    PHPUnit::assertContains(Str::studly($rule), $rules, "Component has no [{$rule}] errors for [{$key}] attribute.");
                 }
             }
         }
@@ -185,12 +182,9 @@ trait MakesAssertions
             } else {
                 $failed = optional($this->lastValidator)->failed() ?: [];
                 $rules = array_keys(Arr::get($failed, $key, []));
-                $snakeCaseRules = array_map(function ($rule) {
-                    return Str::snake($rule);
-                }, $rules);
 
                 foreach ((array) $value as $rule) {
-                    PHPUnit::assertNotContains($rule, $snakeCaseRules, "Component has [{$rule}] errors for [{$key}] attribute.");
+                    PHPUnit::assertNotContains(Str::studly($rule), $rules, "Component has [{$rule}] errors for [{$key}] attribute.");
                 }
             }
         }

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\ViewErrorBag;
 use Livewire\Component;
 use Livewire\LivewireManager;
@@ -146,7 +147,7 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
-    public function multi_word_validation_rules_are_assertable()
+    public function multi_word_validation_rules_failing_are_assertable()
     {
         $component = app(LivewireManager::class)->test(ForValidation::class);
 
@@ -154,6 +155,17 @@ class ValidationTest extends TestCase
             ->set('foo', 'bar123&*(O)')
             ->call('runValidationWithMultiWordRule')
             ->assertHasErrors(['foo' => 'alpha_dash']);
+    }
+
+    /** @test */
+    public function class_based_validation_rules_failing_are_assertable()
+    {
+        $component = app(LivewireManager::class)->test(ForValidation::class);
+
+        $component
+            ->set('foo', 'barbaz')
+            ->call('runValidationWithClassBasedRule')
+            ->assertHasErrors(['foo' => ValueEqualsFoobar::class]);
     }
 
     /** @test */
@@ -166,6 +178,28 @@ class ValidationTest extends TestCase
             ->set('bar', 'bar')
             ->call('runValidation')
             ->assertHasNoErrors(['foo' => 'required']);
+    }
+
+    /** @test */
+    public function multi_word_validation_rules_passing_are_assertable()
+    {
+        $component = app(LivewireManager::class)->test(ForValidation::class);
+
+        $component
+            ->set('foo', 'foo-bar-baz')
+            ->call('runValidationWithMultiWordRule')
+            ->assertHasNoErrors(['foo' => 'alpha_dash']);
+    }
+
+    /** @test */
+    public function class_based_validation_rules_are_assertable()
+    {
+        $component = app(LivewireManager::class)->test(ForValidation::class);
+
+        $component
+            ->set('foo', 'foobar')
+            ->call('runValidationWithClassBasedRule')
+            ->assertHasNoErrors(['foo' => ValueEqualsFoobar::class]);
     }
 }
 
@@ -191,6 +225,13 @@ class ForValidation extends Component
     {
         $this->validate([
             'foo' => 'alpha_dash',
+        ]);
+    }
+
+    public function runValidationWithClassBasedRule()
+    {
+        $this->validate([
+            'foo' => [new ValueEqualsFoobar],
         ]);
     }
 
@@ -246,5 +287,18 @@ class ForValidation extends Component
     public function render()
     {
         return app('view')->make('dump-errors');
+    }
+}
+
+class ValueEqualsFoobar implements Rule
+{
+    public function passes($attribute, $value)
+    {
+        return $value === 'foobar';
+    }
+
+    public function message()
+    {
+        return '';
     }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

No discussion but it's definitely something that is broken

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Nopers

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Yes! and then some.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

This change allows class based rules to be asserted against. Should be a better solution to #819 because we're asserting that the rules match in the expected studly case that `$this->lastValidator->failed()` always returns.

I expanded on the tests to ensure the different use cases are covered.

5️⃣ Thanks for contributing! 🙌