### PR TITLE
Translatable/custom attributes on file upload errors

### DIFF
--- a/src/WithFileUploads.php
+++ b/src/WithFileUploads.php
@@ -51,9 +51,16 @@ trait WithFileUploads
         $this->emit('upload:errored', $name)->self();
 
         if (is_null($errorsInJson)) {
-            $genericValidationMessage = trans('validation.uploaded', ['attribute' => $name]);
-            if ($genericValidationMessage === 'validation.uploaded') $genericValidationMessage = "The {$name} failed to upload.";
-            throw ValidationException::withMessages([$name => $genericValidationMessage]);
+            // Handle any translations/custom names
+            $translator = app()->make('translator');
+
+            $attribute = $translator->get("validation.attributes.{$name}");
+            if ($attribute === "validation.attributes.{$name}") $attribute = $name;
+
+            $message = trans('validation.uploaded', ['attribute' => $attribute]);
+            if ($message === 'validation.uploaded') $message = "The {$name} failed to upload.";
+
+            throw ValidationException::withMessages([$name => $message]);
         }
 
         $errorsInJson = $isMultiple

--- a/tests/Unit/FileUploadsTest.php
+++ b/tests/Unit/FileUploadsTest.php
@@ -271,6 +271,27 @@ class FileUploadsTest extends TestCase
     }
 
     /** @test */
+    public function file_upload_global_validation_can_be_translated()
+    {
+        Storage::fake('avatars');
+
+        $translator = app()->make('translator');
+        $translator->addLines([
+            'validation.uploaded' => 'The :attribute failed to upload.',
+            'validation.attributes.file' => 'upload'
+        ], 'en');
+
+        $file = UploadedFile::fake()->create('upload.xls', 100);
+
+        $test = Livewire::test(FileUploadComponent::class)
+            ->set('file', $file)
+            ->call('uploadError', 'file')
+            ->assertHasErrors(['file']);
+
+        $this->assertEquals('The upload failed to upload.', $test->lastErrorBag->get('file')[0]);
+    }
+
+    /** @test */
     public function image_dimensions_can_be_validated()
     {
         Storage::fake('avatars');
@@ -597,6 +618,7 @@ class FileUploadComponent extends Component
 {
     use WithFileUploads;
 
+    public $file;
     public $photo;
     public $photos;
     public $photosArray = [];
@@ -659,6 +681,11 @@ class FileUploadComponent extends Component
 
     public function removePhoto($key) {
         unset($this->photos[$key]);
+    }
+
+    public function uploadError($name)
+    {
+        $this->uploadErrored($name, null, false);
     }
 
     public function render() { return app('view')->make('null-view'); }

--- a/tests/Unit/FileUploadsTest.php
+++ b/tests/Unit/FileUploadsTest.php
@@ -246,7 +246,7 @@ class FileUploadsTest extends TestCase
     }
 
     /** @test */
-    public function a_file_can_be_valited_in_real_time()
+    public function a_file_can_be_validated_in_real_time()
     {
         Storage::fake('avatars');
 
@@ -258,7 +258,7 @@ class FileUploadsTest extends TestCase
     }
 
     /** @test */
-    public function multiple_files_can_be_valited_in_real_time()
+    public function multiple_files_can_be_validated_in_real_time()
     {
         Storage::fake('avatars');
 


### PR DESCRIPTION
**Issue**

If uploading a with the WithFileUploads-trait – and a server exception occurs (for example that the uploaded file is too large for your PHP/server-setup); Livewire can't properly validate the file and just issues a validation error with the `uploaded`-type with the input's name as the attribute:

``` php
$genericValidationMessage = trans('validation.uploaded', ['attribute' => $name]);
```

This only translates the actual error message, not the name/attribute for the input under validation witch looks bad in non-English UIs.

<img width="282" alt="Screenshot 2021-05-06 at 13 51 42" src="https://user-images.githubusercontent.com/907114/117294029-72c5c300-ae72-11eb-9e70-871b3fad908f.png">  

_English and Swedish in the same sentence_

**What this PR does**

This PR use Laravel's Translator to first check if there is a custom attribute name (`$lang.validation.attributes`) and tries to use that one, else it will fall back on the input's name as it is today – and then translate the validation message.

Test is available 🎉