### PR TITLE
Add lastRenderedCleanDom

### DIFF
--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -26,6 +26,7 @@ class TestableLivewire
     public $lastErrorBag;
     public $lastRenderedView;
     public $lastRenderedDom;
+    public $lastRenderedCleanDom;
     public $lastResponse;
     public $rawMountedResponse;
 
@@ -95,6 +96,7 @@ class TestableLivewire
         // the last known one.
         if ($output['effects']['html'] ?? false) {
             $this->lastRenderedDom = $output['effects']['html'];
+            $this->lastRenderedCleanDom = $this->stripOutInitialData($this->lastRenderedDom);
         }
 
         if ($output['fingerprint'] ?? false) {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first? : https://github.com/livewire/livewire/pull/3290#issuecomment-879553472

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out. : No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have) : No

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

This PR relates to: #3439 

**Details**: https://github.com/livewire/livewire/pull/3290#issuecomment-879553472

This returns a DOM with `wire:id` and `wire:initial-data` data removed from lastRenderedDom.

( If #3439 is merged, it returns a DOM with the wrapper div removed as well )

For example, when testing with Pest, clean results can be obtained with such use.

```php
// PestPHP

expect($component->lastRenderedCleanDom)
      ->toStartWith('foo')
      ->toEndWith('bar');
```

The `assertSee` function produces results. 

But we can use the filtered data multiple times with `$this->lastRenderedCleanDom`.

I sampled this with Pest. But actually I think this will be useful for everyone.