### PR TITLE
Configure Content Disposition as orignial file name

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -63,7 +63,11 @@ class TemporaryUploadedFile extends UploadedFile
     public function temporaryUrl()
     {
         if (FileUploadConfiguration::isUsingS3() && ! app()->environment('testing')) {
-            return $this->storage->temporaryUrl($this->path, now()->addDay());
+            return $this->storage->temporaryUrl(
+                $this->path,
+                now()->addDay(),
+                ['ResponseContentDisposition' => 'filename="' . $this->getClientOriginalName . '"']
+            );
         }
 
         $supportedPreviewTypes = [


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

I did not create an issue, as it is just a tweak to the existing function.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Nope.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Did not modify any test

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

If you are embeding the file the filename can beshown to the user, which is changed to the unique file with the meta data.  This sets `ResponseContentDisposition` to be equal to the orignial file name.

5️⃣ Thanks for contributing! 🙌