### PR TITLE
Ignore blade files for Github linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,6 @@
 /tests              export-ignore
 /.editorconfig      export-ignore
 /github_banner.png  export-ignore
+
+# Ignore blade files
+*.blade.php linguist-vendored


### PR DESCRIPTION
I guess it's better not to show blade language in GitHub as the first language.
With this one line GitHub will ignore *.blade.php files to calculate the first lang!