### PR TITLE
Only return validated data

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -106,11 +106,11 @@ trait ValidatesInput
 
         $this->shortenModelAttributes($data, $rules, $validator);
 
-        $validator->validate();
+        $validatedData = $validator->validate();
 
         $this->resetErrorBag();
 
-        return $data;
+        return $validatedData;
     }
 
     public function validateOnly($field, $rules = null, $messages = [], $attributes = [])

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -294,6 +294,18 @@ class ValidationTest extends TestCase
             ->call('runSameValidation')
             ->assertDontSee('The password and password confirmation must match');
     }
+
+    /** @test */
+    public function only_data_in_validation_rules_is_returned()
+    {
+        $component = new ForValidation();
+        $component->bar = 'is required';
+
+        $validatedData = $component->runValidationWithoutAllPublicPropertiesAndReturnValidatedData();
+        $this->assertSame([
+            'bar' => $component->bar,
+        ], $validatedData);
+    }
 }
 
 class ForValidation extends Component
@@ -433,6 +445,11 @@ class ForValidation extends Component
         $this->validate([
             'password' => 'same:passwordConfirmation',
         ]);
+    }
+
+    public function runValidationWithoutAllPublicPropertiesAndReturnValidatedData()
+    {
+        return $this->validate(['bar' => 'required']);
     }
 
     public function render()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Currently all public properties are returned on validation. This is rather counterintuitive when working with Laravel's validation. https://github.com/livewire/livewire/issues/1649

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope, one change.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes!

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
This PR add backs the default behaviour from Laravel that when you validate data only the validated data is returned. 

5️⃣ Thanks for contributing! 🙌
Thanks for maintining!

Resolves #1649