### PR TITLE
Support quoted Content-Disposition filenames for downloads

### DIFF
--- a/src/RenameMe/SupportFileDownloads.php
+++ b/src/RenameMe/SupportFileDownloads.php
@@ -20,7 +20,13 @@ class SupportFileDownloads
 
             $response = $returned;
 
-            $name = Str::after($response->headers->get('Content-Disposition'), 'filename=');
+            preg_match(
+                '/^.*?filename=(?:(?:(["\'])([^"\']+)\1)|([^"\';]+))/m',
+                $response->headers->get('Content-Disposition'),
+                $matches
+            );
+
+            $name = (count($matches) == 3) ? $matches[2] : $matches[3];
 
             $binary = $this->captureOutput(function () use ($response) {
                 $response->sendContent();

--- a/src/RenameMe/SupportFileDownloads.php
+++ b/src/RenameMe/SupportFileDownloads.php
@@ -20,13 +20,9 @@ class SupportFileDownloads
 
             $response = $returned;
 
-            preg_match(
-                '/^.*?filename=(?:(?:(["\'])([^"\']+)\1)|([^"\';]+))/m',
-                $response->headers->get('Content-Disposition'),
-                $matches
+            $name = $this->getFilenameFromContentDispositionHeader(
+                $response->headers->get('Content-Disposition')
             );
-
-            $name = (count($matches) == 3) ? $matches[2] : $matches[3];
 
             $binary = $this->captureOutput(function () use ($response) {
                 $response->sendContent();
@@ -62,5 +58,28 @@ class SupportFileDownloads
         $callback();
 
         return ob_get_clean();
+    }
+
+    function getFilenameFromContentDispositionHeader($header)
+    {
+        /**
+         * The following conditionals are here to allow for quoted and
+         * non quoted filenames in the Content-Disposition header.
+         *
+         * Both of these values should return the correct filename without quotes.
+         *
+         * Content-Disposition: attachment; filename=filename.jpg
+         * Content-Disposition: attachment; filename="test file.jpg"
+         */
+
+        if (preg_match('/.*?filename="(.+?)"/', $header, $matches)) {
+            return $matches[1];
+        }
+
+        if (preg_match('/.*?filename=([^; ]+)/', $header, $matches)) {
+            return $matches[1];
+        }
+
+        return 'download';
     }
 }

--- a/tests/Browser/FileDownloads/Component.php
+++ b/tests/Browser/FileDownloads/Component.php
@@ -30,6 +30,28 @@ class Component extends BaseComponent
         );
     }
 
+    public function downloadQuotedContentDispositionFilename()
+    {
+        config()->set('filesystems.disks.dusk-tmp', [
+            'driver' => 'local',
+            'root' => __DIR__,
+        ]);
+
+        return Storage::disk('dusk-tmp')->download('download & target.txt');
+    }
+
+    public function downloadQuotedContentDispositionFilenameFromResponse()
+    {
+        config()->set('filesystems.disks.dusk-tmp', [
+            'driver' => 'local',
+            'root' => __DIR__,
+        ]);
+
+        return response()->download(
+            Storage::disk('dusk-tmp')->path('download & target2.txt')
+        );
+    }
+
     public function render()
     {
         return View::file(__DIR__.'/view.blade.php');

--- a/tests/Browser/FileDownloads/Test.php
+++ b/tests/Browser/FileDownloads/Test.php
@@ -63,12 +63,12 @@ class Test extends TestCase
                 ->pause(500);
 
             $this->assertTrue(
-                Storage::disk('dusk-downloads')->exists('download & target.txt')
+                Storage::disk('dusk-downloads')->exists('download & target2.txt')
             );
 
             $this->assertStringContainsString(
                 'I\'m the file you should download.',
-                Storage::disk('dusk-downloads')->get('download & target.txt')
+                Storage::disk('dusk-downloads')->get('download & target2.txt')
             );
         });
     }

--- a/tests/Browser/FileDownloads/Test.php
+++ b/tests/Browser/FileDownloads/Test.php
@@ -26,6 +26,20 @@ class Test extends TestCase
                 Storage::disk('dusk-downloads')->get('download-target.txt')
             );
 
+            Livewire::visit($browser, Component::class)
+                ->waitForLivewire()->click('@download-quoted-disposition-filename')
+                // Wait for download to be triggered.
+                ->pause(500);
+
+            $this->assertTrue(
+                Storage::disk('dusk-downloads')->exists('download & target.txt')
+            );
+
+            $this->assertStringContainsString(
+                'I\'m the file you should download.',
+                Storage::disk('dusk-downloads')->get('download & target.txt')
+            );
+
             /**
              * Trigger download with a response return.
              */
@@ -41,6 +55,20 @@ class Test extends TestCase
             $this->assertStringContainsString(
                 'I\'m the file you should download.',
                 Storage::disk('dusk-downloads')->get('download-target2.txt')
+            );
+
+            Livewire::visit($browser, Component::class)
+                ->waitForLivewire()->click('@download-from-response-quoted-disposition-filename')
+                // Wait for download to be triggered.
+                ->pause(500);
+
+            $this->assertTrue(
+                Storage::disk('dusk-downloads')->exists('download & target.txt')
+            );
+
+            $this->assertStringContainsString(
+                'I\'m the file you should download.',
+                Storage::disk('dusk-downloads')->get('download & target.txt')
             );
         });
     }

--- a/tests/Browser/FileDownloads/download & target.txt
+++ b/tests/Browser/FileDownloads/download & target.txt
@@ -1,0 +1,1 @@
+I'm the file you should download.

--- a/tests/Browser/FileDownloads/download & target2.txt
+++ b/tests/Browser/FileDownloads/download & target2.txt
@@ -1,0 +1,1 @@
+I'm the file you should download.

--- a/tests/Browser/FileDownloads/view.blade.php
+++ b/tests/Browser/FileDownloads/view.blade.php
@@ -3,5 +3,4 @@
     <button wire:click="downloadFromResponse" dusk="download-from-response">Download</button>
     <button wire:click="downloadQuotedContentDispositionFilename" dusk="download-quoted-disposition-filename">Download</button>
     <button wire:click="downloadQuotedContentDispositionFilenameFromResponse" dusk="download-from-response-quoted-disposition-filename">Download</button>
-
 </div>

--- a/tests/Browser/FileDownloads/view.blade.php
+++ b/tests/Browser/FileDownloads/view.blade.php
@@ -1,4 +1,7 @@
 <div>
     <button wire:click="download" dusk="download">Download</button>
     <button wire:click="downloadFromResponse" dusk="download-from-response">Download</button>
+    <button wire:click="downloadQuotedContentDispositionFilename" dusk="download-quoted-disposition-filename">Download</button>
+    <button wire:click="downloadQuotedContentDispositionFilenameFromResponse" dusk="download-from-response-quoted-disposition-filename">Download</button>
+
 </div>


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Needed.  Yes. #1602 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Yes

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

You are unable to download a file in Livewire using a filename like "This & That.txt".  The contents will download but the filename will be surrounded by quotes in the JSON response to Livewire causing weird filename behavior on the saved computer.  Quotes will be replaced with underscores in the filename, etc.

The Content-Disposition header should contain quotes around the filename when special characters or spaces are involved but it is not required when dealing with simple filenames.  It seems Laravel responds with and without quotes depending on the situation.

Content-Disposition: attachment; filename=filename.jpg
Content-Disposition: attachment; filename="filename.jpg"

Are both valid.

5️⃣ Thanks for contributing! 🙌