### PR TITLE
Failing test - showcase DOM update from no events/with directive for binding events issue

### DIFF
--- a/tests/Browser/Actions/Component.php
+++ b/tests/Browser/Actions/Component.php
@@ -8,7 +8,7 @@ use Livewire\Component as BaseComponent;
 class Component extends BaseComponent
 {
     public $output = '';
-    public $showButtonGroup = false;
+    public $showButtonsWithClick = false;
 
     public function setOutputToFoo()
     {
@@ -20,9 +20,9 @@ class Component extends BaseComponent
         $this->output = implode('', $params);
     }
 
-    public function setShowButtonGroup($toggle = true)
+    public function setShowButtonsWithClick($toggle = true)
     {
-        $this->showButtonGroup = $toggle;
+        $this->showButtonsWithClick = $toggle;
     }
 
     public function appendToOutput(...$params)

--- a/tests/Browser/Actions/Component.php
+++ b/tests/Browser/Actions/Component.php
@@ -8,6 +8,7 @@ use Livewire\Component as BaseComponent;
 class Component extends BaseComponent
 {
     public $output = '';
+    public $showButtonGroup = false;
 
     public function setOutputToFoo()
     {
@@ -17,6 +18,11 @@ class Component extends BaseComponent
     public function setOutputTo(...$params)
     {
         $this->output = implode('', $params);
+    }
+
+    public function setShowButtonGroup($toggle = true)
+    {
+        $this->showButtonGroup = $toggle;
     }
 
     public function appendToOutput(...$params)

--- a/tests/Browser/Actions/Test.php
+++ b/tests/Browser/Actions/Test.php
@@ -120,7 +120,7 @@ class Test extends TestCase
         });
     }
 
-    public function test_sibling_buttons()
+    public function test_sibling_buttons_no_ids()
     {
         $this->browse(function ($browser) {
             Livewire::visit($browser, Component::class)
@@ -128,11 +128,28 @@ class Test extends TestCase
                  * sibling buttons
                  */
                 ->press('@show.button.group')
-                ->waitForLivewire()->assertPresent('@button.group')
+                ->waitForLivewire()->pause(100)->assertPresent('@button.group')
                 ->press('@button.group.1')
-                ->waitForLivewire()->assertSeeIn('@output', 'button1 clicked')
+                ->waitForLivewire()->pause(100)->assertSeeIn('@output', 'button1 clicked')
                 ->press('@button.group.2')
-                ->waitForLivewire()->assertSeeIn('@output', 'button2 clicked')
+                ->waitForLivewire()->pause(100)->assertSeeIn('@output', 'button2 clicked')
+            ;
+        });
+    }
+
+    public function test_sibling_buttons_with_ids()
+    {
+        $this->browse(function ($browser) {
+            Livewire::visit($browser, Component::class)
+                /**
+                 * sibling buttons
+                 */
+                ->press('@show.button.group')
+                ->waitForLivewire()->pause(100)->assertPresent('@button.group')
+                ->press('@button.group.3')
+                ->waitForLivewire()->pause(100)->assertSeeIn('@output', 'button3 clicked')
+                ->press('@button.group.4')
+                ->waitForLivewire()->pause(100)->assertSeeIn('@output', 'button4 clicked')
             ;
         });
     }

--- a/tests/Browser/Actions/Test.php
+++ b/tests/Browser/Actions/Test.php
@@ -119,4 +119,21 @@ class Test extends TestCase
             ;
         });
     }
+
+    public function test_sibling_buttons()
+    {
+        $this->browse(function ($browser) {
+            Livewire::visit($browser, Component::class)
+                /**
+                 * sibling buttons
+                 */
+                ->press('@show.button.group')
+                ->waitForLivewire()->assertPresent('@button.group')
+                ->press('@button.group.1')
+                ->waitForLivewire()->assertSeeIn('@output', 'button1 clicked')
+                ->press('@button.group.2')
+                ->waitForLivewire()->assertSeeIn('@output', 'button2 clicked')
+            ;
+        });
+    }
 }

--- a/tests/Browser/Actions/Test.php
+++ b/tests/Browser/Actions/Test.php
@@ -116,36 +116,24 @@ class Test extends TestCase
                 ->pause(50)
                 ->waitForLivewire()->assertDontSeeIn('@output', 'bap')
                 ->assertSeeIn('@output', 'bap')
-            ;
-        });
-    }
 
-    public function test_button_dom_update_click_event()
-    {
-        $this->browse(function ($browser) {
-            Livewire::visit($browser, Component::class)
                 /**
-                 * sibling buttons
+                 * replacing buttons on DOM tree - using ID
                  */
-                ->press('@show.button.actions')
-                ->waitForLivewire()->pause(100)->assertPresent('@button.with-actions')
-                ->press('@button.with-click')
-                ->waitForLivewire()->pause(100)->assertSeeIn('@output', 'button with wire:clicked got triggered')
-            ;
-        });
-    }
+                ->refresh()
+                ->waitForLivewire()->click('@show.button.actions')
+                ->assertPresent('@button.with-actions')
+                ->waitForLivewire()->click('@button.with-id-and-click')
+                ->assertSeeIn('@output', 'button with ID and wire:clicked got triggered')
 
-    public function test_button_dom_update_click_event_with_id()
-    {
-        $this->browse(function ($browser) {
-            Livewire::visit($browser, Component::class)
                 /**
-                 * sibling buttons
+                 * replacing buttons on DOM tree - without IDs or :key
                  */
-                ->press('@show.button.actions')
-                ->waitForLivewire()->pause(100)->assertPresent('@button.with-actions')
-                ->press('@button.with-id-and-click')
-                ->waitForLivewire()->pause(100)->assertSeeIn('@output', 'button with ID and wire:clicked got triggered')
+                ->refresh()
+                ->waitForLivewire()->click('@show.button.actions')
+                ->assertPresent('@button.with-actions')
+                ->click('@button.with-click')
+                ->assertSeeIn('@output', 'button with wire:clicked got triggered')
             ;
         });
     }

--- a/tests/Browser/Actions/Test.php
+++ b/tests/Browser/Actions/Test.php
@@ -120,36 +120,32 @@ class Test extends TestCase
         });
     }
 
-    public function test_sibling_buttons_no_ids()
+    public function test_button_dom_update_click_event()
     {
         $this->browse(function ($browser) {
             Livewire::visit($browser, Component::class)
                 /**
                  * sibling buttons
                  */
-                ->press('@show.button.group')
-                ->waitForLivewire()->pause(100)->assertPresent('@button.group')
-                ->press('@button.group.1')
-                ->waitForLivewire()->pause(100)->assertSeeIn('@output', 'button1 clicked')
-                ->press('@button.group.2')
-                ->waitForLivewire()->pause(100)->assertSeeIn('@output', 'button2 clicked')
+                ->press('@show.button.actions')
+                ->waitForLivewire()->pause(100)->assertPresent('@button.with-actions')
+                ->press('@button.with-click')
+                ->waitForLivewire()->pause(100)->assertSeeIn('@output', 'button with wire:clicked got triggered')
             ;
         });
     }
 
-    public function test_sibling_buttons_with_ids()
+    public function test_button_dom_update_click_event_with_id()
     {
         $this->browse(function ($browser) {
             Livewire::visit($browser, Component::class)
                 /**
                  * sibling buttons
                  */
-                ->press('@show.button.group')
-                ->waitForLivewire()->pause(100)->assertPresent('@button.group')
-                ->press('@button.group.3')
-                ->waitForLivewire()->pause(100)->assertSeeIn('@output', 'button3 clicked')
-                ->press('@button.group.4')
-                ->waitForLivewire()->pause(100)->assertSeeIn('@output', 'button4 clicked')
+                ->press('@show.button.actions')
+                ->waitForLivewire()->pause(100)->assertPresent('@button.with-actions')
+                ->press('@button.with-id-and-click')
+                ->waitForLivewire()->pause(100)->assertSeeIn('@output', 'button with ID and wire:clicked got triggered')
             ;
         });
     }

--- a/tests/Browser/Actions/view.blade.php
+++ b/tests/Browser/Actions/view.blade.php
@@ -23,7 +23,7 @@
     <input wire:keydown.debounce.75ms="setOutputTo('bap')" dusk="bap"></button>
     <span dusk="output">{{ $output }}</span>
 
-    <button type="button" wire:click="showButtonGroup()" dusk="show.button.group">Show Button Group</button>
+    <button type="button" wire:click="setShowButtonGroup" dusk="show.button.group">Show Button Group</button>
 
     @if ($showButtonGroup)
         <div dusk="button.group">
@@ -32,6 +32,12 @@
                     <td>
                         <button type="button" wire:click="setOutputTo('button1 clicked')" dusk="button.group.1">Button 1</button>
                         <button type="button" wire:click="setOutputTo('button2 clicked')" dusk="button.group.2">Button 2</button>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <button id="btn3" type="button" wire:click="setOutputTo('button3 clicked')" dusk="button.group.3">Button 1</button>
+                        <button id="btn4" type="button" wire:click="setOutputTo('button4 clicked')" dusk="button.group.4">Button 2</button>
                     </td>
                 </tr>
             </table>

--- a/tests/Browser/Actions/view.blade.php
+++ b/tests/Browser/Actions/view.blade.php
@@ -23,21 +23,15 @@
     <input wire:keydown.debounce.75ms="setOutputTo('bap')" dusk="bap"></button>
     <span dusk="output">{{ $output }}</span>
 
-    <button type="button" wire:click="setShowButtonGroup" dusk="show.button.group">Show Button Group</button>
+    <button type="button" wire:click="setShowButtonsWithClick" dusk="show.button.actions">Toggle Buttons with Actions</button>
 
-    @if ($showButtonGroup)
-        <div dusk="button.group">
+    @if ($showButtonsWithClick)
+        <div dusk="button.with-actions">
             <table>
                 <tr>
                     <td>
-                        <button type="button" wire:click="setOutputTo('button1 clicked')" dusk="button.group.1">Button 1</button>
-                        <button type="button" wire:click="setOutputTo('button2 clicked')" dusk="button.group.2">Button 2</button>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <button id="btn3" type="button" wire:click="setOutputTo('button3 clicked')" dusk="button.group.3">Button 3</button>
-                        <button id="btn4" type="button" wire:click="setOutputTo('button4 clicked')" dusk="button.group.4">Button 4</button>
+                        <button type="button" wire:click="setOutputTo('button with wire:clicked got triggered')" dusk="button.with-click">Button - with wire:click</button>
+                        <button id="btnWithAction" type="button" wire:click="setOutputTo('button with ID and wire:clicked got triggered')" dusk="button.with-id-and-click">Button with ID - with wire:click</button>
                     </td>
                 </tr>
             </table>
@@ -47,14 +41,8 @@
             <table>
                 <tr>
                     <td>
-                        <button type="button" dusk="button.group.1-noaction">Button 1 - no action</button>
-                        <button type="button" dusk="button.group.2-noaction">Button 2 - no action</button>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <button id="btn5" type="button" wire:click="setOutputTo('button5 clicked')" dusk="button.group.5">Button 5</button>
-                        <button id="btn6" type="button" wire:click="setOutputTo('button6 clicked')" dusk="button.group.6">Button 6</button>
+                        <button type="button">Button - no action</button>
+                        <button id="btnNoAction" type="button">Button with ID - no action</button>
                     </td>
                 </tr>
             </table>

--- a/tests/Browser/Actions/view.blade.php
+++ b/tests/Browser/Actions/view.blade.php
@@ -22,4 +22,19 @@
     </form>
     <input wire:keydown.debounce.75ms="setOutputTo('bap')" dusk="bap"></button>
     <span dusk="output">{{ $output }}</span>
+
+    <button type="button" wire:click="showButtonGroup()" dusk="show.button.group">Show Button Group</button>
+
+    @if ($showButtonGroup)
+        <div dusk="button.group">
+            <table>
+                <tr>
+                    <td>
+                        <button type="button" wire:click="setOutputTo('button1 clicked')" dusk="button.group.1">Button 1</button>
+                        <button type="button" wire:click="setOutputTo('button2 clicked')" dusk="button.group.2">Button 2</button>
+                    </td>
+                </tr>
+            </table>
+        </div>
+    @endif
 </div>

--- a/tests/Browser/Actions/view.blade.php
+++ b/tests/Browser/Actions/view.blade.php
@@ -36,8 +36,25 @@
                 </tr>
                 <tr>
                     <td>
-                        <button id="btn3" type="button" wire:click="setOutputTo('button3 clicked')" dusk="button.group.3">Button 1</button>
-                        <button id="btn4" type="button" wire:click="setOutputTo('button4 clicked')" dusk="button.group.4">Button 2</button>
+                        <button id="btn3" type="button" wire:click="setOutputTo('button3 clicked')" dusk="button.group.3">Button 3</button>
+                        <button id="btn4" type="button" wire:click="setOutputTo('button4 clicked')" dusk="button.group.4">Button 4</button>
+                    </td>
+                </tr>
+            </table>
+        </div>
+    @else
+        <div>
+            <table>
+                <tr>
+                    <td>
+                        <button type="button" dusk="button.group.1-noaction">Button 1 - no action</button>
+                        <button type="button" dusk="button.group.2-noaction">Button 2 - no action</button>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <button id="btn5" type="button" wire:click="setOutputTo('button5 clicked')" dusk="button.group.5">Button 5</button>
+                        <button id="btn6" type="button" wire:click="setOutputTo('button6 clicked')" dusk="button.group.6">Button 6</button>
                     </td>
                 </tr>
             </table>


### PR DESCRIPTION
This is a failing test for the case of DOM updating issue which misses updating the directive event binding `wire:click`.

Test `test_button_dom_update_click_event` will fail, while test `test_button_dom_update_click_event_with_id` will succeed.

There will be an issue for this soon.

