### PR TITLE
Fixed component create with custom path (outside app folder and custom views).

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    
+
     /*
     |--------------------------------------------------------------------------
     | Root Path
@@ -10,8 +10,6 @@ return [
     | This value sets the root path for Livewire component classes in
     | your application. This value affects component auto-discovery and
     | any Livewire file helper commands, like `artisan make:livewire`.
-    |
-    | After changing this item, run: `php artisan livewire:discover`.
     |
     */
 
@@ -34,7 +32,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | View Path
+    | Root View Path
+    |--------------------------------------------------------------------------
+    |
+    | This value sets the path for root views. This affects
+    | file manipulation helper commands like `artisan make:livewire`.
+    |
+    */
+
+    'root_view_path' => resource_path('views'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Component View Path
     |--------------------------------------------------------------------------
     |
     | This value sets the path for Livewire component views. This affects

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -1,6 +1,21 @@
 <?php
 
 return [
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Root Path
+    |--------------------------------------------------------------------------
+    |
+    | This value sets the root path for Livewire component classes in
+    | your application. This value affects component auto-discovery and
+    | any Livewire file helper commands, like `artisan make:livewire`.
+    |
+    | After changing this item, run: `php artisan livewire:discover`.
+    |
+    */
+
+    'root_path' => app('path'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Commands/ComponentParser.php
+++ b/src/Commands/ComponentParser.php
@@ -148,6 +148,6 @@ class ComponentParser
     {
         $name = Str::replaceFirst(app()->getNamespace(), '', $namespace);
 
-        return app('path').'/'.str_replace('\\', '/', $name);
+        return config('livewire.root_path', app('path')).'/'.str_replace('\\', '/', $name);
     }
 }

--- a/src/Commands/ComponentParser.php
+++ b/src/Commands/ComponentParser.php
@@ -115,8 +115,9 @@ class ComponentParser
 
     public function viewName()
     {
+        $rootViewPath = config('livewire.root_view_path', resource_path('views'));
         return collect()
-            ->concat(explode('/',Str::after($this->baseViewPath, resource_path('views'))))
+            ->concat(explode('/',Str::after($this->baseViewPath, $rootViewPath)))
             ->filter()
             ->concat($this->directories)
             ->map([Str::class, 'kebab'])


### PR DESCRIPTION
I'm trying to implement livewire in my module based project. My modules outside the app folder. This package forces to generate component class inside the app folder. So I needed to load the component classpath dynamically. I updated a couple of files and it working for me.

I hope it helps when someone tries to generate a component class in the custom path (Outside or inside the app folder).

Thanks