### PR TITLE
Add ability to setup default Component property values with the use of a "created()" method

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -37,8 +37,8 @@ abstract class Component
         $this->ensureIdPropertyIsntOverridden();
 
         if (method_exists($this, 'created')) {
-            // At this point, the component's traits have been initialized,
-            // but neither Request Data nor Property Bindings have been executed.
+            // At this point, the component has been created,
+            // but neither Request Data, Property Bindings, nor Traits have been done.
             // This is intended for assigning default values to mission-critical properties,
             // or class-based properties, like Collections or Models, since in PHP you can't
             // create classes nor call functions inline when defining class properties)

--- a/src/Component.php
+++ b/src/Component.php
@@ -36,6 +36,15 @@ abstract class Component
 
         $this->ensureIdPropertyIsntOverridden();
 
+        if (method_exists($this, 'created')) {
+            // At this point, the component's traits have been initialized,
+            // but neither Request Data nor Property Bindings have been executed.
+            // This is intended for assigning default values to mission-critical properties,
+            // or class-based properties, like Collections or Models, since in PHP you can't
+            // create classes nor call functions inline when defining class properties)
+            $this->created();
+        }
+
         $this->initializeTraits();
     }
 
@@ -221,7 +230,7 @@ abstract class Component
     public function __call($method, $params)
     {
         if (
-            in_array($method, ['mount', 'hydrate', 'dehydrate', 'updating', 'updated'])
+            in_array($method, ['created', 'mount', 'hydrate', 'dehydrate', 'updating', 'updated'])
             || Str::startsWith($method, ['updating', 'updated', 'hydrate', 'dehydrate'])
         ) {
             // Eat calls to the lifecycle hooks if the dev didn't define them.

--- a/tests/Unit/ComponentCreatedTest.php
+++ b/tests/Unit/ComponentCreatedTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class ComponentCreatedTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('dummy_models', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /** @test */
+    public function default_property_values_are_assigned_on_component_creation_and_used_during_mount()
+    {
+        Livewire::test(ComponentWithCreatedMethod::class)
+            ->assertSet('foo', 'bar')
+            ->assertSet('dummy.name', 'My Named Dummy');
+    }
+
+    /** @test */
+    public function property_values_from_created_are_replicated_on_component_reset_but_mount_is_not_called()
+    {
+        Livewire::test(ComponentWithCreatedMethod::class)
+            ->set('foo', 'bob')
+            ->assertSet('dummy.name', 'My Named Dummy')
+            ->call('resetAction')
+            ->assertSet('foo', 'bar')
+            ->assertSet('dummy.name', null);
+    }
+
+    /** @test */
+    public function ensure_created_method_cant_be_called_as_an_action()
+    {
+        Livewire::test(ComponentWithCreatedMethod::class)
+            ->set('dummy.name', 'Best Dummy Ever')
+            ->call('created')
+            ->assertSet('dummy.name', 'Best Dummy Ever');
+    }
+}
+
+class DummyModel extends Model
+{
+    protected $connection = 'testbench';
+    protected $guarded = false;
+}
+
+class ComponentWithCreatedMethod extends Component
+{
+    public $foo = 'bar';
+
+    public $dummy;
+
+    protected $rules = [
+        'foo' => ['required'],
+        'dummy.name' => ['required']
+    ];
+
+    public function created()
+    {
+        if (!isset($this->foo)) {
+            // This shouldn't be reached.
+            $this->foo = 'baz';
+        }
+
+        if (!isset($this->dummy)) {
+            $this->dummy = DummyModel::make();
+        }
+    }
+
+    public function mount()
+    {
+        if (!isset($this->foo)) {
+            // This shouldn't be reached.
+            $this->foo = 'zap';
+        }
+
+        $this->dummy->name = 'My Named Dummy';
+    }
+
+    public function resetAction()
+    {
+        parent::reset();
+    }
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}

--- a/tests/Unit/LifecycleHooksTest.php
+++ b/tests/Unit/LifecycleHooksTest.php
@@ -9,11 +9,35 @@ use PHPUnit\Framework\Assert as PHPUnit;
 class LifecycleHooksTest extends TestCase
 {
     /** @test */
+    public function created_hook()
+    {
+        $component = Livewire::test(ForLifecycleHooks::class);
+
+        $this->assertEquals([
+            'created' => true,
+            'mount' => true,
+            'hydrate' => false,
+            'hydrateFoo' => false,
+            'dehydrate' => true,
+            'dehydrateFoo' => true,
+            'updating' => false,
+            'updated' => false,
+            'updatingFoo' => false,
+            'updatedFoo' => false,
+            'updatingBar' => false,
+            'updatingBarBaz' => false,
+            'updatedBar' => false,
+            'updatedBarBaz' => false,
+        ], $component->lifecycles);
+    }
+
+    /** @test */
     public function mount_hook()
     {
         $component = Livewire::test(ForLifecycleHooks::class);
 
         $this->assertEquals([
+            'created' => true,
             'mount' => true,
             'hydrate' => false,
             'hydrateFoo' => false,
@@ -38,6 +62,7 @@ class LifecycleHooksTest extends TestCase
         $component->call('$refresh');
 
         $this->assertEquals([
+            'created' => true,
             'mount' => true,
             'hydrate' => true,
             'hydrateFoo' => true,
@@ -72,6 +97,7 @@ class LifecycleHooksTest extends TestCase
 
 
         $this->assertEquals([
+            'created' => true,
             'mount' => true,
             'hydrate' => true,
             'hydrateFoo' => true,
@@ -123,6 +149,7 @@ class LifecycleHooksTest extends TestCase
         $component->updateProperty('bar.cocktail.soft', 'Shirley Cumin');
 
         $this->assertEquals([
+            'created' => true,
             'mount' => true,
             'hydrate' => true,
             'hydrateFoo' => true,
@@ -168,6 +195,7 @@ class LifecycleHooksTest extends TestCase
         $component->set('bar.baz', 'bop');
 
         $this->assertEquals([
+            'created' => true,
             'mount' => true,
             'hydrate' => true,
             'hydrateFoo' => true,
@@ -203,6 +231,7 @@ class LifecycleHooksTest extends TestCase
         $component->call('$set', 'foo', 'bar');
 
         $this->assertEquals([
+            'created' => true,
             'mount' => true,
             'hydrate' => true,
             'hydrateFoo' => true,
@@ -231,6 +260,7 @@ class ForLifecycleHooks extends Component
     public $expected;
 
     public $lifecycles = [
+        'created' => false,
         'mount' => false,
         'hydrate' => false,
         'hydrateFoo' => false,
@@ -245,6 +275,11 @@ class ForLifecycleHooks extends Component
         'updatedBar' => false,
         'updatedBarBaz' => false,
     ];
+
+    public function created()
+    {
+        $this->lifecycles['created'] = true;
+    }
 
     public function mount(array $expected = [])
     {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
There haven't been any discussions for this type of feature, but there has been some cases in which I stumbled upon needing this feature.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Single feature implementation

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yup, all :green_circle: as it should be :) Also, added related tests on the `LifecycleHookTest` suite.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
So, the reason for this PR is to introduce the ability to have a `created` method for Livewire\Component clases, which allows developers to configure their components every time they're called, independently from the context (First render or Property Updating).

This feature is based on [Vuejs' `created` lifecycle hook](https://vuejs.org/v2/api/#created).

In order to assign default property values in a component, a developer may need to define values "inline" with the property definition, or use the `mount` method to do so. But this is not a bulletproof way to do so, since you can't call functions nor create classes "inline" with property definitions, and `mount` will only be called the first time the component is rendered, not after subsequent requests.

So, with this in mind, the `created` method would come in handy. It'll be called every time a component is instantiated, without needing to override the `__construct()` method, and will help to not have to override the `reset()` method either whenever a component is able to be reset. Also, developers will be able to assign class-based values to their components, and would not need to have to do so twice: once in a `mount()` method and once in the `reset()` action. It'll all be down to a single `created()` method.

I'll try to illustrate in code a simple case, which may not be as error-prone in PHP 7.3, but starting with PHP 7.4, things start to break immediately.

Consider the following code:
```php
class MyComponent extends Livewire\Component
{
    public User $user;

    public function mount()
    {
        if (!isset($this->user)) {
            $this->user = User::make();
        }
    }

    public function resetComponent()
    {
        $this->reset();
    }
}
```
Our default class for `$user` is an empty model, and we can call for a _component reset_, so we would get a new instance of our `$user` class. Under the hood, this will try to access "$freshInstance->user" from Livewire's default `reset()` function, which is the most logical way and it is _OK_ in **PHP 7.3**, but it'll be assigned to null instead of our intended default class, so this is not _good_ at all. However, in **PHP 7.4**, this will directly result in a Fatal error, because we're trying to access an "uninitialized" typed property, which is even worse.

So, a way to mitigate this issue is to either duplicate the `mount()` method into the `resetComponent()` method, or reference one to the other:
```php
class MyComponent extends Livewire\Component
{
    public User $user;

    public function mount()
    {
        $this->resetComponent();
    }

    public function resetComponent()
    {
        if (!isset($this->user)) {
            $this->user = User::make();
        }
    }
}
```
This would work "great", however, there's still noise in the component, since we need our `mount()` function to call the `resetComponent()` every time, and that type of spaghetti-boilerplate may not be needed at all.

We can solve this specific case using a `created()` method, which will keep our code simple to the eye, and not having to reference functions one to another, since it'll not be needed:

```php
class MyComponent extends Livewire\Component
{
    public User $user;

    public function created()
    {
        if (!isset($this->user)) {
            $this->user = User::make();
        }
    }

    public function resetComponent()
    {
        $this->reset();
    }
}
```
Now, we're back to our first implementation, but using `create()` instead of `mount()`. Now, when calling `resetComponent`, in both **PHP 7.3** and in **PHP 7.4** the new component will have a fresh User model in the respective property, keeping out the `null` value in 7.3, and the _Uninitialized_ error in 7.4.

I hope the intended use case is clear enough. If not, I'll be happy to keep thinking of useful use cases :smile:.

5️⃣ Thanks for contributing! 🙌