### PR TITLE
Fixed: Livewire subcomponent clears render context after it is finished

### DIFF
--- a/src/ComponentConcerns/RendersLivewireComponents.php
+++ b/src/ComponentConcerns/RendersLivewireComponents.php
@@ -12,28 +12,26 @@ use Throwable;
 
 trait RendersLivewireComponents
 {
-    protected $livewireComponent;
-    protected $isRenderingLivewireComponent = false;
+    protected $livewireComponents = [];
 
     public function startLivewireRendering($component)
     {
-        $this->livewireComponent = $component;
-        $this->isRenderingLivewireComponent = true;
+        $this->livewireComponents[] = $component;
     }
 
     public function endLivewireRendering()
     {
-        $this->isRenderingLivewireComponent = false;
+        array_pop($this->livewireComponents);
     }
 
-    public function setLivewireComponent($component)
+    public function isRenderingLivewireComponent()
     {
-        $this->livewireComponent = $component;
+        return ! empty($this->livewireComponents);
     }
 
     protected function evaluatePath($__path, $__data)
     {
-        if (! $this->isRenderingLivewireComponent) {
+        if (! $this->isRenderingLivewireComponent()) {
             return parent::evaluatePath($__path, $__data);
         }
 
@@ -48,7 +46,7 @@ trait RendersLivewireComponents
             \Closure::bind(function () use ($__path, $__data) {
                 extract($__data, EXTR_SKIP);
                 include $__path;
-            }, $this->livewireComponent ? $this->livewireComponent : $this)();
+            }, end($this->livewireComponents))();
         } catch (Exception $e) {
             $this->handleViewException($e, $obLevel);
         } catch (Throwable $e) {

--- a/tests/Browser/Nesting/RenderContextComponent.php
+++ b/tests/Browser/Nesting/RenderContextComponent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Browser\Nesting;
+
+use Livewire\Component as BaseComponent;
+
+class RenderContextComponent extends BaseComponent
+{
+    public $one = 'Blade 1';
+    public $two = 'Blade 2';
+    public $three = 'Blade 3';
+
+    public function render()
+    {
+        return <<< 'HTML'
+<div>
+    <x-blade-component dusk="output.blade-component1" property="one" />
+    <x-blade-component dusk="output.blade-component2" property="two" />
+
+    <div>
+        @livewire(Tests\Browser\Nesting\NestedComponent::class, ['output' => 'Sub render'])
+    </div>
+
+    <x-blade-component dusk="output.blade-component3" property="three" />
+</div>
+HTML;
+    }
+}

--- a/tests/Browser/Nesting/Test.php
+++ b/tests/Browser/Nesting/Test.php
@@ -36,4 +36,17 @@ class Test extends TestCase
             ;
         });
     }
+
+    /** @test */
+    public function it_returns_the_render_context_back_to_the_parent_component_after_sub_component_is_rendered()
+    {
+        $this->browse(function ($browser) {
+            Livewire::visit($browser, RenderContextComponent::class)
+                ->assertSeeIn('@output.blade-component1', 'Blade 1')
+                ->assertSeeIn('@output.blade-component2', 'Blade 2')
+                ->assertSeeIn('@output.nested', 'Sub render')
+                ->assertSeeIn('@output.blade-component3', 'Blade 3')
+            ;
+        });
+    }
 }

--- a/tests/Browser/views/components/blade-component.blade.php
+++ b/tests/Browser/views/components/blade-component.blade.php
@@ -1,0 +1,5 @@
+@props(['property'])
+
+<div {{ $attributes }}>
+    {{ $this->getPropertyValue($property) }}
+</div>


### PR DESCRIPTION
## Issue

This PR adds a failing test for the issue raised in #2313 and #2380.

If you make use of `$this` within a blade component to access the main Livewire component, it works fine. 

But when you add a Livewire subcomponent to the page and then try to add a blade component after the subcomponent that tries to access `$this` to access the main Livewire component, you get the following error
> Using $this when not in object context

This test demonstrates the issue.

## Cause

I have dug into what causes the issue, and the problem exists in Livewire's blade compiler engine.

What happens is in ComponentConcerns/RendersLivewireComponents.php the Livewire component is bound to the `$this` context.

At the top of the same function it does a check for `isRenderingLivewireComponent`, which if true, enables the render context to be set to the Livewire component, which is also applied to blade components.

https://github.com/livewire/livewire/blob/33101c83b75728651b9e668a4559f97def7c9138/src/ComponentConcerns/RendersLivewireComponents.php#L36-L51

The issue is though, that after a sub component is finished rendering it calls the `endLivewireRendering` method which sets `isRenderingLivewireComponent` to false.

https://github.com/livewire/livewire/blob/33101c83b75728651b9e668a4559f97def7c9138/src/ComponentConcerns/RendersLivewireComponents.php#L24-L27

This then stops the blade components from having this context set, throwing the above error as there is no `$this` set at all.

## Temporary Fix

As a temporary solution (note this is a hack as a word around for the moment), I have added a blade directive to my `AppServiceProvider`

```php
Blade::directive('livewireResetContext', function() {
  return '<?php app("view.engine.resolver")->resolve("blade")->startLivewireRendering($this); ?>';
});
```

Then in my Livewire component blade view, I add the call to that blade directive after any sub component
```blade
<livewire:subcomponent />
@livewireResetContext
```

## Possible Solution

To fix this, I think we need to change the boolean to an array and "stack" each components name into the array and use the last one as the context. Then when a component has finished it can pop itself off the end of the stack. The check can then see if there is anything left in the stack as to whether to bind a Livewire context or not.

The regular blade compiler makes use of a similar concept with `lastCompiled` where each view is pushed on to the "stack" (array) and removed once it has finished compiling.

Happy to give it a crack if you think it is suitable.

Hope this helps!