### PR TITLE
Adds toString for Stringables

### DIFF
--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -59,8 +59,8 @@ trait HandlesActions
         $name = str($name);
 
         $propertyName = $name->studly()->before('.');
-        $keyAfterFirstDot = $name->contains('.') ? $name->after('.') : null;
-        $keyAfterLastDot = $name->contains('.') ? $name->afterLast('.') : null;
+        $keyAfterFirstDot = $name->contains('.') ? $name->after('.')->__toString() : null;
+        $keyAfterLastDot = $name->contains('.') ? $name->afterLast('.')->__toString() : null;
 
         $beforeMethod = 'updating'.$propertyName;
         $afterMethod = 'updated'.$propertyName;

--- a/tests/Unit/LifecycleHooksTest.php
+++ b/tests/Unit/LifecycleHooksTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use Illuminate\Support\Stringable;
 use Livewire\Component;
 use Livewire\Livewire;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -308,6 +309,7 @@ class ForLifecycleHooks extends Component
         $expected_value = $expected[$expected_key];
         [$before, $after] = $expected_value;
 
+        PHPUnit::assertNotInstanceOf(Stringable::class, $key);
         PHPUnit::assertEquals($expected_key, $key);
         PHPUnit::assertEquals($before, data_get($this->bar, $key));
         PHPUnit::assertEquals($after, $value);
@@ -321,6 +323,7 @@ class ForLifecycleHooks extends Component
         $expected_key = array_keys($expected)[0];
         $expected_value = $expected[$expected_key];
 
+        PHPUnit::assertNotInstanceOf(Stringable::class, $key);
         PHPUnit::assertEquals($expected_key, $key);
         PHPUnit::assertEquals($expected_value, $value);
         PHPUnit::assertEquals($expected_value, data_get($this->bar, $key));
@@ -335,6 +338,7 @@ class ForLifecycleHooks extends Component
         $expected_value = $expected[$expected_key];
         [$before, $after] = $expected_value;
 
+        PHPUnit::assertNotInstanceOf(Stringable::class, $key);
         PHPUnit::assertEquals($expected_key, $key);
         PHPUnit::assertEquals($before, data_get($this->bar, $key));
         PHPUnit::assertEquals($after, $value);
@@ -348,6 +352,7 @@ class ForLifecycleHooks extends Component
         $expected_key = array_keys($expected)[0];
         $expected_value = $expected[$expected_key];
 
+        PHPUnit::assertNotInstanceOf(Stringable::class, $key);
         PHPUnit::assertEquals($expected_key, $key);
         PHPUnit::assertEquals($expected_value, $value);
         PHPUnit::assertEquals($expected_value, data_get($this->bar, $key));


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
This fixes a break we picked up on in an app we were using Livewire in. Issue [#2140](https://github.com/livewire/livewire/issues/2140) is open and describes further.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
I have added PHPUnit assertions in `LifecycleHooksTest`.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Since 2.3.2, nested keys passed to the Updated and Updating hooks are instances of `Stringable`. This PR casts the key to a string before passing to the hooks so they can be interacted with as such - as it was prior to 2.3.2.

5️⃣ Thanks for contributing! 🙌

This is my first contribution to this project so if I have misunderstood/not done anything as preferred, please let me know. Thanks!