### PR TITLE
Fixed compiler engine support for php 7

### DIFF
--- a/src/CompilerEngineForIgnition.php
+++ b/src/CompilerEngineForIgnition.php
@@ -14,7 +14,9 @@ class CompilerEngineForIgnition extends CompilerEngine
     protected function handleViewException(Throwable $e, $obLevel)
     {
         if ($this->shouldBypassExceptionForLivewire($e, $obLevel)) {
-            (new PhpEngine($this->files))->handleViewException($e, $obLevel);
+            // On Laravel 7 and before, there is no files property on the underlying
+            // Illuminate\Views\Engines\CompilerEngine class, so pass null in this case
+            (new PhpEngine($this->files ?? null))->handleViewException($e, $obLevel);
 
             return;
         }


### PR DESCRIPTION
In https://github.com/livewire/livewire/issues/2482 several users noted that Laravel 7 didn't have a `$files` property available on the `PhpEngine` and underlying `CompilerEngine` class. 

This PR adds a null coalescing operator to fix that problem. 