### PR TITLE
Allow DI for computed properties

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -212,7 +212,7 @@ abstract class Component
                 return $this->computedPropertyCache[$property];
             }
 
-            return $this->computedPropertyCache[$property] = $this->$computedMethodName();
+            return $this->computedPropertyCache[$property] = app()->call([$this, $computedMethodName]);
         }
 
         throw new \Exception("Property [{$property}] does not exist on the {$this::getName()} component.");

--- a/tests/Unit/ComputedPropertiesTest.php
+++ b/tests/Unit/ComputedPropertiesTest.php
@@ -15,6 +15,13 @@ class ComputedPropertiesTest extends TestCase
     }
 
     /** @test */
+    public function injected_computed_property_is_accessable_within_blade_view()
+    {
+        Livewire::test(InjectedComputedPropertyStub::class)
+            ->assertSee('bar');
+    }
+
+    /** @test */
     public function computed_property_is_memoized_after_its_accessed()
     {
         Livewire::test(MemoizedComputedPropertyStub::class)
@@ -46,6 +53,23 @@ class ComputedPropertyStub extends Component
     public function getFooBarProperty()
     {
         return strtolower($this->upperCasedFoo);
+    }
+
+    public function render()
+    {
+        return view('var-dump-foo-bar');
+    }
+}
+
+class Foo {
+    public $baz = 'bar';
+}
+
+class InjectedComputedPropertyStub extends Component
+{
+    public function getFooBarProperty(Foo $foo)
+    {
+        return $foo->baz;
     }
 
     public function render()

--- a/tests/Unit/ComputedPropertiesTest.php
+++ b/tests/Unit/ComputedPropertiesTest.php
@@ -61,13 +61,13 @@ class ComputedPropertyStub extends Component
     }
 }
 
-class Foo {
+class FooDependency {
     public $baz = 'bar';
 }
 
 class InjectedComputedPropertyStub extends Component
 {
-    public function getFooBarProperty(Foo $foo)
+    public function getFooBarProperty(FooDependency $foo)
     {
         return $foo->baz;
     }

--- a/tests/Unit/TestableLivewireCanAssertPropertiesTest.php
+++ b/tests/Unit/TestableLivewireCanAssertPropertiesTest.php
@@ -54,7 +54,7 @@ class PropertyTestingComponent extends Component
     public $foo = 'bar';
     public $model;
 
-    protected function getBobProperty()
+    public function getBobProperty()
     {
         return 'lob';
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Wanted. No issue / discussion first. 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Yes

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

This change will allow dependencies to be injected into computed property methods. This is useful if the computed property requires another class to return a result. A common example would be a Repository class..

```php
public function getAccountsProperty(AccountsRepo $repo) {
    return $repo->all();
}
```

5️⃣ Thanks for contributing! 🙌