### PR TITLE
Implement multi-pagination in a single component

### DIFF
--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -14,7 +14,7 @@ trait WithPagination
             ? $this->queryString()
             : $this->queryString;
 
-        return array_merge(['page' => ['except' => 1]], $queryString);
+        return array_merge([$this->getPageName() => ['except' => 1]], $this->queryString);
     }
 
     public function initializeWithPagination()
@@ -22,7 +22,7 @@ trait WithPagination
         $this->page = $this->resolvePage();
 
         Paginator::currentPageResolver(function () {
-            return (int) $this->page;
+            return $this->{$this->getPageName()};
         });
 
         Paginator::defaultView($this->paginationView());
@@ -41,12 +41,12 @@ trait WithPagination
 
     public function previousPage()
     {
-        $this->setPage(max($this->page - 1, 1));
+        $this->setPage(max($this->{$this->getPageName()} - 1, 1));
     }
 
     public function nextPage()
     {
-        $this->setPage($this->page + 1);
+        $this->setPage($this->{$this->getPageName()} + 1);
     }
 
     public function gotoPage($page)
@@ -61,13 +61,18 @@ trait WithPagination
 
     public function setPage($page)
     {
-        $this->page = $page;
+        $this->{$this->getPageName()} = $page;
     }
 
     public function resolvePage()
     {
         // The "page" query string item should only be available
         // from within the original component mount run.
-        return (int) request()->query('page', $this->page);
+        return request()->query($this->getPageName(), $this->page);
+    }
+    
+    public function getPageName()
+    {
+        return 'page';
     }
 }

--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -82,6 +82,6 @@ trait WithPagination
 
     public function getPaginatorNames()
     {
-        return ['page'];
+        return $this->paginatorNames ?? ['page'];
     }
 }

--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -82,6 +82,6 @@ trait WithPagination
 
     public function getPaginatorNames()
     {
-        return $this->paginatorNames ?? ['page'];
+        return property_exists($this, 'paginatorNames') ? $this->paginatorNames : ['page'];
     }
 }

--- a/tests/Browser/Pagination/Message.php
+++ b/tests/Browser/Pagination/Message.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Browser\Pagination;
+
+use Illuminate\Database\Eloquent\Model;
+use Sushi\Sushi;
+
+class Message extends Model
+{
+    use Sushi;
+
+    protected $rows = [
+        ['body' => 'Content #1'],
+        ['body' => 'Content #2'],
+        ['body' => 'Content #3'],
+        ['body' => 'Content #4'],
+        ['body' => 'Content #5'],
+        ['body' => 'Content #6'],
+        ['body' => 'Content #7'],
+        ['body' => 'Content #8'],
+        ['body' => 'Content #9'],
+        ['body' => 'Content #10'],
+        ['body' => 'Content #11'],
+        ['body' => 'Content #12'],
+        ['body' => 'Content #13'],
+        ['body' => 'Content #14'],
+        ['body' => 'Content #15'],
+        ['body' => 'Content #16'],
+        ['body' => 'Content #17'],
+        ['body' => 'Content #18'],
+        ['body' => 'Content #19'],
+        ['body' => 'Content #20'],
+        ['body' => 'Content #21'],
+        ['body' => 'Content #22'],
+        ['body' => 'Content #23'],
+        ['body' => 'Content #24'],
+        ['body' => 'Content #25'],
+        ['body' => 'Content #26'],
+        ['body' => 'Content #27'],
+        ['body' => 'Content #28'],
+        ['body' => 'Content #29'],
+        ['body' => 'Content #30'],
+        ['body' => 'Content #31'],
+        ['body' => 'Content #32'],
+        ['body' => 'Content #33'],
+        ['body' => 'Content #34'],
+        ['body' => 'Content #35'],
+        ['body' => 'Content #36'],
+        ['body' => 'Content #37'],
+        ['body' => 'Content #38'],
+        ['body' => 'Content #39'],
+        ['body' => 'Content #40'],
+        ['body' => 'Content #41'],
+        ['body' => 'Content #42'],
+        ['body' => 'Content #43'],
+        ['body' => 'Content #44'],
+        ['body' => 'Content #45'],
+        ['body' => 'Content #46'],
+        ['body' => 'Content #47'],
+        ['body' => 'Content #48'],
+        ['body' => 'Content #49'],
+        ['body' => 'Content #50'],
+        ['body' => 'Content #51'],
+        ['body' => 'Content #52'],
+        ['body' => 'Content #53'],
+        ['body' => 'Content #54'],
+        ['body' => 'Content #55'],
+        ['body' => 'Content #56'],
+        ['body' => 'Content #57'],
+        ['body' => 'Content #58'],
+        ['body' => 'Content #59'],
+        ['body' => 'Content #60'],
+    ];
+}

--- a/tests/Browser/Pagination/TailwindWithMultiplePagination.php
+++ b/tests/Browser/Pagination/TailwindWithMultiplePagination.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Browser\Pagination;
+
+use Tests\Browser\Pagination\Post;
+use Tests\Browser\Pagination\Message;
+use Illuminate\Support\Facades\View;
+use Livewire\Component as BaseComponent;
+use Livewire\WithPagination;
+
+class TailwindWithMultiplePagination extends BaseComponent
+{
+    use WithPagination;
+
+    public $postsPage = 1;
+
+    protected $paginatorNames = ['page', 'postsPage'];
+
+    public function render()
+    {
+        return View::file(__DIR__.'/view-multiple-pagination.blade.php', [
+            'posts' => Post::paginate(3, ['*'], 'postsPage'),
+            'messages' => Message::paginate(3),
+        ]);
+    }
+}

--- a/tests/Browser/Pagination/Test.php
+++ b/tests/Browser/Pagination/Test.php
@@ -103,4 +103,67 @@ class Test extends TestCase
             ;
         });
     }
+
+    public function test_multiple_pagination()
+    {
+        $this->browse(function ($browser) {
+            Livewire::visit($browser, TailwindWithMultiplePagination::class)
+                // Render initial content, both message and posts list are on page 1
+                ->assertSee('Post #1')
+                ->assertSee('Post #2')
+                ->assertSee('Post #3')
+                ->assertSee('Content #1')
+                ->assertSee('Content #2')
+                ->assertSee('Content #3')
+                ->assertDontSee('Post #4')
+                ->assertDontSee('Content #4')
+
+                // Go to posts list page 2, message paginator should keep its initial data
+                ->waitForLivewire()->click('@postsListNextPage')
+
+                ->assertDontSee('Post #1')
+                ->assertSee('Post #4')
+                ->assertQueryStringHas('postsPage', '2')
+                ->assertSee('Content #1')
+                ->assertQueryStringMissing('page')
+
+
+                // Go to posts list page 3, messages paginator should keep its initial data
+                ->waitForLivewire()->click('@postsListNextPage')
+
+                ->assertDontSee('Post #3')
+                ->assertSee('Post #7')
+                ->assertSee('Post #8')
+                ->assertSee('Post #9')
+                ->assertQueryStringHas('postsPage', '3')
+                ->assertSee('Content #1')
+                ->assertQueryStringMissing('page')
+
+
+                // Go to messages list page 2, posts paginator should keep its previous data
+                ->waitForLivewire()->click('@nextPage.after')
+
+                ->assertSee('Content #4')
+                ->assertDontSee('Content #1')
+                ->assertQueryStringHas('page', '2')
+                ->assertDontSee('Post #3')
+                ->assertSee('Post #7')
+                ->assertQueryStringHas('postsPage', '3')
+
+
+                // Go to posts list page 1, messages paginator should keep its previous data
+                ->waitForLivewire()->click('@postsListPreviousPage')
+                ->waitForLivewire()->click('@postsListPreviousPage')
+
+                ->assertDontSee('Post #6')
+                ->assertSee('Post #1')
+                ->assertSee('Post #2')
+                ->assertSee('Post #3')
+                ->assertQueryStringMissing('postsPage')
+                ->assertSee('Content #4')
+                ->assertDontSee('Content #1')
+                ->assertQueryStringHas('page', '2')
+            ;
+        });
+    }
 }

--- a/tests/Browser/Pagination/view-multiple-pagination.blade.php
+++ b/tests/Browser/Pagination/view-multiple-pagination.blade.php
@@ -1,0 +1,13 @@
+<div>
+    @foreach ($posts as $post)
+        <h1 wire:key="post-{{ $post->id }}">{{ $post->title }}</h1>
+    @endforeach
+
+    {{ $posts->links('posts-list-pagination') }}
+
+    @foreach ($messages as $message)
+        <p wire:key="message-{{ $message->id }}">{{ $message->body }}</p>
+    @endforeach
+
+    {{ $messages->links() }}
+</div>

--- a/tests/Browser/views/posts-list-pagination.blade.php
+++ b/tests/Browser/views/posts-list-pagination.blade.php
@@ -1,0 +1,114 @@
+<div>
+    @if ($paginator->hasPages())
+        <nav role="navigation" aria-label="Pagination Navigation" class="flex items-center justify-between">
+            <div class="flex justify-between flex-1 sm:hidden">
+                <span>
+                    @if ($paginator->onFirstPage())
+                        <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">
+                            {!! __('pagination.previous') !!}
+                        </span>
+                    @else
+                        <button wire:click="previousPage('postsPage')" wire:loading.attr="disabled" dusk="postsListPreviousPage" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                            {!! __('pagination.previous') !!}
+                        </button>
+                    @endif
+                </span>
+
+                <span>
+                    @if ($paginator->hasMorePages())
+                        <button wire:click="nextPage('postsPage')" wire:loading.attr="disabled" dusk="postsListNextPage" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                            {!! __('pagination.next') !!}
+                        </button>
+                    @else
+                        <span class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">
+                            {!! __('pagination.next') !!}
+                        </span>
+                    @endif
+                </span>
+            </div>
+
+            <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+                <div>
+                    <p class="text-sm text-gray-700 leading-5">
+                        <span>{!! __('Showing') !!}</span>
+                        <span class="font-medium">{{ $paginator->firstItem() }}</span>
+                        <span>{!! __('to') !!}</span>
+                        <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                        <span>{!! __('of') !!}</span>
+                        <span class="font-medium">{{ $paginator->total() }}</span>
+                        <span>{!! __('results') !!}</span>
+                    </p>
+                </div>
+
+                <div>
+                    <span class="relative z-0 inline-flex rounded-md shadow-sm">
+                        <span>
+                            {{-- Previous Page Link --}}
+                            @if ($paginator->onFirstPage())
+                                <span aria-disabled="true" aria-label="{{ __('pagination.previous') }}">
+                                    <span class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-l-md leading-5" aria-hidden="true">
+                                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                            <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                                        </svg>
+                                    </span>
+                                </span>
+                            @else
+                                <button wire:click="previousPage('postsPage')" dusk="postsListPreviousPage" rel="prev" class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-l-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150" aria-label="{{ __('pagination.previous') }}">
+                                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                        <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                                    </svg>
+                                </button>
+                            @endif
+                        </span>
+
+                        {{-- Pagination Elements --}}
+                        @foreach ($elements as $element)
+                            {{-- "Three Dots" Separator --}}
+                            @if (is_string($element))
+                                <span aria-disabled="true">
+                                    <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 cursor-default leading-5">{{ $element }}</span>
+                                </span>
+                            @endif
+
+                            {{-- Array Of Links --}}
+                            @if (is_array($element))
+                                @foreach ($element as $page => $url)
+                                    <span wire:key="paginator-page{{ $page }}">
+                                        @if ($page == $paginator->currentPage())
+                                            <span aria-current="page">
+                                                <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5">{{ $page }}</span>
+                                            </span>
+                                        @else
+                                            <button wire:click="gotoPage({{ $page }}, 'postsPage')" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
+                                                {{ $page }}
+                                            </button>
+                                        @endif
+                                    </span>
+                                @endforeach
+                            @endif
+                        @endforeach
+
+                        <span>
+                            {{-- Next Page Link --}}
+                            @if ($paginator->hasMorePages())
+                                <button wire:click="nextPage('postsPage')" dusk="postsListNextPage" rel="next" class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-r-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150" aria-label="{{ __('pagination.next') }}">
+                                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                        <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                                    </svg>
+                                </button>
+                            @else
+                                <span aria-disabled="true" aria-label="{{ __('pagination.next') }}">
+                                    <span class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default rounded-r-md leading-5" aria-hidden="true">
+                                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                            <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                                        </svg>
+                                    </span>
+                                </span>
+                            @endif
+                        </span>
+                    </span>
+                </div>
+            </div>
+        </nav>
+    @endif
+</div>

--- a/tests/Unit/ComponentCustomPaginationTest.php
+++ b/tests/Unit/ComponentCustomPaginationTest.php
@@ -6,48 +6,55 @@ use Livewire\Component;
 use Livewire\Livewire;
 use Livewire\WithPagination;
 
-class ComponentPaginationTest extends TestCase
+class ComponentCustomPaginationTest extends TestCase
 {
     /** @test */
     public function can_navigate_to_previous_page()
     {
-        Livewire::test(ComponentWithPaginationStub::class)
-            ->set('page', 2)
+        Livewire::test(ComponentWithCustomPaginationStub::class)
+            ->set('customPage', 2)
             ->call('previousPage')
-            ->assertSet('page', 1);
+            ->assertSet('customPage', 1);
     }
 
     /** @test */
     public function can_navigate_to_next_page()
     {
-        Livewire::test(ComponentWithPaginationStub::class)
+        Livewire::test(ComponentWithCustomPaginationStub::class)
             ->call('nextPage')
-            ->assertSet('page', 2);
+            ->assertSet('customPage', 2);
     }
 
     /** @test */
     public function can_navigate_to_specific_page()
     {
-        Livewire::test(ComponentWithPaginationStub::class)
+        Livewire::test(ComponentWithCustomPaginationStub::class)
             ->call('gotoPage', 5)
-            ->assertSet('page', 5);
+            ->assertSet('customPage', 5);
     }
 
     /** @test */
     public function previous_page_cannot_be_less_than_one()
     {
-        Livewire::test(ComponentWithPaginationStub::class)
+        Livewire::test(ComponentWithCustomPaginationStub::class)
             ->call('previousPage')
-            ->assertSet('page', 1);
+            ->assertSet('customPage', 1);
     }
 }
 
-class ComponentWithPaginationStub extends Component
+class ComponentWithCustomPaginationStub extends Component
 {
     use WithPagination;
+
+    public $customPage = 1;
 
     public function render()
     {
         return view('show-name', ['name' => 'example']);
+    }
+
+    public function getPageName()
+    {
+        return 'customPage';
     }
 }

--- a/tests/Unit/ComponentMultiplePaginationTest.php
+++ b/tests/Unit/ComponentMultiplePaginationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use Livewire\WithPagination;
+
+class ComponentMultiplePaginationTest extends TestCase
+{
+    /** @test */
+    public function can_navigate_to_previous_page_on_both_pagination()
+    {
+        Livewire::test(ComponentWithMultiplePaginationStub::class)
+            ->set(['threadsListPage' => 2, 'messagesListPage' => 2])
+            ->call('previousPage','threadsListPage')
+            ->assertSet('threadsListPage', 1)
+
+            ->call('previousPage','messagesListPage')
+            ->assertSet('messagesListPage', 1);
+    }
+
+    /** @test */
+    public function can_navigate_to_next_page_on_both_pagination()
+    {
+        Livewire::test(ComponentWithMultiplePaginationStub::class)
+            ->call('nextPage', 'threadsListPage')
+            ->assertSet('threadsListPage', 2)
+
+            ->call('nextPage','messagesListPage')
+            ->assertSet('messagesListPage', 2);
+    }
+
+    /** @test */
+    public function can_navigate_to_specific_page_on_both_pagination()
+    {
+        Livewire::test(ComponentWithMultiplePaginationStub::class)
+            ->call('gotoPage',3,'threadsListPage')
+            ->assertSet('threadsListPage', 3)
+
+            ->call('gotoPage',5, 'messagesListPage')
+            ->assertSet('messagesListPage', 5);
+    }
+
+    /** @test */
+    public function previous_page_cannot_be_less_than_one_on_both_pagination()
+    {
+        Livewire::test(ComponentWithMultiplePaginationStub::class)
+            ->call('previousPage', 'threadsListPage')
+            ->assertSet('threadsListPage', 1)
+
+            ->call('previousPage', 'messagesListPage')
+            ->assertSet('messagesListPage', 1);
+    }
+
+    /** @test */
+    public function paginators_are_not_in_conflict()
+    {
+        Livewire::test(ComponentWithMultiplePaginationStub::class)
+            ->call('gotoPage',5,'threadsListPage')
+            ->assertSet('threadsListPage', 5)
+            ->assertSet('messagesListPage', 1)
+
+            ->call('gotoPage',3, 'messagesListPage')
+            ->assertSet('messagesListPage', 3)
+            ->assertSet('threadsListPage', 5);
+    }
+}
+
+class ComponentWithMultiplePaginationStub extends Component
+{
+    use WithPagination;
+
+    public $threadsListPage = 1;
+    public $messagesListPage = 1;
+
+    public function render()
+    {
+        return view('show-name', ['name' => 'example']);
+    }
+
+    public function getPaginatorNames()
+    {
+        return ['threadsListPage', 'messagesListPage'];
+    }
+}

--- a/tests/Unit/ComponentMultiplePaginationTest.php
+++ b/tests/Unit/ComponentMultiplePaginationTest.php
@@ -74,13 +74,10 @@ class ComponentWithMultiplePaginationStub extends Component
     public $threadsListPage = 1;
     public $messagesListPage = 1;
 
+    protected $paginatorNames = ['threadsListPage', 'messagesListPage'];
+
     public function render()
     {
         return view('show-name', ['name' => 'example']);
-    }
-
-    public function getPaginatorNames()
-    {
-        return ['threadsListPage', 'messagesListPage'];
     }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yes, it's a wanted feature, multiple PR has previously opened and closed due to API breaking change.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, but it's an extension of a previous mandatory PR #2663 . I've spitted them as even if this one is not merged, the previous one is still a nice feature to have.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes, unit and browser

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
This PR gives us the ability to manage multiple pagination in a single component, using different properties to store the different page state and an array to store the name of each paginator:
```php
class ComponentWithMultiplePaginationStub extends Component
{
    use WithPagination;

    public $postsPage = 1;

    protected $paginatorNames = ['page', 'postsPage'];

    public function render()
    {
        return view('show-name'[
            'posts' => Post::paginate(3, ['*'], 'postsPage'),
            'messages' => Message::paginate(3), // Will use the default $page attribute
        ]);
    }
}
```

The initial API is not broken, we now can just pass an additional parameter to select the paginator we want to increment/decrement or change:
```html
// Old API still work, it still modify the $page attribute
<button wire:click="previousPage"></button>
<button wire:click="nextPage"></button>
<button wire:click="goToPage(3)"></button>

// New API for multiple paginator component:
<button wire:click="previousPage('postsPage')"></button>
<button wire:click="nextPage('postsPage')"></button>
<button wire:click="goToPage(3, 'postsPage')"></button>
```

Ping @mokhosh as I felt he was in demand of this feature.

5️⃣ Thanks for contributing! 🙌
Hopefully it will help some of us :)