### PR TITLE
Fixed pagination overflow of available page range - closes #1889

### DIFF
--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -37,7 +37,7 @@ trait WithPagination
 
     public function previousPage()
     {
-        $this->setPage($this->page - 1);
+        $this->setPage(max($this->page - 1, 1));
     }
 
     public function nextPage()

--- a/src/views/bootstrap.blade.php
+++ b/src/views/bootstrap.blade.php
@@ -9,7 +9,7 @@
                     </li>
                 @else
                     <li class="page-item">
-                        <button type="button" dusk="previousPage" class="page-link" wire:click="previousPage" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</button>
+                        <button type="button" dusk="previousPage" class="page-link" wire:click="previousPage" wire:loading.attr="disabled" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</button>
                     </li>
                 @endif
 
@@ -35,7 +35,7 @@
                 {{-- Next Page Link --}}
                 @if ($paginator->hasMorePages())
                     <li class="page-item">
-                        <button type="button" dusk="nextPage" class="page-link" wire:click="nextPage" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</button>
+                        <button type="button" dusk="nextPage" class="page-link" wire:click="nextPage" wire:loading.attr="disabled" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</button>
                     </li>
                 @else
                     <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">

--- a/src/views/simple-bootstrap.blade.php
+++ b/src/views/simple-bootstrap.blade.php
@@ -9,14 +9,14 @@
                     </li>
                 @else
                     <li class="page-item">
-                        <button type="button" class="page-link" wire:click="previousPage" rel="prev">@lang('pagination.previous')</button>
+                        <button type="button" class="page-link" wire:click="previousPage" wire:loading.attr="disabled" rel="prev">@lang('pagination.previous')</button>
                     </li>
                 @endif
 
                 {{-- Next Page Link --}}
                 @if ($paginator->hasMorePages())
                     <li class="page-item">
-                        <button type="button" class="page-link" wire:click="nextPage" rel="next">@lang('pagination.next')</button>
+                        <button type="button" class="page-link" wire:click="nextPage" wire:loading.attr="disabled" rel="next">@lang('pagination.next')</button>
                     </li>
                 @else
                     <li class="page-item disabled" aria-disabled="true">

--- a/src/views/simple-tailwind.blade.php
+++ b/src/views/simple-tailwind.blade.php
@@ -8,7 +8,7 @@
                         {!! __('pagination.previous') !!}
                     </span>
                 @else
-                    <button wire:click="previousPage" rel="prev" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                    <button wire:click="previousPage" wire:loading.attr="disabled" rel="prev" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
                         {!! __('pagination.previous') !!}
                     </button>
                 @endif
@@ -17,7 +17,7 @@
             <span>
                 {{-- Next Page Link --}}
                 @if ($paginator->hasMorePages())
-                    <button wire:click="nextPage" rel="next" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                    <button wire:click="nextPage" wire:loading.attr="disabled" rel="next" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
                         {!! __('pagination.next') !!}
                     </button>
                 @else

--- a/src/views/tailwind.blade.php
+++ b/src/views/tailwind.blade.php
@@ -8,7 +8,7 @@
                             {!! __('pagination.previous') !!}
                         </span>
                     @else
-                        <button wire:click="previousPage" dusk="previousPage.before" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                        <button wire:click="previousPage" wire:loading.attr="disabled" dusk="previousPage.before" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
                             {!! __('pagination.previous') !!}
                         </button>
                     @endif
@@ -16,7 +16,7 @@
 
                 <span>
                     @if ($paginator->hasMorePages())
-                        <button wire:click="nextPage" dusk="nextPage.before" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                        <button wire:click="nextPage" wire:loading.attr="disabled" dusk="nextPage.before" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
                             {!! __('pagination.next') !!}
                         </button>
                     @else

--- a/tests/Unit/ComponentPaginationTest.php
+++ b/tests/Unit/ComponentPaginationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use Livewire\WithPagination;
+
+class ComponentPaginationTest extends TestCase
+{
+    /** @test */
+    public function can_navigate_to_previous_page()
+    {
+        Livewire::test(ComponentWithPaginationStub::class)
+            ->set('page', 2)
+            ->call('previousPage')
+            ->assertSet('page', 1);
+    }
+
+    /** @test */
+    public function can_navigate_to_next_page()
+    {
+        Livewire::test(ComponentWithPaginationStub::class)
+            ->call('nextPage')
+            ->assertSet('page', 2);
+    }
+
+    /** @test */
+    public function can_navigate_to_specific_page()
+    {
+        Livewire::test(ComponentWithPaginationStub::class)
+            ->call('gotoPage', 5)
+            ->assertSet('page', 5);
+    }
+
+    /** @test */
+    public function previous_page_cannot_be_less_than_one()
+    {
+        Livewire::test(ComponentWithPaginationStub::class)
+            ->call('previousPage')
+            ->assertSet('page', 1);
+    }
+}
+
+class ComponentWithPaginationStub extends Component
+{
+    use WithPagination;
+    
+    public function render()
+    {
+        return view('show-name', ['name' => 'example']);
+    }
+}


### PR DESCRIPTION
If you have a slow connection (or are really fast at clicking), you can exceed the range of available pages.

This is described in #1889.

I added some Unit tests for this, but ran into a blocker when it came to implementing the `nextPage` portion. 
Since there's not a specific paginator instance in the `WithPagination` trait, we can't easily determine the total number of pages to restrict the `$page` variable (as I did with `previousPage()`).

Instead, I added `wire:loading.attr="disabled"` to the default pagination views to prevent this from happening. It's a bummer we couldn't test _everything_ in the unit test, but it seemed better than trying to hack a paginator instance into everything 🤮 . 

