### PR TITLE
Ability to fill component arrays or model properties

### DIFF
--- a/src/ComponentConcerns/InteractsWithProperties.php
+++ b/src/ComponentConcerns/InteractsWithProperties.php
@@ -142,8 +142,8 @@ trait InteractsWithProperties
         }
 
         foreach ($values as $key => $value) {
-            if (in_array($key, $publicProperties)) {
-                $this->{$key} = $value;
+            if (in_array($this->beforeFirstDot($key), $publicProperties)) {
+                data_set($this, $key, $value);
             }
         }
     }

--- a/tests/Unit/ComponentCanBeFilledTest.php
+++ b/tests/Unit/ComponentCanBeFilledTest.php
@@ -4,7 +4,6 @@ namespace Tests\Unit;
 
 use Livewire\Component;
 use Livewire\Livewire;
-use Livewire\LivewireManager;
 use Illuminate\Database\Eloquent\Model;
 
 class ComponentCanBeFilledTest extends TestCase
@@ -60,6 +59,34 @@ class ComponentCanBeFilledTest extends TestCase
         $component->assertSee('protected');
         $component->assertSee('private');
     }
+
+    /** @test */
+    public function can_fill_using_dot_notation()
+    {
+        Livewire::test(ComponentWithFillableProperties::class)
+            ->assertSet('dotProperty', [])
+            ->call('callFill', [
+                'dotProperty.foo' => 'bar',
+                'dotProperty.bob' => 'lob',
+            ])
+            ->assertSet('dotProperty.foo', 'bar')
+            ->assertSet('dotProperty.bob', 'lob');
+    }
+
+    /** @test */
+    public function can_fill_binded_model_properties()
+    {
+        $component = Livewire::test(ComponentWithFillableProperties::class, ['user' => new UserModel()]);
+
+        $this->assertInstanceOf(UserModel::class, $component->get('user'));
+
+        $component
+            ->assertSet('user.name', null)
+            ->call('callFill', [
+                'user.name' => 'Caleb'
+            ])
+            ->assertSet('user.name', 'Caleb');
+    }
 }
 
 class User {
@@ -93,6 +120,10 @@ class ComponentWithFillableProperties extends Component
     public $publicProperty = 'public';
     protected $protectedProperty = 'protected';
     private $privateProperty = 'private';
+
+    public $dotProperty = [];
+
+    public $user;
 
     public function callFill($values)
     {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yeah, this was discussed in #1776 and a pending PR #1872, but the PR failed to add tests.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope, straight implementation.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Now, it does.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
As discussed in #1776, when using binded models, you can expect the `$this->fill()` method in a component to 
assign values to the model property using dot notation (`'user.name' => $user->name`).

This PR will enable that, as well as to provide support for filling array properties.

5️⃣ Thanks for contributing! 🙌
