### PR TITLE
Model Should Assigned before call rulesForModel

### DIFF
--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -102,6 +102,8 @@ class HydratePublicProperties implements HydrationMiddleware
         } else {
             $model = new $serialized['class'];
         }
+        
+        $instance->$property = $model;
 
         $dirtyModelData = $request->memo['data'][$property];
 
@@ -114,8 +116,6 @@ class HydratePublicProperties implements HydrationMiddleware
                 data_set($model, $key, data_get($dirtyModelData, $key));
             }
         }
-
-        $instance->$property = $model;
     }
 
     protected static function hydrateModels($serialized, $property, $request, $instance)
@@ -125,6 +125,8 @@ class HydratePublicProperties implements HydrationMiddleware
         $models = (new static)->getRestoredPropertyValue(
             new ModelIdentifier($serialized['class'], $serialized['id'], $serialized['relations'], $serialized['connection'])
         );
+        
+        $instance->$property = $models;
 
         $dirtyModelData = $request->memo['data'][$property];
 
@@ -147,8 +149,6 @@ class HydratePublicProperties implements HydrationMiddleware
                 }
             }
         }
-
-        $instance->$property = $models;
     }
 
     protected static function dehydrateModel($value, $property, $response, $instance)


### PR DESCRIPTION
Suppose I am using livewire component for route model binding, where I have to validate ```unique``` a field with except current model id. In that scenario, during hydrate a field I can't use the model from public property to set except id on rules.

Right now, the ```rulesForModel()``` method call before model assigned on property and generate the error ```Typed property must not be accessed before initialization```

If we assigned the model on property first then call "rulesForModel()", it will work.

I have created an issue also #2070