### PR TITLE
Fix stringable array key

### DIFF
--- a/src/LivewireTagCompiler.php
+++ b/src/LivewireTagCompiler.php
@@ -43,7 +43,7 @@ class LivewireTagCompiler extends ComponentTagCompiler
 
             // Convert kebab attributes to camel-case.
             $attributes = collect($attributes)->mapWithKeys(function ($value, $key) {
-                return [str($key)->camel() => $value];
+                return [(string) str($key)->camel() => $value];
             })->toArray();
 
             if ($matches[1] === 'styles') return '@livewireStyles';


### PR DESCRIPTION
The changes made in https://github.com/livewire/livewire/pull/1897 were causing an `Illegal offset type` error in the tag compiler. 

Due to that change, it was trying to return an array with a `Stringable` class as the key, instead of the string itself. Casting explicitly to a string fixes that. 

The other option would be to use `->__toString()`, so let me know if you'd prefer that instead. 