### PR TITLE
fix(using property.match when property is not always string)

### DIFF
--- a/js/component/index.js
+++ b/js/component/index.js
@@ -645,7 +645,7 @@ export default class Component {
                 if (property === '__instance') return component
 
                 // Forward "emits" to base Livewire object.
-                if (property.match(/^emit.*/)) return function (...args) {
+                if (typeof property === 'string' && property.match(/^emit.*/)) return function (...args) {
                     if (property === 'emitSelf') return store.emitSelf(component.id, ...args)
 
                     return store[property].apply(component, args)


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

This is actually a bug I encountered whilst trying to loop over `window.Livewire.all()`.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

The `$wire` Proxy assumes that `property` is a string and will try to call `property.match`. In some cases though, `property` might not be a string and could actually be a `Symbol` or similar.

I experience this in Firefox whilst trying to `console.log(window.Livewire.all())`, but have also reproduced in Chrome.

5️⃣ Thanks for contributing! 🙌