### PR TITLE
Changed messages to validationMessages for better namespacing

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -79,10 +79,10 @@ trait ValidatesInput
         return [];
     }
 
-    protected function getMessages()
+    protected function getValidationMessages()
     {
-        if (method_exists($this, 'messages')) return $this->messages();
-        if (property_exists($this, 'messages')) return $this->messages;
+        if (method_exists($this, 'validationMessages')) return $this->messages();
+        if (property_exists($this, 'validationMessages')) return $this->validationMessages;
 
         return [];
     }
@@ -222,7 +222,7 @@ trait ValidatesInput
 
         throw_if(empty($rules), new MissingRulesException($this::getName()));
 
-        $messages = empty($messages) ? $this->getMessages() : $messages;
+        $messages = empty($messages) ? $this->getValidationMessages() : $messages;
         $attributes = empty($attributes) ? $this->getValidationAttributes() : $attributes;
 
         return [$rules, $messages, $attributes];

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -364,7 +364,7 @@ class ValidationTest extends TestCase
     /** @test */
     public function only_data_in_validation_rules_is_returned()
     {
-        $component = new ForValidation();
+        $component      = new ForValidation();
         $component->bar = 'is required';
 
         $validatedData = $component->runValidationWithoutAllPublicPropertiesAndReturnValidatedData();
@@ -384,14 +384,14 @@ class ValidationTest extends TestCase
 
 class ForValidation extends Component
 {
-    public $foo = 'foo';
-    public $bar = '';
+    public $foo    = 'foo';
+    public $bar    = '';
     public $emails = ['foo@bar.com', 'invalid-email'];
-    public $items = [
+    public $items  = [
         ['foo' => 'bar', 'baz' => 'blab'],
         ['foo' => 'bar', 'baz' => ''],
     ];
-    public $password = '';
+    public $password             = '';
     public $passwordConfirmation = '';
 
     public function runValidation()
@@ -443,14 +443,14 @@ class ForValidation extends Component
                 'foo_length' => strlen($this->foo),
                 'bar_length' => strlen($this->bar),
             ],
-            [ 'foo_length' => 'same:bar_length' ],
-            [ 'same' => 'Lengths must be the same' ]
+            ['foo_length' => 'same:bar_length'],
+            ['same' => 'Lengths must be the same']
         )->validate();
     }
 
     public function runValidationOnlyWithMessageProperty($field)
     {
-        $this->messages = [
+        $this->validationMessages = [
             'foo.required' => 'Foo Message',
             'bar.required' => 'Bar Message',
         ];
@@ -464,8 +464,8 @@ class ForValidation extends Component
     public function runDeeplyNestedValidationOnly($field)
     {
         $this->validateOnly($field, [
-            'items' => ['required', 'array'],
-            'items.*' => 'array',
+            'items'       => ['required', 'array'],
+            'items.*'     => 'array',
             'items.*.foo' => ['required', 'string'],
             'items.*.baz' => ['required', 'string'],
         ]);
@@ -480,12 +480,12 @@ class ForValidation extends Component
 
     public function runValidationWithMessageProperty()
     {
-        $this->messages = [
-            'required' => 'Custom Message'
+        $this->validationMessages = [
+            'required' => 'Custom Message',
         ];
 
         $this->validate([
-            'bar' => 'required'
+            'bar' => 'required',
         ]);
     }
 
@@ -515,13 +515,12 @@ class ForValidation extends Component
     public function runDeeplyNestedValidation()
     {
         $this->validate([
-            'items' => ['required', 'array'],
-            'items.*' => 'array',
+            'items'       => ['required', 'array'],
+            'items.*'     => 'array',
             'items.*.foo' => ['required', 'string'],
             'items.*.baz' => ['required', 'string'],
         ]);
     }
-
 
     public function runSameValidation()
     {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Yes, see my PR in the docs over at 
https://github.com/livewire/docs/pull/307

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Yes; I modified the existing ValidateTest to include this change.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

This started out with me creating a component for storing chat messages. Logically, this would include a property called "messages" for storing a collection of chat messages. There were no issues until I executed `$this->validate()` when I started seeing a `Validation::factory` error that the 3rd argument was expected to be an array. It was too generic for me to understand what the problem was so I started going into the Livewire vendor code to trace the issue. After "dd"ing  various arguments in the validate method, I noticed that the messages being passed in which were meant for the Validation factory, were MY chat messages. The error occurred because they were a collection and not an array. Had they been a normal array this would have gone on silently and I would be none the wiser.

So, anyway, this is obvious in retrospect, but I at least updated the docs to include this caveat in case it trips anyone else up like me. However, in this particular instance, "messages" _is_ fairly generic and it seems unfair that I can't use that for my own property. I also get that this PR would be a major breaking change for those using the messages property as intended. But I thought at the very least this could be useful as a discussion around how you name internal properties moving forward. 

Thanks!

5️⃣ Thanks for contributing! 🙌