### PR TITLE
Clear custom validator errors between actions

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -15,19 +15,39 @@ trait ValidatesInput
 
     public function getErrorBag()
     {
-        return $this->errorBag ?? new MessageBag;
+        if (! $this->errorBag) {
+            $this->errorBag = new MessageBag;
+        }
+
+        return $this->errorBag;
     }
 
     public function addError($name, $message)
     {
-        return $this->getErrorBag()->add($name, $message);
+        return $this->mergeErrorBag([$name => $message]);
+    }
+
+    public function mergeErrorBag($bag)
+    {
+        if (! $bag instanceof MessageBag) {
+            $bag = new MessageBag($bag);
+        }
+
+        // only track/persist component property errors (for validateOnly)
+        foreach ($bag->messages() as $key => $value) {
+            if ($this->hasProperty($key)) {
+                $this->getErrorBag()->merge([$key => $value]);
+            }
+        }
+
+        return $this->getErrorBag();
     }
 
     public function setErrorBag($bag)
     {
-        return $this->errorBag = $bag instanceof MessageBag
-            ? $bag
-            : new MessageBag($bag);
+        $this->errorBag = new MessageBag;
+
+        return $this->mergeErrorBag($bag);
     }
 
     public function resetErrorBag($field = null)

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -120,6 +120,18 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
+    public function component_only_tracks_property_errors()
+    {
+        $component = app(LivewireManager::class)->test(ForValidation::class)->instance();
+
+        $component->addError('foo', 'foo error');
+        $this->assertTrue($component->getErrorBag()->has('foo'));
+
+        $component->addError('foobar', 'foobar error');
+        $this->assertFalse($component->getErrorBag()->has('foobar'));
+    }
+
+    /** @test */
     public function custom_validation_messages_are_cleared_between_validate_only_validations()
     {
         $component = app(LivewireManager::class)->test(ForValidation::class);

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ViewErrorBag;
 use Livewire\Component;
 use Livewire\LivewireManager;
@@ -119,6 +120,36 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
+    public function custom_validation_messages_are_cleared_between_validate_only_validations()
+    {
+        $component = app(LivewireManager::class)->test(ForValidation::class);
+
+        // cleared when custom validation passes
+        $component
+            ->set('foo', 'foo')
+            ->set('bar', 'b')
+            ->call('runValidationOnlyWithCustomValidation', 'bar')
+            ->assertDontSee('The bar field is required')
+            ->assertSee('Lengths must be the same')
+            ->set('bar', 'baz')
+            ->call('runValidationOnlyWithCustomValidation', 'bar')
+            ->assertDontSee('The bar field is required')
+            ->assertDontSee('Lengths must be the same');
+
+        // cleared when custom validation isn't run
+        $component
+            ->set('foo', 'foo')
+            ->set('bar', 'b')
+            ->call('runValidationOnlyWithCustomValidation', 'bar')
+            ->assertDontSee('The bar field is required')
+            ->assertSee('Lengths must be the same')
+            ->set('bar', '')
+            ->call('runValidationOnlyWithCustomValidation', 'bar')
+            ->assertSee('The bar field is required')
+            ->assertDontSee('Lengths must be the same');
+    }
+
+    /** @test */
     public function can_validate_only_a_specific_field_with_deeply_nested_array()
     {
         $component = app(LivewireManager::class)->test(ForValidation::class);
@@ -200,6 +231,23 @@ class ForValidation extends Component
             'foo' => 'required',
             'bar' => 'required',
         ]);
+    }
+
+    public function runValidationOnlyWithCustomValidation($field)
+    {
+        $this->validateOnly($field, [
+            'foo' => 'required',
+            'bar' => 'required',
+        ]);
+
+        Validator::make(
+            [
+                'foo_length' => strlen($this->foo),
+                'bar_length' => strlen($this->bar),
+            ],
+            [ 'foo_length' => 'same:bar_length' ],
+            [ 'same' => 'Lengths must be the same' ]
+        )->validate();
     }
 
     public function runDeeplyNestedValidationOnly($field)


### PR DESCRIPTION
This PR fixes #962 

## What's happening

Livewire's real-time validation feature (`validateOnly`) requires that component property errors are persisted between Livewire requests (actions) so that validation of one property of the component doesn't clear errors that may exist on other properties.

However, the current implementation captures and persists all validation errors. As a result an error returned by a custom validator is persisted between requests (actions), and isn't automatically "cleared" as one expects in a typical Laravel context. This requires the developer to perform a `$this->resetValidation()` to clear the error.

This is demonstrated in this [Laravel Playground gist](https://laravelplayground.com/#/gist/efaf359c5b89467bfb3e603967df940a)  (though a bit slow on my PC) where the length error is not cleared once the two fields reach the same length.

## Solution

This PR modifies how the component ErrorBag is maintained so that only errors related to the component's properties are stored and subsequently persisted by the component. This way component property errors are persisted for the expected behavior of `validateOnly()`, and custom validator errors behave like they would in a native Laravel context, being cleared once the custom validator passes.

Tests are included.

### Alternate approach

An alternate approach would be to filter the error bag in the `PersistErrorBag` hydration middleware so that only errors pertaining to component properties are persisted. Something like:
```php
    public static function dehydrate($instance, $response)
    {
        if ($errors = $instance->getErrorBag()->toArray()) {
            $response->errorBag = collect($errors)
                ->filter(function ($value, $key) use ($instance) {
                    return $instance->hasProperty($key);
                })->toArray();
        }
    }

```

This alternate approach differs from this PR in the following ways:
- The alternate approach would prevent *any* non-property errors from being persisted. Since the approach taken by this PR doesn't prevent a developer from accessing the component error bag (`$component->getErrorBag()`) and inserting something through direct manipulation, this PR would technically allow non-property errors to be persisted.
- The alternate approach would allow non-property errors to populate the component error bag until it is persisted in the response, but this doesn't offer any real advantages as all errors are available in the session and view anyway. 
- The alternate approach is a simpler change.


I can pursue the alternate approach in a separate PR if interested.