### PR TITLE
Add assertViewIs testing helper

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -254,6 +254,13 @@ trait MakesAssertions
         return $this;
     }
 
+    public function assertViewIs($name)
+    {
+        PHPUnit::assertEquals($name, $this->lastRenderedView->getName());
+
+        return $this;
+    }
+
     public function assertViewHas($key, $value = null)
     {
         if (is_null($value)) {


### PR DESCRIPTION
This PR adds an `assertViewIs` testing helper method. This will allow users to ensure that a certain view is returned from a component. It's similar to [Laravel's `assertViewIs` method](https://laravel.com/docs/8.x/http-tests#assert-view-is).

Usage:

```php
Livewire::test(SomeComponent::class)
    ->assertViewIs('livewire.some-component');
```