### PR TITLE
Add failing test Alpine clicks firing twice after Livewire change

### DIFF
--- a/tests/Browser/Alpine/ClickComponent.php
+++ b/tests/Browser/Alpine/ClickComponent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Browser\Alpine;
+
+use Illuminate\Support\Facades\View;
+use Livewire\Component as BaseComponent;
+
+class ClickComponent extends BaseComponent
+{
+    public $show = false;
+
+    public function render()
+    {
+        return
+<<<'HTML'
+<div>
+    <div x-data="{output: []}">
+        <button dusk="show" wire:click="$set('show', true)">Toggle Options</button>
+
+        <div>
+            @if($show)
+                <button dusk="click" x-on:click="output.push('Clicked')">Click</button>
+            @endif
+        </div>
+
+        <div>Number of clicks: <span dusk="alpineNumberClicksFired" x-text="output.length"></span></div>
+    </div>
+</div>
+HTML;
+    }
+}

--- a/tests/Browser/Alpine/Test.php
+++ b/tests/Browser/Alpine/Test.php
@@ -121,4 +121,19 @@ class Test extends TestCase
             ;
         });
     }
+
+    public function test_alpine_registers_click_handlers_properly_on_livewire_change()
+    {
+        $this->browse(function ($browser) {
+            Livewire::visit($browser, ClickComponent::class)
+                ->waitForLivewire()->click('@show')
+                ->click('@click')
+                ->assertSeeIn('@alpineNumberClicksFired', 1)
+                ->click('@click')
+                ->assertSeeIn('@alpineNumberClicksFired', 2)
+                ->click('@click')
+                ->assertSeeIn('@alpineNumberClicksFired', 3)
+            ;
+        });
+    }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Yes - see issue #763 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Yes

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

This is a failing tests to demonstrate that Alpine click handlers are firing twice after Livewire changes the content on the page.

It seems like any x-on:click that is attached to an element inside blade conditional or loop is getting registered twice after a Livewire request is sent that may change/modify that element (e.g. show).

5️⃣ Thanks for contributing! 🙌