### PR TITLE
Install dependencies with prefer-lowest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         php: [7.2, 7.3, 7.4]
         laravel: [7.*, 8.x-dev]
-        dependency-version: [prefer-stable]
+        dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - php: 7.2
             laravel: 8.x-dev


### PR DESCRIPTION
Adding `prefer-lowest` to the build matrix will discover issues like #1498 in CI.

Can be merged after #1507.