### PR TITLE
Don't error out if $key not found in memo

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -91,7 +91,7 @@ class Response
         // If 'data' is present in the response memo, diff it one level deep.
         if (isset($dirtyMemo['data']) && isset($requestMemo['data'])) {
             foreach ($dirtyMemo['data'] as $key => $value) {
-                if ($value === $requestMemo['data'][$key]) {
+                if (isset($requestMemo['data'][$key]) && $value === $requestMemo['data'][$key]) {
                     unset($dirtyMemo['data'][$key]);
                 }
             }


### PR DESCRIPTION
This error happens in instances where a property is added to a component, but a user still has an old copy of the page active. The solution would be to log everyone out, but this is tedious and disruptive in a production environment, especially when the actual change is not material enough that they should actually need to.

Given the error seems unintentional (this wasn't a problem in Livewire 2), I propose just guarding the comparison which seems to work fine and I don't think will have and unintended consequences.