### PR TITLE
use rfc 3986 in query string

### DIFF
--- a/src/RenameMe/SupportBrowserHistory.php
+++ b/src/RenameMe/SupportBrowserHistory.php
@@ -176,6 +176,6 @@ class SupportBrowserHistory
 
     protected function stringifyQueryParams($queryParams)
     {
-        return $queryParams->isEmpty() ? '' : '?'.http_build_query($queryParams->toArray());
+        return $queryParams->isEmpty() ? '' : '?'.Arr::query($queryParams->toArray());
     }
 }

--- a/tests/Browser/QueryString/Test.php
+++ b/tests/Browser/QueryString/Test.php
@@ -81,6 +81,19 @@ class Test extends TestCase
         });
     }
 
+    public function test_query_string_format_in_rfc_3986()
+    {
+        $this->browse(function (Browser $browser) {
+            Livewire::visit($browser, Component::class)
+                ->waitForLivewire()->type('@input', 'foo bar')
+                ->assertSeeIn('@output', 'foo bar')
+                ->assertInputValue('@input', 'foo bar')
+                ->assertQueryStringHas('foo', 'foo bar')
+                ->assertScript('return !! window.location.search.match(/foo=foo%20bar/)')
+            ;
+        });
+    }
+
     public function test_back_button_after_refresh_works_with_nested_components()
     {
         $this->browse(function (Browser $browser) {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
No 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No 

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
This will make url consistency between `url()->full()` and real current url. 
in my case i use  `<link rel="next" href="{{ $paginate->withQueryString()->nextPageUrl() }}" />`. and google report that duplicate other url. because livewire encode whitespace to `+` but normal paginate encode it as `%20` .

5️⃣ Thanks for contributing! 🙌