### PR TITLE
Fix octane issue with unresolved route params

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -39,8 +39,10 @@ abstract class Component
         $this->ensureIdPropertyIsntOverridden();
     }
 
-    public function __invoke(Container $container, Route $route)
+    public function __invoke(Container $container)
     {
+        $route = request()->route();
+
         try {
             $componentParams = (new ImplicitRouteBinding($container))
                 ->resolveAllParameters($route, $this);


### PR DESCRIPTION
If laravel octane is used, and a livewire component gets called again after the initial request, the following expection is thrown:

Illuminate\Contracts\Container\BindingResolutionException
Unresolvable dependency resolving [Parameter #0 [ <required> $methods ]] in class Illuminate\Routing\Route

Since laravel octane does not resolve the route binding propertly, the following PR utilizes another way of resolving that class.

This should fix the open issue https://github.com/laravel/octane/issues/267