### PR TITLE
Google Cloud Storage driver compatibility for temporary file uploads

### DIFF
--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -45,13 +45,6 @@ class FileUploadConfiguration
         return config('filesystems.disks.'.strtolower($diskBeforeTestFake).'.driver') === 's3';
     }
 
-    public static function isUsingGCS()
-    {
-        $diskBeforeTestFake = config('livewire.temporary_file_upload.disk') ?: config('filesystems.default');
-
-        return config('filesystems.disks.'.strtolower($diskBeforeTestFake).'.driver') === 'gcs';
-    }
-
     protected static function directory()
     {
         return Util::normalizeRelativePath(config('livewire.temporary_file_upload.directory') ?: 'livewire-tmp');

--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -45,6 +45,13 @@ class FileUploadConfiguration
         return config('filesystems.disks.'.strtolower($diskBeforeTestFake).'.driver') === 's3';
     }
 
+    public static function isUsingGCS()
+    {
+        $diskBeforeTestFake = config('livewire.temporary_file_upload.disk') ?: config('filesystems.default');
+
+        return config('filesystems.disks.'.strtolower($diskBeforeTestFake).'.driver') === 'gcs';
+    }
+
     protected static function directory()
     {
         return Util::normalizeRelativePath(config('livewire.temporary_file_upload.directory') ?: 'livewire-tmp');

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -67,7 +67,7 @@ class TemporaryUploadedFile extends UploadedFile
             );
         }
 
-        if (FileUploadConfiguration::isUsingGCS() || ! $this->isPreviewable()) {
+        if (method_exists($this->storage->getAdapter(), 'getTemporaryUrl') || ! $this->isPreviewable()) {
             // This will throw an error because it's not used with S3.
             return $this->storage->temporaryUrl($this->path, now()->addDay());
         }

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -67,7 +67,7 @@ class TemporaryUploadedFile extends UploadedFile
             );
         }
 
-        if (! $this->isPreviewable()) {
+        if (FileUploadConfiguration::isUsingGCS() || ! $this->isPreviewable()) {
             // This will throw an error because it's not used with S3.
             return $this->storage->temporaryUrl($this->path, now()->addDay());
         }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
I know we need this and I hope this is needed. I created a discussion.
2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
This PR should pass a tests
4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
The TemporaryUploadedFile->temporaryUrl function does not work for other storage drivers such as Google Cloud Storage (only works with S3). This change allows the function to use the storage defined temporaryUrl.
5️⃣ Thanks for contributing! 🙌