### PR TITLE
initialize with an empy div to ensure initial render redirects for ne…

### DIFF
--- a/src/RenameMe/SupportRedirects.php
+++ b/src/RenameMe/SupportRedirects.php
@@ -40,6 +40,7 @@ class SupportRedirects
             }
 
             $response->effects['redirect'] = $component->redirectTo;
+            $response->effects['html'] = $response->effects['html'] ?? '<div></div>';
         });
     }
 }

--- a/tests/Unit/ComponentSkipRenderTest.php
+++ b/tests/Unit/ComponentSkipRenderTest.php
@@ -35,7 +35,7 @@ class ComponentSkipRenderTest extends TestCase
         $component = Livewire::test(ComponentSkipRenderOnRedirectInMountStub::class);
 
         $this->assertEquals('/foo', $component->payload['effects']['redirect']);
-        $this->assertNull($component->payload['effects']['html']);
+        $this->assertNull($component->lastRenderedView);
 
         Route::get('/403', ComponentSkipRenderOnRedirectInMountStub::class);
         $this->get('/403')->assertRedirect('/foo');
@@ -43,7 +43,7 @@ class ComponentSkipRenderTest extends TestCase
         $component = Livewire::test(ComponentSkipRenderOnRedirectHelperInMountStub::class);
 
         $this->assertStringEndsWith('/bar', $component->payload['effects']['redirect']);
-        $this->assertNull($component->payload['effects']['html']);
+        $this->assertNull($component->lastRenderedView);
 
         Route::get('/403', ComponentSkipRenderOnRedirectHelperInMountStub::class);
         $this->get('/403')->assertRedirect('/bar');


### PR DESCRIPTION
Livewire sill needs a dom element to initially render a component.

Therefore we still skip rendering from the component but add an empty div so livewire can initialize the component properly to then redirect.

---
Fixes #2348 