### PR TITLE
Add excluded middlewares in configuration file

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -59,6 +59,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Livewire Excluded Middlewares
+    |--------------------------------------------------------------------------
+    |
+    | This value sets the middlewares that will be excluded from the main Livewire 
+    | "message" endpoint. It is set to null by default, but should be set to 
+    | exclude the TrimStrings Middleware if the location is different.
+    |
+    */
+    'middlewares_to_exclude' => [
+        //\App\Http\Middleware\TrimStrings::class,
+    ],
+    
+
+    /*
+    |--------------------------------------------------------------------------
     | Livewire Temporary File Uploads Endpoint Configuration
     |--------------------------------------------------------------------------
     |

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -71,12 +71,14 @@ class LivewireServiceProvider extends ServiceProvider
         // Bypass specific middlewares during Livewire requests.
         // These are usually helpful during a typical request, but
         // during Livewire requests, they can damage data properties.
-        $this->bypassTheseMiddlewaresDuringLivewireRequests([
-            TrimStrings::class,
-            ConvertEmptyStringsToNull::class,
-            // If the app overrode "TrimStrings".
-            \App\Http\Middleware\TrimStrings::class,
-        ]);
+        $this->bypassTheseMiddlewaresDuringLivewireRequests(
+            array_merge([
+                TrimStrings::class,
+                ConvertEmptyStringsToNull::class,
+                // If the app overrode "TrimStrings".
+                \App\Http\Middleware\TrimStrings::class,
+            ], config('livewire.middlewares_to_exclude', []))
+        );
     }
 
     protected function registerLivewireSingleton()


### PR DESCRIPTION
Related to this issue: https://github.com/livewire/livewire/issues/2059

My middlewares are not namespaced \App\Http\Middleware (they are in a subfolder), so the TrimString middleware isn't bypassed and it causes checksum errors.

This is an edge-case, but I think a package like Livewire shouldn't rely on a specific application directory structure (or at least, we should be able to modify it).

Second reason: The problem can be silent for a long time, and is difficult to identify and debug. It took me a few hours to understand where the checksum error was coming from. If other developers changed their middleware directory structure (like me), it can take them a long time to understand the origin of the problem.

Third reason: Not related to my problem, but it's nice to have the option to bypass other middlewares in the config file. Particularly if the user has some middlewares that can mess-up livewire requests (I'm thinking about some Pagespeeds/Cache/etc. middlewares).

I didn't delete the "overridden" \App\Http\Middleware\TrimStrings::class from the LivewireServiceProvider to avoid any backward compatibility issue. But I think it should be only in the config file by default.

Let me know what you think 😀