### PR TITLE
Extract Dusk macros

### DIFF
--- a/src/Macros/DuskBrowserMacros.php
+++ b/src/Macros/DuskBrowserMacros.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Livewire\Macros;
+
+use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Support\Str;
+
+class DuskBrowserMacros
+{
+    public function assertAttributeMissing() {
+        function ($selector, $attribute) {
+            /** @var \Laravel\Dusk\Browser $this */
+            $fullSelector = $this->resolver->format($selector);
+
+            $actual = $this->resolver->findOrFail($selector)->getAttribute($attribute);
+
+            PHPUnit::assertNull(
+                $actual,
+                "Did not see expected attribute [{$attribute}] within element [{$fullSelector}]."
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertNotVisible() {
+        function ($selector) {
+            /** @var \Laravel\Dusk\Browser $this */
+            $fullSelector = $this->resolver->format($selector);
+
+            PHPUnit::assertFalse(
+                $this->resolver->findOrFail($selector)->isDisplayed(),
+                "Element [{$fullSelector}] is visible."
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertNotPresent() {
+        function ($selector) {
+            /** @var \Laravel\Dusk\Browser $this */
+            $fullSelector = $this->resolver->format($selector);
+
+            PHPUnit::assertTrue(
+                is_null($this->resolver->find($selector)),
+                "Element [{$fullSelector}] is present."
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertHasClass() {
+        function ($selector, $className) {
+            /** @var \Laravel\Dusk\Browser $this */
+            $fullSelector = $this->resolver->format($selector);
+
+            PHPUnit::assertContains(
+                $className,
+                explode(' ', $this->attribute($selector, 'class')),
+                "Element [{$fullSelector}] missing class [{$className}]."
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertScript() {
+        function ($js, $expects = true) {
+            /** @var \Laravel\Dusk\Browser $this */
+            PHPUnit::assertEquals($expects, head($this->script(
+                Str::start( $js, 'return ')
+            )));
+
+            return $this;
+        };
+    }
+
+    public function assertClassMissing() {
+        function ($selector, $className) {
+            /** @var \Laravel\Dusk\Browser $this */
+            $fullSelector = $this->resolver->format($selector);
+
+            PHPUnit::assertNotContains(
+                $className,
+                explode(' ', $this->attribute($selector, 'class')),
+                "Element [{$fullSelector}] has class [{$className}]."
+            );
+
+            return $this;
+        };
+    }
+
+    public function waitForLivewireToLoad() {
+        function () {
+            /** @var \Laravel\Dusk\Browser $this */
+            return $this->waitUsing(5, 75, function () {
+                return $this->driver->executeScript("return !! window.Livewire.components.initialRenderIsFinished");
+            });
+        };
+    }
+
+    public function waitForLivewire() {
+        function ($callback = null) {
+            /** @var \Laravel\Dusk\Browser $this */
+            $id = rand(100, 1000);
+
+            $this->script([
+                "window.duskIsWaitingForLivewireRequest{$id} = true",
+                "window.Livewire.hook('message.sent', () => { window.duskIsWaitingForLivewireRequest{$id} = true })",
+                "window.Livewire.hook('message.processed', () => { delete window.duskIsWaitingForLivewireRequest{$id} })",
+                "window.Livewire.hook('message.failed', () => { delete window.duskIsWaitingForLivewireRequest{$id} })",
+            ]);
+
+            if ($callback) {
+                $callback($this);
+
+                // Wait a quick sec for Livewire to hear a click and send a request.
+                $this->pause(25);
+
+                return $this->waitUsing(5, 50, function () use ($id) {
+                    return $this->driver->executeScript("return window.duskIsWaitingForLivewireRequest{$id} === undefined");
+                }, 'Livewire request was never triggered');
+            }
+
+            // If no callback is passed, make ->waitForLivewire a higher-order method.
+            return new class($this, $id) {
+                public function __construct($browser, $id) { $this->browser = $browser; $this->id = $id; }
+
+                public function __call($method, $params)
+                {
+                    return tap($this->browser->{$method}(...$params), function ($browser) {
+                        $browser->waitUsing(5, 25, function () use ($browser) {
+                            return $browser->driver->executeScript("return window.duskIsWaitingForLivewireRequest{$this->id} === undefined");
+                        }, 'Livewire request was never triggered');
+                    });
+                }
+            };
+        };
+    }
+
+    public function online() {
+        function () {
+            /** @var \Laravel\Dusk\Browser $this */
+            return tap($this)->script("window.dispatchEvent(new Event('online'))");
+        };
+    }
+
+    public function offline() {
+        function () {
+            /** @var \Laravel\Dusk\Browser $this */
+            return tap($this)->script("window.dispatchEvent(new Event('offline'))");
+        };
+    }
+}

--- a/src/Macros/DuskBrowserMacros.php
+++ b/src/Macros/DuskBrowserMacros.php
@@ -9,7 +9,7 @@ class DuskBrowserMacros
 {
     public function assertAttributeMissing()
     {
-        function ($selector, $attribute) {
+        return function ($selector, $attribute) {
             /** @var \Laravel\Dusk\Browser $this */
             $fullSelector = $this->resolver->format($selector);
 
@@ -26,7 +26,7 @@ class DuskBrowserMacros
 
     public function assertNotVisible()
     {
-        function ($selector) {
+        return function ($selector) {
             /** @var \Laravel\Dusk\Browser $this */
             $fullSelector = $this->resolver->format($selector);
 
@@ -41,7 +41,7 @@ class DuskBrowserMacros
 
     public function assertNotPresent()
     {
-        function ($selector) {
+        return function ($selector) {
             /** @var \Laravel\Dusk\Browser $this */
             $fullSelector = $this->resolver->format($selector);
 
@@ -56,7 +56,7 @@ class DuskBrowserMacros
 
     public function assertHasClass()
     {
-        function ($selector, $className) {
+        return function ($selector, $className) {
             /** @var \Laravel\Dusk\Browser $this */
             $fullSelector = $this->resolver->format($selector);
 
@@ -72,7 +72,7 @@ class DuskBrowserMacros
 
     public function assertScript()
     {
-        function ($js, $expects = true) {
+        return function ($js, $expects = true) {
             /** @var \Laravel\Dusk\Browser $this */
             PHPUnit::assertEquals($expects, head($this->script(
                 Str::start( $js, 'return ')
@@ -84,7 +84,7 @@ class DuskBrowserMacros
 
     public function assertClassMissing()
     {
-        function ($selector, $className) {
+        return function ($selector, $className) {
             /** @var \Laravel\Dusk\Browser $this */
             $fullSelector = $this->resolver->format($selector);
 
@@ -100,7 +100,7 @@ class DuskBrowserMacros
 
     public function waitForLivewireToLoad()
     {
-        function () {
+        return function () {
             /** @var \Laravel\Dusk\Browser $this */
             return $this->waitUsing(5, 75, function () {
                 return $this->driver->executeScript("return !! window.Livewire.components.initialRenderIsFinished");
@@ -110,7 +110,7 @@ class DuskBrowserMacros
 
     public function waitForLivewire()
     {
-        function ($callback = null) {
+        return function ($callback = null) {
             /** @var \Laravel\Dusk\Browser $this */
             $id = rand(100, 1000);
 
@@ -150,7 +150,7 @@ class DuskBrowserMacros
 
     public function online()
     {
-        function () {
+        return function () {
             /** @var \Laravel\Dusk\Browser $this */
             return tap($this)->script("window.dispatchEvent(new Event('online'))");
         };
@@ -158,7 +158,7 @@ class DuskBrowserMacros
 
     public function offline()
     {
-        function () {
+        return function () {
             /** @var \Laravel\Dusk\Browser $this */
             return tap($this)->script("window.dispatchEvent(new Event('offline'))");
         };

--- a/src/Macros/DuskBrowserMacros.php
+++ b/src/Macros/DuskBrowserMacros.php
@@ -7,7 +7,8 @@ use Illuminate\Support\Str;
 
 class DuskBrowserMacros
 {
-    public function assertAttributeMissing() {
+    public function assertAttributeMissing()
+    {
         function ($selector, $attribute) {
             /** @var \Laravel\Dusk\Browser $this */
             $fullSelector = $this->resolver->format($selector);
@@ -23,7 +24,8 @@ class DuskBrowserMacros
         };
     }
 
-    public function assertNotVisible() {
+    public function assertNotVisible()
+    {
         function ($selector) {
             /** @var \Laravel\Dusk\Browser $this */
             $fullSelector = $this->resolver->format($selector);
@@ -37,7 +39,8 @@ class DuskBrowserMacros
         };
     }
 
-    public function assertNotPresent() {
+    public function assertNotPresent()
+    {
         function ($selector) {
             /** @var \Laravel\Dusk\Browser $this */
             $fullSelector = $this->resolver->format($selector);
@@ -51,7 +54,8 @@ class DuskBrowserMacros
         };
     }
 
-    public function assertHasClass() {
+    public function assertHasClass()
+    {
         function ($selector, $className) {
             /** @var \Laravel\Dusk\Browser $this */
             $fullSelector = $this->resolver->format($selector);
@@ -66,7 +70,8 @@ class DuskBrowserMacros
         };
     }
 
-    public function assertScript() {
+    public function assertScript()
+    {
         function ($js, $expects = true) {
             /** @var \Laravel\Dusk\Browser $this */
             PHPUnit::assertEquals($expects, head($this->script(
@@ -77,7 +82,8 @@ class DuskBrowserMacros
         };
     }
 
-    public function assertClassMissing() {
+    public function assertClassMissing()
+    {
         function ($selector, $className) {
             /** @var \Laravel\Dusk\Browser $this */
             $fullSelector = $this->resolver->format($selector);
@@ -92,7 +98,8 @@ class DuskBrowserMacros
         };
     }
 
-    public function waitForLivewireToLoad() {
+    public function waitForLivewireToLoad()
+    {
         function () {
             /** @var \Laravel\Dusk\Browser $this */
             return $this->waitUsing(5, 75, function () {
@@ -101,7 +108,8 @@ class DuskBrowserMacros
         };
     }
 
-    public function waitForLivewire() {
+    public function waitForLivewire()
+    {
         function ($callback = null) {
             /** @var \Laravel\Dusk\Browser $this */
             $id = rand(100, 1000);
@@ -140,14 +148,16 @@ class DuskBrowserMacros
         };
     }
 
-    public function online() {
+    public function online()
+    {
         function () {
             /** @var \Laravel\Dusk\Browser $this */
             return tap($this)->script("window.dispatchEvent(new Event('online'))");
         };
     }
 
-    public function offline() {
+    public function offline()
+    {
         function () {
             /** @var \Laravel\Dusk\Browser $this */
             return tap($this)->script("window.dispatchEvent(new Event('offline'))");

--- a/tests/Browser/TestCase.php
+++ b/tests/Browser/TestCase.php
@@ -27,7 +27,7 @@ class TestCase extends BaseTestCase
             DuskOptions::withoutUI();
         }
 
-        Browser::mixin(DuskBrowserMacros::class);
+        Browser::mixin(new DuskBrowserMacros);
 
         $this->afterApplicationCreated(function () {
             $this->makeACleanSlate();

--- a/tests/Browser/TestCase.php
+++ b/tests/Browser/TestCase.php
@@ -7,15 +7,14 @@ use Exception;
 use Psy\Shell;
 use Throwable;
 use Laravel\Dusk\Browser;
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 use Livewire\LivewireServiceProvider;
 use Illuminate\Support\Facades\Artisan;
-use PHPUnit\Framework\Assert as PHPUnit;
 use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Livewire\Macros\DuskBrowserMacros;
 use Orchestra\Testbench\Dusk\Options as DuskOptions;
 use Orchestra\Testbench\Dusk\TestCase as BaseTestCase;
 
@@ -28,7 +27,7 @@ class TestCase extends BaseTestCase
             DuskOptions::withoutUI();
         }
 
-        $this->registerMacros();
+        Browser::mixin(DuskBrowserMacros::class);
 
         $this->afterApplicationCreated(function () {
             $this->makeACleanSlate();
@@ -169,128 +168,6 @@ class TestCase extends BaseTestCase
     protected function livewireViewsPath($path = '')
     {
         return resource_path('views').'/livewire'.($path ? '/'.$path : '');
-    }
-
-    protected function registerMacros()
-    {
-        Browser::macro('assertAttributeMissing', function ($selector, $attribute) {
-            $fullSelector = $this->resolver->format($selector);
-
-            $actual = $this->resolver->findOrFail($selector)->getAttribute($attribute);
-
-            PHPUnit::assertNull(
-                $actual,
-                "Did not see expected attribute [{$attribute}] within element [{$fullSelector}]."
-            );
-
-            return $this;
-        });
-
-        Browser::macro('assertNotVisible', function ($selector) {
-            $fullSelector = $this->resolver->format($selector);
-
-            PHPUnit::assertFalse(
-                $this->resolver->findOrFail($selector)->isDisplayed(),
-                "Element [{$fullSelector}] is visible."
-            );
-
-            return $this;
-        });
-
-        Browser::macro('assertNotPresent', function ($selector) {
-            $fullSelector = $this->resolver->format($selector);
-
-            PHPUnit::assertTrue(
-                is_null($this->resolver->find($selector)),
-                "Element [{$fullSelector}] is present."
-            );
-
-            return $this;
-        });
-
-        Browser::macro('assertHasClass', function ($selector, $className) {
-            /** @var \Laravel\Dusk\Browser $this */
-            $fullSelector = $this->resolver->format($selector);
-
-            PHPUnit::assertContains(
-                $className,
-                explode(' ', $this->attribute($selector, 'class')),
-                "Element [{$fullSelector}] missing class [{$className}]."
-            );
-
-            return $this;
-        });
-
-        Browser::macro('assertScript', function ($js, $expects = true) {
-            PHPUnit::assertEquals($expects, head($this->script(
-                Str::start( $js, 'return ')
-            )));
-
-            return $this;
-        });
-
-        Browser::macro('assertClassMissing', function ($selector, $className) {
-            /** @var \Laravel\Dusk\Browser $this */
-            $fullSelector = $this->resolver->format($selector);
-
-            PHPUnit::assertNotContains(
-                $className,
-                explode(' ', $this->attribute($selector, 'class')),
-                "Element [{$fullSelector}] has class [{$className}]."
-            );
-
-            return $this;
-        });
-
-        Browser::macro('waitForLivewireToLoad', function () {
-            return $this->waitUsing(5, 75, function () {
-                return $this->driver->executeScript("return !! window.Livewire.components.initialRenderIsFinished");
-            });
-        });
-
-        Browser::macro('waitForLivewire', function ($callback = null) {
-            $id = rand(100, 1000);
-
-            $this->script([
-                "window.duskIsWaitingForLivewireRequest{$id} = true",
-                "window.Livewire.hook('message.sent', () => { window.duskIsWaitingForLivewireRequest{$id} = true })",
-                "window.Livewire.hook('message.processed', () => { delete window.duskIsWaitingForLivewireRequest{$id} })",
-                "window.Livewire.hook('message.failed', () => { delete window.duskIsWaitingForLivewireRequest{$id} })",
-            ]);
-
-            if ($callback) {
-                $callback($this);
-
-                // Wait a quick sec for Livewire to hear a click and send a request.
-                $this->pause(25);
-
-                return $this->waitUsing(5, 50, function () use ($id) {
-                    return $this->driver->executeScript("return window.duskIsWaitingForLivewireRequest{$id} === undefined");
-                }, 'Livewire request was never triggered');
-            }
-
-            // If no callback is passed, make ->waitForLivewire a higher-order method.
-            return new class($this, $id) {
-                public function __construct($browser, $id) { $this->browser = $browser; $this->id = $id; }
-
-                public function __call($method, $params)
-                {
-                    return tap($this->browser->{$method}(...$params), function ($browser) {
-                        $browser->waitUsing(5, 25, function () use ($browser) {
-                            return $browser->driver->executeScript("return window.duskIsWaitingForLivewireRequest{$this->id} === undefined");
-                        }, 'Livewire request was never triggered');
-                    });
-                }
-            };
-        });
-
-        Browser::macro('online', function () {
-            return tap($this)->script("window.dispatchEvent(new Event('online'))");
-        });
-
-        Browser::macro('offline', function () {
-            return tap($this)->script("window.dispatchEvent(new Event('offline'))");
-        });
     }
 
     protected function driver(): RemoteWebDriver


### PR DESCRIPTION
**This pull request just pulls the macros for the `Laravel\Dusk\Browser` class out into its own mixin class.**

The reason for this is that these macro functions would be extremely handy to use in our own applications that use Livewire and need Dusk testing. With this change, we could easily register the mixins (or individual macros from it) into our own tests as needed.

The `Livewire::test()` utility is nice for testing backend logic, but when we have increasingly complex frontends with a mix of Alpine and other stuff happening on the frontend, Dusk still serves a good purpose in testing our own apps - and having access to some of these more complex test methods like `waitForLivewire()` would help make testing using Dusk a lot easier.