### PR TITLE
Add getComponentAliases() to LivewireManager

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -43,6 +43,11 @@ class LivewireManager
         return $alias === false ? $default : $alias;
     }
 
+    public function getComponentAliases()
+    {
+        return $this->componentAliases;
+    }
+
     public function getClass($alias)
     {
         $finder = app(LivewireComponentsFinder::class);


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
This is needed to check if an alias is already set / exists. It mimics the Laravel `BladeCompiler::getClassComponentAliases()` to get access to the current list of aliases.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, this just a simple accessor.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No, this method is just an accessor to the protected property: `componentAliases`.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Currently to check if an Alias exists we need to do something like:
```
try {
    $exist = boolval(Livewire::getClass($alias));
} catch (Exception $error) {
    $exist = false;
}
```
this PR let you do:
```
$exist = isset(Livewire::getComponentAliases()[$alias]);
```
Mind that I on purpose did not make a more precise method like `aliasExists` to mimic Laravel's component function `BladeCompiler::getClassComponentAliases()` that return the list of aliases and they assigned classes.

5️⃣ Thanks for contributing! 🙌