### PR TITLE
[2.0] Browser history feature clean up

### DIFF
--- a/js/component/SyncBrowserHistory.js
+++ b/js/component/SyncBrowserHistory.js
@@ -19,7 +19,7 @@ export default function () {
         let { response } = message
         let effects = response.effects || {}
 
-        if ('path' in response.effects && effects.path !== window.location.href) {
+        if ('path' in effects && effects.path !== window.location.href) {
             let state = generateNewState(component, response)
 
             history.pushState(state, '', effects.path)

--- a/src/Component.php
+++ b/src/Component.php
@@ -96,14 +96,9 @@ abstract class Component
         return $fullName;
     }
 
-    public function getFromQueryString()
+    public function getQueryString()
     {
         return $this->queryString;
-    }
-
-    public function getCasts()
-    {
-        return $this->casts;
     }
 
     public function skipRender()

--- a/src/ComponentConcerns/InteractsWithProperties.php
+++ b/src/ComponentConcerns/InteractsWithProperties.php
@@ -7,8 +7,6 @@ use Illuminate\Database\Eloquent\Model;
 
 trait InteractsWithProperties
 {
-    protected $casts = [];
-
     public function handleHydrateProperty($property, $value)
     {
         $newValue = $value;

--- a/src/RenameMe/SupportBrowserHistory.php
+++ b/src/RenameMe/SupportBrowserHistory.php
@@ -67,7 +67,7 @@ class SupportBrowserHistory
     public function getQueryParamsFromReferrerHeader()
     {
         if (empty($referrer = request()->header('Referrer'))) return [];
-        
+
         parse_str(parse_url($referrer, PHP_URL_QUERY), $referrerQueryString);
 
         return $referrerQueryString;

--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -8,7 +8,7 @@ trait WithPagination
 {
     public $page = 1;
 
-    public function getFromQueryString()
+    public function getQueryString()
     {
         return array_merge(['page' => ['except' => 1]], $this->queryString);
     }

--- a/tests/Browser/PushState/ComponentWithExcepts.php
+++ b/tests/Browser/PushState/ComponentWithExcepts.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Browser\PushState;
+
+use Illuminate\Support\Facades\View;
+use Livewire\Component as BaseComponent;
+
+class ComponentWithExcepts extends BaseComponent
+{
+    public $page = 1;
+
+    protected $queryString = ['page' => ['except' => 1]];
+
+    public function render()
+    {
+        return View::file(__DIR__.'/excepts.blade.php');
+    }
+}

--- a/tests/Browser/PushState/Test.php
+++ b/tests/Browser/PushState/Test.php
@@ -8,7 +8,7 @@ use Tests\Browser\TestCase;
 
 class Test extends TestCase
 {
-    public function test()
+    public function test_core_pushstate_logic()
     {
         $this->browse(function (Browser $browser) {
             Livewire::visit($browser, Component::class, '?foo=baz')
@@ -61,6 +61,25 @@ class Test extends TestCase
                 ->back()
                 ->back()
                 ->assertQueryStringHas('baz', 'lop');
+        });
+    }
+
+    public function test_excepts_results_in_no_query_string()
+    {
+        $this->browse(function (Browser $browser) {
+            Livewire::visit($browser, ComponentWithExcepts::class)
+                ->assertSeeIn('@output', 'On page 1');
+
+            $this->assertStringNotContainsString('?', $browser->driver->getCurrentURL());
+
+            Livewire::visit($browser, ComponentWithExcepts::class, '?page=1')
+                ->assertSeeIn('@output', 'On page 1');
+
+            $this->assertStringNotContainsString('?', $browser->driver->getCurrentURL());
+
+            Livewire::visit($browser, ComponentWithExcepts::class, '?page=2')
+                ->assertSeeIn('@output', 'On page 2')
+                ->assertQueryStringHas('page', 2);
         });
     }
 }

--- a/tests/Browser/PushState/excepts.blade.php
+++ b/tests/Browser/PushState/excepts.blade.php
@@ -1,0 +1,3 @@
+<div>
+    <span dusk="output">On page {{ $page }}</span>
+</div>

--- a/tests/Unit/PublicPropertyHydrationHooksTest.php
+++ b/tests/Unit/PublicPropertyHydrationHooksTest.php
@@ -33,11 +33,6 @@ class ComponentWithPublicPropertyCasters extends Component
     public $allCaps;
     public $typeOfs;
 
-    protected $casts = [
-        'dateWithFormat' => 'date:y-m-d',
-        'allCaps' => AllCapsCaster::class,
-    ];
-
     public function updatedDateWithFormat($value)
     {
         $this->dateWithFormat = \Carbon\Carbon::createFromFormat('y-m-d', $value);


### PR DESCRIPTION
I took one pass over the browser history implementation and cleaned things up a bit:

- Minor tweak to JS
- Renamed `getFromQueryString` to `getQueryString` to keep naming consistent with the rest of the component API
- Removed `$casts` property and `getCasts()` method because that functionality was removed
- Removed leftover call to an `AllCapsCaster` class
- Refactored `SupportBrowserHistory` for consistent naming (there was still a mix of `$queryStringParams` vs `$queryStringParams` vs `$queryParams` throughout)
- Other general refactors to `SupportBrowserHistory` to remove unnecessary duplication/etc