### PR TITLE
Add params method to view macros

### DIFF
--- a/src/Macros/ViewMacros.php
+++ b/src/Macros/ViewMacros.php
@@ -38,6 +38,18 @@ class ViewMacros
         };
     }
 
+    public function params()
+    {
+        return function ($params = []) {
+
+            $this->livewireLayout = [
+                'params' => $params,
+            ];
+
+            return $this;
+        };
+    }
+
     public function section()
     {
         return function ($section) {

--- a/tests/Unit/ComponentLayoutTest.php
+++ b/tests/Unit/ComponentLayoutTest.php
@@ -59,6 +59,28 @@ class ComponentLayoutTest extends TestCase
             ->assertSee('bar')
             ->assertSee('baz');
     }
+
+    /** @test */
+    public function can_show_the_params()
+    {
+        Livewire::component(ComponentWithCustomParams::class);
+
+        Route::get('/foo', ComponentWithCustomParams::class);
+
+        $this->withoutExceptionHandling()->get('/foo')
+            ->assertSee('foo');
+    }
+
+    /** @test */
+    public function can_show_params_with_custom_layout()
+    {
+        Livewire::component(ComponentWithCustomParamsAndLayout::class);
+
+        Route::get('/foo', ComponentWithCustomParamsAndLayout::class);
+
+        $this->withoutExceptionHandling()->get('/foo')
+            ->assertSee('foo');
+    }
 }
 
 class ComponentWithExtendsLayout extends Component
@@ -107,6 +129,26 @@ class ComponentWithClassBasedComponentLayout extends Component
     {
         return view('null-view')->layout(\Tests\AppLayout::class, [
             'bar' => 'baz'
+        ]);
+    }
+}
+
+class ComponentWithCustomParams extends Component
+{
+    public function render()
+    {
+        return view('null-view')->params([
+            'slot' => 'foo'
+        ]);
+    }
+}
+
+class ComponentWithCustomParamsAndLayout extends Component
+{
+    public function render()
+    {
+        return view('null-view')->layout('layouts.app-custom-slot')->params([
+            'main' => 'foo',
         ]);
     }
 }


### PR DESCRIPTION
In some cases we just need to pass some data like the title to the base layout and now to do that in Livewire we have to use `layout` method then pass the params as the second param like this : 

```php
return view('login')->layout('layouts.app', [
    'title' => 'Login Page'
]);
```

With these changes, we will be able to use a syntax like this:
```php
return view('login')->params([
    'title' => 'Login Page'
]);
```
Also, all tests have been passed and new tests have been written!