### PR TITLE
Replace array_merge to prevent reindexing in some cases

### DIFF
--- a/src/HydrationMiddleware/NormalizeDataForJavaScript.php
+++ b/src/HydrationMiddleware/NormalizeDataForJavaScript.php
@@ -22,7 +22,8 @@ abstract class NormalizeDataForJavaScript
             return ! is_numeric($key);
         }, ARRAY_FILTER_USE_KEY);
 
-        $normalizedData = array_merge($itemsWithNumericKeys, $itemsWithStringKeys);
+        //array_merge will reindex in some cases so we stick to array_replace
+        $normalizedData = array_replace($itemsWithNumericKeys, $itemsWithStringKeys);
 
         return array_map(function ($value) {
             return static::reindexArrayWithNumericKeysOtherwiseJavaScriptWillMessWithTheOrder($value);

--- a/tests/Unit/PublicPropertiesAreCastToJavaScriptUsableTypesTest.php
+++ b/tests/Unit/PublicPropertiesAreCastToJavaScriptUsableTypesTest.php
@@ -20,7 +20,7 @@ class PublicPropertiesAreCastToJavaScriptUsableTypesTest extends TestCase
     }
 
     /** @test */
-    public function unordered_numeric_arrays_are_reordered_so_javascript_doesnt_do_it_for_us()
+    public function unordered_numeric_keyed_arrays_are_reordered_so_javascript_doesnt_do_it_for_us()
     {
         $orderedNumericArray = [
             1 => 'foo',
@@ -32,6 +32,24 @@ class PublicPropertiesAreCastToJavaScriptUsableTypesTest extends TestCase
         $this->assertSame([
             0 => 'bar',
             1 => 'foo',
+        ], $foo);
+    }
+
+    /** @test */
+    public function unordered_string_keyed_arrays_are_reordered_so_javascript_doesnt_do_it_for_us()
+    {
+        $orderedNumericArray = [
+            '20' => 'baz',
+            '19' => 'bar',
+            '0' => 'foo',
+        ];
+
+        $foo = Livewire::test(ComponentWithPropertiesStub::class, ['foo' => $orderedNumericArray])->foo;
+
+        $this->assertSame([
+            '0' => 'foo',
+            '19' => 'bar',
+            '20' => 'baz',
         ], $foo);
     }
 


### PR DESCRIPTION
- Added a test to cover all cases
- replaced `array_merge` with `array_replace` [see why](https://stackoverflow.com/questions/34367511/differences-between-array-replace-and-array-merge-in-php#answer-34367698)

---
Fixes #2049 & #2042