### PR TITLE
add $reset magic action

### DIFF
--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -91,6 +91,10 @@ trait HandlesActions
                 return;
                 break;
 
+            case '$reset':
+                $this->reset();
+                break;
+
             default:
                 if (! method_exists($this, $method)) {
                     throw_if($method === 'startUpload', new MissingFileUploadsTraitException($this));


### PR DESCRIPTION
Please include a thorough description of the improvement and reasons why it's useful.

I understand the reason we have magic actions is to avoid having common one line methods.
There is this one line method that I have in many projects:
```php
public function cancelEdit()
{
    $this->reset();
}
```

This little magic action helps me do this instead:
```html
<button wire:click="$reset">Cancel</button>
```