### PR TITLE
Correctly get the S3 adapter when it is cached

### DIFF
--- a/src/GenerateSignedUploadUrl.php
+++ b/src/GenerateSignedUploadUrl.php
@@ -3,6 +3,7 @@
 namespace Livewire;
 
 use Illuminate\Support\Facades\URL;
+use League\Flysystem\Cached\CachedAdapter;
 
 class GenerateSignedUploadUrl
 {
@@ -16,6 +17,10 @@ class GenerateSignedUploadUrl
     public function forS3($file, $visibility = 'private')
     {
         $adapter = FileUploadConfiguration::storage()->getDriver()->getAdapter();
+
+        if ($adapter instanceof CachedAdapter) {
+            $adapter = $adapter->getAdapter();
+        }
 
         $fileType = $file->getMimeType();
         $fileHashName = TemporaryUploadedFile::generateHashNameWithOriginalNameEmbedded($file);


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Yes, [discussion here](https://github.com/livewire/livewire/discussions/3573)

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Livewire crashes when uploading a temporary file to s3 if cache is defined in `filesystems.php`

5️⃣ Thanks for contributing! 🙌