### PR TITLE
Adds the ability to define Validation Messages via  property

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -66,6 +66,14 @@ trait ValidatesInput
         return [];
     }
 
+    protected function getMessages()
+    {
+        if (method_exists($this, 'messages')) return $this->messages();
+        if (property_exists($this, 'messages')) return $this->messages;
+
+        return [];
+    }
+
     public function rulesForModel($name)
     {
         if (empty($this->getRules())) return collect();
@@ -91,6 +99,8 @@ trait ValidatesInput
         $rules = is_null($rules) ? $this->getRules() : $rules;
 
         throw_if(empty($rules), new MissingRulesException($this::getName()));
+
+        $messages = empty($messages) ? $this->getMessages() : $messages;
 
         $result = $this->getPublicPropertiesDefinedBySubClass();
 

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -32,6 +32,16 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
+    public function validate_component_properties_with_custom_message_property()
+    {
+        $component = Livewire::test(ForValidation::class);
+
+        $component->runAction('runValidationWithMessageProperty');
+
+        $this->assertStringContainsString('Custom Message', $component->payload['effects']['html']);
+    }
+
+    /** @test */
     public function validate_component_properties_with_custom_attribute()
     {
         $component = Livewire::test(ForValidation::class);
@@ -259,6 +269,17 @@ class ForValidation extends Component
         $this->validate([
             'bar' => 'required',
         ], ['required' => 'Custom Message']);
+    }
+
+    public function runValidationWithMessageProperty()
+    {
+        $this->messages = [
+            'required' => 'Custom Message'
+        ];
+
+        $this->validate([
+            'bar' => 'required'
+        ]);
     }
 
     public function runValidationWithCustomAttribute()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
* Nope, just went directly to implementation

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
* Single feature

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
* Yup, and they're working (at least on my end)

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
As PR title says, this feature is intended to mirror the new `$rules` property for validation introduced in v2, but instead of working with rules, now we work with validation messages.

This will help people that abstract component logic (like myself) in traits, so they can share, in this case, most of the validation logic between similar components, without needing to implement custom validation functions nor global validation messages.

Just, define your `$rules` and your `$messages` in a trait, then call `$this->validate()` on your actions and you're ready to go!

PS: I added this feature because most of my work is done in Spanish, and I love to give context on why the validations fail, so I kept creating my own `validateData()` functions in order to provide custom messages without overriding the core `validate()` function, nor creating generic app-wide messages. So, that's the true background for this PR.

5️⃣ Thanks for contributing! 🙌