### PR TITLE
Fix file upload error message formatting

### DIFF
--- a/src/WithFileUploads.php
+++ b/src/WithFileUploads.php
@@ -57,8 +57,8 @@ trait WithFileUploads
         }
 
         $errorsInJson = $isMultiple
-            ? str_replace('files', $name, $errorsInJson)
-            : str_replace('files.0', $name, $errorsInJson);
+            ? str_ireplace('files', $name, $errorsInJson)
+            : str_ireplace('files.0', $name, $errorsInJson);
 
         $errors = json_decode($errorsInJson, true)['errors'];
 


### PR DESCRIPTION
Fixes #1303 

When using translation translation strings with uppercase attributes
the file upload error messages displays "files.0" instead of the
attribute name.

