### PR TITLE
Add ability to change pagination page name

### DIFF
--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -19,10 +19,10 @@ trait WithPagination
 
     public function initializeWithPagination()
     {
-        $this->setPage($this->resolvePage());
+        $this->page = $this->resolvePage();
 
         Paginator::currentPageResolver(function () {
-            return $this->getPage();
+            return (int)$this->getPage();
         });
 
         Paginator::defaultView($this->paginationView());
@@ -64,16 +64,16 @@ trait WithPagination
         $this->{$this->pageName} = $page;
     }
 
-    public function getPage()
-    {
-        return object_get($this, $this->pageName, 1);
-    }
-
     public function resolvePage()
     {
         // The "page" query string item should only be available
         // from within the original component mount run.
-        return request()->query($this->pageName, $this->getPage());
+        return (int)request()->query($this->pageName, $this->getPage());
+    }
+
+    public function getPage()
+    {
+        return object_get($this, $this->pageName, 1);
     }
 
     public function getPublicPropertiesDefinedBySubClass()
@@ -82,4 +82,5 @@ trait WithPagination
             $props[$this->pageName] = $this->getPage();
         });
     }
+
 }

--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -66,7 +66,7 @@ trait WithPagination
 
     public function resolvePage()
     {
-        // The "page name" query string item should only be available
+        // The "pagination page name" query string item should only be available
         // from within the original component mount run.
         return (int)request()->query($this->pageName, $this->getPage());
     }
@@ -76,11 +76,11 @@ trait WithPagination
         return object_get($this, $this->pageName, 1);
     }
 
-    public function getPublicPropertiesDefinedBySubClass()
-    {
-        return tap(parent::getPublicPropertiesDefinedBySubClass(), function (&$props) {
-            $props[$this->pageName] = $this->getPage();
-        });
-    }
+//    public function getPublicPropertiesDefinedBySubClass()
+//    {
+//        return tap(parent::getPublicPropertiesDefinedBySubClass(), function (&$props) {
+//            $props[$this->pageName] = $this->getPage();
+//        });
+//    }
 
 }

--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -6,7 +6,7 @@ use Illuminate\Pagination\Paginator;
 
 trait WithPagination
 {
-    public $page = 1;
+    public $pageName = 'page';
 
     public function getQueryString()
     {
@@ -14,15 +14,15 @@ trait WithPagination
             ? $this->queryString()
             : $this->queryString;
 
-        return array_merge(['page' => ['except' => 1]], $queryString);
+        return array_merge([$this->pageName => ['except' => 1]], $queryString);
     }
 
     public function initializeWithPagination()
     {
-        $this->page = $this->resolvePage();
+        $this->setPage($this->resolvePage());
 
         Paginator::currentPageResolver(function () {
-            return $this->page;
+            return $this->getPage();
         });
 
         Paginator::defaultView($this->paginationView());
@@ -41,12 +41,12 @@ trait WithPagination
 
     public function previousPage()
     {
-        $this->setPage(max($this->page - 1, 1));
+        $this->setPage(max($this->getPage() - 1, 1));
     }
 
     public function nextPage()
     {
-        $this->setPage($this->page + 1);
+        $this->setPage($this->getPage() + 1);
     }
 
     public function gotoPage($page)
@@ -61,13 +61,18 @@ trait WithPagination
 
     public function setPage($page)
     {
-        $this->page = $page;
+        $this->{$this->pageName} = $page;
+    }
+
+    public function getPage()
+    {
+        return object_get($this, $this->pageName, 1);
     }
 
     public function resolvePage()
     {
         // The "page" query string item should only be available
         // from within the original component mount run.
-        return request()->query('page', $this->page);
+        return request()->query($this->pageName, $this->getPage());
     }
 }

--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -75,4 +75,11 @@ trait WithPagination
         // from within the original component mount run.
         return request()->query($this->pageName, $this->getPage());
     }
+
+    public function getPublicPropertiesDefinedBySubClass()
+    {
+        return tap(parent::getPublicPropertiesDefinedBySubClass(), function (&$props) {
+            $props[$this->pageName] = $this->getPage();
+        });
+    }
 }

--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -66,7 +66,7 @@ trait WithPagination
 
     public function resolvePage()
     {
-        // The "page" query string item should only be available
+        // The "page name" query string item should only be available
         // from within the original component mount run.
         return (int)request()->query($this->pageName, $this->getPage());
     }

--- a/tests/Unit/ComponentPaginationTest.php
+++ b/tests/Unit/ComponentPaginationTest.php
@@ -12,7 +12,7 @@ class ComponentPaginationTest extends TestCase
     public function can_navigate_to_previous_page()
     {
         Livewire::test(ComponentWithPaginationStub::class)
-            ->set('page', 2)
+            ->call('setPage', 2)
             ->call('previousPage')
             ->assertSet('page', 1);
     }
@@ -45,7 +45,7 @@ class ComponentPaginationTest extends TestCase
 class ComponentWithPaginationStub extends Component
 {
     use WithPagination;
-    
+
     public function render()
     {
         return view('show-name', ['name' => 'example']);


### PR DESCRIPTION
add the ability to change pagination's page name

sometimes we use multiple tables in the same page and this will make conflict between the tables pagination

This PR will help make anyone uses `WithPagination` trait to override the `pageName` and this will solve the conflict

This will fix this issue https://github.com/MedicOneSystems/livewire-datatables/issues/119 too


![image](https://user-images.githubusercontent.com/35740977/110527054-2e8e9e80-811f-11eb-980f-bc1f8c4acc0b.png)


