### PR TITLE
Only initialize child components when necessary - closes #1726

### DIFF
--- a/js/component/index.js
+++ b/js/component/index.js
@@ -475,11 +475,14 @@ export default class Component {
                         return false
                     }
                 } else if (DOM.isComponentRootEl(node)) {
-                    store.addComponent(new Component(node, this.connection))
+                    // Only initialize "new" components if they don't exist on the page already
+                    if (node.hasAttribute('wire:initial-data')) {
+                        store.addComponent(new Component(node, this.connection))
 
-                    // We don't need to initialize children, the
-                    // new Component constructor will do that for us.
-                    node.skipAddingChildren = true
+                        // We don't need to initialize children, the
+                        // new Component constructor will do that for us.
+                        node.skipAddingChildren = true
+                    }
                 }
 
                 this.morphChanges.added.push(node)

--- a/tests/Browser/Nesting/Component.php
+++ b/tests/Browser/Nesting/Component.php
@@ -11,9 +11,23 @@ class Component extends BaseComponent
 
     public $showChild = false;
     public $key = 'foo';
+    public $search;
 
     public function render()
     {
-        return View::file(__DIR__.'/view.blade.php');
+        $items = collect([
+            'a' => 'Item #1',
+            'b' => 'Item #2'
+        ]);
+
+        if ($this->search) {
+            $items = $items->filter(function ($item) {
+                return stripos($item, $this->search) !== false;
+            });
+        }
+
+        return View::file(__DIR__ . '/view.blade.php', [
+            'items' => $items
+        ]);
     }
 }

--- a/tests/Browser/Nesting/ListedComponent.php
+++ b/tests/Browser/Nesting/ListedComponent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Browser\Nesting;
+
+use Illuminate\Support\Facades\View;
+use Livewire\Component as BaseComponent;
+
+class ListedComponent extends BaseComponent
+{
+    public function render()
+    {
+        return View::file(__DIR__ . '/view-listed.blade.php');
+    }
+}

--- a/tests/Browser/Nesting/Test.php
+++ b/tests/Browser/Nesting/Test.php
@@ -33,7 +33,16 @@ class Test extends TestCase
                 ->assertDontSeeIn('@output.nested', 'foo')
                 ->waitForLivewire()->click('@button.nested')
                 ->assertSeeIn('@output.nested', 'foo')
-            ;
+
+                /**
+                 * Nested component constructors aren't called again when they already exist on the page
+                 */
+                ->waitForLivewire()->type('@input.search', 2)
+                ->assertDontSee('Item #1')
+                ->assertSee('Item #2')
+                ->waitForLivewire()->type('@input.search', ' ')
+                ->assertSee('Item #1')
+                ->assertSee('Item #2');
         });
     }
 }

--- a/tests/Browser/Nesting/view-listed.blade.php
+++ b/tests/Browser/Nesting/view-listed.blade.php
@@ -1,0 +1,3 @@
+<div>
+    <span>Nested List Component</span>
+</div>

--- a/tests/Browser/Nesting/view.blade.php
+++ b/tests/Browser/Nesting/view.blade.php
@@ -1,9 +1,13 @@
 <div>
     <button wire:click="$toggle('showChild')" dusk="button.toggleChild"></button>
-
     <button wire:click="$set('key', 'bar')" dusk="button.changeKey"></button>
+    <input type="text" wire:model="search" dusk="input.search">
 
     @if ($showChild)
         @livewire(Tests\Browser\Nesting\NestedComponent::class, key($key))
     @endif
+
+    @foreach ($items as $key => $item)
+        <div>{{ $item }} @livewire(Tests\Browser\Nesting\ListedComponent::class, key($key))</div>
+    @endforeach
 </div>


### PR DESCRIPTION
This fixes a case where `initial-data` could be undefined on nested components as reported in #1726.

After an initial filter with an input, if you then clear the input, Livewire was _always_ calling the JS constructor when adding elements back to the DOM, even if the element was a component that had already been initialized. Since the `initial-data` is removed when the constructor is called, it was causing the fingerprint error reported in the issue.

The error message isn't as detailed as I'd prefer from the failing test, but it does fail without the fix in place. 👍 

**Here's a GIF of the original issue**
![livewire-bug](https://user-images.githubusercontent.com/575421/98499070-b9a96780-2205-11eb-8bac-84fbd2d8d2f5.gif)
