### PR TITLE
Add support for Collections when using $queryString

### DIFF
--- a/src/RenameMe/SupportBrowserHistory.php
+++ b/src/RenameMe/SupportBrowserHistory.php
@@ -34,7 +34,18 @@ class SupportBrowserHistory
                     : json_decode($fromQueryString, true);
 
                 if ($fromQueryString !== null) {
-                    $component->$property = $decoded === null ? $fromQueryString : $decoded;
+                    if ($decoded === null) {
+                        $component->$property = $fromQueryString;
+                    } else {
+                        // If the property is as Collection, we transform the value
+                        $type = (new ReflectionObject($component))->getProperty($property)->getType()->getName();
+
+                        if ($type === Collection::class) {
+                            $decoded = new Collection($decoded);
+                        }
+
+                        $component->$property = $decoded;
+                    }
                 }
             }
         });

--- a/src/RenameMe/SupportBrowserHistory.php
+++ b/src/RenameMe/SupportBrowserHistory.php
@@ -8,6 +8,8 @@ use Livewire\Component;
 use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Support\Collection;
+use ReflectionObject;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use function Livewire\str;
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

It's a bugfix

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

It does not

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

A regression test could be useful, though I didn't have the time to write one and I wanted to submit this at least in some form.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

When you have a typed `Collection` property, Livewire will treat it as an array when setting data from the query string. Resulting in an error saying that the object is uninitialized.

5️⃣ Thanks for contributing! 🙌