### PR TITLE
Add failing test for server-rendered selected option

### DIFF
--- a/tests/Browser/DataBinding/InputSelect/Component.php
+++ b/tests/Browser/DataBinding/InputSelect/Component.php
@@ -11,6 +11,8 @@ class Component extends BaseComponent
     public $singleValue;
     public $singleNumber = 3;
     public $placeholder = '';
+    public $selected = '';
+    public $selectOptions = ['', 'foo', 'bar', 'baz'];
     public $multiple = [];
 
     public function render()

--- a/tests/Browser/DataBinding/InputSelect/Test.php
+++ b/tests/Browser/DataBinding/InputSelect/Test.php
@@ -47,6 +47,15 @@ class Test extends TestCase
                 ->assertSeeIn('@placeholder.output', 'foo')
 
                 /**
+                 * Select with a server-rendered `selected` option.
+                 */
+                ->assertSelected('@selected.input', '')
+                ->assertDontSeeIn('@selected.output', 'foo')
+                ->waitForLivewire()->select('@selected.input', 'bar')
+                ->assertSelected('@selected.input', 'bar')
+                ->assertSeeIn('@selected.output', 'bar')
+
+                /**
                  * Select multiple.
                  */
                 ->assertDontSeeIn('@multiple.output', 'bar')

--- a/tests/Browser/DataBinding/InputSelect/view.blade.php
+++ b/tests/Browser/DataBinding/InputSelect/view.blade.php
@@ -28,6 +28,13 @@
         <option>baz</option>
     </select>
 
+    <h1 dusk="selected.output">{{ $selected }}</h1>
+    <select wire:model="selected" dusk="selected.input">
+        @foreach($selectOptions as $option)
+        <option @if($selected == $option) selected @endif>{{ $option }}</option>
+        @endforeach
+    </select>
+
     <h1 dusk="multiple.output">@json($multiple)</h1>
     <select wire:model="multiple" multiple dusk="multiple.input">
         <option>foo</option>


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

This PR demonstrates an unexpected behavior/bug in Livewire when using `select` elements with options where the `selected` attribute is set on the server.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Only a test is included!

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

I stumbled upon this issue when I created a simple blade component for form selects, where I can pass in the options as an array. The component loops over the options, rendering each one and setting the `selected` attribute on the currently selected value. I was using this component on regular server-rendered pages and it works fine. However, when dropping it into a Livewire component, and adding a `wire:model` property to it - it would start deselecting the selected value.

Here's a demo on Laravel Playground: https://laravelplayground.com/#/snippets/70b3675e-286f-4509-906d-3be0508a403d

I think the behaviour at the moment can be considered a bug. I would expect I can just re-use my blade select component for both regular blade views and inside Livewire components.

I was able to fix the issue by commenting out https://github.com/livewire/livewire/blob/master/js/component/index.js#L424-L429 - all tests were green. However, I'm not sure of the full implications of that change, so I didn't want to PR it as a fix myself.

Sidenote: it seems that MorphDOM itself might have some issues with selecting the correct element when any option attributes aside from `selected` have changed (such as some `data-` attribute).

5️⃣ Thanks for contributing! 🙌