### PR TITLE
PHP8 Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
         laravel: [7.*, 8.*]
         dependency-version: [prefer-stable]
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "symfony/http-kernel": "^5.0",
         "illuminate/support": "^7.0|^8.0",
         "illuminate/database": "^7.0|^8.0",

--- a/src/HydrationMiddleware/HashDataPropertiesForDirtyDetection.php
+++ b/src/HydrationMiddleware/HashDataPropertiesForDirtyDetection.php
@@ -45,7 +45,10 @@ class HashDataPropertiesForDirtyDetection implements HydrationMiddleware
 
     public static function hash($value)
     {
-        if (! is_null($value) && ! is_string($value) && ! is_numeric($value)) {
+        if (! is_null($value) && ! is_string($value) && ! is_numeric($value) && ! is_bool($value)) {
+            if (is_array($value)) {
+                return json_encode($value);
+            }
             $value = method_exists($value, '__toString')
                 ? (string) $value
                 : json_encode($value);

--- a/src/ImplicitlyBoundMethod.php
+++ b/src/ImplicitlyBoundMethod.php
@@ -5,6 +5,7 @@ namespace Livewire;
 use Illuminate\Container\BoundMethod;
 use Illuminate\Contracts\Routing\UrlRoutable as ImplicitlyBindable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use ReflectionClass;
 
 class ImplicitlyBoundMethod extends BoundMethod
 {
@@ -74,14 +75,14 @@ class ImplicitlyBoundMethod extends BoundMethod
 
     protected static function getClassForDependencyInjection($parameter)
     {
-        if (! is_null($className = static::getParameterClassName($parameter)) && ! $parameter->getClass()->implementsInterface(ImplicitlyBindable::class)) {
+        if (! is_null($className = static::getParameterClassName($parameter)) && ! static::implementsInterface($parameter)) {
             return $className;
         }
     }
 
     protected static function getClassForImplicitBinding($parameter)
     {
-        if (! is_null($className = static::getParameterClassName($parameter)) && $parameter->getClass()->implementsInterface(ImplicitlyBindable::class)) {
+        if (! is_null($className = static::getParameterClassName($parameter)) && static::implementsInterface($parameter)) {
             return $className;
         }
 
@@ -104,5 +105,10 @@ class ImplicitlyBoundMethod extends BoundMethod
         $type = $parameter->getType();
 
         return ($type && ! $type->isBuiltin()) ? $type->getName() : null;
+    }
+
+    public static function implementsInterface($parameter)
+    {
+        return (new ReflectionClass($parameter->getType()->getName()))->implementsInterface(ImplicitlyBindable::class);
     }
 }


### PR DESCRIPTION
As we are working on getting Laravel working on PHP 8 and we fixed jetstream, frontify and scantum yesterday. Now we need Livewire to be compatible as well :) 

Dependencies without PHP8 support: 

- [x] Sushi https://github.com/calebporzio/sushi/pull/81 
- [x] `orchestra/testbench-dusk` uses `orchestral/dusk-updater` https://github.com/orchestral/dusk-updater/pull/6
- [x] php-webdriver https://github.com/php-webdriver/php-webdriver/pull/828

Once we have that fixed, we should be green. 