### PR TITLE
Fix: Regression in ValidatesInput for conditional rules

### DIFF
--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -271,6 +271,29 @@ class ValidationTest extends TestCase
             ->assertSee('The bar field is required')
             ->assertDontSee('Lengths must be the same');
     }
+
+    /** @test */
+    public function validation_fails_when_same_rule_is_used_without_matching()
+    {
+        $component = Livewire::test(ForValidation::class);
+
+        $component
+            ->set('password', 'supersecret')
+            ->call('runSameValidation')
+            ->assertSee('The password and password confirmation must match');
+    }
+
+    /** @test */
+    public function validation_passes_when_same_rule_is_used_and_matches()
+    {
+        $component = Livewire::test(ForValidation::class);
+
+        $component
+            ->set('password', 'supersecret')
+            ->set('passwordConfirmation', 'supersecret')
+            ->call('runSameValidation')
+            ->assertDontSee('The password and password confirmation must match');
+    }
 }
 
 class ForValidation extends Component
@@ -282,6 +305,8 @@ class ForValidation extends Component
         ['foo' => 'bar', 'baz' => 'blab'],
         ['foo' => 'bar', 'baz' => ''],
     ];
+    public $password = '';
+    public $passwordConfirmation = '';
 
     public function runValidation()
     {
@@ -399,6 +424,14 @@ class ForValidation extends Component
             'items.*' => 'array',
             'items.*.foo' => ['required', 'string'],
             'items.*.baz' => ['required', 'string'],
+        ]);
+    }
+
+
+    public function runSameValidation()
+    {
+        $this->validate([
+            'password' => 'same:passwordConfirmation',
         ]);
     }
 


### PR DESCRIPTION
Consider the following validation:

```php
$this->validate([
    'password' => ['required', 'min:8', 'same:passwordConfirmation'],
]);
```

That is to say that the `password` property is required, be a minimum of 8 characters, and match the `passwordConfirmation` property.

The `ValidatesInput@validate` method used to [append properties](https://github.com/livewire/livewire/blob/v2.2.3/src/ComponentConcerns/ValidatesInput.php#L105-L129) from the rules array, which meant that conditional rules like this would work as expected in 2.2.3.

In 2.2.4, however, Livewire now uses the [`getDataForValidation`](https://github.com/livewire/livewire/blob/b1f5eae5ef5f5942d8d334b4ecb718bac580454f/src/ComponentConcerns/ValidatesInput.php#L185-L198) method, which will return only the rules array.

That is to say, anything _not_ in the explicit `rules` array or in the global `rules` property or method will be omitted from the data passed to the validator.

The userland workaround for this as of 2.2.4 is to modify the validation rules slightly:

```php
$this->validate([
    'password' => ['required', 'min:8'],
    'passwordConfirmation' => ['same:password'],
]);
```

For the time being, this PR just includes a failing test as I'm not sure how you'd best like to tackle the regression. The `getDataForValidation` rule certainly makes sense for the `validateOnly` method, however, there may be a suitable extraction of this logic that both methods can use.

Note also that the [TALL preset](https://github.com/laravel-frontend-presets/tall/blob/fa1af0dc84355a65f516f089a405fb64fd451dd4/stubs/auth/app/Http/Livewire/Auth/Register.php#L28-L32) leans on this behaviour, which means the tests it includes will be broken for users installing the preset into a new app currently.

This resolves laravel-frontend-presets/tall#65 once updated.