### PR TITLE
Fixes Starting Livewire with Alpine 3 when debug=false

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -289,22 +289,21 @@ HTML;
         });
     };
 
-    let started = false
+    let started = false;
 
-    // Support for Alpine V3.
     window.addEventListener('alpine:initializing', () => {
         if (! started) {
             window.livewire.start();
 
-            started = true
+            started = true;
         }
-    })
+    });
 
     document.addEventListener("DOMContentLoaded", function () {
         if (! started) {
             window.livewire.start();
 
-            started = true
+            started = true;
         }
     });
 </script>


### PR DESCRIPTION

- Added semicolons for JavaScript (Adding semicolons for this JavaScript is important, because it will be minified in production.)

- Removed '// Support for Alpine V3.' as it causes an issue (see below)

![image](https://user-images.githubusercontent.com/56897604/122037541-560b9c00-cddd-11eb-8d1f-12c9689e568a.png)
