### PR TITLE
fix: decode query string to associative array instead of stdClass

### DIFF
--- a/src/RenameMe/SupportBrowserHistory.php
+++ b/src/RenameMe/SupportBrowserHistory.php
@@ -29,7 +29,7 @@ class SupportBrowserHistory
                 $fromQueryString = Arr::get($queryParams, $property);
 
                 $decoded = is_array($fromQueryString)
-                    ? json_decode(json_encode($fromQueryString))
+                    ? json_decode(json_encode($fromQueryString), true)
                     : json_decode($fromQueryString);
 
                 if ($fromQueryString !== null) {


### PR DESCRIPTION
this fix a problem with query string array properties during component initial rendering: it encode the value and decode it but it's decoded to sdtClass instead of array and it throw an exception