### PR TITLE
Check if manifest.json exists

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -191,7 +191,7 @@ HTML;
         $assetWarning = null;
 
         // Use static assets if they have been published
-        if (file_exists(public_path('vendor/livewire'))) {
+        if (file_exists(public_path('vendor/livewire/manifest.json'))) {
             $publishedManifest = json_decode(file_get_contents(public_path('vendor/livewire/manifest.json')), true);
             $versionedFileName = $publishedManifest['/livewire.js'];
 


### PR DESCRIPTION
The issue is when vendor/livewire folder exists but is empty it will still go into the if block and look for the manifest.json file therefore throwing an error. In my case this happened when I ran "php artisan vendor:publish" and selected livewire, once I saw the files created I discarded the scrips and only kept the config file because that's all I needed. VS code only deleted the files but not the folder. 

Googling the issue, I found that I'm not the only one experiencing this. Most advise was to publish the assets but I don't want to keep a copy since I'm not customizing it and I want it kept in the vendor folder.