### PR TITLE
Fix Google Cloud Storage preview URL in Temporary file upload

### DIFF
--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -45,6 +45,13 @@ class FileUploadConfiguration
         return config('filesystems.disks.'.strtolower($diskBeforeTestFake).'.driver') === 's3';
     }
 
+    public static function isUsingGCS()
+    {
+        $diskBeforeTestFake = config('livewire.temporary_file_upload.disk') ?: config('filesystems.default');
+
+        return config('filesystems.disks.'.strtolower($diskBeforeTestFake).'.driver') === 'gcs';
+    }
+
     protected static function directory()
     {
         return Util::normalizeRelativePath(config('livewire.temporary_file_upload.directory') ?: 'livewire-tmp');

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -59,7 +59,7 @@ class TemporaryUploadedFile extends UploadedFile
 
     public function temporaryUrl()
     {
-        if (FileUploadConfiguration::isUsingS3() && ! app()->environment('testing')) {
+        if ((FileUploadConfiguration::isUsingS3() or FileUploadConfiguration::isUsingGCS()) && ! app()->environment('testing')) {
             return $this->storage->temporaryUrl(
                 $this->path,
                 now()->addDay(),


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yes, this is a bub that we have been facing, issue is at https://github.com/livewire/livewire/discussions/3483
2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
NO, one change to add support for google cloud storage preview upload
3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No
4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
The change lets livewire correctly preview uploaded files (eg:images) when using google cloud storage instead of S3. Both GCS and S3 have a very similar storage engine and API, but not identical implementation. 
5️⃣ Thanks for contributing! 🙌