### PR TITLE
fix assertSet() when testing string that matches a function name

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -13,7 +13,7 @@ trait MakesAssertions
 {
     public function assertSet($name, $value)
     {
-        if (!is_string($value) && is_callable($value)) {
+        if (! is_string($value) && is_callable($value)) {
             PHPUnit::assertTrue($value($this->get($name)));
         } else {
             PHPUnit::assertEquals($value, $this->get($name));
@@ -251,7 +251,7 @@ trait MakesAssertions
             'Component did not perform a redirect.'
         );
 
-        if (!is_null($uri)) {
+        if (! is_null($uri)) {
             PHPUnit::assertSame(url($uri), url($this->payload['effects']['redirect']));
         }
 

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -13,7 +13,7 @@ trait MakesAssertions
 {
     public function assertSet($name, $value)
     {
-        if (is_callable($value)) {
+        if (!is_string($value) && is_callable($value)) {
             PHPUnit::assertTrue($value($this->get($name)));
         } else {
             PHPUnit::assertEquals($value, $this->get($name));
@@ -251,7 +251,7 @@ trait MakesAssertions
             'Component did not perform a redirect.'
         );
 
-        if (! is_null($uri)) {
+        if (!is_null($uri)) {
             PHPUnit::assertSame(url($uri), url($this->payload['effects']['redirect']));
         }
 

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -12,7 +12,7 @@ class LivewireTestingTest extends TestCase
     /** @test */
     public function testing_livewire_route_works_with_user_route_with_the_same_signature()
     {
-        Route::get('/{param1}/{param2}', function () {
+        Route::get('/{param1}/{param2}', function() {
             throw new \Exception('I shouldn\'t get executed!');
         });
 

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -12,7 +12,7 @@ class LivewireTestingTest extends TestCase
     /** @test */
     public function testing_livewire_route_works_with_user_route_with_the_same_signature()
     {
-        Route::get('/{param1}/{param2}', function() {
+        Route::get('/{param1}/{param2}', function () {
             throw new \Exception('I shouldn\'t get executed!');
         });
 
@@ -42,7 +42,11 @@ class LivewireTestingTest extends TestCase
     {
         app(LivewireManager::class)
             ->test(HasMountArguments::class, ['name' => 'foo'])
-            ->assertSet('name', 'foo');
+            ->assertSet('name', 'foo')
+            ->set('name', 'info')
+            ->assertSet('name', 'info')
+            ->set('name', 'is_array')
+            ->assertSet('name', 'is_array');
     }
 
     /** @test */


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first? 

This relates to the following forum discussion:
https://forum.laravel-livewire.com/t/issue-with-basic-assertset-following-upgrade-to-v2/1977

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, the PR is for related changes

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes, I have updated the existing tests.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

After upgrading to Livewire v2.2.9 some of my assertSet() failed and not related to using assertPayloadSet().

In v2 if you try to test a class property with a string value that is the same name as a valid function it runs the function rather than testing the string for a match.  e.g.

```
Livewire::test(SomeComponet::class)
                ->assertSet('name', 'info');
```

Will fail with the error

```
Failed asserting that null is true.
```

In this case the `assertSet()` function runs `info('info')` which returns a null and actually writes

```
[2020-10-12 07:06:35] testing.INFO: info
```

In the Laravel log.

5️⃣ Thanks for contributing! 🙌