### PR TITLE
Support File Uploads as Nested Properties Within Multi Typed Object

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -164,17 +164,15 @@ class TemporaryUploadedFile extends UploadedFile
 
                 return collect($paths)->map(function ($path) { return static::createFromLivewire($path); })->toArray();
             }
-
-            return $subject;
         }
 
         if (is_array($subject)) {
             foreach ($subject as $key => $value) {
                 $subject[$key] =  static::unserializeFromLivewireRequest($value);
             }
-
-            return $subject;
         }
+
+        return $subject;
     }
 
     public function serializeForLivewireResponse()

--- a/tests/Unit/FileUploadsTest.php
+++ b/tests/Unit/FileUploadsTest.php
@@ -559,6 +559,54 @@ class FileUploadsTest extends TestCase
 
         $this->assertStringStartsWith('livewire-file:', $component->get('obj.file_uploads'));
     }
+
+    /** @test */
+    public function it_can_update_numbers_after_upload_single_file_with_in_array_public_property()
+    {
+        $file1 = UploadedFile::fake()->image('avatar1.jpg');
+
+        $component = Livewire::test(FileUploadInArrayWithNumberPropertiesComponent::class)
+                             ->set('obj.file_uploads', $file1)
+                             ->set('obj.first_name', 'john')
+                             ->set('obj.last_name', 'doe');
+
+        $this->assertSame($component->get('obj.first_name'), 'john');
+
+        $this->assertSame($component->get('obj.last_name'), 'doe');
+
+        $component->updateProperty('obj.first_number', 10);
+
+        $this->assertSame($component->get('obj.second_number'), 99);
+
+        $this->assertStringStartsWith('livewire-file:', $component->get('obj.file_uploads'));
+    }
+
+    /** @test */
+    public function it_can_update_numbers_after_upload_multiple_file_with_in_array_public_property()
+    {
+        $file1 = UploadedFile::fake()->image('avatar1.jpg');
+        $file2 = UploadedFile::fake()->image('avatar2.jpg');
+        $file3 = UploadedFile::fake()->image('avatar3.jpg');
+        $file4 = UploadedFile::fake()->image('avatar4.jpg');
+
+        $component = Livewire::test(FileUploadInArrayComponent::class)
+                             ->set('obj.file_uploads', [$file1, $file2, $file3, $file4])
+                             ->set('obj.first_name', 'john')
+                             ->set('obj.last_name', 'doe');
+
+        $tmpFiles = $component->viewData('obj')['file_uploads'];
+
+        $this->assertSame($component->get('obj.first_name'), 'john');
+        $this->assertSame($component->get('obj.last_name'), 'doe');
+
+        $component->updateProperty('obj.first_number', 10);
+
+        $this->assertSame($component->get('obj.second_number'), 99);
+
+        $this->assertStringStartsWith('livewire-files:', $component->get('obj.file_uploads'));
+
+        $this->assertCount(4, $tmpFiles);
+    }
 }
 
 class DummyMiddleware
@@ -657,6 +705,21 @@ class FileUploadInArrayComponent extends FileUploadComponent
     public $obj = [
         'first_name' => null,
         'last_name' => null,
+        'file_uploads' => null
+    ];
+
+    public function removePhoto($key) {
+        unset($this->obj['file_uploads'][$key]);
+    }
+}
+
+class FileUploadInArrayWithNumberPropertiesComponent extends FileUploadComponent
+{
+    public $obj = [
+        'first_name' => null,
+        'last_name' => null,
+        'first_number' => 2,
+        'second_number' => 99,
         'file_uploads' => null
     ];
 

--- a/tests/Unit/FileUploadsTest.php
+++ b/tests/Unit/FileUploadsTest.php
@@ -520,7 +520,7 @@ class FileUploadsTest extends TestCase
     }
 
     /** @test */
-    public function it_can_upload_multiple_file_with_in_array_public_property()
+    public function it_can_upload_multiple_file_within_array_public_property()
     {
         $file1 = UploadedFile::fake()->image('avatar1.jpg');
         $file2 = UploadedFile::fake()->image('avatar2.jpg');
@@ -538,13 +538,19 @@ class FileUploadsTest extends TestCase
 
         $this->assertSame($component->get('obj.last_name'), 'doe');
 
+        $component->updateProperty('obj.first_number', 10);
+
+        $this->assertSame($component->get('obj.first_number'), 10);
+
+        $this->assertSame($component->get('obj.second_number'), 99);
+
         $this->assertStringStartsWith('livewire-files:', $component->get('obj.file_uploads'));
 
         $this->assertCount(4, $tmpFiles);
     }
 
     /** @test */
-    public function it_can_upload_single_file_with_in_array_public_property()
+    public function it_can_upload_single_file_within_array_public_property()
     {
         $file1 = UploadedFile::fake()->image('avatar1.jpg');
 
@@ -557,56 +563,15 @@ class FileUploadsTest extends TestCase
 
         $this->assertSame($component->get('obj.last_name'), 'doe');
 
-        $this->assertStringStartsWith('livewire-file:', $component->get('obj.file_uploads'));
-    }
-
-    /** @test */
-    public function it_can_update_numbers_after_upload_single_file_with_in_array_public_property()
-    {
-        $file1 = UploadedFile::fake()->image('avatar1.jpg');
-
-        $component = Livewire::test(FileUploadInArrayWithNumberPropertiesComponent::class)
-                             ->set('obj.file_uploads', $file1)
-                             ->set('obj.first_name', 'john')
-                             ->set('obj.last_name', 'doe');
-
-        $this->assertSame($component->get('obj.first_name'), 'john');
-
-        $this->assertSame($component->get('obj.last_name'), 'doe');
-
         $component->updateProperty('obj.first_number', 10);
+
+        $this->assertSame($component->get('obj.first_number'), 10);
 
         $this->assertSame($component->get('obj.second_number'), 99);
 
         $this->assertStringStartsWith('livewire-file:', $component->get('obj.file_uploads'));
     }
 
-    /** @test */
-    public function it_can_update_numbers_after_upload_multiple_file_with_in_array_public_property()
-    {
-        $file1 = UploadedFile::fake()->image('avatar1.jpg');
-        $file2 = UploadedFile::fake()->image('avatar2.jpg');
-        $file3 = UploadedFile::fake()->image('avatar3.jpg');
-        $file4 = UploadedFile::fake()->image('avatar4.jpg');
-
-        $component = Livewire::test(FileUploadInArrayWithNumberPropertiesComponent::class)
-                             ->set('obj.file_uploads', [$file1, $file2, $file3, $file4])
-                             ->set('obj.first_name', 'john')
-                             ->set('obj.last_name', 'doe');
-
-        $tmpFiles = $component->viewData('obj')['file_uploads'];
-
-        $this->assertSame($component->get('obj.first_name'), 'john');
-        $this->assertSame($component->get('obj.last_name'), 'doe');
-
-        $component->updateProperty('obj.first_number', 10);
-
-        $this->assertSame($component->get('obj.second_number'), 99);
-
-        $this->assertStringStartsWith('livewire-files:', $component->get('obj.file_uploads'));
-
-        $this->assertCount(4, $tmpFiles);
-    }
 }
 
 class DummyMiddleware
@@ -701,19 +666,6 @@ class FileUploadComponent extends Component
 }
 
 class FileUploadInArrayComponent extends FileUploadComponent
-{
-    public $obj = [
-        'first_name' => null,
-        'last_name' => null,
-        'file_uploads' => null
-    ];
-
-    public function removePhoto($key) {
-        unset($this->obj['file_uploads'][$key]);
-    }
-}
-
-class FileUploadInArrayWithNumberPropertiesComponent extends FileUploadComponent
 {
     public $obj = [
         'first_name' => null,

--- a/tests/Unit/FileUploadsTest.php
+++ b/tests/Unit/FileUploadsTest.php
@@ -589,7 +589,7 @@ class FileUploadsTest extends TestCase
         $file3 = UploadedFile::fake()->image('avatar3.jpg');
         $file4 = UploadedFile::fake()->image('avatar4.jpg');
 
-        $component = Livewire::test(FileUploadInArrayComponent::class)
+        $component = Livewire::test(FileUploadInArrayWithNumberPropertiesComponent::class)
                              ->set('obj.file_uploads', [$file1, $file2, $file3, $file4])
                              ->set('obj.first_name', 'john')
                              ->set('obj.last_name', 'doe');


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

This is a bug fix for #1714 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Yes

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Its resolves an an issue with the file upload component not correctly rehydrating an object with non string or array properties after a file has been uploaded.  

5️⃣ Thanks for contributing! 🙌