### PR TITLE
Fixed uncaught TypeError for file input

### DIFF
--- a/js/component/FileUploads.js
+++ b/js/component/FileUploads.js
@@ -34,7 +34,7 @@ export default function () {
         // There's a bug in browsers where selecting a file, removing it,
         // then re-adding it doesn't fire the change event. This fixes it.
         // Reference: https://stackoverflow.com/questions/12030686/html-input-file-selection-event-not-firing-upon-selecting-the-same-file
-        let clearFileInputValue = e => { this.value = null }
+        let clearFileInputValue = () => { el.value = null }
         el.addEventListener('click', clearFileInputValue)
 
         component.addListenerForTeardown(() => {


### PR DESCRIPTION
Current code throws an error whenever you click on an `<input type="file" wire:model="photo">`
```
Uncaught TypeError: Cannot set property 'value' of undefined
    at HTMLInputElement.clearFileInputValue (FileUploads.js:37)
clearFileInputValue @ FileUploads.js:37
```

This is because `this` is `undefined`, since we want to clear the value of the element we can just use the `el` variable instead.

---
Closes https://github.com/livewire/livewire/issues/2091