### PR TITLE
Fix nonce in console warning

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -195,7 +195,7 @@ HTML;
         $fullAssetPath = "{$appUrl}/livewire{$versionedFileName}";
         $assetWarning = null;
 
-        $nonce = isset($options['nonce']) ? " nonce=\"{$options['nonce']}\"" : '';
+        $nonce = isset($options['nonce']) ? "nonce=\"{$options['nonce']}\"" : '';
 
         // Use static assets if they have been published
         if (file_exists(public_path('vendor/livewire/manifest.json'))) {
@@ -206,7 +206,7 @@ HTML;
 
             if ($manifest !== $publishedManifest) {
                 $assetWarning = <<<'HTML'
-<script{$nonce}>
+<script {$nonce}>
     console.warn("Livewire: The published Livewire assets are out of date\n See: https://laravel-livewire.com/docs/installation/")
 </script>
 HTML;


### PR DESCRIPTION
The fix in https://github.com/livewire/livewire/pull/1847 wasn't quite working. 

**Before**
![image](https://user-images.githubusercontent.com/575421/98270720-622ca280-1f4c-11eb-9d0d-8edaeb853cfc.png)
_(ignore the devtools error, that's unrelated)_

**After**
![image](https://user-images.githubusercontent.com/575421/98270617-47f2c480-1f4c-11eb-9615-677de343403f.png)
