### PR TITLE
Fix: Paginator footer text

### DIFF
--- a/src/views/pagination/tailwind.blade.php
+++ b/src/views/pagination/tailwind.blade.php
@@ -30,13 +30,7 @@
             <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
                 <div>
                     <p class="text-sm text-gray-700 leading-5">
-                        <span>{!! __('Showing') !!}</span>
-                        <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                        <span>{!! __('to') !!}</span>
-                        <span class="font-medium">{{ $paginator->lastItem() }}</span>
-                        <span>{!! __('of') !!}</span>
-                        <span class="font-medium">{{ $paginator->total() }}</span>
-                        <span>{!! __('results') !!}</span>
+                        {!! __('<span>Showing <span class="font-medium">:firstItem</span> to <span class="font-medium">:lastItem</span> of <span class="font-medium">:total</span> results</span>', ['firstItem' => $paginator->firstItem(), 'lastItem' => $paginator->lastItem(), 'total' => $paginator->total()]) !!}
                     </p>
                 </div>
 


### PR DESCRIPTION
Previous codes were not compatible for all languages.

For example, in my language (Turkish), the places of words are different.

English: Showing 1 to 2 of 4 results
Turkish: Toplam 4 sonuç arasından 1 ile 2 arasındaki sonuçlar gösteriliyor