### PR TITLE
Set max_upload_time fallback default if config doesn't exist

### DIFF
--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -90,6 +90,6 @@ class FileUploadConfiguration
 
     public static function maxUploadTime()
     {
-        return config('livewire.temporary_file_upload.max_upload_time');
+        return config('livewire.temporary_file_upload.max_upload_time', 5);
     }
 }


### PR DESCRIPTION
This fixes #2395 where temporary uploads to S3 were failing for apps that already had a published config and were missing the max_upload_time key introduced in #2347.

See other PR #2412 in relation to merging configs and why that won't work for this config option.

So instead I've had to set a default fallback if the config option is missing.

Hope this helps!