### PR TITLE
Removes hardcoded disk when in testing environment

### DIFF
--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -26,10 +26,6 @@ class FileUploadConfiguration
 
     public static function disk()
     {
-        if (app()->environment('testing')) {
-            return 'tmp-for-tests';
-        }
-
         return config('livewire.temporary_file_upload.disk') ?: config('filesystems.default');
     }
 


### PR DESCRIPTION
When in a test environment, the disk is hardcoded in the code here and file uploads don't work unless you add this disk to your filesystems config.
This fixes that.

If we want custom disks per environment, maybe we should add env() to the config file?