### PR TITLE
[Failing Test] Fingerprint of null issue

### DIFF
--- a/tests/Browser/Nesting/ChildValueComponent.php
+++ b/tests/Browser/Nesting/ChildValueComponent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Browser\Nesting;
+
+use Livewire\Component as BaseComponent;
+
+class ChildValueComponent extends BaseComponent
+{
+    public $value;
+
+    public function render()
+    {
+        return <<< 'HTML'
+<div>
+    Value {{ $value }}
+</div>
+HTML;
+    }
+}

--- a/tests/Browser/Nesting/ParentWithValuesComponent.php
+++ b/tests/Browser/Nesting/ParentWithValuesComponent.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Browser\Nesting;
+
+use Livewire\Component as BaseComponent;
+
+class ParentWithValuesComponent extends BaseComponent
+{
+    public $values = [
+        1,
+        2,
+        3,
+        4,
+        5,
+    ];
+
+    public function change()
+    {
+        array_shift($this->values);
+    }
+
+    public function render()
+    {
+        return <<< 'HTML'
+<div>
+    <button type="button" wire:click="change" dusk="change-button">Change</button>
+
+    <div dusk="values">
+        @foreach($values as $value)
+            @livewire(Tests\Browser\Nesting\ChildValueComponent::class, ['value' => $value])
+        @endforeach
+    </div>
+</div>
+HTML;
+    }
+}

--- a/tests/Browser/Nesting/Test.php
+++ b/tests/Browser/Nesting/Test.php
@@ -11,24 +11,18 @@ class Test extends TestCase
     {
         $this->browse(function ($browser) {
             Livewire::visit($browser, Component::class, '?showChild=true')
-                /**
-                 * click inside nested component is assigned to nested component
-                 */
+                // click inside nested component is assigned to nested component
                 ->waitForLivewire()->click('@button.nested')
                 ->assertSeeIn('@output.nested', 'foo')
                 ->waitForLivewire()->click('@button.toggleChild')
                 ->refresh()->pause(500)
 
-                /**
-                 * added component gets initialized
-                 */
+                // added component gets initialized
                 ->waitForLivewire()->click('@button.toggleChild')
                 ->waitForLivewire()->click('@button.nested')
                 ->assertSeeIn('@output.nested', 'foo')
 
-                /**
-                 * can switch components
-                 */
+                // can switch components
                 ->waitForLivewire()->click('@button.changeKey')
                 ->assertDontSeeIn('@output.nested', 'foo')
                 ->waitForLivewire()->click('@button.nested')
@@ -46,6 +40,37 @@ class Test extends TestCase
                 ->assertSeeIn('@output.blade-component2', 'Blade 2')
                 ->assertSeeIn('@output.nested', 'Sub render')
                 ->assertSeeIn('@output.blade-component3', 'Blade 3')
+            ;
+        });
+    }
+
+    /** @test */
+    public function it_renders_a_list_and_an_doesnt_error_when_the_list_changes()
+    {
+        $this->browse(function ($browser) {
+            Livewire::visit($browser, ParentWithValuesComponent::class)
+                ->assertSeeIn('@values', 'Value 1')
+                ->assertSeeIn('@values', 'Value 2')
+                ->assertSeeIn('@values', 'Value 3')
+                ->assertSeeIn('@values', 'Value 4')
+                ->assertSeeIn('@values', 'Value 5')
+
+                // For some reason without this pause the test only failed sometimes
+                ->pause(500)
+
+                ->waitForLivewire()->click('@change-button')
+                ->assertDontSeeIn('@values', 'Value 1')
+                ->assertSeeIn('@values', 'Value 2')
+                ->assertSeeIn('@values', 'Value 3')
+                ->assertSeeIn('@values', 'Value 4')
+                ->assertSeeIn('@values', 'Value 5')
+
+                ->waitForLivewire()->click('@change-button')
+                ->assertDontSeeIn('@values', 'Value 1')
+                ->assertDontSeeIn('@values', 'Value 2')
+                ->assertSeeIn('@values', 'Value 3')
+                ->assertSeeIn('@values', 'Value 4')
+                ->assertSeeIn('@values', 'Value 5')
             ;
         });
     }


### PR DESCRIPTION
Currently if you have nested components in a loop and you don't have a `wire:key`, you get the following error

![image](https://user-images.githubusercontent.com/882837/132795725-ed5fd940-623a-4033-ae9b-c3fc30b35fad.png)

The issue is, when morphdom tries to add a new node and create a new component, the node already has a `wire:id` on it instead of `wire:initial-data` and so it errors out when it tries to read fingerprint from initial data.

There is two ways we can approach fixing this:

- Do a check in the new component method and throw a nicer error if initial data is not set - like "Make sure you have a `wire:key` on your components"

- The other way, involves digging deep into the morphdom stuff finding out why it's trying to add a component on an element that already has `wire:id` on it

Hope this helps!