### PR TITLE
Restrict error bag persistence to component property errors

### DIFF
--- a/src/HydrationMiddleware/PersistErrorBag.php
+++ b/src/HydrationMiddleware/PersistErrorBag.php
@@ -14,7 +14,10 @@ class PersistErrorBag implements HydrationMiddleware
     public static function dehydrate($instance, $response)
     {
         if ($errors = $instance->getErrorBag()->toArray()) {
-            $response->errorBag = $errors;
+            $response->errorBag = collect($errors)
+                ->filter(function ($value, $key) use ($instance) {
+                    return $instance->hasProperty($key);
+                })->toArray();
         }
     }
 }

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ViewErrorBag;
 use Livewire\Component;
 use Livewire\LivewireManager;
@@ -117,6 +118,36 @@ class ValidationTest extends TestCase
             ->call('runValidationOnly', 'foo')
             ->assertSee('The foo field is required')
             ->assertSee('The bar field is required');
+    }
+
+    /** @test */
+    public function custom_validation_messages_are_cleared_between_validate_only_validations()
+    {
+        $component = app(LivewireManager::class)->test(ForValidation::class);
+
+        // cleared when custom validation passes
+        $component
+            ->set('foo', 'foo')
+            ->set('bar', 'b')
+            ->call('runValidationOnlyWithCustomValidation', 'bar')
+            ->assertDontSee('The bar field is required')
+            ->assertSee('Lengths must be the same')
+            ->set('bar', 'baz')
+            ->call('runValidationOnlyWithCustomValidation', 'bar')
+            ->assertDontSee('The bar field is required')
+            ->assertDontSee('Lengths must be the same');
+
+        // cleared when custom validation isn't run
+        $component
+            ->set('foo', 'foo')
+            ->set('bar', 'b')
+            ->call('runValidationOnlyWithCustomValidation', 'bar')
+            ->assertDontSee('The bar field is required')
+            ->assertSee('Lengths must be the same')
+            ->set('bar', '')
+            ->call('runValidationOnlyWithCustomValidation', 'bar')
+            ->assertSee('The bar field is required')
+            ->assertDontSee('Lengths must be the same');
     }
 
     /** @test */
@@ -241,6 +272,23 @@ class ForValidation extends Component
             'foo' => 'required',
             'bar' => 'required',
         ]);
+    }
+
+    public function runValidationOnlyWithCustomValidation($field)
+    {
+        $this->validateOnly($field, [
+            'foo' => 'required',
+            'bar' => 'required',
+        ]);
+
+        Validator::make(
+            [
+                'foo_length' => strlen($this->foo),
+                'bar_length' => strlen($this->bar),
+            ],
+            [ 'foo_length' => 'same:bar_length' ],
+            [ 'same' => 'Lengths must be the same' ]
+        )->validate();
     }
 
     public function runDeeplyNestedValidationOnly($field)


### PR DESCRIPTION
This PR implements the alternate approach discussed in #1264 (see the discussion there for details), and fixes #962.