### PR TITLE
only clear session flash data on subsequent dehydrate - closes #2294

### DIFF
--- a/src/RenameMe/SupportRedirects.php
+++ b/src/RenameMe/SupportRedirects.php
@@ -32,15 +32,21 @@ class SupportRedirects
             // Put the old redirector back into the container.
             app()->instance('redirect', array_pop(static::$redirectorCacheStack));
 
+            if (empty($component->redirectTo)) {
+                return;
+            }
+
+            $response->effects['redirect'] = $component->redirectTo;
+            $response->effects['html'] = $response->effects['html'] ?? '<div></div>';
+        });
+
+        Livewire::listen('component.dehydrate.subsequent', function ($component, $response) {
             // If there was no redirect. Clear flash session data.
             if (empty($component->redirectTo)) {
                 session()->forget(session()->get('_flash.new'));
 
                 return;
             }
-
-            $response->effects['redirect'] = $component->redirectTo;
-            $response->effects['html'] = $response->effects['html'] ?? '<div></div>';
         });
     }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Original Issue: https://github.com/livewire/livewire/issues/2294

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

I tried to write a test for this, but it seems to be difficult to flash data to the session prior to dusk running. Hopefully someone can point out an easy way to do this and I'd be happy to include a test. 

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Data flashed to the session is not available on the initial render like you'd expect. This PR changes it so that Livewire only  
clears flash data from the session on subsequent dehydrates.

5️⃣ Thanks for contributing! 🙌

🍻 