### PR TITLE
Fix app/asset URL usage

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -31,18 +31,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Livewire Assets URL
+    | Livewire App URL
     |--------------------------------------------------------------------------
     |
-    | This value sets the path to Livewire JavaScript assets, for cases where
-    | your app's domain root is not the correct path. By default, Livewire
-    | will load its JavaScript assets from the app's "relative root".
+    | This value sets the path to your Laravel app, for cases where
+    | your app's domain root is not the correct path. It's used by Livewire's
+    | JavaScript portion when communicating with the server. By default, Livewire
+    | will use the "relative root" ("/") to set up AJAX request paths.
     |
-    | Examples: "/assets", "myurl.com/app".
+    | Examples: "/app", "myurl.com/app".
     |
     */
 
-    'asset_url'  => null,
+    'app_url'  => null,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -165,7 +165,8 @@ HTML;
     {
         $jsonEncodedOptions = $options ? json_encode($options) : '';
 
-        $appUrl = config('livewire.asset_url', rtrim($options['asset_url'] ?? '', '/'));
+        $appUrl = rtrim($options['app_url'] ?? config('livewire.app_url'), '/');
+        $assetUrl = rtrim(config('app.asset_url') ?? '', '/');
 
         $csrf = csrf_token();
 
@@ -181,7 +182,7 @@ HTML;
             $publishedManifest = json_decode(file_get_contents(public_path('vendor/livewire/manifest.json')), true);
             $versionedFileName = $publishedManifest['/livewire.js'];
 
-            $fullAssetPath = ($this->isOnVapor() ? config('app.asset_url') : $appUrl).'/vendor/livewire'.$versionedFileName;
+            $fullAssetPath = $assetUrl.'/vendor/livewire'.$versionedFileName;
 
             if ($manifest !== $publishedManifest) {
                 $assetWarning = <<<'HTML'


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Yes, see https://github.com/livewire/livewire/issues/1662. Note that https://github.com/livewire/livewire/discussions/1674 would also benefit from this, although this PR does not directly related to the proposal there.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

It does :)

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Please see https://github.com/livewire/livewire/issues/1662. The way Livewire currently uses the `asset_url` config value breaks Livewire under certain circumstances (see issue for more details). Given that `asset_url` is _not_ used for serving (static, published) assets at all, but rather for determining the path to LW routes on the frontend, the key naming is also misleading.

Note that this PR only handles the asset/app URL handling reported in #1662, it does not handle tmp files/bootstrapping mentioned in the original issue.

Consider this PR a proposed fix - I'm happy to change the implementation, so long it addresses the underlying issue.

### Changes
* Rename `livewire.asset_url` to `livewire.app_url`. 
* Always use `app.asset_url` when serving published assets, regardless if on Vapor or not
* Add tests to ensure the above scenarios work

### Other considerations

**`app.url` vs `livewire.app_url`**

I initially wanted to do away with the Livewire-specific app URL configuration value entirely, because we already have `config('app.url')` (set by `APP_URL` ENV variable) available. However:
* if the APP_URL is not correctly set, it might break existing installations (although [you should always set the APP_URL](https://quickadminpanel.com/blog/why-its-important-to-change-app_url-in-laravel-env-file/))
* even if `APP_URL` is correctly set, it may not work in a multi-tenant app with different subdomains, where the `APP_URL` points to the main domain, but livewire is only available on a specific subdomain

Then again, Laravel expects the `APP_URL` to be correctly set when you're using CLI, emails, etc anyway, so I'd be happy to remove the LW config value and simply use `APP_URL`.

**Deprecating `asset_url`**

This PR might be a breaking change for some sites (depending on their setup), so we might want to soft-deprecate the `asset_url` option instead of outright removing/renaming it and issue console warnings if it's still used?

5️⃣ Thanks for contributing! 🙌