### PR TITLE
Add test flag to all commands

### DIFF
--- a/src/Commands/CopyCommand.php
+++ b/src/Commands/CopyCommand.php
@@ -32,14 +32,14 @@ class CopyCommand extends FileManipulationCommand
         $class = $this->copyClass($force, $inline);
         if (! $inline) $view = $this->copyView($force);
         if ($test){
-            $this->copyTest($force);
+            $test = $this->copyTest($force);
         }
         $this->refreshComponentAutodiscovery();
 
         $this->line("<options=bold,reverse;fg=green> COMPONENT COPIED </> 🤙\n");
         $class && $this->line("<options=bold;fg=green>CLASS:</> {$this->parser->relativeClassPath()} <options=bold;fg=green>=></> {$this->newParser->relativeClassPath()}");
         if (! $inline) $view && $this->line("<options=bold;fg=green>VIEW:</>  {$this->parser->relativeViewPath()} <options=bold;fg=green>=></> {$this->newParser->relativeViewPath()}");
-        if ($test)$view && $this->line("<options=bold;fg=green>Test:</>  {$this->parser->relativeTestPath()} <options=bold;fg=green>=></> {$this->newParser->relativeTestPath()}");
+        if ($test) $test && $this->line("<options=bold;fg=green>Test:</>  {$this->parser->relativeTestPath()} <options=bold;fg=green>=></> {$this->newParser->relativeTestPath()}");
     }
 
     protected function copyTest($force)

--- a/src/Commands/CopyCommand.php
+++ b/src/Commands/CopyCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\File;
 
 class CopyCommand extends FileManipulationCommand
 {
-    protected $signature = 'livewire:copy {name} {new-name} {--inline} {--force}';
+    protected $signature = 'livewire:copy {name} {new-name} {--inline} {--force} {--test}';
 
     protected $description = 'Copy a Livewire component';
 
@@ -27,15 +27,32 @@ class CopyCommand extends FileManipulationCommand
 
         $force = $this->option('force');
         $inline = $this->option('inline');
+        $test = $this->option('test');
 
         $class = $this->copyClass($force, $inline);
         if (! $inline) $view = $this->copyView($force);
-
+        if ($test){
+            $this->copyTest($force);
+        }
         $this->refreshComponentAutodiscovery();
 
         $this->line("<options=bold,reverse;fg=green> COMPONENT COPIED </> 🤙\n");
         $class && $this->line("<options=bold;fg=green>CLASS:</> {$this->parser->relativeClassPath()} <options=bold;fg=green>=></> {$this->newParser->relativeClassPath()}");
         if (! $inline) $view && $this->line("<options=bold;fg=green>VIEW:</>  {$this->parser->relativeViewPath()} <options=bold;fg=green>=></> {$this->newParser->relativeViewPath()}");
+        if ($test)$view && $this->line("<options=bold;fg=green>Test:</>  {$this->parser->relativeTestPath()} <options=bold;fg=green>=></> {$this->newParser->relativeTestPath()}");
+    }
+
+    protected function copyTest($force)
+    {
+        if (File::exists($this->newParser->testPath()) && ! $force) {
+            $this->line("<options=bold,reverse;fg=red> WHOOPS-IE-TOOTLES </> 😳 \n");
+            $this->line("<fg=red;options=bold>Test already exists:</> {$this->newParser->relativeTestPath()}");
+            return false;
+        }
+
+        $this->ensureDirectoryExists($this->newParser->testPath());
+
+        return File::copy("{$this->parser->testPath()}", $this->newParser->testPath());
     }
 
     protected function copyClass($force, $inline)

--- a/src/Commands/CpCommand.php
+++ b/src/Commands/CpCommand.php
@@ -4,7 +4,7 @@ namespace Livewire\Commands;
 
 class CpCommand extends CopyCommand
 {
-    protected $signature = 'livewire:cp {name} {new-name} {--inline} {--force}';
+    protected $signature = 'livewire:cp {name} {new-name} {--inline} {--force} {--test}';
 
     protected function configure()
     {

--- a/src/Commands/DeleteCommand.php
+++ b/src/Commands/DeleteCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\File;
 
 class DeleteCommand extends FileManipulationCommand
 {
-    protected $signature = 'livewire:delete {name} {--inline} {--force}';
+    protected $signature = 'livewire:delete {name} {--inline} {--force} {--test}';
 
     protected $description = 'Delete a Livewire component';
 
@@ -29,17 +29,34 @@ class DeleteCommand extends FileManipulationCommand
         }
 
         $inline = $this->option('inline');
+        $test = $this->option('test');
 
         $class = $this->removeClass($force);
         if (! $inline) $view = $this->removeView($force);
+        if ($test) $test = $this->removeTest($force);
 
         $this->refreshComponentAutodiscovery();
 
         $this->line("<options=bold,reverse;fg=yellow> COMPONENT DESTROYED </> 🦖💫\n");
         $class && $this->line("<options=bold;fg=yellow>CLASS:</> {$this->parser->relativeClassPath()}");
         if (! $inline) $view && $this->line("<options=bold;fg=yellow>VIEW:</>  {$this->parser->relativeViewPath()}");
+        if ($test) $test && $this->line("<options=bold;fg=yellow>Test:</>  {$this->parser->relativeTestPath()}");
     }
 
+    protected function removeTest($force = false)
+    {
+        $testPath = $this->parser->testPath();
+
+        if (! File::exists($testPath) && ! $force) {
+            $this->line("<options=bold,reverse;fg=red> WHOOPS-IE-TOOTLES </> 😳 \n");
+            $this->line("<fg=red;options=bold>Test doesn't exist:</> {$this->parser->relativeTestPath()}");
+            return false;
+        }
+
+        File::delete($testPath);
+
+        return $testPath;
+    }
     protected function removeClass($force = false)
     {
         $classPath = $this->parser->classPath();

--- a/src/Commands/MoveCommand.php
+++ b/src/Commands/MoveCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\File;
 
 class MoveCommand extends FileManipulationCommand
 {
-    protected $signature = 'livewire:move {name} {new-name} {--force} {--test} {--inline}';
+    protected $signature = 'livewire:move {name} {new-name} {--force} {--inline} {--test}';
 
     protected $description = 'Move a Livewire component';
 
@@ -39,6 +39,7 @@ class MoveCommand extends FileManipulationCommand
         $this->line("<options=bold,reverse;fg=green> COMPONENT MOVED </> 🤙\n");
         $class && $this->line("<options=bold;fg=green>CLASS:</> {$this->parser->relativeClassPath()} <options=bold;fg=green>=></> {$this->newParser->relativeClassPath()}");
         if (! $inline) $view && $this->line("<options=bold;fg=green>VIEW:</>  {$this->parser->relativeViewPath()} <options=bold;fg=green>=></> {$this->newParser->relativeViewPath()}");
+        if ($test)$view && $this->line("<options=bold;fg=green>Test:</>  {$this->parser->relativeTestPath()} <options=bold;fg=green>=></> {$this->newParser->relativeTestPath()}");
     }
 
     protected function renameClass()

--- a/src/Commands/MoveCommand.php
+++ b/src/Commands/MoveCommand.php
@@ -32,14 +32,14 @@ class MoveCommand extends FileManipulationCommand
 
         $test = $this->option('test');
         if ($test) {
-            $this->renameTest();
+            $test = $this->renameTest();
         }
         $this->refreshComponentAutodiscovery();
 
         $this->line("<options=bold,reverse;fg=green> COMPONENT MOVED </> 🤙\n");
         $class && $this->line("<options=bold;fg=green>CLASS:</> {$this->parser->relativeClassPath()} <options=bold;fg=green>=></> {$this->newParser->relativeClassPath()}");
         if (! $inline) $view && $this->line("<options=bold;fg=green>VIEW:</>  {$this->parser->relativeViewPath()} <options=bold;fg=green>=></> {$this->newParser->relativeViewPath()}");
-        if ($test)$view && $this->line("<options=bold;fg=green>Test:</>  {$this->parser->relativeTestPath()} <options=bold;fg=green>=></> {$this->newParser->relativeTestPath()}");
+        if ($test) $test && $this->line("<options=bold;fg=green>Test:</>  {$this->parser->relativeTestPath()} <options=bold;fg=green>=></> {$this->newParser->relativeTestPath()}");
     }
 
     protected function renameClass()

--- a/src/Commands/MoveCommand.php
+++ b/src/Commands/MoveCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\File;
 
 class MoveCommand extends FileManipulationCommand
 {
-    protected $signature = 'livewire:move {name} {new-name} {--force} {--inline}';
+    protected $signature = 'livewire:move {name} {new-name} {--force} {--test} {--inline}';
 
     protected $description = 'Move a Livewire component';
 
@@ -30,6 +30,10 @@ class MoveCommand extends FileManipulationCommand
         $class = $this->renameClass();
         if (! $inline) $view = $this->renameView();
 
+        $test = $this->option('test');
+        if ($test) {
+            $this->renameTest();
+        }
         $this->refreshComponentAutodiscovery();
 
         $this->line("<options=bold,reverse;fg=green> COMPONENT MOVED </> 🤙\n");
@@ -68,5 +72,18 @@ class MoveCommand extends FileManipulationCommand
         File::move($this->parser->viewPath(), $newViewPath);
 
         return $newViewPath;
+    }
+
+    protected function renameTest()
+    {
+        $newTestPath = $this->newParser->testPath();
+        if (File::exists($newTestPath)) {
+            $this->line("<fg=red;options=bold>Test already exists:</> {$this->newParser->relativeViewPath()}");
+
+            return false;
+        }
+        $this->ensureDirectoryExists($newTestPath);
+        File::move($this->parser->testPath(), $newTestPath);
+        return $newTestPath;
     }
 }

--- a/src/Commands/MvCommand.php
+++ b/src/Commands/MvCommand.php
@@ -4,7 +4,7 @@ namespace Livewire\Commands;
 
 class MvCommand extends MoveCommand
 {
-    protected $signature = 'livewire:mv {name} {new-name} {--inline} {--force}';
+    protected $signature = 'livewire:mv {name} {new-name} {--inline} {--force} {--test}';
 
     protected function configure()
     {

--- a/src/Commands/RmCommand.php
+++ b/src/Commands/RmCommand.php
@@ -4,7 +4,7 @@ namespace Livewire\Commands;
 
 class RmCommand extends DeleteCommand
 {
-    protected $signature = 'livewire:rm {name} {--inline} {--force}';
+    protected $signature = 'livewire:rm {name} {--inline} {--force} {--test}';
 
     protected function configure()
     {

--- a/tests/Unit/CopyCommandTest.php
+++ b/tests/Unit/CopyCommandTest.php
@@ -40,73 +40,106 @@ class CopyCommandTest extends TestCase
         $this->assertTrue(File::exists($this->livewireClassesPath('Bob.php')));
         $this->assertFalse(File::exists($this->livewireViewsPath('bob.blade.php')));
     }
-
     /** @test */
-    public function component_is_copied_by_cp_command()
+    public function component_with_test_is_copied_by_copy_command()
     {
-        Artisan::call('make:livewire', ['name' => 'bob']);
+        Artisan::call('make:livewire', ['name' => 'bob','--test'=>true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Bob.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('BobTest.php')));
 
-        Artisan::call('livewire:cp', ['name' => 'bob', 'new-name' => 'lob']);
+        Artisan::call('livewire:copy', ['name' => 'bob', 'new-name' => 'lob','--test'=>true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Lob.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('lob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('LobTest.php')));
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Bob.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('BobTest.php')));
+    }
+    /** @test */
+    public function component_is_copied_by_cp_command()
+    {
+        Artisan::call('make:livewire', ['name' => 'bob','--test'=>true]);
+
+        $this->assertTrue(File::exists($this->livewireClassesPath('Bob.php')));
+        $this->assertTrue(File::exists($this->livewireViewsPath('bob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('BobTest.php')));
+
+        Artisan::call('livewire:cp', ['name' => 'bob', 'new-name' => 'lob','--test'=>true]);
+
+        $this->assertTrue(File::exists($this->livewireClassesPath('Lob.php')));
+        $this->assertTrue(File::exists($this->livewireViewsPath('lob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('LobTest.php')));
+
+        $this->assertTrue(File::exists($this->livewireClassesPath('Bob.php')));
+        $this->assertTrue(File::exists($this->livewireViewsPath('bob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('BobTest.php')));
+
     }
 
     /** @test */
     public function nested_component_is_copied_by_copy_command()
     {
-        Artisan::call('make:livewire', ['name' => 'bob.lob']);
+        Artisan::call('make:livewire', ['name' => 'bob.lob','--test'=>true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Bob/Lob.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob/lob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('Bob/LobTest.php')));
 
-        Artisan::call('livewire:copy', ['name' => 'bob.lob', 'new-name' => 'bob.lob.law']);
+        Artisan::call('livewire:copy', ['name' => 'bob.lob', 'new-name' => 'bob.lob.law','--test'=>true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Bob/Lob/Law.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob/lob/law.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('Bob/Lob/LawTest.php')));
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Bob/Lob.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob/lob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('Bob/LobTest.php')));
+
     }
 
     /** @test */
     public function multiword_component_is_copied_by_copy_command()
     {
-        Artisan::call('make:livewire', ['name' => 'bob-lob']);
+        Artisan::call('make:livewire', ['name' => 'bob-lob','--test'=>true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('BobLob.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob-lob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('BobLobTest.php')));
 
-        Artisan::call('livewire:copy', ['name' => 'bob-lob', 'new-name' => 'lob-law']);
+        Artisan::call('livewire:copy', ['name' => 'bob-lob', 'new-name' => 'lob-law','--test'=>true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('/LobLaw.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('lob-law.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('LobLawTest.php')));
 
         $this->assertTrue(File::exists($this->livewireClassesPath('BobLob.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob-lob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('BobLobTest.php')));
+
     }
 
     /** @test */
     public function pascal_case_component_is_automatically_converted_by_copy_command()
     {
-        Artisan::call('make:livewire', ['name' => 'BobLob.BobLob']);
+        Artisan::call('make:livewire', ['name' => 'BobLob.BobLob','--test'=>true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('BobLob/BobLob.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob-lob/bob-lob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('BobLob/BobLobTest.php')));
 
-        Artisan::call('livewire:copy', ['name' => 'BobLob.BobLob', 'new-name' => 'LobLaw.LobLaw']);
+        Artisan::call('livewire:copy', ['name' => 'BobLob.BobLob', 'new-name' => 'LobLaw.LobLaw','--test'=>true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('BobLob/BobLob.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob-lob/bob-lob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('BobLob/BobLobTest.php')));
 
         $this->assertTrue(File::exists($this->livewireClassesPath('LobLaw/LobLaw.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('lob-law/lob-law.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('LobLaw/LobLawTest.php')));
     }
 
     /** @test */

--- a/tests/Unit/DeleteCommandTest.php
+++ b/tests/Unit/DeleteCommandTest.php
@@ -42,36 +42,61 @@ class DeleteCommandTest extends TestCase
     }
 
     /** @test */
-    public function component_is_removed_by_rm_command()
+    public function component_with_test_is_removed_by_delete_command()
     {
-        Artisan::call('make:livewire', ['name' => 'foo']);
+        Artisan::call('make:livewire', ['name' => 'foo','--test'=>true]);
 
         $classPath = $this->livewireClassesPath('Foo.php');
         $viewPath = $this->livewireViewsPath('foo.blade.php');
+        $testPath = $this->livewireTestsPath('FooTest.php');
 
         $this->assertTrue(File::exists($classPath));
         $this->assertTrue(File::exists($viewPath));
+        $this->assertTrue(File::exists($testPath));
 
-        Artisan::call('livewire:rm', ['name' => 'foo', '--force' => true]);
+        Artisan::call('livewire:delete', ['name' => 'foo', '--force' => true,'--test'=>true]);
 
         $this->assertFalse(File::exists($classPath));
         $this->assertFalse(File::exists($viewPath));
+        $this->assertFalse(File::exists($testPath));
+    }
+    /** @test */
+    public function component_is_removed_by_rm_command()
+    {
+        Artisan::call('make:livewire', ['name' => 'foo','--test'=>true]);
+
+        $classPath = $this->livewireClassesPath('Foo.php');
+        $viewPath = $this->livewireViewsPath('foo.blade.php');
+        $testPath = $this->livewireTestsPath('FooTest.php');
+
+        $this->assertTrue(File::exists($classPath));
+        $this->assertTrue(File::exists($viewPath));
+        $this->assertTrue(File::exists($testPath));
+
+        Artisan::call('livewire:rm', ['name' => 'foo', '--force' => true,'--test'=>true]);
+
+        $this->assertFalse(File::exists($classPath));
+        $this->assertFalse(File::exists($viewPath));
+        $this->assertFalse(File::exists($testPath));
     }
 
     /** @test */
     public function component_is_removed_without_confirmation_if_forced()
     {
-        Artisan::call('make:livewire', ['name' => 'foo']);
+        Artisan::call('make:livewire', ['name' => 'foo','--test'=>true]);
 
         $classPath = $this->livewireClassesPath('Foo.php');
         $viewPath = $this->livewireViewsPath('foo.blade.php');
+        $testPath = $this->livewireTestsPath('FooTest.php');
 
         $this->assertTrue(File::exists($classPath));
         $this->assertTrue(File::exists($viewPath));
+        $this->assertTrue(File::exists($testPath));
 
-        Artisan::call('livewire:delete', ['name' => 'foo', '--force' => true]);
+        Artisan::call('livewire:delete', ['name' => 'foo', '--force' => true,'--test'=>true]);
 
         $this->assertFalse(File::exists($classPath));
         $this->assertFalse(File::exists($viewPath));
+        $this->assertFalse(File::exists($testPath));
     }
 }

--- a/tests/Unit/MoveCommandTest.php
+++ b/tests/Unit/MoveCommandTest.php
@@ -39,7 +39,26 @@ class MoveCommandTest extends TestCase
 
         $this->assertFalse(File::exists($this->livewireClassesPath('Bob.php')));
     }
+    /** @test */
+    public function component_with_test_is_renamed_by_move_command()
+    {
+        Artisan::call('make:livewire', ['name' => 'bob','--test'=>true]);
 
+        $this->assertTrue(File::exists($this->livewireClassesPath('Bob.php')));
+        $this->assertTrue(File::exists($this->livewireViewsPath('bob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('BobTest.php')));
+
+        Artisan::call('livewire:move', ['name' => 'bob', 'new-name' => 'lob','--test'=>true]);
+
+        $this->assertTrue(File::exists($this->livewireClassesPath('Lob.php')));
+        $this->assertTrue(File::exists($this->livewireViewsPath('lob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('LobTest.php')));
+
+        $this->assertFalse(File::exists($this->livewireClassesPath('Bob.php')));
+        $this->assertFalse(File::exists($this->livewireViewsPath('bob.blade.php')));
+        $this->assertFalse(File::exists($this->livewireTestsPath('BobTest.php')));
+
+    }
     /** @test */
     public function component_is_renamed_by_mv_command()
     {
@@ -60,51 +79,62 @@ class MoveCommandTest extends TestCase
     /** @test */
     public function nested_component_is_renamed_by_move_command()
     {
-        Artisan::call('make:livewire', ['name' => 'bob.lob']);
+        Artisan::call('make:livewire', ['name' => 'bob.lob','--test'=>true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Bob/Lob.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob/lob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('Bob/LobTest.php')));
 
-        Artisan::call('livewire:move', ['name' => 'bob.lob', 'new-name' => 'bob.lob.law']);
+        Artisan::call('livewire:move', ['name' => 'bob.lob', 'new-name' => 'bob.lob.law','--test'=>true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Bob/Lob/Law.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob/lob/law.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('Bob/Lob/LawTest.php')));
 
         $this->assertFalse(File::exists($this->livewireClassesPath('Bob/Lob.php')));
         $this->assertFalse(File::exists($this->livewireViewsPath('bob/lob.blade.php')));
+        $this->assertFalse(File::exists($this->livewireTestsPath('Bob/LobTest.php')));
+
     }
 
     /** @test */
     public function multiword_component_is_renamed_by_move_command()
     {
-        Artisan::call('make:livewire', ['name' => 'bob-lob']);
+        Artisan::call('make:livewire', ['name' => 'bob-lob','--test'=>true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('BobLob.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob-lob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('BobLobTest.php')));
 
-        Artisan::call('livewire:move', ['name' => 'bob-lob', 'new-name' => 'lob-law']);
+        Artisan::call('livewire:move', ['name' => 'bob-lob', 'new-name' => 'lob-law','--test'=>true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('/LobLaw.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('lob-law.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('LobLawTest.php')));
 
         $this->assertFalse(File::exists($this->livewireClassesPath('BobLob.php')));
         $this->assertFalse(File::exists($this->livewireViewsPath('bob-lob.blade.php')));
+        $this->assertFalse(File::exists($this->livewireTestsPath('BobLobTest.php')));
+
     }
 
     /** @test */
     public function pascal_case_component_is_automatically_converted_by_move_command()
     {
-        Artisan::call('make:livewire', ['name' => 'BobLob.BobLob']);
+        Artisan::call('make:livewire', ['name' => 'BobLob.BobLob','--test'=>true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('BobLob/BobLob.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob-lob/bob-lob.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('BobLob/BobLobTest.php')));
 
-        Artisan::call('livewire:move', ['name' => 'BobLob.BobLob', 'new-name' => 'LobLaw.LobLaw']);
+        Artisan::call('livewire:move', ['name' => 'BobLob.BobLob', 'new-name' => 'LobLaw.LobLaw','--test'=>true]);
 
         $this->assertFalse(File::exists($this->livewireClassesPath('BobLob/BobLob.php')));
         $this->assertFalse(File::exists($this->livewireViewsPath('bob-lob/bob-lob.blade.php')));
+        $this->assertFalse(File::exists($this->livewireTestsPath('BobLob/BobLobTest.php')));
 
         $this->assertTrue(File::exists($this->livewireClassesPath('LobLaw/LobLaw.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('lob-law/lob-law.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('LobLaw/LobLawTest.php')));
     }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
No
2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes
4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
added --test flag for move copy and delete command
since we have this flag with make command it is nice to have the same flag for move copy and delete command so we can manage livewire tests like how we manage the components using the cli 

5️⃣ Thanks for contributing! 🙌