### PR TITLE
Add max_upload_time configuration

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -90,7 +90,7 @@ return [
             'mov', 'avi', 'wmv', 'mp3', 'm4a',
             'jpg', 'jpeg', 'mpga', 'webp', 'wma',
         ],
-        'max_upload_time' => null, // Max duration (in minutes) before an upload gets invalidated. Default: 5
+        'max_upload_time' => 5, // Max duration (in minutes) before an upload gets invalidated.
     ],
 
     /*

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -90,6 +90,7 @@ return [
             'mov', 'avi', 'wmv', 'mp3', 'm4a',
             'jpg', 'jpeg', 'mpga', 'webp', 'wma',
         ],
+        'max_upload_time' => null, // Max duration (in minutes) before an upload gets invalidated. Default: 5
     ],
 
     /*

--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -90,6 +90,6 @@ class FileUploadConfiguration
 
     public static function maxUploadTime()
     {
-        return config('livewire.temporary_file_upload.max_upload_time') ?: 5;
+        return config('livewire.temporary_file_upload.max_upload_time');
     }
 }

--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -66,7 +66,7 @@ class FileUploadConfiguration
         return $prefix.($prefix ? '/' : '').$directory.($path ? '/' : '').$path;
     }
 
-     public static function mimeType($filename)
+    public static function mimeType($filename)
     {
         $mimeType = static::storage()->getMimeType(static::path($filename));
         return $mimeType === 'image/svg' ? 'image/svg+xml' : $mimeType;
@@ -86,5 +86,10 @@ class FileUploadConfiguration
         if (is_array($rules)) return $rules;
 
         return explode('|', $rules);
+    }
+
+    public static function maxUploadTime()
+    {
+        return config('livewire.temporary_file_upload.max_upload_time') ?: 5;
     }
 }

--- a/src/GenerateSignedUploadUrl.php
+++ b/src/GenerateSignedUploadUrl.php
@@ -9,7 +9,7 @@ class GenerateSignedUploadUrl
     public function forLocal()
     {
         return URL::temporarySignedRoute(
-            'livewire.upload-file', now()->addMinutes(5)
+            'livewire.upload-file', now()->addMinutes(FileUploadConfiguration::maxUploadTime())
         );
     }
 
@@ -32,7 +32,7 @@ class GenerateSignedUploadUrl
 
         $signedRequest = $adapter->getClient()->createPresignedRequest(
             $command,
-            '+5 minutes'
+            '+' . FileUploadConfiguration::maxUploadTime() . ' minutes'
         );
 
         return [


### PR DESCRIPTION
This PR addresses the issue #2344.

When uploading a large files, if the upload takes more than 5 minutes, the request gets invalidated and returns a 401. This PR adds a `livewire.temporary_file_upload.max_upload_time` configuration.