### PR TITLE
Fix 404 Error when making ajax Requests in projects hosted on a path in the domain

### DIFF
--- a/src/RenameMe/SupportBrowserHistory.php
+++ b/src/RenameMe/SupportBrowserHistory.php
@@ -51,8 +51,16 @@ class SupportBrowserHistory
 
             if (! $referer = request()->header('Referer')) return;
 
+            $assetUrl = config("livewire.asset_url");
+            // Get the path for sure;
+            $path = parse_url($referer,PHP_URL_PATH);
+            // Remove the asset_url segment
+            if ($assetUrl) {
+                $path = Str::replaceFirst($assetUrl,"",$path);
+            }
+
             $route = app('router')->getRoutes()->match(
-                Request::create($referer, 'GET')
+                Request::create($path,"GET")
             );
 
             $queryParams = $this->mergeComponentPropertiesWithExistingQueryParamsFromOtherComponentsAndTheRequest($component);


### PR DESCRIPTION
This PR fixes the issue of having 404 errors when the asset_url setting is set to a sub-path, especially for projects NOT hosted on the root domain.

Fixes #1535 , #1482 