### PR TITLE
Fix: non-typed initialized properties were not begin hydrated when setting value to null

### DIFF
--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -49,12 +49,16 @@ class HydratePublicProperties implements HydrationMiddleware
 
                 // If the value is null and the property is typed, don't set it, because all values start off as null and this
                 // will prevent Typed properties from wining about being set to null.
-
-                if((new ReflectionProperty($instance, $property))->getType()){
-                    is_null($value) || $instance->$property = $value;
-                } else {
+                if (version_compare(PHP_VERSION, '7.4', '<')) {
                     $instance->$property = $value;
+                } else {
+                    if((new ReflectionProperty($instance, $property))->getType()){
+                        is_null($value) || $instance->$property = $value;
+                    } else {
+                        $instance->$property = $value;
+                    }
                 }
+
             }
         }
     }

--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Carbon as IlluminateCarbon;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use Livewire\Exceptions\PublicPropertyTypeNotAllowedException;
+use ReflectionProperty;
 
 class HydratePublicProperties implements HydrationMiddleware
 {
@@ -45,9 +46,15 @@ class HydratePublicProperties implements HydrationMiddleware
             } else if (in_array($property, $stringables)) {
                 data_set($instance, $property, new Stringable($value));
             } else {
-                // If the value is null, don't set it, because all values start off as null and this
+
+                // If the value is null and the property is typed, don't set it, because all values start off as null and this
                 // will prevent Typed properties from wining about being set to null.
-                is_null($value) || $instance->$property = $value;
+
+                if((new ReflectionProperty($instance, $property))->getType()){
+                    is_null($value) || $instance->$property = $value;
+                } else {
+                    $instance->$property = $value;
+                }
             }
         }
     }

--- a/tests/Unit/PublicPropertiesAreInitializedTest.php
+++ b/tests/Unit/PublicPropertiesAreInitializedTest.php
@@ -22,6 +22,18 @@ class PublicPropertiesAreInitializedTest extends TestCase
     }
 
     /** @test */
+    public function modified_initialized_public_property_should_not_revert_after_subsequent_hydration()
+    {
+        $dirty = Livewire::test(InitializedPublicPropertyComponent::class)
+            ->set('some_id', null)
+            ->set('message', 'whatever')
+            ->get('some_id')
+        ;
+
+        $this->assertEquals(null, $dirty);
+    }
+
+    /** @test */
     public function uninitialized_public_typed_property_is_null()
     {
         if (version_compare(PHP_VERSION, '7.4', '<')) {
@@ -98,6 +110,7 @@ PHP;
 
         Livewire::test(InitializedPublicTypedPropertyComponent::class)
             ->assertSee('Typed Properties FTW!');
+
     }
 }
 
@@ -114,6 +127,7 @@ class UninitializedPublicPropertyComponent extends Component
 class InitializedPublicPropertyComponent extends Component
 {
     public $message = 'Non-typed Properties are boring';
+    public $some_id = 3;
 
     public function render()
     {

--- a/tests/Unit/PublicPropertiesAreInitializedTest.php
+++ b/tests/Unit/PublicPropertiesAreInitializedTest.php
@@ -24,13 +24,13 @@ class PublicPropertiesAreInitializedTest extends TestCase
     /** @test */
     public function modified_initialized_public_property_should_not_revert_after_subsequent_hydration()
     {
-        $dirty = Livewire::test(InitializedPublicPropertyComponent::class)
+        $propertyValue = Livewire::test(InitializedPublicPropertyComponent::class)
             ->set('some_id', null)
             ->set('message', 'whatever')
             ->get('some_id')
         ;
 
-        $this->assertEquals(null, $dirty);
+        $this->assertEquals(null, $propertyValue);
     }
 
     /** @test */


### PR DESCRIPTION
 Initialized properties were not begin hydrated when setting value to null.
Therefore livewire considered the value dirty and reverted the changed value on the next hydration.
The provided test fails without the change to the HydratePublicProperties test.

This fix actually requires php7.4 or higher I think because I used the ReflectionProperty . 