### PR TITLE
Fix hydration hook, property hydration called twice

### DIFF
--- a/src/HydrationMiddleware/CallPropertyHydrationHooks.php
+++ b/src/HydrationMiddleware/CallPropertyHydrationHooks.php
@@ -18,10 +18,6 @@ class CallPropertyHydrationHooks implements HydrationMiddleware
             $studlyProperty = str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $property)));
             $method = 'hydrate'.$studlyProperty;
             $instance->{$method}($value, $request);
-
-            if (method_exists($instance, $method = 'hydrate'.$studlyProperty)) {
-                $instance->{$method}($value, $request);
-            }
         }
     }
 

--- a/src/HydrationMiddleware/CallPropertyHydrationHooks.php
+++ b/src/HydrationMiddleware/CallPropertyHydrationHooks.php
@@ -14,7 +14,7 @@ class CallPropertyHydrationHooks implements HydrationMiddleware
             Livewire::dispatch('property.hydrate', $property, $value, $instance, $request);
 
             // Call magic hydrateProperty methods on the component.
-            // If the method doesn't exist, the __call with eat it.
+            // If the method doesn't exist, the __call will eat it.
             $studlyProperty = str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $property)));
             $method = 'hydrate'.$studlyProperty;
             $instance->{$method}($value, $request);

--- a/tests/Unit/LifecycleHooksTest.php
+++ b/tests/Unit/LifecycleHooksTest.php
@@ -16,10 +16,10 @@ class LifecycleHooksTest extends TestCase
 
         $this->assertEquals([
             'mount' => true,
-            'hydrate' => false,
-            'hydrateFoo' => false,
-            'dehydrate' => true,
-            'dehydrateFoo' => true,
+            'hydrate' => 0,
+            'hydrateFoo' => 0,
+            'dehydrate' => 1,
+            'dehydrateFoo' => 1,
             'updating' => false,
             'updated' => false,
             'updatingFoo' => false,
@@ -40,10 +40,10 @@ class LifecycleHooksTest extends TestCase
 
         $this->assertEquals([
             'mount' => true,
-            'hydrate' => true,
-            'hydrateFoo' => true,
-            'dehydrate' => true,
-            'dehydrateFoo' => true,
+            'hydrate' => 1,
+            'hydrateFoo' => 1,
+            'dehydrate' => 2,
+            'dehydrateFoo' => 2,
             'updating' => false,
             'updated' => false,
             'updatingFoo' => false,
@@ -74,10 +74,10 @@ class LifecycleHooksTest extends TestCase
 
         $this->assertEquals([
             'mount' => true,
-            'hydrate' => true,
-            'hydrateFoo' => true,
-            'dehydrate' => true,
-            'dehydrateFoo' => true,
+            'hydrate' => 1,
+            'hydrateFoo' => 1,
+            'dehydrate' => 2,
+            'dehydrateFoo' => 2,
             'updating' => true,
             'updated' => true,
             'updatingFoo' => true,
@@ -125,10 +125,10 @@ class LifecycleHooksTest extends TestCase
 
         $this->assertEquals([
             'mount' => true,
-            'hydrate' => true,
-            'hydrateFoo' => true,
-            'dehydrate' => true,
-            'dehydrateFoo' => true,
+            'hydrate' => 3,
+            'hydrateFoo' => 3,
+            'dehydrate' => 4,
+            'dehydrateFoo' => 4,
             'updating' => true,
             'updated' => true,
             'updatingFoo' => false,
@@ -205,10 +205,10 @@ class LifecycleHooksTest extends TestCase
 
         $this->assertEquals([
             'mount' => true,
-            'hydrate' => true,
-            'hydrateFoo' => true,
-            'dehydrate' => true,
-            'dehydrateFoo' => true,
+            'hydrate' => 1,
+            'hydrateFoo' => 1,
+            'dehydrate' => 2,
+            'dehydrateFoo' => 2,
             'updating' => true,
             'updated' => true,
             'updatingFoo' => true,
@@ -233,10 +233,10 @@ class ForLifecycleHooks extends Component
 
     public $lifecycles = [
         'mount' => false,
-        'hydrate' => false,
-        'hydrateFoo' => false,
-        'dehydrate' => false,
-        'dehydrateFoo' => false,
+        'hydrate' => 0,
+        'hydrateFoo' => 0,
+        'dehydrate' => 0,
+        'dehydrateFoo' => 0,
         'updating' => false,
         'updated' => false,
         'updatingFoo' => false,
@@ -256,22 +256,22 @@ class ForLifecycleHooks extends Component
 
     public function hydrate()
     {
-        $this->lifecycles['hydrate'] = true;
+        $this->lifecycles['hydrate']++;
     }
 
     public function hydrateFoo()
     {
-        $this->lifecycles['hydrateFoo'] = true;
+        $this->lifecycles['hydrateFoo']++;
     }
 
     public function dehydrate()
     {
-        $this->lifecycles['dehydrate'] = true;
+        $this->lifecycles['dehydrate']++;
     }
 
     public function dehydrateFoo()
     {
-        $this->lifecycles['dehydrateFoo'] = true;
+        $this->lifecycles['dehydrateFoo']++;
     }
 
     public function updating($name, $value)


### PR DESCRIPTION
Currently property hydration functions like `hydrateFoo` are called twice, this PR simply fixes that.
I assumed that calling the hydrate function should always be done because of the following documentation in the code.

```
// Call magic hydrateProperty methods on the component.
// If the method doesn't exist, the __call with eat it.
```

I didn't create an issue because the fix seems to be trival. 