### PR TITLE
Allow use of custom rule classes in validation

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -70,9 +70,9 @@ trait ValidatesInput
 
     public function rulesForModel($name)
     {
-        if (empty($this->rules)) return collect();
+        if (empty($this->rules())) return collect();
 
-        return collect($this->rules)
+        return collect($this->rules())
             ->filter(function ($value, $key) use ($name) {
                 return $this->beforeFirstDot($key) === $name;
             });
@@ -82,7 +82,7 @@ trait ValidatesInput
     {
         if (! property_exists($this, 'rules')) return true;
 
-        return ! in_array($key, array_keys($this->rules));
+        return ! in_array($key, array_keys($this->rules()));
     }
 
     public function validate($rules = null, $messages = [], $attributes = [])


### PR DESCRIPTION
This is a relatively minor change that uses the `rules` _method_ as the sole accessor for the validation rules array.  As the existing method uses a class property, one cannot instantiate a new rule inside it.

```php
class SomeComponent extends Component {
    public $rules = [
        'phone' => ['required', new ValidPhone], // Not valid php
    ];
}
```

The intent here is to allow the use of the `$rules` property if the user wants, but to also allow the `rules` method as a way to make the above possible.