### PR TITLE
Add support for binding to model collections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "calebporzio/sushi": "^2.1"
     },
     "autoload": {
+        "files": [
+            "src/helpers.php"
+        ],
         "psr-4": {
             "Livewire\\": "src/"
         }

--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -10,6 +10,7 @@ use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Exceptions\NonPublicComponentMethodCall;
 use Livewire\Exceptions\PublicPropertyNotFoundException;
 use Livewire\Exceptions\MissingFileUploadsTraitException;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Livewire\HydrationMiddleware\HashDataPropertiesForDirtyDetection;
 use Livewire\Exceptions\CannotBindToModelDataWithoutValidationRuleException;
 
@@ -20,7 +21,7 @@ trait HandlesActions
         $propertyName = $this->beforeFirstDot($name);
 
         throw_if(
-            $this->{$propertyName} instanceof Model && $this->missingRuleFor($name),
+            ($this->{$propertyName} instanceof Model || $this->{$propertyName} instanceof EloquentCollection) && $this->missingRuleFor($name),
             new CannotBindToModelDataWithoutValidationRuleException($name, $this::getName())
         );
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Livewire;
+
+use Illuminate\Support\Str;
+
+if (! function_exists('Livewire\str')) {
+    function str($string = null)
+    {
+        if (is_null($string)) return new class {
+            public function __call($method, $params) {
+                return Str::$method(...$params);
+            }
+        };
+
+        return Str::of($string);
+    }
+}

--- a/tests/Unit/ModelCollectionAttributesCanBeBoundDirectlyTest.php
+++ b/tests/Unit/ModelCollectionAttributesCanBeBoundDirectlyTest.php
@@ -6,6 +6,7 @@ use Sushi\Sushi;
 use Livewire\Livewire;
 use Livewire\Component;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Livewire\Exceptions\CorruptComponentPayloadException;
 use Livewire\Exceptions\CannotBindToModelDataWithoutValidationRuleException;
 
@@ -67,6 +68,32 @@ class ModelCollectionAttributesCanBeBoundDirectlyTest extends TestCase
     }
 
     /** @test */
+    public function can_use_a_custom_model_collection_and_bind_to_values()
+    {
+        // Reset Sushi model.
+        (new ModelWithCustomCollectionForBinding)->resolveConnection()->getSchemaBuilder()->drop((new ModelWithCustomCollectionForBinding)->getTable());
+        (new ModelWithCustomCollectionForBinding)->migrate();
+
+        Livewire::test(ComponentWithModelsProperty::class)
+            ->call('setModelsToCustomCollection')
+            ->assertSet('models.0.title', 'foo')
+            ->assertPayloadSet('models.0.title', 'foo')
+            ->set('models.0.title', 'bo')
+            ->assertSet('models.0.title', 'bo')
+            ->call('refreshModels')
+            ->assertSet('models.0.title', 'foo')
+            ->set('models.0.title', 'bo')
+            ->call('save')
+            ->assertHasErrors('models.0.title')
+            ->set('models.0.title', 'boo')
+            ->call('save')
+            ->call('refreshModels')
+            ->assertSet('models.0.title', 'boo')
+            ->call('getTypeOfModels')
+            ->assertSet('modelsType', CustomCollection::class);
+    }
+
+    /** @test */
     public function cant_set_a_model_attribute_that_isnt_present_in_rules_array()
     {
         // Reset Sushi model.
@@ -108,9 +135,31 @@ class ModelForBinding extends Model
     ];
 }
 
+class CustomCollection extends EloquentCollection
+{
+    //
+}
+
+class ModelWithCustomCollectionForBinding extends Model
+{
+    use Sushi;
+
+    protected $rows = [
+        ['title' => 'foo'],
+        ['title' => 'bar'],
+        ['title' => 'baz'],
+    ];
+
+    public function newCollection(array $models = [])
+    {
+        return new CustomCollection($models);
+    }
+}
+
 class ComponentWithModelsProperty extends Component
 {
     public $models;
+    public $modelsType;
 
     protected $rules = [
         'models.*.title' => 'required|min:3',
@@ -124,6 +173,16 @@ class ComponentWithModelsProperty extends Component
     public function addModel()
     {
         $this->models->push(new ModelForBinding);
+    }
+
+    public function setModelsToCustomCollection()
+    {
+        $this->models = ModelWithCustomCollectionForBinding::all();
+    }
+
+    public function getTypeOfModels()
+    {
+        $this->modelsType = get_class($this->models);
     }
 
     public function save()

--- a/tests/Unit/ModelCollectionAttributesCanBeBoundDirectlyTest.php
+++ b/tests/Unit/ModelCollectionAttributesCanBeBoundDirectlyTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Unit;
+
+use Sushi\Sushi;
+use Livewire\Livewire;
+use Livewire\Component;
+use Illuminate\Database\Eloquent\Model;
+use Livewire\Exceptions\CorruptComponentPayloadException;
+use Livewire\Exceptions\CannotBindToModelDataWithoutValidationRuleException;
+
+class ModelCollectionAttributesCanBeBoundDirectlyTest extends TestCase
+{
+    /** @test */
+    public function can_set_a_model_attribute_inside_a_models_collection_and_save()
+    {
+        // Reset Sushi model.
+        (new ModelForBinding)->resolveConnection()->getSchemaBuilder()->drop((new ModelForBinding)->getTable());
+        (new ModelForBinding)->migrate();
+
+        Livewire::test(ComponentWithModelsProperty::class)
+            ->assertSet('models.0.title', 'foo')
+            ->assertPayloadSet('models.0.title', 'foo')
+            ->set('models.0.title', 'bo')
+            ->assertSet('models.0.title', 'bo')
+            ->call('refreshModels')
+            ->assertSet('models.0.title', 'foo')
+            ->set('models.0.title', 'bo')
+            ->call('save')
+            ->assertHasErrors('models.0.title')
+            ->set('models.0.title', 'boo')
+            ->call('save')
+            ->call('refreshModels')
+            ->assertSet('models.0.title', 'boo');
+    }
+
+    /** @test */
+    public function can_set_non_persisted_models_in_model_collection()
+    {
+        // Reset Sushi model.
+        (new ModelForBinding)->resolveConnection()->getSchemaBuilder()->drop((new ModelForBinding)->getTable());
+        (new ModelForBinding)->migrate();
+
+        Livewire::test(ComponentWithModelsProperty::class)
+            ->assertSet('models.2.title', 'baz')
+            ->assertSet('models.3', null)
+            ->assertPayloadSet('models.3', null)
+            ->call('addModel')
+            ->assertNotSet('models.3', null)
+            ->assertPayloadNotSet('models.3', null)
+            ->set('models.3.title', 'bob')
+            ->assertSet('models.3.title', 'bob')
+            ->assertPayloadSet('models.3.title', 'bob')
+            ->set('models.3.title', 'bo')
+            ->call('refreshModels')
+            ->assertSet('models.3', null)
+            ->assertPayloadSet('models.3', null)
+            ->call('addModel')
+            ->set('models.3.title', 'bo')
+            ->call('save')
+            ->assertHasErrors('models.3.title')
+            ->set('models.3.title', 'boo')
+            ->call('save')
+            ->call('refreshModels')
+            ->assertSet('models.3.title', 'boo');
+        ;
+    }
+
+    /** @test */
+    public function cant_set_a_model_attribute_that_isnt_present_in_rules_array()
+    {
+        // Reset Sushi model.
+        (new ModelForBinding)->resolveConnection()->getSchemaBuilder()->drop((new ModelForBinding)->getTable());
+        (new ModelForBinding)->migrate();
+
+        $this->expectException(CannotBindToModelDataWithoutValidationRuleException::class);
+
+        Livewire::test(ComponentWithModelsProperty::class)
+            ->set('models.1.restricted', 'bar')
+            ->assertSet('models.1.restricted', null);
+    }
+
+    /** @test */
+    public function an_eloquent_models_meta_cannot_be_hijacked_by_tampering_with_data()
+    {
+        // Reset Sushi model.
+        (new ModelForBinding)->resolveConnection()->getSchemaBuilder()->drop((new ModelForBinding)->getTable());
+        (new ModelForBinding)->migrate();
+
+        $this->expectException(CorruptComponentPayloadException::class);
+
+        $component = Livewire::test(ComponentWithModelsProperty::class);
+
+        $component->payload['serverMemo']['dataMeta']['modelCollections']['models']['id'] = [1];
+
+        $component->call('$refresh');
+    }
+}
+
+class ModelForBinding extends Model
+{
+    use Sushi;
+
+    protected $rows = [
+        ['title' => 'foo'],
+        ['title' => 'bar'],
+        ['title' => 'baz'],
+    ];
+}
+
+class ComponentWithModelsProperty extends Component
+{
+    public $models;
+
+    protected $rules = [
+        'models.*.title' => 'required|min:3',
+    ];
+
+    public function mount()
+    {
+        $this->models = ModelForBinding::all();
+    }
+
+    public function addModel()
+    {
+        $this->models->push(new ModelForBinding);
+    }
+
+    public function save()
+    {
+        $this->validate();
+
+        $this->models->each->save();
+    }
+
+    public function refreshModels()
+    {
+        $this->models = $this->models->filter->exists->fresh();
+    }
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}
+
+class ComponentWithoutRulesArray extends Component
+{
+    public $models;
+
+    public function mount()
+    {
+        $this->models = ModelForBinding::all();
+    }
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}

--- a/tests/Unit/ModelCollectionAttributesCanBeBoundDirectlyTest.php
+++ b/tests/Unit/ModelCollectionAttributesCanBeBoundDirectlyTest.php
@@ -202,18 +202,3 @@ class ComponentWithModelCollectionProperty extends Component
         return view('null-view');
     }
 }
-
-class ComponentWithoutRulesArray extends Component
-{
-    public $models;
-
-    public function mount()
-    {
-        $this->models = ModelForBinding::all();
-    }
-
-    public function render()
-    {
-        return view('null-view');
-    }
-}

--- a/tests/Unit/ModelCollectionAttributesCanBeBoundDirectlyTest.php
+++ b/tests/Unit/ModelCollectionAttributesCanBeBoundDirectlyTest.php
@@ -19,7 +19,7 @@ class ModelCollectionAttributesCanBeBoundDirectlyTest extends TestCase
         (new ModelForBinding)->resolveConnection()->getSchemaBuilder()->drop((new ModelForBinding)->getTable());
         (new ModelForBinding)->migrate();
 
-        Livewire::test(ComponentWithModelsProperty::class)
+        Livewire::test(ComponentWithModelCollectionProperty::class)
             ->assertSet('models.0.title', 'foo')
             ->assertPayloadSet('models.0.title', 'foo')
             ->set('models.0.title', 'bo')
@@ -42,7 +42,7 @@ class ModelCollectionAttributesCanBeBoundDirectlyTest extends TestCase
         (new ModelForBinding)->resolveConnection()->getSchemaBuilder()->drop((new ModelForBinding)->getTable());
         (new ModelForBinding)->migrate();
 
-        Livewire::test(ComponentWithModelsProperty::class)
+        Livewire::test(ComponentWithModelCollectionProperty::class)
             ->assertSet('models.2.title', 'baz')
             ->assertSet('models.3', null)
             ->assertPayloadSet('models.3', null)
@@ -74,7 +74,7 @@ class ModelCollectionAttributesCanBeBoundDirectlyTest extends TestCase
         (new ModelWithCustomCollectionForBinding)->resolveConnection()->getSchemaBuilder()->drop((new ModelWithCustomCollectionForBinding)->getTable());
         (new ModelWithCustomCollectionForBinding)->migrate();
 
-        Livewire::test(ComponentWithModelsProperty::class)
+        Livewire::test(ComponentWithModelCollectionProperty::class)
             ->call('setModelsToCustomCollection')
             ->assertSet('models.0.title', 'foo')
             ->assertPayloadSet('models.0.title', 'foo')
@@ -102,7 +102,7 @@ class ModelCollectionAttributesCanBeBoundDirectlyTest extends TestCase
 
         $this->expectException(CannotBindToModelDataWithoutValidationRuleException::class);
 
-        Livewire::test(ComponentWithModelsProperty::class)
+        Livewire::test(ComponentWithModelCollectionProperty::class)
             ->set('models.1.restricted', 'bar')
             ->assertSet('models.1.restricted', null);
     }
@@ -116,7 +116,7 @@ class ModelCollectionAttributesCanBeBoundDirectlyTest extends TestCase
 
         $this->expectException(CorruptComponentPayloadException::class);
 
-        $component = Livewire::test(ComponentWithModelsProperty::class);
+        $component = Livewire::test(ComponentWithModelCollectionProperty::class);
 
         $component->payload['serverMemo']['dataMeta']['modelCollections']['models']['id'] = [1];
 
@@ -156,7 +156,7 @@ class ModelWithCustomCollectionForBinding extends Model
     }
 }
 
-class ComponentWithModelsProperty extends Component
+class ComponentWithModelCollectionProperty extends Component
 {
     public $models;
     public $modelsType;

--- a/tests/Unit/ModelsCanBeSetAsPublicPropertiesTest.php
+++ b/tests/Unit/ModelsCanBeSetAsPublicPropertiesTest.php
@@ -98,11 +98,11 @@ class ModelsCanBeSetAsPublicPropertiesTest extends TestCase
 
         $component = Livewire::test(ComponentWithModelsPublicProperty::class, ['models' => $models]);
 
-        $this->assertEquals([2, 1], $component->payload['serverMemo']['dataMeta']['models']['models']['id']);
+        $this->assertEquals([2, 1], $component->payload['serverMemo']['dataMeta']['modelCollections']['models']['id']);
 
         $component ->call('refresh');
 
-        $this->assertEquals([2, 1], $component->payload['serverMemo']['dataMeta']['models']['models']['id']);
+        $this->assertEquals([2, 1], $component->payload['serverMemo']['dataMeta']['modelCollections']['models']['id']);
     }
 }
 


### PR DESCRIPTION
This PR adds support for `wire:model` binding to eloquent collections:

Class
```php
public $users;

protected $rules = ['users.*.title' => 'required'];
```

View
```html
<input type="text" wire:model="users.0.title">
```