### PR TITLE
Add validation `$attributes` property

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -74,6 +74,14 @@ trait ValidatesInput
         return [];
     }
 
+    protected function getAttributes()
+    {
+        if (method_exists($this, 'attributes')) return $this->attributes();
+        if (property_exists($this, 'attributes')) return $this->attributes;
+
+        return [];
+    }
+
     public function rulesForModel($name)
     {
         if (empty($this->getRules())) return collect();
@@ -96,7 +104,7 @@ trait ValidatesInput
 
     public function validate($rules = null, $messages = [], $attributes = [])
     {
-        [$rules, $messages] = $this->providedOrGlobalRulesAndMessages($rules, $messages);
+        [$rules, $messages, $attributes] = $this->providedOrGlobalRulesAndMessages($rules, $messages, $attributes);
 
         $data = $this->prepareForValidation(
             $this->getDataForValidation($rules)
@@ -115,7 +123,7 @@ trait ValidatesInput
 
     public function validateOnly($field, $rules = null, $messages = [], $attributes = [])
     {
-        [$rules, $messages] = $this->providedOrGlobalRulesAndMessages($rules, $messages);
+        [$rules, $messages, $attributes] = $this->providedOrGlobalRulesAndMessages($rules, $messages, $attributes);
 
         // If the field is "items.0.foo", we should apply the validation rule for "items.*.foo".
         $rulesForField = collect($rules)->filter(function ($rule, $fullFieldKey) use ($field) {
@@ -175,7 +183,9 @@ trait ValidatesInput
 
         $messages = empty($messages) ? $this->getMessages() : $messages;
 
-        return [$rules, $messages];
+        $attributes = empty($attributes) ? $this->getAttributes() : $attributes;
+
+        return [$rules, $messages, $attributes];
     }
 
     protected function getDataForValidation($rules)


### PR DESCRIPTION
Using Custom Validation Attributes.

See #1546.

1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Yep.
Nop. I found a issue maybe about this: #1546 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Nop.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Yep.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

The `$attributes` property not work when my code like this:

```php
    public $form = [
        'email', 'password', 'remember', 'password_confirmation',
    ];

    protected $rules = [
        'form.email' => 'required|email|unique:users',
        'form.password' => 'required|min:6|confirmed',
        'form.password_confirmation' => 'required',
    ];

    protected $attributes = [
        'form.email' => '邮箱',
    ];
```

Sorry, my English is not so good 😢, but this PR really fixes the problem.

5️⃣ Thanks for contributing! 🙌