### PR TITLE
Fix route model parameters in query string

### DIFF
--- a/src/RenameMe/SupportBrowserHistory.php
+++ b/src/RenameMe/SupportBrowserHistory.php
@@ -40,7 +40,12 @@ class SupportBrowserHistory
         Livewire::listen('component.dehydrate.initial', function (Component $component, Response $response) {
             if (! $this->shouldSendPath($component)) return;
 
-            $queryParams = $this->mergeComponentPropertiesWithExistingQueryParamsFromOtherComponentsAndTheRequest($component);
+            $route = app('router')->current();
+            $queryParams = $this->mergeComponentPropertiesWithExistingQueryParamsFromOtherComponentsAndTheRequest($component)
+                // We need to filter any route parameters so they won't get embedded in the query string.
+                ->filter(function ($parameter, $key) use ($route) {
+                    return ! $route->hasParameter($key);
+                });
 
             $response->effects['path'] = url()->current().$this->stringifyQueryParams($queryParams);
         });
@@ -131,7 +136,7 @@ class SupportBrowserHistory
             )
         );
 
-        return app(UrlGenerator::class)->toRoute($route, $boundParameters + $queryString->toArray(), true);
+        return app(UrlGenerator::class)->toRoute($route, $boundParameters + $queryString->all(), true);
     }
 
     protected function mergeComponentPropertiesWithExistingQueryParamsFromOtherComponentsAndTheRequest($component)


### PR DESCRIPTION
I was surprised to discover that the query string functionality supports named route parameters seamlessly. Awesome!

However, it appears that implicitly bound route model parameters don't work in the query string. (#2605)

If you try to use such parameters in the query string, the following `ErrorException` will be thrown: `Array to string conversion` (`from vendor/laravel/framework/src/Illuminate/Routing/RouteUrlGenerator.php:220`; `Illuminate/Routing/RouteUrlGenerator::replaceNamedParameters()`).

The reason is that model parameters are not converted back into their route key equivalents for the query string.

This PR fixes that by making sure any query string parameters that are `UrlRoutable` are converted into their route key equivalents for the query string.

Let me know if tests are necessary, and I will look into adding those.