### PR TITLE
Fix browserSync and rending components on POST request

### DIFF
--- a/src/Controllers/HttpConnectionHandler.php
+++ b/src/Controllers/HttpConnectionHandler.php
@@ -29,12 +29,12 @@ class HttpConnectionHandler extends ConnectionHandler
         try {
             $request = $this->makeRequestFromUrlAndMethod(
                 Livewire::originalUrl(),
-                Livewire::originalMethod(),
+                Livewire::originalMethod()
             );
         } catch (NotFoundHttpException $e) {
             $request = $this->makeRequestFromUrlAndMethod(
                 Str::replaceFirst(Livewire::originalUrl(), request('fingerprint')['locale'].'/', ''),
-                Livewire::originalMethod(),
+                Livewire::originalMethod()
             );
         }
 

--- a/src/Controllers/HttpConnectionHandler.php
+++ b/src/Controllers/HttpConnectionHandler.php
@@ -27,12 +27,14 @@ class HttpConnectionHandler extends ConnectionHandler
     public function applyPersistentMiddleware()
     {
         try {
-            $request = $this->makeRequestFromUrl(
-                Livewire::originalUrl()
+            $request = $this->makeRequestFromUrlAndMethod(
+                Livewire::originalUrl(),
+                Livewire::originalMethod(),
             );
         } catch (NotFoundHttpException $e) {
-            $request = $this->makeRequestFromUrl(
-                Str::replaceFirst(Livewire::originalUrl(), request('fingerprint')['locale'].'/', '')
+            $request = $this->makeRequestFromUrlAndMethod(
+                Str::replaceFirst(Livewire::originalUrl(), request('fingerprint')['locale'].'/', ''),
+                Livewire::originalMethod(),
             );
         }
 
@@ -58,9 +60,9 @@ class HttpConnectionHandler extends ConnectionHandler
             });
     }
 
-    protected function makeRequestFromUrl($url)
+    protected function makeRequestFromUrlAndMethod($url, $method = 'GET')
     {
-        $request = Request::create($url, 'GET');
+        $request = Request::create($url, $method);
 
         if ($session = request()->getSession()) {
             $request->setLaravelSession($session);

--- a/src/LifecycleManager.php
+++ b/src/LifecycleManager.php
@@ -28,7 +28,13 @@ class LifecycleManager
         return tap(new static, function ($instance) use ($name, $id) {
             $instance->instance = app('livewire')->getInstance($name, $id);
             $instance->request = new Request([
-                'fingerprint' => ['id' => $id, 'name' => $name, 'locale' => app()->getLocale(), 'url' => Livewire::originalUrl()],
+                'fingerprint' => [
+                    'id' => $id,
+                    'name' => $name,
+                    'locale' => app()->getLocale(),
+                    'path' => Livewire::originalPath(),
+                    'method' => Livewire::originalMethod(),
+                ],
                 'updates' => [],
                 'serverMemo' => [],
             ]);
@@ -42,7 +48,13 @@ class LifecycleManager
         return tap(new static, function ($instance) use ($component,  $name) {
             $instance->instance = $component;
             $instance->request = new Request([
-                'fingerprint' => ['id' => $component->id, 'name' => $name, 'locale' => app()->getLocale(), 'url' => Livewire::originalUrl()],
+                'fingerprint' => [
+                    'id' => $component->id,
+                    'name' => $name,
+                    'locale' => app()->getLocale(),
+                    'path' => Livewire::originalPath(),
+                    'method' => Livewire::originalMethod(),
+                ],
                 'updates' => [],
                 'serverMemo' => [],
             ]);

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -310,10 +310,44 @@ HTML;
     public function originalUrl()
     {
         if ($this->isDefinitelyLivewireRequest()) {
-            return request('fingerprint')['url'];
+            return url()->to($this->originalPath());
         }
 
         return url()->current();
+    }
+
+    public function originalPath()
+    {
+        if ($this->isDefinitelyLivewireRequest()) {
+            // @depricted: "url" usage was removed in v2.3.17
+            // This can be removed after a period of time
+            // as users will have refreshed all pages
+            // that still used "url".
+            if (isset(request('fingerprint')['url'])) {
+                return str(request('fingerprint')['url'])->after(request()->root());
+            }
+
+            return request('fingerprint')['path'];
+        }
+
+        return request()->path();
+    }
+
+    public function originalMethod()
+    {
+        if ($this->isDefinitelyLivewireRequest()) {
+            // @depricted: "url" usage was removed in v2.3.17
+            // This can be removed after a period of time
+            // as users will have refreshed all pages
+            // that still used "url".
+            if (isset(request('fingerprint')['url'])) {
+                return 'GET';
+            }
+
+            return request('fingerprint')['method'];
+        }
+
+        return request()->method();
     }
 
     public function getRootElementTagName($dom)

--- a/src/RenameMe/SupportBrowserHistory.php
+++ b/src/RenameMe/SupportBrowserHistory.php
@@ -71,7 +71,7 @@ class SupportBrowserHistory
         try {
             // See if we can get the route from the referer.
             return app('router')->getRoutes()->match(
-                Request::create($referer, 'GET')
+                Request::create($referer, Livewire::originalMethod())
             );
         } catch (NotFoundHttpException $e) {
             // If not, use the current route.

--- a/tests/Browser/Security/Component.php
+++ b/tests/Browser/Security/Component.php
@@ -23,7 +23,7 @@ class Component extends BaseComponent
         return <<<'HTML'
 <div>
     <span dusk="middleware">@json($middleware)</span>
-    <span dusk="url">{{ \Livewire\Livewire::isDefinitelyLivewireRequest() ? request('fingerprint')['url'] : '' }}</span>
+    <span dusk="path">{{ \Livewire\Livewire::isDefinitelyLivewireRequest() ? request('fingerprint')['path'] : '' }}</span>
 
     <button wire:click="$refresh" dusk="refresh">Refresh</button>
     <button wire:click="showNestedComponent" dusk="showNested">Show Nested</button>

--- a/tests/Browser/Security/NestedComponent.php
+++ b/tests/Browser/Security/NestedComponent.php
@@ -15,7 +15,7 @@ class NestedComponent extends BaseComponent
         return <<<'HTML'
 <div>
     <span dusk="nested-middleware">@json($middleware)</span>
-    <span dusk="nested-url">{{ \Livewire\Livewire::isDefinitelyLivewireRequest() ? request('fingerprint')['url'] : '' }}</span>
+    <span dusk="nested-path">{{ \Livewire\Livewire::isDefinitelyLivewireRequest() ? request('fingerprint')['path'] : '' }}</span>
 
     <button wire:click="$refresh" dusk="refreshNested">Refresh</button>
 </div>

--- a/tests/Browser/Security/Test.php
+++ b/tests/Browser/Security/Test.php
@@ -14,29 +14,29 @@ class Test extends TestCase
             Livewire::visit($browser, Component::class)
                 // See allow-listed middleware from original request.
                 ->assertSeeIn('@middleware', '["Tests\\\\Browser\\\\AllowListedMiddleware","Tests\\\\Browser\\\\BlockListedMiddleware"]')
-                ->assertDontSeeIn('@url', 'http://127.0.0.1:8001/livewire-dusk/Tests%5CBrowser%5CSecurity%5CComponent')
+                ->assertDontSeeIn('@path', 'livewire-dusk/Tests%5CBrowser%5CSecurity%5CComponent')
 
                 ->waitForLivewire()->click('@refresh')
 
                 // See that the original request middleware was re-applied.
                 ->assertSeeIn('@middleware', '["Tests\\\\Browser\\\\AllowListedMiddleware"]')
-                ->assertSeeIn('@url', 'http://127.0.0.1:8001/livewire-dusk/Tests%5CBrowser%5CSecurity%5CComponent')
+                ->assertSeeIn('@path', 'livewire-dusk/Tests%5CBrowser%5CSecurity%5CComponent')
 
                 ->waitForLivewire()->click('@showNested')
 
                 // Even to nested components shown AFTER the first load.
                 ->assertSeeIn('@middleware', '["Tests\\\\Browser\\\\AllowListedMiddleware"]')
-                ->assertSeeIn('@url', 'http://127.0.0.1:8001/livewire-dusk/Tests%5CBrowser%5CSecurity%5CComponent')
+                ->assertSeeIn('@path', 'livewire-dusk/Tests%5CBrowser%5CSecurity%5CComponent')
                 ->assertSeeIn('@nested-middleware', '["Tests\\\\Browser\\\\AllowListedMiddleware"]')
-                ->assertSeeIn('@nested-url', 'http://127.0.0.1:8001/livewire-dusk/Tests%5CBrowser%5CSecurity%5CComponent')
+                ->assertSeeIn('@path', 'livewire-dusk/Tests%5CBrowser%5CSecurity%5CComponent')
 
                 ->waitForLivewire()->click('@refreshNested')
 
                 // Make sure they are still applied when stand-alone requests are made to that component.
                 ->assertSeeIn('@middleware', '["Tests\\\\Browser\\\\AllowListedMiddleware"]')
-                ->assertSeeIn('@url', 'http://127.0.0.1:8001/livewire-dusk/Tests%5CBrowser%5CSecurity%5CComponent')
+                ->assertSeeIn('@path', 'livewire-dusk/Tests%5CBrowser%5CSecurity%5CComponent')
                 ->assertSeeIn('@nested-middleware', '["Tests\\\\Browser\\\\AllowListedMiddleware"]')
-                ->assertSeeIn('@nested-url', 'http://127.0.0.1:8001/livewire-dusk/Tests%5CBrowser%5CSecurity%5CComponent')
+                ->assertSeeIn('@path', 'livewire-dusk/Tests%5CBrowser%5CSecurity%5CComponent')
             ;
         });
     }


### PR DESCRIPTION
This PR fixes #2453 and #2461

Rather than storing and referencing the full URL in the component fingerprint for re-playing persistent middleware (which breaks the route lookup when using browser-sync), we are only storing the "path" (after the root domain of the url) which will be "root" agnostic and allow browser-sync to work properly..

In addition, we are also now storing the original request method in the fingerprint in cases where applications return Livewire views from POST requests.