### PR TITLE
Improve assertSeeLivewire

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -169,8 +169,8 @@ class LivewireServiceProvider extends ServiceProvider
     {
         // Usage: $this->assertSeeLivewire('counter');
         TestResponse::macro('assertSeeLivewire', function ($component) {
-            if (class_exists($component)) {
-                $component = (new $component())::getName();
+            if (is_subclass_of($component, Component::class)) {
+                $component = $component::getName();
             }
 
             $escapedComponentName = trim(htmlspecialchars(json_encode(['name' => $component])), '{}');
@@ -186,8 +186,8 @@ class LivewireServiceProvider extends ServiceProvider
 
         // Usage: $this->assertDontSeeLivewire('counter');
         TestResponse::macro('assertDontSeeLivewire', function ($component) {
-            if (class_exists($component)) {
-                $component = (new $component())::getName();
+            if (is_subclass_of($component, Component::class)) {
+                $component = $component::getName();
             }
 
             $escapedComponentName = trim(htmlspecialchars(json_encode(['name' => $component])), '{}');


### PR DESCRIPTION
Follow up for #2754 

make sure the given string extends a livewire component
don't instantiate the component to get its name