### PR TITLE
Allow psr client to build URL

### DIFF
--- a/src/GenerateSignedUploadUrl.php
+++ b/src/GenerateSignedUploadUrl.php
@@ -35,11 +35,9 @@ class GenerateSignedUploadUrl
             '+5 minutes'
         );
 
-        $uri = $signedRequest->getUri();
-
         return [
             'path' => $fileHashName,
-            'url' => 'https://'.$uri->getHost().$uri->getPath().'?'.$uri->getQuery(),
+            'url' => (string)$signedRequest->getUri(),
             'headers' => $this->headers($signedRequest, $fileType),
         ];
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

This is part of #1294 in that it allows the PSR client to set the URL.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

In the current code, when the temp URL is created, it is being manually made, but not taking into consideration `schema` & `port`, so it will not work when running s3 compatable storage on non https.  This just cast `GuzzleHttp\Psr7\Uri` to a string, so it keeps up with the correct path

5️⃣ Thanks for contributing! 🙌