### PR TITLE
Tests assertSee and dontSee allow multiple values

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -57,22 +57,34 @@ trait MakesAssertions
         return $this;
     }
 
-    public function assertSee($value)
+    public function assertSee($value, $escape = true)
     {
-        PHPUnit::assertStringContainsString(
-            e($value),
-            $this->stripOutInitialData($this->lastRenderedDom)
-        );
+        $value = static::wrapInArray($value);
+
+        $values = $escape ? array_map('e', ($value)) : $value;
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringContainsString(
+                e($value),
+                $this->stripOutInitialData($this->lastRenderedDom)
+            );
+        }
 
         return $this;
     }
 
-    public function assertDontSee($value)
+    public function assertDontSee($value, $escape = true)
     {
-        PHPUnit::assertStringNotContainsString(
-            e($value),
-            $this->stripOutInitialData($this->lastRenderedDom)
-        );
+        $value = static::wrapInArray($value);
+
+        $values = $escape ? array_map('e', ($value)) : $value;
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringNotContainsString(
+                e($value),
+                $this->stripOutInitialData($this->lastRenderedDom)
+            );
+        }
 
         return $this;
     }
@@ -120,6 +132,15 @@ trait MakesAssertions
     protected function stripOutInitialData($subject)
     {
         return preg_replace('/((?:[\n\s+]+)?wire:initial-data=\".+}"\n?|(?:[\n\s+]+)?wire:id=\"[^"]*"\n?)/m', '', $subject);
+    }
+
+    protected function wrapInArray($value)
+    {
+        if (is_null($value)) {
+            return [];
+        }
+
+        return is_array($value) ? $value : [$value];
     }
 
     public function assertEmitted($value, ...$params)

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -80,6 +80,14 @@ class LivewireTestingTest extends TestCase
     }
 
     /** @test */
+    public function assert_see_multiple()
+    {
+        app(LivewireManager::class)
+            ->test(HasMountArguments::class, ['name' => 'should see me'])
+            ->assertSee(['should', 'see', 'me']);
+    }
+
+    /** @test */
     public function assert_see_html()
     {
         app(LivewireManager::class)
@@ -93,6 +101,22 @@ class LivewireTestingTest extends TestCase
         app(LivewireManager::class)
             ->test(HasHtml::class)
             ->assertDontSeeHtml('<span style="display: none">Hello HTML</span>');
+    }
+
+    /** @test */
+    public function assert_dont_see()
+    {
+        app(LivewireManager::class)
+            ->test(HasMountArguments::class, ['name' => 'should see me'])
+            ->assertDontSee('no one should see this');
+    }
+
+    /** @test */
+    public function assert_dont_see_multiple()
+    {
+        app(LivewireManager::class)
+            ->test(HasMountArguments::class, ['name' => 'should see me'])
+            ->assertDontSee(['no', 'one', 'really']);
     }
 
     /** @test */


### PR DESCRIPTION
Hello this is my first PR on this project I hope I did everything right :).

This PR adds the capability to pass arrays to the assertSee and assertDontSee assertions.
Before this PR:
```php
Livewire:test(myTestableComponent::class)
    ->call('foo')
    ->assertSee('bar')
    ->assertSee('foo')
    ->assertSee('baz');
```
After this PR:
```php
Livewire:test(myTestableComponent::class)
    ->call('foo')
    ->assertSee(['bar', 'foo', 'baz']);
```