### PR TITLE
remove trailing question mark

### DIFF
--- a/js/component/SyncBrowserHistory.js
+++ b/js/component/SyncBrowserHistory.js
@@ -90,7 +90,7 @@ export default function () {
 
         let destination = new URL(url)
 
-        let afterOrigin = destination.href.replace(destination.origin, '')
+        let afterOrigin = destination.href.replace(destination.origin, '').replace(/\?$/, '')
 
         return window.location.origin + afterOrigin + window.location.hash
     }


### PR DESCRIPTION
The PR ensures there is no `?` left at the end of the href.

The occurrence I've been having for this is when you navigate back to page 1 which removes the `page` parameter from the query string, resulting in an empty query string. Instead of `example.com/posts` you'd end up with the URL `example.com/posts?`.

Apologies, I don't have experience in writing the tests for this or building the assets. I've popped it on a branch so that it can be modified by others. Thanks