### PR TITLE
[Update fix] Add failing test for dynamic nested entangled components

### DIFF
--- a/tests/Browser/Alpine/Entangle/EntangleNestedChildComponent.php
+++ b/tests/Browser/Alpine/Entangle/EntangleNestedChildComponent.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Browser\Alpine\Entangle;
+
+use Livewire\Component as BaseComponent;
+
+class EntangleNestedChildComponent extends BaseComponent
+{
+    public $item;
+
+    protected $rules = ['item.name' => ''];
+
+    public function render()
+    {
+        return
+<<<'HTML'
+<div x-data="{ name: @entangle('item.name') }">
+    <div dusk="livewire-output-{{ $item['name']}}">{{ $item['name']}}</div>
+    <div dusk="alpine-output-{{ $item['name']}}"><span x-text="name"></span></div>
+</div>
+HTML;
+    }
+}

--- a/tests/Browser/Alpine/Entangle/EntangleNestedParentComponent.php
+++ b/tests/Browser/Alpine/Entangle/EntangleNestedParentComponent.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Browser\Alpine\Entangle;
+
+use Livewire\Component as BaseComponent;
+
+class EntangleNestedParentComponent extends BaseComponent
+{
+    public $list = [
+        ['id' => 1, 'name' => 'test1'],
+    ];
+
+    public function addList()
+    {
+        $this->list[] = ['id' => (count($this->list) + 1), 'name' => 'test' . (count($this->list) + 1)];
+    }
+
+    public function removeList()
+    {
+        array_pop($this->list);
+    }
+
+    public function render()
+    {
+        return
+<<<'HTML'
+<div x-data>
+    <div dusk="output">
+        @foreach($list as $key => $item)
+            @livewire(Tests\Browser\Alpine\Entangle\EntangleNestedChildComponent::class, ['item' => $item], key($key))
+        @endforeach
+    </div>
+
+    <div>
+        <button dusk="add" type="button" wire:click="addList">Add</button>
+        <button dusk="remove" type="button" wire:click="removeList">Delete</button>
+    </div>
+</div>
+HTML;
+    }
+}

--- a/tests/Browser/Alpine/Entangle/Test.php
+++ b/tests/Browser/Alpine/Entangle/Test.php
@@ -125,6 +125,19 @@ class Test extends TestCase
         });
     }
 
+    public function test_entangle_does_not_throw_wire_undefined_error_after_dynamically_adding_child_component()
+    {
+        $this->browse(function ($browser) {
+            Livewire::visit($browser, EntangleNestedParentComponent::class)
+                ->assertSeeIn('@livewire-output-test1', "test1")
+                ->assertSeeIn('@alpine-output-test1', "test1")
+                ->waitForLivewire()->click('@add')
+                ->assertSeeIn('@livewire-output-test2', "test2")
+                ->assertSeeIn('@alpine-output-test2', "test2")
+            ;
+        });
+    }
+
     public function test_entangle_equality_check_ensures_alpine_does_not_update_livewire()
     {
         $this->browse(function ($browser) {

--- a/tests/Browser/views/layouts/app.blade.php
+++ b/tests/Browser/views/layouts/app.blade.php
@@ -1,7 +1,7 @@
 <html>
 <head>
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.8.1/dist/alpine.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.8.2/dist/alpine.min.js" defer></script>
     <!-- <script src="http://alpine.test/dist/alpine.js" defer></script> -->
     @livewireStyles
 </head>


### PR DESCRIPTION
**Update 25 Mar 21:**

I have bumped Alpine to 2.8.2 which contains the required fix, so this test now passes.

I've merged in master, and so this is ready to be merged.

Hope this helps!

---

**Update 05 Mar 21:**

A fix for this issue has been submitted on the Alpine repo alpinejs/alpine#1160.
See the details on that PR.

The test added in this PR passes if the above fix is applied to Alpine.

If it gets merged, I will add another commit to this PR to bump the Alpine version in Livewire's dusk tests, so then it should all pass.

I have also rebased these changes on master.

Hope this helps!

Fixes #2531

---

This PR adds a failing test which replicates issues #1611 and  #1914 with nested components that make use of entangle.

The error that occurs is
> Uncaught (in promise) TypeError: Cannot read property '$wire' of undefined

This happens when you have a parent Livewire component that has an Alpine component in it, and inside of that is nested Livewire components, that also have an Alpine component in them and uses `@entangle`, that are loaded dynamically (not in initial request).

What I suspect is happening is either:
- Alpine on the parent component is trying to evaluate the `@entangle` before the Alpine and Livewire in the nested component have loaded (I suspect this because if you remove Alpine from the parent component, it all runs fine).
- Or Alpine in the nested component is evaluating before the Livewire nested component is initialised.

If fixed this should fix #1611 and fix #1914 (already been closed).

Hope this helps!