### PR TITLE
Allow 'validationOnly' to use validation messages property

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -142,7 +142,10 @@ trait ValidatesInput
     public function validateOnly($field, $rules = null, $messages = [], $attributes = [])
     {
         $rules = is_null($rules) ? $this->getRules() : $rules;
+
         throw_if(empty($rules), new MissingRulesException($this::getName()));
+
+        $messages = empty($messages) ? $this->getMessages() : $messages;
 
         $result = $this->getPublicPropertiesDefinedBySubClass();
 

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -131,6 +131,23 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
+    public function can_validate_only_a_specific_field_with_custom_message_property()
+    {
+        $component = Livewire::test(ForValidation::class);
+
+        $component
+            ->set('foo', 'foo')
+            ->set('bar', '')
+            ->call('runValidationOnlyWithMessageProperty', 'foo')
+            ->assertDontSee('Foo Message') // Foo is set, no error
+            ->assertDontSee('Bar Message') // Bar is not being validated, don't show
+            ->set('foo', '')
+            ->call('runValidationOnlyWithMessageProperty', 'bar')
+            ->assertDontSee('Foo Message') // Foo is not being validated, don't show
+            ->assertSee('Bar Message'); // Bar is not set, show message
+    }
+
+    /** @test */
     public function can_validate_only_a_specific_field_with_deeply_nested_array()
     {
         $component = Livewire::test(ForValidation::class);
@@ -248,6 +265,19 @@ class ForValidation extends Component
 
     public function runValidationOnly($field)
     {
+        $this->validateOnly($field, [
+            'foo' => 'required',
+            'bar' => 'required',
+        ]);
+    }
+
+    public function runValidationOnlyWithMessageProperty($field)
+    {
+        $this->messages = [
+            'foo.required' => 'Foo Message',
+            'bar.required' => 'Bar Message',
+        ];
+
         $this->validateOnly($field, [
             'foo' => 'required',
             'bar' => 'required',


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
- Was [commented](https://github.com/livewire/livewire/pull/1518#issuecomment-691505392) on a previous PR.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
- Straight implementation

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
- Simple working test :star2: 

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
- The #1518 pull added the ability to define a `protected $messages` property that allowed validation function to use those messages, but it only worked for the `validate()` function. I missed the `validateOnly()` one, but it was brought to my attention after the PR was merged. So, this is to fix that :sweat_smile: 

5️⃣ Thanks for contributing! 🙌