### PR TITLE
Better support for blade component layouts.

### DIFF
--- a/src/Macros/ViewMacros.php
+++ b/src/Macros/ViewMacros.php
@@ -2,6 +2,8 @@
 
 namespace Livewire\Macros;
 
+use Illuminate\View\AnonymousComponent;
+
 class ViewMacros
 {
     public function extends()
@@ -25,6 +27,9 @@ class ViewMacros
                 $layout = new $view();
                 $params = array_merge($params, $layout->data());
                 $view = $layout->resolveView()->name();
+            } else {
+                $layout = new AnonymousComponent($view, $params);
+                $params = array_merge($params, $layout->data());
             }
 
             $this->livewireLayout = [

--- a/src/Macros/ViewMacros.php
+++ b/src/Macros/ViewMacros.php
@@ -25,18 +25,18 @@ class ViewMacros
         return function ($view, $params = []) {
             if (is_subclass_of($view, \Illuminate\View\Component::class)) {
                 $layout = new $view();
-                $params = array_merge($params, $layout->data());
                 $view = $layout->resolveView()->name();
             } else {
                 $layout = new AnonymousComponent($view, $params);
-                $params = array_merge($params, $layout->data());
             }
+
+            $layout->withAttributes($params['attributes'] ?? []);
 
             $this->livewireLayout = [
                 'type' => 'component',
                 'slotOrSection' => 'slot',
                 'view' => $view,
-                'params' => $params,
+                'params' => array_merge($params, $layout->data()),
             ];
 
             return $this;

--- a/tests/Unit/ComponentLayoutTest.php
+++ b/tests/Unit/ComponentLayoutTest.php
@@ -49,7 +49,7 @@ class ComponentLayoutTest extends TestCase
     }
 
     /** @test */
-    public function can_load_dynamic_layout_properties()
+    public function can_show_params_with_a_custom_class_based_component_layout()
     {
         Livewire::component(ComponentWithClassBasedComponentLayout::class);
 
@@ -58,6 +58,41 @@ class ComponentLayoutTest extends TestCase
         $this->withoutExceptionHandling()->get('/foo')
             ->assertSee('bar')
             ->assertSee('baz');
+    }
+
+    /** @test */
+    public function can_show_attributes_with_a_custom_class_based_component_layout()
+    {
+        Livewire::component(ComponentWithClassBasedComponentLayoutAndAttributes::class);
+
+        Route::get('/foo', ComponentWithClassBasedComponentLayoutAndAttributes::class);
+
+        $this->withoutExceptionHandling()->get('/foo')
+            ->assertSee('class="foo"', false);
+    }
+
+    /** @test */
+    public function can_show_params_with_a_custom_anonymous_component_layout()
+    {
+        Livewire::component(ComponentWithAnonymousComponentLayout::class);
+
+        Route::get('/foo', ComponentWithAnonymousComponentLayout::class);
+
+        $this->withoutExceptionHandling()->get('/foo')
+            ->assertSee('bar')
+            ->assertSee('baz');
+    }
+
+    /** @test */
+    public function can_show_attributes_with_a_custom_anonymous_component_layout()
+    {
+        Livewire::component(ComponentWithAnonymousComponentLayoutAndAttributes::class);
+
+        Route::get('/foo', ComponentWithAnonymousComponentLayoutAndAttributes::class);
+
+        $this->withoutExceptionHandling()->get('/foo')
+            ->assertSee('class="foo"', false)
+            ->assertSee('id="foo"', false);
     }
 
     /** @test */
@@ -129,6 +164,40 @@ class ComponentWithClassBasedComponentLayout extends Component
     {
         return view('null-view')->layout(\Tests\AppLayout::class, [
             'bar' => 'baz'
+        ]);
+    }
+}
+
+class ComponentWithClassBasedComponentLayoutAndAttributes extends Component
+{
+    public function render()
+    {
+        return view('null-view')->layout(\Tests\AppLayout::class, [
+            'attributes' => [
+                'class' => 'foo',
+            ],
+        ]);
+    }
+}
+
+class ComponentWithAnonymousComponentLayout extends Component
+{
+    public function render()
+    {
+        return view('null-view')->layout('layouts.app-anonymous-component', [
+            'bar' => 'baz'
+        ]);
+    }
+}
+
+class ComponentWithAnonymousComponentLayoutAndAttributes extends Component
+{
+    public function render()
+    {
+        return view('null-view')->layout('layouts.app-anonymous-component', [
+            'attributes' => [
+                'class' => 'foo',
+            ],
         ]);
     }
 }

--- a/tests/Unit/ConfigurableLayoutTest.php
+++ b/tests/Unit/ConfigurableLayoutTest.php
@@ -2,8 +2,9 @@
 
 namespace Tests\Unit;
 
-use Livewire\Component;
 use Illuminate\Support\Facades\Route;
+use Livewire\Component;
+use Tests\AppLayout;
 
 class ConfigurableLayoutTest extends TestCase
 {
@@ -14,7 +15,7 @@ class ConfigurableLayoutTest extends TestCase
 
         $this
             ->get('/configurable-layout')
-            ->assertSee('bar')
+            ->assertSee('foo')
             ->assertDontSee('baz');
     }
 
@@ -27,17 +28,161 @@ class ConfigurableLayoutTest extends TestCase
 
         $this
             ->get('/configurable-layout')
+            ->assertSee('foo')
+            ->assertSee('baz');
+    }
+
+    /** @test */
+    public function can_configure_the_default_layout_to_a_class_based_component_layout()
+    {
+        config()->set('livewire.layout', AppLayout::class);
+
+        Route::get('/configurable-layout', ComponentForConfigurableLayoutTest::class);
+
+        $this
+            ->get('/configurable-layout')
+            ->assertSee('foo')
             ->assertSee('bar')
+            ->assertDontSee('baz');
+    }
+
+    /** @test */
+    public function can_show_params_with_a_configured_class_based_component_layout()
+    {
+        config()->set('livewire.layout', AppLayout::class);
+
+        Route::get('/configurable-layout', ComponentForConfigurableLayoutTestWithCustomParams::class);
+
+        $this
+            ->get('/configurable-layout')
+            ->assertSee('foo')
+            ->assertSee('bar')
+            ->assertSee('baz');
+    }
+
+    /** @test */
+    public function can_set_custom_slot_for_a_configured_class_based_component_layout()
+    {
+        config()->set('livewire.layout', AppLayout::class);
+
+        Route::get('/configurable-layout', ComponentForConfigurableLayoutTestWithCustomSlot::class);
+
+        $this
+            ->get('/configurable-layout')
+            ->assertSee('foo')
+            ->assertSee('bar');
+    }
+
+    /** @test */
+    public function can_configure_the_default_layout_to_an_anonymous_component_layout()
+    {
+        config()->set('livewire.layout', 'layouts.app-anonymous-component');
+
+        Route::get('/configurable-layout', ComponentForConfigurableLayoutTest::class);
+
+        $this
+            ->get('/configurable-layout')
+            ->assertSee('foo')
+            ->assertSee('bar')
+            ->assertDontSee('baz');
+    }
+
+    /** @test */
+    public function can_show_params_with_a_configured_anonymous_component_layout()
+    {
+        config()->set('livewire.layout', 'layouts.app-anonymous-component');
+
+        Route::get('/configurable-layout', ComponentForConfigurableLayoutTestWithCustomParams::class);
+
+        $this
+            ->get('/configurable-layout')
+            ->assertSee('foo')
+            ->assertSee('bar')
+            ->assertSee('baz');
+    }
+
+    /** @test */
+    public function can_set_custom_slot_for_a_configured_anonymous_component_layout()
+    {
+        config()->set('livewire.layout', 'layouts.app-anonymous-component');
+
+        Route::get('/configurable-layout', ComponentForConfigurableLayoutTestWithCustomSlot::class);
+
+        $this
+            ->get('/configurable-layout')
+            ->assertSee('foo')
+            ->assertSee('bar');
+    }
+
+    /** @test */
+    public function can_show_params_with_a_configured_anonymous_component_layout_that_has_a_required_prop()
+    {
+        config()->set('livewire.layout', 'layouts.app-anonymous-component-with-required-prop');
+
+        Route::get('/configurable-layout', ComponentForConfigurableLayoutTestWithCustomParams::class);
+
+        $this
+            ->get('/configurable-layout')
+            ->assertSee('foo')
+            ->assertSee('bar')
+            ->assertSee('baz');
+    }
+
+    /** @test */
+    public function can_override_optional_props_with_a_configured_anonymous_component_layout()
+    {
+        config()->set('livewire.layout', 'layouts.app-anonymous-component');
+
+        Route::get('/configurable-layout', ComponentForConfigurableLayoutTestWithCustomFooParam::class);
+
+        $this
+            ->get('/configurable-layout')
+            ->assertSee('foo')
+            ->assertDontSee('bar')
             ->assertSee('baz');
     }
 }
 
 class ComponentForConfigurableLayoutTest extends Component
 {
-    public $name = 'bar';
+    public $name = 'foo';
 
     public function render()
     {
         return view('show-name');
+    }
+}
+
+class ComponentForConfigurableLayoutTestWithCustomParams extends Component
+{
+    public $name = 'foo';
+
+    public function render()
+    {
+        return view('show-name')->layoutData([
+            'bar' => 'baz',
+        ]);
+    }
+}
+
+class ComponentForConfigurableLayoutTestWithCustomSlot extends Component
+{
+    public $name = 'foo';
+
+    public function render()
+    {
+        return view('show-name')->slot('bar');
+    }
+}
+
+class ComponentForConfigurableLayoutTestWithCustomFooParam extends Component
+{
+    public $name = 'foo';
+
+    public function render()
+    {
+        return view('show-name')->layoutData([
+            'foo' => 'baz',
+        ]);
     }
 }

--- a/tests/Unit/ConfigurableLayoutTest.php
+++ b/tests/Unit/ConfigurableLayoutTest.php
@@ -141,6 +141,31 @@ class ConfigurableLayoutTest extends TestCase
             ->assertDontSee('bar')
             ->assertSee('baz');
     }
+
+    /** @test */
+    public function can_pass_attributes_to_a_configured_class_based_component_layout()
+    {
+        config()->set('livewire.layout', AppLayout::class);
+
+        Route::get('/configurable-layout', ComponentForConfigurableLayoutTestWithCustomAttributes::class);
+
+        $this
+            ->get('/configurable-layout')
+            ->assertSee('class="foo"', false)
+            ->assertSee('id="foo"', false);
+    }
+
+    /** @test */
+    public function can_pass_attributes_to_a_configured_anonymous_component_layout()
+    {
+        config()->set('livewire.layout', 'layouts.app-anonymous-component');
+
+        Route::get('/configurable-layout', ComponentForConfigurableLayoutTestWithCustomAttributes::class);
+
+        $this
+            ->get('/configurable-layout')
+            ->assertSee('class="foo"', false);
+    }
 }
 
 class ComponentForConfigurableLayoutTest extends Component
@@ -183,6 +208,20 @@ class ComponentForConfigurableLayoutTestWithCustomFooParam extends Component
     {
         return view('show-name')->layoutData([
             'foo' => 'baz',
+        ]);
+    }
+}
+
+class ComponentForConfigurableLayoutTestWithCustomAttributes extends Component
+{
+    public $name = 'foo';
+
+    public function render()
+    {
+        return view('show-name')->layoutData([
+            'attributes' => [
+                'class' => 'foo',
+            ]
         ]);
     }
 }

--- a/tests/Unit/views/layouts/app-anonymous-component-with-required-prop.blade.php
+++ b/tests/Unit/views/layouts/app-anonymous-component-with-required-prop.blade.php
@@ -1,0 +1,12 @@
+@props([
+    'foo' => 'bar',
+    'bar',
+])
+
+<div {{$attributes}}>
+    {{ $foo }}
+</div>
+
+{{ $slot }}
+
+{{ $bar }}

--- a/tests/Unit/views/layouts/app-anonymous-component.blade.php
+++ b/tests/Unit/views/layouts/app-anonymous-component.blade.php
@@ -1,0 +1,13 @@
+@props([
+    'foo' => 'bar',
+])
+
+<div {{$attributes}}>
+    {{ $foo }}
+</div>
+
+{{ $slot }}
+
+@isset($bar)
+    {{ $bar }}
+@endisset

--- a/tests/Unit/views/layouts/app-anonymous-component.blade.php
+++ b/tests/Unit/views/layouts/app-anonymous-component.blade.php
@@ -2,7 +2,7 @@
     'foo' => 'bar',
 ])
 
-<div {{$attributes}}>
+<div {{ $attributes->merge(['id' => 'foo']) }}>
     {{ $foo }}
 </div>
 

--- a/tests/Unit/views/layouts/app-from-class-component.blade.php
+++ b/tests/Unit/views/layouts/app-from-class-component.blade.php
@@ -2,7 +2,9 @@
 
 {{ $slot }}
 
-{{ $foo }}
+<div {{ $attributes->merge(['id' => 'foo']) }}>
+    {{ $foo }}
+</div>
 
 @isset($bar)
     {{ $bar }}

--- a/tests/Unit/views/layouts/app-from-class-component.blade.php
+++ b/tests/Unit/views/layouts/app-from-class-component.blade.php
@@ -4,4 +4,6 @@
 
 {{ $foo }}
 
-{{ $bar }}
+@isset($bar)
+    {{ $bar }}
+@endisset


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue/discussion about it first?
Yes, it's wanted/needed. Issues and discussions already existed so I didn't create any new ones. Plus, it's hard to discuss it without seeing code, at least for me anyway.
- #2499 
- #1807 
- #1707 
- https://forum.laravel-livewire.com/t/layout-class-constructor-is-not-triggered-while-rendering/1985
- https://forum.laravel-livewire.com/t/livewire-with-custom-layout/1666/8

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, all related

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes! 
I tried my best to keep it consistent with how I saw the rest of the tests being written however, all the foo, bar, baz stuff was a little hard to keep track of. Mostly cause the slot names and the data rendered in them were mixing them. Also, naming the test classes was challenging since they're all in the same namespace so need to be unique. So please feel free to refactor to whatever makes sense to you.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
So @RomainMazB had added support for using class-based component layouts in #2499. Thanks, @RomainMazB 🙏!
This builds on top of that and adds support for:
- Setting class-based component layouts in the config file
- Setting anonymous (aka class-less) component layouts in the config file
- Using anonymous component layouts via `Livewire\Macros\ViewMacros::layout()`
- `Illuminate\View\ComponentAttributeBag $attributes` is always available to the layout components now
- can fill `$attributes` with `Livewire\Macros\ViewMacros::layout()` or `Livewire\Macros\ViewMacros::layoutData()`

5️⃣ Thanks for contributing! 🙌
No prob. 🙌

## 😱 Possible breaking changes 😱
### Removed protected `Livewire\Component::$initialLayoutConfiguration`

This property didn't seem needed. We pass the view in the `component.rendered` event and it was only being read from in `Livewire\Component::__invoke()`. But idk what your policy is for supporting undocumented things that were purely intended for internal use. It's possible that people were creating livewire components and using `$initialLayoutConfiguration` as an alternative to calling the various view macros that populate `$initialLayoutConfiguration`. But I removed it to make the code simpler and overall have less "public" code to support.

### `$view->livewireLayout['params']['attributes']` is handled uniquely.
If the user didn't call `layout()` or `extends()` then we'll end up calling `layout()` which will call `Illuminate\View\Component::data()` which returrns a `Illuminate\View\ComponentAttributeBag`  as the value for the `attributes` key. This will end up replacing the one from the user's livewire component when we merge with `array_merge($params, $layout->data())`.

However, we do pass it to the layout component like with `$layout->withAttributes($params['attributes'] ?? []);`.  So this should only really be an issue if they're not using `$attributes` in their view in a way that's compatible with `Illuminate\View\ComponentAttributeBag`. 

Hope all that makes sense. 