### PR TITLE
add multiple pagination support on single component

### DIFF
--- a/src/WithCursorPagination.php
+++ b/src/WithCursorPagination.php
@@ -16,7 +16,7 @@ trait WithCursorPagination
             ? $this->queryString()
             : $this->queryString;
 
-        return array_merge(['cursor' => ['except' => null]], $queryString);
+        return array_merge(['cursor' => ['except' => '']], $queryString);
     }
 
     public function initializeWithCursorPagination()

--- a/src/WithCursorPagination.php
+++ b/src/WithCursorPagination.php
@@ -11,8 +11,7 @@ trait WithCursorPagination
     public $cursor = '';
     public $allCursor = '';
     public $paginations = [
-        'cursor',
-        'allCursor'
+        'cursor'
     ];
 
     public function getQueryString()
@@ -28,7 +27,7 @@ trait WithCursorPagination
     {
 
         array_walk($this->paginations, function ($value, $key) {
-            if (!property_exists(this, $key))
+            if (!property_exists($this, $key))
                 return;
             $this->{$key} = $this->resolvePage($key);
         });
@@ -70,9 +69,9 @@ trait WithCursorPagination
 
     public function setPage($cursor = '', $name = 'cursor')
     {
-        if (!property_exists(this, $name))
-            return
-                $this->{$name} = $cursor;
+        if (!property_exists($this, $name))
+            return;
+        $this->{$name} = $cursor;
     }
 
     public function resolvePage($key)

--- a/src/WithCursorPagination.php
+++ b/src/WithCursorPagination.php
@@ -9,7 +9,7 @@ use Illuminate\Pagination\Paginator;
 trait WithCursorPagination
 {
     public $cursor = '';
-    public $paginations = [
+    protected $paginations = [
         'cursor'
     ];
 

--- a/src/WithCursorPagination.php
+++ b/src/WithCursorPagination.php
@@ -9,7 +9,6 @@ use Illuminate\Pagination\Paginator;
 trait WithCursorPagination
 {
     public $cursor = '';
-    public $allCursor = '';
     public $paginations = [
         'cursor'
     ];

--- a/src/WithCursorPagination.php
+++ b/src/WithCursorPagination.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Livewire;
+
+use Illuminate\Pagination\Cursor;
+use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Pagination\Paginator;
+
+trait WithCursorPagination
+{
+    public $cursor = '';
+
+    public function getQueryString()
+    {
+        $queryString = method_exists($this, 'queryString')
+            ? $this->queryString()
+            : $this->queryString;
+
+        return array_merge(['cursor' => ['except' => null]], $queryString);
+    }
+
+    public function initializeWithCursorPagination()
+    {
+        $this->cursor = $this->resolvePage();
+
+        CursorPaginator::currentCursorResolver(function () {
+            return Cursor::fromEncoded($this->cursor);
+        });
+        Paginator::defaultSimpleView($this->cursorPaginationView());
+    }
+
+    public function cursorPaginationView()
+    {
+        return 'livewire::cursor-' . (property_exists($this, 'paginationTheme') ? $this->paginationTheme : 'tailwind');
+    }
+
+    public function previousPage($cursor)
+    {
+        $this->setPage($cursor);
+    }
+
+    public function nextPage($cursor)
+    {
+        $this->setPage($cursor);
+    }
+
+    public function gotoPage($cursor)
+    {
+        if ($cursor instanceof Cursor) {
+            $this->setPage($cursor->encode());
+        } else {
+            $this->setPage($page);
+        }
+    }
+
+    public function resetPage()
+    {
+        $this->setPage();
+    }
+
+    public function setPage($cursor = '')
+    {
+        $this->cursor = $cursor;
+    }
+
+    public function resolvePage()
+    {
+        // The "page" query string item should only be available
+        // from within the original component mount run.
+        return request()->query('cursor', $this->cursor);
+    }
+}

--- a/src/views/pagination/cursor-bootstrap.blade.php
+++ b/src/views/pagination/cursor-bootstrap.blade.php
@@ -1,0 +1,29 @@
+<div>
+    @if ($paginator->hasPages())
+        <nav>
+            <ul class="pagination">
+                {{-- Previous Page Link --}}
+                @if ($paginator->onFirstPage())
+                    <li class="page-item disabled" aria-disabled="true">
+                        <span class="page-link">@lang('pagination.previous')</span>
+                    </li>
+                @else
+                    <li class="page-item">
+                        <button type="button" class="page-link" wire:click="previousPage('{{$paginator->previousCursor()->encode()}}')" wire:loading.attr="disabled" rel="prev">@lang('pagination.previous')</button>
+                    </li>
+                @endif
+
+                {{-- Next Page Link --}}
+                @if ($paginator->hasMorePages())
+                    <li class="page-item">
+                        <button type="button" class="page-link" wire:click="nextPage('{{$paginator->nextCursor()->encode()}}')" wire:loading.attr="disabled" rel="next">@lang('pagination.next')</button>
+                    </li>
+                @else
+                    <li class="page-item disabled" aria-disabled="true">
+                        <span class="page-link">@lang('pagination.next')</span>
+                    </li>
+                @endif
+            </ul>
+        </nav>
+    @endif
+</div>

--- a/src/views/pagination/cursor-bootstrap.blade.php
+++ b/src/views/pagination/cursor-bootstrap.blade.php
@@ -9,14 +9,14 @@
                     </li>
                 @else
                     <li class="page-item">
-                        <button type="button" class="page-link" wire:click="previousPage('{{$paginator->previousCursor()->encode()}}')" wire:loading.attr="disabled" rel="prev">@lang('pagination.previous')</button>
+                        <button type="button" class="page-link" wire:click="previousPage('{{$paginator->previousCursor()->encode()}}','{{$paginator->getCursorName()}}')" wire:loading.attr="disabled" rel="prev">@lang('pagination.previous')</button>
                     </li>
                 @endif
 
                 {{-- Next Page Link --}}
                 @if ($paginator->hasMorePages())
                     <li class="page-item">
-                        <button type="button" class="page-link" wire:click="nextPage('{{$paginator->nextCursor()->encode()}}')" wire:loading.attr="disabled" rel="next">@lang('pagination.next')</button>
+                        <button type="button" class="page-link" wire:click="nextPage('{{$paginator->nextCursor()->encode()}}','{{$paginator->getCursorName()}}')" wire:loading.attr="disabled" rel="next">@lang('pagination.next')</button>
                     </li>
                 @else
                     <li class="page-item disabled" aria-disabled="true">

--- a/src/views/pagination/cursor-tailwind.blade.php
+++ b/src/views/pagination/cursor-tailwind.blade.php
@@ -1,0 +1,31 @@
+<div>
+    @if ($paginator->hasPages())
+        <nav role="navigation" aria-label="Pagination Navigation" class="flex items-center justify-between">
+            <div class="flex justify-between flex-1 sm:hidden">
+                <span>
+                    @if ($paginator->onFirstPage())
+                        <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">
+                            {!! __('pagination.previous') !!}
+                        </span>
+                    @else
+                        <button wire:click="previousPage('{{$paginator->previousCursor()->encode()}}')" wire:loading.attr="disabled" dusk="previousPage.before" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                            {!! __('pagination.previous') !!}
+                        </button>
+                    @endif
+                </span>
+
+                <span>
+                    @if ($paginator->hasMorePages())
+                        <button wire:click="nextPage('{{$paginator->nextCursor()->encode()}}')" wire:loading.attr="disabled" dusk="nextPage.before" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                            {!! __('pagination.next') !!}
+                        </button>
+                    @else
+                        <span class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">
+                            {!! __('pagination.next') !!}
+                        </span>
+                    @endif
+                </span>
+            </div>
+        </nav>
+    @endif
+</div>

--- a/src/views/pagination/cursor-tailwind.blade.php
+++ b/src/views/pagination/cursor-tailwind.blade.php
@@ -8,7 +8,7 @@
                             {!! __('pagination.previous') !!}
                         </span>
                     @else
-                        <button wire:click="previousPage('{{$paginator->previousCursor()->encode()}}')" wire:loading.attr="disabled" dusk="previousPage.before" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                        <button wire:click="previousPage('{{$paginator->previousCursor()->encode()}}','{{$paginator->getCursorName()}}')" wire:loading.attr="disabled" dusk="previousPage.before" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
                             {!! __('pagination.previous') !!}
                         </button>
                     @endif
@@ -16,7 +16,7 @@
 
                 <span>
                     @if ($paginator->hasMorePages())
-                        <button wire:click="nextPage('{{$paginator->nextCursor()->encode()}}')" wire:loading.attr="disabled" dusk="nextPage.before" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                        <button wire:click="nextPage('{{$paginator->nextCursor()->encode()}}','{{$paginator->getCursorName()}}')" wire:loading.attr="disabled" dusk="nextPage.before" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
                             {!! __('pagination.next') !!}
                         </button>
                     @else


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
yes its discussed here https://github.com/livewire/livewire/discussions/3145 and here https://github.com/livewire/livewire/pull/3215#issuecomment-875787631
2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No
4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

ok so i add a PR for the Cursor Pagination Support here https://github.com/livewire/livewire/pull/3215 and @danharrin asked about multiple pagination in single component support so i make this Pr to add multiple pagination support.
its only work on cursor pagination but if @calebporzio approve the design and workflow i can add support for regular pagination too.

so lets see how it's work :
![image](https://user-images.githubusercontent.com/15873972/124892636-46076680-dfef-11eb-818d-ea49ee5be8eb.png)
as you can see in the picture i add a `protected $paginations` to the trait that contains the name of the querystring that we want to use and i will create the query strings based on it.

now if anyone want to add multiple pagination in 1 component they can use the `setCursorName()` or pass the key name to the `cursorPaginate()` function like this:

![image](https://user-images.githubusercontent.com/15873972/124893246-ce860700-dfef-11eb-8613-fbf681f1a1fe.png)

ok so we have `allCursor` here as key now we need to add a public property and add the key to `paginations` property :
```php
    protected $paginations = [
        'cursor',
        'allCursor'
    ];
    public $allCursor = '';
```
now we have multiple pagination in our single component with `cursor` and `allCursor` queryString.
the good thing here is that we can chage default `cursor` key for single pagination too. 

5️⃣ Thanks for contributing! 🙌