### PR TITLE
Ensure base64 encoded strings dont lead to unwanted sub-directories

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -124,7 +124,7 @@ class TemporaryUploadedFile extends UploadedFile
     public static function generateHashNameWithOriginalNameEmbedded($file)
     {
         $hash = Str::random(30);
-        $meta = '-meta'.base64_encode($file->getClientOriginalName()).'-';
+        $meta = Str::of('-meta'.base64_encode($file->getClientOriginalName()).'-')->replace('/', '_');
         $extension = '.'.$file->guessExtension();
 
         return $hash.$meta.$extension;
@@ -132,7 +132,7 @@ class TemporaryUploadedFile extends UploadedFile
 
     public function extractOriginalNameFromFilePath($path)
     {
-        return base64_decode(head(explode('-', last(explode('-meta', $path)))));
+        return base64_decode(head(explode('-', last(explode('-meta', Str::of($path)->replace('_', '/'))))));
     }
 
     public static function createFromLivewire($filePath)


### PR DESCRIPTION
The real issue behind #1798 is that a base64 encoded string can contain a `/`, so the uploaded file will be stored in a sub-folder.
@alhoqbani Please could you check if this fixes your issue?

---
Closes #1798 
Co-Authored-By: @mathiasonea