### PR TITLE
Fix php8 ReflectionUnionType::isBuiltin()

### DIFF
--- a/src/ImplicitlyBoundMethod.php
+++ b/src/ImplicitlyBoundMethod.php
@@ -99,10 +99,24 @@ class ImplicitlyBoundMethod extends BoundMethod
 
         return $model;
     }
-
+    
     public static function getParameterClassName($parameter)
     {
         $type = $parameter->getType();
+
+        if ($type === null){
+            return null;
+        }
+
+        if ($type instanceof \ReflectionNamedType){
+            return $type->isBuiltin() ? null : $type->getName();
+        }
+
+        if ($type instanceof \ReflectionUnionType){
+            foreach ($type->getTypes() as $union_type){
+                return $union_type->isBuiltin() ? null : $union_type->getName();
+            }
+        }
 
         return ($type && ! $type->isBuiltin()) ? $type->getName() : null;
     }

--- a/src/ImplicitlyBoundMethod.php
+++ b/src/ImplicitlyBoundMethod.php
@@ -105,7 +105,7 @@ class ImplicitlyBoundMethod extends BoundMethod
         $type = $parameter->getType();
 
         if ($type == null) return null;
-        if ($type instanceof \ReflectionNamedType) return !$type->isBuiltin() ? $type->getName() : null;
+
         if ($type instanceof \ReflectionUnionType) return static::getFirstReflectionUnionTypeName($type);
 
         return !$type->isBuiltin() ? $type->getName() : null;

--- a/src/ImplicitlyBoundMethod.php
+++ b/src/ImplicitlyBoundMethod.php
@@ -104,21 +104,22 @@ class ImplicitlyBoundMethod extends BoundMethod
     {
         $type = $parameter->getType();
 
-        if ($type === null){
+        if ($type == null){
             return null;
         }
 
         if ($type instanceof \ReflectionNamedType){
-            return $type->isBuiltin() ? null : $type->getName();
+            return !$type->isBuiltin() ? $type->getName() : null;
         }
 
         if ($type instanceof \ReflectionUnionType){
             foreach ($type->getTypes() as $union_type){
-                return $union_type->isBuiltin() ? null : $union_type->getName();
+                if(!$union_type->isBuiltin()) return $union_type->getName();
             }
+            return null;
         }
 
-        return ($type && ! $type->isBuiltin()) ? $type->getName() : null;
+        return !$type->isBuiltin() ? $type->getName() : null;
     }
 
     public static function implementsInterface($parameter)


### PR DESCRIPTION
In php8 the `ReflectionType` has become abstract and `ReflectionType::isBuiltin()` has been moved to `ReflectionNamedType::isBuiltin()`.

The `$type->isBuiltin()` results in an error:

```php
Call to undefined method ReflectionUnionType::isBuiltin()
```

https://www.php.net/manual/en/class.reflectiontype.php

Discussed in #3403

