### PR TITLE
WIP - test(dusk): allow custom path for web drivers

### DIFF
--- a/tests/Browser/SupportsSafari.php
+++ b/tests/Browser/SupportsSafari.php
@@ -2,31 +2,25 @@
 
 namespace Tests\Browser;
 
+use Symfony\Component\Process\Process;
+
 // Thanks to https://github.com/appstract/laravel-dusk-safari for most of this source.
 trait SupportsSafari
 {
-    protected static $safariProcess;
+    protected static $safariDriver = '/usr/bin/safaridriver';
 
-    /** @beforeClass */
-    public static function prepare()
-    {
-        if (static::$useSafari) {
-            static::startSafariDriver();
-        } else {
-            static::startChromeDriver(['port' => 9515]);
-        }
-    }
+    protected static $safariProcess;
 
     public function onlyRunOnChrome()
     {
         static::$useSafari && $this->markTestSkipped();
     }
 
-    public static function startSafariDriver()
+    public static function startSafariDriver(array $arguments = [])
     {
-        static::$safariProcess = new \Symfony\Component\Process\Process([
-            '/usr/bin/safaridriver', '-p 9515',
-        ]);
+        static::$safariProcess = new Process(
+            array_merge([static::$safariDriver], $arguments)
+        );
 
         static::$safariProcess->start();
 
@@ -35,5 +29,10 @@ trait SupportsSafari
                 static::$safariProcess->stop();
             }
         });
+    }
+
+    public static function useSafaridriver($path)
+    {
+        static::$safariDriver = $path;
     }
 }

--- a/tests/Browser/TestCase.php
+++ b/tests/Browser/TestCase.php
@@ -33,6 +33,18 @@ class TestCase extends BaseTestCase
 
     public static $useSafari = false;
 
+    /** @beforeClass */
+    public static function prepare()
+    {
+        if (static::$useSafari) {
+            // static::useSafaridriver('/usr/bin/safaridriver');
+            static::startSafariDriver('-p 9515');
+        } else {
+            // static::useChromedriver('/usr/bin/chromedriver');
+            static::startChromeDriver(['--port=9515']);
+        }
+    }
+
     public function setUp(): void
     {
         // DuskOptions::withoutUI();


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
I wanted to run browser tests locally and i had same error as [this issue comment](https://github.com/livewire/livewire/issues/1765#issuecomment-725331231). (chrome version error)

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope, it only refactor web driver process creation code.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
It is part of browser testing setup.
By default it will attempt to run the chromedriver packaged with current dev. requirements. I guess (but i may be wrong) it is working in github action because the running image has the previous versions of chrome available.

On your workstation, you may (like myself) have the lastest chrome installed with [latest chrome drivers](https://chromedriver.chromium.org/downloads); When i attempt to run locally a browser test; i get an exception like :

```
Facebook\WebDriver\Exception\SessionNotCreatedException: session not created: Chrome version must be between 70 and 73
  (Driver info: chromedriver=2.45.615279 (12b89733300bd268cff3b78fc76cb8f3a7cc44e5),platform=Linux 4.19.0-14-amd64 x86_64)
```

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

It adds a simple way to specify your web driver binary path. Currently it is commented in the `TestCase.php` file, in the `prepare()` static method. (i moved `prepare()` from SupportsSafari trait to TestCase class, i think it is a proper location)

You can specify custom Safari or Chrome driver respectivelly using `static::useSafaridriver('/path/to/bin/safaridriver')` and `static::useChromedriver('/path/to/bin/chromedriver')`.

---

This pull request is a work on progress, i need some suggestion on best/proper way to :

* Specify if browser tests are run using Safari or Chrome driver __without__ editing `TestCase.php`
* Specify Safari or Chrome driver custom path __without__ editing `TestCase.php`

Maybe using ENV variable ? add commented available ENV variables in a phpunit.xml.dist file ? (and add phpunit.xml in git ignore file ?), so you can copy phpunit.xml.dist to phpunit.xml and edit it.

Or should we keep it commented as is for now in the `TestCase.php` file ?
