### PR TITLE
Add validation errors to $wire.errors

### DIFF
--- a/tests/Browser/ValidationErrors/Component.php
+++ b/tests/Browser/ValidationErrors/Component.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Browser\ValidationErrors;
+
+use Illuminate\Support\Facades\View;
+use Livewire\Component as BaseComponent;
+
+class Component extends BaseComponent
+{
+    public $foo = '';
+
+    protected $rules = [
+        'foo' => 'required'
+    ];
+
+    public function render()
+    {
+        return View::file(__DIR__.'/view.blade.php');
+    }
+}

--- a/tests/Browser/ValidationErrors/Test.php
+++ b/tests/Browser/ValidationErrors/Test.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Browser\ValidationErrors;
+
+use Livewire\Livewire;
+use Tests\Browser\TestCase;
+use Illuminate\Support\Facades\Artisan;
+
+class Test extends TestCase
+{
+    public function test_validation_errors_are_returned_in_dollar_wire()
+    {
+        $this->browse(function ($browser) {
+           Livewire::visit($browser, Component::class)
+               ->assertDontSee('@errors')
+               ->assertValue('@foo', '')
+               ->click('@submit')
+               ->assertSee('@errors');
+        });
+    }
+}

--- a/tests/Browser/ValidationErrors/view.blade.php
+++ b/tests/Browser/ValidationErrors/view.blade.php
@@ -1,0 +1,5 @@
+<div x-data>
+    <span v-if="$wire.errors.length" dusk="errors"></span>
+    <input wire:model="foo" dusk="foo">
+    <input type="submit" dusk="submit">
+</div>


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
This came about from a discussion with @calebporzio, from which he suggested I create this PR.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
This is an exploratory attempt to add validation errors (or anything in the error bag) into a new component `$wire.errors`. There are use cases when it would be helpful to have access to the error messages, or even just check for the existence of errors. I just stubbed out a test to get the ball rolling.

5️⃣ Thanks for contributing! 🙌
I just hope the check clears.