### PR TITLE
Allow to use ComponentName::class with emitTo method.

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -51,7 +51,19 @@ class Event
 
         if ($this->up) $output['ancestorsOnly'] = true;
         if ($this->self) $output['selfOnly'] = true;
-        if ($this->component) $output['to'] = $this->component;
+        if ($this->component) {
+            try {
+                if (app($this->component) instanceof Component) {
+                    info('entrou');
+                    $component = Str::afterLast($this->component, '\\');
+                    $this->component = Str::lower(preg_replace('/([a-zA-Z])(?=[A-Z])/', '$1-', $component));
+                }
+            } catch (\Exception $exception) {
+                //
+            }
+            
+            $output['to'] = $this->component;
+        }
 
         return $output;
     }

--- a/src/Event.php
+++ b/src/Event.php
@@ -54,17 +54,8 @@ class Event
         if ($this->up) $output['ancestorsOnly'] = true;
         if ($this->self) $output['selfOnly'] = true;
         if ($this->component) {
-            try {
-                if (app($this->component) instanceof Component) {
-                    $this->component = Str::lower(
-                        preg_replace(
-                            '/([a-zA-Z])(?=[A-Z])/', '$1-',
-                            Str::afterLast($this->component, '\\')
-                        )
-                    );
-                }
-            } catch (\Exception $exception) {
-                //
+            if (is_subclass_of($this->component, Component::class)) {
+                $this->component = $this->component::getName();
             }
 
             $output['to'] = $this->component;

--- a/src/Event.php
+++ b/src/Event.php
@@ -2,8 +2,6 @@
 
 namespace Livewire;
 
-use Illuminate\Support\Str;
-
 class Event
 {
     protected $name;

--- a/src/Event.php
+++ b/src/Event.php
@@ -2,6 +2,8 @@
 
 namespace Livewire;
 
+use Illuminate\Support\Str;
+
 class Event
 {
     protected $name;
@@ -54,14 +56,17 @@ class Event
         if ($this->component) {
             try {
                 if (app($this->component) instanceof Component) {
-                    info('entrou');
-                    $component = Str::afterLast($this->component, '\\');
-                    $this->component = Str::lower(preg_replace('/([a-zA-Z])(?=[A-Z])/', '$1-', $component));
+                    $this->component = Str::lower(
+                        preg_replace(
+                            '/([a-zA-Z])(?=[A-Z])/', '$1-',
+                            Str::afterLast($this->component, '\\')
+                        )
+                    );
                 }
             } catch (\Exception $exception) {
                 //
             }
-            
+
             $output['to'] = $this->component;
         }
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -51,13 +51,9 @@ class Event
 
         if ($this->up) $output['ancestorsOnly'] = true;
         if ($this->self) $output['selfOnly'] = true;
-        if ($this->component) {
-            if (is_subclass_of($this->component, Component::class)) {
-                $this->component = $this->component::getName();
-            }
-
-            $output['to'] = $this->component;
-        }
+        if ($this->component) $output['to'] = is_subclass_of($this->component, Component::class)
+            ? $this->component::getName()
+            : $this->component;
 
         return $output;
     }

--- a/tests/Unit/ComponentEventsTest.php
+++ b/tests/Unit/ComponentEventsTest.php
@@ -102,6 +102,16 @@ class ComponentEventsTest extends TestCase
                 ->emit('bob', 'lob')
                 ->assertSet('foo', 'lob');
     }
+
+    /** @test */
+    public function component_receives_events_emitted_using_classname()
+    {
+        $component = Livewire::test(ReceivesEvents::class);
+
+        $component->call('emitToComponentUsingClassname');
+
+        $this->assertTrue(in_array(['to' => 'it-can-receive-event-using-classname', 'event' => 'foo', 'params' => ['test']], $component->payload['effects']['emits']));
+    }
 }
 
 class ReceivesEvents extends Component
@@ -133,6 +143,11 @@ class ReceivesEvents extends Component
     public function emitToGooGone()
     {
         $this->emitTo('goo', 'gone', 'car');
+    }
+
+    public function emitToComponentUsingClassname()
+    {
+        $this->emitTo(ItCanReceiveEventUsingClassname::class, 'foo', 'test');
     }
 
     public function render()
@@ -188,6 +203,25 @@ class DispatchesBrowserEvents extends Component
     public function dispatchFoo()
     {
         $this->dispatchBrowserEvent('foo', ['bar' => 'baz']);
+    }
+
+    public function render()
+    {
+        return app('view')->make('null-view');
+    }
+}
+
+class ItCanReceiveEventUsingClassname extends Component {
+
+    public $bar;
+
+    public $listeners = [
+        'foo' => 'bar'
+    ];
+
+    public function onBar($value)
+    {
+        $this->bar = $value;
     }
 
     public function render()

--- a/tests/Unit/ComponentEventsTest.php
+++ b/tests/Unit/ComponentEventsTest.php
@@ -110,7 +110,7 @@ class ComponentEventsTest extends TestCase
 
         $component->call('emitToComponentUsingClassname');
 
-        $this->assertTrue(in_array(['to' => 'it-can-receive-event-using-classname', 'event' => 'foo', 'params' => ['test']], $component->payload['effects']['emits']));
+        $this->assertTrue(in_array(['to' => 'tests.unit.it-can-receive-event-using-classname', 'event' => 'foo', 'params' => ['test']], $component->payload['effects']['emits']));
     }
 }
 


### PR DESCRIPTION
This PR allows users to use the component classname when using `emitTo` method:

```php
$this->emitTo(TestComponent::class, 'testEvent')
```
It does not introduce any breaking changes, and it's beneficial if developers want to rename components and have many `emitTo` calls in their projects.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
**No.**

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
**Yes.**
