### PR TITLE
Support binding to hidden model attributes when explicitly present in Component $rules.

### DIFF
--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -164,9 +164,9 @@ class HydratePublicProperties implements HydrationMiddleware
         if ($rules = $instance->rulesForModel($property)) {
             $keys = $rules->keys()->map(function ($key) use ($instance) {
                 return $instance->beforeFirstDot($instance->afterFirstDot($key));
-            });
+            })->toArray();
 
-            $fullModelData = $instance->$property->toArray();
+            $fullModelData = $instance->$property->makeVisible($keys)->toArray();
 
             foreach ($keys as $key) {
                 data_set($filteredModelData, $key, data_get($fullModelData, $key));


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
It was rised on #1868.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Straight to implementation :nerd_face: 

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yup, all looking good :green_circle: 

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
As discussed in #1868, sometimes you may want to hide certain attribute values from a Model (for implementation reasons), but you may stumble across feature implementations that require that you bind into those attributes using Livewire (or maybe entangled to Alpine).

Well, this PR tries to solve that.

In order to prevent all hidden attributes to be exposed via Livewire, only the attributes specified in the `$rules` property (or `rules()` method) will be exposed to Livewire. This way, we try to force developers to think about their implementation needs, unless they're just copy-pasting without understanding anything.

5️⃣ Thanks for contributing! 🙌