### PR TITLE
remove spans from bootstrap pagination view

### DIFF
--- a/src/views/bootstrap.blade.php
+++ b/src/views/bootstrap.blade.php
@@ -2,7 +2,7 @@
     @if ($paginator->hasPages())
         <nav>
             <ul class="pagination">
-                <span>
+               
                     {{-- Previous Page Link --}}
                     @if ($paginator->onFirstPage())
                         <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
@@ -13,9 +13,9 @@
                             <button type="button" dusk="previousPage" class="page-link" wire:click="previousPage" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</button>
                         </li>
                     @endif
-                </span>
+               
 
-                <span>
+               
                     {{-- Pagination Elements --}}
                     @foreach ($elements as $element)
                         {{-- "Three Dots" Separator --}}
@@ -34,9 +34,9 @@
                             @endforeach
                         @endif
                     @endforeach
-                </span>
+               
 
-                <span>
+               
                     {{-- Next Page Link --}}
                     @if ($paginator->hasMorePages())
                         <li class="page-item">
@@ -47,7 +47,7 @@
                             <span class="page-link" aria-hidden="true">&rsaquo;</span>
                         </li>
                     @endif
-                </span>
+                
             </ul>
         </nav>
     @endif


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
didn't create an issue as it was just as quick to fix it
2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
no
3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
no
4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Bootstrap pagination was being output with spans wrapping the li tags which caused the layout of the numbers to break. Simply removed the spans leaving a clean list ul>li
5️⃣ Thanks for contributing! 🙌