### PR TITLE
Fixes a race condition when Livewire uploads is used on busy websites

### DIFF
--- a/src/WithFileUploads.php
+++ b/src/WithFileUploads.php
@@ -96,11 +96,13 @@ trait WithFileUploads
         $storage = FileUploadConfiguration::storage();
 
         foreach ($storage->allFiles(FileUploadConfiguration::path()) as $filePathname) {
-            if ($storage->exists($filePathname)) {
-                $yesterdaysStamp = now()->subDay()->timestamp;
-                if ($yesterdaysStamp > $storage->lastModified($filePathname)) {
-                    $storage->delete($filePathname);
-                }
+            if (! $storage->exists($filePathname)) {
+                continue;
+            }
+
+            $yesterdaysStamp = now()->subDay()->timestamp;
+            if ($yesterdaysStamp > $storage->lastModified($filePathname)) {
+                $storage->delete($filePathname);
             }
         }
     }

--- a/src/WithFileUploads.php
+++ b/src/WithFileUploads.php
@@ -96,9 +96,11 @@ trait WithFileUploads
         $storage = FileUploadConfiguration::storage();
 
         foreach ($storage->allFiles(FileUploadConfiguration::path()) as $filePathname) {
-            $yesterdaysStamp = now()->subDay()->timestamp;
-            if ($yesterdaysStamp > $storage->lastModified($filePathname)) {
-                $storage->delete($filePathname);
+            if ($storage->exists($filePathname)) {
+                $yesterdaysStamp = now()->subDay()->timestamp;
+                if ($yesterdaysStamp > $storage->lastModified($filePathname)) {
+                    $storage->delete($filePathname);
+                }
             }
         }
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yes, issue #2491 2491

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No, unfortunately I don't know how to test race conditions

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
On very busy websites, the cleanup code can run in multiple threads causing part of the output of allFiles() to have already been deleted by another thread.

5️⃣ Thanks for contributing! 🙌