### PR TITLE
Fix component multi-root detection

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,1 +1,1 @@
-{"/livewire.js":"/livewire.js?id=74df826a8a1d27ca9478"}
+{"/livewire.js":"/livewire.js?id=8366cc0fed0a80ad4fc8"}

--- a/src/Features/SupportRootElementTracking.php
+++ b/src/Features/SupportRootElementTracking.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Livewire\Features;
+
+use Livewire\Livewire;
+use Livewire\ImplicitlyBoundMethod;
+
+class SupportRootElementTracking
+{
+    static function init() { return new static; }
+
+    protected $componentIdMethodMap = [];
+
+    function __construct()
+    {
+        Livewire::listen('component.dehydrate.initial', function ($component, $response) {
+            if (! $html = data_get($response, 'effects.html')) return
+
+            data_set($response, 'effects.html', $this->addComponentEndingMarker($html, $component));
+        });
+    }
+
+    public function addComponentEndingMarker($html, $component)
+    {
+        return $html."\n<!-- Livewire Component wire-end:".$component->id.' -->';
+    }
+}

--- a/src/Features/SupportRootElementTracking.php
+++ b/src/Features/SupportRootElementTracking.php
@@ -3,13 +3,10 @@
 namespace Livewire\Features;
 
 use Livewire\Livewire;
-use Livewire\ImplicitlyBoundMethod;
 
 class SupportRootElementTracking
 {
     static function init() { return new static; }
-
-    protected $componentIdMethodMap = [];
 
     function __construct()
     {

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -62,7 +62,7 @@ class LivewireServiceProvider extends ServiceProvider
         $this->registerViews();
         $this->registerRoutes();
         $this->registerCommands();
-        $this->registerRenameMes();
+        $this->registerFeatures();
         $this->registerViewMacros();
         $this->registerTagCompiler();
         $this->registerPublishables();
@@ -305,7 +305,7 @@ class LivewireServiceProvider extends ServiceProvider
         });
     }
 
-    protected function registerRenameMes()
+    protected function registerFeatures()
     {
         Features\SupportEvents::init();
         Features\SupportLocales::init();
@@ -318,6 +318,7 @@ class LivewireServiceProvider extends ServiceProvider
         Features\SupportActionReturns::init();
         Features\SupportBrowserHistory::init();
         Features\SupportComponentTraits::init();
+        Features\SupportRootElementTracking::init();
     }
 
     protected function registerHydrationMiddleware()

--- a/src/Macros/livewire-view-component.blade.php
+++ b/src/Macros/livewire-view-component.blade.php
@@ -1,6 +1,5 @@
 @component($view, $params)
     @slot($slotOrSection)
         {!! $manager->initialDehydrate()->toInitialResponse()->effects['html'] !!}
-        <!-- Livewire Component wire-end:{{ $manager->initialDehydrate()->toInitialResponse()->fingerprint['id'] }} -->
     @endslot
 @endcomponent

--- a/src/Macros/livewire-view-extends.blade.php
+++ b/src/Macros/livewire-view-extends.blade.php
@@ -2,5 +2,4 @@
 
 @section($slotOrSection)
     {!! $manager->initialDehydrate()->toInitialResponse()->effects['html'] !!}
-    <!-- Livewire Component wire-end:{{ $manager->initialDehydrate()->toInitialResponse()->fingerprint['id'] }} -->
 @endsection

--- a/tests/Browser/DetectMultipleRootElements/ComponentWithNestedSingleRootElement.php
+++ b/tests/Browser/DetectMultipleRootElements/ComponentWithNestedSingleRootElement.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Browser\DetectMultipleRootElements;
+
+use Livewire\Component as BaseComponent;
+
+class ComponentWithNestedSingleRootElement extends BaseComponent
+{
+    public function render()
+    {
+        return
+<<<'HTML'
+<div>
+    Nested: @livewire(\Tests\Browser\DetectMultipleRootElements\ComponentWithSingleRootElement::class)
+    <span>Dummy Element</span>
+</div>
+HTML;
+    }
+}

--- a/tests/Browser/DetectMultipleRootElements/ComponentWithSingleRootElement.php
+++ b/tests/Browser/DetectMultipleRootElements/ComponentWithSingleRootElement.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Browser\DetectMultipleRootElements;
+
+use Livewire\Component as BaseComponent;
+
+class ComponentWithSingleRootElement extends BaseComponent
+{
+    public function render()
+    {
+        return
+<<<'HTML'
+<div>Only Element</div>
+HTML;
+    }
+}

--- a/tests/Browser/DetectMultipleRootElements/Test.php
+++ b/tests/Browser/DetectMultipleRootElements/Test.php
@@ -4,6 +4,7 @@ namespace Tests\Browser\DetectMultipleRootElements;
 
 use Livewire\Livewire;
 use Tests\Browser\TestCase;
+use Tests\Browser\DetectMultipleRootElements\ComponentWithNestedSingleRootElement;
 
 class Test extends TestCase
 {
@@ -13,6 +14,16 @@ class Test extends TestCase
         $this->browse(function ($browser) {
             Livewire::visit($browser, ComponentWithMultipleRootElements::class)
                 ->assertConsoleLogHasWarning('Multiple root elements detected')
+                ;
+        });
+    }
+
+    /** @test */
+    public function it_doesnt_throw_an_error_when_a_single_root_component_is_included_from_the_livewire_directive()
+    {
+        $this->browse(function ($browser) {
+            Livewire::visit($browser, ComponentWithNestedSingleRootElement::class)
+                ->assertConsoleLogMissingWarning('Multiple root elements detected')
                 ;
         });
     }


### PR DESCRIPTION
Multi-root element detection for components was recently, PR'd but was broken for components that were included via standard `@livewire()` or `<livewire:` methods rather than `Route::get(...`.

This PR isolates the backend code related to this feature into a single dehydration listener.