### PR TITLE
Bugfix: re-add window.location.hash to updated url

### DIFF
--- a/js/component/UpdateQueryString.js
+++ b/js/component/UpdateQueryString.js
@@ -43,6 +43,7 @@ export default function () {
 
         var stringifiedQueryString = queryString.stringify(queryData)
 
-        history.replaceState({turbolinks: {}}, "", [window.location.pathname, stringifiedQueryString].filter(Boolean).join('?'))
+
+        history.replaceState({turbolinks: {}}, "", [window.location.pathname, stringifiedQueryString].filter(Boolean).join('?') + window.location.hash)
     })
 }


### PR DESCRIPTION
**What is the problem?**

When the current url has a hash/fragment (e.g. `http://localhost/hello-world#hash`), that hash/fragment disappears when the querystring is being updated.

**How did I fix the problem?**

I updated `UpdateQueryString` js-file to re-add `window.location.hash` to the newly constructed url.



_I did not include a new build of `livewire.js` because building the javascript did not work on my local machine 😔_