### PR TITLE
Allow polling to be disabled outside viewport

### DIFF
--- a/js/component/Polling.js
+++ b/js/component/Polling.js
@@ -56,8 +56,9 @@ function fireActionOnInterval(node, component) {
             if (Math.random() < .95) return
         }
 
-        // Don't poll if the element is not in the viewport, unless `keep-alive` is used
-        if (! inViewPort(directive.el) && ! directive.modifiers.includes('keep-alive')) {
+        // Only poll visible elements - effectively this prevents 95% of the requests
+        // if the element is not in the viewport
+        if (! inViewPort(directive.el) && directive.modifiers.includes('visible')) {
             if (Math.random() < .95) return
         }
 

--- a/js/component/Polling.js
+++ b/js/component/Polling.js
@@ -56,7 +56,7 @@ function fireActionOnInterval(node, component) {
             if (Math.random() < .95) return
         }
 
-        // Don't poll if the element is not in the viewport if "wire.poll.disable-hidden" is attached
+        // Don't poll if the element is not in the viewport, unless `keep-alive` is used
         if (! inViewPort(directive.el) && ! directive.modifiers.includes('keep-alive')) {
             if (Math.random() < .95) return
         }

--- a/js/component/Polling.js
+++ b/js/component/Polling.js
@@ -56,13 +56,13 @@ function fireActionOnInterval(node, component) {
             if (Math.random() < .95) return
         }
 
+        // Don't poll if the element is not in the viewport if "wire.poll.disable-hidden" is attached
+        if (! inViewPort(directive.el) && ! directive.modifiers.includes('keep-alive')) {
+            if (Math.random() < .95) return
+        }
+
         // Don't poll if livewire is offline as well.
         if (store.livewireIsOffline) return
-
-        // Don't poll if the element is not in the viewport if "wire.poll.disable-hidden" is attached
-        if (directive.modifiers.includes('disable-hidden') && ! inViewPort(directive.el)) {
-            return
-        }
 
         component.addAction(new MethodAction(method, directive.params, node))
     }, interval);

--- a/js/component/Polling.js
+++ b/js/component/Polling.js
@@ -1,5 +1,5 @@
 import MethodAction from '@/action/method'
-import { wireDirectives} from '@/util'
+import { wireDirectives, inViewPort } from '@/util'
 import store from '@/Store'
 
 export default function () {
@@ -58,6 +58,11 @@ function fireActionOnInterval(node, component) {
 
         // Don't poll if livewire is offline as well.
         if (store.livewireIsOffline) return
+
+        // Don't poll if the element is not in the viewport if "wire.poll.disable-hidden" is attached
+        if (directive.modifiers.includes('disable-hidden') && ! inViewPort(directive.el)) {
+            return
+        }
 
         component.addAction(new MethodAction(method, directive.params, node))
     }, interval);

--- a/js/util/inViewPort.js
+++ b/js/util/inViewPort.js
@@ -1,0 +1,10 @@
+export function inViewPort(element) {
+    var bounding = element.getBoundingClientRect();
+
+    return (
+        bounding.top >= 0 &&
+        bounding.left >= 0 &&
+        bounding.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+        bounding.right <= (window.innerWidth || document.documentElement.clientWidth)
+    );
+}

--- a/js/util/index.js
+++ b/js/util/index.js
@@ -4,6 +4,7 @@ export * from './wire-directives'
 export * from './walk'
 export * from './dispatch'
 export * from './getCsrfToken'
+export * from './inViewPort'
 
 export function kebabCase(subject) {
     return subject.replace(/([a-z])([A-Z])/g, '$1-$2').replace(/[_\s]/, '-').toLowerCase()


### PR DESCRIPTION
This PR adds a polling modifier that limits polling when an element is not in the current viewport. It is used like this:

```blade
<div wire:poll.visible>
    {{ now() }}
</div>
```

The `visible` modifier tells Livewire to only poll visible elements. If the element is not visible, for example when a user has scrolled it out of view, the element is only being refreshed 5% of the time.

Another example, in case you want to change the polling frequency:

```blade
<div wire:poll.visible.1000ms>
    {{ now() }}
</div>
```

This solves discussion [2233](https://github.com/livewire/livewire/discussions/2233). It doesn't come with tests yet as I couldn't think of how to make them for this feature. Any help on tests (if possible) would be appreciated!