### PR TITLE
Wrap pagination text in spans

### DIFF
--- a/src/views/tailwind.blade.php
+++ b/src/views/tailwind.blade.php
@@ -30,13 +30,13 @@
             <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
                 <div>
                     <p class="text-sm text-gray-700 leading-5">
-                        {!! __('Showing') !!}
+                        <span>{!! __('Showing') !!}</span>
                         <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                        {!! __('to') !!}
+                        <span>{!! __('to') !!}</span>
                         <span class="font-medium">{{ $paginator->lastItem() }}</span>
-                        {!! __('of') !!}
+                        <span>{!! __('of') !!}</span>
                         <span class="font-medium">{{ $paginator->total() }}</span>
-                        {!! __('results') !!}
+                        <span>{!! __('results') !!}</span>
                     </p>
                 </div>
 


### PR DESCRIPTION
Fixes #1558

With freeform text mixed with tags inside an element, Morphdom occasionally removes some of the text as it fails to diff it properly. Wrapping the free text in elements like spans helps prevent this.

This is the same fix we had in the TALL preset a while back too: laravel-frontend-presets/tall#45