### PR TITLE
fixed svg preview mime type detection

### DIFF
--- a/src/Controllers/CanPretendToBeAFile.php
+++ b/src/Controllers/CanPretendToBeAFile.php
@@ -4,7 +4,7 @@ namespace Livewire\Controllers;
 
 trait CanPretendToBeAFile
 {
-    public function pretendResponseIsFile($file)
+    public function pretendResponseIsFile($file, $mimeType = 'application/javascript')
     {
         $expires = strtotime('+1 year');
         $lastModified = filemtime($file);
@@ -18,7 +18,7 @@ trait CanPretendToBeAFile
         }
 
         return response()->file($file, [
-            'Content-Type' => 'application/javascript; charset=utf-8',
+            'Content-Type' => "$mimeType; charset=utf-8",
             'Expires' => $this->httpDate($expires),
             'Cache-Control' => $cacheControl,
             'Last-Modified' => $this->httpDate($lastModified),

--- a/src/Controllers/FilePreviewHandler.php
+++ b/src/Controllers/FilePreviewHandler.php
@@ -12,6 +12,9 @@ class FilePreviewHandler
     {
         abort_unless(request()->hasValidSignature(), 401);
 
-        return $this->pretendResponseIsFile(FileUploadConfiguration::storage()->path(FileUploadConfiguration::path($filename)));
+        return $this->pretendResponseIsFile(
+            FileUploadConfiguration::storage()->path(FileUploadConfiguration::path($filename)),
+            FileUploadConfiguration::mimeType($filename)
+        );
     }
 }

--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -66,6 +66,12 @@ class FileUploadConfiguration
         return $prefix.($prefix ? '/' : '').$directory.($path ? '/' : '').$path;
     }
 
+     public static function mimeType($filename)
+    {
+        $mimeType = static::storage()->getMimeType(static::path($filename));
+        return $mimeType === 'image/svg' ? 'image/svg+xml' : $mimeType;
+    }
+
     public static function middleware()
     {
         return config('livewire.temporary_file_upload.middleware') ?: 'throttle:60,1';


### PR DESCRIPTION
**Is this something that is wanted/needed? Did you create an issue / discussion about it first?**

An issue was opened here: https://github.com/livewire/livewire/issues/2061

This PR improves the `Content-Type` sent for preview image responses by first trying to guess the file's mime type. Additionally, it accounts for a PHP bug with `.svg` mime type detection so that preview images for uploaded SVGs also work.

While investigating this, I noticed Livewire is always sending `application/json` as the mime type for file previews. Instead, it should probably try to guess the mime type and respond with that in the `Content-Type` header. 

There's a problem with SVG mime type detection in PHP though, see [here](https://github.com/symfony/symfony/issues/37148) and [here](https://bugs.php.net/bug.php?id=79045).

The PR includes a workaround for this PHP bug. Without it, all SVG's are detected as `image/svg` (instead of `image/svg+xml`) and the previews do not show up correctly. 

**Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)**
It doesn't, but if you have an idea of how to test this, let me know!