### PR TITLE
Allow components to update full history path (not just query string)

### DIFF
--- a/js/Message.js
+++ b/js/Message.js
@@ -53,6 +53,7 @@ export default class {
             redirectTo: payload.redirectTo,
             errorBag: payload.errorBag || {},
             updatesQueryString: payload.updatesQueryString,
+            historyPath: payload.historyPath,
         }
     }
 }

--- a/js/component/UpdateHistoryPath.js
+++ b/js/component/UpdateHistoryPath.js
@@ -1,0 +1,10 @@
+import store from '@/Store'
+import queryString from '@/util/query-string'
+
+export default function () {
+    store.registerHook('responseReceived', (component, response) => {
+        if (response.historyPath === undefined) return
+
+        history.replaceState({turbolinks: {}, livewire: component.data}, "", response.historyPath)
+    })
+}

--- a/js/index.js
+++ b/js/index.js
@@ -12,6 +12,7 @@ import DirtyStates from '@/component/DirtyStates'
 import OfflineStates from '@/component/OfflineStates'
 import Polling from '@/component/Polling'
 import UpdateQueryString from '@/component/UpdateQueryString'
+import UpdateHistoryPath from '@/component/UpdateHistoryPath'
 
 class Livewire {
     constructor(options = {}) {
@@ -110,6 +111,7 @@ if (!window.Livewire) {
 }
 
 UpdateQueryString()
+UpdateHistoryPath()
 OfflineStates()
 LoadingStates()
 DisableForms()

--- a/src/Component.php
+++ b/src/Component.php
@@ -75,6 +75,11 @@ abstract class Component
     {
         return $this->updatesQueryString;
     }
+    
+    public function mapStateToUrl()
+    {
+    	return null;
+    }
 
     public function getCasts()
     {

--- a/src/Exceptions/CannotCombineHistoryPathAndQueryStringException.php
+++ b/src/Exceptions/CannotCombineHistoryPathAndQueryStringException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Livewire\Exceptions;
+
+class CannotCombineHistoryPathAndQueryStringException extends \Exception
+{
+    use BypassViewHandler;
+
+    public function __construct($component)
+    {
+        parent::__construct(
+            "Livewire encountered both a query string and history path when trying to hydrate the [{$component}] component. \n".
+            "You cannot combine these features. If you need both, you must set the query string in your mapStateToUrl method."
+        );
+    }
+}

--- a/src/Exceptions/InvalidHistoryPathException.php
+++ b/src/Exceptions/InvalidHistoryPathException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Livewire\Exceptions;
+
+class InvalidHistoryPathException extends \Exception
+{
+    use BypassViewHandler;
+
+    public function __construct($component)
+    {
+        parent::__construct(
+            "Livewire encountered an invalid URL when trying to hydrate the [{$component}] component. \n".
+            "You cannot update the history state to a URL that is not on the same root domain as your app."
+        );
+    }
+}

--- a/src/HydrationMiddleware/UpdateHistoryPath.php
+++ b/src/HydrationMiddleware/UpdateHistoryPath.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Livewire\HydrationMiddleware;
+
+use Illuminate\Support\Str;
+use Livewire\Exceptions\CannotCombineHistoryPathAndQueryStringException;
+use Livewire\Exceptions\InvalidHistoryPathException;
+
+class UpdateHistoryPath implements HydrationMiddleware
+{
+    public static function hydrate($instance, $request)
+    {
+        //
+    }
+
+    public static function dehydrate($instance, $response)
+    {
+        if (! empty($url = $instance->mapStateToUrl())) {
+        	$root = url()->to('/');
+	        
+        	throw_if(isset($response->updatesQueryString), new CannotCombineHistoryPathAndQueryStringException($instance->getName()));
+        	throw_unless(Str::startsWith($url, $root), new InvalidHistoryPathException($instance->getName()));
+        	
+            $response->historyPath = Str::after($url, $root);
+        }
+    }
+}

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -39,6 +39,7 @@ use Livewire\HydrationMiddleware\{
     ForwardPrefetch,
     PersistErrorBag,
     UpdateQueryString,
+    UpdateHistoryPath,
     InterceptRedirects,
     CastPublicProperties,
     RegisterEmittedEvents,
@@ -273,6 +274,7 @@ class LivewireServiceProvider extends ServiceProvider
         /* v */ PrioritizeDataUpdatesBeforeActionCalls::class,      /* ^ */
         /* v */ ForwardPrefetch::class,                             /* ^ */
         /* v */ UpdateQueryString::class,                           /* ^ */
+        /* v */ UpdateHistoryPath::class,                           /* ^ */
         ]);
 
         Livewire::registerInitialHydrationMiddleware([

--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -80,6 +80,7 @@ class TestableLivewire
             'redirectTo' => $output->redirectTo,
             'dirtyInputs' => $output->dirtyInputs,
             'updatesQueryString' => $output->updatesQueryString,
+            'historyPath' => $output->historyPath,
         ];
     }
 

--- a/tests/UpdatesHistoryPathTest.php
+++ b/tests/UpdatesHistoryPathTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests;
+
+use Livewire\Component;
+use Livewire\LivewireManager;
+
+class UpdatesHistoryPathTest extends TestCase
+{
+	/** @test */
+	public function no_path_data_is_present_by_default()
+	{
+		$component = app(LivewireManager::class)->test(DoesNotUpdateHistoryPathStub::class);
+		
+		$component->set('foo', 'baz');
+		
+		$this->assertFalse(isset($component->payload['historyPath']));
+	}
+	
+    /** @test */
+    public function changing_properties_updates_history_path()
+    {
+        $component = app(LivewireManager::class)->test(UpdatesHistoryPathStub::class);
+
+        $component->set('foo', 'baz');
+
+        $this->assertEquals('/foo/baz', $component->payload['historyPath']);
+        $this->assertEquals('baz', $component->payload['data']['foo']);
+    }
+}
+
+class UpdatesHistoryPathStub extends Component
+{
+    public $foo = 'bar';
+    
+    public function mapStateToUrl()
+    {
+	    return url("/foo/{$this->foo}");
+    }
+	
+	public function render()
+    {
+        return app('view')->make('null-view');
+    }
+}
+
+class DoesNotUpdateHistoryPathStub extends Component
+{
+	public $foo = 'bar';
+	
+	public function render()
+	{
+		return app('view')->make('null-view');
+	}
+}

--- a/tests/js/history_path.spec.js
+++ b/tests/js/history_path.spec.js
@@ -1,0 +1,46 @@
+import {wait} from 'dom-testing-library'
+import Livewire from 'laravel-livewire'
+
+test('data can be added to the query string', async () => {
+    var newUri
+    var newData
+
+    window.history.replaceState = (object, title, uri) => {
+        newUri = uri
+        newData = object.livewire
+    }
+
+    document.body.innerHTML = `
+        <div wire:id="123" wire:initial-data="${JSON.stringify({foo: 'bar'}).replace(/\"/g, '&quot;')}">
+            <button wire:click="$refresh"></button>
+        </div>
+    `
+
+    window.livewire = new Livewire({
+        driver: {
+            onMessage: null,
+            init() {
+            },
+            async sendMessage(payload) {
+                setTimeout(() => {
+                    this.onMessage({
+                        fromPrefetch: payload.fromPrefetch,
+                        id: payload.id,
+                        data: {foo: 'baz'},
+                        historyPath: '/foo/baz',
+                        dirtyInputs: [],
+                        dom: '<div wire:id="123"><button wire:click="$refresh"></button></div>',
+                    })
+                }, 1)
+            },
+        }
+    })
+    window.livewire.start()
+
+    document.querySelector('button').click()
+
+    await wait(async () => {
+        expect(newUri).toEqual('/foo/baz')
+        expect(newData).toEqual({foo: 'baz'})
+    })
+})


### PR DESCRIPTION
This is WIP PR — I was running into issues getting the jest tests to run (tried Node 10, 12, and 14 and ran into regeneratorRuntime errors), so the hope is that the tests will work in CI.

```
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

5️⃣ Thanks for contributing! 🙌
```