### PR TITLE
Support layout specified by route

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -51,7 +51,7 @@ abstract class Component
         $layoutType = $this->initialLayoutConfiguration['type'] ?? 'component';
 
         return app('view')->file(__DIR__."/Macros/livewire-view-{$layoutType}.blade.php", [
-            'view' => $this->initialLayoutConfiguration['view'] ?? 'layouts.app',
+            'view' => $this->initialLayoutConfiguration['view'] ?? $route->getAction('layout') ?? 'layouts.app',
             'params' => $this->initialLayoutConfiguration['params'] ?? [],
             'slotOrSection' => $this->initialLayoutConfiguration['slotOrSection'] ?? [
                 'extends' => 'content', 'component' => 'default',


### PR DESCRIPTION
In Livewire 1 I was specifying a custom layout file in my route group, something like this:

```php
Route::group(['prefix' => 'admin', 'layout' => 'layouts.admin']) {
    Route::livewire('/', 'admin.dashboard');

    // Dozens more!
});
```

With Livewire 2, we lost the ability to specify a custom layout file in the routes file, now it has to be specified inside each individual component. For a situation where there are dozens of components, all that need the same custom layout file, this can be tedious.

This PR re-introduces support for the route-specified layout. It still will use the component specified layout first if it exists, but then fall back to the route layout before falling all the way back to the hardcoded default.