### PR TITLE
Fix not being able to set values on specific numerical indexes of array attributes of models

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -86,12 +86,22 @@ trait ValidatesInput
 
     public function missingRuleFor($dotNotatedProperty)
     {
-        return ! collect($this->getRules())
+        // Prepare numerical-indexed properties for array attributes
+        $preparedProperty = (string) Str::of($dotNotatedProperty)
+            ->replaceMatches('/(?<=(\.))\d+\./', '.*.')
+            ->replace('..', '.');
+
+        $isANumericallyIndexedProperty = $dotNotatedProperty !== $preparedProperty;
+
+        return !collect($this->getRules())
             ->keys()
-            ->map(function ($key) {
-                return Str::of($key)->before('.*');
-            })
-            ->contains($dotNotatedProperty);
+            ->map(function ($key) use ($isANumericallyIndexedProperty) {
+                if ($isANumericallyIndexedProperty) {
+                    return $key;
+                }
+
+                return (string) Str::of($key)->before('.*');
+            })->contains($preparedProperty);
     }
 
     public function validate($rules = null, $messages = [], $attributes = [])

--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -100,8 +100,15 @@ trait ValidatesInput
     {
         // Prepare numerical-indexed properties for array attributes
         $preparedProperty = (string) Str::of($dotNotatedProperty)
-            ->replaceMatches('/(?<=(\.))\d+\./', '.*.')
-            ->replace('..', '.');
+            // Replace all numeric indexes with an array wildcard: (.0., .10., .007.) => .*.
+            // In order to match overlapping numerical indexes (foo.1.2.3.4.name),
+            // We need to use a positive look-behind, that's technically all the magic here.
+            // For better understanding, see: https://regexr.com/5d1n3
+            ->replaceMatches('/(?<=(\.))\d+\./', '*.')
+            // Replace all numeric indexes at the end of the name with an array wildcard
+            // (Same as the previous regex, but ran only at the end of the string)
+            // For better undestanding, see: https://regexr.com/5d1n6
+            ->replaceMatches('/\.\d+$/', '.*');
 
         $isANumericallyIndexedProperty = $dotNotatedProperty !== $preparedProperty;
 

--- a/tests/Unit/EloquentModelValidationTest.php
+++ b/tests/Unit/EloquentModelValidationTest.php
@@ -90,6 +90,21 @@ class EloquentModelValidationTest extends TestCase
     }
 
     /** @test */
+    public function array_index_key_model_property_validation()
+    {
+        Livewire::test(ComponentForEloquentModelHydrationMiddleware::class, [
+            'foo' => $foo = Foo::first(),
+        ])  ->set('foo.bob.0', 'b')
+            ->call('save')
+            ->assertHasErrors('foo.bob.*')
+            ->set('foo.bob', 'bbo')
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertEquals(['bbo'], $foo->fresh()->bob);
+    }
+
+    /** @test */
     public function array_wildcard_key_with_key_after_model_property_validation()
     {
         Livewire::test(ComponentForEloquentModelHydrationMiddleware::class, [


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Previously created an issue: #1667 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Straight to the neck... Ermm... Implementation...

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yup, tests where added to ensure it is not broken in the future.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Mostly, what #1667 says.

If your model contains an array of arrays on which you would like to `wire:model` a specific index, validation would fail, even if your rules are properly set as arrayable (`model.attribute.*.nested`).

This is an attempt to fix that.

5️⃣ Thanks for contributing! 🙌