### PR TITLE
Fix magic toggle nested property

### DIFF
--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -119,9 +119,16 @@ trait HandlesActions
 
             case '$toggle':
                 $prop = array_shift($params);
-                $propertyName = $this->beforeFirstDot($prop);
-                $targetKey = $this->afterFirstDot($prop);
-                $this->syncInput($prop, ! data_get($this->{$propertyName}, $targetKey), $rehash = false);
+
+                if ($this->containsDots($prop)) {
+                    $propertyName = $this->beforeFirstDot($prop);
+                    $targetKey = $this->afterFirstDot($prop);
+                    $currentValue = data_get($this->{$propertyName}, $targetKey);
+                } else {
+                    $currentValue = $this->{$prop};
+                }
+                
+                $this->syncInput($prop, ! $currentValue, $rehash = false);
 
                 return;
 

--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -119,7 +119,9 @@ trait HandlesActions
 
             case '$toggle':
                 $prop = array_shift($params);
-                $this->syncInput($prop, ! $this->{$prop}, $rehash = false);
+                $propertyName = $this->beforeFirstDot($prop);
+                $targetKey = $this->afterFirstDot($prop);
+                $this->syncInput($prop, ! data_get($this->{$propertyName}, $targetKey), $rehash = false);
 
                 return;
 

--- a/tests/Browser/MagicActions/Component.php
+++ b/tests/Browser/MagicActions/Component.php
@@ -7,6 +7,7 @@ use Livewire\Component as BaseComponent;
 
 class Component extends BaseComponent
 {
+    public $active = false;
     public $foo = ['bar' => ['baz' => false]];
 
     public function render()
@@ -14,8 +15,11 @@ class Component extends BaseComponent
         return
 <<<'HTML'
 <div>
-    <div dusk="output">{{ $foo['bar']['baz'] ? "true" : "false" }}</div>
-    <button wire:click="$toggle('foo.bar.baz')" dusk="toggle">Toggle Nested</button>
+    <div dusk="output">{{ $active ? "true" : "false" }}</div>
+    <button wire:click="$toggle('active')" dusk="toggle">Toggle Property</button>
+
+    <div dusk="outputNested">{{ $foo['bar']['baz'] ? "true" : "false" }}</div>
+    <button wire:click="$toggle('foo.bar.baz')" dusk="toggleNested">Toggle Nested</button>
 </div>
 HTML;
     }

--- a/tests/Browser/MagicActions/Component.php
+++ b/tests/Browser/MagicActions/Component.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Browser\MagicActions;
+
+use Illuminate\Support\Facades\View;
+use Livewire\Component as BaseComponent;
+
+class Component extends BaseComponent
+{
+    public $foo = ['bar' => ['baz' => false]];
+
+    public function render()
+    {
+        return
+<<<'HTML'
+<div>
+    <div dusk="output">{{ $foo['bar']['baz'] ? "true" : "false" }}</div>
+    <button wire:click="$toggle('foo.bar.baz')" dusk="toggle">Toggle Nested</button>
+</div>
+HTML;
+    }
+}

--- a/tests/Browser/MagicActions/Test.php
+++ b/tests/Browser/MagicActions/Test.php
@@ -8,13 +8,23 @@ use Tests\Browser\MagicActions\Component;
 
 class Test extends TestCase
 {
-    public function test_magic_toggle_can_toggle_nested()
+    public function test_magic_toggle_can_toggle_properties()
     {
         $this->browse(function ($browser) {
             Livewire::visit($browser, Component::class)
+                //Toggle boolean property
                 ->assertSeeIn('@output', 'false')
                 ->waitForLivewire()->click('@toggle')
                 ->assertSeeIn('@output', 'true')
+                ->waitForLivewire()->click('@toggle')
+                ->assertSeeIn('@output', 'false')
+
+                //Toggle nested boolean property
+                ->assertSeeIn('@outputNested', 'false')
+                ->waitForLivewire()->click('@toggleNested')
+                ->assertSeeIn('@outputNested', 'true')
+                ->waitForLivewire()->click('@toggleNested')
+                ->assertSeeIn('@outputNested', 'false')
             ;
         });
     }

--- a/tests/Browser/MagicActions/Test.php
+++ b/tests/Browser/MagicActions/Test.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Browser\MagicActions;
+
+use Livewire\Livewire;
+use Tests\Browser\TestCase;
+use Tests\Browser\MagicActions\Component;
+
+class Test extends TestCase
+{
+    public function test_magic_toggle_can_toggle_nested()
+    {
+        $this->browse(function ($browser) {
+            Livewire::visit($browser, Component::class)
+                ->assertSeeIn('@output', 'false')
+                ->waitForLivewire()->click('@toggle')
+                ->assertSeeIn('@output', 'true')
+            ;
+        });
+    }
+}


### PR DESCRIPTION
Currently using the magic action `$toggle` doesn't work with dot notation.

Example: `wire:click="$toggle('users.0.active')"` throws the below error due to the `$this->{$prop}` call.

>Livewire\Exceptions\PropertyNotFoundException
>Property [$users.0.active] not found on component

This PR fixes that and adds tests for `$toggle`.

Hope this helps!


**Side Note:** I think a helper function should be made for getting and setting properties using dot notation. That would extract the logic out of this code and clean it up, and it could be useful in other areas.


**Related Issues:** There as a comment on #1886 noting this issue, but I don't think it's the original issue.
https://github.com/livewire/livewire/issues/1886#issuecomment-715872847

