### PR TITLE
redirect before even render the default layout

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -48,6 +48,10 @@ abstract class Component
             ->mount($componentParams)
             ->renderToView();
 
+        if ($this->redirectTo) {
+            return redirect()->response($this->redirectTo);
+        }
+
         $layoutType = $this->initialLayoutConfiguration['type'] ?? 'component';
 
         return app('view')->file(__DIR__."/Macros/livewire-view-{$layoutType}.blade.php", [

--- a/src/Redirector.php
+++ b/src/Redirector.php
@@ -24,4 +24,9 @@ class Redirector extends BaseRedirector
 
         return $this;
     }
+
+    public function response($to)
+    {
+        return $this->createRedirect($to, 302, []);
+    }
 }

--- a/tests/Unit/ComponentSkipRenderTest.php
+++ b/tests/Unit/ComponentSkipRenderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use Illuminate\Support\Facades\Route;
 use Livewire\Component;
 use Livewire\Livewire;
 use function Livewire\str;
@@ -35,6 +36,17 @@ class ComponentSkipRenderTest extends TestCase
 
         $this->assertEquals('/foo', $component->payload['effects']['redirect']);
         $this->assertNull($component->payload['effects']['html']);
+
+        Route::get('/403', ComponentSkipRenderOnRedirectInMountStub::class);
+        $this->get('/403')->assertRedirect('/foo');
+
+        $component = Livewire::test(ComponentSkipRenderOnRedirectHelperInMountStub::class);
+
+        $this->assertStringEndsWith('/bar', $component->payload['effects']['redirect']);
+        $this->assertNull($component->payload['effects']['html']);
+
+        Route::get('/403', ComponentSkipRenderOnRedirectHelperInMountStub::class);
+        $this->get('/403')->assertRedirect('/bar');
     }
 }
 
@@ -64,6 +76,19 @@ class ComponentSkipRenderOnRedirectInMountStub extends Component
     public function mount()
     {
         $this->redirect('/foo');
+    }
+
+    public function render()
+    {
+        throw new \RuntimeException('Render should not be called on redirect');
+    }
+}
+
+class ComponentSkipRenderOnRedirectHelperInMountStub extends Component
+{
+    public function mount()
+    {
+        return redirect('/bar');
     }
 
     public function render()


### PR DESCRIPTION
As mentioned by @AdvancedStyle [here](https://github.com/livewire/livewire/pull/2223#issuecomment-751668193)

Redirect doesn't work if you use a `redirect()` within `mount()` in Full-Page components.

I don't think this is related, but I noticed that the target URL isn't always the same
| Call        | Url           |
| ------------- |-------------|
|  `$this->redirect('/foo')` | `/foo` |
|  `redirect('/foo')` | `http://localhost/foo` |

therefore I used `assertStringEndsWith()`