### PR TITLE
[Fix] query string on nested component

### DIFF
--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -74,7 +74,6 @@ class SupportBrowserHistory
 
     protected function getPathFromReferer($referer, $component, $response)
     {
-        
         $route = $this->getRouteFromReferer($referer);
 
         if ( ! $this->shouldSendPath($component, $route)) return;

--- a/tests/Browser/QueryString/ParentComponentWithNoQueryString.php
+++ b/tests/Browser/QueryString/ParentComponentWithNoQueryString.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Browser\QueryString;
+
+use Livewire\Component as BaseComponent;
+
+class ParentComponentWithNoQueryString extends BaseComponent
+{
+    public $showNestedComponent = false;
+
+    public function render()
+    {
+        return <<< 'HTML'
+<div>
+    <button type="button" wire:click="$toggle('showNestedComponent')" dusk="toggle-nested">Toggle Nested</button>
+    
+    <div>
+        @if ($showNestedComponent)
+            @livewire(\Tests\Browser\QueryString\NestedComponent::class)
+        @endif
+    </div>
+</div>
+HTML;
+    }
+}

--- a/tests/Browser/QueryString/Test.php
+++ b/tests/Browser/QueryString/Test.php
@@ -205,4 +205,18 @@ class Test extends TestCase
             ;
         });
     }
+
+    public function test_nested_component_query_string_works_when_parent_is_not_using_query_string()
+    {
+        $this->browse(function (Browser $browser) {
+            Livewire::visit($browser, ParentComponentWithNoQueryString::class)
+                ->assertPathBeginsWith('/livewire-dusk')
+                ->waitForLivewire()->click('@toggle-nested')
+
+                // assert the path hasn't change to /livewire/message
+                ->assertPathBeginsWith('/livewire-dusk')
+                ->assertQueryStringHas('baz', 'bop')
+            ;
+        });
+    }
 }


### PR DESCRIPTION
Currently if you use query strings in a conditionally shown nested component, such as pagination, but don't have query string usage in the parent component, then the displayed URL is changed to `/livewire/message...` when the nested component is loaded.

This PR fixes that.

Hope this helps!