### PR TITLE
Eliminate need to resetErrorBag() or resetValidation() when using a custom validator

### DIFF
--- a/src/RenameMe/SupportValidation.php
+++ b/src/RenameMe/SupportValidation.php
@@ -11,7 +11,11 @@ class SupportValidation
     function __construct()
     {
         Livewire::listen('component.dehydrate', function ($component, $response) {
-            $response->memo['errors'] = $component->getErrorBag()->toArray();
+            $response->memo['errors'] = collect(
+                $component->getErrorBag()->toArray()
+            )->filter(function ($value, $key) use ($component) {
+                return $component->hasProperty($key);
+            })->toArray();
         });
 
         Livewire::listen('component.hydrate', function ($component, $request) {

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ViewErrorBag;
 use Livewire\Component;
 use Livewire\Livewire;
@@ -145,6 +146,36 @@ class ValidationTest extends TestCase
             ->call('runValidationOnlyWithMessageProperty', 'bar')
             ->assertDontSee('Foo Message') // Foo is not being validated, don't show
             ->assertSee('Bar Message'); // Bar is not set, show message
+    }
+
+    /** @test */
+    public function custom_validation_messages_are_cleared_between_validate_only_validations()
+    {
+        $component = app(LivewireManager::class)->test(ForValidation::class);
+
+        // cleared when custom validation passes
+        $component
+            ->set('foo', 'foo')
+            ->set('bar', 'b')
+            ->call('runValidationOnlyWithCustomValidation', 'bar')
+            ->assertDontSee('The bar field is required')
+            ->assertSee('Lengths must be the same')
+            ->set('bar', 'baz')
+            ->call('runValidationOnlyWithCustomValidation', 'bar')
+            ->assertDontSee('The bar field is required')
+            ->assertDontSee('Lengths must be the same');
+
+        // cleared when custom validation isn't run
+        $component
+            ->set('foo', 'foo')
+            ->set('bar', 'b')
+            ->call('runValidationOnlyWithCustomValidation', 'bar')
+            ->assertDontSee('The bar field is required')
+            ->assertSee('Lengths must be the same')
+            ->set('bar', '')
+            ->call('runValidationOnlyWithCustomValidation', 'bar')
+            ->assertSee('The bar field is required')
+            ->assertDontSee('Lengths must be the same');
     }
 
     /** @test */
@@ -324,6 +355,23 @@ class ForValidation extends Component
         $this->validate([
             'emails.*' => 'email',
         ]);
+    }
+
+    public function runValidationOnlyWithCustomValidation($field)
+    {
+        $this->validateOnly($field, [
+            'foo' => 'required',
+            'bar' => 'required',
+        ]);
+
+        Validator::make(
+            [
+                'foo_length' => strlen($this->foo),
+                'bar_length' => strlen($this->bar),
+            ],
+            [ 'foo_length' => 'same:bar_length' ],
+            [ 'same' => 'Lengths must be the same' ]
+        )->validate();
     }
 
     public function runDeeplyNestedValidation()


### PR DESCRIPTION
Here is the V2 version of 1.x PR #1398 - complete with test.
