### PR TITLE
Add before validation hook

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -141,6 +141,11 @@ trait ValidatesInput
         return ! $this->hasRuleFor($dotNotatedProperty);
     }
 
+    protected function beforeValidation(\Illuminate\Validation\Validator $validator)
+    {
+        return $validator;
+    }
+
     public function validate($rules = null, $messages = [], $attributes = [])
     {
         [$rules, $messages, $attributes] = $this->providedOrGlobalRulesMessagesAndAttributes($rules, $messages, $attributes);
@@ -152,6 +157,8 @@ trait ValidatesInput
         $validator = Validator::make($data, $rules, $messages, $attributes);
 
         $this->shortenModelAttributes($data, $rules, $validator);
+
+        $this->beforeValidation($validator);
 
         $validatedData = $validator->validate();
 

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -584,7 +584,9 @@ class ForValidationWithRulesAndBeforeValidationHook extends Component {
     ];
 
     protected function beforeValidation(\Illuminate\Validation\Validator $validator) {
-        $validator->sometimes('permission', 'required', fn() => $this->age < 18);
+        $validator->sometimes('permission', 'required', function () {
+            return $this->age < 18;
+        });
     }
 
     public function runValidation()


### PR DESCRIPTION
In Laravel you can manipulate your validator after it's created and before you run it on the input. Livewire makes validation super easy, but if you want to do complex things with the validator you have to go back to using a normal validator.

This PR adds a before validation hook so you can do anything you need to the validator before running the actual validation. For example https://laravel.com/docs/8.x/validation#complex-conditional-validation

You just add a `protected beforeValidation` and it's gonna get called right before validation and receive the validator as argument.