### PR TITLE
Make public component methods available in view

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Container\Container;
 use Livewire\Exceptions\CannotUseReservedLivewireComponentProperties;
 use Livewire\Exceptions\PropertyNotFoundException;
-use ReflectionMethod;
 
 abstract class Component
 {

--- a/tests/Unit/PublicMethodsAreAvailableInTheViewTest.php
+++ b/tests/Unit/PublicMethodsAreAvailableInTheViewTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class PublicMethodsAreAvailableInTheViewTest extends TestCase
+{
+    /** @test */
+    public function public_methods_is_accessible_in_view_via_this()
+    {
+        Livewire::test(PublicMethodsInViewWithoutThisStub::class)
+            ->assertSee('Your Name is Chris');
+    }
+
+    /** @test */
+    public function public_methods_are_accessible_in_view_without_this()
+    {
+        Livewire::test(PublicMethodsInViewWithoutThisStub::class)
+            ->assertSee('Your Name is Chris');
+    }
+}
+
+class PublicMethodsInViewWithThisStub extends Component
+{
+    public function render()
+    {
+        return app('view')->make('call-name-with-this');
+    }
+
+    public function name($name)
+    {
+        return 'Your Name is '.$name;
+    }
+}
+
+class PublicMethodsInViewWithoutThisStub extends Component
+{
+    public function render()
+    {
+        return app('view')->make('call-name');
+    }
+
+    public function name($name)
+    {
+        return 'Your Name is '.$name;
+    }
+}

--- a/tests/Unit/views/call-name-with-this.blade.php
+++ b/tests/Unit/views/call-name-with-this.blade.php
@@ -1,0 +1,1 @@
+<span>{{ $this->name('Chris') }}</span>

--- a/tests/Unit/views/call-name.blade.php
+++ b/tests/Unit/views/call-name.blade.php
@@ -1,0 +1,1 @@
+<span>{{ $name('Chris') }}</span>


### PR DESCRIPTION
Right now public properties are automatically made available to Blade (i.e. `$this->foo` is `$foo` in your Blade template). This PR adds public methods, as well, so that `public function isFooAllowed()` is available as `$isFooAllowed()` in your Blade template.