### PR TITLE
Entangle breaks when using Turbo.js

### DIFF
--- a/tests/Browser/Alpine/Entangle/Test.php
+++ b/tests/Browser/Alpine/Entangle/Test.php
@@ -207,4 +207,16 @@ class Test extends TestCase
             ;
         });
     }
+
+    public function test_entangle_works_with_turbo()
+    {
+        $this->browse(function ($browser) {
+            $browser->visit(route('entangle-turbo', [], false))
+                ->assertSeeIn('@page.title', 'Testing Entangle with Turbo')
+                ->click('@turbo.link')
+                ->waitForTextIn('@page.title', 'Showing Livewire&Alpine Component after a Turbo Visit')
+                ->assertSeeIn('@output.livewire', 'false')
+                ->assertSeeIn('@output.alpine', 'false');
+        });
+    }
 }

--- a/tests/Browser/Alpine/Entangle/ToggleEntangledTurbo.php
+++ b/tests/Browser/Alpine/Entangle/ToggleEntangledTurbo.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Browser\Alpine\Entangle;
+
+use Livewire\Component as BaseComponent;
+
+class ToggleEntangledTurbo extends BaseComponent
+{
+    public $active = false;
+    public $title = 'Showing Livewire&Alpine Component after a Turbo Visit';
+
+    public function render()
+    {
+        return view()->file(__DIR__ . '/view-toggle-entangled-turbo.blade.php')
+            ->layout('components.layouts.app-for-turbo-views');
+    }
+}

--- a/tests/Browser/Alpine/Entangle/view-toggle-entangled-turbo.blade.php
+++ b/tests/Browser/Alpine/Entangle/view-toggle-entangled-turbo.blade.php
@@ -1,0 +1,11 @@
+<div>
+    <h1 dusk="page.title">{{ $title }}</h1>
+
+    <div x-data="{
+        active: @entangle('active')
+    }">
+        <div dusk="output.alpine" x-text="active"></div>
+        <div dusk="output.livewire">{{ $active ? 'true' : 'false' }}</div>
+        <button dusk="toggle" x-on:click="active = !active">Toggle Active</button>
+    </div>
+</div>

--- a/tests/Browser/TestCase.php
+++ b/tests/Browser/TestCase.php
@@ -137,6 +137,12 @@ class TestCase extends BaseTestCase
                 return app()->call(new $class);
             })->middleware(['web', 'auth', 'can:update,post']);
 
+            Route::middleware('web')->get('/entangle-turbo', function () {
+                return view('turbo', [
+                    'link' => '/livewire-dusk/' . urlencode(\Tests\Browser\Alpine\Entangle\ToggleEntangledTurbo::class),
+                ]);
+            })->name('entangle-turbo');
+
             app('session')->put('_token', 'this-is-a-hack-because-something-about-validating-the-csrf-token-is-broken');
 
             app('config')->set('view.paths', [

--- a/tests/Browser/views/components/layouts/app-for-turbo-views.blade.php
+++ b/tests/Browser/views/components/layouts/app-for-turbo-views.blade.php
@@ -1,0 +1,39 @@
+<html>
+<head>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    <script src="https://unpkg.com/alpinejs@3.0.6/dist/cdn.min.js" defer></script>
+
+    <script type="module">
+        import hotwiredTurbo from 'https://cdn.skypack.dev/@hotwired/turbo';
+    </script>
+
+    @livewireStyles
+</head>
+<body>
+    {{ $slot }}
+
+    @livewireScripts
+    <script src="https://cdn.jsdelivr.net/gh/livewire/turbolinks@v0.1.x/dist/livewire-turbolinks.js" data-turbolinks-eval="false" data-turbo-eval="false"></script>
+    <script data-turbo-eval="false">
+        document.addEventListener('turbo:before-render', () => {
+            let permanents = document.querySelectorAll('[data-turbo-permanent]')
+
+            let undos = Array.from(permanents).map(el => {
+                el._x_ignore = true
+
+                return () => {
+                    delete el._x_ignore
+                }
+            })
+
+            document.addEventListener('turbo:render', function handler() {
+                while(undos.length) undos.shift()()
+
+                document.removeEventListener('turbo:render', handler)
+            })
+        })
+    </script>
+    @stack('scripts')
+</body>
+</html>

--- a/tests/Browser/views/turbo.blade.php
+++ b/tests/Browser/views/turbo.blade.php
@@ -1,0 +1,5 @@
+<x-layouts.app-for-turbo-views>
+    <h1 dusk="page.title">Testing Entangle with Turbo</h1>
+
+    <a dusk="turbo.link" href="{{ $link }}">Go to Livewire Component</a>
+</x-layouts.app-for-turbo-views>


### PR DESCRIPTION
Hey, folks.

I've been chasing this error for a while. I've created a discussion in the [Alpine repository](https://github.com/alpinejs/alpine/discussions/1534) but looks like not many people are using this combo (Alpine+Livewire+Turbo).

I couldn't find a fix for it yet but was able to write a failing Dusk test to reproduce it.

As I mentioned in the Alpine discussion issue referenced above, the issue seems to happen when making a Turbo Visit to a page that has a Livewire&Alpine component using entangle. These can be seen on any settings page of Jetstream right now (since the modals all use entangle).

I wish I was able to identify the root cause (there were some attempts in the Alpine issue if you want to check those out).