### PR TITLE
Added a prepareForValidation() method to modify the attributes before validation

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -74,6 +74,8 @@ trait ValidatesInput
                 = $this->getPropertyValue($propertyNameFromValidationField);
         }
 
+        $result = $this->prepareForValidation($result);
+
         $result = Validator::make($result, Arr::only($rules, $fields), $messages, $attributes)
             ->validate();
 
@@ -123,5 +125,10 @@ trait ValidatesInput
         $this->resetErrorBag($field);
 
         return $result;
+    }
+
+    protected function prepareForValidation(array $attributes)
+    {
+        return $attributes;
     }
 }


### PR DESCRIPTION
I stumbled upon making the users able to add tags using commas, but on validation, there was no way of preparing my data for validation to swap the words separated by commas to an array.

I have added a `prepareForValidation()` method just like Laravel has: https://laravel.com/docs/7.x/validation#prepare-input-for-validation

It can be overwritten in the component class:

```php
class MyLivewireComponent
{
    protected function prepareForValidation($attributes)
    {
        $attributes['tags'] = explode(',', $attributes['tags'] ?? null);

        return $attributes;
    }
}
```