### PR TITLE
add route model binding missing function support

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -16,9 +16,7 @@ use Livewire\Exceptions\PropertyNotFoundException;
 
 abstract class Component
 {
-    use Macroable {
-        __call as macroCall;
-    }
+    use Macroable { __call as macroCall; }
 
     use ComponentConcerns\ValidatesInput,
         ComponentConcerns\HandlesActions,
@@ -64,12 +62,12 @@ abstract class Component
 
         $layoutType = $this->initialLayoutConfiguration['type'] ?? 'component';
 
-        return app('view')->file(__DIR__ . "/Macros/livewire-view-{$layoutType}.blade.php", [
+        return app('view')->file(__DIR__."/Macros/livewire-view-{$layoutType}.blade.php", [
             'view' => $this->initialLayoutConfiguration['view'] ?? config('livewire.layout'),
             'params' => $this->initialLayoutConfiguration['params'] ?? [],
             'slotOrSection' => $this->initialLayoutConfiguration['slotOrSection'] ?? [
-                    'extends' => 'content', 'component' => 'slot',
-                ][$layoutType],
+                'extends' => 'content', 'component' => 'slot',
+            ][$layoutType],
             'manager' => $manager,
         ]);
     }
@@ -85,7 +83,7 @@ abstract class Component
     public function initializeTraits()
     {
         foreach (class_uses_recursive($class = static::class) as $trait) {
-            if (method_exists($class, $method = 'initialize' . class_basename($trait))) {
+            if (method_exists($class, $method = 'initialize'.class_basename($trait))) {
                 $this->{$method}();
             }
         }
@@ -102,7 +100,7 @@ abstract class Component
             ->implode('.');
 
         if (str($fullName)->startsWith($namespace)) {
-            return (string)str($fullName)->substr(strlen($namespace) + 1);
+            return (string) str($fullName)->substr(strlen($namespace) + 1);
         }
 
         return $fullName;
@@ -135,7 +133,7 @@ abstract class Component
         }
 
         throw_unless($view instanceof View,
-            new \Exception('"render" method on [' . get_class($this) . '] must return instance of [' . View::class . ']'));
+            new \Exception('"render" method on ['.get_class($this).'] must return instance of ['.View::class.']'));
 
         // Get the layout config from the view.
         if ($view->livewireLayout) {
@@ -175,9 +173,9 @@ abstract class Component
         );
 
         $view->with([
-                'errors' => $errors,
-                '_instance' => $this,
-            ] + $this->getPublicPropertiesDefinedBySubClass());
+            'errors' => $errors,
+            '_instance' => $this,
+        ] + $this->getPublicPropertiesDefinedBySubClass());
 
         app('view')->share('errors', $errors);
         app('view')->share('_instance', $this);
@@ -211,8 +209,8 @@ abstract class Component
     public function forgetComputed($key = null)
     {
         if (is_null($key)) {
-            $this->computedPropertyCache = [];
-            return;
+           $this->computedPropertyCache = [];
+           return;
         }
 
         $keys = is_array($key) ? $key : func_get_args();
@@ -228,7 +226,7 @@ abstract class Component
     {
         $studlyProperty = str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $property)));
 
-        if (method_exists($this, $computedMethodName = 'get' . $studlyProperty . 'Property')) {
+        if (method_exists($this, $computedMethodName = 'get'.$studlyProperty.'Property')) {
             if (isset($this->computedPropertyCache[$property])) {
                 return $this->computedPropertyCache[$property];
             }

--- a/tests/Unit/ComponentTypedPropertyBindingsMissingTest.php
+++ b/tests/Unit/ComponentTypedPropertyBindingsMissingTest.php
@@ -1,0 +1,58 @@
+<?php
+
+
+namespace Tests\Unit;
+
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+use Livewire\Component;
+
+class ComponentTypedPropertyBindingsMissingTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped('Only applies to PHP 7.4 and above.');
+            return;
+        }
+        Schema::create('model_for_attribute_bindings', function ($table) {
+            $table->bigIncrements('id');
+            $table->string('title');
+            $table->timestamps();
+        });
+    }
+
+    /** @test */
+    public function missing_function_fire_if_route_prop_missing()
+    {
+        \Route::get('/foo/{parent}/{child}', ComponentWithPropAndMountBindings::class)
+            ->missing(fn(Request $request) => redirect('/bar'));
+        $this->get('/foo/bar/zap')->assertRedirect('/bar');
+    }
+}
+
+class ModelForTypedPropertyBindings extends Model
+{
+    protected $connection = 'testbench';
+    protected $guarded = [];
+}
+
+class ComponentWithPropAndMountBindings extends Component
+{
+    public ModelForTypedPropertyBindings $child;
+
+    public $parent;
+
+    public function mount(ModelForTypedPropertyBindings $parent)
+    {
+        $this->parent = $parent;
+    }
+
+    public function render()
+    {
+        return 'foo';
+    }
+}

--- a/tests/Unit/ComponentTypedPropertyBindingsMissingTest.php
+++ b/tests/Unit/ComponentTypedPropertyBindingsMissingTest.php
@@ -18,7 +18,7 @@ class ComponentTypedPropertyBindingsMissingTest extends TestCase
             $this->markTestSkipped('Only applies to PHP 7.4 and above.');
             return;
         }
-        Schema::create('model_for_attribute_bindings', function ($table) {
+        Schema::create('model_for_property_bindings', function ($table) {
             $table->bigIncrements('id');
             $table->string('title');
             $table->timestamps();
@@ -30,11 +30,12 @@ class ComponentTypedPropertyBindingsMissingTest extends TestCase
     {
         \Route::get('/foo/{parent}/{child}', ComponentWithPropAndMountBindings::class)
             ->missing(fn(Request $request) => redirect('/bar'));
+
         $this->get('/foo/bar/zap')->assertRedirect('/bar');
     }
 }
 
-class ModelForTypedPropertyBindings extends Model
+class ModelForPropertyBinding extends Model
 {
     protected $connection = 'testbench';
     protected $guarded = [];
@@ -42,11 +43,10 @@ class ModelForTypedPropertyBindings extends Model
 
 class ComponentWithPropAndMountBindings extends Component
 {
-    public ModelForTypedPropertyBindings $child;
-
+    public ModelForPropertyBinding $child;
     public $parent;
 
-    public function mount(ModelForTypedPropertyBindings $parent)
+    public function mount(ModelForPropertyBinding $parent)
     {
         $this->parent = $parent;
     }

--- a/tests/Unit/ComponentTypedPropertyBindingsMissingTest.php
+++ b/tests/Unit/ComponentTypedPropertyBindingsMissingTest.php
@@ -18,6 +18,9 @@ class ComponentTypedPropertyBindingsMissingTest extends TestCase
             $this->markTestSkipped('Only applies to PHP 7.4 and above.');
             return;
         }
+        if (! method_exists(\Illuminate\Routing\Route::class, 'missing')) {
+                    $this->markTestSkipped('Need Laravel >= 8');
+        }
         Schema::create('model_for_property_bindings', function ($table) {
             $table->bigIncrements('id');
             $table->string('title');


### PR DESCRIPTION
according to https://github.com/livewire/livewire/issues/2951 there is a missing functionality vs laravel route model binding that is missing function that fire when the given values are missing.

this feature wouldn't implemented in livewire and i tryed to add this to livewire