### PR TITLE
Update phpunit.xml configuration format

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,9 +16,9 @@
             <directory suffix="Test.php">./tests/Browser</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
PHPUnit 9.3.0 has changed coverage filtering from filter tag to coverage tag. So, this pull request migrates `phpunit.xml` to the new configuration format.