### PR TITLE
Avoid exception for unsupported HTTP methods

### DIFF
--- a/src/RenameMe/SupportBrowserHistory.php
+++ b/src/RenameMe/SupportBrowserHistory.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Routing\UrlGenerator;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use function Livewire\str;
 
 class SupportBrowserHistory
@@ -73,7 +74,7 @@ class SupportBrowserHistory
             return app('router')->getRoutes()->match(
                 Request::create($referer, Livewire::originalMethod())
             );
-        } catch (NotFoundHttpException $e) {
+        } catch (NotFoundHttpException|MethodNotAllowedHttpException $e) {
             // If not, use the current route.
             return app('router')->current();
         }

--- a/tests/Browser/DynamicComponentLoading/ClickableComponent.php
+++ b/tests/Browser/DynamicComponentLoading/ClickableComponent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Browser\DynamicComponentLoading;
+
+use Illuminate\Support\Facades\View;
+use Livewire\Component as BaseComponent;
+
+class ClickableComponent extends BaseComponent
+{
+    public $success = false;
+
+    public function clickMe()
+    {
+        // Calling this method should never fail, even if the component is loaded dynamically via POST.
+        // By setting the component property here, we can draw the final message for the test to succeed.
+
+        $this->success = true;
+    }
+
+    public function render()
+    {
+        return View::file(__DIR__.'/view-clickable-component.blade.php');
+    }
+}

--- a/tests/Browser/DynamicComponentLoading/Test.php
+++ b/tests/Browser/DynamicComponentLoading/Test.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Browser\DynamicComponentLoading;
+
+use Illuminate\Support\Facades\File;
+use Laravel\Dusk\Browser;
+use Tests\Browser\TestCase;
+
+class Test extends TestCase
+{
+    public function test_that_component_loaded_dynamically_via_post_action_causes_no_method_not_allowed()
+    {
+        File::makeDirectory($this->livewireClassesPath('App'), 0755, true);
+
+        $this->browse(function (Browser $browser) {
+            $browser->visit(route('load-dynamic-component', [], false))
+                ->waitForText('Step 1 Active')
+                ->waitFor('#click_me')
+                ->click('#click_me')
+                ->waitForText('Test succeeded')
+                ->assertSee('Test succeeded');
+        });
+    }
+}

--- a/tests/Browser/DynamicComponentLoading/view-clickable-component.blade.php
+++ b/tests/Browser/DynamicComponentLoading/view-clickable-component.blade.php
@@ -1,0 +1,7 @@
+<div>
+    <button id="click_me" wire:click="clickMe">Click me</button>
+
+    @if($success)
+        <h1>Test succeeded</h1>
+    @endif
+</div>

--- a/tests/Browser/DynamicComponentLoading/view-dynamic-component.blade.php
+++ b/tests/Browser/DynamicComponentLoading/view-dynamic-component.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.app-for-normal-views')
+
+@section('content')
+    <div>
+        @livewire(\Tests\Browser\DynamicComponentLoading\ClickableComponent::class)
+    </div>
+@endsection

--- a/tests/Browser/DynamicComponentLoading/view-load-dynamic-component.blade.php
+++ b/tests/Browser/DynamicComponentLoading/view-load-dynamic-component.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app-for-normal-views')
+
+@section('content')
+    <div>
+        <h1>Step 1 Active</h1>
+
+        <div id="load_target"></div>
+    </div>
+@endsection
+
+@push('scripts')
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function(event) {
+            fetch('{{ route("dynamic-component") }}', { 
+                method: 'POST',
+                headers: {
+                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                }
+            })
+                .then(res => res.text())
+                .then(res => document.getElementById('load_target').innerHTML = res)
+                .then(x => window.livewire.rescan());
+        });
+    </script>
+@endpush

--- a/tests/Browser/TestCase.php
+++ b/tests/Browser/TestCase.php
@@ -23,6 +23,7 @@ use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Illuminate\Foundation\Auth\User as AuthUser;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\Dusk\Options as DuskOptions;
 use Orchestra\Testbench\Dusk\TestCase as BaseTestCase;
 use Tests\Browser\Security\Component as SecurityComponent;
@@ -88,6 +89,16 @@ class TestCase extends BaseTestCase
                 '/livewire-dusk/tests/browser/sync-history-with-optional-parameter/{step?}',
                 \Tests\Browser\SyncHistory\ComponentWithOptionalParameter::class
             )->middleware('web')->name('sync-history-with-optional-parameter');
+
+            // The following two routes belong together. The first one serves a view which in return
+            // loads and renders a component dynamically. There may not be a POST route for the first one.
+            Route::get('/livewire-dusk/tests/browser/load-dynamic-component', function () {
+                return View::file(__DIR__ . '/DynamicComponentLoading/view-load-dynamic-component.blade.php');
+            })->middleware('web')->name('load-dynamic-component');
+
+            Route::post('/livewire-dusk/tests/browser/dynamic-component', function () {
+                return View::file(__DIR__ . '/DynamicComponentLoading/view-dynamic-component.blade.php');
+            })->middleware('web')->name('dynamic-component');
 
             Route::get('/livewire-dusk/{component}', function ($component) {
                 $class = urldecode($component);

--- a/tests/Browser/views/layouts/app-for-normal-views.blade.php
+++ b/tests/Browser/views/layouts/app-for-normal-views.blade.php
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    @livewireStyles
+</head>
+<body>
+    @yield('content')
+
+    @livewireScripts
+    @stack('scripts')
+</body>
+</html>


### PR DESCRIPTION
Working with the browser history for dynamically loaded components is currently broken. Assume we have a route `GET foo/bar` rendering a view, which in return uses `POST biz/baz` (via ajax) to load Livewire components dynamically. Then actions of the component will send `foo/bar` as `Referer` in the header but `POST` and `biz/baz` as `fingerprint` in the body.

This seems totally right, as the referer is what the user sees in their browser and `POST biz/baz` is the route which generated the component in the first place. The Symfony router will throw a `MethodNotAllowedHttpException` though if the route exists and the method is not allowed. In my opinion, a not supported method is a sub-case of `NotFoundHttpException` - but the exception class inheritance says otherwise. Therefore the PR adds `MethodNotAllowedHttpException` to the `catch` clause.

I'm not sure if this fix could potentially cause issues in other areas.

## Background

I have a simple `GET /list` route which renders a [DataTable](https://datatables.net/). The DataTable uses `POST` to retrieve data, but from another route than `/list` (because there are multiple such tables on the same page). Some of the tables contain Livewire components in the response (which works totally fine by the way, all that's needed is a `window.livewire.rescan()` after drawing the table). If a component contains a button to trigger a server-side action, clicking the button will cause the issue described above.