### PR TITLE
Failing Test: Add failing loop clicks to alpine click handlers test

### DIFF
--- a/tests/Browser/Alpine/ClickComponent.php
+++ b/tests/Browser/Alpine/ClickComponent.php
@@ -2,19 +2,25 @@
 
 namespace Tests\Browser\Alpine;
 
-use Illuminate\Support\Facades\View;
 use Livewire\Component as BaseComponent;
 
 class ClickComponent extends BaseComponent
 {
     public $show = false;
 
+    public $items = [1, 2, 3];
+
+    public function reverseItems()
+    {
+        $this->items = array_reverse($this->items);
+    }
+
     public function render()
     {
         return
 <<<'HTML'
 <div>
-    <div x-data="{ clicks: [] }">
+    <div x-data="{ clicks: [], loopClicks: [] }">
         <button dusk="show" wire:click="$set('show', true)">Toggle Options</button>
 
         <div>
@@ -28,6 +34,16 @@ class ClickComponent extends BaseComponent
         </div>
 
         <div>Number of clicks: <span dusk="alpineClicksFired" x-text="clicks.length"></span></div>
+
+        <div>
+            <button wire:click="reverseItems()" dusk="reverseItems">Reverse Items</button>
+
+            @foreach ($items as $item)
+                <span wire:key='{{ $item }}' dusk='loopClick{{ $item }}' x-on:click="loopClicks.push('Clicked')">Click {{ $item }}</span>
+            @endforeach
+        </div>
+
+        <div>Number of loop clicks: <span dusk="alpineLoopClicksFired" x-text="loopClicks.length"></span></div>
     </div>
 </div>
 HTML;

--- a/tests/Browser/Alpine/Test.php
+++ b/tests/Browser/Alpine/Test.php
@@ -159,6 +159,12 @@ class Test extends TestCase
                 ->assertSeeIn('@alpineComponentClicksFired', 2)
                 ->click('@componentClick')
                 ->assertSeeIn('@alpineComponentClicksFired', 3)
+
+                ->click('@loopClick1')
+                ->assertSeeIn('@alpineLoopClicksFired', 1)
+                ->waitForLivewire()->click('@reverseItems')
+                ->click('@loopClick1')
+                ->assertSeeIn('@alpineLoopClicksFired', 2)
             ;
         });
     }


### PR DESCRIPTION
The alpine click handlers within a blade if statement was fixed in PR #2434 but I have found that the same issue is still happening in foreach loops.

This PR adds loops to the test which now makes it a failing test.

When I get a chance I will look into fixing.

Hope this helps!