### PR TITLE
Support using class names with assertSeeLivewire

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -165,6 +165,10 @@ class LivewireServiceProvider extends ServiceProvider
     {
         // Usage: $this->assertSeeLivewire('counter');
         TestResponse::macro('assertSeeLivewire', function ($component) {
+            if (class_exists($component)) {
+                $component = (new $component())::getName();
+            }
+
             $escapedComponentName = trim(htmlspecialchars(json_encode(['name' => $component])), '{}');
 
             \PHPUnit\Framework\Assert::assertStringContainsString(
@@ -178,6 +182,10 @@ class LivewireServiceProvider extends ServiceProvider
 
         // Usage: $this->assertDontSeeLivewire('counter');
         TestResponse::macro('assertDontSeeLivewire', function ($component) {
+            if (class_exists($component)) {
+                $component = (new $component())::getName();
+            }
+
             $escapedComponentName = trim(htmlspecialchars(json_encode(['name' => $component])), '{}');
 
             \PHPUnit\Framework\Assert::assertStringNotContainsString(

--- a/tests/Unit/LivewireDirectivesTest.php
+++ b/tests/Unit/LivewireDirectivesTest.php
@@ -6,6 +6,7 @@ use Livewire\Livewire;
 use Livewire\Component;
 use Illuminate\Testing\TestResponse;
 use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\ExpectationFailedException;
 
 class LivewireDirectivesTest extends TestCase
 {
@@ -41,6 +42,63 @@ class LivewireDirectivesTest extends TestCase
     }
 
     /** @test */
+    public function can_assert_see_livewire_on_standard_blade_view_using_class_name()
+    {
+        Artisan::call('make:livewire', ['name' => 'foo']);
+
+        $fakeClass = new class {
+            public function getContent()
+            {
+                return view('render-component', [
+                    'component' => 'foo',
+                ])->render();
+            }
+        };
+
+        $testResponse = new TestResponse($fakeClass);
+
+        $testResponse->assertSeeLivewire(\App\Http\Livewire\Foo::class);
+    }
+
+    /** @test */
+    public function assert_see_livewire_fails_when_the_component_is_not_present()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        Artisan::call('make:livewire', ['name' => 'foo']);
+
+        $fakeClass = new class {
+            public function getContent()
+            {
+                return view('null-view')->render();
+            }
+        };
+
+        $testResponse = new TestResponse($fakeClass);
+
+        $testResponse->assertSeeLivewire('foo');
+    }
+
+    /** @test */
+    public function assert_see_livewire_fails_when_the_component_is_not_present_using_class_name()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        Artisan::call('make:livewire', ['name' => 'foo']);
+
+        $fakeClass = new class {
+            public function getContent()
+            {
+                return view('null-view')->render();
+            }
+        };
+
+        $testResponse = new TestResponse($fakeClass);
+
+        $testResponse->assertSeeLivewire(\App\Http\Livewire\Foo::class);
+    }
+
+    /** @test */
     public function can_assert_dont_see_livewire_on_standard_blade_view()
     {
         $fakeClass = new class {
@@ -53,6 +111,65 @@ class LivewireDirectivesTest extends TestCase
         $testResponse = new TestResponse($fakeClass);
 
         $testResponse->assertDontSeeLivewire('foo');
+    }
+
+    /** @test */
+    public function assert_dont_see_livewire_fails_when_the_component_is_present()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        Artisan::call('make:livewire', ['name' => 'foo']);
+
+        $fakeClass = new class {
+            public function getContent()
+            {
+                return view('render-component', [
+                    'component' => 'foo',
+                ])->render();
+            }
+        };
+
+        $testResponse = new TestResponse($fakeClass);
+
+        $testResponse->assertDontSeeLivewire('foo');
+    }
+
+    /** @test */
+    public function assert_dont_see_livewire_fails_when_the_component_is_present_using_class_name()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        Artisan::call('make:livewire', ['name' => 'foo']);
+
+        $fakeClass = new class {
+            public function getContent()
+            {
+                return view('render-component', [
+                    'component' => 'foo',
+                ])->render();
+            }
+        };
+
+        $testResponse = new TestResponse($fakeClass);
+
+        $testResponse->assertDontSeeLivewire(\App\Http\Livewire\Foo::class);
+    }
+
+    /** @test */
+    public function can_assert_dont_see_livewire_on_standard_blade_view_using_class_name()
+    {
+        Artisan::call('make:livewire', ['name' => 'foo']);
+
+        $fakeClass = new class {
+            public function getContent()
+            {
+                return view('null-view')->render();
+            }
+        };
+
+        $testResponse = new TestResponse($fakeClass);
+
+        $testResponse->assertDontSeeLivewire(\App\Http\Livewire\Foo::class);
     }
 
     /** @test */


### PR DESCRIPTION
In this PR, I added a few lines to support passing a component class string when calling `assertSeeLivewire()` and `assertDontSeeLivewire()`. I also added some additional test coverage for these two methods. Let me know if these tests would be more appropriate in the `LivewireTestingTest` class or somewhere else.
