### PR TITLE
Remove unused uploadDangerous function on FileUploadsTest

### DIFF
--- a/tests/Unit/FileUploadsTest.php
+++ b/tests/Unit/FileUploadsTest.php
@@ -636,11 +636,6 @@ class FileUploadComponent extends Component
         $this->storedFilename = $this->photo->store('/', $disk = 'avatars');
     }
 
-    public function uploadDangerous()
-    {
-        $this->photo->store();
-    }
-
     public function validateUpload()
     {
         $this->validate(['photo' => 'file|max:100']);


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
No

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
The `uploadDangerous` function from `FileUploadsTest` is not used.

This function was introduced (maybe for convenience while testing) in [this commit](https://github.com/livewire/livewire/commit/7d4af7df6160792ef5eb148e0a21b2ab9b19d576#diff-92ed53a475f7ff939fc2af939bbe806ff880b10dd936a0867565a544b40b331f), but is not removed in the next cleanup commit

5️⃣ Thanks for contributing! 🙌