### PR TITLE
Fix undefined index error

### DIFF
--- a/src/ComponentConcerns/ReceivesEvents.php
+++ b/src/ComponentConcerns/ReceivesEvents.php
@@ -69,8 +69,10 @@ trait ReceivesEvents
 
     public function fireEvent($event, $params)
     {
-        $method = $this->getEventsAndHandlers()[$event];
+        $method = $this->getEventsAndHandlers()[$event] ?? null;
 
-        $this->callMethod($method, $params);
+        if($method) {
+            $this->callMethod($method, $params);
+        }
     }
 }

--- a/tests/Unit/ComponentEventsTest.php
+++ b/tests/Unit/ComponentEventsTest.php
@@ -43,8 +43,8 @@ class ComponentEventsTest extends TestCase
     {
         $component = Livewire::test(ReceivesEventsWithModifiedDynamicListeners::class, ['listener' => 'bar']);
 
-        $component->call('delete', 2);
-        $component->emit('bar:2');
+        $component->call('delete', 2)
+            ->emit('bar:2');
 
         $component->emit('bar:3', 'goo')
             ->assertSet('foo', 'goo');


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Fix for issue #2401 

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Added test which fails without this fix and passed after the fix.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Added null coalescing operator when finding the event method to handle this and added tests.

**Exact steps to reproduce**
Override getListeners() to add dynamic events
Call an action which would cause one of the dynamic events to be removed
Emit the event which has now been removed
See "Undefined index" error

This will cause the following error:
ErrorException: Undefined index: itemUpdated:2
/Users/mje/Sites/packages/livewire/src/ComponentConcerns/ReceivesEvents.php:72

5️⃣ Thanks for contributing! 🙌