### PR TITLE
Fix for undefined array key (500 error, ErrorException) when there is a property mismatch on livewire requests

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -91,7 +91,7 @@ class Response
         // If 'data' is present in the response memo, diff it one level deep.
         if (isset($dirtyMemo['data']) && isset($requestMemo['data'])) {
             foreach ($dirtyMemo['data'] as $key => $value) {
-                if (!isset($requestMemo['data'][$key])) continue;
+                if (! isset($requestMemo['data'][$key])) continue;
 
                 if ($value === $requestMemo['data'][$key]) {
                     unset($dirtyMemo['data'][$key]);

--- a/src/Response.php
+++ b/src/Response.php
@@ -15,7 +15,7 @@ class Response
     public static function fromRequest($request)
     {
         return new static($request);
-   }
+    }
 
     public function __construct($request)
     {
@@ -91,6 +91,8 @@ class Response
         // If 'data' is present in the response memo, diff it one level deep.
         if (isset($dirtyMemo['data']) && isset($requestMemo['data'])) {
             foreach ($dirtyMemo['data'] as $key => $value) {
+                if (!isset($requestMemo['data'][$key])) continue;
+
                 if ($value === $requestMemo['data'][$key]) {
                     unset($dirtyMemo['data'][$key]);
                 }
@@ -101,7 +103,7 @@ class Response
         foreach (data_get($this, 'effects.dirty', []) as $property) {
             $property = head(explode('.', $property));
 
-            data_set($dirtyMemo, 'data.'.$property, $responseMemo['data'][$property]);
+            data_set($dirtyMemo, 'data.'.$property, $responseMemo['data'][$property] ?? null);
         }
 
         return [

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -10,11 +10,11 @@ use Livewire\Response;
 
 class ResponseTest extends TestCase
 {
-    public function testToSubsequentResponseWorksWithPropertiesInComponentNotInRequest()
+    /** @test */
+    public function subsequent_response_works_with_in_component_but_not_in_request()
     {
         $request = new Request([
-            'fingerprint' => [
-            ],
+            'fingerprint' => [],
             'updates' => [],
             'serverMemo' => [
                 'data' => [
@@ -40,11 +40,11 @@ class ResponseTest extends TestCase
         );
     }
 
-    public function testToSubsequentResponseWorksWorksWithPropertiesInRequestNotInComponent()
+    /** @test */
+    public function subsequent_response_works_with_properties_in_request_but_not_in_component()
     {
         $request = new Request([
-            'fingerprint' => [
-            ],
+            'fingerprint' => [],
             'updates' => [],
             'serverMemo' => [
                 'data' => [
@@ -55,11 +55,13 @@ class ResponseTest extends TestCase
         ]);
 
         $response = new Response($request);
+
         $response->memo = [
             'data' => [
                 'count' => 1,
             ],
         ];
+
         $response->effects = [
             'dirty' => ['count', 'aNewProperty']
         ];

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Livewire;
+use Livewire\Component;
+use Illuminate\Support\Facades\Route;
+use Livewire\Request;
+use Livewire\Response;
+
+class ResponseTest extends TestCase
+{
+    public function testToSubsequentResponseWorksWithPropertiesInComponentNotInRequest()
+    {
+        $request = new Request([
+            'fingerprint' => [
+            ],
+            'updates' => [],
+            'serverMemo' => [
+                'data' => [
+                    'count' => 0
+                ],
+            ]
+        ]);
+
+        $response = new Response($request);
+        $response->memo = [
+            'data' => [
+                'count' => 1,
+                'aNewProperty' => 'A New Value',
+            ],
+        ];
+
+        $this->assertEquals(
+            [
+                'effects' => [],
+                'serverMemo' => ['data' => ['count' => 1, 'aNewProperty' => 'A New Value']]
+            ],
+            $response->toSubsequentResponse()
+        );
+    }
+
+    public function testToSubsequentResponseWorksWorksWithPropertiesInRequestNotInComponent()
+    {
+        $request = new Request([
+            'fingerprint' => [
+            ],
+            'updates' => [],
+            'serverMemo' => [
+                'data' => [
+                    'count' => 0,
+                    'aNewProperty' => 'A New Value',
+                ],
+            ]
+        ]);
+
+        $response = new Response($request);
+        $response->memo = [
+            'data' => [
+                'count' => 1,
+            ],
+        ];
+        $response->effects = [
+            'dirty' => ['count', 'aNewProperty']
+        ];
+
+        $this->assertEquals(
+            [
+                'effects' => [
+                    'dirty' => ['count', 'aNewProperty']
+                ],
+                'serverMemo' => ['data' => ['count' => 1, 'aNewProperty' => null]]
+            ],
+            $response->toSubsequentResponse()
+        );
+    }
+}


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

This is a bug fix. It attempts to be true to the spirit of Livewire in the fix delivered (permissive request responses, few errors unless a critical and unrecoverable error is encountered).

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

There is a single bug fix in this PR.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

There are currently no tests directory for the Response::toSubsequentResponse() method, but I would be willing to add one if needed.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

In certain situations, the state of the initial render of a livewire component may become out of sync with the endpoint delivering the components subsequent state. This may be due to the initial page being full page cached at the edge, or could be the result of a browser aggressively caching certain pages, or could be a user initial rendered a page and the server software was updated.

In situations where properties were added to or removed from the Livewire component, the Response::toSubsequentResponse() method would be checking for a non-existent key which would in turn produce a PHP error of `ErrorException: Undefined array key "xxxx"`. This can, and arguably should, be mitigated in the Response method when checking for dirty state, this is the route this particular fix has taken.

5️⃣ Thanks for contributing! 🙌


https://user-images.githubusercontent.com/76674/122300940-a1997500-cec5-11eb-948e-7cb1b3887eed.mov

