### PR TITLE
fix non latin characters throwing exception in loading state

### DIFF
--- a/js/component/LoadingStates.js
+++ b/js/component/LoadingStates.js
@@ -256,5 +256,5 @@ function endLoading(els) {
 }
 
 function generateSignatureFromMethodAndParams(method, params) {
-    return method + btoa(params.toString())
+    return method + btoa(encodeURIComponent(params.toString()))
 }


### PR DESCRIPTION
Apparently this issue existed in other areas https://github.com/livewire/livewire/issues/182 and it's been fixed with this PR https://github.com/livewire/livewire/pull/211

But I'm getting the same error with loading states and sure enough there is one btoa that's been left out in js/component/LoadingStates.js. I think this one has been added later. So, this PR is trying to fix the issue with the same method.

Some more related issues and PRs:
https://github.com/livewire/livewire/issues/2390
https://github.com/livewire/livewire/issues/182
https://github.com/livewire/livewire/pull/186