### PR TITLE
Ability to use AssertNotEmitted when no events are present

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -139,15 +139,15 @@ trait MakesAssertions
         $assertionSuffix = '.';
 
         if (empty($params)) {
-            $test = collect($this->payload['effects']['emits'] ?? [])->contains('event', '=', $value);
+            $test = collect(data_get($this->payload, 'effects.emits'))->contains('event', '=', $value);
         } elseif (is_callable($params[0])) {
-            $event = collect($this->payload['effects']['emits'] ?? [])->first(function ($item) use ($value) {
+            $event = collect(data_get($this->payload, 'effects.emits'))->first(function ($item) use ($value) {
                 return $item['event'] === $value;
             });
 
             $test = $event && $params[0]($event['event'], $event['params']);
         } else {
-            $test = (bool) collect($this->payload['effects']['emits'] ?? [])->first(function ($item) use ($value, $params) {
+            $test = (bool) collect(data_get($this->payload, 'effects.emits'))->first(function ($item) use ($value, $params) {
                 return $item['event'] === $value
                     && $item['params'] === $params;
             });

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -139,15 +139,15 @@ trait MakesAssertions
         $assertionSuffix = '.';
 
         if (empty($params)) {
-            $test = collect($this->payload['effects']['emits'])->contains('event', '=', $value);
+            $test = collect($this->payload['effects']['emits'] ?? [])->contains('event', '=', $value);
         } elseif (is_callable($params[0])) {
-            $event = collect($this->payload['effects']['emits'])->first(function ($item) use ($value) {
+            $event = collect($this->payload['effects']['emits'] ?? [])->first(function ($item) use ($value) {
                 return $item['event'] === $value;
             });
 
             $test = $event && $params[0]($event['event'], $event['params']);
         } else {
-            $test = (bool) collect($this->payload['effects']['emits'])->first(function ($item) use ($value, $params) {
+            $test = (bool) collect($this->payload['effects']['emits'] ?? [])->first(function ($item) use ($value, $params) {
                 return $item['event'] === $value
                     && $item['params'] === $params;
             });

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -106,6 +106,8 @@ class LivewireTestingTest extends TestCase
     {
         app(LivewireManager::class)
             ->test(EmitsEventsComponentStub::class)
+            ->call('methodWithoutEmit')
+            ->assertNotEmitted('foo')
             ->call('emitFoo')
             ->assertNotEmitted('bar')
             ->call('emitFooWithParam', 'not-bar')
@@ -216,6 +218,11 @@ class EmitsEventsComponentStub extends Component
     public function emitFoo()
     {
         $this->emit('foo');
+    }
+
+    public function methodWithoutEmit()
+    {
+        //
     }
 
     public function emitFooWithParam($param)

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -106,7 +106,6 @@ class LivewireTestingTest extends TestCase
     {
         app(LivewireManager::class)
             ->test(EmitsEventsComponentStub::class)
-            ->call('methodWithoutEmit')
             ->assertNotEmitted('foo')
             ->call('emitFoo')
             ->assertNotEmitted('bar')
@@ -218,11 +217,6 @@ class EmitsEventsComponentStub extends Component
     public function emitFoo()
     {
         $this->emit('foo');
-    }
-
-    public function methodWithoutEmit()
-    {
-        //
     }
 
     public function emitFooWithParam($param)


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Closes #1673 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes, includes tests.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Currently, it's not possible to use `assertNotEmitted()` when no emits were fired at all on the component.

Returns: `ErrorException: Undefined index: emits`.

This PR allows the ability for `assertNotEmitted()` to be called when no emits at all were fired on the component.

Real world example:
```php
public function test_updating_only_state_doesnt_fire_shipping_methods_event()
{
    Livewire::test(EstimateShippingAndTax::class)
        ->set('state', 'AL');
        ->assertNotEmitted('refreshShippingMethods'); // ErrorException: Undefined index: emits
}

public function test_updating_only_zip_doesnt_fire_shipping_methods_event()
{
    Livewire::test(EstimateShippingAndTax::class)
        ->set('zip', '00001');
        ->assertNotEmitted('refreshShippingMethods'); // ErrorException: Undefined index: emits
}

public function test_updating_zip_and_state_fires_shipping_method_event()
{
    Livewire::test(EstimateShippingAndTax::class)
        ->set('state', 'AL')
        ->set('zip', '00001')
        ->assertEmitted('refreshShippingMethods');
}
```
5️⃣ Thanks for contributing! 🙌