### PR TITLE
Octane Prep

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -72,12 +72,14 @@ class LivewireServiceProvider extends ServiceProvider
         // Bypass specific middlewares during Livewire requests.
         // These are usually helpful during a typical request, but
         // during Livewire requests, they can damage data properties.
-        $this->bypassTheseMiddlewaresDuringLivewireRequests([
-            TrimStrings::class,
-            ConvertEmptyStringsToNull::class,
-            // If the app overrode "TrimStrings".
-            \App\Http\Middleware\TrimStrings::class,
-        ]);
+        if (! $this->attemptToBypassRequestModifyingMiddlewareViaCallbacks()) {
+            $this->bypassTheseMiddlewaresDuringLivewireRequests([
+                TrimStrings::class,
+                ConvertEmptyStringsToNull::class,
+                // If the app overrode "TrimStrings".
+                \App\Http\Middleware\TrimStrings::class,
+            ]);
+        }
     }
 
     protected function registerLivewireSingleton()
@@ -322,6 +324,24 @@ class LivewireServiceProvider extends ServiceProvider
                 [CallHydrationHooks::class, 'initialHydrate'],
 
         ]);
+    }
+
+    protected function attemptToBypassRequestModifyingMiddlewareViaCallbacks()
+    {
+        if (method_exists(TrimStrings::class, 'skipWhen') &&
+            method_exists(ConvertEmptyStringsToNull::class, 'skipWhen')) {
+            TrimStrings::skipWhen(function () {
+                return Livewire::isProbablyLivewireRequest();
+            });
+
+            ConvertEmptyStringsToNull::skipWhen(function () {
+                return Livewire::isProbablyLivewireRequest();
+            });
+
+            return true;
+        }
+
+        return false;
     }
 
     protected function bypassTheseMiddlewaresDuringLivewireRequests(array $middlewareToExclude)


### PR DESCRIPTION
So far, this is all I have found that needs to be changed to prepare Livewire for Octane. These methods will be tagged in an official release on Tuesday (4/6).

I don't have a *huge* understanding of the rest of Livewire but nothing else has jumped out at me so far as needing adjustment. The liberal use of `app()` and `request()` actually helps a lot in terms of Octane preparation since those will always return the latest instance of the container and the request.

Can you think of anywhere else in Livewire where you may keep the request or container around as state such that they could be stale on a subsequent request? Or anywhere where a component is kept around as state that could leak into the next request? Or anything that adds data to a static array on a property on each request?