### PR TITLE
Add getEventPayload() for consuming event payloads in tests

### DIFF
--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -6,6 +6,7 @@ use Mockery;
 use Livewire\Livewire;
 use Illuminate\Support\Str;
 use Illuminate\Routing\Route;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\View;
 use Livewire\GenerateSignedUploadUrl;
 use Illuminate\Routing\RouteCollection;
@@ -179,6 +180,17 @@ class TestableLivewire
     public function instance()
     {
         return Livewire::getInstance($this->componentName, $this->id());
+    }
+
+    public function getEventPayload(string $name)
+    {
+        $event = Collection::make($this->payload['effects']['emits'] ?? [])
+            ->firstWhere('event', $name);
+
+        $parameters = Collection::make($event['params'] ?? []);
+
+        return $parameters->count() <= 1
+            ? $parameters->first() : $parameters;
     }
 
     public function viewData($key)

--- a/tests/Unit/ComponentEventsTest.php
+++ b/tests/Unit/ComponentEventsTest.php
@@ -19,6 +19,33 @@ class ComponentEventsTest extends TestCase
     }
 
     /** @test */
+    public function receive_event_and_assert_payload()
+    {
+        // We should get NULL if the event doesn't exist...
+        $component = Livewire::test(ReceivesEvents::class);
+        $this->assertNull($component->getEventPayload('not-a-real-event'));
+
+        // We should be able to get the single payload parameter...
+        $component = Livewire::test(ReceivesEvents::class);
+
+        $component->call('emitGoo')
+            ->assertEmitted('goo');
+
+        $this->assertEquals('car', $component->getEventPayload('goo'));
+
+        // We should be able to destructure a tuple...
+        $component = Livewire::test(ReceivesEvents::class);
+
+        $component->call('emitTuple')
+            ->assertEmitted('goo');
+
+        [$vehicle, $color] = $component->getEventPayload('goo');
+
+        $this->assertEquals('car', $vehicle);
+        $this->assertEquals('red', $color);
+    }
+
+    /** @test */
     public function receive_event_with_single_value_listener()
     {
         $component = Livewire::test(ReceivesEventsWithSingleValueListener::class);
@@ -136,6 +163,11 @@ class ReceivesEvents extends Component
     public function emitToGooGone()
     {
         $this->emit('gone', 'car')->to()->component('goo');
+    }
+
+    public function emitTuple()
+    {
+        $this->emit('goo', 'car', 'red');
     }
 
     public function render()


### PR DESCRIPTION
This PR adds a method to the `TestableLivewire` class that lets you grab the event payload to use in your tests. Apologies if this is already available in some way - I couldn't find a method to achieve this so I've been using this macro, and thought I'd PR it incase it's beneficial to others.

It allows you to make assertions about the data you've emitted in an event, for scenarios where you're handling it on the client and don't necessarily have that state to call on from the Livewire component directly.

Here's a snippet from a real-world test I use this on:
```php
/** @test */
public function upgrade_modal_completes_successfully()
{
    $user = factory(User::class)->create();

    $livewire = Livewire::actingAs($user)
        ->test(Upgrade\PremiumPlan::class)
        ->call('billingSetupAuthorised', ['payment_method' => 'pm_card_visa'])
        ->assertEmitted('billingSetupComplete');

    /** @var \Illuminate\Support\Carbon $renewal */
    $renewal = $livewire->getEventPayload('billingSetupComplete');

    $this->assertEquals(now()->addMonth()->toDateString(), $renewal->toDateString());
}
```