### PR TITLE
Change the mimetype for mp3 files from 'mp3' to 'mpga'

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -69,7 +69,7 @@ class TemporaryUploadedFile extends UploadedFile
         $supportedPreviewTypes = [
             'jpeg', 'png', 'gif', 'bmp', 'svg', 'webp',
             'mp4', 'mov', 'avi', 'wmv',
-            'mp3', 'wav', 'm4a', 'wma',
+            'mpga', 'wav', 'm4a', 'wma',
         ];
 
         if (! in_array($this->guessExtension(), $supportedPreviewTypes)) {


### PR DESCRIPTION
I think for this no tests are needed. 

It just makes it possible to preview mp3 files because the mimetype for mp3 files is 'mpga'.