### PR TITLE
Add assertFileDownloaded test helper

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -281,4 +281,23 @@ trait MakesAssertions
 
         return $this;
     }
+
+    public function assertFileDownloaded($filename, $content = null)
+    {
+        PHPUnit::assertEquals(
+            $filename,
+            data_get($this->lastResponse, 'original.effects.download.name')
+        );
+
+        if ($content) {
+            $downloadedContent = data_get($this->lastResponse, 'original.effects.download.content');
+
+            PHPUnit::assertEquals(
+                $content,
+                base64_decode($downloadedContent)
+            );
+        }
+
+        return $this;
+    }
 }


### PR DESCRIPTION
This PR adds an `assertFileDownloaded` test helper.

Usage:

```php
/** @test */
public function a_file_can_be_downloaded ()
{
       // ... Do some stuff

        Livewire::actingAs($user)
            ->test(TestComponent::class)
            ->call('download')
            ->assertFileDownloaded('Test file.txt', 'Hello world');
}
```