### PR TITLE
support numbers larger than javascript maximum safe integer - #1857

### DIFF
--- a/src/HydrationMiddleware/NormalizeComponentPropertiesForJavaScript.php
+++ b/src/HydrationMiddleware/NormalizeComponentPropertiesForJavaScript.php
@@ -3,11 +3,10 @@
 namespace Livewire\HydrationMiddleware;
 
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
 
 class NormalizeComponentPropertiesForJavaScript extends NormalizeDataForJavaScript implements HydrationMiddleware
 {
-    protected const JAVASCRIPT_MAX_SAFE_INTEGER = 9007199254740991;
-
     public static function hydrate($instance, $request)
     {
         //
@@ -16,10 +15,7 @@ class NormalizeComponentPropertiesForJavaScript extends NormalizeDataForJavaScri
     public static function dehydrate($instance, $response)
     {
         foreach ($instance->getPublicPropertiesDefinedBySubClass() as $key => $value) {
-
-            // The javascript maximum integer is 9007199254740991. 
-            // If the value is larger than that, it should be converted to a string
-            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+            // If the value is larger than the javascript integer maximum, it should be converted to a string
             if (is_numeric($value) && $value > self::JAVASCRIPT_MAX_SAFE_INTEGER) {
                 $instance->$key = (string) $value;
             }

--- a/src/HydrationMiddleware/NormalizeComponentPropertiesForJavaScript.php
+++ b/src/HydrationMiddleware/NormalizeComponentPropertiesForJavaScript.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 class NormalizeComponentPropertiesForJavaScript extends NormalizeDataForJavaScript implements HydrationMiddleware
 {
+    protected const JAVASCRIPT_MAX_SAFE_INTEGER = 9007199254740991;
+
     public static function hydrate($instance, $request)
     {
         //
@@ -14,6 +16,14 @@ class NormalizeComponentPropertiesForJavaScript extends NormalizeDataForJavaScri
     public static function dehydrate($instance, $response)
     {
         foreach ($instance->getPublicPropertiesDefinedBySubClass() as $key => $value) {
+
+            // The javascript maximum integer is 9007199254740991. 
+            // If the value is larger than that, it should be converted to a string
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+            if (is_numeric($value) && $value > self::JAVASCRIPT_MAX_SAFE_INTEGER) {
+                $instance->$key = (string) $value;
+            }
+
             if (is_array($value)) {
                 $instance->$key = static::reindexArrayWithNumericKeysOtherwiseJavaScriptWillMessWithTheOrder($value);
             }

--- a/src/HydrationMiddleware/NormalizeDataForJavaScript.php
+++ b/src/HydrationMiddleware/NormalizeDataForJavaScript.php
@@ -4,9 +4,17 @@ namespace Livewire\HydrationMiddleware;
 
 abstract class NormalizeDataForJavaScript
 {
+    // The javascript maximum integer is 9007199254740991, or 2^53.
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+    protected const JAVASCRIPT_MAX_SAFE_INTEGER = 9007199254740991;
+
     protected static function reindexArrayWithNumericKeysOtherwiseJavaScriptWillMessWithTheOrder($value)
     {
         if (! is_array($value)) {
+            if (is_numeric($value) && $value > self::JAVASCRIPT_MAX_SAFE_INTEGER) {
+               return (string) $value;
+            }
+
             return $value;
         }
 

--- a/tests/Unit/DataBindingTest.php
+++ b/tests/Unit/DataBindingTest.php
@@ -83,6 +83,15 @@ class DataBindingTest extends TestCase
         $this->assertEquals('something else', $component->propertyWithHook);
         $this->assertContains('propertyWithHook', $component->payload['effects']['dirty']);
     }
+
+    /** @test */
+    public function property_larger_than_javascript_maximum_is_converted_to_string()
+    {
+        $component = Livewire::test(DataBindingStub::class);
+        $component->updateProperty('foo', 100000000000000000);
+        $this->assertEquals('100000000000000000', $component->foo);
+        $this->assertIsString($component->foo);
+    }
 }
 
 class DataBindingStub extends Component


### PR DESCRIPTION
As reported in #1857, using integers larger than Javascript's `Number.MAX_SAFE_INTEGER` causes problems. 

This PR should solve that problem by casting large integers to a string when dehydrating (nice suggestion @nuernbergerA !) 

For more info on Javascript's limitation see here:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER