### PR TITLE
resetExcept func added

### DIFF
--- a/src/ComponentConcerns/InteractsWithProperties.php
+++ b/src/ComponentConcerns/InteractsWithProperties.php
@@ -172,6 +172,25 @@ trait InteractsWithProperties
         }
     }
 
+    public function resetExcept($exceptions)
+    {
+        $properties = array_keys($this->getPublicPropertiesDefinedBySubClass());
+
+        // Remove exceptions from properties
+        if (is_array($exceptions)) {
+            $properties = array_diff($properties, $exceptions);
+        } elseif (is_string($exceptions)) {
+            $exceptions = [$exceptions];
+            $properties = array_diff($properties, $exceptions);
+        }
+
+        foreach ($properties as $property) {
+            $freshInstance = new static($this->id);
+
+            $this->{$property} = $freshInstance->{$property};
+        }
+    }
+
     public function only($properties)
     {
         $results = [];


### PR DESCRIPTION
1️⃣ This function will reset all the properties of the subClass but the ones passed in the parameter

3️⃣ N

4️⃣ Sometimes I want to reset all my properties but some ones, and I don't find a way to do it

5️⃣ Thanks for contributing! 🙌