### PR TITLE
Fix bug where was calling property instead of method

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -66,7 +66,7 @@ class TemporaryUploadedFile extends UploadedFile
             return $this->storage->temporaryUrl(
                 $this->path,
                 now()->addDay(),
-                ['ResponseContentDisposition' => 'filename="' . $this->getClientOriginalName . '"']
+                ['ResponseContentDisposition' => 'filename="' . $this->getClientOriginalName() . '"']
             );
         }
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

This is a bug I introdcued in #1604 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

I wanted to add a test for this, but the clod is wrapped in a `! app()->environment('testing')` block, so unless I have the test change the env at runtime, I cannot get to the code to test it.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Just try to mane a `temporaryUrl` for a file on `s3` with `1.3.4`

5️⃣ Thanks for contributing! 🙌

Again, I am sorry.