### PR TITLE
Add assertSeeInOrder() and assertSeeHtmlInOrder() assertions

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\MessageBag;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Testing\Constraints\SeeInOrder;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 trait MakesAssertions
@@ -59,6 +60,26 @@ trait MakesAssertions
         PHPUnit::assertStringNotContainsString(
             $value,
             $this->stripOutInitialData($this->payload['dom'])
+        );
+
+        return $this;
+    }
+
+    public function assertSeeHtmlInOrder(array $values)
+    {
+        PHPUnit::assertThat(
+            $values,
+            new SeeInOrder($this->stripOutInitialData($this->payload['dom']))
+        );
+
+        return $this;
+    }
+
+    public function assertSeeInOrder(array $values)
+    {
+        PHPUnit::assertThat(
+            array_map('e', ($values)),
+            new SeeInOrder($this->stripOutInitialData($this->payload['dom']))
         );
 
         return $this;


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
I think so, as it creates further parity with available Laravel testing assertions. No discussion was created first.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Sorry, no. Testing the testing is beyond my brain power.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Assertions that the given string (or HTML) are contained in order within the response. Similar to the Laravel equivalents.

5️⃣ Thanks for contributing! 🙌