### PR TITLE
[Feature] Customize query params via component hydrate/dehydrate methods

### DIFF
--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -149,8 +149,18 @@ class SupportBrowserHistory
         $this->mergedQueryParamsFromDehydratedComponents = collect(request()->query())
             ->merge($this->mergedQueryParamsFromDehydratedComponents)
             ->merge($componentParams)
-            ->reject(function ($value, $key) use ($componentParams) {
-                return empty($componentParams[$key]);
+            ->reject(function ($value, $key) use ($component, $componentParams) {
+                if (! isset($component->queryString)) {
+                    return false;
+                }
+
+                foreach ($component->queryString as $param) {
+                    if (is_array($param) && isset($param[$key])) {
+                        return empty($componentParams[$key]);
+                    }
+
+                    return empty($componentParams[$key]);
+                }
             })
             ->reject(function ($value, $key) use ($excepts) {
                 return isset($excepts[$key]) && $excepts[$key] === $value;

--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -38,6 +38,10 @@ class SupportBrowserHistory
 
                 $component->$property = $decoded === null ? $fromQueryString : $decoded;
             }
+
+            if (method_exists($component, 'hydratePropertiesFromQueryParams')) {
+                $component->hydratePropertiesFromQueryParams($properties);
+            }
         });
 
         Livewire::listen('component.dehydrate.initial', function (Component $component, Response $response) {
@@ -171,6 +175,10 @@ class SupportBrowserHistory
 
     protected function getQueryParamsFromComponentProperties($component)
     {
+        if (method_exists($component, 'dehydratePropertiesToQueryParams')) {
+            return $component->dehydratePropertiesToQueryParams();
+        }
+
         return collect($component->getQueryString())
             ->mapWithKeys(function($value, $key) use ($component) {
                 $key = is_string($key) ? $key : $value;

--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -143,11 +143,15 @@ class SupportBrowserHistory
             $this->mergedQueryParamsFromDehydratedComponents = collect($this->getExistingQueryParams());
         }
 
+        $componentParams = $this->getQueryParamsFromComponentProperties($component);
         $excepts = $this->getExceptsFromComponent($component);
 
         $this->mergedQueryParamsFromDehydratedComponents = collect(request()->query())
             ->merge($this->mergedQueryParamsFromDehydratedComponents)
-            ->merge($this->getQueryParamsFromComponentProperties($component))
+            ->merge($componentParams)
+            ->reject(function ($value, $key) use ($componentParams) {
+                return empty($componentParams[$key]);
+            })
             ->reject(function ($value, $key) use ($excepts) {
                 return isset($excepts[$key]) && $excepts[$key] === $value;
             })

--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -154,13 +154,7 @@ class SupportBrowserHistory
                     return false;
                 }
 
-                foreach ($component->queryString as $param) {
-                    if (is_array($param) && isset($param[$key])) {
-                        return empty($componentParams[$key]);
-                    }
-
-                    return empty($componentParams[$key]);
-                }
+                return empty($componentParams[$key]);
             })
             ->reject(function ($value, $key) use ($excepts) {
                 return isset($excepts[$key]) && $excepts[$key] === $value;

--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -38,10 +38,6 @@ class SupportBrowserHistory
 
                 $component->$property = $decoded === null ? $fromQueryString : $decoded;
             }
-
-            if (method_exists($component, 'hydratePropertiesFromQueryParams')) {
-                $component->hydratePropertiesFromQueryParams($properties);
-            }
         });
 
         Livewire::listen('component.dehydrate.initial', function (Component $component, Response $response) {

--- a/src/LifecycleManager.php
+++ b/src/LifecycleManager.php
@@ -96,13 +96,9 @@ class LifecycleManager
 
     public function mount($params = [])
     {
-        $properties = collect(array_intersect_key(
-            $params, 
-            $this->instance->getPublicPropertiesDefinedBySubClass()
-        ));
-
         // Assign all public component properties that have matching parameters.
-        $properties->each(function ($value, $property) {
+        collect(array_intersect_key($params, $this->instance->getPublicPropertiesDefinedBySubClass()))
+            ->each(function ($value, $property) {
                 $this->instance->{$property} = $value;
             });
 

--- a/src/LifecycleManager.php
+++ b/src/LifecycleManager.php
@@ -96,9 +96,13 @@ class LifecycleManager
 
     public function mount($params = [])
     {
+        $properties = collect(array_intersect_key(
+            $params, 
+            $this->instance->getPublicPropertiesDefinedBySubClass()
+        ));
+
         // Assign all public component properties that have matching parameters.
-        collect(array_intersect_key($params, $this->instance->getPublicPropertiesDefinedBySubClass()))
-            ->each(function ($value, $property) {
+        $properties->each(function ($value, $property) {
                 $this->instance->{$property} = $value;
             });
 
@@ -113,6 +117,10 @@ class LifecycleManager
         }
 
         Livewire::dispatch('component.mount', $this->instance, $params);
+
+        if (method_exists($this->instance, 'hydratePropertiesFromQueryParams')) {
+            $this->instance->hydratePropertiesFromQueryParams();
+        }
 
         return $this;
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yes, this extends PR #3524 (which provided clean URLs) with the ability to customize how the parameters are generated from the component itself. Related discussions: #2036, #3030 and https://forum.laravel-livewire.com/t/ability-to-use-computed-properties-for-updatequerystring/236

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, this just focuses on giving users the ability to customize query params from within the component

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No additional tests (yet), however current query-string related tests (and all tests at the time of writing) are passing.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Current query strings with an array:
`?filters[make][0]=Tesla&filters[make][1]=VW`

Query strings with PR after implementing `dehydratePropertiesToQueryParams()` & `hydratePropertiesFromQueryParams()` methods:
`?make=Tesla,VW`

This PR does not automatically flatten arrays, rather simply provides the ability to extend logic for defining the parameters. The above example was achieved by appending the following methods to the Livewire component:

```php

// Create query parameters from component properties (specified in $queryString)
public function dehydratePropertiesToQueryParams()
{
    $params = collect($this->queryString)->map(function ($param) {
        return collect($this->{$param})
            ->map(function ($value) {
                if (is_array($value)) {
                    return implode(',', $value);
                }

                return $value;
            })->reject(function ($value) {
                return empty($value);
            });
    });

    return $params->collapse();
}

// Fill component properties with query string values
public function hydratePropertiesFromQueryParams()
{
    collect($this->queryString)->each(function ($param) {
        if (is_array($this->{$param})) {
            return collect($this->{$param})->each(function ($value, $key) use ($param) {
                if (request()->has($key)) {
                    $this->{$param}[$key] = explode(',', request()->input($key));
                }
            });
        }
        
        if (request()->has($param)) {
            $this->{$param} = request()->input($param);
        }
    });
}
```

**This PR is a WIP** and opened for collaboration purposes. I believe there might be better placement options (in the lifecycle) for checking-for and calling both methods.

5️⃣ Thanks for contributing! 🙌