### PR TITLE
Dynamic livewire components

### DIFF
--- a/src/Exceptions/ComponentAttributeMissingOnDynamicComponentException.php
+++ b/src/Exceptions/ComponentAttributeMissingOnDynamicComponentException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Livewire\Exceptions;
+
+class ComponentAttributeMissingOnDynamicComponentException extends \Exception
+{
+    use BypassViewHandler;
+
+    public function __construct()
+    {
+        parent::__construct('Dynamic component tag is missing component attribute.');
+    }
+}

--- a/src/LivewireTagCompiler.php
+++ b/src/LivewireTagCompiler.php
@@ -3,6 +3,7 @@
 namespace Livewire;
 
 use Illuminate\View\Compilers\ComponentTagCompiler;
+use Livewire\Exceptions\ComponentAttributeMissingOnDynamicComponentException;
 
 class LivewireTagCompiler extends ComponentTagCompiler
 {
@@ -46,10 +47,25 @@ class LivewireTagCompiler extends ComponentTagCompiler
                 return [(string) str($key)->camel() => $value];
             })->toArray();
 
-            if ($matches[1] === 'styles') return '@livewireStyles';
-            if ($matches[1] === 'scripts') return '@livewireScripts';
+            $component = $matches[1];
 
-            return $this->componentString($matches[1], $attributes);
+            if ($component === 'styles') return '@livewireStyles';
+            if ($component === 'scripts') return '@livewireScripts';
+            if ($component === 'dynamic-component') {
+                if(! isset($attributes['component'])) {
+                    throw new ComponentAttributeMissingOnDynamicComponentException;
+                }
+
+                // Does not need quotes as resolved with quotes already.
+                $component = $attributes['component'];
+
+                unset($attributes['component']);
+            } else {
+                // Add single quotes to the component name to compile it as string in quotes
+                $component = "'{$component}'";
+            }
+
+            return $this->componentString($component, $attributes);
         }, $value);
     }
 
@@ -59,9 +75,9 @@ class LivewireTagCompiler extends ComponentTagCompiler
             $key = $attributes['key'];
             unset($attributes['key']);
 
-            return "@livewire('{$component}', [".$this->attributesToString($attributes, $escapeBound = false)."], key({$key}))";
+            return "@livewire({$component}, [".$this->attributesToString($attributes, $escapeBound = false)."], key({$key}))";
         }
 
-        return "@livewire('{$component}', [".$this->attributesToString($attributes, $escapeBound = false).'])';
+        return "@livewire({$component}, [".$this->attributesToString($attributes, $escapeBound = false).'])';
     }
 }

--- a/src/LivewireTagCompiler.php
+++ b/src/LivewireTagCompiler.php
@@ -51,7 +51,7 @@ class LivewireTagCompiler extends ComponentTagCompiler
 
             if ($component === 'styles') return '@livewireStyles';
             if ($component === 'scripts') return '@livewireScripts';
-            if ($component === 'dynamic-component') {
+            if ($component === 'dynamic-component' || $component === 'is') {
                 if(! isset($attributes['component'])) {
                     throw new ComponentAttributeMissingOnDynamicComponentException;
                 }

--- a/src/LivewireTagCompiler.php
+++ b/src/LivewireTagCompiler.php
@@ -53,6 +53,15 @@ class LivewireTagCompiler extends ComponentTagCompiler
             if ($component === 'scripts') return '@livewireScripts';
             if ($component === 'dynamic-component' || $component === 'is') {
                 if(! isset($attributes['component'])) {
+                    $dynamicComponentExists = rescue(function() use ($component, $attributes) {
+                        // Need to run this in rescue otherwise running this during a test causes Livewire directory not found exception
+                        return $component === 'dynamic-component' && app('livewire')->getClass('dynamic-component');
+                    });
+
+                    if($dynamicComponentExists) {
+                        return $this->componentString("'{$component}'", $attributes);
+                    }
+
                     throw new ComponentAttributeMissingOnDynamicComponentException;
                 }
 

--- a/tests/Unit/TagCompilerTest.php
+++ b/tests/Unit/TagCompilerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Exceptions\ComponentAttributeMissingOnDynamicComponentException;
+use Livewire\LivewireTagCompiler;
+
+class TagCompilerTest extends TestCase
+{
+    /**
+     * @var \Illuminate\View\Compilers\BladeCompiler
+     */
+    protected $compiler;
+
+    public function setUp(): void
+    {
+        $this->compiler = new LivewireTagCompiler();
+        parent::setUp();
+    }
+
+    /** @test */
+    public function it_compiles_livewire_self_closing_tags()
+    {
+        $alertComponent = '<livewire:alert />';
+        $result = $this->compiler->compile($alertComponent);
+
+        $this->assertEquals("@livewire('alert', [])", $result);
+    }
+
+    /** @test */
+    public function it_compiles_livewire_styles_tag()
+    {
+        $alertComponent = '<livewire:styles />';
+        $result = $this->compiler->compile($alertComponent);
+
+        $this->assertEquals('@livewireStyles', $result);
+    }
+
+    /** @test */
+    public function it_compiles_livewire_scripts_tag()
+    {
+        $alertComponent = '<livewire:scripts />';
+        $result = $this->compiler->compile($alertComponent);
+
+        $this->assertEquals('@livewireScripts', $result);
+    }
+
+    /** @test */
+    public function it_compiles_livewire_self_closing_tags_with_attributes()
+    {
+        $alertComponent = '<livewire:alert type="danger" />';
+        $result = $this->compiler->compile($alertComponent);
+
+        $this->assertEquals("@livewire('alert', ['type' => 'danger'])", $result);
+    }
+
+    /** @test */
+    public function it_converts_kebab_attribute_names_to_camel_case()
+    {
+        $alertComponent = '<livewire:alert alert-type="success" />';
+        $result = $this->compiler->compile($alertComponent);
+
+        $this->assertEquals("@livewire('alert', ['alertType' => 'success'])", $result);
+    }
+
+    /** @test */
+    public function it_compiles_livewire_dynamic_component_self_closing_tags()
+    {
+        $alertComponent = '<livewire:dynamic-component component="alert" type="warning" />';
+        $result = $this->compiler->compile($alertComponent);
+
+        $this->assertEquals("@livewire('alert', ['type' => 'warning'])", $result);
+    }
+
+    /** @test */
+    public function it_compiles_livewire_dynamic_component_self_closing_tags_with_component_attribute_as_expression()
+    {
+        $alertComponent = '<livewire:dynamic-component :component="\'alert\'" type="warning" />';
+        $result = $this->compiler->compile($alertComponent);
+
+        $this->assertEquals("@livewire('alert', ['type' => 'warning'])", $result);
+    }
+
+    /** @test */
+    public function it_throws_exception_if_livewire_dynamic_component_is_missing_component_name_attribute()
+    {
+        $this->expectException(ComponentAttributeMissingOnDynamicComponentException::class);
+
+        $alertComponent = '<livewire:dynamic-component />';
+        $this->compiler->compile($alertComponent);
+    }
+}

--- a/tests/Unit/TagCompilerTest.php
+++ b/tests/Unit/TagCompilerTest.php
@@ -89,4 +89,13 @@ class TagCompilerTest extends TestCase
         $alertComponent = '<livewire:dynamic-component />';
         $this->compiler->compile($alertComponent);
     }
+
+    /** @test */
+    public function it_compiles_livewire_dynamic_component_self_closing_tags_using_is_syntax()
+    {
+        $alertComponent = '<livewire:is component="alert" type="warning" />';
+        $result = $this->compiler->compile($alertComponent);
+
+        $this->assertEquals("@livewire('alert', ['type' => 'warning'])", $result);
+    }
 }

--- a/tests/Unit/TagCompilerTest.php
+++ b/tests/Unit/TagCompilerTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Unit;
 
+use Livewire\Component;
 use Livewire\Exceptions\ComponentAttributeMissingOnDynamicComponentException;
+use Livewire\Livewire;
 use Livewire\LivewireTagCompiler;
 
 class TagCompilerTest extends TestCase
@@ -98,4 +100,19 @@ class TagCompilerTest extends TestCase
 
         $this->assertEquals("@livewire('alert', ['type' => 'warning'])", $result);
     }
+
+    /** @test */
+    public function it_uses_existing_dynamic_component_if_one_exists()
+    {
+        Livewire::component('dynamic-component', DynamicComponent::class);
+
+        $alertComponent = '<livewire:dynamic-component />';
+        $result = $this->compiler->compile($alertComponent);
+
+        $this->assertEquals("@livewire('dynamic-component', [])", $result);
+    }
+}
+
+class DynamicComponent extends Component {
+
 }


### PR DESCRIPTION
This PR adds dynamic Livewire component support to new component syntax.

This will now be possible (the same syntax as blade dynamic components https://laravel.com/docs/8.x/blade#dynamic-components):
```html
<livewire:dynamic-component component="counter" />
```

It also supports component attribute as an evaluated expression:
```html
<livewire:dynamic-component :component="'counter-'.$loop->index" />
```

There were no tests for the Livewire tag compiler, so I have added them and added tests for dynamic component tag compilation.

Hope this helps!