### PR TITLE
Support constructor DI

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -239,4 +239,9 @@ abstract class Component
             'Method %s::%s does not exist.', static::class, $method
         ));
     }
+
+    public function setId($id): void
+    {
+        $this->id = $id;
+    }
 }

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -65,7 +65,9 @@ class LivewireManager
             "Component [{$component}] class not found: [{$componentClass}]"
         ));
 
-        return new $componentClass($id);
+        return tap(app($componentClass), static function (Component $component) use ($id): void {
+            $component->setId($id);
+        });
     }
 
     public function mount($name, $params = [])

--- a/tests/Unit/ComponentDependencyInjectionTest.php
+++ b/tests/Unit/ComponentDependencyInjectionTest.php
@@ -9,6 +9,14 @@ use Illuminate\Routing\UrlGenerator;
 class ComponentDependencyInjectionTest extends TestCase
 {
     /** @test */
+    public function component_constructor_with_dependency()
+    {
+        $component = app(ComponentWithDependencyInjection::class);
+        
+        $this->assertInstanceOf(Dependency::class, $component->getDep());
+    }
+
+    /** @test */
     public function component_mount_action_with_dependency()
     {
         $component = Livewire::test(ComponentWithDependencyInjection::class, ['id' => 123]);
@@ -120,10 +128,24 @@ class ComponentDependencyInjectionTest extends TestCase
     }
 }
 
+class Dependency {}
+
 class ComponentWithDependencyInjection extends Component
 {
     public $foo;
     public $bar;
+    private $dep;
+
+    public function __construct(Dependency $dep)
+    {
+        parent::__construct();
+        $this->dep = $dep;
+    }
+
+    public function getDep()
+    {
+        return $this->dep;
+    }
 
     public function mount(UrlGenerator $generator, $id = 123)
     {


### PR DESCRIPTION
This PR attempts to add support for constructor's dependency injection, allowing usage of dependent services throughout the component's actions and events:

```php
class FooComponent extends Component {
    private Dep $dep;

    public function __construct(Dep $dep) 
    {
        $this->dep = $dep;
    }

    public function hydrate(Request $request): void
    {
        $this->dep->handleRequest($request);
    }

    public function updatedFoo(string $value): void
    {
        $this->dep->doSomethingWithFoo($value);
    }
}
```

Also this way, one wouldn't need to resort to method DI. For components that heavily depend on external services, this should keep the codebase as DRY as possible.