### PR TITLE
Allow expressions inside the @entangle directive

### DIFF
--- a/src/LivewireBladeDirectives.php
+++ b/src/LivewireBladeDirectives.php
@@ -14,7 +14,7 @@ class LivewireBladeDirectives
     public static function entangle($expression)
     {
         return <<<EOT
-<?php if ((object) {$expression} instanceof \Livewire\WireDirective) : ?>window.Livewire.find('{{ \$_instance->id }}').entangle('{{ {$expression}->value() }}'){{ {$expression}->hasModifier('defer') ? '.defer' : '' }} <?php else : ?> window.Livewire.find('{{ \$_instance->id }}').entangle('{{ {$expression} }}') <?php endif; ?>
+<?php if ((object) ({$expression}) instanceof \Livewire\WireDirective) : ?>window.Livewire.find('{{ \$_instance->id }}').entangle('{{ {$expression}->value() }}'){{ {$expression}->hasModifier('defer') ? '.defer' : '' }} <?php else : ?> window.Livewire.find('{{ \$_instance->id }}').entangle('{{ {$expression} }}') <?php endif; ?>
 EOT;
     }
 

--- a/tests/Browser/Alpine/view.blade.php
+++ b/tests/Browser/Alpine/view.blade.php
@@ -33,7 +33,8 @@
         <span dusk="bob.output" x-text="count"></span>
     </div>
 
-    <div x-data="{ count: @entangle('count') }">
+    <!-- Concatonating inside @@entangle to make sure full PHP expressions work. -->
+    <div x-data="{ count: @entangle('co' . 'unt') }">
         <button wire:click="$set('count', 100)" dusk="lob.reset">Reset</button>
         <button type="button" dusk="lob.increment" x-on:click="count++"></button>
         <button type="button" dusk="lob.decrement" x-on:click="$wire.count--"></button>


### PR DESCRIPTION
When trying to use the `@entangle()` directive, you currently can't pass through actual PHP expressions because of the operator precedence in the `(object) {$expression}` cast, particularly in this bit of code:

```php
<?php if ((object) {$expression} instanceof \Livewire\WireDirective) : ?>
```

For example, using:

```
@entangle('foo' . 'bar')

// Or something more realistic
@entangle('inputs.' . $input->id)
```

This if statement will essentially result in:

```
(object) 'foo' . 'bar'

// aka with the precedence:
((object) 'foo') . 'bar'
```

This triggers an error when rendering the view and it tries to concatenate these two values together:

```
Object of class stdClass could not be converted to string
```

In order to support actual expressions like this, this pull request simply wraps the expression in parenthesis to change the precedence - so the result of the expression is then cast to an object instead.

```
<?php if ((object) ({$expression}) instanceof \Livewire\WireDirective) : ?>
```