### PR TITLE
update/nonce-Attribute (missing space)

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -274,8 +274,8 @@ HTML;
         // because it will be minified in production.
         return <<<HTML
 {$assetWarning}
-<script src="{$fullAssetPath}" data-turbo-eval="false" data-turbolinks-eval="false"{$nonce}></script>
-<script data-turbo-eval="false" data-turbolinks-eval="false"{$nonce}>
+<script src="{$fullAssetPath}" data-turbo-eval="false" data-turbolinks-eval="false" {$nonce}></script>
+<script data-turbo-eval="false" data-turbolinks-eval="false" {$nonce}>
     {$windowLivewireCheck}
 
     window.livewire = new Livewire({$jsonEncodedOptions});

--- a/tests/Unit/LivewireAssetsDirectiveTest.php
+++ b/tests/Unit/LivewireAssetsDirectiveTest.php
@@ -91,7 +91,7 @@ class LivewireAssetsDirectiveTest extends TestCase
         ])->render();
 
         $this->assertStringContainsString(
-            'nonce="foobarnonce">',
+            ' nonce="foobarnonce">',
             $output
         );
     }


### PR DESCRIPTION
I've noticed that firefox is complaining about the missing space in front of the `nonce`-Attribute (I don't know if it creates problems).
Safari and Chrome handle it well (just add the space), but the official spec form W3C is complaing aswell.

Firefox sources:  
![Bildschirmfoto 2021-07-21 um 19 26 49](https://user-images.githubusercontent.com/10073766/126537132-f9b8075f-d1e9-4038-ade3-16c7381e44d6.jpg)

W3C Error:  
![Bildschirmfoto 2021-07-21 um 19 29 20](https://user-images.githubusercontent.com/10073766/126537178-bd60ce75-5252-4446-b495-37b849cadab7.jpg)
![Bildschirmfoto 2021-07-21 um 19 28 53](https://user-images.githubusercontent.com/10073766/126537183-6571383e-cafe-4a95-821d-43f2ed4f8abf.jpg)


Changes
---
- adds a space between the `none`-Attribute and the other Attributes (eb. `data-turbolinks-eval`)
- updates the Test `nonce_passed_into_directive_gets_added_as_script_tag_attribute()` to match this criteria
