### PR TITLE
Removed the wrapper div for assertSee

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -119,7 +119,13 @@ trait MakesAssertions
 
     protected function stripOutInitialData($subject)
     {
-        return preg_replace('/((?:[\n\s+]+)?wire:initial-data=\".+}"\n?|(?:[\n\s+]+)?wire:id=\"[^"]*"\n?)/m', '', $subject);
+        $content = preg_replace('/((?:[\n\s+]+)?wire:initial-data=\".+}"\n?|(?:[\n\s+]+)?wire:id=\"[^"]*"\n?)/m', '', $subject);
+
+        if (Str::startsWith($content, '<div>')) {
+            $content = preg_replace('/^<div>\n?([\S\s]*)\n?<\/div>\n?$/m', '$1', $content);
+        }
+
+        return $content;
     }
 
     public function assertEmitted($value, ...$params)

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -96,15 +96,50 @@ class LivewireTestingTest extends TestCase
     }
 
     /** @test */
-    public function assert_see_doesnt_include_wire_id_and_wire_data_attribute()
+    public function assert_see_doesnt_include_wire_data_attribute()
     {
         /*
         * See for more info: https://github.com/calebporzio/livewire/issues/62
-        * Regex test: https://regex101.com/r/UhjREC/2/
         */
         app(LivewireManager::class)
             ->test(HasMountArgumentsButDoesntPassThemToBladeView::class, ['name' => 'shouldnt see me'])
             ->assertDontSee('shouldnt see me');
+    }
+
+    /** @test */
+    public function assert_see_doesnt_include_wire_id()
+    {
+        /*
+        * Regex test: https://regex101.com/r/UhjREC
+        */
+        app(LivewireManager::class)
+            ->test(HasHtml::class)
+            ->assertSeeHtml('<p style="display: none">Hello HTML</p>')
+            ->assertDontSee('wire:id="');
+    }
+
+    /** @test */
+    public function assert_see_doesnt_include_wrapper_div()
+    {
+        /*
+        * Regex test: https://regex101.com/r/XKeZYf
+        */
+        app(LivewireManager::class)
+            ->test(HasHtml::class)
+            ->assertSeeHtml('<p style="display: none">Hello HTML</p>')
+            ->assertDontSeeHtml('<div>')
+            ->assertDontSeeHtml('</div>');
+    }
+
+    /** @test */
+    public function assert_see_include_wrapper_div()
+    {
+        /*
+        * Regex test: https://regex101.com/r/XKeZYf
+        */
+        app(LivewireManager::class)
+            ->test(HasHtmlWithWrapperAttributes::class)
+            ->assertSeeHtml('<div class="alpine"><p style="display: none">Hello HTML</p></div>');
     }
 
     /** @test */
@@ -224,6 +259,14 @@ class HasHtml extends Component
     public function render()
     {
         return app('view')->make('show-html');
+    }
+}
+
+class HasHtmlWithWrapperAttributes extends Component
+{
+    public function render()
+    {
+        return app('view')->make('show-html-with-wrapper-attr');
     }
 }
 

--- a/tests/Unit/views/show-html-with-wrapper-attr.blade.php
+++ b/tests/Unit/views/show-html-with-wrapper-attr.blade.php
@@ -1,0 +1,1 @@
+<div class="alpine"><p style="display: none">Hello HTML</p></div>


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first? : #3290

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out. : No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have): Yes

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

---

This PR relates to: #3290 #62

This way I think it would be more appropriate to completely remove the wrapper div.

If the wrapper has no other attributes:

```blade
<!-- before -->
<div wire:id="foo" wire:initial-data="bar">
content
</div>

<!-- after -->
content
```

If the wrapper has another attribute:

```blade
<!-- before -->
<div class="hello" wire:id="foo" wire:initial-data="bar">
content
</div>

<!-- after -->
<div class="hello">
content
</div>
```

### Regex: https://regex101.com/r/XKeZYf