### PR TITLE
feature(add new redirecting hook)

### DIFF
--- a/js/HookManager.js
+++ b/js/HookManager.js
@@ -14,6 +14,7 @@ export default {
         'message.failed',
         'message.received',
         'message.processed',
+        'redirecting',
 
         /**
          * Private Hooks
@@ -35,6 +36,6 @@ export default {
     },
 
     call(name, ...params) {
-        this.bus.call(name, ...params)
+        return this.bus.call(name, ...params)
     },
 }

--- a/js/MessageBus.js
+++ b/js/MessageBus.js
@@ -13,9 +13,13 @@ export default class MessageBus {
     }
 
     call(name, ...params) {
+        let result = true
+
         (this.listeners[name] || []).forEach(callback => {
-            callback(...params)
+            result = !! callback(...params)
         })
+
+        return result
     }
 
     has(name) {

--- a/js/Store.js
+++ b/js/Store.js
@@ -117,7 +117,7 @@ const store = {
     },
 
     callHook(name, ...params) {
-        this.hooks.call(name, ...params)
+        return this.hooks.call(name, ...params)
     },
 
     changeComponentId(component, newId) {

--- a/js/component/index.js
+++ b/js/component/index.js
@@ -255,9 +255,7 @@ export default class Component {
         store.callHook('message.received', message, this)
 
         // This means "$this->redirect()" was called in the component. let's just bail and redirect.
-        if (response.effects.redirect) {
-            this.redirect(response.effects.redirect)
-
+        if (response.effects.redirect && this.redirect(response.effects.redirect)) {
             return
         }
 
@@ -314,16 +312,21 @@ export default class Component {
             }
         }
 
-
         store.callHook('message.processed', message, this)
     }
 
     redirect(url) {
+        if (! store.callHook('redirecting', url, this)) {
+            return false
+        }
+
         if (window.Turbolinks && window.Turbolinks.supported) {
             window.Turbolinks.visit(url)
         } else {
             window.location.href = url
         }
+
+        return true
     }
 
     forceRefreshDataBoundElementsMarkedAsDirty(dirtyInputs) {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

I didn't create an issue or discussion, but I think this could be helpful.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Pending!

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

This PR adds a new `redirecting` hook that is run / checked when the `redirect(url)` method is called. This new hook has a return value of true or false.

If the return value is false, then the redirect never actually happens. This will allow you to hook into the redirecting process from JavaScript and cancel a redirect from the server response.

This also has some changes for hook callbacks, where the return value of a callback is returning from `HookManager.call()`.

5️⃣ Thanks for contributing! 🙌