### PR TITLE
Add assertListeningFor

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -267,4 +267,13 @@ trait MakesAssertions
 
         return $this;
     }
+
+    public function assertListener($listener)
+    {
+        $test = collect($this->payload['effects']['listeners'])->contains($listener);
+
+        PHPUnit::assertTrue($test, "Failed asserting component is listening for the [{$listener}] method.");
+
+        return $this;
+    }
 }

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -268,7 +268,7 @@ trait MakesAssertions
         return $this;
     }
 
-    public function assertListener($listener)
+    public function assertListeningFor($listener)
     {
         $test = collect($this->payload['effects']['listeners'])->contains($listener);
 

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -171,6 +171,20 @@ class LivewireTestingTest extends TestCase
             ->set('bar', '')
             ->assertHasErrors(['foo', 'bar']);
     }
+
+    /** @test */
+    public function assert_listener()
+    {
+        app(LivewireManager::class)
+            ->test(ListenersComponentStub::class)
+            ->assertListener('foo')
+            ->assertListener('key');
+
+        app(LivewireManager::class)
+            ->test(DynamicListenersComponentStub::class)
+            ->assertListener('foo')
+            ->assertListener('key');
+    }
 }
 
 class HasMountArguments extends Component
@@ -277,6 +291,29 @@ class ValidatesDataWithRealTimeStub extends Component
             'foo' => 'required|min:6',
             'bar' => 'required',
         ]);
+    }
+
+    public function render()
+    {
+        return app('view')->make('null-view');
+    }
+}
+
+class ListenersComponentStub extends Component
+{
+    protected $listeners = ['foo', 'key' => 'value'];
+
+    public function render()
+    {
+        return app('view')->make('null-view');
+    }
+}
+
+class DynamicListenersComponentStub extends Component
+{
+    protected function getListeners()
+    {
+        return ['foo', 'key' => 'value'];
     }
 
     public function render()

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -173,17 +173,17 @@ class LivewireTestingTest extends TestCase
     }
 
     /** @test */
-    public function assert_listener()
+    public function assert_listening_for()
     {
         app(LivewireManager::class)
             ->test(ListenersComponentStub::class)
-            ->assertListener('foo')
-            ->assertListener('key');
+            ->assertListeningFor('foo')
+            ->assertListeningFor('key');
 
         app(LivewireManager::class)
             ->test(DynamicListenersComponentStub::class)
-            ->assertListener('foo')
-            ->assertListener('key');
+            ->assertListeningFor('foo')
+            ->assertListeningFor('key');
     }
 }
 


### PR DESCRIPTION
This PR adds `assertListeningFor($string)` to components; Allowing developers to ensure the event is listening on the component.

We recently ran into an issue where an event was being emitted from a different component but the listening components property `$listeners` was inadvertently removed. The supplied value to `assertListeningFor` will check component payload to ensure the value is within the array of listeners.

Example:
```php
public function test_listens_for_refresh_shipping_methods()
{
    Livewire::test(ShippingMethods::class)
        ->assertListeningFor('refreshShippingMethods');
}
```