### PR TITLE
poll if any part is visible, not if every part is visible

### DIFF
--- a/js/component/Polling.js
+++ b/js/component/Polling.js
@@ -73,9 +73,9 @@ function inViewport(el) {
     var bounding = el.getBoundingClientRect();
 
     return (
-        bounding.top >= 0 &&
-        bounding.left >= 0 &&
-        bounding.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-        bounding.right <= (window.innerWidth || document.documentElement.clientWidth)
+        bounding.top < (window.innerHeight || document.documentElement.clientHeight) &&
+        bounding.left < (window.innerWidth || document.documentElement.clientWidth) &&
+        bounding.bottom > 0 &&
+        bounding.right > 0
     );
 }


### PR DESCRIPTION
The https://github.com/livewire/livewire/pull/2560 PR added ability to poll only when the element is visible, but it currently checks if all of the element is inside the boundaries of the viewport. I've changed it so it checks if any part of the element is visible.

For example if you have a section that is slightly longer than viewport's hight, it will never do the poll because the bounding box will never fully fit within the page.