### PR TITLE
Add the new turbo eval tags to scripts

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -218,8 +218,8 @@ HTML;
         // because it will be minified in production.
         return <<<HTML
 {$assetWarning}
-<script src="{$fullAssetPath}" data-turbolinks-eval="false"></script>
-<script data-turbolinks-eval="false"{$nonce}>
+<script src="{$fullAssetPath}" data-turbo-eval="false" data-turbolinks-eval="false"></script>
+<script data-turbo-eval="false" data-turbolinks-eval="false"{$nonce}>
     if (window.livewire) {
         console.warn('Livewire: It looks like Livewire\'s @livewireScripts JavaScript assets have already been loaded. Make sure you aren\'t loading them twice.')
     }


### PR DESCRIPTION
### Added

- Adds the new `data-turbo-eval` for Turbo Drive (see the [documentation here](https://turbo.hotwire.dev/handbook/building#working-with-script-elements)). This PR has a companion PR on the `livewire/turbolinks` plugin (see [here](https://github.com/livewire/turbolinks/pull/12))

---

I haven't created an issue for it, but since Turbolinks is supported, I figure adding support for the new Turbo Drive would be OK.

I tested it out locally and it works fine persisting the component state across turbo visits (with the new livewire/turbolinks package)