### PR TITLE
Support missing() for route model binding

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -46,7 +46,7 @@ abstract class Component
             $componentParams = (new ImplicitRouteBinding($container))
                 ->resolveAllParameters($route, $this);
         } catch (ModelNotFoundException $exception) {
-            if ($route->getMissing()) {
+            if (method_exists($route, 'getMissing') && $route->getMissing()) {
                 return $route->getMissing()(request());
             }
 

--- a/src/Component.php
+++ b/src/Component.php
@@ -2,6 +2,7 @@
 
 namespace Livewire;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\View\View;
 use BadMethodCallException;
 use Illuminate\Support\Str;
@@ -41,8 +42,16 @@ abstract class Component
 
     public function __invoke(Container $container, Route $route)
     {
-        $componentParams = (new ImplicitRouteBinding($container))
-            ->resolveAllParameters($route, $this);
+        try {
+            $componentParams = (new ImplicitRouteBinding($container))
+                ->resolveAllParameters($route, $this);
+        } catch (ModelNotFoundException $exception) {
+            if ($route->getMissing()) {
+                return $route->getMissing()(request());
+            }
+
+            throw $exception;
+        }
 
         $manager = LifecycleManager::fromInitialInstance($this)
             ->initialHydrate()

--- a/tests/Unit/RouteMissingTest.php
+++ b/tests/Unit/RouteMissingTest.php
@@ -17,6 +17,10 @@ class RouteMissingTest extends TestCase
         if (PHP_VERSION_ID < 70400) {
             $this->markTestSkipped('Only applies to PHP 7.4 and above.');
         }
+
+        if (! method_exists(\Illuminate\Routing\Route::class, 'missing')) {
+            $this->markTestSkipped('Need Laravel >= 8');
+        }
     }
 
     /** @test */

--- a/tests/Unit/RouteMissingTest.php
+++ b/tests/Unit/RouteMissingTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
+use Livewire\Component;
+use Illuminate\Support\Facades\Route;
+
+class RouteMissingTest extends TestCase
+{
+    /** @test */
+    public function route_supports_laravels_missing_fallback_function(): void
+    {
+        Route::get('awesome-js/{framework}', ComponentWithModel::class)
+             ->missing(function (Request $request) {
+                 $this->assertEquals(request(), $request);
+                 return redirect()->to('awesome-js/alpine');
+             });
+
+        $this->get('/awesome-js/jquery')->assertRedirect('/awesome-js/alpine');
+    }
+}
+
+class FrameworkModel extends Model
+{
+    public function resolveRouteBinding($value, $field = null)
+    {
+        throw new ModelNotFoundException;
+    }
+}
+
+class ComponentWithModel extends Component
+{
+    public FrameworkModel $framework;
+}

--- a/tests/Unit/RouteMissingTest.php
+++ b/tests/Unit/RouteMissingTest.php
@@ -10,6 +10,15 @@ use Illuminate\Support\Facades\Route;
 
 class RouteMissingTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped('Only applies to PHP 7.4 and above.');
+        }
+    }
+
     /** @test */
     public function route_supports_laravels_missing_fallback_function(): void
     {

--- a/tests/Unit/RouteMissingTest.php
+++ b/tests/Unit/RouteMissingTest.php
@@ -22,6 +22,16 @@ class RouteMissingTest extends TestCase
     /** @test */
     public function route_supports_laravels_missing_fallback_function(): void
     {
+        $class = <<<'PHP'
+namespace Tests\Unit;
+use Livewire\Component;
+class ComponentWithModel extends Component
+{
+    public FrameworkModel $framework;
+}
+PHP;
+        eval($class);
+
         Route::get('awesome-js/{framework}', ComponentWithModel::class)
              ->missing(function (Request $request) {
                  $this->assertEquals(request(), $request);
@@ -38,9 +48,4 @@ class FrameworkModel extends Model
     {
         throw new ModelNotFoundException;
     }
-}
-
-class ComponentWithModel extends Component
-{
-    public FrameworkModel $framework;
 }


### PR DESCRIPTION
Laravel recently added `missing()` to [customize missing model behavior](https://laravel.com/docs/8.x/routing#customizing-missing-model-behavior)

This PR adds support invoked `Components`.

![image](https://user-images.githubusercontent.com/13331388/121776192-c3c08980-cb8b-11eb-9ebe-70307ce72939.png)

@calebporzio hope you like my test :joy: 

---
Closes #2951