### PR TITLE
Fix error when new variable is present

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -91,7 +91,7 @@ class Response
         // If 'data' is present in the response memo, diff it one level deep.
         if (isset($dirtyMemo['data']) && isset($requestMemo['data'])) {
             foreach ($dirtyMemo['data'] as $key => $value) {
-                if ($value === $requestMemo['data'][$key]) {
+                if (isset($requestMemo['data'][$key]) && $value === $requestMemo['data'][$key]) {
                     unset($dirtyMemo['data'][$key]);
                 }
             }


### PR DESCRIPTION
This fixes an error that occurs when a new variable is added to an existing component.

When a user is on an old session when re-rendering the component happens it throws a 500 since the array offset does not exist in the `requestMemo['data']` object.