### PR TITLE
Add missing dusk tests for wire:loading.delay

### DIFF
--- a/tests/Browser/Loading/Test.php
+++ b/tests/Browser/Loading/Test.php
@@ -36,6 +36,22 @@ class Test extends TestCase
                 })
                 ->tap($this->assertInitialState())
                 ->waitForLivewire(function (Browser $browser) {
+                    $browser->click('@button');
+
+                    $browser->pause(100);
+
+                    $browser->assertNotVisible('@show-w-delay');
+                })
+                ->tap($this->assertInitialState())
+                ->waitForLivewire(function (Browser $browser) {
+                    $browser->click('@button');
+
+                    $browser->pause(200);
+
+                    $browser->assertVisible('@show-w-delay');
+                })
+                ->tap($this->assertInitialState())
+                ->waitForLivewire(function (Browser $browser) {
                     $browser->click('@target-button');
 
                     $browser->waitFor('@targeting');
@@ -77,6 +93,8 @@ class Test extends TestCase
         return function (Browser $browser) {
             $browser->assertNotVisible('@show');
             $browser->assertVisible('@hide');
+
+            $browser->assertNotVisible('@show-w-delay');
 
             $browser->assertAttribute('@add-class', 'class', '');
             $browser->assertAttribute('@remove-class', 'class', 'foo');

--- a/tests/Browser/Loading/view.blade.php
+++ b/tests/Browser/Loading/view.blade.php
@@ -17,6 +17,8 @@
     <h1 wire:loading wire:target="foo" dusk="targeting">Loading...</h1>
     <h1 wire:loading wire:target="foo, bar" dusk="targeting-both">Loading...</h1>
 
+    <h1 wire:loading.delay dusk="show-w-delay">Loading with delay...</h1>
+
     <button wire:click="foo" dusk="target-button">targeted button</button>
     <button wire:click="foo('bar')" dusk="target-button-w-param">targeted button with param</button>
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yes: https://github.com/livewire/livewire/issues/1698

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Add missing dusk tests for `wire:loading.delay` directive.

5️⃣ Thanks for contributing! 🙌