### PR TITLE
Add nullable as a default validation rule when property is not in the rules array

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -138,7 +138,7 @@ trait ValidatesInput
 
     public function missingRuleFor($dotNotatedProperty)
     {
-        return ! $this->hasRuleFor($dotNotatedProperty);
+        return !$this->hasRuleFor($dotNotatedProperty);
     }
 
     public function validate($rules = null, $messages = [], $attributes = [])
@@ -168,6 +168,10 @@ trait ValidatesInput
         $rulesForField = collect($rules)->filter(function ($rule, $fullFieldKey) use ($field) {
             return str($field)->is($fullFieldKey);
         })->toArray();
+
+        if (empty($rulesForField)) {
+            $rulesForField[$field] = "nullable";
+        }
 
         $ruleKeysForField = array_keys($rulesForField);
 
@@ -236,7 +240,7 @@ trait ValidatesInput
             ->each(function ($ruleKey) use ($properties) {
                 $propertyName = $this->beforeFirstDot($ruleKey);
 
-                throw_unless(array_key_exists($propertyName, $properties), new \Exception('No property found for validation: ['.$ruleKey.']'));
+                throw_unless(array_key_exists($propertyName, $properties), new \Exception('No property found for validation: [' . $ruleKey . ']'));
             });
 
         return collect($properties)->map(function ($value) {

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -153,6 +153,20 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
+    public function validating_only_a_specific_field_will_throw_expected_errors__if_the_field_doesnt_exist()
+    {
+        $component = Livewire::test(ForValidation::class);
+
+        $component
+            ->set('foo', '')
+            ->set('bar', '')
+            ->call('runValidationOnlyWithMissingPropertyRules', 'foo')
+            ->call('runValidationOnlyWithMissingPropertyRules', 'bar')
+            ->assertSee('The foo field is required')
+            ->assertDontSee('The bar field is required');
+    }
+
+    /** @test */
     public function can_validate_only_a_specific_field_with_custom_message_property()
     {
         $component = Livewire::test(ForValidation::class);
@@ -431,6 +445,13 @@ class ForValidation extends Component
         ]);
     }
 
+    public function runValidationOnlyWithMissingPropertyRules($field)
+    {
+        $this->validateOnly($field, [
+            'foo' => 'required',
+        ]);
+    }
+
     public function runValidationOnlyWithCustomValidation($field)
     {
         $this->validateOnly($field, [
@@ -443,8 +464,8 @@ class ForValidation extends Component
                 'foo_length' => strlen($this->foo),
                 'bar_length' => strlen($this->bar),
             ],
-            [ 'foo_length' => 'same:bar_length' ],
-            [ 'same' => 'Lengths must be the same' ]
+            ['foo_length' => 'same:bar_length'],
+            ['same' => 'Lengths must be the same']
         )->validate();
     }
 


### PR DESCRIPTION
**Issue**: You need to define all properties in the rules array even when that property is nullable when using `validateOnly` method.

In the following example we are missing the `company` property in the `$rules` array. If you have validation errors for the `email` field and then fill the `company` field in the form, all the errors will disappear.
```php
public $email;
public $company;

protected $rules = [
    'email' => 'required|email',
];
```

This will empty the error bag if the `$propertyName` is `company`.
```php
public function updated($propertyName)
{
    $this->validateOnly($propertyName);
}
```

HTML
```html
<form wire:submit.prevent="submit">
    <input type="text" wire:model="email">
    @error('email') <span class="error">{{ $message }}</span> @enderror

    <input type="text" wire:model="company">
    @error('company') <span class="error">{{ $message }}</span> @enderror

    <button type="submit">Save Contact</button>
</form>
```

This is an issue specially when you are using `debounce` in your `wire:model` and your user use `tab` to the next field and type something.

This can be fixed just adding the property to the `$rules` array as `nullable` but that's annoying :D

```php
protected $rules = [
    'email' => 'required|email',
   'company' => 'nullable'
];
```