### PR TITLE
Allow TemporaryUploadedFile to use storage defined temporaryURL function

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -67,7 +67,7 @@ class TemporaryUploadedFile extends UploadedFile
             );
         }
 
-        if (! $this->isPreviewable()) {
+        if (method_exists($this->storage, 'temporaryUrl') || !$this->isPreviewable()) {
             // This will throw an error because it's not used with S3.
             return $this->storage->temporaryUrl($this->path, now()->addDay());
         }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
I know we need this and I hope this is needed. I created a discussion.
2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No
4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
The TemporaryUploadedFile->temporaryUrl function does not work for other storage drivers such as Google Cloud Storage (only works with S3). This change allows the function to use the storage defined temporaryUrl.
5️⃣ Thanks for contributing! 🙌