### PR TITLE
Allow a component to skip its initial render

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -107,6 +107,8 @@ abstract class Component
 
     public function renderToView()
     {
+        if ($this->shouldSkipRender) return null;
+
         $view = method_exists($this, 'render')
             ? app()->call([$this, 'render'])
             : view("livewire.{$this::getName()}");

--- a/tests/Unit/ComponentCanSkipRender.php
+++ b/tests/Unit/ComponentCanSkipRender.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Livewire;
+use Livewire\Component;
+
+class ComponentCanSkipRender extends TestCase
+{
+    /** @test */
+    public function a_livewire_component_can_skip_render()
+    {
+        Livewire::test(ComponentWithSkipRender::class);
+    }
+}
+
+class ComponentWithSkipRender extends Component
+{
+    public function mount()
+    {
+        $this->skipRender();
+    }
+}


### PR DESCRIPTION
Components can now skip their initial render using `$this->skipRender()`, which has been part of the component API since v2.

This is especially useful when redirecting in a `mount()` method, as it skips the requirement for an obsolete view:

```php
class ComponentWithSkipRender extends Component
{
    public function mount()
    {
        $this->redirect('foo');

        $this->skipRender();
    }
}
```