### PR TITLE
Last attempt to fix failing CI tests

### DIFF
--- a/tests/Browser/Alpine/Test.php
+++ b/tests/Browser/Alpine/Test.php
@@ -86,10 +86,17 @@ class Test extends TestCase
                  * Make sure property change from Livewire doesn't trigger an additional
                  * request because of @entangle.
                  */
+                ->tap(function ($b) {
+                    $b->script([
+                        'window.livewireRequestCount = 0',
+                        "window.Livewire.hook('message.sent', () => { window.livewireRequestCount++ })",
+                    ]);
+                })
+                ->assertScript('window.livewireRequestCount', 0)
                 ->waitForLivewire(function ($b) {
                     $b->click('@lob.reset');
-                    $b->assertSeeIn('@lob.output', '6');
                 })
+                ->assertScript('window.livewireRequestCount', 1)
                 ->pause(500)
                 ->assertMissing('#livewire-error')
                 ->assertSeeIn('@lob.output', '100')

--- a/tests/Browser/Events/Test.php
+++ b/tests/Browser/Events/Test.php
@@ -15,19 +15,21 @@ class Test extends TestCase
                  * receive event from global fire
                  */
                 ->waitForLivewire()->tap(function ($browser) { $browser->script('window.livewire.emit("foo", "bar")'); })
-                ->pause(350)
-                ->assertSeeIn('@lastEventForParent', 'bar')
-                ->assertSeeIn('@lastEventForChildA', 'bar')
-                ->assertSeeIn('@lastEventForChildB', 'bar')
+                ->waitUsing(5, 75, function () use ($browser) {
+                    return $browser->assertSeeIn('@lastEventForParent', 'bar')
+                             ->assertSeeIn('@lastEventForChildA', 'bar')
+                             ->assertSeeIn('@lastEventForChildB', 'bar');
+                })
 
                 /**
                  * receive event from action fire
                  */
                 ->waitForLivewire()->click('@emit.baz')
-                ->pause(350)
-                ->assertSeeIn('@lastEventForParent', 'baz')
-                ->assertSeeIn('@lastEventForChildA', 'baz')
-                ->assertSeeIn('@lastEventForChildB', 'baz')
+                ->waitUsing(5, 75, function () use ($browser) {
+                    return $browser->assertSeeIn('@lastEventForParent', 'baz')
+                                   ->assertSeeIn('@lastEventForChildA', 'baz')
+                                   ->assertSeeIn('@lastEventForChildB', 'baz');
+                })
 
                 /**
                  * receive event from component fire, and make sure global listener receives event too
@@ -37,38 +39,43 @@ class Test extends TestCase
                     "window.livewire.on('foo', value => { lastFooEventValue = value })",
                 ]);})
                 ->waitForLivewire()->click('@emit.bob')
-                ->pause(350)
-                ->assertScript('window.lastFooEventValue', 'bob')
+                ->waitUsing(5, 75, function () use ($browser) {
+                    return $browser->assertScript('window.lastFooEventValue', 'bob');
+                })
+
 
                 /**
                  * receive event from component fired only to ancestors, and make sure global listener doesnt receive it
                  */
                 ->waitForLivewire()->click('@emit.lob')
-                ->pause(350)
-                ->assertSeeIn('@lastEventForParent', 'lob')
-                ->assertSeeIn('@lastEventForChildA', 'bob')
-                ->assertSeeIn('@lastEventForChildB', 'bob')
-                ->assertScript('window.lastFooEventValue', 'bob')
+                ->waitUsing(5, 75, function () use ($browser) {
+                    return $browser->assertSeeIn('@lastEventForParent', 'lob')
+                                   ->assertSeeIn('@lastEventForChildA', 'bob')
+                                   ->assertSeeIn('@lastEventForChildB', 'bob')
+                                   ->assertScript('window.lastFooEventValue', 'bob');
+                })
 
                 /**
                  * receive event from action fired only to ancestors, and make sure global listener doesnt receive it
                  */
                 ->waitForLivewire()->click('@emit.law')
-                ->pause(350)
-                ->assertSeeIn('@lastEventForParent', 'law')
-                ->assertSeeIn('@lastEventForChildA', 'bob')
-                ->assertSeeIn('@lastEventForChildB', 'bob')
-                ->assertScript('window.lastFooEventValue', 'bob')
+                ->waitUsing(5, 75, function () use ($browser) {
+                    return $browser->assertSeeIn('@lastEventForParent', 'law')
+                                   ->assertSeeIn('@lastEventForChildA', 'bob')
+                                   ->assertSeeIn('@lastEventForChildB', 'bob')
+                                   ->assertScript('window.lastFooEventValue', 'bob');
+                })
 
                 /**
                  * receive event from action fired only to component name, and make sure global listener doesnt receive it
                  */
                 ->waitForLivewire()->click('@emit.blog')
-                ->pause(350)
-                ->assertSeeIn('@lastEventForParent', 'law')
-                ->assertSeeIn('@lastEventForChildA', 'bob')
-                ->assertSeeIn('@lastEventForChildB', 'blog')
-                ->assertScript('window.lastFooEventValue', 'bob')
+                ->waitUsing(5, 75, function () use ($browser) {
+                    return $browser->assertSeeIn('@lastEventForParent', 'law')
+                                   ->assertSeeIn('@lastEventForChildA', 'bob')
+                                   ->assertSeeIn('@lastEventForChildB', 'blog')
+                                   ->assertScript('window.lastFooEventValue', 'bob');
+                })
             ;
         });
     }

--- a/tests/Browser/FileDownloads/Test.php
+++ b/tests/Browser/FileDownloads/Test.php
@@ -14,12 +14,9 @@ class Test extends TestCase
         $this->browse(function ($browser) {
             Livewire::visit($browser, Component::class)
                 ->waitForLivewire()->click('@download')
-                // Wait for download to be triggered.
-                ->pause(500);
-
-            $this->assertTrue(
-                Storage::disk('dusk-downloads')->exists('download-target.txt')
-            );
+                ->waitUsing(5, 75, function () {
+                    return Storage::disk('dusk-downloads')->exists('download-target.txt');
+                });
 
             $this->assertStringContainsString(
                 'I\'m the file you should download.',
@@ -28,12 +25,9 @@ class Test extends TestCase
 
             Livewire::visit($browser, Component::class)
                 ->waitForLivewire()->click('@download-quoted-disposition-filename')
-                // Wait for download to be triggered.
-                ->pause(500);
-
-            $this->assertTrue(
-                Storage::disk('dusk-downloads')->exists('download & target.txt')
-            );
+                ->waitUsing(5, 75, function () {
+                    return Storage::disk('dusk-downloads')->exists('download & target.txt');
+                });
 
             $this->assertStringContainsString(
                 'I\'m the file you should download.',
@@ -45,12 +39,9 @@ class Test extends TestCase
              */
             Livewire::visit($browser, Component::class)
                 ->waitForLivewire()->click('@download-from-response')
-                // Wait for download to be triggered.
-                ->pause(500);
-
-            $this->assertTrue(
-                Storage::disk('dusk-downloads')->exists('download-target2.txt')
-            );
+                ->waitUsing(5, 75, function () {
+                    return Storage::disk('dusk-downloads')->exists('download-target2.txt');
+                });
 
             $this->assertStringContainsString(
                 'I\'m the file you should download.',
@@ -59,12 +50,9 @@ class Test extends TestCase
 
             Livewire::visit($browser, Component::class)
                 ->waitForLivewire()->click('@download-from-response-quoted-disposition-filename')
-                // Wait for download to be triggered.
-                ->pause(500);
-
-            $this->assertTrue(
-                Storage::disk('dusk-downloads')->exists('download & target2.txt')
-            );
+                ->waitUsing(5, 75, function () {
+                    return Storage::disk('dusk-downloads')->exists('download & target2.txt');
+                });
 
             $this->assertStringContainsString(
                 'I\'m the file you should download.',

--- a/tests/Browser/TestCase.php
+++ b/tests/Browser/TestCase.php
@@ -291,18 +291,6 @@ class TestCase extends BaseTestCase
         Browser::macro('offline', function () {
             return tap($this)->script("window.dispatchEvent(new Event('offline'))");
         });
-
-        Browser::macro('captureLivewireRequest', function () {
-            $this->driver->executeScript('window.capturedRequestsForDusk = []');
-
-            return $this;
-        });
-
-        Browser::macro('replayLivewireRequest', function () {
-            $this->driver->executeScript('window.capturedRequestsForDusk.forEach(callback => callback()); delete window.capturedRequestsForDusk;');
-
-            return $this;
-        });
     }
 
     protected function driver(): RemoteWebDriver


### PR DESCRIPTION
Changed the assertion to reflect what we want to actually test - that only 1 request fires with `@entangle`

also removed some `pause()` calls and wrapped assertions within `waitUsing()` to eliminate all timing issues in CI

after some test re-runs, we are still 🟢