### PR TITLE
fixed escaping in heredoc string

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -234,7 +234,7 @@ HTML;
         /* Defer showing the warning so it doesn't get buried under downstream errors. */
         document.addEventListener("DOMContentLoaded", function () {
             setTimeout(function() {
-                console.warn("Livewire: It looks like AlpineJS has already been loaded. Make sure Livewire\'s scripts are loaded before Alpine.\n\n Reference docs for more info: http://laravel-livewire.com/docs/alpine-js")
+                console.warn("Livewire: It looks like AlpineJS has already been loaded. Make sure Livewire\'s scripts are loaded before Alpine.\\n\\n Reference docs for more info: http://laravel-livewire.com/docs/alpine-js")
             })
         });
     }


### PR DESCRIPTION
Fixed escaping in the heredoc string so it doesn't cause a javascript syntax error.