### PR TITLE
Hydrate model before asking for rules

### DIFF
--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -45,6 +45,7 @@ class HydratePublicProperties implements HydrationMiddleware
                 }
 
                 $dirtyModelData = $request->memo['data'][$property];
+                $instance->$property = $model;
 
                 if ($rules = $instance->rulesForModel($property)) {
                     $keys = $rules->keys()->map(function ($key) use ($instance) {
@@ -55,8 +56,6 @@ class HydratePublicProperties implements HydrationMiddleware
                         data_set($model, $key, data_get($dirtyModelData, $key));
                     }
                 }
-
-                $instance->$property = $model;
             } else {
                 $instance->$property = $value;
             }


### PR DESCRIPTION
1️⃣ **Is this something that is wanted/needed? Did you create an issue / discussion about it first?**
I have started a discussion on discord in help channel, so far not much has been discussed (https://discordapp.com/channels/698229985755791471/698231501501890600/757185963238883410) . However, I found other people asking the same question without much luck. (https://discordapp.com/channels/698229985755791471/698231501501890600/753633894607355986) The solution to this issue is ugly.


2️⃣ **Does it contain multiple, unrelated changes? Please separate the PRs out.**
No.

3️⃣ **Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)**
Yes.

4️⃣ **Please include a thorough description of the improvement and reasons why it's useful.**
Currently if we want to use uniqueness validation, there is no easy way to exclude an ID. 

- We cannot use `$this->model->id` inside `$rules` property, because of the restriction from php.
- We cannot use `$this->model->id` inside `rules` method, because `$this->model` is not hydrated yet and it throws an error.
- So to actually use this uniqueness rule, we cannot use `$rules` property. We must call `$this->validate()` and pass our uniqueness rule there together with other rules. This would be fine, but then we loose the ability to bind wire:model to model properties, because it throws 
`Cannot bind property [item.name] without a validation rule present in the [$rules] array on Livewire component: [items.create].`
- In discord there were some suggestions to modify $rules from within `mount()` or `hydrate()`- however that does not seem to work at all, unless I am missing something?

So this is my attempt to fix this issue, the actual fix is very simple - hydrate the model before it tries to get the rules, not after. I am not sure if there was a reason why it was done this way and I am not aware if this could possibly bring more issues. So really looking for any feedback here.

If this is accepted, it would be possible to use it inside `rules` method like this:

```

    public function rules()
    {
        return [
            'foo.bar' => 'required|unique:foo,bar,'.$this->foo->id
        ];
    }
```

5️⃣ **Thanks for contributing!** 🙌