### PR TITLE
Fix dehydrate using Collections

### DIFF
--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -106,9 +106,12 @@ class HydratePublicProperties implements HydrationMiddleware
 
         // Deserialize the models into the "meta" bag.
         data_set($response, 'memo.dataMeta.models.'.$property, $serializedModel);
-
         $modelData = [];
-        if ($rules = $instance->rulesForModel($property)) {
+        if (data_get($instance, $property) instanceof Collection) {
+            $modelData = data_get($instance, $property)->map(function ($item) {
+                return $item->toArray();
+            });
+        } elseif ($rules = $instance->rulesForModel($property)) {
             $keys = $rules->keys()->map(function ($key) use ($instance) {
                 return $instance->beforeFirstDot($instance->afterFirstDot($key));
             });


### PR DESCRIPTION
Issue related: #1585 

From Livewire 2.2.2 there is a problem to dehydrate Collection. For example, if you follow the code like so:
```php
namespace App\Http\Livewire\Users\Index;

use App\Models\User;
use Illuminate\Database\Eloquent\Collection;
use Livewire\Component;

class Index extends Component
{
    public Collection $users;

    public function mount()
    {
        $this->users = User::orderBy('name')->get();
    }
}
```

```blade
@foreach ($users as $key => $user)
    <input type="text" 
           wire:key="users-{{ $user->id }}"
           wire:model.lazy="users.{{$key}}.name" />
@endforeach
```

Using the code above, you won't see the users' names.

The PR fixes the problem.