### PR TITLE
String encode large integers for javascript safety

### DIFF
--- a/src/ComponentChecksumManager.php
+++ b/src/ComponentChecksumManager.php
@@ -2,10 +2,16 @@
 
 namespace Livewire;
 
+use Livewire\Concerns\EncodesJsonSafely;
+
 class ComponentChecksumManager
 {
+    use EncodesJsonSafely;
+
     public function generate($fingerprint, $memo)
     {
+        self::stringEncodeTooLargeIntegers($memo);
+
         $hashKey = app('encrypter')->getKey();
 
         // It's actually Ok if the "children" tracking is tampered with.

--- a/src/Concerns/EncodesJsonSafely.php
+++ b/src/Concerns/EncodesJsonSafely.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Livewire\Concerns;
+
+trait EncodesJsonSafely
+{
+    protected static $javascriptMaxInteger = 2**53-1;
+
+    protected static function stringEncodeTooLargeIntegers(&$mixed)
+    {
+        if (is_numeric($mixed) && $mixed > self::$javascriptMaxInteger) {
+            $mixed = (string) $mixed;
+        } elseif (is_array($mixed)) {
+            array_walk_recursive($mixed, function (&$value, $key) {
+                self::stringEncodeTooLargeIntegers($value);
+            });
+        }
+    }
+}

--- a/src/HydrationMiddleware/AddAttributesToRootTagOfHtml.php
+++ b/src/HydrationMiddleware/AddAttributesToRootTagOfHtml.php
@@ -2,10 +2,13 @@
 
 namespace Livewire\HydrationMiddleware;
 
+use Livewire\Concerns\EncodesJsonSafely;
 use Livewire\Exceptions\RootTagMissingFromViewException;
 
 class AddAttributesToRootTagOfHtml
 {
+    use EncodesJsonSafely;
+
     public function __invoke($dom, $data)
     {
         $attributesFormattedForHtmlElement = collect($data)
@@ -36,6 +39,8 @@ class AddAttributesToRootTagOfHtml
 
     protected function escapeStringForHtml($subject)
     {
+        self::stringEncodeTooLargeIntegers($subject);
+
         if (is_string($subject) || is_numeric($subject)) {
             return htmlspecialchars($subject);
         }

--- a/src/HydrationMiddleware/NormalizeComponentPropertiesForJavaScript.php
+++ b/src/HydrationMiddleware/NormalizeComponentPropertiesForJavaScript.php
@@ -14,6 +14,9 @@ class NormalizeComponentPropertiesForJavaScript extends NormalizeDataForJavaScri
     public static function dehydrate($instance, $response)
     {
         foreach ($instance->getPublicPropertiesDefinedBySubClass() as $key => $value) {
+
+            self::stringEncodeTooLargeIntegers($value);
+
             if (is_array($value)) {
                 $instance->$key = static::reindexArrayWithNumericKeysOtherwiseJavaScriptWillMessWithTheOrder($value);
             }

--- a/src/HydrationMiddleware/NormalizeDataForJavaScript.php
+++ b/src/HydrationMiddleware/NormalizeDataForJavaScript.php
@@ -2,10 +2,16 @@
 
 namespace Livewire\HydrationMiddleware;
 
+use Livewire\Concerns\EncodesJsonSafely;
+
 abstract class NormalizeDataForJavaScript
 {
+    use EncodesJsonSafely;
+
     protected static function reindexArrayWithNumericKeysOtherwiseJavaScriptWillMessWithTheOrder($value)
     {
+        self::stringEncodeTooLargeIntegers($value);
+
         if (! is_array($value)) {
             return $value;
         }

--- a/src/Response.php
+++ b/src/Response.php
@@ -2,10 +2,14 @@
 
 namespace Livewire;
 
+use Illuminate\Support\Facades\Log;
+use Livewire\Concerns\EncodesJsonSafely;
 use Livewire\HydrationMiddleware\AddAttributesToRootTagOfHtml;
 
 class Response
 {
+    use EncodesJsonSafely;
+
     public $request;
 
     public $fingerprint;
@@ -24,6 +28,8 @@ class Response
         $this->fingerprint = $request->fingerprint;
         $this->memo = $request->memo;
         $this->effects = [];
+
+        self::stringEncodeTooLargeIntegers($this->memo);
     }
 
     public function id() { return $this->fingerprint['id']; }
@@ -71,6 +77,10 @@ class Response
 
         $requestMemo = $this->request->memo;
         $responseMemo = $this->memo;
+
+        self::stringEncodeTooLargeIntegers($requestMemo);
+        self::stringEncodeTooLargeIntegers($responseMemo);
+
         $dirtyMemo = [];
 
         // Only send along the memos that have changed to not bloat the payload.


### PR DESCRIPTION
This is in reference to #1900 and #1857. The goal is to safely encode large integers (that exceed Javascript's maximum) as strings whenever Livewire generates JSON. 

These changes appear to solve the problem for me. However, I don't understand Livewire's internals well enough to feel confident, so this warrants a careful review from someone who has a better understanding than I. Unfortunately, I'm not able to write any useful tests since I can't seem to get Livewire's Dusk tests to run locally, and that's the only good way to test this. (Sorry, I tried, really.) Unit tests are passing, at least.