### PR TITLE
Resolve only valid page number or set default 1

### DIFF
--- a/src/RenameMe/SupportBrowserHistory.php
+++ b/src/RenameMe/SupportBrowserHistory.php
@@ -2,12 +2,13 @@
 
 namespace Livewire\RenameMe;
 
-use Livewire\Livewire;
-use Livewire\Response;
-use Livewire\Component;
-use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Support\Arr;
+use Livewire\Component;
+use Livewire\Livewire;
+use Livewire\Response;
+use Livewire\WithPagination;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use function Livewire\str;
 
@@ -34,6 +35,12 @@ class SupportBrowserHistory
                     : json_decode($fromQueryString, true);
 
                 if ($fromQueryString !== null) {
+                    // Skip property "page" if component uses the trait WithPagination.
+                    // Since the property "page" has already been set in the initializeWithPagination() method.
+                    if ($property === 'page' && in_array(WithPagination::class, class_uses_recursive($component))) {
+                        continue;
+                    }
+
                     $component->$property = $decoded === null ? $fromQueryString : $decoded;
                 }
             }

--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -64,6 +64,12 @@ trait WithPagination
     {
         // The "page" query string item should only be available
         // from within the original component mount run.
-        return request()->query('page', $this->page);
+        $page = request()->query('page', $this->page);
+
+        if (filter_var($page, FILTER_VALIDATE_INT) !== false && (int) $page >= 1) {
+            return (int) $page;
+        }
+
+        return 1;
     }
 }

--- a/tests/Unit/ComponentPaginationTest.php
+++ b/tests/Unit/ComponentPaginationTest.php
@@ -40,12 +40,29 @@ class ComponentPaginationTest extends TestCase
             ->call('previousPage')
             ->assertSet('page', 1);
     }
+
+    /** @test */
+    public function resolve_default_page_number_if_request_has_wrong_page_parameter()
+    {
+        Livewire::withQueryParams(['page' => '2/foo'])
+            ->test(ComponentWithPaginationStub::class)
+            ->assertSet('page', 1);
+    }
+
+    /** @test */
+    public function resolve_integer_page_number_from_query()
+    {
+        Livewire::withQueryParams(['page' => 43])
+            ->test(ComponentWithPaginationStub::class)
+            ->call('initializeWithPagination')
+            ->assertSet('page', 43);
+    }
 }
 
 class ComponentWithPaginationStub extends Component
 {
     use WithPagination;
-    
+
     public function render()
     {
         return view('show-name', ['name' => 'example']);

--- a/tests/Unit/ComponentPaginationTest.php
+++ b/tests/Unit/ComponentPaginationTest.php
@@ -52,10 +52,10 @@ class ComponentPaginationTest extends TestCase
     /** @test */
     public function resolve_integer_page_number_from_query()
     {
-        Livewire::withQueryParams(['page' => 43])
+        Livewire::withQueryParams(['page' => 45])
             ->test(ComponentWithPaginationStub::class)
             ->call('initializeWithPagination')
-            ->assertSet('page', 43);
+            ->assertSet('page', 45);
     }
 }
 


### PR DESCRIPTION
If you specify the 'page' parameter in the request with a string (for example 'foo'), livewire does not filter the parameter. And when paginating (i use $collection->forPage($this->page, 10)), an error appears.

Added check of the 'page' parameter in the resolvePage() method.
I also added a check for the 'page' parameter in the SupportBrowserHistory because it was overwriting the property set by the initialization of the WithPagination trait.

2 tests have been written that check the correctness of setting the page number.

Thanks for contributing! 🙌