### PR TITLE
add registerExternal for component

### DIFF
--- a/tests/RegisterExternalComponentTest.php
+++ b/tests/RegisterExternalComponentTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Filesystem\Filesystem;
+use Livewire\Component;
+use Livewire\Livewire;
+use Livewire\LivewireComponentsFinder;
+
+class RegisterExternalComponentTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = new Filesystem;
+        $this->files->makeDirectory(app_path('Http/Livewire'));
+    }
+
+    /** @test */
+    public function can_register_external_component() {
+        $finder = app()->make(LivewireComponentsFinder::class);
+
+        $finder->registerExternal('external', ExternalComponent\Hello::class);
+
+        $this->assertNotNull($finder->find('external'));
+    }
+}
+
+namespace ExternalComponent;
+
+use Livewire\Component;
+
+class Hello extends Component
+{
+    //
+}


### PR DESCRIPTION
## Problems?

when i write another package than use livewire as dep, i want use my own namespace for component, so i add registerExternal function.

## usecase

```php
$finder = app()->make(LivewireComponentsFinder::class);

$finder->registerExternal('external', ExternalComponent\Hello::class);
```

LivewireComponentsFinder is singleton, so it can be used easily.