### PR TITLE
Add missing semi-colon

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -259,7 +259,7 @@ HTML;
     }
 
     window.livewire = new Livewire({$jsonEncodedOptions});
-    window.Livewire = window.livewire
+    window.Livewire = window.livewire;
     window.livewire_app_url = '{$appUrl}';
     window.livewire_token = '{$csrf}';
 


### PR DESCRIPTION
This fixes an error I'm getting:

```
monitors:344 Uncaught TypeError: Cannot set property 'livewire_app_url' of undefined
```