### PR TITLE
Merge published config with package config

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -53,6 +53,7 @@ class LivewireServiceProvider extends ServiceProvider
         $this->registerTestMacros();
         $this->registerLivewireSingleton();
         $this->registerComponentAutoDiscovery();
+        $this->registerConfig();
     }
 
     public function boot()
@@ -104,6 +105,11 @@ class LivewireServiceProvider extends ServiceProvider
                 )
             );
         });
+    }
+
+    protected function registerConfig()
+    {
+        $this->mergeConfigFrom(__DIR__.'/../config/livewire.php', 'livewire');
     }
 
     protected function registerViews()


### PR DESCRIPTION
This was intended to fix an issue #2395 caused by #2347 where the default max_upload_time wasn't being populated if it wasn't in the apps published config.

But this doesn't actually fix it, as per this note in the Laravel docs, as max_upload_time is a second level configuration option.
>This method only merges the first level of the configuration array. If your users partially define a multi-dimensional configuration array, the missing options will not be merged.

I will submit a separate fix for #2395, but I thought this merge should still happen to prevent this issue for any future first level config options.

Hope this helps!