### PR TITLE
[Fix] FileUploadHandler didn't handle long filenames

### DIFF
--- a/src/Controllers/FileUploadHandler.php
+++ b/src/Controllers/FileUploadHandler.php
@@ -2,9 +2,11 @@
 
 namespace Livewire\Controllers;
 
+use function Livewire\str;
 use Livewire\TemporaryUploadedFile;
 use Livewire\FileUploadConfiguration;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 
 class FileUploadHandler
 {
@@ -35,6 +37,10 @@ class FileUploadHandler
 
         $fileHashPaths = collect($files)->map(function ($file) use ($disk) {
             $filename = TemporaryUploadedFile::generateHashNameWithOriginalNameEmbedded($file);
+
+            if (str($filename)->length() >= 256) {
+                throw ValidationException::withMessages(['files.0' => 'File name too long']);
+            }
 
             return $file->storeAs('/'.FileUploadConfiguration::path(), $filename, [
                 'disk' => $disk

--- a/src/Testing/Concerns/MakesCallsToComponent.php
+++ b/src/Testing/Concerns/MakesCallsToComponent.php
@@ -112,10 +112,20 @@ trait MakesCallsToComponent
         // We are going to encode the file size in the filename so that when we create
         // a new TemporaryUploadedFile instance we can fake a specific file size.
         $newFileHashes = collect($files)->zip($fileHashes)->mapSpread(function ($file, $fileHash) {
+            // Skip appending file sizes in the file name of blank file
+            // Because testing the maximum length of file name cause that throwing "File name too long" errors.
+            if ($file->getSize() === 0) {
+                return $fileHash;
+            }
+
             return (string) str($fileHash)->replaceFirst('.', "-size={$file->getSize()}.");
         })->toArray();
 
         collect($fileHashes)->zip($newFileHashes)->mapSpread(function ($fileHash, $newFileHash) use ($storage) {
+            if ($fileHash == $newFileHash) {
+                return;
+            }
+
             $storage->move('/'.FileUploadConfiguration::path($fileHash), '/'.FileUploadConfiguration::path($newFileHash));
         });
 

--- a/tests/Unit/FileUploadsTest.php
+++ b/tests/Unit/FileUploadsTest.php
@@ -597,6 +597,20 @@ class FileUploadsTest extends TestCase
         $this->assertStringStartsWith('livewire-file:', $component->get('obj.file_uploads'));
     }
 
+    /** @test */
+    public function generated_hash_names_cant_be_longer_than_256_characters()
+    {
+        Storage::fake('avatars');
+
+        // Random string(30) + '-meta'(5) + Encoded filename(216) + '-.txt'(5) = 256 characters
+        $originalFilename = str_repeat('a', 156).'.txt';
+
+        $file = UploadedFile::fake()->create($originalFilename, 0); // Blank file
+
+        Livewire::test(FileUploadComponent::class)
+            ->set('file', $file)
+            ->assertHasErrors('file');
+    }
 }
 
 class DummyMiddleware


### PR DESCRIPTION
Fixes #2834 

* Add checking the filename lengths
* Add test
* Add skip renaming in test syncUploadedFiles() when a blank file