### PR TITLE
Added flags for type checking set/not-set on TestableLivewire

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -11,12 +11,16 @@ use PHPUnit\Framework\Assert as PHPUnit;
 
 trait MakesAssertions
 {
-    public function assertSet($name, $value)
+    public function assertSet($name, $value, $same = false)
     {
         if (is_callable($value)) {
             PHPUnit::assertTrue($value($this->get($name)));
         } else {
-            PHPUnit::assertEquals($value, $this->get($name));
+            if ($same) {
+                PHPUnit::assertSame($value, $this->get($name));
+            } else {
+                PHPUnit::assertEquals($value, $this->get($name));
+            }
         }
 
         return $this;

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -11,12 +11,12 @@ use PHPUnit\Framework\Assert as PHPUnit;
 
 trait MakesAssertions
 {
-    public function assertSet($name, $value, $same = false)
+    public function assertSet($name, $value, $assertSame = false)
     {
         if (is_callable($value)) {
             PHPUnit::assertTrue($value($this->get($name)));
         } else {
-            if ($same) {
+            if ($assertSame) {
                 PHPUnit::assertSame($value, $this->get($name));
             } else {
                 PHPUnit::assertEquals($value, $this->get($name));
@@ -26,9 +26,13 @@ trait MakesAssertions
         return $this;
     }
 
-    public function assertNotSet($name, $value)
+    public function assertNotSet($name, $value, $assertNotSame = false)
     {
-        PHPUnit::assertNotEquals($value, $this->get($name));
+        if ($assertNotSame) {
+            PHPUnit::assertNotSame($value, $this->get($name));
+        } else {
+            PHPUnit::assertNotEquals($value, $this->get($name));
+        }
 
         return $this;
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
No previous discussion nor issue, just something I've been looking for for quite some time

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Single feature

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
I don't think there are tests for the "test" definitions, but correct me if I'm wrong.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
The `TestableLivewire` is the founding block for component testing, and it has two basic assertions: `assertSet()` and `assertNotSet`.

These two assertions use [PHPUnit's `assertEquals()`](https://phpunit.readthedocs.io/en/9.3/assertions.html#assertequals), which helps to determine if a certain value is properly assigned to a given property. However, `assertEquals()` doesn't test for type matching, it just test for value equality.

[As mentioned in PHP's Documentation](https://www.php.net/manual/en/language.operators.comparison.php#language.operators.comparison), some fun things may happen if you only rely on value equality, when you should be looking for both, value and type equality. This is however not always the case, and some developers may not always need type-checking.

Instead creating new `assertSameType()` and `assertNotSameType()` functions, we could just introduce an optional flag in the existing functions to switch from `assertEquals()` to [`assertSame()`](https://phpunit.readthedocs.io/en/9.3/assertions.html#assertsame).

This would be a backwards-compatible change, since it'll default to use `assertEquals()`, and still allow type testing when needed.

5️⃣ Thanks for contributing! 🙌