### PR TITLE
Update SupportBrowserHistory.php

### DIFF
--- a/src/RenameMe/SupportBrowserHistory.php
+++ b/src/RenameMe/SupportBrowserHistory.php
@@ -134,8 +134,7 @@ class SupportBrowserHistory
             })
             ->map(function ($property) {
                 return is_bool($property) ? json_encode($property) : $property;
-            })
-            ->sortKeys();
+            });
 
         return $this->mergedQueryParamsFromDehydratedComponents;
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

There is an issue here:

https://github.com/livewire/livewire/issues/1549

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No. 

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No tests.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

The `sortKeys()` method call in the collection pipeline within the `mergeComponentPropertiesWithExistingQueryParamsFromOtherComponentsAndTheRequest()` method causes query strings to be re-written in alphabetical order on any page with multiple query strings in the URL.

This should not be default behavior. Sites that rely upon query strings for locating separate resources can receive duplicate content SEO warnings from this behavior. We have confirmed this side effect in production on a high traffic message board with Google Search.

