### PR TITLE
Add --test flag to make command

### DIFF
--- a/src/Commands/MakeLivewireCommand.php
+++ b/src/Commands/MakeLivewireCommand.php
@@ -4,5 +4,5 @@ namespace Livewire\Commands;
 
 class MakeLivewireCommand extends MakeCommand
 {
-    protected $signature = 'make:livewire {name} {--force} {--inline} {--stub=default}';
+    protected $signature = 'make:livewire {name} {--force} {--inline} {--test} {--stub=default}';
 }

--- a/src/Commands/TouchCommand.php
+++ b/src/Commands/TouchCommand.php
@@ -4,7 +4,7 @@ namespace Livewire\Commands;
 
 class TouchCommand extends MakeCommand
 {
-    protected $signature = 'livewire:touch {name} {--force} {--inline} {--stub=default}';
+    protected $signature = 'livewire:touch {name} {--force} {--inline} {--test} {--stub=default}';
 
     protected function configure()
     {

--- a/src/Commands/livewire.test.stub
+++ b/src/Commands/livewire.test.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace [testnamespace];
+
+use [classwithnamespace];
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class [testclass] extends TestCase
+{
+    /** @test */
+    public function the_component_can_render()
+    {
+        $component = Livewire::test([class]::class);
+
+        $component->assertStatus(200);
+    }
+}

--- a/tests/Unit/MakeCommandTest.php
+++ b/tests/Unit/MakeCommandTest.php
@@ -27,84 +27,103 @@ class MakeCommandTest extends TestCase
     }
 
     /** @test */
-    public function component_is_created_by_livewire_make_command()
+    public function component_test_is_created_by_make_command_with_test_option()
     {
-        Artisan::call('livewire:make', ['name' => 'foo']);
+        Artisan::call('make:livewire', ['name' => 'foo', '--test' => true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('FooTest.php')));
+    }
+
+    /** @test */
+    public function component_is_created_by_livewire_make_command()
+    {
+        Artisan::call('livewire:make', ['name' => 'foo', '--test' => true]);
+
+        $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
+        $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('FooTest.php')));
     }
 
     /** @test */
     public function component_is_created_by_touch_command()
     {
-        Artisan::call('livewire:touch', ['name' => 'foo']);
+        Artisan::call('livewire:touch', ['name' => 'foo', '--test' => true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('FooTest.php')));
     }
 
     /** @test */
     public function dot_nested_component_is_created_by_make_command()
     {
-        Artisan::call('make:livewire', ['name' => 'foo.bar']);
+        Artisan::call('make:livewire', ['name' => 'foo.bar', '--test' => true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Foo/Bar.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('foo/bar.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('Foo/BarTest.php')));
     }
 
     /** @test */
     public function forward_slash_nested_component_is_created_by_make_command()
     {
-        Artisan::call('make:livewire', ['name' => 'foo/bar']);
+        Artisan::call('make:livewire', ['name' => 'foo/bar', '--test' => true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Foo/Bar.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('foo/bar.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('Foo/BarTest.php')));
     }
 
     /** @test */
     public function multiword_component_is_created_by_make_command()
     {
-        Artisan::call('make:livewire', ['name' => 'foo-bar']);
+        Artisan::call('make:livewire', ['name' => 'foo-bar', '--test' => true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('FooBar.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('foo-bar.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('FooBarTest.php')));
     }
 
     /** @test */
     public function pascal_case_component_is_automatically_converted_by_make_command()
     {
-        Artisan::call('make:livewire', ['name' => 'FooBar.FooBar']);
+        Artisan::call('make:livewire', ['name' => 'FooBar.FooBar', '--test' => true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('FooBar/FooBar.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('foo-bar/foo-bar.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('FooBar/FooBarTest.php')));
     }
 
     /** @test */
     public function pascal_case_component_with_double_backslashes_is_automatically_converted_by_make_command()
     {
-        Artisan::call('make:livewire', ['name' => 'FooBar\\FooBar']);
+        Artisan::call('make:livewire', ['name' => 'FooBar\\FooBar', '--test' => true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('FooBar/FooBar.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('foo-bar/foo-bar.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('FooBar/FooBarTest.php')));
     }
 
     /** @test */
     public function snake_case_component_is_automatically_converted_by_make_command()
     {
-        Artisan::call('make:livewire', ['name' => 'text_replace']);
+        Artisan::call('make:livewire', ['name' => 'text_replace', '--test' => true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('TextReplace.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('text-replace.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('TextReplaceTest.php')));
     }
 
     /** @test */
     public function snake_case_component_is_automatically_converted_by_make_command_on_nested_component()
     {
-        Artisan::call('make:livewire', ['name' => 'TextManager.text_replace']);
+        Artisan::call('make:livewire', ['name' => 'TextManager.text_replace', '--test' => true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('TextManager/TextReplace.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('text-manager/text-replace.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('TextManager/TextReplaceTest.php')));
     }
 
     /** @test */

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -28,6 +28,7 @@ class TestCase extends BaseTestCase
 
         File::deleteDirectory($this->livewireViewsPath());
         File::deleteDirectory($this->livewireClassesPath());
+        File::deleteDirectory($this->livewireTestsPath());
         File::delete(app()->bootstrapPath('cache/livewire-components.php'));
     }
 
@@ -68,5 +69,10 @@ class TestCase extends BaseTestCase
     protected function livewireViewsPath($path = '')
     {
         return resource_path('views').'/livewire'.($path ? '/'.$path : '');
+    }
+
+    protected function livewireTestsPath($path = '')
+    {
+        return base_path('tests/Feature/Livewire'.($path ? '/'.$path : ''));
     }
 }


### PR DESCRIPTION
This PR adds a `--test` flag to the `php artisan make:livewire` (and aliased) commands. When the `--test` flag is passed, the make command will now scaffold a basic test for the component.

If this PR is merged, we should probably go through all the copy, delete, move, etc. commands to make sure they also perform their duties on the test file.