### PR TITLE
Add helper method for making custom component assertions

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Testing\Concerns;
 
+use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
@@ -278,6 +279,13 @@ trait MakesAssertions
         } else {
             PHPUnit::assertEquals($value, $this->lastRenderedView->gatherData()[$key]);
         }
+
+        return $this;
+    }
+    
+    public function assertComponent(Closure $closure)
+    {
+        $closure($this->viewData('_instance'));
 
         return $this;
     }


### PR DESCRIPTION
This is just a convenience method for this:
```php
$component = Livewire::test(Foo::class);

$response = $component->viewData('_instance')->someMethod();

$this->assertEquals('bar', $response);
```
So now you can keep the conga line going 😎 
```php
Livewire::test(Foo::class)
    ->assertComponent(function ($component) {
        $this->assertEquals('bar', $component->someMethod());
    })
    ->call('keepOnGoing');
```