### PR TITLE
Feature/emit livewire event after validation failure

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -153,6 +153,10 @@ trait ValidatesInput
 
         $this->shortenModelAttributes($data, $rules, $validator);
 
+        if($validator->fails()) {
+            $this->emit('failed-validation');
+        }
+
         $validatedData = $validator->validate();
 
         $this->resetErrorBag();

--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -153,11 +153,12 @@ trait ValidatesInput
 
         $this->shortenModelAttributes($data, $rules, $validator);
 
-        if($validator->fails()) {
+        try {
+            $validatedData = $validator->validate();
+        } catch (ValidationException $e) {
             $this->emit('failed-validation');
+            throw ValidationException::withMessages($e->validator->errors()->toArray());
         }
-
-        $validatedData = $validator->validate();
 
         $this->resetErrorBag();
 

--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -157,7 +157,7 @@ trait ValidatesInput
             $validatedData = $validator->validate();
         } catch (ValidationException $e) {
             $this->emit('failed-validation');
-            throw new ValidationException($validator);
+            throw $e;
         }
 
         $this->resetErrorBag();

--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -157,7 +157,7 @@ trait ValidatesInput
             $validatedData = $validator->validate();
         } catch (ValidationException $e) {
             $this->emit('failed-validation');
-            throw ValidationException::withMessages($e->validator->errors()->toArray());
+            throw new ValidationException($validator);
         }
 
         $this->resetErrorBag();

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -22,6 +22,16 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
+    public function validate_emits_validation_failed_event()
+    {
+        $component = Livewire::test(ForValidation::class);
+
+        $component->runAction('runValidation');
+
+        $this->assertStringContainsString('failed-validation', $component->payload['effects']['emits'][0]['event']);
+    }
+
+    /** @test */
     public function validate_component_properties_with_custom_message()
     {
         $component = Livewire::test(ForValidation::class);


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
I created a discussion, but there wasn't any responses, so apologies if this is too much of a niche request, but I thought it would be useful to others to easily display a toast message each time validation fails. 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Single change

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
A simple test has been added, but could probably be improved

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
You can listen for the failed-validation [event in JavaScript](https://laravel-livewire.com/docs/2.x/events#in-js) to display a toast message. This may not be needed on short forms, but on larger forms that require scrolling it will allow a message to be displayed to users each time they press submit on the form to inform them of validation errors. 

5️⃣ Thanks for contributing! 🙌