### PR TITLE
Allow the use of layout as a Component

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -97,4 +97,15 @@ return [
 
     'manifest_path' => null,
 
+    /*
+    |--------------------------------------------------------------------------
+    | X-Layout
+    |--------------------------------------------------------------------------
+    |
+    | This value sets the default layout render behavior to use x-blade components styles.
+    |
+    */
+
+    'uses_x-layout' => false
+
 ];

--- a/src/Component.php
+++ b/src/Component.php
@@ -49,14 +49,16 @@ abstract class Component
             ->mount($componentParams)
             ->renderToView();
 
-        $layoutType = $this->initialLayoutConfiguration['type'] ?? 'component';
+        $layoutType = $this->initialLayoutConfiguration['type'] ?? config('livewire.uses_x-layout') ? 'x-layout' : 'component';
+
+        $view = $this->initialLayoutConfiguration['view'] ?? config('livewire.uses_x-layout') ? 'app-layout' : 'layouts.app';
 
         return app('view')->file(__DIR__."/Macros/livewire-view-{$layoutType}.blade.php", [
-            'view' => $this->initialLayoutConfiguration['view'] ?? 'layouts.app',
+            'view' => $view,
             'params' => $this->initialLayoutConfiguration['params'] ?? [],
             'slotOrSection' => $this->initialLayoutConfiguration['slotOrSection'] ?? [
-                'extends' => 'content', 'component' => 'default',
-            ][$layoutType],
+                    'extends' => 'content', 'component' => 'default', 'x-layout' => 'default'
+                ][$layoutType],
             'manager' => $manager,
         ]);
     }

--- a/src/Component.php
+++ b/src/Component.php
@@ -49,9 +49,9 @@ abstract class Component
             ->mount($componentParams)
             ->renderToView();
 
-        $layoutType = $this->initialLayoutConfiguration['type'] ?? config('livewire.uses_x-layout') ? 'x-layout' : 'component';
+        $layoutType = $this->initialLayoutConfiguration['type'] ?? (config('livewire.uses_x-layout', false) ? 'x-layout' : 'component');
 
-        $view = $this->initialLayoutConfiguration['view'] ?? config('livewire.uses_x-layout') ? 'app-layout' : 'layouts.app';
+        $view = $this->initialLayoutConfiguration['view'] ?? (config('livewire.uses_x-layout', false) ? 'app-layout' : 'layouts.app');
 
         return app('view')->file(__DIR__."/Macros/livewire-view-{$layoutType}.blade.php", [
             'view' => $view,

--- a/src/Macros/ViewMacros.php
+++ b/src/Macros/ViewMacros.php
@@ -32,6 +32,20 @@ class ViewMacros
         };
     }
 
+    public function xLayout()
+    {
+        return function ($view, $params = []) {
+            $this->livewireLayout = [
+                'type' => 'x-layout',
+                'slotOrSection' => 'default',
+                'view' => $view,
+                'params' => $params,
+            ];
+
+            return $this;
+        };
+    }
+
     public function section()
     {
         return function ($section) {

--- a/src/Macros/livewire-view-x-layout.blade.php
+++ b/src/Macros/livewire-view-x-layout.blade.php
@@ -1,0 +1,3 @@
+<x-dynamic-component :component="$view">
+    {!! $manager->initialDehydrate()->toInitialResponse()->effects['html']; !!}
+</x-dynamic-component>


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
I did not create an issue, but it's probably related with this one: #1748 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
When using layout as a Component, like it's done in Jetstream (as an example) for the [AppLayout](https://github.com/laravel/jetstream/blob/master/stubs/livewire/app/View/Components/AppLayout.php) and [GuestLayout](https://github.com/laravel/jetstream/blob/master/stubs/livewire/app/View/Components/AppLayout.php), we are able to define some "complex data" we don't want to put in our blade file:
```php
class AppLayout extends Component
{
    public bool $canCreateCharacter;

    public function __construct()
    {
        $user = Auth::user();

        $userCharacters = $user->characters->map(
            static fn ($character) => $character->id
        );

        // Retrieve the world not full where the user doesn't have a character yet
        $this->canCreateCharacter = World::whereDoesntHave('characters',
                static fn (Builder $query) =>
                $query->whereIn('id', $userCharacters)
            )
                ->subscriptionAvailable()
                ->count() > 0;
    }

    public function render()
    {
        return view('layouts.app');
    }
}
```

But since our blade file is strongly attached to our Component class, some errors appear when we are trying to render our Livewire components using its class directly:
```php
Route::get('/', 'Livewire\\Messenger\\Messenger')->name('messenger.index');
```
> ErrorException
Undefined variable: canCreateCharacter (View: /home/maz/websites/terrajdr/resources/views/layouts/app.blade.php) (View: /home/maz/websites/terrajdr/resources/views/layouts/app.blade.php)

As mentioned in a thread on the [Livewire forum](https://forum.laravel-livewire.com/t/layout-class-constructor-is-not-triggered-while-rendering/1985), I've succeed into resolving it using base Livewire methods by manually instantiate the AppLayout class and passing its data as parameters:
```php
// Somewhere in my Livewire Component class
    public function render()
    {
        $view = view('livewire.messenger.index')->layout('layouts.app', (new AppLayout())->data());
    }
```
But manually add this code, referencing the default layout and passing its data manually is totally boring and we don't want that.

So I've dive into the Livewire code and searched why I needed to do that.
I finally understood that Livewire do not use x-blade component syntax, which is (I suppose) the source of the problem.

First I tried to search for a method to programmatically know if x-component was used by the layout file, but didn't find one (open to suggestion).
Then I figured out that I just needed to create a view file to render the layouts that are extending Component class
I've made some tests, using a x-blade specific layout to render my components and it worked perfectly well.

Since x-blade syntax is not natively supported by Laravel 7 which is supported by Livewire and assuming the fact that most of us don't use Blade Component to render layouts, I propose to just set a config boolean to change the default behavior to use this feature.

I've created the viewMacro method to change the default layout and pass data to it the same way we use `->layout()` or `->extend()`. You can just use `->xLayout('custom-layout', ['parameter' => 'custom data'])`

Doing so, we can use basic feature for some layout, and xLayout to render specific Component extending layout.

I'm totally open to suggestion to upgrade my code, I think this feature in my implementation-style or another should be merged in near future.

5️⃣ Thanks @calebporzio for providing this good package! 🙌