### PR TITLE
Remove base url for correct route matching.

### DIFF
--- a/src/Controllers/HttpConnectionHandler.php
+++ b/src/Controllers/HttpConnectionHandler.php
@@ -62,6 +62,8 @@ class HttpConnectionHandler extends ConnectionHandler
 
     protected function makeRequestFromUrlAndMethod($url, $method = 'GET')
     {
+        $url = str_replace(config('app.url'), '', $url);
+
         $request = Request::create($url, $method);
 
         if ($session = request()->getSession()) {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

There are a couple of similar reports regarding this issue, or might be related to this.

https://github.com/livewire/livewire/issues/2445
https://github.com/livewire/livewire/pull/1544
https://github.com/livewire/livewire/issues/1535

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No, all changes done are just for fixing the issue.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No, I did not :(

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

We are running our application in a subdirectory. In our .env file our APP_URL looks like `APP_URL=http://localhost:8080/public`

On the url: `http://localhost:8080/public/manage/some-page`

When laravel does route matching, it manages to detect it correctly and says `/manage/some-page` is the path to use for route matching.

However in makeRequestFromUrlAndMethod, the request build is using `/public/manage/some-page` for the matching which will result in a 404.

I am not saying the provided solution is the best, because I am not sure about the implications on various setups. But it does solve our issue.

If you have alternative suggestions on how to handle it, let me know, happy to provide an updated or.

I hope I made all clear.

Thanks in advance and thank you for all the great work on Livewire to all the contributors!

5️⃣ Thanks for contributing! 🙌