### PR TITLE
Support collection re-ordering

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -199,20 +199,6 @@ abstract class Component
         return $output;
     }
 
-    public function normalizePublicPropertiesForJavaScript()
-    {
-        foreach ($this->getPublicPropertiesDefinedBySubClass() as $key => $value) {
-            if (is_array($value)) {
-                $this->$key = $this->reindexArrayWithNumericKeysOtherwiseJavaScriptWillMessWithTheOrder($value);
-            }
-
-            if ($value instanceof EloquentCollection) {
-                // Preserve collection items order by reindexing underlying array.
-                $this->$key = $value->values();
-            }
-        }
-    }
-
     public function forgetComputed($key = null)
     {
         if (is_null($key)) {

--- a/src/HydrationMiddleware/NormalizeComponentPropertiesForJavaScript.php
+++ b/src/HydrationMiddleware/NormalizeComponentPropertiesForJavaScript.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\HydrationMiddleware;
 
+use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 class NormalizeComponentPropertiesForJavaScript extends NormalizeDataForJavaScript implements HydrationMiddleware
@@ -14,7 +15,7 @@ class NormalizeComponentPropertiesForJavaScript extends NormalizeDataForJavaScri
     public static function dehydrate($instance, $response)
     {
         foreach ($instance->getPublicPropertiesDefinedBySubClass() as $key => $value) {
-            if (is_array($value)) {
+            if (is_array($value) || $value instanceof Collection) {
                 $instance->$key = static::reindexArrayWithNumericKeysOtherwiseJavaScriptWillMessWithTheOrder($value);
             }
 

--- a/src/HydrationMiddleware/NormalizeDataForJavaScript.php
+++ b/src/HydrationMiddleware/NormalizeDataForJavaScript.php
@@ -2,16 +2,28 @@
 
 namespace Livewire\HydrationMiddleware;
 
+use Illuminate\Support\Collection;
+
 abstract class NormalizeDataForJavaScript
 {
     protected static function reindexArrayWithNumericKeysOtherwiseJavaScriptWillMessWithTheOrder($value)
     {
+        // Make sure string keys are last (but not ordered) and numeric keys are ordered.
+        // JSON.parse will do this on the frontend, so we'll get ahead of it.
+
+        $isCollection = false;
+        $collectionClass = Collection::class;
+
+        if ($value instanceof Collection) {
+            $isCollection = true;
+            $collectionClass = get_class($value);
+
+            $value = $value->toArray();
+        }
+
         if (! is_array($value)) {
             return $value;
         }
-
-        // Make sure string keys are last (but not ordered) and numeric keys are ordered.
-        // JSON.parse will do this on the frontend, so we'll get ahead of it.
 
         $itemsWithNumericKeys = array_filter($value, function ($key) {
             return is_numeric($key);
@@ -25,8 +37,14 @@ abstract class NormalizeDataForJavaScript
         //array_merge will reindex in some cases so we stick to array_replace
         $normalizedData = array_replace($itemsWithNumericKeys, $itemsWithStringKeys);
 
-        return array_map(function ($value) {
+        $output = array_map(function ($value) {
             return static::reindexArrayWithNumericKeysOtherwiseJavaScriptWillMessWithTheOrder($value);
         }, $normalizedData);
+
+        if ($isCollection) {
+            return new $collectionClass($output);
+        }
+
+        return $output;
     }
 }

--- a/tests/Browser/SupportCollections/Component.php
+++ b/tests/Browser/SupportCollections/Component.php
@@ -8,19 +8,41 @@ use Livewire\Component as BaseComponent;
 class Component extends BaseComponent
 {
     public $things;
+    public $unorderedKeyedThings;
 
     public function mount()
     {
         $this->things = collect('foo');
+        $this->unorderedKeyedThings = collect([
+            2 => 'foo',
+            1 => 'bar',
+        ]);
     }
 
     public function addBar()
     {
         $this->things->push('bar');
+        $this->unorderedKeyedThings[3] = 'baz';
     }
 
     public function render()
     {
-        return View::file(__DIR__.'/view.blade.php');
+        return <<<'HTML'
+<div>
+    <button wire:click="addBar" dusk="add-bar">Add Bar</button>
+
+    <div dusk="things">
+        @foreach ($things as $thing)
+            <h1>{{ $thing }}</h1>
+        @endforeach
+    </div>
+
+    <div dusk="unordered">
+        @foreach ($unorderedKeyedThings as $thing)
+            <h1>{{ $thing }}</h1>
+        @endforeach
+    </div>
+</div>
+HTML;
     }
 }

--- a/tests/Browser/SupportCollections/Test.php
+++ b/tests/Browser/SupportCollections/Test.php
@@ -13,8 +13,13 @@ class Test extends TestCase
             Livewire::visit($browser, Component::class)
                 ->assertSeeIn('@things', 'foo')
                 ->assertDontSeeIn('@things', 'bar')
+                ->assertSeeIn('@unordered', 'foo')
+                ->assertSeeIn('@unordered', 'bar')
                 ->waitForLivewire()->click('@add-bar')
                 ->assertSeeIn('@things', 'bar')
+                ->assertSeeIn('@unordered', 'foo')
+                ->assertSeeIn('@unordered', 'bar')
+                ->assertSeeIn('@unordered', 'baz')
             ;
         });
     }

--- a/tests/Browser/SupportCollections/Test.php
+++ b/tests/Browser/SupportCollections/Test.php
@@ -11,10 +11,11 @@ class Test extends TestCase
     {
         $this->browse(function ($browser) {
             Livewire::visit($browser, Component::class)
-                ->assertSee('foo')
-                ->assertDontSee('bar')
+                ->assertSeeIn('@things', 'foo')
+                ->assertDontSeeIn('@things', 'bar')
                 ->waitForLivewire()->click('@add-bar')
-                ->assertSee('bar');
+                ->assertSeeIn('@things', 'bar')
+            ;
         });
     }
 }


### PR DESCRIPTION
Currently, if you have a collection instance set as a public property on a Livewire component AND that collection has numeric keys AND those keys are out of numerical order in the array (wew), Livewire will throw one of those dreaded corrupt payload error things that are crazy hard to debug.

This PR fixes that.