### PR TITLE
don't publish config with --assets flag - closes #1831

### DIFF
--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -6,16 +6,31 @@ use Illuminate\Console\Command;
 
 class PublishCommand extends Command
 {
-    protected $signature = 'livewire:publish {--assets : Indicates if Livewire\'s front-end assets should be published}';
+    protected $signature = 'livewire:publish 
+        { --assets : Indicates if Livewire\'s front-end assets should be published }
+        { --config : Indicates if Livewire\'s config file should be published }';
 
     protected $description = 'Publish Livewire configuration';
 
     public function handle()
     {
         if ($this->option('assets')) {
-            $this->call('vendor:publish', ['--tag' => 'livewire:assets', '--force' => true]);
+            $this->publishAssets();
+        } elseif ($this->option('config')) {
+            $this->publishConfig();
         } else {
-            $this->call('vendor:publish', ['--tag' => 'livewire:config', '--force' => true]);
+            $this->publishAssets();
+            $this->publishConfig();
         }
+    }
+
+    public function publishAssets()
+    {
+        $this->call('vendor:publish', ['--tag' => 'livewire:assets', '--force' => true]);
+    }
+
+    public function publishConfig()
+    {
+        $this->call('vendor:publish', ['--tag' => 'livewire:config', '--force' => true]);
     }
 }

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -12,11 +12,10 @@ class PublishCommand extends Command
 
     public function handle()
     {
-        $this->call('vendor:publish', ['--tag' => 'livewire:config', '--force' => true]);
-
         if ($this->option('assets')) {
             $this->call('vendor:publish', ['--tag' => 'livewire:assets', '--force' => true]);
+        } else {
+            $this->call('vendor:publish', ['--tag' => 'livewire:config', '--force' => true]);
         }
-
     }
 }


### PR DESCRIPTION
A potential fix for #1831, which brings up a good point -- the `publish` command probably shouldn't overwrite previously-published config files.

This feature could be supported in several ways, so the intent of this PR is to open up that discussion. Here are a couple options:

**Option 1 -- This PR**
`livewire:publish` does only config (same as now)
`livewire:publish --assets` does only assets and no config (currently it does both, this PR changes that)

**Option 2 -- More flexible?**
`livewire:publish` would do everything (change from current behavior, docs would need updating)
`livewire:publish --config` is only config
`livewire:publish --assets` is only assets

Thinking Option 2 might be nicer for end users, if you agree I'll update this PR to support that. 👍 



