### PR TITLE
Add config to define the temporary file upload disk using tests

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -38,7 +38,7 @@ return [
     | the view returned by SomeComponent will be wrapped in "layouts.app"
     |
     */
-    
+
     'layout' => 'layouts.app',
 
     /*
@@ -92,6 +92,7 @@ return [
             'jpg', 'jpeg', 'mpga', 'webp', 'wma',
         ],
         'max_upload_time' => 5, // Max duration (in minutes) before an upload gets invalidated.
+        'test_disk' => null // Overwrite disk to be used during tests, defaults to 'tmp-for-tests'
     ],
 
     /*

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -92,7 +92,7 @@ return [
             'jpg', 'jpeg', 'mpga', 'webp', 'wma',
         ],
         'max_upload_time' => 5, // Max duration (in minutes) before an upload gets invalidated.
-        'test_disk' => null // Overwrite disk to be used during tests, defaults to 'tmp-for-tests'
+        //'test_disk' => 'tmp-for-tests' // Overwrite disk to be used during tests
     ],
 
     /*

--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -27,7 +27,7 @@ class FileUploadConfiguration
     public static function disk()
     {
         if (app()->environment('testing')) {
-            return 'tmp-for-tests';
+            return config('livewire.temporary_file_upload.test_disk', 'tmp-for-tests');
         }
 
         return config('livewire.temporary_file_upload.disk') ?: config('filesystems.default');


### PR DESCRIPTION
**Is this something that is wanted/needed? Did you create an issue / discussion about it first?**
This will resolve https://github.com/livewire/livewire/issues/2566 and https://github.com/livewire/livewire/issues/1341

**Please include a thorough description of the improvement and reasons why it's useful.**
This will make it easier for people to override the disk to be used when running tests.
