### PR TITLE
Automatic Component Routing

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -118,6 +118,10 @@ class LivewireServiceProvider extends ServiceProvider
 
     protected function registerRoutes()
     {
+        $this->loadRoutesFrom(
+            __DIR__.DIRECTORY_SEPARATOR.'routes'.DIRECTORY_SEPARATOR.'web.php'
+        );
+        
         if ($this->app->runningUnitTests()) {
             RouteFacade::get('/livewire-dusk/{component}', function ($component) {
                 $class = urldecode($component);

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('web')->group(function () {
+    $classNamespace = config('livewire.class_namespace');
+    $filesystem = new Filesystem;
+    $dir = base_path(str_replace(['App', '\\'], ['app', '/'], rtrim($classNamespace, '\\')));
+
+    if ($filesystem->exists($dir)) {
+        foreach ($filesystem->allFiles($dir) as $file) {
+            $namespace = $classNamespace.'\\'.str_replace(['/', '.php'], ['\\', ''], $file->getRelativePathname());
+            $class = app($namespace);
+
+            if (property_exists($class, 'routeUri') && $class->routeUri) {
+                $route = Route::get($class->routeUri, $namespace);
+
+                if (property_exists($class, 'routeDomain') && $class->routeDomain) {
+                    $route->domain($class->routeDomain);
+                }
+
+                if (property_exists($class, 'routeMiddleware') && $class->routeMiddleware) {
+                    $route->middleware($class->routeMiddleware);
+                }
+
+                if (property_exists($class, 'routeName') && $class->routeName) {
+                    $route->name($class->routeName);
+                }
+
+                if (property_exists($class, 'routeWhere') && $class->routeWhere) {
+                    $route->where($class->routeWhere);
+                }
+            }
+        }
+    }
+});


### PR DESCRIPTION
This PR will add auto-routing for full page Livewire components.

## Usage

Specify public `$route*` properties in your full page Livewire component:

    class Vehicle extends Component
    {
        public $routeUri = '/vehicle/{name}';
        public $routeDomain = null;
        public $routeMiddleware = ['guest'];
        public $routeName = 'vehicle';
        public $routeWhere = ['name' => '[A-Za-z]+'];
    
        public function render()
        {
            return view('livewire.vehicle');
        }
    }

A minimum of `$routeUri` is required.