### PR TITLE
Add support for history sync with optional route parameters

### DIFF
--- a/src/RenameMe/SupportBrowserHistory.php
+++ b/src/RenameMe/SupportBrowserHistory.php
@@ -92,7 +92,7 @@ class SupportBrowserHistory
             // If the component is registered using `Route::get()`.
             && str($action)->contains(get_class($component))
             // AND, the component is tracking route params as its public properties
-            && count(array_intersect_key($component->getPublicPropertiesDefinedBySubClass(), $route->parametersWithoutNulls()))
+            && count(array_intersect_key($component->getPublicPropertiesDefinedBySubClass(), array_flip($route->parameterNames())))
         ) {
             return true;
         }
@@ -127,7 +127,7 @@ class SupportBrowserHistory
             $route->parametersWithoutNulls(),
             array_intersect_key(
                 $component->getPublicPropertiesDefinedBySubClass(),
-                $route->parametersWithoutNulls()
+                array_flip($route->parameterNames())
             )
         );
 

--- a/tests/Browser/SyncHistory/ComponentWithOptionalParameter.php
+++ b/tests/Browser/SyncHistory/ComponentWithOptionalParameter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Browser\SyncHistory;
+
+use Illuminate\Support\Facades\View;
+use Livewire\Component as BaseComponent;
+
+class ComponentWithOptionalParameter extends BaseComponent
+{
+    public $step;
+
+    public function mount(Step $step)
+    {
+        $this->step = $step;
+    }
+
+    public function setStep($id)
+    {
+        $this->step = Step::findOrFail($id);
+    }
+
+    public function render()
+    {
+        return View::file(__DIR__.'/view-without-subcomponent.blade.php')->with([ 'id' => $this->id]);
+    }
+}

--- a/tests/Browser/SyncHistory/Test.php
+++ b/tests/Browser/SyncHistory/Test.php
@@ -223,11 +223,13 @@ class Test extends TestCase
     public function test_optional_route_bound_properties_are_synced_with_browser_history()
     {
         $this->browse(function(Browser $browser) {
-            $browser->visit(route('sync-history-with-optional-parameter', [], false))->waitForText('Activate Step 1');
-
-            $browser->waitForLivewire()->click('@step-1')->assertRouteIs('sync-history-with-optional-parameter', [ 'step' => 1 ]);
-
-            $browser->back()->assertRouteIs('sync-history-with-optional-parameter', []);
+            $browser->visit(route('sync-history-with-optional-parameter', [], false))
+                ->waitForText('Activate Step 1')
+                ->waitForLivewire()
+                ->click('@step-1')
+                ->assertRouteIs('sync-history-with-optional-parameter', [ 'step' => 1 ])
+                ->back()
+                ->assertRouteIs('sync-history-with-optional-parameter', []);
         });
     }
 }

--- a/tests/Browser/SyncHistory/Test.php
+++ b/tests/Browser/SyncHistory/Test.php
@@ -219,4 +219,15 @@ class Test extends TestCase
             ;
         });
     }
+
+    public function test_optional_route_bound_properties_are_synced_with_browser_history()
+    {
+        $this->browse(function(Browser $browser) {
+            $browser->visit(route('sync-history-with-optional-parameter', [], false))->waitForText('Activate Step 1');
+
+            $browser->waitForLivewire()->click('@step-1')->assertRouteIs('sync-history-with-optional-parameter', [ 'step' => 1 ]);
+
+            $browser->back()->assertRouteIs('sync-history-with-optional-parameter', []);
+        });
+    }
 }

--- a/tests/Browser/TestCase.php
+++ b/tests/Browser/TestCase.php
@@ -84,6 +84,11 @@ class TestCase extends BaseTestCase
                 \Tests\Browser\SyncHistory\ComponentWithoutQueryString::class
             )->middleware('web')->name('sync-history-without-query-string');
 
+            Route::get(
+                '/livewire-dusk/tests/browser/sync-history-with-optional-parameter/{step?}',
+                \Tests\Browser\SyncHistory\ComponentWithOptionalParameter::class
+            )->middleware('web')->name('sync-history-with-optional-parameter');
+
             Route::get('/livewire-dusk/{component}', function ($component) {
                 $class = urldecode($component);
 

--- a/tests/Browser/console/.gitignore
+++ b/tests/Browser/console/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Browser/screenshots/.gitignore
+++ b/tests/Browser/screenshots/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Browser/source/.gitignore
+++ b/tests/Browser/source/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
History sync for full-page Livewire components with optional route-parameters appears to be broken  (#2710)

This PR fixes that.

Tests have been included to demonstrate the problem.