### PR TITLE
Testing Components can generate false positives from wire:id

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -119,7 +119,7 @@ trait MakesAssertions
 
     protected function stripOutInitialData($subject)
     {
-        return preg_replace('(wire:initial-data=\".+}")', '', $subject);
+        return preg_replace('/((?:[\n\s+]+)?wire:initial-data=\".+}"\n?|(?:[\n\s+]+)?wire:id=\"[^"]*"\n?)/m', '', $subject);
     }
 
     public function assertEmitted($value, ...$params)

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -96,9 +96,12 @@ class LivewireTestingTest extends TestCase
     }
 
     /** @test */
-    public function assert_see_doesnt_include_json_encoded_data_put_in_wire_data_attribute()
+    public function assert_see_doesnt_include_wire_id_and_wire_data_attribute()
     {
-        // See for more info: https://github.com/calebporzio/livewire/issues/62
+        /*
+        * See for more info: https://github.com/calebporzio/livewire/issues/62
+        * Regex test: https://regex101.com/r/UhjREC/2/
+        */
         app(LivewireManager::class)
             ->test(HasMountArgumentsButDoesntPassThemToBladeView::class, ['name' => 'shouldnt see me'])
             ->assertDontSee('shouldnt see me');


### PR DESCRIPTION
1️⃣  Is this something that is wanted/needed? Did you create an issue / discussion about it first? : No

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out. : No

3️⃣  Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have) : Yes

---

Details on this change are available here #62

Some tests also pass with `wire:id`. Please watch the video.

https://user-images.githubusercontent.com/13007665/125180269-d668c580-e200-11eb-9cf9-2997c6c1b411.mov

Additionally, the current pattern was not removing the trailing space.

**before:**
```blade
<div wire:id="123Abc" wire:initial-data="{...}">...</div>

<div wire:id="123Abc" >...</div>
```
**after:**
```blade
<div wire:id="123Abc" wire:initial-data="{...}">...</div>

<div>...<div>
```

## Demo/Test: 
https://regex101.com/r/UhjREC/3

