### PR TITLE
Allow customizing livewire route prefix

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -31,6 +31,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Livewire Route Prefix
+    |--------------------------------------------------------------------------
+    |
+    | This value sets the prefix for Livewire routes, for cases where
+    | you need to customize where livewire mounts it's routes. By default, Livewire
+    | will prefix its routes with "/livewire".
+    |
+    | Examples: "/livewire", "/{tenant}/livewire".
+    |
+    */
+
+    'route_prefix'  => '/livewire',
+
+    /*
+    |--------------------------------------------------------------------------
     | Livewire Assets URL
     |--------------------------------------------------------------------------
     |

--- a/js/connection/index.js
+++ b/js/connection/index.js
@@ -22,7 +22,7 @@ export default class Connection {
 
         // Forward the query string for the ajax requests.
         fetch(
-            `${window.livewire_app_url}/livewire/message/${payload.fingerprint.name}`,
+            `${window.livewire_app_url}${window.livewire_prefix}/message/${payload.fingerprint.name}`,
             {
                 method: 'POST',
                 body: JSON.stringify(payload),

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -166,6 +166,7 @@ HTML;
         $jsonEncodedOptions = $options ? json_encode($options) : '';
 
         $appUrl = config('livewire.asset_url', rtrim($options['asset_url'] ?? '', '/'));
+        $prefix = rtrim(route('livewire.base', null, false), '/');
 
         $csrf = csrf_token();
 
@@ -173,7 +174,7 @@ HTML;
         $versionedFileName = $manifest['/livewire.js'];
 
         // Default to dynamic `livewire.js` (served by a Laravel route).
-        $fullAssetPath = "{$appUrl}/livewire{$versionedFileName}";
+        $fullAssetPath = $appUrl . $prefix . $versionedFileName;
         $assetWarning = null;
 
         // Use static assets if they have been published
@@ -207,6 +208,7 @@ HTML;
     window.livewire = new Livewire({$jsonEncodedOptions});
     window.Livewire = window.livewire;
     window.livewire_app_url = '{$appUrl}';
+    window.livewire_prefix = '{$prefix}';
     window.livewire_token = '{$csrf}';
 
     /* Make Alpine wait until Livewire is finished rendering to do its thing. */

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -126,19 +126,23 @@ class LivewireServiceProvider extends ServiceProvider
             })->middleware('web');
         }
 
-        RouteFacade::get('/livewire/livewire.js', [LivewireJavaScriptAssets::class, 'source']);
-        RouteFacade::get('/livewire/livewire.js.map', [LivewireJavaScriptAssets::class, 'maps']);
+        RouteFacade::prefix(config('livewire.route_prefix', '/livewire'))->group(function () {
+            RouteFacade::get('/livewire.js', [LivewireJavaScriptAssets::class, 'source']);
+            RouteFacade::get('/livewire.js.map', [LivewireJavaScriptAssets::class, 'maps']);
 
-        RouteFacade::post('/livewire/message/{name}', HttpConnectionHandler::class)
-            ->middleware(config('livewire.middleware_group', 'web'));
+            RouteFacade::get('/')->name('livewire.base');
 
-        RouteFacade::post('/livewire/upload-file', [FileUploadHandler::class, 'handle'])
-            ->middleware(config('livewire.middleware_group', 'web'))
-            ->name('livewire.upload-file');
+            RouteFacade::post('/message/{name}', HttpConnectionHandler::class)
+                    ->middleware(config('livewire.middleware_group', 'web'));
 
-        RouteFacade::get('/livewire/preview-file/{filename}', [FilePreviewHandler::class, 'handle'])
-            ->middleware(config('livewire.middleware_group', 'web'))
-            ->name('livewire.preview-file');
+            RouteFacade::post('/upload-file', [FileUploadHandler::class, 'handle'])
+                    ->middleware(config('livewire.middleware_group', 'web'))
+                    ->name('livewire.upload-file');
+
+            RouteFacade::get('/preview-file/{filename}', [FilePreviewHandler::class, 'handle'])
+                    ->middleware(config('livewire.middleware_group', 'web'))
+                    ->name('livewire.preview-file');
+        });
     }
 
     protected function registerCommands()

--- a/tests/Unit/LivewireRoutePrefixTest.php
+++ b/tests/Unit/LivewireRoutePrefixTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Livewire;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\Artisan;
+
+class LivewireRoutePrefixTest extends TestCase
+{
+    public function setUp(): void
+    {
+        // Before the application is created, config() is not available. After it's created,
+        // routes are already registered, so it's too late to use config().
+        // Instead, we'll need to manually "publish" the config file so Laravel picks it up automatically
+        $this->configFilePath = 'vendor/orchestra/testbench-core/laravel/config/livewire.php';
+
+        $config = Str::replaceFirst(
+            "'route_prefix'  => '/livewire'",
+            "'route_prefix'  => '/{tenant}/foo'",
+            file_get_contents('config/livewire.php')
+        );
+
+        file_put_contents($this->configFilePath, $config);
+
+        parent::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        // lets' make sure to clean up the configuration file afterwards
+        unlink($this->configFilePath);
+    }
+
+    /** @test */
+    public function livewire_prefix_can_be_customized()
+    {
+        // Set a default so that the route param does not need to be passed to the `route()` helper.
+        // In a real application, this would need to be done anyway.
+        URL::defaults(['tenant' => 'acme']);
+
+        $this->assertEquals('/acme/foo', route('livewire.base', null, false));
+
+        $this->assertStringContainsString(
+            '<script src="/acme/foo/livewire.js?',
+            Livewire::scripts()
+        );
+
+        $this->assertStringContainsString(
+            "window.livewire_prefix = '/acme/foo';",
+            Livewire::scripts()
+        );
+    }
+}


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Yes. See https://github.com/livewire/livewire/discussions/1674

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

It sure does

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

This makes possible to identify a tenant on livewire routes in a multi-tenant app using path identification. Consider `example.com/{tenant}/livewire/message` - if the middleware group includes tenant identification, there's no need to identify the tenant in each individual livewire component. The app would need to provide a default value for the `{tenant}` param, but that's expected in such a scenario anyway.

It also makes it possible to simply adjust the livewire route namespace/prefix. Ie use `foo/message` instead of `livewire/message`. Given that this prefix is somewhat internal, I'd be happy remove this possibility and simply allow adding an additional prefix to `/livewire`, so you'd have `/foo/livewire/message`

Note: if https://github.com/livewire/livewire/pull/1693gets merged, this PR might need to be refactored a bit.

5️⃣ Thanks for contributing! 🙌