### PR TITLE
Get the correct data when json TemporaryUploadedFile

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -7,7 +7,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Storage;
 
-class TemporaryUploadedFile extends UploadedFile
+class TemporaryUploadedFile extends UploadedFile implements JsonSerializable
 {
     protected $storage;
     protected $path;
@@ -183,5 +183,10 @@ class TemporaryUploadedFile extends UploadedFile
     public static function serializeMultipleForLivewireResponse($files)
     {
         return 'livewire-files:'.json_encode(collect($files)->map->getFilename());
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->serializeForLivewireResponse();
     }
 }

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Storage;
+use JsonSerializable;
 
 class TemporaryUploadedFile extends UploadedFile implements JsonSerializable
 {

--- a/tests/Browser/FileUploads/Component.php
+++ b/tests/Browser/FileUploads/Component.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Browser\FileUploads;
+
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\Stringable;
+use Livewire\Component as BaseComponent;
+use Livewire\WithFileUploads;
+
+class Component extends BaseComponent
+{
+    use WithFileUploads;
+
+    public $foo;
+
+    public function render()
+    {
+        return View::file(__DIR__.'/view.blade.php');
+    }
+}

--- a/tests/Browser/FileUploads/Test.php
+++ b/tests/Browser/FileUploads/Test.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Browser\FileUploads;
+
+use Illuminate\Http\UploadedFile;
+use Laravel\Dusk\Browser;
+use Livewire\Livewire;
+use Tests\Browser\TestCase;
+
+class Test extends TestCase
+{
+    public function test_set_uploaded_file_from_livewire_component()
+    {
+        $this->onlyRunOnChrome();
+
+        $this->browse(function (Browser $browser) {
+            $fakeFile = UploadedFile::fake()->create('foo');
+
+            Livewire::visit($browser, Component::class)
+                ->waitForLivewire()
+                ->attach('@foo', $fakeFile)
+                ->waitUsing(5, 75, function () use ($browser) {
+                    $browser->script([
+                        'foo = livewire.first().get("foo")',
+                        'livewire.first().set("foo", foo)',
+                    ]);
+
+                    return $browser->assertScript('foo.indexOf("livewire-files:") >= 0', true);
+                });
+        });
+    }
+}

--- a/tests/Browser/FileUploads/Test.php
+++ b/tests/Browser/FileUploads/Test.php
@@ -11,8 +11,6 @@ class Test extends TestCase
 {
     public function test_set_uploaded_file_from_livewire_component()
     {
-        $this->onlyRunOnChrome();
-
         $this->browse(function (Browser $browser) {
             $fakeFile = UploadedFile::fake()->create('foo');
 

--- a/tests/Browser/FileUploads/view.blade.php
+++ b/tests/Browser/FileUploads/view.blade.php
@@ -1,0 +1,3 @@
+<div>
+    <input type="file" wire:model="foo" dusk="foo" multiple>
+</div>

--- a/tests/Browser/TestCase.php
+++ b/tests/Browser/TestCase.php
@@ -137,6 +137,11 @@ class TestCase extends BaseTestCase
             'driver' => 'local',
             'root' => __DIR__.'/downloads',
         ]);
+
+        $app['config']->set('filesystems.disks.tmp-for-tests', [
+            'driver' => 'local',
+            'root' => __DIR__.'/uploads',
+        ]);
     }
 
     protected function resolveApplicationHttpKernel($app)


### PR DESCRIPTION
In somehow, I keep getting `[{"disk": "local"}, {"disk": "local"}]` as a result when I do something like `@this.set(field, ['livewire-file:***', 'livewire-file:***'])` which means there is a `json_encode` somewhere on response lifecycle and it leads to an incorrect `TemporaryUploadedFile` serialized data, so this fixed it.