### PR TITLE
[2.x] Improve pagination morphdom

### DIFF
--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -22,7 +22,7 @@ trait WithPagination
         });
 
         Paginator::defaultView($this->paginationView());
-        Paginator::defaultSimpleView($this->paginationView());
+        Paginator::defaultSimpleView($this->paginationSimpleView());
     }
 
     public function paginationView()

--- a/src/views/bootstrap.blade.php
+++ b/src/views/bootstrap.blade.php
@@ -4,11 +4,11 @@
             <ul class="pagination">
                 {{-- Previous Page Link --}}
                 @if ($paginator->onFirstPage())
-                    <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                    <li wire:key="paginator-previous" class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
                         <span class="page-link" aria-hidden="true">&lsaquo;</span>
                     </li>
                 @else
-                    <li class="page-item">
+                    <li wire:key="paginator-previous" class="page-item">
                         <button class="page-link" wire:click="previousPage" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</button>
                     </li>
                 @endif
@@ -24,9 +24,9 @@
                     @if (is_array($element))
                         @foreach ($element as $page => $url)
                             @if ($page == $paginator->currentPage())
-                                <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                                <li class="page-item active" wire:key="paginator-page{{ $page }}" aria-current="page"><span class="page-link">{{ $page }}</span></li>
                             @else
-                                <li class="page-item"><button class="page-link" wire:click="gotoPage({{ $page }})">{{ $page }}</button></li>
+                                <li class="page-item" wire:key="paginator-page{{ $page }}"><button class="page-link" wire:click="gotoPage({{ $page }})">{{ $page }}</button></li>
                             @endif
                         @endforeach
                     @endif
@@ -34,11 +34,11 @@
 
                 {{-- Next Page Link --}}
                 @if ($paginator->hasMorePages())
-                    <li class="page-item">
+                    <li class="page-item" wire:key="paginator-next">
                         <button class="page-link" wire:click="nextPage" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</button>
                     </li>
                 @else
-                    <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                    <li class="page-item disabled" wire:key="paginator-next" aria-disabled="true" aria-label="@lang('pagination.next')">
                         <span class="page-link" aria-hidden="true">&rsaquo;</span>
                     </li>
                 @endif

--- a/src/views/tailwind.blade.php
+++ b/src/views/tailwind.blade.php
@@ -27,11 +27,11 @@
                 <div>
                     <p class="text-sm text-gray-700 leading-5">
                         {!! __('Showing') !!}
-                        <span class="font-medium">{{ $paginator->firstItem() }}</span>
+                        <span class="font-medium" wire:key="paginator-first">{{ $paginator->firstItem() }}</span>
                         {!! __('to') !!}
-                        <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                        <span class="font-medium" wire:key="paginator-last">{{ $paginator->lastItem() }}</span>
                         {!! __('of') !!}
-                        <span class="font-medium">{{ $paginator->total() }}</span>
+                        <span class="font-medium" wire:key="paginator-total">{{ $paginator->total() }}</span>
                         {!! __('results') !!}
                     </p>
                 </div>
@@ -40,7 +40,7 @@
                     <span class="relative z-0 inline-flex shadow-sm">
                         {{-- Previous Page Link --}}
                         @if ($paginator->onFirstPage())
-                            <span aria-disabled="true" aria-label="{{ __('pagination.previous') }}">
+                            <span wire:key="paginator-previous" aria-disabled="true" aria-label="{{ __('pagination.previous') }}">
                                 <span class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-l-md leading-5" aria-hidden="true">
                                     <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                                         <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
@@ -48,7 +48,7 @@
                                 </span>
                             </span>
                         @else
-                            <button wire:click="previousPage" rel="prev" class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-l-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150" aria-label="{{ __('pagination.previous') }}">
+                            <button wire:key="paginator-previous" wire:click="previousPage" rel="prev" class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-l-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150" aria-label="{{ __('pagination.previous') }}">
                                 <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                                     <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
                                 </svg>
@@ -68,11 +68,11 @@
                             @if (is_array($element))
                                 @foreach ($element as $page => $url)
                                     @if ($page == $paginator->currentPage())
-                                        <span aria-current="page">
+                                        <span wire:key="paginator-page{{ $page }}" aria-current="page">
                                             <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5">{{ $page }}</span>
                                         </span>
                                     @else
-                                        <button wire:click="gotoPage({{ $page }})" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
+                                        <button wire:key="paginator-page{{ $page }}" wire:click="gotoPage({{ $page }})" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
                                             {{ $page }}
                                         </button>
                                     @endif
@@ -82,13 +82,13 @@
 
                         {{-- Next Page Link --}}
                         @if ($paginator->hasMorePages())
-                            <button wire:click="nextPage" rel="next" class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-r-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150" aria-label="{{ __('pagination.next') }}">
+                            <button wire:key="paginator-next" wire:click="nextPage" rel="next" class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-r-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150" aria-label="{{ __('pagination.next') }}">
                                 <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                                     <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
                                 </svg>
                             </button>
                         @else
-                            <span aria-disabled="true" aria-label="{{ __('pagination.next') }}">
+                            <span wire:key="paginator-next" aria-disabled="true" aria-label="{{ __('pagination.next') }}">
                                 <span class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-r-md leading-5" aria-hidden="true">
                                     <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                                         <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />


### PR DESCRIPTION
This PR corrects pagination so that `simplePaginate` uses the `paginationSimpleView`.

I've also added `wire:key` to the dom elements, since there is an issue when clicking the pagination links, whereby words disappear. I believe the issue is related to https://github.com/livewire/livewire/issues/1387, however @MaxGiting is using a custom pagination view so would need to add. Keying the buttons also stops the focus remaining on the wrong button when the dom is updated (since the `button` changes to a `span` and so the browser shifts its focus to the previous button, if that makes any sense).

The particular issue I had that this aims to resolve is the word "of" vanishes when going back a page.

1) Initial state
<img width="598" alt="Screenshot 2020-09-06 at 14 01 50" src="https://user-images.githubusercontent.com/20431294/92326385-99183200-f049-11ea-967c-ccb6e8f0babb.png">

2) Click on page 2 (note button focus shifts back one despite clicking page 2 and not the "previous" button)
<img width="591" alt="Screenshot 2020-09-06 at 14 01 58" src="https://user-images.githubusercontent.com/20431294/92326389-9d444f80-f049-11ea-9e6d-5b623b737a7d.png">

3) Click on page 3 (note button focus shifts back one despite clicking page 3 and not page 2)
<img width="594" alt="Screenshot 2020-09-06 at 14 02 06" src="https://user-images.githubusercontent.com/20431294/92326391-a03f4000-f049-11ea-89b8-a4f2e5ed3165.png">

4) Click back to page 2 (note wording has lost "of")
<img width="589" alt="Screenshot 2020-09-06 at 14 02 14" src="https://user-images.githubusercontent.com/20431294/92326392-a2a19a00-f049-11ea-9499-4bad5da87512.png">
