### PR TITLE
Macro actions

### DIFF
--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -2,17 +2,16 @@
 
 namespace Livewire\ComponentConcerns;
 
-use Illuminate\Support\Traits\Macroable;
-use Livewire\Livewire;
-use Livewire\ImplicitlyBoundMethod;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\Exceptions\CannotBindToModelDataWithoutValidationRuleException;
 use Livewire\Exceptions\MethodNotFoundException;
+use Livewire\Exceptions\MissingFileUploadsTraitException;
 use Livewire\Exceptions\NonPublicComponentMethodCall;
 use Livewire\Exceptions\PublicPropertyNotFoundException;
-use Livewire\Exceptions\MissingFileUploadsTraitException;
-use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Livewire\HydrationMiddleware\HashDataPropertiesForDirtyDetection;
-use Livewire\Exceptions\CannotBindToModelDataWithoutValidationRuleException;
+use Livewire\ImplicitlyBoundMethod;
+use Livewire\Livewire;
 use function Livewire\str;
 
 trait HandlesActions

--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\ComponentConcerns;
 
+use Illuminate\Support\Traits\Macroable;
 use Livewire\Livewire;
 use Livewire\ImplicitlyBoundMethod;
 use Illuminate\Database\Eloquent\Model;
@@ -129,13 +130,21 @@ trait HandlesActions
                 } else {
                     $currentValue = $this->{$prop};
                 }
-                
+
                 $this->syncInput($prop, ! $currentValue, $rehash = false);
 
                 return;
 
             case '$refresh':
                 return;
+        }
+
+        if (method_exists($this, 'macroCall') && static::hasMacro($method)) {
+            $returned = $this->macroCall($method, $params);
+
+            Livewire::dispatch('action.returned', $this, $method, $returned);
+
+            return;
         }
 
         if (! method_exists($this, $method)) {

--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -2,16 +2,16 @@
 
 namespace Livewire\ComponentConcerns;
 
-use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Livewire\Livewire;
+use Livewire\ImplicitlyBoundMethod;
 use Illuminate\Database\Eloquent\Model;
-use Livewire\Exceptions\CannotBindToModelDataWithoutValidationRuleException;
 use Livewire\Exceptions\MethodNotFoundException;
-use Livewire\Exceptions\MissingFileUploadsTraitException;
 use Livewire\Exceptions\NonPublicComponentMethodCall;
 use Livewire\Exceptions\PublicPropertyNotFoundException;
+use Livewire\Exceptions\MissingFileUploadsTraitException;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Livewire\HydrationMiddleware\HashDataPropertiesForDirtyDetection;
-use Livewire\ImplicitlyBoundMethod;
-use Livewire\Livewire;
+use Livewire\Exceptions\CannotBindToModelDataWithoutValidationRuleException;
 use function Livewire\str;
 
 trait HandlesActions

--- a/tests/Unit/ComponentCanHaveActionsDefinedWithMacrosTest.php
+++ b/tests/Unit/ComponentCanHaveActionsDefinedWithMacrosTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Livewire;
+use Livewire\Component;
+
+class ComponentCanHaveActionsDefinedWithMacrosTest extends TestCase
+{
+    /** @test */
+    public function a_livewire_component_can_use_a_macro_closure_without_parameters_as_a_callable_action()
+    {
+        ComponentWithMacroAction::macro('foo', function(){
+            $this->bar = 'New Bar';
+        });
+
+        Livewire::test(ComponentWithMacroAction::class)
+            ->call('foo')
+            ->assertSet('bar', 'New Bar');
+    }
+
+    /** @test */
+    public function a_livewire_component_can_use_a_macro_closure_with_parameters_as_a_callable_action()
+    {
+        ComponentWithMacroAction::macro('foo', function($param){
+            $this->bar = $param;
+        });
+
+        Livewire::test(ComponentWithMacroAction::class)
+            ->call('foo', 'New Bar')
+            ->assertSet('bar', 'New Bar');
+    }
+
+    /** @test */
+    public function a_livewire_component_can_use_a_mixin_class_to_set_callable_actions()
+    {
+        ComponentWithMacroAction::mixin(new TestComponentMixin());
+
+        Livewire::test(ComponentWithMacroAction::class)
+            ->call('foo', 'New Bar')
+            ->assertSet('bar', 'New Bar');
+    }
+}
+
+class ComponentWithMacroAction extends Component
+{
+    public $bar = 'Bar';
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}
+
+class TestComponentMixin {
+
+    public function foo()
+    {
+        return function ($param) {
+            $this->bar = $param;
+        };
+    }
+}
+


### PR DESCRIPTION
This PR adds the ability to define action methods on components via macros or mixin classes.

**Use case**

I'm developing a package that will ultimately allow other developers to extend the functionality in a set of Livewire components.  Although the `Livewire\Component` class is `Macroable`, if you try to extend a Component class using `macro(...)` or `mixin(...)`, Livewire will currently throw a `Livewire\Exceptions\MethodNotFoundException` when you try to call this method via something like `wire:click="foo"`.

As the `Component` class is `Macroable` already it feels like this should be allowed behaviour and it would certainly open up options for third party component extension.

**Solution**

This PR takes a simple (hopefully not naive) solution to this by adding a check within the `callMethod` method within the `HandlesActions` concern.  This check ensures that the parent class has the custom `macroCall` trait method and that a macro with the method name exists.  If those conditions are met, the macro is called and the Livewire action is dispatched as it would be for a regular method.

This implementation supports closure-based macros (with or without parameters) as well as mixin class-based macros.  Tests are included.

**Questions/Concerns**

I'm not too sure I fully grok what's happening within the `ImplicitlyBoundMethod` class which is what is called for a regular component method.  Bit short on time to really dig into that but if there's some magic happening there that won't be applied if calling a macro then that might be something that makes this feature less simple.

I'm also slightly torn on whether it's OK to make methods set via a macro higher priority than those that might be 'native' to the component.  For example if a component has a method `foo` and then a `foo` method is set via a macro, the macro one will be called as this is evaluated first.  On balance I think this is fine (sharp knives and all that) but I wanted to flag it.