### PR TITLE
Fix x layout

### DIFF
--- a/src/Macros/ViewMacros.php
+++ b/src/Macros/ViewMacros.php
@@ -21,6 +21,12 @@ class ViewMacros
     public function layout()
     {
         return function ($view, $params = []) {
+            if (is_subclass_of($view, \Illuminate\View\Component::class)) {
+                $layout = new $view();
+                $params = array_merge($params, $layout->data());
+                $view = $layout->resolveView()->name();
+            }
+
             $this->livewireLayout = [
                 'type' => 'component',
                 'slotOrSection' => 'slot',

--- a/tests/AppLayout.php
+++ b/tests/AppLayout.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\View\Component;
+
+class AppLayout extends Component
+{
+	public $foo = 'bar';
+
+    public function render()
+    {
+        return view('layouts.app-x');
+    }
+}

--- a/tests/Unit/ComponentLayoutTest.php
+++ b/tests/Unit/ComponentLayoutTest.php
@@ -47,6 +47,16 @@ class ComponentLayoutTest extends TestCase
 
         $this->withoutExceptionHandling()->get('/foo')->assertSee('baz');
     }
+
+    /** @test */
+    public function can_load_dynamic_layout_properties()
+    {
+        Livewire::component(ComponentWithDynamicLayout::class);
+
+        Route::get('/foo', ComponentWithDynamicLayout::class);
+
+        $this->withoutExceptionHandling()->get('/foo')->assertSee('bar')->assertSee('baz');
+    }
 }
 
 class ComponentWithExtendsLayout extends Component
@@ -86,5 +96,15 @@ class ComponentWithCustomSlotForLayout extends Component
     public function render()
     {
         return view('show-name')->layout('layouts.app-custom-slot')->slot('main');
+    }
+}
+
+class ComponentWithDynamicLayout extends Component
+{
+    public function render()
+    {
+        return view('null-view')->layout(\Tests\AppLayout::class, [
+            'bar' => 'baz'
+        ]);
     }
 }

--- a/tests/Unit/views/layouts/app-x.blade.php
+++ b/tests/Unit/views/layouts/app-x.blade.php
@@ -1,0 +1,7 @@
+@yield('content')
+
+{{ $slot }}
+
+{{ $foo }}
+
+{{ $bar }}


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
[Yes](https://forum.laravel-livewire.com/t/layout-class-constructor-is-not-triggered-while-rendering/1985), there is some other issues related to this: #1707, https://forum.laravel-livewire.com/t/livewire-with-custom-layout/1666/8

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
This PR follows a [previous one](https://github.com/livewire/livewire/pull/1807), already discussed and closed due to the way I tried to solved it.

I'm trying to follow the @calebporzio guideline and re-implement this in an acceptable way.

To use this new implementation, we just need to define the layout class into the layout method:
```
<?php namespace App\Http\Livewire;

use Livewire\Component;
use App\View\Components\AppLayout;

class MyComponent extends Component
{
    public function render()
    {
        return view('livewire.my-component')->layout(AppLayout::class);
    }
}
```