### PR TITLE
Entangle attributes of nested components

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -30,6 +30,15 @@ abstract class Component
     protected $initialLayoutConfiguration = [];
     protected $shouldSkipRender = false;
     protected $preRenderedView;
+    
+    // TO make entanglement (child->parent) work, copy this part to your child and parent components.
+    // ----------------------------------------------------------------------------------------------
+    public $entangled = [];
+    public $entangledByChildren = [];
+    protected $listeners = ['fillEntangled', 'registerEntangled'];
+    public function fillEntangled($data) { $this->fill($data); }
+    public function registerEntangled($data) { $this->entangledByChildren = array_merge_recursive($this->entangledByChildren, $data); }
+    // ----------------------------------------------------------------------------------------------
 
     public function __construct($id = null)
     {

--- a/src/HydrationMiddleware/HandlesEntangledProperties.php
+++ b/src/HydrationMiddleware/HandlesEntangledProperties.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Livewire\HydrationMiddleware;
+
+use Illuminate\Support\Arr;
+
+class HandlesEntangledProperties implements HydrationMiddleware
+{
+    protected static $propertyHashesByComponentId = [];
+
+    public static function hydrate($instance, $request)
+    {
+        $data = data_get($request, 'memo.data', []);
+
+        collect($data)->each(function ($value, $key) use ($instance) {
+            if (is_array($value)) {
+                foreach (Arr::dot($value, $key . '.') as $dottedKey => $value) {
+                    static::rehashProperty($dottedKey, $value, $instance);
+                }
+            } else {
+                static::rehashProperty($key, $value, $instance);
+            }
+        });
+    }
+
+    public static function dehydrate($instance, $response)
+    {
+        self::handleEntanglementToParent($instance, $response);
+        // self::handleEntanglementToChildren($instance, $response);
+    }
+
+    public static function handleEntanglementToParent($instance, $response)
+    {
+        $entangledToParent = data_get($response, 'memo.data.entangled', []);
+
+        $dirtyEntangledProps = self::dirtyProps($instance, $response)
+            ->intersectByKeys($entangledToParent)
+            ->mapWithKeys(fn ($_, $key) => [$entangledToParent[$key] => data_get($instance, $key)])
+            ->toArray();
+
+        $instance->emitUp('fillEntangled', $dirtyEntangledProps);
+    }
+
+    public static function handleEntanglementToChildren($instance, $response)
+    {
+        $entangledByChildren = data_get($response, 'memo.data.entangledByChildren', []);
+
+        $dirtyEntangledProps = self::dirtyProps($instance, $response)
+            ->intersectByKeys($entangledByChildren)
+            ->map(fn ($_, $key) => data_get($instance, $key))
+            ->flatten()
+            ->unique();
+
+        // TODO: this probably doesn't work.
+        $dirtyEntangledProps->each(fn ($id) => $instance->emitTo($id, 'refresh'));
+    }
+
+    public static function initialDehydrate($instance, $response)
+    {
+        $entangled = collect(data_get($response, 'memo.data.entangled', []))
+            ->flip()
+            ->map(fn ($_) => [$instance->id]);
+
+        // TODO: this (emitUp) doesn't work.
+        $instance->emitUp('registerEntangled', $entangled);
+    }
+
+    public static function dirtyProps($instance, $response)
+    {
+        // Only return the propertyHashes/props that have changed.
+        return collect(static::$propertyHashesByComponentId[$instance->id] ?? [])
+            ->filter(fn ($hash, $key) => static::hash(data_get($instance, $key)) !== $hash);
+    }
+
+    public static function rehashProperty($name, $value, $component)
+    {
+        static::$propertyHashesByComponentId[$component->id][$name] = static::hash($value);
+    }
+
+    public static function hash($value)
+    {
+        if (!is_null($value) && !is_string($value) && !is_numeric($value) && !is_bool($value)) {
+            if (is_array($value)) {
+                return json_encode($value);
+            }
+            $value = method_exists($value, '__toString')
+                ? (string) $value
+                : json_encode($value);
+        }
+
+        // Using crc32 because it's fast, and this doesn't have to be secure.
+        return crc32($value);
+    }
+}

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -39,6 +39,7 @@ use Livewire\HydrationMiddleware\{
     HydratePublicProperties,
     PerformDataBindingUpdates,
     CallPropertyHydrationHooks,
+    HandlesEntangledProperties,
     SecureHydrationWithChecksum,
     HashDataPropertiesForDirtyDetection,
     NormalizeServerMemoSansDataForJavaScript,
@@ -295,6 +296,7 @@ class LivewireServiceProvider extends ServiceProvider
             /* ↓ */ PerformDataBindingUpdates::class, /* ----------------- ↑ */
             /* ↓ */ PerformActionCalls::class, /* ------------------------ ↑ */
             /* ↓ */ PerformEventEmissions::class, /* --------------------- ↑ */
+            /* ↓ */ HandlesEntangledProperties::class, /* ---------------- ↑ */
             /* ↓                                                           ↑ */
             /* ↓    Output Stuff                                           ↑ */
             /* ↓ */ RenderView::class, /* -------------------------------- ↑ */
@@ -307,6 +309,7 @@ class LivewireServiceProvider extends ServiceProvider
             /* Initial Response */
             /* ↑ */ [SecureHydrationWithChecksum::class, 'dehydrate'],
             /* ↑ */ [NormalizeServerMemoSansDataForJavaScript::class, 'dehydrate'],
+            /* ↑ */ [HandlesEntangledProperties::class, 'initialDehydrate'],
             /* ↑ */ [HydratePublicProperties::class, 'dehydrate'],
             /* ↑ */ [CallPropertyHydrationHooks::class, 'dehydrate'],
             /* ↑ */ [CallHydrationHooks::class, 'initialDehydrate'],


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

The issue of making nested components reactive has been brought up [here](https://github.com/livewire/livewire/issues/677). This PR is merely a suggestion for new functionality.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No(t yet).

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

This pull requests (partly) implements functionality of entangling attributes of nested components, through events that are submitted in a `HydrationMiddleware`. Listening to these events could possibly be done by a trait on the `Component` class. The goal is to provide a simple api for entangling attributes between parent- and child-components, without any boilerplate.  For instance, if one considers the following components:

Parent.php:
```
class Parent extends Component
{
    public $fooParent;

    public function render()
    {
        return view('parent');
    }
}
```
parent.blade.php:
```
<input type="text" wire:model="fooParent" />

<livewire:child wire:entangle:foo-child="fooParent"></livewire:child>
```

Child.php:
```
class Child extends Component
{
    public $fooChild;

    public function render()
    {
        return view('child');
    }
}
```

child.blade.php:
```
<input type="text" wire:model="fooChild" />
```

Then updating the `fooChild` attribute would be applied to `fooParent` and vice-versa.

This PR currently only facilitates entangling `fooChild -> fooParent`, but not (yet) the other way around.  Also, the implemented syntax for entangling these properties is
`<livewire:child :foo-child="$fooParent" :entangled="['fooChild' => 'fooParent']">`
to prevent from having to dive into the parser and add the `wire:entangle:` attribute.

I was mainly wondering whether something like this could eventually be added to livewire, as this functionality would eliminate much work on boilerplate input events and refreshing child components.

5️⃣ Thanks for contributing! 🙌

