### PR TITLE
Fix eloquent on event emitting when the model uses other route key name distinct to id

### DIFF
--- a/src/ImplicitlyBoundMethod.php
+++ b/src/ImplicitlyBoundMethod.php
@@ -91,7 +91,8 @@ class ImplicitlyBoundMethod extends BoundMethod
 
     protected static function getImplicitBinding($container, $className, $value)
     {
-        $model = $container->make($className)->resolveRouteBinding($value);
+        $class = $container->make($className);
+        $model = $class->resolveRouteBinding($value[$class->getRouteKeyName()]);
 
         if (! $model) {
             throw (new ModelNotFoundException)->setModel($className, [$value]);

--- a/src/ImplicitlyBoundMethod.php
+++ b/src/ImplicitlyBoundMethod.php
@@ -4,6 +4,7 @@ namespace Livewire;
 
 use Illuminate\Container\BoundMethod;
 use Illuminate\Contracts\Routing\UrlRoutable as ImplicitlyBindable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use ReflectionClass;
 
@@ -91,8 +92,13 @@ class ImplicitlyBoundMethod extends BoundMethod
 
     protected static function getImplicitBinding($container, $className, $value)
     {
-        $class = $container->make($className);
-        $model = $class->resolveRouteBinding($value[$class->getRouteKeyName()]);
+        $instance = $container->make($className);
+
+        if ($instance instanceof Model && is_array($value)) {
+            $model = $instance->resolveRouteBinding($value[$instance->getRouteKeyName()]);
+        } else {
+            $model = $instance->resolveRouteBinding($value);
+        }
 
         if (! $model) {
             throw (new ModelNotFoundException)->setModel($className, [$value]);


### PR DESCRIPTION
I'm working a lot with Livewire on a new project, when trying to improve the SEO of my app using slugs on eloquent models I found a bug when I use that models in event emitting, example:

```php
class Book extends Model
{
    public function getRouteKeyName(): string
    {
        return 'slug';
    }
}
```

```php
$this->emit('bookTracked', $book, $track);
```

```php
class Header extends Component
{
    protected $listeners = [
        'bookTracked',
    ];

    public function bookTracked(Book $book, bool $tracked): void
    {
        ...
    }
```

After emitting the event an error is throw indicating that the model can't be found, after some research I detect the **ImplicitlyBoundMethod@getImplicitBinding** method is passing the model as array in **resolveRouteBinding($value)**, internally the default implementation of resolveRouteBinding do: 
```php
   /**
     * Retrieve the model for a bound value.
     *
     * @param  mixed  $value
     * @param  string|null  $field
     * @return \Illuminate\Database\Eloquent\Model|null
     */
    public function resolveRouteBinding($value, $field = null)
    {
        return $this->where($field ?? $this->getRouteKeyName(), $value)->first();
    }
```
so I think internally the where method is fetching by default the id from the model array, and this causes a mismatch when the model use other route key name distinct to the id.