### PR TITLE
Providing a failing test for #1592

### DIFF
--- a/tests/Unit/ComponentEventsTest.php
+++ b/tests/Unit/ComponentEventsTest.php
@@ -19,6 +19,15 @@ class ComponentEventsTest extends TestCase
     }
 
     /** @test */
+    public function receive_event_from_mount()
+    {
+        $component = Livewire::test(ReceivesEvents::class);
+
+        $this->assertTrue(in_array(['event' => 'mounted', 'params' => ['cool']], $component->payload['effects']['emits']));
+        $this->assertEquals($component->get('bar'), 'cool');
+    }
+
+    /** @test */
     public function receive_event_with_single_value_listener()
     {
         $component = Livewire::test(ReceivesEventsWithSingleValueListener::class);
@@ -107,12 +116,23 @@ class ComponentEventsTest extends TestCase
 class ReceivesEvents extends Component
 {
     public $foo;
+    public $bar;
 
-    protected $listeners = ['bar' => 'onBar'];
+    protected $listeners = ['bar' => 'onBar', 'mounted' => 'onFoo'];
 
     public function onBar($value, $otherValue = '')
     {
         $this->foo = $value.$otherValue;
+    }
+
+    public function onFoo($value, $otherValue = '')
+    {
+        $this->bar = $value.$otherValue;
+    }
+
+    public function mount()
+    {
+        $this->emit('mounted', 'cool');
     }
 
     public function emitGoo()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

I am trying to provide a failing test case for #1592 as requested.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

no

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

it's only a test

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

I'm trying to show that when you emit an event from the mount method.  Listeners don't "hear" it.  I created a new listener on the test class so it wouldn't break other tests that also rely on the 'bar' listener within the class (or the foo property).

5️⃣ Thanks for contributing! 🙌