### PR TITLE
Update Discord server invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Awesome Livewire stuff here: https://github.com/imliam/awesome-livewire
 
 All contributions are welcomed! (but please submit an issue to make sure the PR is warranted first)
 
-Open GitHub issues for all bugs. Ideas and questions belong on the [forum](https://forum.laravel-livewire.com) or [Discord server](https://discord.gg/H884eyt).
+Open GitHub issues for all bugs. Ideas and questions belong on the [forum](https://forum.laravel-livewire.com) or [Discord server](https://discord.gg/livewire).
 
 Contribute to the docs here: https://github.com/livewire/docs
 


### PR DESCRIPTION
The Livewire Discord server has now been officially verified by Discord, and they have granted us access to [discord.gg/livewire](https://discord.gg/livewire).

This PR updates the invite link in the README.