### PR TITLE
add safari autofill support for .lazy fields

### DIFF
--- a/js/node_initializer.js
+++ b/js/node_initializer.js
@@ -70,7 +70,7 @@ export default {
             || directive.modifiers.includes('lazy') ? 'change' : 'input'
 
         // If it's a text input and not .lazy, debounce, otherwise fire immediately.
-        let handler = debounceIf(hasDebounceModifier || (DOM.isTextInput(el) && !isLazy), e => {
+        let handler = debounceIf(hasDebounceModifier || (DOM.isTextInput(el) && (!isLazy || !el.wasRecentlyAutofilled)), e => {
             let model = directive.value
             let el = e.target
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Wanted by safari users, hated by anyone writing code to detect input changes.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

If safari would let you automate autofill it sure would!

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

When using Safari autofill with fields set with .lazy modifier the changes are not picked up.  This is all I could see to do and it works 100% for me after the change and 0% of the time before.  All other field modifiers work without this change so thank you for your work on this Caleb!  Am I barking up the wrong tree in terms of where to handle this?  I ran all the dusk tests and they passed still.

5️⃣ Thanks for contributing! 🙌
