### PR TITLE
add config option for detecting serverless

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -110,4 +110,20 @@ return [
 
     'manifest_path' => null,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Serverless Identifier
+    |--------------------------------------------------------------------------
+    |
+    | This value is used to check the $_ENV['SERVER_SOFTWARE'] to determine
+    | the assets and manifest paths.
+    |
+    | Examples:
+    |       - for Laravel Vapor, it would be "vapor".
+    |       - for Bref, it would be "bref".
+    |
+    */
+
+    'serverless_identifier' => 'vapor',
+
 ];

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -110,20 +110,4 @@ return [
 
     'manifest_path' => null,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Serverless Identifier
-    |--------------------------------------------------------------------------
-    |
-    | This value is used to check the $_ENV['SERVER_SOFTWARE'] to determine
-    | the assets and manifest paths.
-    |
-    | Examples:
-    |       - for Laravel Vapor, it would be "vapor".
-    |       - for Bref, it would be "bref".
-    |
-    */
-
-    'serverless_identifier' => 'vapor',
-
 ];

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -386,7 +386,12 @@ HTML;
 
     public function isOnVapor()
     {
-        return ($_ENV['SERVER_SOFTWARE'] ?? null) === 'vapor';
+        return $this->isRunningServerless();
+    }
+
+    public function isRunningServerless()
+    {
+        return ($_ENV['SERVER_SOFTWARE'] ?? null) === config('livewire.serverless_identifier');
     }
 
     public function withQueryParams($queryParams)

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -229,7 +229,7 @@ HTML;
             $publishedManifest = json_decode(file_get_contents(public_path('vendor/livewire/manifest.json')), true);
             $versionedFileName = $publishedManifest['/livewire.js'];
 
-            $fullAssetPath = ($this->isOnVapor() ? config('app.asset_url') : $appUrl).'/vendor/livewire'.$versionedFileName;
+            $fullAssetPath = ($this->isRunningServerless() ? config('app.asset_url') : $appUrl).'/vendor/livewire'.$versionedFileName;
 
             if ($manifest !== $publishedManifest) {
                 $assetWarning = <<<'HTML'
@@ -384,14 +384,12 @@ HTML;
         $this->listeners[$event][] = $callback;
     }
 
-    public function isOnVapor()
-    {
-        return $this->isRunningServerless();
-    }
-
     public function isRunningServerless()
     {
-        return ($_ENV['SERVER_SOFTWARE'] ?? null) === config('livewire.serverless_identifier');
+        return in_array($_ENV['SERVER_SOFTWARE'] ?? null, [
+            'vapor',
+            'bref',
+        ]);
     }
 
     public function withQueryParams($queryParams)

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -384,6 +384,11 @@ HTML;
         $this->listeners[$event][] = $callback;
     }
 
+    public function isOnVapor()
+    {
+        return $this->isRunningServerless();
+    }
+
     public function isRunningServerless()
     {
         return in_array($_ENV['SERVER_SOFTWARE'] ?? null, [

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -96,7 +96,7 @@ class LivewireServiceProvider extends ServiceProvider
         // alias. For instance: 'examples.foo' => App\Http\Livewire\Examples\Foo
 
         // We will generate a manifest file so we don't have to do the lookup every time.
-        $defaultManifestPath = $this->app['livewire']->isOnVapor()
+        $defaultManifestPath = $this->app['livewire']->isRunningServerless()
             ? '/tmp/storage/bootstrap/cache/livewire-components.php'
             : app()->bootstrapPath('cache/livewire-components.php');
 


### PR DESCRIPTION
Hi, hopefully this is ok to add? I'm using bref to serve my application serverless using AWS Lambda. Currently, during the deploy process, I'm having to `sed` replace `vapor` with `bref` and it just feels dirty 🙈

My thinking behind this, is that the default livewire config will still retain the reference to `vapor`, and allow developers to specify the value in their application's overridden livewire config. I've added an "alias" method too since if this value is changeable `isRunningServerless` felt more natural. I haven't changed the 2 references to the `isOnVapor` but if you like this idea I can happily change them to reference the new method. I've left the `isOnVapor` to prevent breaking changes.

Thanks