### PR TITLE
Fix: ES6 syntax preventing further JS execution

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -233,8 +233,8 @@ HTML;
     if (window.Alpine) {
         /* Defer showing the warning so it doesn't get buried under downstream errors. */
         document.addEventListener("DOMContentLoaded", function () {
-            setTimeout(() => {
-                console.warn(`Livewire: It looks like AlpineJS has already been loaded. Make sure Livewire\'s scripts are loaded before Alpine.\n\n Reference docs for more info: http://laravel-livewire.com/docs/alpine-js`)
+            setTimeout(function() {
+                console.warn("Livewire: It looks like AlpineJS has already been loaded. Make sure Livewire\'s scripts are loaded before Alpine.\n\n Reference docs for more info: http://laravel-livewire.com/docs/alpine-js")
             })
         });
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
No

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
In the following commit [Add warning about Alpine being loaded too soon](https://github.com/livewire/livewire/commit/cde038a773f9906cc5f27996bceea558f9d56cea) a console warning for alpine was added. This breaks further JS execution in browsers that do not support arrow functions and template literals (like IE11). This PR should fix that issue.

5️⃣ Thanks for contributing! 🙌