### PR TITLE
wire:model separate file uploads to array property bug

### DIFF
--- a/src/RenameMe/SupportFileUploads.php
+++ b/src/RenameMe/SupportFileUploads.php
@@ -10,7 +10,7 @@ class SupportFileUploads
 {
     static function init() { return new static; }
 
-    function __construct()
+    public function __construct()
     {
         Livewire::listen('property.hydrate', function ($property, $value, $component, $request) {
             $uses = array_flip(class_uses_recursive($component));
@@ -42,11 +42,11 @@ class SupportFileUploads
         }
 
         if ($value instanceof TemporaryUploadedFile) {
-            return  $value->serializeForLivewireResponse();
+            return $value->serializeForLivewireResponse();
         }
 
-        if (is_array($value) && isset(array_values($value)[0]) && array_values($value)[0] instanceof TemporaryUploadedFile && is_numeric(key($value))) {
-            return array_values($value)[0]::serializeMultipleForLivewireResponse($value);
+        if (is_array($value) && isset($value[0]) && $value[0] instanceof TemporaryUploadedFile && is_numeric(key($value))) {
+            return $value[0]::serializeMultipleForLivewireResponse($value);
         }
 
         if (is_array($value)) {


### PR DESCRIPTION
Fixed wire:model separate file uploads to array property bug explained in this issue: #2040

Unwrapping `array_values($value)` fixed the issue in my case. I didn't see any reasons why they're wrapped.