### PR TITLE
Improve handling for missing properties in testing

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -10,6 +10,7 @@ use Illuminate\Support\ViewErrorBag;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Container\Container;
 use Livewire\Exceptions\CannotUseReservedLivewireComponentProperties;
+use Livewire\Exceptions\PropertyNotFoundException;
 
 abstract class Component
 {
@@ -230,7 +231,7 @@ abstract class Component
             return $this->computedPropertyCache[$property] = app()->call([$this, $computedMethodName]);
         }
 
-        throw new \Exception("Property [{$property}] does not exist on the {$this::getName()} component.");
+        throw new PropertyNotFoundException($property, $this::getName());
     }
 
     public function __call($method, $params)

--- a/src/Exceptions/PropertyNotFoundException.php
+++ b/src/Exceptions/PropertyNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Livewire\Exceptions;
+
+class PropertyNotFoundException extends \Exception
+{
+    use BypassViewHandler;
+
+    public function __construct($property, $component)
+    {
+        parent::__construct(
+            "Property [\${$property}] not found on component: [{$component}]"
+        );
+    }
+}

--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -11,6 +11,7 @@ use Livewire\GenerateSignedUploadUrl;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Traits\Macroable;
 use Facades\Livewire\GenerateSignedUploadUrl as GenerateSignedUploadUrlFacade;
+use Livewire\Exceptions\PropertyNotFoundException;
 
 class TestableLivewire
 {
@@ -209,7 +210,7 @@ class TestableLivewire
 
                 try {
                     $value = $this->instance()->{$root};
-                } catch (\Throwable $e) {
+                } catch (PropertyNotFoundException $e) {
                     $value = null;
                 }
 

--- a/tests/Unit/TestableLivewireCanAssertPropertiesTest.php
+++ b/tests/Unit/TestableLivewireCanAssertPropertiesTest.php
@@ -33,6 +33,22 @@ class TestableLivewireCanAssertPropertiesTest extends TestCase
         Livewire::test(PropertyTestingComponent::class)
             ->assertSet('bob', 'lob');
     }
+
+    /** @test */
+    public function swallows_property_not_found_exceptions()
+    {
+        Livewire::test(PropertyTestingComponent::class)
+            ->assertSet('nonExistentProperty', null);
+    }
+
+    /** @test */
+    public function throws_non_property_not_found_exceptions()
+    {
+        $this->expectException(\Exception::class);
+
+        Livewire::test(PropertyTestingComponent::class)
+            ->assertSet('throwsException', null);
+    }
 }
 
 class ModelForPropertyTesting extends Model
@@ -57,6 +73,11 @@ class PropertyTestingComponent extends Component
     public function getBobProperty()
     {
         return 'lob';
+    }
+
+    public function getThrowsExceptionProperty()
+    {
+        throw new \Exception('Test exception');
     }
 
     public function render()


### PR DESCRIPTION
This PR improves how missing properties or computed properties are handled by the `TestableLivewire` class. Previously, the `TestableLivewire` class would catch all exceptions that occured in a computed property making it harder to debug errors when writing tests. With these changes, only the `PropertyNotFound` exception will be caught and all other exceptions will be allowed through.