### PR TITLE
[2.x] Check if Alpine is present

### DIFF
--- a/js/component/index.js
+++ b/js/component/index.js
@@ -634,8 +634,10 @@ export default class Component {
             },
 
             set: function (obj, prop, value) {
-                // This prevents a "blip" when using x-model to set a Livewire property.
-                Alpine.ignoreFocusedForValueBinding = true
+                if (window.Alpine) {
+                    // This prevents a "blip" when using x-model to set a Livewire property.
+                    Alpine.ignoreFocusedForValueBinding = true
+                }
 
                 component.set(prop, value)
 


### PR DESCRIPTION
This code currently breaks, when using the Livewire JS component API on a page without Alpine.

This PR fixes that.