### PR TITLE
Replace "testing" env check with native runningUnitTests check

### DIFF
--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -51,7 +51,7 @@ class MakeCommand extends FileManipulationCommand
                 $test && $this->line("<options=bold;fg=green>TEST:</>  {$this->parser->relativeTestPath()}");
             }
 
-            if ($showWelcomeMessage && ! app()->environment('testing')) {
+            if ($showWelcomeMessage && ! app()->runningUnitTests()) {
                 $this->writeWelcomeMessage();
             }
         }

--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -9,7 +9,7 @@ class FileUploadConfiguration
 {
     public static function storage()
     {
-        if (app()->environment('testing')) {
+        if (app()->runningUnitTests()) {
             // We want to "fake" the first time in a test run, but not again because
             // ::fake() whipes the storage directory every time its called.
             rescue(function () {
@@ -26,7 +26,7 @@ class FileUploadConfiguration
 
     public static function disk()
     {
-        if (app()->environment('testing')) {
+        if (app()->runningUnitTests()) {
             return 'tmp-for-tests';
         }
 

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -30,7 +30,7 @@ class TemporaryUploadedFile extends UploadedFile
 
     public function getSize()
     {
-        if (app()->environment('testing') && str($this->getfilename())->contains('-size=')) {
+        if (app()->runningUnitTests() && str($this->getfilename())->contains('-size=')) {
             return (int) str($this->getFilename())->between('-size=', '.')->__toString();
         }
 
@@ -59,7 +59,7 @@ class TemporaryUploadedFile extends UploadedFile
 
     public function temporaryUrl()
     {
-        if ((FileUploadConfiguration::isUsingS3() or FileUploadConfiguration::isUsingGCS()) && ! app()->environment('testing')) {
+        if ((FileUploadConfiguration::isUsingS3() or FileUploadConfiguration::isUsingGCS()) && ! app()->runningUnitTests()) {
             return $this->storage->temporaryUrl(
                 $this->path,
                 now()->addDay(),


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

I've encountered issue #2566 and read PR #2571, which caused confusion as to why the "testing"-env is forbidden.  That "testing"-magic-string is quickly mentioned in [the Laravel docs][1]) but it wasn't all that clear to me.

[1]: https://laravel.com/docs/8.x/testing#environment

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Nope, just one change across several files.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No, it doesn't change anything functionally and should be covered by existing tests.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

I've encountered the "disk not found" error on our DTAP-testing server (we used the names from the DTAP-pattern, which is wrong, apparently). 
Of course I grepped into the vendor folder looking for the disk name, and found the
disk-definition with the magic `app()->environment('testing')` string. 
This confused me, as I thought this was a convention thought up by Livewire.

By using a Laravel-native method which is very explicit about what it checks, the code quickly shifts the "blame" to the Laravel framework, where (if all goes well) the encountering dev will find the aforementioned paragraph.

Functionally, it doesn't do anything other than `app()->environment('testing')`, it just words it differently so one can quickly draw conclusions.

5️⃣ Thanks for contributing! 🙌

Thank you for your time 💜
