### PR TITLE
Fix Laravel Echo presence channels listening

### DIFF
--- a/js/component/LaravelEcho.js
+++ b/js/component/LaravelEcho.js
@@ -35,7 +35,7 @@ export default function () {
                             store.emit(event, e)
                         })
                     } else if (channel_type == 'presence') {
-                        Echo.join(channel)[event_name](e => {
+                        Echo.join(channel).listen(event_name, e => {
                             store.emit(event, e)
                         })
                     } else if (channel_type == 'notification') {


### PR DESCRIPTION
Fix Laravel Echo presence channels registering listeners

`Uncaught TypeError: Echo.join(...)[event_name] is not a function`