### PR TITLE
Add nonce to out of date console warning

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -202,7 +202,7 @@ HTML;
             if ($manifest !== $publishedManifest) {
                 $assetWarning = <<<HTML
 <script{$nonce}>
-    console.warn("Livewire: The published Livewire assets are out of date\n See: https://laravel-livewire.com/docs/installation/")
+    console.warn("Livewire: The published Livewire assets are out of date\\n See: https://laravel-livewire.com/docs/installation/")
 </script>
 HTML;
             }

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -190,6 +190,8 @@ HTML;
         $fullAssetPath = "{$appUrl}/livewire{$versionedFileName}";
         $assetWarning = null;
 
+        $nonce = isset($options['nonce']) ? " nonce=\"{$options['nonce']}\"" : '';
+
         // Use static assets if they have been published
         if (file_exists(public_path('vendor/livewire/manifest.json'))) {
             $publishedManifest = json_decode(file_get_contents(public_path('vendor/livewire/manifest.json')), true);
@@ -198,15 +200,13 @@ HTML;
             $fullAssetPath = ($this->isOnVapor() ? config('app.asset_url') : $appUrl).'/vendor/livewire'.$versionedFileName;
 
             if ($manifest !== $publishedManifest) {
-                $assetWarning = <<<'HTML'
-<script>
+                $assetWarning = <<<HTML
+<script{$nonce}>
     console.warn("Livewire: The published Livewire assets are out of date\n See: https://laravel-livewire.com/docs/installation/")
 </script>
 HTML;
             }
         }
-
-        $nonce = isset($options['nonce']) ? " nonce=\"{$options['nonce']}\"" : '';
 
         // Adding semicolons for this JavaScript is important,
         // because it will be minified in production.


### PR DESCRIPTION
The nonce is missing from the _out of date_ console warning, causing CSP violations. The nonce attribute used on the normal `<script>` block can be used on the _out of date_ block too, so I shifted the definition of `$nonce` and included it on the tag. 

I'm guessing it was overlooked when either the nonce or the _out of date_ warning was added.

1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
This is a bugfix to prevent avoidable CSP violations.
2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Single change.
3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No
4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
See above. 😄 
5️⃣ Thanks for contributing! 🙌