### PR TITLE
add rounded border to tailwind pagination

### DIFF
--- a/src/views/pagination/tailwind.blade.php
+++ b/src/views/pagination/tailwind.blade.php
@@ -41,7 +41,7 @@
                 </div>
 
                 <div>
-                    <span class="relative z-0 inline-flex shadow-sm">
+                    <span class="relative z-0 inline-flex rounded-md shadow-sm">
                         <span>
                             {{-- Previous Page Link --}}
                             @if ($paginator->onFirstPage())


### PR DESCRIPTION
Noticed that if you zoom right in, the shadow isn't wrapped:

<img width="252" alt="Screenshot 2021-02-25 at 21 54 59" src="https://user-images.githubusercontent.com/20431294/109225081-b4702880-77b4-11eb-9a58-1c2f5d4cfdc6.png">

I've checked with TailwindUI which has `rounded-md` on the element too.