### PR TITLE
Autoload components by namespace

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -101,11 +101,25 @@ abstract class Component
 
     public static function getPrefix()
     {
-        return Str::startsWith(static::class, app('livewire')->getComponentNamespaces())
-            ? array_search(Arr::first(app('livewire')->getComponentNamespaces(), function ($namesapce) {
-                return str_starts_with(static::class, $namesapce);
-            }), app('livewire')->getComponentNamespaces())
-            : null;
+        $prefix = null;
+
+        // Look for the first occurrence of the component namespace.
+        Arr::first(
+            app('livewire')->getComponentNamespaces(),
+            function ($namespace, $key) use (&$prefix) {
+                // If we don't get it on this run, just continue with the next registered prefix.
+                if (! Str::contains(static::class, $namespace)) {
+                    return false;
+                }
+
+                // If we do match the class name in the namespace,
+                // provide the prefix on the outer-scope and exit the loop.
+                $prefix = $key;
+                return true;
+            }
+        );
+
+        return $prefix;
     }
 
     public static function getNamespace()

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -54,7 +54,7 @@ class LivewireManager
         $class = $class ?: (
             // Let's check registered namespaced components for an existing
             // class with the same alias under the same namespace.
-            $this->guessNamespacedComponentClass($alias)
+            $this->findComponentByClass($alias)
         );
 
         $class = $class ?: (
@@ -70,20 +70,25 @@ class LivewireManager
         return $class;
     }
 
-    public function guessNamespacedComponentClass($alias)
+    public function findComponentByClass($alias)
     {
         $pieces = explode(ViewFinderInterface::HINT_PATH_DELIMITER, $alias);
 
         $prefix = $pieces[0];
 
-        if (isset($this->componentNamespaces[$prefix]) && isset($pieces[1])) {
-            $component = implode('\\', array_map(function ($componentPiece) {
-                return Str::studly($componentPiece);
-            }, explode('.', $pieces[1])));
+        if (!isset($this->componentNamespaces[$prefix]) || !isset($pieces[1])) {
+            return false;
+        }
 
-            if (class_exists($class = $this->componentNamespaces[$prefix].'\\'.$component)) {
-                return $class;
-            }
+        $component = Str::of($pieces[1])
+            ->explode('.')
+            ->map(function ($componentPiece) {
+                return Str::studly($componentPiece);
+            })
+            ->implode('\\');
+
+        if (class_exists($class = $this->componentNamespaces[$prefix].'\\'.$component)) {
+            return $class;
         }
 
         return false;

--- a/tests/Unit/ComponentNamespacedTest.php
+++ b/tests/Unit/ComponentNamespacedTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Livewire;
+use Illuminate\Support\Facades\File;
+use Illuminate\View\ViewFinderInterface;
+
+class ComponentNamespacedTest extends TestCase
+{
+    public function makeACleanSlate()
+    {
+        parent::makeACleanSlate();
+
+        File::deleteDirectory(base_path('Package'));
+    }
+
+    protected function moduleClassesPath($path = '')
+    {
+        return base_path('Package/src/Http/Livewire'.($path ? '/'.$path : ''));
+    }
+
+    protected function moduleViewsPath($path = '')
+    {
+        return base_path('Package/resources/views/livewire'.($path ? '/'.$path : ''));
+    }
+
+    /** @test */
+    public function can_get_component_with_namespace_registeration()
+    {
+        File::makeDirectory($this->moduleClassesPath(), 0755, true);
+        File::makeDirectory($this->moduleViewsPath(), 0755, true);
+
+        File::put(
+            $this->moduleClassesPath('DefaultNamespace.php'),
+<<<EOT
+<?php
+
+namespace Package\Http\Livewire;
+
+use Livewire\Component;
+
+class DefaultNamespace extends Component {}
+EOT
+        );
+
+        File::put(
+            $this->moduleViewsPath('default-namespace.blade.php'),
+<<<EOT
+<div>I've been namespaced!</div>
+EOT
+        );
+
+        include $this->moduleClassesPath('DefaultNamespace.php');
+
+        app('livewire')->componentNamespace('Package\\Http\\Livewire', 'package');
+
+        app('view')->addNamespace('package', $this->moduleViewsPath('..'));
+
+        $component = Livewire::test('Package\Http\Livewire\DefaultNamespace');
+
+        $this->assertEquals('package::default-namespace', $component->instance()->getPrefix().ViewFinderInterface::HINT_PATH_DELIMITER.$component->instance()->getName());
+    }
+
+    /** @test */
+    public function can_get_child_component_with_namespace_registeration()
+    {
+        File::makeDirectory($this->moduleClassesPath('Custom'), 0755, true);
+        File::makeDirectory($this->moduleViewsPath('custom'), 0755, true);
+
+        File::put(
+            $this->moduleClassesPath('Custom/DefaultNamespace.php'),
+<<<EOT
+<?php
+
+namespace Package\Http\Livewire\Custom;
+
+use Livewire\Component;
+
+class DefaultNamespace extends Component {}
+EOT
+        );
+
+        File::put(
+            $this->moduleViewsPath('custom/default-namespace.blade.php'),
+<<<EOT
+<div>I've been namespaced!</div>
+EOT
+        );
+
+        include $this->moduleClassesPath('Custom/DefaultNamespace.php');
+
+        app('livewire')->componentNamespace('Package\\Http\\Livewire', 'package');
+
+        app('view')->addNamespace('package', $this->moduleViewsPath('..'));
+
+        $component = Livewire::test('Package\Http\Livewire\Custom\DefaultNamespace');
+
+        $this->assertEquals('package::custom.default-namespace', $component->instance()->getPrefix().ViewFinderInterface::HINT_PATH_DELIMITER.$component->instance()->getName());
+    }
+}


### PR DESCRIPTION
This PR will allow developers to autoload components in a similar way to Laravel autoload class components feature https://github.com/laravel/framework/pull/34144

```
Livewire::componentNamespace('Package\\Http\\Livewire', 'package');
```

Then use it as

```
@livewire('package::livewire-component')
```

or

```
<livewire:package::livewire-component />
```

Also, It will look for the view (if the render method isn't provided for Livewire component) using

```
view('package::livewire.livewire-component');
```

which is registered using

```
$this->loadViewsFrom('path/to/package/views', 'package');
```

-----
:heavy_check_mark: Unit test