### PR TITLE
[1.x] Only return integers for pages

### DIFF
--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -18,7 +18,7 @@ trait WithPagination
         $this->page = $this->resolvePage();
 
         Paginator::currentPageResolver(function () {
-            return $this->page;
+            return (int) $this->page;
         });
 
         Paginator::defaultView($this->paginationView());
@@ -53,6 +53,6 @@ trait WithPagination
     {
         // The "page" query string item should only be available
         // from within the original component mount run.
-        return request()->query('page', $this->page);
+        return (int) request()->query('page', $this->page);
     }
 }


### PR DESCRIPTION
I've recently had an issue in Laravel.io where if you passed a non-integer value as the page query string parameter the internal page resolving in Laravel would crash and burn. At the moment as it stands, only an integer can be passed as the page number: https://github.com/laravel/framework/blob/8.x/src/Illuminate/Pagination/AbstractPaginator.php#L492

One could also argue we should type cast in the method I linked above. I'll also PR that to the framework as a companion PR.