### PR TITLE
Update to getClientOriginalExtension in order to use later on

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -125,7 +125,7 @@ class TemporaryUploadedFile extends UploadedFile
     {
         $hash = Str::random(30);
         $meta = Str::of('-meta'.base64_encode($file->getClientOriginalName()).'-')->replace('/', '_');
-        $extension = '.'.$file->guessExtension();
+        $extension = '.'.$file->getClientOriginalExtension();
 
         return $hash.$meta.$extension;
     }


### PR DESCRIPTION
Fixes #1107 

Existing functionality passes on the Laravel bug with extensions.

Using this allows the file extension to be passed all the way to the Livewire component using the getClientOriginalExtension() at the component level.