### PR TITLE
Fixed TestableLivewire to always return an instance of itself

### DIFF
--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -247,6 +247,7 @@ class TestableLivewire
             return $this->macroCall($method, $params);
         }
 
-        return $this->lastResponse->$method(...$params);
+        $this->lastResponse->$method(...$params);
+        return $this;
     }
 }

--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -248,6 +248,7 @@ class TestableLivewire
         }
 
         $this->lastResponse->$method(...$params);
+        
         return $this;
     }
 }

--- a/tests/Unit/TestableLivewireCanAssertStatusCodesTest.php
+++ b/tests/Unit/TestableLivewireCanAssertStatusCodesTest.php
@@ -40,6 +40,15 @@ class TestableLivewireCanAssertStatusCodesTest extends TestCase
 
         $component->assertForbidden();
     }
+
+    /** @test */
+    public function can_assert_status_and_continue_making_livewire_assertions()
+    {
+        Livewire::test(NormalComponent::class)
+            ->assertStatus(200)
+            ->assertSee('Hello!')
+            ->assertSeeHtml('</example>');
+    }
 }
 
 class NotFoundComponent extends Component
@@ -63,5 +72,13 @@ class ForbiddenComponent extends Component
     public function render()
     {
         throw new HttpException(403);
+    }
+}
+
+class NormalComponent extends Component
+{
+    public function render()
+    {
+        return '<example>Hello!</example>';
     }
 }


### PR DESCRIPTION
Fixes https://github.com/livewire/livewire/issues/2507 

Having `assertStatus` (or any other assertion not extended by Livewire) and then trying to use Livewire-specific assertions causes an error. This is because `assertStatus` returns an instance of `TestReponse` and not an instance of `TestableLivewire`. 