### PR TITLE
Make extractOriginalNameFromFilePath() static

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -54,7 +54,7 @@ class TemporaryUploadedFile extends UploadedFile
 
     public function getClientOriginalName()
     {
-        return $this->extractOriginalNameFromFilePath($this->path);
+        return static::extractOriginalNameFromFilePath($this->path);
     }
 
     public function temporaryUrl()

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -127,7 +127,7 @@ class TemporaryUploadedFile extends UploadedFile
         return $hash.$meta.$extension;
     }
 
-    public function extractOriginalNameFromFilePath($path)
+    public static function extractOriginalNameFromFilePath($path)
     {
         return base64_decode(head(explode('-', last(explode('-meta', str($path)->replace('_', '/'))))));
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

I did not.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

The method doesn't use any object state, and is basically a counterpart to the already-static `generateHashNameWithOriginalNameEmbedded()`.

Making this method static will make it possible to convert the hash back to the human-readable filename, without having to awkwardly instantiate the object.

Example from my package:
```php
->resolveDisplayValueUsing(fn (File $field, string $path) => (new TemporaryUploadedFile($path, 'public'))->extractOriginalNameFromFilePath($path))
->storeFileUsing(fn (File $field, TemporaryUploadedFile $file) => $file->storePubliclyAs('files', $file->generateHashNameWithOriginalNameEmbedded($file), ['disk' => 'public']))
```

This would make it possible to do just:
```php
->resolveDisplayValueUsing(fn (File $field, string $path) => TemporaryUploadedFile::extractOriginalNameFromFilePath($path))
```

5️⃣ Thanks for contributing! 🙌