### PR TITLE
Use Arrayable Interface for casting array types in the component fill method.

### DIFF
--- a/src/ComponentConcerns/InteractsWithProperties.php
+++ b/src/ComponentConcerns/InteractsWithProperties.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\ComponentConcerns;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Support\Arrayable;
 use function Livewire\str;
 
 trait InteractsWithProperties
@@ -137,7 +137,7 @@ trait InteractsWithProperties
     {
         $publicProperties = array_keys($this->getPublicPropertiesDefinedBySubClass());
 
-        if ($values instanceof Model) {
+        if ($values instanceof Arrayable) {
             $values = $values->toArray();
         }
 

--- a/tests/Unit/ComponentCanBeFilledTest.php
+++ b/tests/Unit/ComponentCanBeFilledTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Livewire\Component;
 use Livewire\Livewire;
 use Illuminate\Database\Eloquent\Model;
@@ -29,7 +30,7 @@ class ComponentCanBeFilledTest extends TestCase
     }
 
     /** @test */
-    public function can_fill_from_an_object()
+    public function can_fill_from_object_properties()
     {
         $component = Livewire::test(ComponentWithFillableProperties::class);
 
@@ -54,6 +55,22 @@ class ComponentCanBeFilledTest extends TestCase
         $component->assertSee('private');
 
         $component->call('callFill', new UserModel());
+
+        $component->assertSee('Caleb');
+        $component->assertSee('protected');
+        $component->assertSee('private');
+    }
+
+    /** @test */
+    public function can_fill_from_arrayable_interfaces()
+    {
+        $component = Livewire::test(ComponentWithFillableProperties::class);
+
+        $component->assertSee('public');
+        $component->assertSee('protected');
+        $component->assertSee('private');
+
+        $component->call('callFill', new ArrayableUser());
 
         $component->assertSee('Caleb');
         $component->assertSee('protected');
@@ -112,6 +129,19 @@ class UserModel extends Model {
 
     public function getPrivatePropertyAttribute() {
         return 'private';
+    }
+}
+
+class ArrayableUser implements Arrayable {
+    private $attributes = [
+        'publicProperty' => 'Caleb',
+        'protectedProperty' => 'Caleb',
+        'privateProperty' => 'Caleb'
+    ];
+
+    public function toArray()
+    {
+        return $this->attributes;
     }
 }
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Suggested in #1958

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yup, perfectly balanced... :green_circle: 

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
When using the `fill` method in a component, only instances of `Model` are converted to Array representation
to fill public properties in the component, however, there may cases when you need to use other type of
objects that are indeed castable as Arrays, but since we're looking only for `Model` instances, properties are
not being properly segregated.

This PR fixes that.

5️⃣ Thanks for contributing! 🙌
