### PR TITLE
Render CSP Nonce On Style Tag If Available As An Option

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -154,7 +154,7 @@ class LivewireManager
     {
         $debug = config('app.debug');
 
-        $styles = $this->cssAssets();
+        $styles = $this->cssAssets($options);
 
         // HTML Label.
         $html = $debug ? ['<!-- Livewire Styles -->'] : [];
@@ -180,10 +180,11 @@ class LivewireManager
         return implode("\n", $html);
     }
 
-    protected function cssAssets()
+    protected function cssAssets($options)
     {
+        $nonce = isset($options['nonce']) ? " nonce=\"{$options['nonce']}\"" : '';
         return <<<HTML
-<style>
+<style{$nonce}>
     [wire\:loading] {
         display: none;
     }

--- a/tests/LivewireAssetsDirectiveTest.php
+++ b/tests/LivewireAssetsDirectiveTest.php
@@ -95,4 +95,14 @@ class LivewireAssetsDirectiveTest extends TestCase
             $output
         );
     }
+
+    /** @test */
+    public function nonce_passed_into_directive_gets_added_as_style_tag_attribute()
+    {
+        $output = View::make('assets-directive-styles', [
+            'options' => ['nonce' => 'hastalavista'],
+        ])->render();
+
+        $this->assertStringContainsString('nonce="hastalavista"', $output);
+    }
 }

--- a/tests/views/assets-directive-styles.blade.php
+++ b/tests/views/assets-directive-styles.blade.php
@@ -1,0 +1,2 @@
+@livewireStyles($options)
+@livewireScripts


### PR DESCRIPTION
Fixes #1364 

This adds support for passing a **nonce** option to the `@livewireStyles` directive and have the generated ```<style>``` tag contain a **nonce** attribute.

E.g. 
`@livewireStyles(['nonce' => 'somenoncevalue'])`
Will output:
`<style nonce="somenoncevalue">...</style>`