### PR TITLE
feat: make Livewire default routes configurable and publishable

### DIFF
--- a/routes/livewire.php
+++ b/routes/livewire.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Livewire\Controllers\FilePreviewHandler;
+use Livewire\Controllers\FileUploadHandler;
+use Livewire\Controllers\HttpConnectionHandler;
+use Livewire\Controllers\LivewireJavaScriptAssets;
+
+Route::group([
+    'namespace' => config('livewire.routes_namespace', null),
+    'domain' => config('livewire.routes_domain', null),
+    'prefix' => config('livewire.routes_prefix', null),
+], function () {
+    Route::post('/livewire/message/{name}', HttpConnectionHandler::class)
+        ->name('livewire.message')
+        ->middleware(config('livewire.middleware_group', ''));
+
+    Route::post('/livewire/upload-file', [FileUploadHandler::class, 'handle'])
+        ->name('livewire.upload-file')
+        ->middleware(config('livewire.middleware_group', ''));
+
+    Route::get('/livewire/preview-file/{filename}', [FilePreviewHandler::class, 'handle'])
+        ->name('livewire.preview-file')
+        ->middleware(config('livewire.middleware_group', ''));
+
+    Route::get('/livewire/livewire.js', [LivewireJavaScriptAssets::class, 'source']);
+    Route::get('/livewire/livewire.js.map', [LivewireJavaScriptAssets::class, 'maps']);
+});

--- a/routes/livewire.php
+++ b/routes/livewire.php
@@ -11,17 +11,16 @@ Route::group([
     'domain' => config('livewire.routes_domain', null),
     'prefix' => config('livewire.routes_prefix', null),
 ], function () {
-    Route::post('/livewire/message/{name}', HttpConnectionHandler::class)
-        ->name('livewire.message')
-        ->middleware(config('livewire.middleware_group', ''));
+    Route::middleware(config('livewire.middleware_group', ''))->group(function () {
+        Route::post('/livewire/message/{name}', HttpConnectionHandler::class)
+            ->name('livewire.message');
 
-    Route::post('/livewire/upload-file', [FileUploadHandler::class, 'handle'])
-        ->name('livewire.upload-file')
-        ->middleware(config('livewire.middleware_group', ''));
+        Route::post('/livewire/upload-file', [FileUploadHandler::class, 'handle'])
+            ->name('livewire.upload-file');
 
-    Route::get('/livewire/preview-file/{filename}', [FilePreviewHandler::class, 'handle'])
-        ->name('livewire.preview-file')
-        ->middleware(config('livewire.middleware_group', ''));
+        Route::get('/livewire/preview-file/{filename}', [FilePreviewHandler::class, 'handle'])
+            ->name('livewire.preview-file');
+    });
 
     Route::get('/livewire/livewire.js', [LivewireJavaScriptAssets::class, 'source']);
     Route::get('/livewire/livewire.js.map', [LivewireJavaScriptAssets::class, 'maps']);

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -9,7 +9,8 @@ class PublishCommand extends Command
     protected $signature = 'livewire:publish 
         { --assets : Indicates if Livewire\'s front-end assets should be published }
         { --config : Indicates if Livewire\'s config file should be published }
-        { --pagination : Indicates if Livewire\'s pagination views should be published }';
+        { --pagination : Indicates if Livewire\'s pagination views should be published }
+        { --routes : Indicates if Livewire\'s routes file should be published }';
 
     protected $description = 'Publish Livewire configuration';
 
@@ -21,6 +22,8 @@ class PublishCommand extends Command
             $this->publishConfig();
         } elseif ($this->option('pagination')) {
             $this->publishPagination();
+        } elseif ($this->option('routes')) {
+            $this->publishRoutes();
         } else {
             $this->publishAssets();
             $this->publishConfig();
@@ -41,5 +44,10 @@ class PublishCommand extends Command
     public function publishPagination()
     {
         $this->call('vendor:publish', ['--tag' => 'livewire:pagination', '--force' => true]);
+    }
+
+    public function publishRoutes()
+    {
+        $this->call('vendor:publish', ['--tag' => 'livewire:routes', '--force' => true]);
     }
 }

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -215,6 +215,10 @@ class LivewireServiceProvider extends ServiceProvider
         $this->publishesToGroups([
             __DIR__.'/views/pagination' => $this->app->resourcePath('views/vendor/livewire'),
         ], ['livewire', 'livewire:pagination']);
+
+        $this->publishesToGroups([
+            __DIR__.'/../routes/livewire.php' => base_path('routes/livewire.php'),
+        ], ['livewire', 'livewire:routes']);
     }
 
     protected function registerBladeDirectives()

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -8,11 +8,6 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\ComponentAttributeBag;
-use Livewire\Controllers\FileUploadHandler;
-use Livewire\Controllers\FilePreviewHandler;
-use Livewire\Controllers\HttpConnectionHandler;
-use Livewire\Controllers\LivewireJavaScriptAssets;
-use Illuminate\Support\Facades\Route as RouteFacade;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Livewire\Commands\{
@@ -124,20 +119,11 @@ class LivewireServiceProvider extends ServiceProvider
 
     protected function registerRoutes()
     {
-        RouteFacade::post('/livewire/message/{name}', HttpConnectionHandler::class)
-            ->name('livewire.message')
-            ->middleware(config('livewire.middleware_group', ''));
+        if (config('livewire.routes') === false) {
+            return;
+        }
 
-        RouteFacade::post('/livewire/upload-file', [FileUploadHandler::class, 'handle'])
-            ->name('livewire.upload-file')
-            ->middleware(config('livewire.middleware_group', ''));
-
-        RouteFacade::get('/livewire/preview-file/{filename}', [FilePreviewHandler::class, 'handle'])
-            ->name('livewire.preview-file')
-            ->middleware(config('livewire.middleware_group', ''));
-
-        RouteFacade::get('/livewire/livewire.js', [LivewireJavaScriptAssets::class, 'source']);
-        RouteFacade::get('/livewire/livewire.js.map', [LivewireJavaScriptAssets::class, 'maps']);
+        $this->loadRoutesFrom(__DIR__.'/../routes/livewire.php');
     }
 
     protected function registerCommands()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yes, i added some comments to #1674.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope, the commits only apply to Livewire routes.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Publish command has no unit test (yet ?)

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

 - It introduce the `routes/livewire.php` file, which contains Livewire default routes
 - It add the `--routes` option to `livewire:publish` artisan command (to publish routes file)
 - It add the `routes` configuration option, if set to `false`, to disable default routes (to use published one)
 - It add `routes_namespace`, `routes_domain` and `routes_prefix` configuration options (all default to null to keep current behaviour)
 - It should __not introduce any breaking changes__ (it only adds optional features)

__Example use case 1 :__

Default behaviour is to execute requests using `/livewire/` path. Let's say i want to add a prefix and execute request using `/acme/livewire` path, all i need is :

Publish configuration file :

```console
php artisan livewire:publish --config
```
Then change `asset_url` and add the `routes_prefix` option in application `config/livewire.php` file :

```php
// [...]
'asset_url' => '/acme'
// [...]
'routes_prefix' => 'acme',
```

Finally since we modified the assets url, don't forget to rebuild Laravel application assets (`npm run dev`).

__Example use case 2 :__

Let's says we want to modify the Livewire default routes : then publish also the routes file :

```console
php artisan livewire:publish --routes
```
Then add the `routes` option (and set value to `false`) in application `config/livewire.php` file :

```php
// [...]
'routes' => false, // Disable Livewire default routes
```

Finally require the published livewire routes file, for example,  in your application `routes/web.php` file :

```php
// [...]
require_once 'livewire.php';
```

At this stade you can modify application `routes/livewire.php` to suit your needs.

---

__Miscellaneous :__

 - The `routes*` options are a proposition, i can rename them if required
 - By default if you run the `livewire:publish` command without option, it __does not publish__ routes files. I made this choice to keep current behaviour. I can modify the command to also to publish routes file if required.

