### PR TITLE
Make LivewireManager singleton injectable to other services

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -82,7 +82,8 @@ class LivewireServiceProvider extends ServiceProvider
 
     protected function registerLivewireSingleton()
     {
-        $this->app->singleton('livewire', LivewireManager::class);
+        $this->app->singleton(LivewireManager::class);
+        $this->app->alias(LivewireManager::class, 'livewire');
     }
 
     protected function registerComponentAutoDiscovery()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
This is something necessary to use dependency injection via constructors.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, this is only about making LivewireManager injectable to other components/services.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No as this is already tested extensively.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Currently the `LivewireManager::class` is linked to 'livewire' key which is not a class. This means that we cannot use type to inject a LivewireManager singleton instance to an other service as this will fail:

```
class MyService {
    public function __construct(LivewireManager $livewire) {
        assert($livewire === app('livewire'), "Not the same manager");
    }
}
app()->make(MyService::class);
```

To correct this `LivewireManager::class` must first be set as singleton and then Aliased.

5️⃣ Thanks for contributing! 🙌