### PR TITLE
Support Wireable Objects (DTOs)

### DIFF
--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -47,7 +47,7 @@ class HydratePublicProperties implements HydrationMiddleware
                 static::hydrateModels($serialized, $property, $request, $instance);
             } else if (in_array($property, $stringables)) {
                 data_set($instance, $property, new Stringable($value));
-            } else if (in_array($property, $wireables)) {
+            } else if (in_array($property, $wireables) && version_compare(PHP_VERSION, '7.4', '>=')) {
                 $type = (new \ReflectionClass($instance))
                     ->getProperty($property)
                     ->getType()
@@ -108,7 +108,7 @@ class HydratePublicProperties implements HydrationMiddleware
                 $response->memo['dataMeta']['stringables'][] = $key;
 
                 data_set($response, 'memo.data.'.$key, $value->__toString());
-            } else if ($value instanceof Wireable) {
+            } else if ($value instanceof Wireable && version_compare(PHP_VERSION, '7.4', '>=')) {
                 $response->memo['dataMeta']['wireables'][] = $key;
 
                 data_set($response, 'memo.data.'.$key, $value->toLivewire());

--- a/src/Wireable.php
+++ b/src/Wireable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Livewire;
+
+trait Wireable
+{
+    public function toLivewire()
+    {
+        return serialize($this);
+    }
+
+    public static function fromLivewire($value): self
+    {
+        return unserialize($value);
+    }
+}

--- a/src/Wireable.php
+++ b/src/Wireable.php
@@ -2,15 +2,9 @@
 
 namespace Livewire;
 
-trait Wireable
+interface Wireable
 {
-    public function toLivewire()
-    {
-        return serialize($this);
-    }
+    public function toLivewire();
 
-    public static function fromLivewire($value): self
-    {
-        return unserialize($value);
-    }
+    public static function fromLivewire($value): self;
 }

--- a/tests/Unit/WireablesCanBeSetAsPublicPropertiesStubs.php
+++ b/tests/Unit/WireablesCanBeSetAsPublicPropertiesStubs.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Component;
+use Livewire\Wireable;
+
+class WireableClass implements Wireable
+{
+    public $message;
+
+    public EmbeddedWireableClass $embeddedWireable;
+
+    public function __construct($message, $embeddedMessage)
+    {
+        $this->message = $message;
+        $this->embeddedWireable = new EmbeddedWireableClass($embeddedMessage);
+    }
+
+    public function toLivewire()
+    {
+        return [
+            'message' => $this->message,
+            'embeddedWireable' => $this->embeddedWireable->toLivewire(),
+        ];
+    }
+
+    public static function fromLivewire($value): self
+    {
+        return new self($value['message'], $value['embeddedWireable']['message']);
+    }
+}
+
+class EmbeddedWireableClass implements Wireable
+{
+    public $message;
+
+    public function __construct($message)
+    {
+        $this->message = $message;
+    }
+
+    public function toLivewire()
+    {
+        return [
+            'message' => $this->message,
+        ];
+    }
+
+    public static function fromLivewire($value): self
+    {
+        return new self($value['message']);
+    }
+}
+
+class ComponentWithWireablePublicProperty extends Component
+{
+    public ?WireableClass $wireable;
+
+    public function mount($wireable)
+    {
+        $this->wireable = $wireable;
+    }
+
+    public function removeWireable()
+    {
+        $this->wireable = null;
+    }
+
+    public function render()
+    {
+        return view('wireables');
+    }
+}

--- a/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
+++ b/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Livewire\Component;
+use Livewire\Wireable;
+
+class WireablesCanBeSetAsPublicPropertiesTest extends TestCase
+{
+    /** @test */
+    public function a_wireable_can_be_set_as_a_public_property()
+    {
+        $wireable = new WireableClass($message = Str::random(), $embeddedMessage = Str::random());
+
+        Livewire::test(ComponentWithWireablePublicProperty::class, ['wireable' => $wireable])
+            ->assertSee($message)
+            ->assertSee($embeddedMessage)
+            ->call('$refresh')
+            ->assertSee($message)
+            ->assertSee($embeddedMessage);
+    }
+
+    /** @test */
+    public function a_wireable_can_be_set_then_removed_as_a_public_property()
+    {
+        $wireable = new WireableClass($message = Str::random(), $embeddedMessage = Str::random());
+
+        Livewire::test(ComponentWithWireablePublicProperty::class, ['wireable' => $wireable])
+            ->assertSee($message)
+            ->assertSee($embeddedMessage)
+            ->call('removeWireable')
+            ->assertDontSee($message)
+            ->assertDontSee($embeddedMessage);
+    }
+
+    /** @test */
+    public function a_wireable_can_use_custom_serialization()
+    {
+        $wireable = new WireableClassWithCustomSerialization($message = Str::random());
+
+        Livewire::test(ComponentWithWireablePublicProperty::class, ['wireable' => $wireable])
+            ->assertSee($message)
+            ->call('$refresh')
+            ->assertSee($message);
+    }
+}
+
+class WireableClass
+{
+    use Wireable;
+
+    public $message;
+
+    public $embeddedWireable;
+
+    public function __construct($message, $embeddedMessage)
+    {
+        $this->message = $message;
+        $this->embeddedWireable = new EmbeddedWireableClass($embeddedMessage);
+    }
+}
+
+class EmbeddedWireableClass
+{
+    use Wireable;
+
+    public $message;
+
+    public function __construct($message)
+    {
+        $this->message = $message;
+    }
+}
+
+class WireableClassWithCustomSerialization
+{
+    use Wireable;
+
+    public $message;
+
+    public function toLivewire()
+    {
+        return [
+            'message' => $this->message,
+        ];
+    }
+
+    public static function fromLivewire($value): self
+    {
+        $self = new self();
+        $self->message = $value['message'];
+
+        return $self;
+    }
+}
+
+class ComponentWithWireablePublicProperty extends Component
+{
+    public $wireable;
+
+    public function removeWireable()
+    {
+        $this->wireable = null;
+    }
+
+    public function render()
+    {
+        return view('wireables');
+    }
+}

--- a/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
+++ b/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
@@ -4,8 +4,6 @@ namespace Tests\Unit;
 
 use Illuminate\Support\Str;
 use Livewire\Livewire;
-use Livewire\Component;
-use Livewire\Wireable;
 
 class WireablesCanBeSetAsPublicPropertiesTest extends TestCase
 {
@@ -16,6 +14,8 @@ class WireablesCanBeSetAsPublicPropertiesTest extends TestCase
             $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
         }
 
+        require_once __DIR__.'/WireablesCanBeSetAsPublicPropertiesStubs.php';
+
         $wireable = new WireableClass($message = Str::random(), $embeddedMessage = Str::random());
 
         Livewire::test(ComponentWithWireablePublicProperty::class, ['wireable' => $wireable])
@@ -23,91 +23,9 @@ class WireablesCanBeSetAsPublicPropertiesTest extends TestCase
             ->assertSee($embeddedMessage)
             ->call('$refresh')
             ->assertSee($message)
-            ->assertSee($embeddedMessage);
-    }
-
-    /** @test */
-    public function a_wireable_can_be_set_then_removed_as_a_public_property()
-    {
-        if (version_compare(PHP_VERSION, '7.4', '<')) {
-            $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
-        }
-
-        $wireable = new WireableClass($message = Str::random(), $embeddedMessage = Str::random());
-
-        Livewire::test(ComponentWithWireablePublicProperty::class, ['wireable' => $wireable])
-            ->assertSee($message)
             ->assertSee($embeddedMessage)
             ->call('removeWireable')
             ->assertDontSee($message)
             ->assertDontSee($embeddedMessage);
-    }
-}
-
-class WireableClass implements Wireable
-{
-    public $message;
-
-    public EmbeddedWireableClass $embeddedWireable;
-
-    public function __construct($message, $embeddedMessage)
-    {
-        $this->message = $message;
-        $this->embeddedWireable = new EmbeddedWireableClass($embeddedMessage);
-    }
-
-    public function toLivewire()
-    {
-        return [
-            'message' => $this->message,
-            'embeddedWireable' => $this->embeddedWireable->toLivewire(),
-        ];
-    }
-
-    public static function fromLivewire($value): self
-    {
-        return new self($value['message'], $value['embeddedWireable']['message']);
-    }
-}
-
-class EmbeddedWireableClass implements Wireable
-{
-    public $message;
-
-    public function __construct($message)
-    {
-        $this->message = $message;
-    }
-
-    public function toLivewire()
-    {
-        return [
-            'message' => $this->message,
-        ];
-    }
-
-    public static function fromLivewire($value): self
-    {
-        return new self($value['message']);
-    }
-}
-
-class ComponentWithWireablePublicProperty extends Component
-{
-    public ?WireableClass $wireable;
-
-    public function mount($wireable)
-    {
-        $this->wireable = $wireable;
-    }
-
-    public function removeWireable()
-    {
-        $this->wireable = null;
-    }
-
-    public function render()
-    {
-        return view('wireables');
     }
 }

--- a/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
+++ b/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
@@ -34,23 +34,10 @@ class WireablesCanBeSetAsPublicPropertiesTest extends TestCase
             ->assertDontSee($message)
             ->assertDontSee($embeddedMessage);
     }
-
-    /** @test */
-    public function a_wireable_can_use_custom_serialization()
-    {
-        $wireable = new WireableClassWithCustomSerialization($message = Str::random());
-
-        Livewire::test(ComponentWithWireablePublicProperty::class, ['wireable' => $wireable])
-            ->assertSee($message)
-            ->call('$refresh')
-            ->assertSee($message);
-    }
 }
 
-class WireableClass
+class WireableClass implements Wireable
 {
-    use Wireable;
-
     public $message;
 
     public $embeddedWireable;
@@ -60,25 +47,31 @@ class WireableClass
         $this->message = $message;
         $this->embeddedWireable = new EmbeddedWireableClass($embeddedMessage);
     }
+
+    public function toLivewire()
+    {
+        return [
+            'message' => $this->message,
+        ];
+    }
+
+    public static function fromLivewire($value): self
+    {
+        $self = new self();
+        $self->message = $value['message'];
+
+        return $self;
+    }
 }
 
-class EmbeddedWireableClass
+class EmbeddedWireableClass implements Wireable
 {
-    use Wireable;
-
     public $message;
 
     public function __construct($message)
     {
         $this->message = $message;
     }
-}
-
-class WireableClassWithCustomSerialization
-{
-    use Wireable;
-
-    public $message;
 
     public function toLivewire()
     {

--- a/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
+++ b/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
@@ -40,7 +40,7 @@ class WireableClass implements Wireable
 {
     public $message;
 
-    public $embeddedWireable;
+    public EmbeddedWireableClass $embeddedWireable;
 
     public function __construct($message, $embeddedMessage)
     {
@@ -91,7 +91,7 @@ class EmbeddedWireableClass implements Wireable
 
 class ComponentWithWireablePublicProperty extends Component
 {
-    public $wireable;
+    public WireableClass $wireable;
 
     public function mount($wireable)
     {

--- a/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
+++ b/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
@@ -93,6 +93,11 @@ class ComponentWithWireablePublicProperty extends Component
 {
     public $wireable;
 
+    public function mount($wireable)
+    {
+        $this->wireable = $wireable;
+    }
+
     public function removeWireable()
     {
         $this->wireable = null;

--- a/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
+++ b/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
@@ -12,6 +12,10 @@ class WireablesCanBeSetAsPublicPropertiesTest extends TestCase
     /** @test */
     public function a_wireable_can_be_set_as_a_public_property()
     {
+        if (version_compare(PHP_VERSION, '7.4', '<')) {
+            $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
+        }
+
         $wireable = new WireableClass($message = Str::random(), $embeddedMessage = Str::random());
 
         Livewire::test(ComponentWithWireablePublicProperty::class, ['wireable' => $wireable])
@@ -25,6 +29,10 @@ class WireablesCanBeSetAsPublicPropertiesTest extends TestCase
     /** @test */
     public function a_wireable_can_be_set_then_removed_as_a_public_property()
     {
+        if (version_compare(PHP_VERSION, '7.4', '<')) {
+            $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
+        }
+
         $wireable = new WireableClass($message = Str::random(), $embeddedMessage = Str::random());
 
         Livewire::test(ComponentWithWireablePublicProperty::class, ['wireable' => $wireable])

--- a/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
+++ b/tests/Unit/WireablesCanBeSetAsPublicPropertiesTest.php
@@ -52,15 +52,13 @@ class WireableClass implements Wireable
     {
         return [
             'message' => $this->message,
+            'embeddedWireable' => $this->embeddedWireable->toLivewire(),
         ];
     }
 
     public static function fromLivewire($value): self
     {
-        $self = new self();
-        $self->message = $value['message'];
-
-        return $self;
+        return new self($value['message'], $value['embeddedWireable']['message']);
     }
 }
 
@@ -82,16 +80,13 @@ class EmbeddedWireableClass implements Wireable
 
     public static function fromLivewire($value): self
     {
-        $self = new self();
-        $self->message = $value['message'];
-
-        return $self;
+        return new self($value['message']);
     }
 }
 
 class ComponentWithWireablePublicProperty extends Component
 {
-    public WireableClass $wireable;
+    public ?WireableClass $wireable;
 
     public function mount($wireable)
     {

--- a/tests/Unit/views/wireables.blade.php
+++ b/tests/Unit/views/wireables.blade.php
@@ -3,7 +3,7 @@
         @if ($wireable)
             {{ $wireable->message }}
 
-            @if ($wireable->embeddedWireable)
+            @if ($wireable->embeddedWireable ?? false)
                 {{ $wireable->embeddedWireable->message }}
             @endif
         @endif

--- a/tests/Unit/views/wireables.blade.php
+++ b/tests/Unit/views/wireables.blade.php
@@ -1,0 +1,11 @@
+<div>
+    <div>
+        @if ($wireable)
+            {{ $wireable->message }}
+
+            @if ($wireable->embeddedWireable)
+                {{ $wireable->embeddedWireable->message }}
+            @endif
+        @endif
+    </div>
+</div>


### PR DESCRIPTION
This PR finally introduces support for custom DTO public properties in Livewire! 🚀 

> Additional credit to @ryangjchandler who I hacked on this with yesterday,

Any object may be `Wireable`, which allows it to be persisted between Livewire requests. Some use case ideas for this feature...
- Custom DTOs, commonly used in PHP development in general.
- Persisting unsaved Eloquent models between requests (implementing the interface on the model, and then serializing / unserializing from the `$attributes` property).
- Any other class you might want to persist and use in Livewire.

This feature even supports `wire:modelling` to a property in the custom object, using model-style dot syntax!

### How to use it

1. Implement the `Livewire\Wireable` interface on the custom class.
2. Set up `toLivewire()` and `fromLivewire()` methods on the class, which serializes it to and from an array.
3. Add the type of the custom class to the component's public property, like you would for a model.

### Example

```php
class Component extends \Livewire\Component
{
    public DTO $dto;

    public function mount()
    {
        $this->dto = new DTO('Message');
    }
}
```

```php
use Livewire\Wireable;

class DTO implements Wireable
{
    public $message;

    public function __construct($message)
    {
        $this->message = $message;
    }

    public function toLivewire()
    {
        return [
            'message' => $this->message,
        ];
    }

    public static function fromLivewire($value): self
    {
        return new self($value['message']);
    }
}
```

You can now use the `$dto` in your Livewire view, and even bind to it with `wire:model`...

```html
<div>
    <span>{{ $dto->message }}</span>

    <input wire:model="dto.message" />
</div>
```

This pattern is incredibly flexible, and (in theory) you can now use *any* PHP class in *any* state with Livewire!

### Considerations

Like other typed-property powered features in Livewire, this only supports PHP 7.4+.