### PR TITLE
Fix skipRender() to actually skip the render method

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -106,6 +106,8 @@ abstract class Component
 
     public function renderToView()
     {
+        if ($this->shouldSkipRender) return null;
+
         Livewire::dispatch('component.rendering', $this);
 
         $view = method_exists($this, 'render')

--- a/tests/Unit/ComponentSkipRenderTest.php
+++ b/tests/Unit/ComponentSkipRenderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use function Livewire\str;
+
+class ComponentSkipRenderTest extends TestCase
+{
+    /** @test */
+    public function component_renders_like_normal()
+    {
+        $component = Livewire::test(ComponentSkipRenderStub::class);
+
+        $this->assertTrue(
+            str($component->payload['effects']['html'])->contains([$component->id(), 'foo'])
+        );
+    }
+
+    /** @test */
+    public function on_skip_render_render_is_not_called()
+    {
+        $component = Livewire::test(ComponentSkipRenderStub::class);
+
+        $component->call('noop');
+
+        $this->assertNull($component->payload['effects']['html']);
+    }
+}
+
+class ComponentSkipRenderStub extends Component
+{
+    private $noop = false;
+
+    public function noop()
+    {
+        $this->noop = true;
+
+        $this->skipRender();
+    }
+
+    public function render()
+    {
+        if ($this->noop) {
+            throw new \RuntimeException('Render should not be called after noop()');
+        }
+
+        return app('view')->make('null-view');
+    }
+}


### PR DESCRIPTION
Skip the actual render on skipRender(). Same as https://github.com/livewire/livewire/pull/1738 but with a test to confirm it.

Not sure why the render() method is still called otherwise, which can load/query data still, but it's not used.