### PR TITLE
Avoid reflection exception on virtual properties

### DIFF
--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -52,7 +52,8 @@ class HydratePublicProperties implements HydrationMiddleware
                 if (version_compare(PHP_VERSION, '7.4', '<')) {
                     $instance->$property = $value;
                 } else {
-                    if((new ReflectionProperty($instance, $property))->getType()){
+                    // do not use reflection for virtual component properties
+                    if(property_exists($instance, $property) && (new ReflectionProperty($instance, $property))->getType()){
                         is_null($value) || $instance->$property = $value;
                     } else {
                         $instance->$property = $value;

--- a/tests/Unit/VirtualPropertyTest.php
+++ b/tests/Unit/VirtualPropertyTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+const PROPERTY_NAME = 'virtualProperty';
+
+class VirtualPropertyTest extends TestCase
+{
+    /** @test */
+    public function virtual_property_is_accessible()
+    {
+        $component = Livewire::test(ComponentWithPublicVirtualproperty::class)
+            ->assertSee('Caleb')
+            ->set(PROPERTY_NAME, 'Porzio')
+            ->assertSet('name', 'Porzio');
+
+        $this->assertEquals($component->get(PROPERTY_NAME), 'Porzio');
+    }
+}
+
+class ComponentWithPublicVirtualproperty extends Component
+{
+    public $name = 'Caleb';
+
+    public function render()
+    {
+        return app('view')->make('show-name');
+    }
+
+    public function getPublicPropertiesDefinedBySubClass()
+    {
+        $data = parent::getPublicPropertiesDefinedBySubClass();
+        $data[PROPERTY_NAME] = $this->name;
+        return $data;
+    }
+
+    public function __get($property)
+    {
+        if($property == PROPERTY_NAME) return $this->name;
+        return parent::__get($property);
+    }
+
+    public function __set($property, $value)
+    {
+        if($property == PROPERTY_NAME) {
+            $this->name = $value;
+            return;
+        }
+        parent::__set($property, $value);
+    }
+
+    public function propertyIsPublicAndNotDefinedOnBaseClass($propertyName)
+    {
+        if($propertyName == PROPERTY_NAME) return true;
+        return parent::propertyIsPublicAndNotDefinedOnBaseClass($propertyName);
+    }
+}


### PR DESCRIPTION
This is a fix for the latest changes on hydration that making impossible to use virtual properties in Livewire components. Discussion is here: https://github.com/livewire/livewire/discussions/3305

Unfortunately this PR does not have tests, but it fixes the issue..

The virtual properties are work around for missing aliases in query string. Aliases are needed to resolve pagination issue, search, filter etc. Just to have an ability to use the same code base for components, but change only query strings aliases. So virtual properties are kind of complicated work around to have aliases. 

Thank you!