### PR TITLE
Create tests from Make Component command

### DIFF
--- a/src/Commands/ComponentParser.php
+++ b/src/Commands/ComponentParser.php
@@ -11,6 +11,7 @@ class ComponentParser
 {
     protected $appPath;
     protected $viewPath;
+    protected $testPath;
     protected $component;
     protected $componentClass;
     protected $directories;
@@ -21,9 +22,11 @@ class ComponentParser
         $this->baseClassNamespace = $classNamespace;
 
         $classPath = static::generatePathFromNamespace($classNamespace);
+        $testPath = base_path('tests/Feature');
 
         $this->baseClassPath = rtrim($classPath, DIRECTORY_SEPARATOR).'/';
         $this->baseViewPath = rtrim($viewPath, DIRECTORY_SEPARATOR).'/';
+        $this->baseTestPath = rtrim($testPath, DIRECTORY_SEPARATOR).'/';
 
         $directories = preg_split('/[.\/(\\\\)]+/', $rawCommand);
 
@@ -134,6 +137,38 @@ class ComponentParser
         return preg_replace(
             '/\[quote\]/',
             $this->wisdomOfTheTao(),
+            file_get_contents($stubPath)
+        );
+    }
+
+    public function testPath()
+    {
+        return $this->baseTestPath.collect()
+                ->concat($this->directories)
+                ->map([Str::class, 'kebab'])
+                ->push($this->testFile())
+                ->implode(DIRECTORY_SEPARATOR);
+    }
+
+    public function relativeTestPath() : string
+    {
+        return str($this->testPath())->replaceFirst(base_path().'/', '');
+    }
+
+    public function testFile()
+    {
+        return ucfirst($this->component).'Test.php';
+    }
+
+    public function testContents()
+    {
+        if( ! File::exists($stubPath = base_path('stubs/test.stub'))) {
+            $stubPath = __DIR__.DIRECTORY_SEPARATOR.'test.stub';
+        }
+
+        return preg_replace(
+            '/\[class\]/',
+            $this->className(),
             file_get_contents($stubPath)
         );
     }

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -32,10 +32,7 @@ class MakeCommand extends FileManipulationCommand
 
         $class = $this->createClass($force, $inline);
         $view = $this->createView($force, $inline);
-
-        if ($makeTest) {
-            $this->createTest();
-        }
+        $test = $makeTest ? $this->createTest() : false;
 
         $this->refreshComponentAutodiscovery();
 
@@ -49,6 +46,11 @@ class MakeCommand extends FileManipulationCommand
 
             if ($showWelcomeMessage && ! app()->environment('testing')) {
                 $this->writeWelcomeMessage();
+            }
+
+            if ($test) {
+                $this->line("<options=bold,reverse;fg=green> TEST CREATED </> 🤙\n");
+                $class && $this->line("<options=bold;fg=green>TEST:</> {$this->parser->relativeTestPath()}");
             }
         }
     }

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\File;
 
 class MakeCommand extends FileManipulationCommand
 {
-    protected $signature = 'livewire:make {name} {--force} {--inline}';
+    protected $signature = 'livewire:make {name} {--force} {--inline} {--test}';
 
     protected $description = 'Create a new Livewire component';
 
@@ -26,11 +26,16 @@ class MakeCommand extends FileManipulationCommand
 
         $force = $this->option('force');
         $inline = $this->option('inline');
+        $makeTest = $this->option('test');
 
         $showWelcomeMessage = $this->isFirstTimeMakingAComponent();
 
         $class = $this->createClass($force, $inline);
         $view = $this->createView($force, $inline);
+
+        if ($makeTest) {
+            $this->createTest();
+        }
 
         $this->refreshComponentAutodiscovery();
 
@@ -84,6 +89,23 @@ class MakeCommand extends FileManipulationCommand
         File::put($viewPath, $this->parser->viewContents());
 
         return $viewPath;
+    }
+
+    protected function createTest()
+    {
+        $testPath = $this->parser->testPath();
+
+        if (File::exists($testPath)) {
+            $this->line("<fg=red;options=bold>Test already exists:</>  {$this->parser->relativeTestPath()}");
+
+            return false;
+        }
+
+        $this->ensureDirectoryExists($testPath);
+
+        File::put($testPath, $this->parser->testContents());
+
+        return $testPath;
     }
 
     public function isReservedClassName($name)

--- a/src/Commands/MakeLivewireCommand.php
+++ b/src/Commands/MakeLivewireCommand.php
@@ -4,5 +4,5 @@ namespace Livewire\Commands;
 
 class MakeLivewireCommand extends MakeCommand
 {
-    protected $signature = 'make:livewire {name} {--force} {--inline} {--stub=default}';
+    protected $signature = 'make:livewire {name} {--force} {--inline} {--test} {--stub=default}';
 }

--- a/src/Commands/TouchCommand.php
+++ b/src/Commands/TouchCommand.php
@@ -4,7 +4,7 @@ namespace Livewire\Commands;
 
 class TouchCommand extends MakeCommand
 {
-    protected $signature = 'livewire:touch {name} {--force} {--inline} {--stub=default}';
+    protected $signature = 'livewire:touch {name} {--force} {--inline} {--test} {--stub=default}';
 
     protected function configure()
     {

--- a/src/Commands/test.stub
+++ b/src/Commands/test.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Livewire\Livewire;
+
+class [class]Test extends TestCase
+{
+    public function test()
+    {
+        //
+    }
+}

--- a/tests/Unit/MakeCommandTest.php
+++ b/tests/Unit/MakeCommandTest.php
@@ -129,4 +129,14 @@ class MakeCommandTest extends TestCase
         $this->assertFalse(File::exists($this->livewireClassesPath('Component.php')));
         $this->assertFalse(File::exists($this->livewireViewsPath('component.blade.php')));
     }
+
+    /** @test */
+    public function a_component_is_created_with_a_test()
+    {
+        $this->withoutExceptionHandling();
+
+        Artisan::call('make:livewire', ['name' => 'foo', '--test' => true]);
+
+        $this->assertTrue(File::exists(base_path('tests/Feature/FooTest.php')));
+    }
 }

--- a/tests/Unit/MakeCommandTest.php
+++ b/tests/Unit/MakeCommandTest.php
@@ -133,10 +133,8 @@ class MakeCommandTest extends TestCase
     /** @test */
     public function a_component_is_created_with_a_test()
     {
-        $this->withoutExceptionHandling();
-
         Artisan::call('make:livewire', ['name' => 'foo', '--test' => true]);
 
-        $this->assertTrue(File::exists(base_path('tests/Feature/FooTest.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('FooTest.php')));
     }
 }

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -69,4 +69,9 @@ class TestCase extends BaseTestCase
     {
         return resource_path('views').'/livewire'.($path ? '/'.$path : '');
     }
+
+    protected function livewireTestsPath($path = '')
+    {
+        return base_path('tests/Feature').($path ? '/'.$path : '');
+    }
 }


### PR DESCRIPTION
When creating new Livewire components, I find myself immediately creating tests for them as well. This PR adds a flag in the livewire:make (and livewire:touch) command to also generate a test file.

Running `php artisan livewire:make Foo --test` would create the Component, View, and Test files.

I have also included tests to ensure this works.

Here's a photo of a puppy chewing on a wire (probably not live) ~as a bribe~.

![Cute, right?](http://setewindowblinds.com/wp-content/uploads/2016/06/Stop-A-Dog-From-Chewing-Electrical-Cords.jpg)
