### PR TITLE
Fixed bootstrap pagination button type

### DIFF
--- a/src/views/bootstrap.blade.php
+++ b/src/views/bootstrap.blade.php
@@ -9,7 +9,7 @@
                     </li>
                 @else
                     <li wire:key="paginator-previous" class="page-item">
-                        <button class="page-link" wire:click="previousPage" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</button>
+                        <button type="button" class="page-link" wire:click="previousPage" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</button>
                     </li>
                 @endif
 
@@ -26,7 +26,7 @@
                             @if ($page == $paginator->currentPage())
                                 <li class="page-item active" wire:key="paginator-page{{ $page }}" aria-current="page"><span class="page-link">{{ $page }}</span></li>
                             @else
-                                <li class="page-item" wire:key="paginator-page{{ $page }}"><button class="page-link" wire:click="gotoPage({{ $page }})">{{ $page }}</button></li>
+                                <li class="page-item" wire:key="paginator-page{{ $page }}"><button type="button" class="page-link" wire:click="gotoPage({{ $page }})">{{ $page }}</button></li>
                             @endif
                         @endforeach
                     @endif
@@ -35,7 +35,7 @@
                 {{-- Next Page Link --}}
                 @if ($paginator->hasMorePages())
                     <li class="page-item" wire:key="paginator-next">
-                        <button class="page-link" wire:click="nextPage" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</button>
+                        <button type="button" class="page-link" wire:click="nextPage" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</button>
                     </li>
                 @else
                     <li class="page-item disabled" wire:key="paginator-next" aria-disabled="true" aria-label="@lang('pagination.next')">

--- a/src/views/simple-bootstrap.blade.php
+++ b/src/views/simple-bootstrap.blade.php
@@ -9,14 +9,14 @@
                     </li>
                 @else
                     <li class="page-item">
-                        <button class="page-link" wire:click="previousPage" rel="prev">@lang('pagination.previous')</button>
+                        <button type="button" class="page-link" wire:click="previousPage" rel="prev">@lang('pagination.previous')</button>
                     </li>
                 @endif
 
                 {{-- Next Page Link --}}
                 @if ($paginator->hasMorePages())
                     <li class="page-item">
-                        <button class="page-link" wire:click="nextPage" rel="next">@lang('pagination.next')</button>
+                        <button type="button" class="page-link" wire:click="nextPage" rel="next">@lang('pagination.next')</button>
                     </li>
                 @else
                     <li class="page-item disabled" aria-disabled="true">


### PR DESCRIPTION
I ran into an issue using a Livewire component with pagination inside an HTML form.

Since the pagination `<button>` tags don't have a type attribute, they default to `submit` and therefore try to submit the form / hit HTML5 validation in Chrome.

This PR adds `type="button"` to the pagination buttons to stop them from submitting an outer form.

Thanks for Livewire 🙌