### PR TITLE
[1.x] Add nonce to livewire script tag

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -243,7 +243,7 @@ HTML;
         // because it will be minified in production.
         return <<<HTML
 {$assetWarning}
-<script src="{$fullAssetPath}" data-turbolinks-eval="false"></script>
+<script src="{$fullAssetPath}" data-turbolinks-eval="false"{$nonce}></script>
 <script data-turbolinks-eval="false"{$nonce}>
     if (window.livewire) {
         console.warn('Livewire: It looks like Livewire\'s @livewireScripts JavaScript assets have already been loaded. Make sure you aren\'t loading them twice.')


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Yes, for CSP.   Created issue https://github.com/livewire/livewire/discussions/3444

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Using a CSP rule of `script-src 'nonce-xxx' 'strict-dynamic' https:;` for Laravel 6.x site almost works with livewire 1.x

A nonce is added to the inline script, but not the script source.  Changing https://github.com/livewire/livewire/blob/1.x/src/LivewireManager.php to use

    <script src="{$fullAssetPath}" data-turbolinks-eval="false"{$nonce}></script>
    <script data-turbolinks-eval="false"{$nonce}>

Resolves the CSP warning and the master branch already has this change https://github.com/livewire/livewire/blob/master/src/LivewireManager.php#L277

5️⃣ Thanks for contributing! 🙌