### PR TITLE
Add assert count to tests

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -28,6 +28,13 @@ trait MakesAssertions
         return $this;
     }
 
+    public function assertCount($name, $value)
+    {
+        PHPUnit::assertCount($value, $this->get($name));
+
+        return $this;
+    }
+
     public function assertPayloadSet($name, $value)
     {
         if (is_callable($value)) {

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -58,6 +58,20 @@ class LivewireTestingTest extends TestCase
     }
 
     /** @test */
+    public function assert_count()
+    {
+        app(LivewireManager::class)
+            ->test(HasMountArgumentsButDoesntPassThemToBladeView::class, ['name' => ['foo']])
+            ->assertCount('name', 1)
+            ->set('name', ['foo', 'bar'])
+            ->assertCount('name', 2)
+            ->set('name', ['foo', 'bar', 'baz'])
+            ->assertCount('name', 3)
+            ->set('name', [])
+            ->assertCount('name', 0);
+    }
+
+    /** @test */
     public function assert_see()
     {
         app(LivewireManager::class)


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
I haven't created an issue or discussion for it, but it is something that I have thought would be useful to make it easier to test arrays or results of queries are what you expect

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Single PR

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
This would be useful to count a property, such as the number of results returned in a data table before and then after a search or filter has been done by updating another Livewire component property. 

5️⃣ Thanks for contributing! 🙌