### PR TITLE
use interface Arrayable instead of Model

### DIFF
--- a/src/ComponentConcerns/InteractsWithProperties.php
+++ b/src/ComponentConcerns/InteractsWithProperties.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\ComponentConcerns;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use function Livewire\str;
 
@@ -137,7 +138,7 @@ trait InteractsWithProperties
     {
         $publicProperties = array_keys($this->getPublicPropertiesDefinedBySubClass());
 
-        if ($values instanceof Model) {
+        if ($values instanceof Arrayable) {
             $values = $values->toArray();
         }
 


### PR DESCRIPTION
InteractsWithPoperties::fill() explicitly checks that the object is a Model before calling toArray. Thus using fill with objects that do not extend Model but do implement the toArray method will not be converted to array and will not fill.

Allow using fill with objects that are not models but do implement \Illuminate\Contracts\Support\Arrayable

resolves #1958 