### PR TITLE
Update assertSeeInOrder() and assertSeeHtmlInOrder() assertions

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -95,7 +95,7 @@ trait MakesAssertions
     {
         PHPUnit::assertThat(
             $values,
-            new SeeInOrder($this->stripOutInitialData($this->payload['dom']))
+            new SeeInOrder($this->stripOutInitialData($this->lastRenderedDom))
         );
 
         return $this;
@@ -105,7 +105,7 @@ trait MakesAssertions
     {
         PHPUnit::assertThat(
             array_map('e', ($values)),
-            new SeeInOrder($this->stripOutInitialData($this->payload['dom']))
+            new SeeInOrder($this->stripOutInitialData($this->lastRenderedDom))
         );
 
         return $this;


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

This updates this PR as it no longer works in v2: https://github.com/livewire/livewire/pull/1318. 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

I just updated the way the DOM is being accessed since it changed in v2.

I also added a PR for the docs: https://github.com/livewire/docs/pull/238

5️⃣ Thanks for contributing! 🙌