### PR TITLE
Add `assertExists` and `assertNotExists` custom assertions

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -3,9 +3,11 @@
 namespace Livewire\Testing\Concerns;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Illuminate\Support\MessageBag;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\FileUploadConfiguration;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 trait MakesAssertions
@@ -223,6 +225,22 @@ trait MakesAssertions
         } else {
             PHPUnit::assertEquals($value, $this->lastRenderedView->gatherData()[$key]);
         }
+
+        return $this;
+    }
+
+    public function assertExists($path)
+    {
+        FileUploadConfiguration::storage()
+            ->assertExists($path);
+
+        return $this;
+    }
+
+    public function assertNotExists($path)
+    {
+        FileUploadConfiguration::storage()
+            ->assertMissing($path);
 
         return $this;
     }

--- a/tests/FileUploadsTest.php
+++ b/tests/FileUploadsTest.php
@@ -53,6 +53,18 @@ class FileUploadsTest extends TestCase
     }
 
     /** @test */
+    public function can_test_a_file_was_uploaded_in_the_default_driver()
+    {
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->assertNotExists('uploaded-avatar.png')
+            ->call('uploadInDefaultDriver', 'uploaded-avatar.png')
+            ->assertExists('uploaded-avatar.png');
+    }
+
+    /** @test */
     public function can_remove_a_file_property()
     {
         $file = UploadedFile::fake()->image('avatar.jpg');
@@ -534,6 +546,11 @@ class FileUploadComponent extends Component
     public function uploadAndSetStoredFilename()
     {
         $this->storedFilename = $this->photo->store('/', $disk = 'avatars');
+    }
+
+    public function uploadInDefaultDriver($name)
+    {
+        $this->photo->storeAs('/', $name);
     }
 
     public function uploadDangerous()


### PR DESCRIPTION
This provide an easier way to test if a file was uploaded inside a Livewire component by using the Storage Livewire fakes under the hood.

Example of usage:

```
    $file = UploadedFile::fake()->image('avatar.jpg');

    Livewire::test(FileUploadComponent::class)
        ->set('photo', $file)
        ->assertNotExists('uploaded-avatar.png')
        ->call('uploadInDefaultDriver', 'uploaded-avatar.png')
        ->assertExists('uploaded-avatar.png');
```
