### PR TITLE
Add nonce support for style and add nonce to script src tag

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -150,7 +150,7 @@ class LivewireManager
     {
         $debug = config('app.debug');
 
-        $styles = $this->cssAssets();
+        $styles = $this->cssAssets($options);
 
         // HTML Label.
         $html = $debug ? ['<!-- Livewire Styles -->'] : [];
@@ -176,10 +176,12 @@ class LivewireManager
         return implode("\n", $html);
     }
 
-    protected function cssAssets()
+    protected function cssAssets($options)
     {
+        $nonce = isset($options['nonce']) ? "nonce=\"{$options['nonce']}\"" : '';
+
         return <<<HTML
-<style>
+<style {$nonce}>
     [wire\:loading], [wire\:loading\.delay], [wire\:loading\.inline-block], [wire\:loading\.inline], [wire\:loading\.block], [wire\:loading\.flex], [wire\:loading\.table], [wire\:loading\.grid] {
         display: none;
     }
@@ -233,9 +235,9 @@ HTML;
             $fullAssetPath = ($this->isOnVapor() ? config('app.asset_url') : $appUrl).'/vendor/livewire'.$versionedFileName;
 
             if ($manifest !== $publishedManifest) {
-                $assetWarning = <<<'HTML'
+                $assetWarning = <<<HTML
 <script {$nonce}>
-    console.warn("Livewire: The published Livewire assets are out of date\n See: https://laravel-livewire.com/docs/installation/")
+    console.warn("Livewire: The published Livewire assets are out of date\\n See: https://laravel-livewire.com/docs/installation/")
 </script>
 HTML;
             }
@@ -245,8 +247,8 @@ HTML;
         // because it will be minified in production.
         return <<<HTML
 {$assetWarning}
-<script src="{$fullAssetPath}" data-turbo-eval="false" data-turbolinks-eval="false"></script>
-<script data-turbo-eval="false" data-turbolinks-eval="false"{$nonce}>
+<script src="{$fullAssetPath}" data-turbo-eval="false" data-turbolinks-eval="false" {$nonce}></script>
+<script data-turbo-eval="false" data-turbolinks-eval="false" {$nonce}>
     if (window.livewire) {
         console.warn('Livewire: It looks like Livewire\'s @livewireScripts JavaScript assets have already been loaded. Make sure you aren\'t loading them twice.')
     }

--- a/tests/Unit/LivewireAssetsDirectiveTest.php
+++ b/tests/Unit/LivewireAssetsDirectiveTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit;
 
-use Livewire\Livewire;
 use Illuminate\Support\Facades\View;
+use Livewire\Livewire;
 
 class LivewireAssetsDirectiveTest extends TestCase
 {
@@ -92,6 +92,11 @@ class LivewireAssetsDirectiveTest extends TestCase
 
         $this->assertStringContainsString(
             'nonce="foobarnonce">',
+            $output
+        );
+
+        $this->assertStringContainsString(
+            '<style nonce="foobarnonce">',
             $output
         );
     }

--- a/tests/Unit/views/assets-directive.blade.php
+++ b/tests/Unit/views/assets-directive.blade.php
@@ -1,2 +1,2 @@
-@livewireStyles
+@livewireStyles($options)
 @livewireScripts($options)


### PR DESCRIPTION
This PR does the following things:

1. It adds space (back) in front of the `nonce=""` property.
2. It adds the nonce to the `<script src="">` tag as well (useful when using [strict-dynamic](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic)
3. It allows setting a nonce for the style tag