### PR TITLE
Resolve `ParseError ` due to excess semicolon. Affects Laravel 8.45.0 [Urgent?]

### DIFF
--- a/src/Macros/livewire-view-component.blade.php
+++ b/src/Macros/livewire-view-component.blade.php
@@ -1,5 +1,5 @@
 @component($view, $params)
     @slot($slotOrSection)
-        {!! $manager->initialDehydrate()->toInitialResponse()->effects['html']; !!}
+        {!! $manager->initialDehydrate()->toInitialResponse()->effects['html'] !!}
     @endslot
 @endcomponent

--- a/src/Macros/livewire-view-extends.blade.php
+++ b/src/Macros/livewire-view-extends.blade.php
@@ -1,5 +1,5 @@
 @extends($view, $params)
 
 @section($slotOrSection)
-    {!! $manager->initialDehydrate()->toInitialResponse()->effects['html']; !!}
+    {!! $manager->initialDehydrate()->toInitialResponse()->effects['html'] !!}
 @endsection


### PR DESCRIPTION
The extra semicolon causes the Blade compiler in the latest Laravel 8.45.0 release to throw a `ParseError` exception.

Anyone who upgrades to the latest Laravel release will break their application, so I'm not sure if this needs an urgent patch release?