### PR TITLE
support lifecycle hooks from multiple traits - closes #1860

### DIFF
--- a/src/RenameMe/SupportComponentTraits.php
+++ b/src/RenameMe/SupportComponentTraits.php
@@ -87,7 +87,7 @@ class SupportComponentTraits
             $methods = $this->componentIdMethodMap[$component->id]['dehydrate'] ?? [];
 
             foreach ($methods as $method) {
-                ImplicitlyBoundMethod::call(app(), $method,);
+                ImplicitlyBoundMethod::call(app(), $method);
             }
         });
     }

--- a/src/RenameMe/SupportComponentTraits.php
+++ b/src/RenameMe/SupportComponentTraits.php
@@ -31,50 +31,64 @@ class SupportComponentTraits
                     $method = $hook.class_basename($trait);
 
                     if (method_exists($component, $method)) {
-                        $this->componentIdMethodMap[$component->id][$hook] = [$component, $method];
+                        $this->componentIdMethodMap[$component->id][$hook][] = [$component, $method];
                     }
                 }
             }
 
-            $method = $this->componentIdMethodMap[$component->id]['hydrate'] ?? function () {};
+            $methods = $this->componentIdMethodMap[$component->id]['hydrate'] ?? [];
 
-            ImplicitlyBoundMethod::call(app(), $method, []);
+            foreach ($methods as $method) {
+                ImplicitlyBoundMethod::call(app(), $method);
+            }
         });
 
         Livewire::listen('component.mount', function ($component, $params) {
-            $method = $this->componentIdMethodMap[$component->id]['mount'] ?? function () {};
+            $methods = $this->componentIdMethodMap[$component->id]['mount'] ?? [];
 
-            ImplicitlyBoundMethod::call(app(), $method, $params);
+            foreach ($methods as $method) {
+                ImplicitlyBoundMethod::call(app(), $method, $params);
+            }
         });
 
         Livewire::listen('component.updating', function ($component, $name, $value) {
-            $method = $this->componentIdMethodMap[$component->id]['updating'] ?? function () {};
+            $methods = $this->componentIdMethodMap[$component->id]['updating'] ?? [];
 
-            ImplicitlyBoundMethod::call(app(), $method, [$name, $value]);
+            foreach ($methods as $method) {
+                ImplicitlyBoundMethod::call(app(), $method, [$name, $value]);
+            }
         });
 
         Livewire::listen('component.updated', function ($component, $name, $value) {
-            $method = $this->componentIdMethodMap[$component->id]['updated'] ?? function () {};
+            $methods = $this->componentIdMethodMap[$component->id]['updated'] ?? [];
 
-            ImplicitlyBoundMethod::call(app(), $method, [$name, $value]);
+            foreach ($methods as $method) {
+                ImplicitlyBoundMethod::call(app(), $method, [$name, $value]);
+            }
         });
 
         Livewire::listen('component.rendering', function ($component) {
-            $method = $this->componentIdMethodMap[$component->id]['rendering'] ?? function () {};
+            $methods = $this->componentIdMethodMap[$component->id]['rendering'] ?? [];
 
-            ImplicitlyBoundMethod::call(app(), $method, []);
+            foreach ($methods as $method) {
+                ImplicitlyBoundMethod::call(app(), $method);
+            }
         });
 
         Livewire::listen('component.rendered', function ($component, $view) {
-            $method = $this->componentIdMethodMap[$component->id]['rendered'] ?? function () {};
+            $methods = $this->componentIdMethodMap[$component->id]['rendered'] ?? [];
 
-            ImplicitlyBoundMethod::call(app(), $method, [$view]);
+            foreach ($methods as $method) {
+                ImplicitlyBoundMethod::call(app(), $method, [$view]);
+            }
         });
 
         Livewire::listen('component.dehydrate', function ($component) {
-            $method = $this->componentIdMethodMap[$component->id]['dehydrate'] ?? function () {};
+            $methods = $this->componentIdMethodMap[$component->id]['dehydrate'] ?? [];
 
-            ImplicitlyBoundMethod::call(app(), $method, []);
+            foreach ($methods as $method) {
+                ImplicitlyBoundMethod::call(app(), $method,);
+            }
         });
     }
 }

--- a/tests/Unit/ComponentTraitsTest.php
+++ b/tests/Unit/ComponentTraitsTest.php
@@ -21,6 +21,30 @@ class ComponentTraitsTest extends TestCase
                 ['initialized', 'hydrate', 'updating:foobar', 'updated:foobar', 'rendering', 'rendered:show-name', 'dehydrate']
             );
     }
+
+    /** @test */
+    public function multiple_traits_can_intercept_lifecycle_hooks()
+    {
+        Livewire::test(ComponentWithTwoTraitsStub::class)
+            ->assertSet('hooksFromTrait', [
+                'initialized', 'secondInitialized', 
+                'hydrate', 'secondHydrate', 
+                'mount', 'secondMount',
+                'rendering', 'secondRendering',
+                'rendered:show-name', 'secondRendered:show-name', 
+                'dehydrate', 'secondDehydrate'
+            ])
+            ->set('foo', 'bar')
+            ->assertSet('hooksFromTrait', [
+                'initialized', 'secondInitialized', 
+                'hydrate', 'secondHydrate', 
+                'updating:foobar', 'secondUpdating:foobar', 
+                'updated:foobar', 'secondUpdated:foobar', 
+                'rendering', 'secondRendering', 
+                'rendered:show-name', 'secondRendered:show-name', 
+                'dehydrate', 'secondDehydrate'
+            ]);
+    }
 }
 
 trait TraitForComponent
@@ -81,4 +105,53 @@ class ComponentWithTraitStub extends Component
     {
         return view('show-name', ['name' => $this->foo]);
     }
+}
+
+trait SecondTraitForComponent
+{
+    public function mountSecondTraitForComponent()
+    {
+        $this->hooksFromTrait[] = 'secondMount';
+    }
+
+    public function hydrateSecondTraitForComponent()
+    {
+        $this->hooksFromTrait[] = 'secondHydrate';
+    }
+
+    public function dehydrateSecondTraitForComponent()
+    {
+        $this->hooksFromTrait[] = 'secondDehydrate';
+    }
+
+    public function updatingSecondTraitForComponent($name, $value)
+    {
+        $this->hooksFromTrait[] = 'secondUpdating:'.$name.$value;
+    }
+
+    public function updatedSecondTraitForComponent($name, $value)
+    {
+        $this->hooksFromTrait[] = 'secondUpdated:'.$name.$value;
+    }
+
+    public function renderingSecondTraitForComponent()
+    {
+        $this->hooksFromTrait[] = 'secondRendering';
+    }
+
+    public function renderedSecondTraitForComponent($view)
+    {
+        $this->hooksFromTrait[] = 'secondRendered:'.$view->getName();
+    }
+
+    public function initializeSecondTraitForComponent()
+    {
+        $this->hooksFromTrait[] = 'secondInitialized';
+    }
+
+}
+
+class ComponentWithTwoTraitsStub extends ComponentWithTraitStub
+{
+    use TraitForComponent, SecondTraitForComponent;
 }


### PR DESCRIPTION
This PR adds support for using multiple traits with lifecycle methods. 

Original issue here: 
https://github.com/livewire/livewire/issues/1860