### PR TITLE
Add a way to bail out of property updates

### DIFF
--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -75,7 +75,9 @@ trait HandlesActions
 
         $name = $name->__toString();
 
-        $this->updating($name, $value);
+        if ($this->updating($name, $value) === false) {
+            return;
+        }
 
         if (method_exists($this, $beforeMethod)) {
             $this->{$beforeMethod}($value, $keyAfterFirstDot);

--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -91,7 +91,9 @@ trait HandlesActions
             }
         }
 
-        Livewire::dispatch('component.updating', $this, $name, $value);
+        if (Livewire::dispatch('component.updating', $this, $name, $value) === false) {
+            return;
+        }
 
         $callback($name, $value);
 

--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -91,7 +91,7 @@ trait HandlesActions
             }
         }
 
-        if (Livewire::dispatch('component.updating', $this, $name, $value) === false) {
+        if (Livewire::dispatchStrict('component.updating', $this, $name, $value) === false) {
             return;
         }
 

--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -80,11 +80,15 @@ trait HandlesActions
         }
 
         if (method_exists($this, $beforeMethod)) {
-            $this->{$beforeMethod}($value, $keyAfterFirstDot);
+            if ($this->{$beforeMethod}($value, $keyAfterFirstDot) === false) {
+                return;
+            }
         }
 
         if ($beforeNestedMethod && method_exists($this, $beforeNestedMethod)) {
-            $this->{$beforeNestedMethod}($value, $keyAfterLastDot);
+            if ($this->{$beforeNestedMethod}($value, $keyAfterLastDot) === false) {
+                return;
+            }
         }
 
         Livewire::dispatch('component.updating', $this, $name, $value);

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -374,9 +374,15 @@ HTML;
 
     public function dispatch($event, ...$params)
     {
+        $continue = true;
+
         foreach ($this->listeners[$event] ?? [] as $listener) {
-            $listener(...$params);
+            if ($listener(...$params) === false) {
+                $continue = false;
+            }
         }
+
+        return $continue;
     }
 
     public function listen($event, $callback)

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -374,15 +374,18 @@ HTML;
 
     public function dispatch($event, ...$params)
     {
-        $continue = true;
+        foreach ($this->listeners[$event] ?? [] as $listener) {
+            $listener(...$params);
+        }
+    }
 
+    public function dispatchStrict($event, ...$params)
+    {
         foreach ($this->listeners[$event] ?? [] as $listener) {
             if ($listener(...$params) === false) {
-                $continue = false;
+                return false;
             }
         }
-
-        return $continue;
     }
 
     public function listen($event, $callback)

--- a/src/RenameMe/SupportComponentTraits.php
+++ b/src/RenameMe/SupportComponentTraits.php
@@ -52,11 +52,16 @@ class SupportComponentTraits
         });
 
         Livewire::listen('component.updating', function ($component, $name, $value) {
+            $continue = true;
             $methods = $this->componentIdMethodMap[$component->id]['updating'] ?? [];
 
             foreach ($methods as $method) {
-                ImplicitlyBoundMethod::call(app(), $method, [$name, $value]);
+                if (ImplicitlyBoundMethod::call(app(), $method, [$name, $value]) === false) {
+                    $continue = false;
+                }
             }
+
+            return $continue;
         });
 
         Livewire::listen('component.updated', function ($component, $name, $value) {

--- a/src/RenameMe/SupportComponentTraits.php
+++ b/src/RenameMe/SupportComponentTraits.php
@@ -52,16 +52,13 @@ class SupportComponentTraits
         });
 
         Livewire::listen('component.updating', function ($component, $name, $value) {
-            $continue = true;
             $methods = $this->componentIdMethodMap[$component->id]['updating'] ?? [];
 
             foreach ($methods as $method) {
                 if (ImplicitlyBoundMethod::call(app(), $method, [$name, $value]) === false) {
-                    $continue = false;
+                    return false;
                 }
             }
-
-            return $continue;
         });
 
         Livewire::listen('component.updated', function ($component, $name, $value) {

--- a/tests/Unit/ComponentCanBailUpdatesTest.php
+++ b/tests/Unit/ComponentCanBailUpdatesTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Livewire;
+use Livewire\Component;
+
+class ComponentCanBailUpdatesTest extends TestCase
+{
+    /** @test */
+    public function it_bails_in_the_updating_hook()
+    {
+        Livewire::test(ComponentWithUpdatingHookThatBails::class)
+            ->assertSet('name', 'Jeff')
+            ->set('name', 'Jiff')
+            ->assertSet('name', 'Jeff')
+            ->assertSet('age', 77)
+            ->set('age', 78)
+            ->assertSet('age', 77)
+            ->assertSet('traits.interests', ['Breathing', 'Sticks'])
+            ->set('traits.interests', ['Breathing'])
+            ->assertSet('traits.interests', ['Breathing', 'Sticks']);
+    }
+
+    /** @test */
+    public function it_bails_in_the_trait_updating_hook()
+    {
+        Livewire::test(ComponentWithTraitUpdatingHookThatBails::class)
+            ->assertSet('name', 'Jeff')
+            ->set('name', 'Jiff')
+            ->assertSet('name', 'Jeff');
+    }
+}
+
+class ComponentWithUpdatingHookThatBails extends Component
+{
+    public $name = 'Jeff';
+    public $age = 77;
+    public $traits = [
+        'interests' => ['Breathing', 'Sticks'],
+    ];
+
+    public function updating($attribute)
+    {
+        if ($attribute === 'name') {
+            return false;
+        }
+    }
+
+    public function updatingTraitsInterests()
+    {
+        return false;
+    }
+
+    public function updatingAge()
+    {
+        return false;
+    }
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}
+
+trait TraitWithUpdatingHook
+{
+    public function updatingTraitWithUpdatingHook()
+    {
+        return false;
+    }
+}
+
+class ComponentWithTraitUpdatingHookThatBails extends Component
+{
+    use TraitWithUpdatingHook;
+
+    public $name = 'Jeff';
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}


### PR DESCRIPTION
This is a backdoor for cancelling a property update by just returning `false` in the `updating()` hook.

Addresses https://github.com/livewire/livewire/discussions/2349