### PR TITLE
[2.x] Allow ?page=1 in pagination history

### DIFF
--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -6,11 +6,11 @@ use Illuminate\Pagination\Paginator;
 
 trait WithPagination
 {
-    public $page = 1;
+    public $page = 0;
 
     public function getQueryString()
     {
-        return array_merge(['page' => ['except' => 1]], $this->queryString);
+        return array_merge(['page' => ['except' => 0]], $this->queryString);
     }
 
     public function initializeWithPagination()


### PR DESCRIPTION
When using withPagination, navigate to any page greater than 1 and the url query string is updated to `?page=x`

When navigating back to page 1 the expected query string `?page=1` will instead remain the same as the previous page. 

This meant if you went from page 3 -> 2 -> 1 

You would have:
Page 3 query string: `?page=3`
Page 2 query string: `?page=2`
Page 1 query string: `?page=2`

Then clicking the back button you go back from page 1 takes you to page 3.

Using 0 as the initial value allows you to ignore it on first page load and also allow `?page=1` when you navigate to it via the pagination button.