### PR TITLE
Add docblock tags to provide auto-completion in IDE's

### DIFF
--- a/src/Livewire.php
+++ b/src/Livewire.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static void component($alias, $viewClass)
  * @method static \Livewire\Testing\TestableLivewire test($name, $params = [])
+ * @method static \Livewire\LivewireManager actingAs($user, $driver = null)
  *
  * @see \Livewire\LivewireManager
  */

--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -15,6 +15,7 @@ use Livewire\LivewireManager;
 
 use function Livewire\str;
 
+/** @mixin \Illuminate\Testing\TestResponse */
 class TestableLivewire
 {
     protected static $instancesById = [];


### PR DESCRIPTION
When writing tests it's always slightly bothered me that it doesn't autocomplete the assertion methods, so I figured I'd make this PR that adds the necessary Docblock tags to fix that.