### PR TITLE
Fix Unable to call component method

### DIFF
--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -104,6 +104,8 @@ trait HandlesActions
 
     public function callMethod($method, $params = [])
     {
+        $method = trim($method);
+
         switch ($method) {
             case '$sync':
                 $prop = array_shift($params);

--- a/tests/Browser/Actions/Test.php
+++ b/tests/Browser/Actions/Test.php
@@ -36,6 +36,12 @@ class Test extends TestCase
                 ->assertSeeIn('@output', 'foo')
 
                 /**
+                 * Action with no params, but still parenthesis and having some spaces.
+                 */
+                ->waitForLivewire()->click('@baw')
+                ->assertSeeIn('@output', 'foo')
+
+                /**
                  * wire:click.self
                  */
                 ->waitForLivewire()->click('@baz.inner')

--- a/tests/Browser/Actions/view.blade.php
+++ b/tests/Browser/Actions/view.blade.php
@@ -3,6 +3,7 @@
     <button type="button" wire:click="setOutputTo('bar', 'bell')" dusk="bar">Bar</button>
     <button type="button" wire:click="setOutputTo('a', &quot;b&quot; , 'c','d' ,'e', ''.concat('f'))" dusk="ball">Ball</button>
     <button type="button" wire:click="setOutputToFoo()" dusk="bowl">Bowl</button>
+    <button type="button" wire:click="@if (1) setOutputToFoo() @else setOutputToFoo() @endif" dusk="baw">Baw</button>
     <button type="button" wire:click="setOutputTo('baz')" dusk="baz.outer"><button type="button" wire:click="$refresh" dusk="baz.inner">Inner</button> Outer</button>
     <input type="text" wire:blur="appendToOutput('bop')" dusk="bop.input"><button type="button" wire:mousedown="appendToOutput('bop')" dusk="bop.button">Blur &</button>
     <input type="text" wire:keydown="appendToOutput('bob')" wire:keydown.enter="appendToOutput('bob')" dusk="bob">


### PR DESCRIPTION
When I do something like this `wire:click="@if (true) method1() @else method2() @endif"`

I got `Unable to call component method. Public method [ method1] not found on component`

Clearly the issue was because there is a space in the method name, so we need to trim it first.