### PR TITLE
[Maintenance] use str all over the place

### DIFF
--- a/src/Commands/ComponentParser.php
+++ b/src/Commands/ComponentParser.php
@@ -5,6 +5,7 @@ namespace Livewire\Commands;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\File;
+use function Livewire\str;
 
 class ComponentParser
 {
@@ -26,11 +27,11 @@ class ComponentParser
 
         $directories = preg_split('/[.\/(\\\\)]+/', $rawCommand);
 
-        $camelCase = Str::camel(array_pop($directories));
-        $kebabCase = Str::kebab($camelCase);
+        $camelCase = str(array_pop($directories))->camel();
+        $kebabCase = str($camelCase)->kebab();
 
         $this->component = $kebabCase;
-        $this->componentClass = Str::studly($this->component);
+        $this->componentClass = str($this->component)->studly();
 
         $this->directories = array_map([Str::class, 'studly'], $directories);
     }
@@ -48,9 +49,9 @@ class ComponentParser
             ->implode('/');
     }
 
-    public function relativeClassPath()
+    public function relativeClassPath() : string
     {
-        return Str::replaceFirst(base_path().DIRECTORY_SEPARATOR, '', $this->classPath());
+        return str($this->classPath())->replaceFirst(base_path().DIRECTORY_SEPARATOR, '');
     }
 
     public function classFile()
@@ -103,9 +104,9 @@ class ComponentParser
             ->implode(DIRECTORY_SEPARATOR);
     }
 
-    public function relativeViewPath()
+    public function relativeViewPath() : string
     {
-        return Str::replaceFirst(base_path().'/', '', $this->viewPath());
+        return str($this->viewPath())->replaceFirst(base_path().'/', '');
     }
 
     public function viewFile()
@@ -116,7 +117,7 @@ class ComponentParser
     public function viewName()
     {
         return collect()
-            ->concat(explode('/',Str::after($this->baseViewPath, resource_path('views'))))
+            ->concat(explode('/',str($this->baseViewPath)->after(resource_path('views'))))
             ->filter()
             ->concat($this->directories)
             ->map([Str::class, 'kebab'])
@@ -146,7 +147,7 @@ class ComponentParser
 
     public static function generatePathFromNamespace($namespace)
     {
-        $name = Str::replaceFirst(app()->getNamespace(), '', $namespace);
+        $name = str($namespace)->replaceFirst(app()->getNamespace(), '');
 
         return app('path').'/'.str_replace('\\', '/', $name);
     }

--- a/src/Commands/FileManipulationCommand.php
+++ b/src/Commands/FileManipulationCommand.php
@@ -2,10 +2,10 @@
 
 namespace Livewire\Commands;
 
-use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Livewire\LivewireComponentsFinder;
+use function Livewire\str;
 
 class FileManipulationCommand extends Command
 {
@@ -25,9 +25,9 @@ class FileManipulationCommand extends Command
 
     public function isFirstTimeMakingAComponent()
     {
-        $namespace = Str::replaceFirst(app()->getNamespace(), '', config('livewire.class_namespace', 'App\\Http\\Livewire'));
+        $namespace = str(config('livewire.class_namespace', 'App\\Http\\Livewire'))->replaceFirst(app()->getNamespace(), '');
 
-        $livewireFolder = app_path(collect(explode('\\', $namespace))->implode(DIRECTORY_SEPARATOR));
+        $livewireFolder = app_path($namespace->explode('\\')->implode(DIRECTORY_SEPARATOR));
 
         return ! File::isDirectory($livewireFolder);
     }

--- a/src/Commands/StubParser.php
+++ b/src/Commands/StubParser.php
@@ -3,6 +3,7 @@
 namespace Livewire\Commands;
 
 use Illuminate\Support\Str;
+use function Livewire\str;
 
 class StubParser extends ComponentParser
 {
@@ -17,8 +18,8 @@ class StubParser extends ComponentParser
 
         $directories = preg_split('/[.\/]+/', $rawCommand);
 
-        $this->component = Str::kebab(array_pop($directories));
-        $this->componentClass = Str::studly($this->component);
+        $this->component = str(array_pop($directories))->kebab();
+        $this->componentClass = str($this->component)->studly();
 
         $this->directories = array_map([Str::class, 'studly'], $directories);
     }

--- a/src/Component.php
+++ b/src/Component.php
@@ -33,7 +33,7 @@ abstract class Component
 
     public function __construct($id = null)
     {
-        $this->id = $id ?? Str::random(20);
+        $this->id = $id ?? str()->random(20);
 
         $this->ensureIdPropertyIsntOverridden();
     }
@@ -87,8 +87,8 @@ abstract class Component
             ->map([Str::class, 'kebab'])
             ->implode('.');
 
-        if (Str::startsWith($fullName, $namespace)) {
-            return Str::substr($fullName, strlen($namespace) + 1);
+        if (str($fullName)->startsWith($namespace)) {
+            return (string) str($fullName)->substr(strlen($namespace) + 1);
         }
 
         return $fullName;
@@ -225,7 +225,7 @@ abstract class Component
     {
         if (
             in_array($method, ['mount', 'hydrate', 'dehydrate', 'updating', 'updated'])
-            || Str::startsWith($method, ['updating', 'updated', 'hydrate', 'dehydrate'])
+            || str($method)->startsWith(['updating', 'updated', 'hydrate', 'dehydrate'])
         ) {
             // Eat calls to the lifecycle hooks if the dev didn't define them.
             return;

--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -3,7 +3,6 @@
 namespace Livewire\ComponentConcerns;
 
 use Livewire\Livewire;
-use Illuminate\Support\Str;
 use Livewire\ImplicitlyBoundMethod;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Exceptions\MethodNotFoundException;
@@ -13,6 +12,7 @@ use Livewire\Exceptions\MissingFileUploadsTraitException;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Livewire\HydrationMiddleware\HashDataPropertiesForDirtyDetection;
 use Livewire\Exceptions\CannotBindToModelDataWithoutValidationRuleException;
+use function Livewire\str;
 
 trait HandlesActions
 {
@@ -56,20 +56,24 @@ trait HandlesActions
 
     protected function callBeforeAndAfterSyncHooks($name, $value, $callback)
     {
-        $propertyName = Str::before(Str::studly($name), '.');
-        $keyAfterFirstDot = Str::contains($name, '.') ? Str::after($name, '.') : null;
-        $keyAfterLastDot = Str::contains($name, '.') ? Str::afterLast($name, '.') : null;
+        $name = str($name);
+
+        $propertyName = $name->studly()->before('.');
+        $keyAfterFirstDot = $name->contains('.') ? $name->after('.') : null;
+        $keyAfterLastDot = $name->contains('.') ? $name->afterLast('.') : null;
 
         $beforeMethod = 'updating'.$propertyName;
         $afterMethod = 'updated'.$propertyName;
 
-        $beforeNestedMethod = Str::contains($name, '.')
-            ? 'updating'.Str::of($name)->replace('.', '_')->studly()
+        $beforeNestedMethod = $name->contains('.')
+            ? 'updating'.$name->replace('.', '_')->studly()
             : false;
 
-        $afterNestedMethod = Str::contains($name, '.')
-            ? 'updated'.Str::of($name)->replace('.', '_')->studly()
+        $afterNestedMethod = $name->contains('.')
+            ? 'updated'.$name->replace('.', '_')->studly()
             : false;
+
+        $name = $name->__toString();
 
         $this->updating($name, $value);
 

--- a/src/ComponentConcerns/InteractsWithProperties.php
+++ b/src/ComponentConcerns/InteractsWithProperties.php
@@ -2,8 +2,8 @@
 
 namespace Livewire\ComponentConcerns;
 
-use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
+use function Livewire\str;
 
 trait InteractsWithProperties
 {
@@ -118,9 +118,9 @@ trait InteractsWithProperties
         return head(explode('.', $subject));
     }
 
-    public function afterFirstDot($subject)
+    public function afterFirstDot($subject) : string
     {
-        return Str::after($subject, '.');
+        return str($subject)->after('.');
     }
 
     public function propertyIsPublicAndNotDefinedOnBaseClass($propertyName)

--- a/src/LivewireBladeDirectives.php
+++ b/src/LivewireBladeDirectives.php
@@ -2,8 +2,6 @@
 
 namespace Livewire;
 
-use Illuminate\Support\Str;
-
 class LivewireBladeDirectives
 {
     public static function this()
@@ -30,15 +28,15 @@ EOT;
 
     public static function livewire($expression)
     {
-        $lastArg = trim(last(explode(',', $expression)));
+        $lastArg = str(last(explode(',', $expression)))->trim();
 
-        if (Str::startsWith($lastArg, 'key(') && Str::endsWith($lastArg, ')')) {
-            $cachedKey = Str::replaceFirst('key(', '', Str::replaceLast(')', '', $lastArg));
+        if ($lastArg->startsWith('key(') && $lastArg->endsWith(')')) {
+            $cachedKey = $lastArg->replaceFirst('key(', '')->replaceLast(')', '');
             $args = explode(',', $expression);
             array_pop($args);
             $expression = implode(',', $args);
         } else {
-            $cachedKey = "'".Str::random(7)."'";
+            $cachedKey = "'".str()->random(7)."'";
         }
 
         return <<<EOT

--- a/src/LivewireComponentsFinder.php
+++ b/src/LivewireComponentsFinder.php
@@ -4,7 +4,6 @@ namespace Livewire;
 
 use Exception;
 use ReflectionClass;
-use Illuminate\Support\Str;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -65,11 +64,10 @@ class LivewireComponentsFinder
     {
         return collect($this->files->allFiles($this->path))
             ->map(function (SplFileInfo $file) {
-                return app()->getNamespace().str_replace(
-                    ['/', '.php'],
-                    ['\\', ''],
-                    Str::after($file->getPathname(), app_path().'/')
-                );
+                return app()->getNamespace().
+                    str($file->getPathname())
+                        ->after(app_path().'/')
+                        ->replace(['/', '.php'], ['\\', ''])->__toString();
             })
             ->filter(function (string $class) {
                 return is_subclass_of($class, Component::class) &&

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -2,7 +2,6 @@
 
 namespace Livewire;
 
-use Illuminate\Support\Str;
 use Livewire\Testing\TestableLivewire;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Livewire\Exceptions\ComponentNotFoundException;
@@ -73,7 +72,7 @@ class LivewireManager
         // This is if a user doesn't pass params, BUT passes key() as the second argument.
         if (is_string($params)) $params = [];
 
-        $id = Str::random(20);
+        $id = str()->random(20);
 
         if (class_exists($name)) {
             $name = $name::getName();

--- a/src/LivewireTagCompiler.php
+++ b/src/LivewireTagCompiler.php
@@ -2,7 +2,6 @@
 
 namespace Livewire;
 
-use Illuminate\Support\Str;
 use Illuminate\View\Compilers\ComponentTagCompiler;
 
 class LivewireTagCompiler extends ComponentTagCompiler
@@ -44,7 +43,7 @@ class LivewireTagCompiler extends ComponentTagCompiler
 
             // Convert kebab attributes to camel-case.
             $attributes = collect($attributes)->mapWithKeys(function ($value, $key) {
-                return [Str::camel($key) => $value];
+                return [str($key)->camel() => $value];
             })->toArray();
 
             if ($matches[1] === 'styles') return '@livewireStyles';

--- a/src/Macros/DuskBrowserMacros.php
+++ b/src/Macros/DuskBrowserMacros.php
@@ -3,7 +3,7 @@
 namespace Livewire\Macros;
 
 use PHPUnit\Framework\Assert as PHPUnit;
-use Illuminate\Support\Str;
+use function Livewire\str;
 
 class DuskBrowserMacros
 {
@@ -75,7 +75,7 @@ class DuskBrowserMacros
         return function ($js, $expects = true) {
             /** @var \Laravel\Dusk\Browser $this */
             PHPUnit::assertEquals($expects, head($this->script(
-                Str::start( $js, 'return ')
+                str($js)->start('return ')
             )));
 
             return $this;

--- a/src/RenameMe/SupportBrowserHistory.php
+++ b/src/RenameMe/SupportBrowserHistory.php
@@ -6,10 +6,10 @@ use Livewire\Livewire;
 use Livewire\Response;
 use Livewire\Component;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Routing\UrlGenerator;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use function Livewire\str;
 
 class SupportBrowserHistory
 {
@@ -92,7 +92,7 @@ class SupportBrowserHistory
             $route
             && is_string($action = $route->getActionName())
             // If the component is registered using `Route::get()`.
-            && Str::of($action)->contains(get_class($component))
+            && str($action)->contains(get_class($component))
             // AND, the component is tracking route params as its public properties
             && count(array_intersect_key($component->getPublicPropertiesDefinedBySubClass(), $route->parametersWithoutNulls()))
         ) {
@@ -118,9 +118,9 @@ class SupportBrowserHistory
         return $refererQueryString;
     }
 
-    protected function buildPathFromReferer($referer, $queryParams)
+    protected function buildPathFromReferer($referer, $queryParams) : string
     {
-        return Str::before($referer, '?').$this->stringifyQueryParams($queryParams);
+        return str($referer)->before('?').$this->stringifyQueryParams($queryParams);
     }
 
     protected function buildPathFromRoute($component, $route, $queryString)

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -31,9 +31,7 @@ class TemporaryUploadedFile extends UploadedFile
     public function getSize()
     {
         if (app()->environment('testing') && str($this->getfilename())->contains('-size=')) {
-            // This head/explode/last/explode nonsense is the equivelant of Str::between().
-            [$beginning, $end] = ['-size=', '.'];
-            return (int) head(explode($end, last(explode($beginning, $this->getFilename()))));
+            return (int) str($this->getFilename())->between('-size=', '.')->__toString();
         }
 
         return (int) $this->storage->size($this->path);

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -3,7 +3,6 @@
 namespace Livewire;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Storage;
@@ -31,7 +30,7 @@ class TemporaryUploadedFile extends UploadedFile
 
     public function getSize()
     {
-        if (app()->environment('testing') && str::contains($this->getfilename(), '-size=')) {
+        if (app()->environment('testing') && str($this->getfilename())->contains('-size=')) {
             // This head/explode/last/explode nonsense is the equivelant of Str::between().
             [$beginning, $end] = ['-size=', '.'];
             return (int) head(explode($end, last(explode($beginning, $this->getFilename()))));
@@ -123,8 +122,8 @@ class TemporaryUploadedFile extends UploadedFile
 
     public static function generateHashNameWithOriginalNameEmbedded($file)
     {
-        $hash = Str::random(30);
-        $meta = Str::of('-meta'.base64_encode($file->getClientOriginalName()).'-')->replace('/', '_');
+        $hash = str()->random(30);
+        $meta = str('-meta'.base64_encode($file->getClientOriginalName()).'-')->replace('/', '_');
         $extension = '.'.$file->guessExtension();
 
         return $hash.$meta.$extension;
@@ -132,7 +131,7 @@ class TemporaryUploadedFile extends UploadedFile
 
     public function extractOriginalNameFromFilePath($path)
     {
-        return base64_decode(head(explode('-', last(explode('-meta', Str::of($path)->replace('_', '/'))))));
+        return base64_decode(head(explode('-', last(explode('-meta', str($path)->replace('_', '/'))))));
     }
 
     public static function createFromLivewire($filePath)
@@ -143,7 +142,7 @@ class TemporaryUploadedFile extends UploadedFile
     public static function canUnserialize($subject)
     {
         if (is_string($subject)) {
-            return Str::startsWith($subject, ['livewire-file:', 'livewire-files:']);
+            return (string) str($subject)->startsWith(['livewire-file:', 'livewire-files:']);
         }
 
         if (is_array($subject)) {
@@ -158,12 +157,12 @@ class TemporaryUploadedFile extends UploadedFile
     public static function unserializeFromLivewireRequest($subject)
     {
         if (is_string($subject)) {
-            if (Str::startsWith($subject, 'livewire-file:')) {
-                return static::createFromLivewire(Str::after($subject, 'livewire-file:'));
+            if (str($subject)->startsWith('livewire-file:')) {
+                return static::createFromLivewire(str($subject)->after('livewire-file:'));
             }
 
-            if (Str::startsWith($subject, 'livewire-files:')) {
-                $paths = json_decode(Str::after($subject, 'livewire-files:'), true);
+            if (str($subject)->startsWith('livewire-files:')) {
+                $paths = json_decode(str($subject)->after('livewire-files:'), true);
 
                 return collect($paths)->map(function ($path) { return static::createFromLivewire($path); })->toArray();
             }

--- a/src/Testing/Concerns/MakesCallsToComponent.php
+++ b/src/Testing/Concerns/MakesCallsToComponent.php
@@ -2,11 +2,11 @@
 
 namespace Livewire\Testing\Concerns;
 
-use Illuminate\Support\Str;
 use Illuminate\Http\UploadedFile;
 use Livewire\FileUploadConfiguration;
 use Livewire\Controllers\FileUploadHandler;
 use Illuminate\Validation\ValidationException;
+use function Livewire\str;
 
 trait MakesCallsToComponent
 {
@@ -112,7 +112,7 @@ trait MakesCallsToComponent
         // We are going to encode the file size in the filename so that when we create
         // a new TemporaryUploadedFile instance we can fake a specific file size.
         $newFileHashes = collect($files)->zip($fileHashes)->mapSpread(function ($file, $fileHash) {
-            return Str::replaceFirst('.', "-size={$file->getSize()}.", $fileHash);
+            return (string) str($fileHash)->replaceFirst('.', "-size={$file->getSize()}.");
         })->toArray();
 
         collect($fileHashes)->zip($newFileHashes)->mapSpread(function ($fileHash, $newFileHash) use ($storage) {

--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -4,7 +4,6 @@ namespace Livewire\Testing;
 
 use Mockery;
 use Livewire\Livewire;
-use Illuminate\Support\Str;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\View;
 use Livewire\GenerateSignedUploadUrl;
@@ -12,6 +11,7 @@ use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Traits\Macroable;
 use Facades\Livewire\GenerateSignedUploadUrl as GenerateSignedUploadUrlFacade;
 use Livewire\Exceptions\PropertyNotFoundException;
+use function Livewire\str;
 
 class TestableLivewire
 {
@@ -68,7 +68,7 @@ class TestableLivewire
         // and not have to register an alias.
         if (class_exists($name)) {
             $componentClass = $name;
-            app('livewire')->component($name = Str::random(20), $componentClass);
+            app('livewire')->component($name = str()->random(20), $componentClass);
         }
 
         $this->componentName = $name;
@@ -122,7 +122,7 @@ class TestableLivewire
 
     public function pretendWereMountingAComponentOnAPage($name, $params)
     {
-        $randomRoutePath = '/testing-livewire/'.Str::random(20);
+        $randomRoutePath = '/testing-livewire/'.str()->random(20);
 
         $this->registerRouteBeforeExistingRoutes($randomRoutePath, function () use ($name, $params) {
             return View::file(__DIR__.'/../views/mount-component.blade.php', [
@@ -216,7 +216,7 @@ class TestableLivewire
                 } catch (\Throwable $e) {
                     if ($e instanceof PropertyNotFoundException) {
                         $value = null;
-                    } else if (Str::of($e->getMessage())->contains('must not be accessed before initialization')) {
+                    } else if (str($e->getMessage())->contains('must not be accessed before initialization')) {
                         $value = null;
                     } else {
                         throw $e;

--- a/src/WireDirective.php
+++ b/src/WireDirective.php
@@ -3,7 +3,6 @@
 namespace Livewire;
 
 use Stringable;
-use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\View\ComponentAttributeBag;
 
@@ -33,7 +32,7 @@ class WireDirective implements Htmlable, Stringable
 
     public function modifiers()
     {
-        return Str::of($this->directive)
+        return str($this->directive)
             ->replace("wire:{$this->name}", '')
             ->explode('.')
             ->filter()->values();

--- a/tests/Unit/ComponentRootHasIdAndComponentDataTest.php
+++ b/tests/Unit/ComponentRootHasIdAndComponentDataTest.php
@@ -7,6 +7,7 @@ use Livewire\Component;
 use Livewire\Exceptions\RootTagMissingFromViewException;
 use Livewire\Livewire;
 use Livewire\LivewireManager;
+use function Livewire\str;
 
 class ComponentRootHasIdAndComponentDataTest extends TestCase
 {
@@ -15,10 +16,9 @@ class ComponentRootHasIdAndComponentDataTest extends TestCase
     {
         $component = Livewire::test(ComponentRootHasIdAndDataStub::class);
 
-        $this->assertTrue(Str::contains(
-            $component->payload['effects']['html'],
-            [$component->id(), 'foo']
-        ));
+        $this->assertTrue(
+            str($component->payload['effects']['html'])->contains([$component->id(), 'foo'])
+        );
     }
 
     /** @test */
@@ -26,7 +26,7 @@ class ComponentRootHasIdAndComponentDataTest extends TestCase
     {
         $this->expectException(RootTagMissingFromViewException::class);
 
-        $component = Livewire::test(ComponentRootExists::class);
+        Livewire::test(ComponentRootExists::class);
     }
 
     /** @test */
@@ -49,13 +49,9 @@ EOT
 
         $component->call('$refresh');
 
-        $this->assertTrue(Str::contains(
-            $component->lastRenderedDom, $component->id()
-        ));
+        $this->assertStringContainsString($component->id(), $component->lastRenderedDom);
 
-        $this->assertFalse(Str::contains(
-            $component->lastRenderedDom, 'foo'
-        ));
+        $this->assertStringNotContainsString('foo', $component->lastRenderedDom);
     }
 }
 
@@ -70,7 +66,7 @@ class ComponentRootHasIdAndDataStub extends Component
 
     public function render()
     {
-        return app('view')->make('show-name', ['name' => Str::random(5)]);
+        return app('view')->make('show-name', ['name' => str()->random(5)]);
     }
 }
 

--- a/tests/Unit/FileUploadsTest.php
+++ b/tests/Unit/FileUploadsTest.php
@@ -6,7 +6,6 @@ use LogicException;
 use RuntimeException;
 use Livewire\Livewire;
 use Livewire\Component;
-use Illuminate\Support\Str;
 use Livewire\WithFileUploads;
 use Illuminate\Validation\Rule;
 use Illuminate\Http\UploadedFile;
@@ -15,6 +14,7 @@ use Illuminate\Support\Facades\Storage;
 use Facades\Livewire\GenerateSignedUploadUrl;
 use Livewire\Exceptions\MissingFileUploadsTraitException;
 use Livewire\Exceptions\S3DoesntSupportMultipleFileUploads;
+use function Livewire\str;
 
 class FileUploadsTest extends TestCase
 {
@@ -433,7 +433,7 @@ class FileUploadsTest extends TestCase
             ->set('photo', UploadedFile::fake()->image('avatar.jpg'))
             ->viewData('photo');
 
-        $this->get(Str::before($photo->temporaryUrl(), '&signature='))->assertStatus(401);
+        $this->get(str($photo->temporaryUrl())->before('&signature='))->assertStatus(401);
     }
 
     /** @test */

--- a/tests/Unit/NestingComponentsTest.php
+++ b/tests/Unit/NestingComponentsTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Unit;
 
-use Illuminate\Support\Str;
 use Livewire\Component;
 
 class NestingComponentsTest extends TestCase
@@ -14,10 +13,7 @@ class NestingComponentsTest extends TestCase
         app('livewire')->component('child', ChildComponentForNestingStub::class);
         $component = app('livewire')->test('parent');
 
-        $this->assertTrue(Str::contains(
-            $component->payload['effects']['html'],
-            'foo'
-        ));
+        $this->assertStringContainsString('foo', $component->payload['effects']['html']);
     }
 
     /** @test */
@@ -27,17 +23,11 @@ class NestingComponentsTest extends TestCase
         app('livewire')->component('child', ChildComponentForNestingStub::class);
         $component = app('livewire')->test('parent');
 
-        $this->assertTrue(Str::contains(
-            $component->payload['effects']['html'],
-            'foo'
-        ));
+        $this->assertStringContainsString('foo', $component->payload['effects']['html']);
 
         $component->runAction('$refresh');
 
-        $this->assertFalse(Str::contains(
-            $component->payload['effects']['html'],
-            'foo'
-        ));
+        $this->assertStringNotContainsString('foo', $component->payload['effects']['html']);
     }
 
     /** @test */
@@ -47,17 +37,11 @@ class NestingComponentsTest extends TestCase
         app('livewire')->component('child', ChildComponentForNestingStub::class);
         $component = app('livewire')->test('parent');
 
-        $this->assertTrue(Str::contains(
-            $component->payload['effects']['html'],
-            'span'
-        ));
+        $this->assertStringContainsString('span', $component->payload['effects']['html']);
 
         $component->runAction('$refresh');
 
-        $this->assertTrue(Str::contains(
-            $component->payload['effects']['html'],
-            'span'
-        ));
+        $this->assertStringContainsString('span', $component->payload['effects']['html']);
     }
 
     /** @test */
@@ -67,15 +51,15 @@ class NestingComponentsTest extends TestCase
         app('livewire')->component('child', ChildComponentForNestingStub::class);
         $component = app('livewire')->test('parent');
 
-        $this->assertTrue(Str::contains($component->payload['effects']['html'], 'foo'));
+        $this->assertStringContainsString('foo', $component->payload['effects']['html'] );
 
         $component->runAction('setChildren', ['foo', 'bar']);
-        $this->assertFalse(Str::contains($component->payload['effects']['html'], 'foo'));
-        $this->assertTrue(Str::contains($component->payload['effects']['html'], 'bar'));
+        $this->assertStringNotContainsString('foo', $component->payload['effects']['html']);
+        $this->assertStringContainsString('bar', $component->payload['effects']['html'] );
 
         $component->runAction('setChildren', ['foo', 'bar']);
-        $this->assertFalse(Str::contains($component->payload['effects']['html'], 'foo'));
-        $this->assertFalse(Str::contains($component->payload['effects']['html'], 'bar'));
+        $this->assertStringNotContainsString('foo', $component->payload['effects']['html']);
+        $this->assertStringNotContainsString('bar', $component->payload['effects']['html']);
     }
 }
 


### PR DESCRIPTION
- replaced `Str` with `str()`
- to make sure a string is returned some methods now have a return type `string` (could be removed and return needs to cast stuff to `string`)
- kept `Str` only for `Stringable` tests to be explicit
- in some tests we now use `assertStringContainsString` and `assertStringNotContainsString`
- [separated commit](https://github.com/livewire/livewire/pull/1897/commits/2e94090ad360e281b480d62fc08a6113bcb6810e#diff-bc1a1c611931be05f4fd946bdc7dff27c6a67685f272b6e1369017a259d2b950) where I replaced a strange between hack with the actual `between()`