### PR TITLE
[Feature] Support 'withValidator' method

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -19,6 +19,8 @@ trait ValidatesInput
 {
     protected $errorBag;
 
+    protected $withValidatorCallback;
+
     public function getErrorBag()
     {
         return $this->errorBag ?? new MessageBag;
@@ -144,6 +146,13 @@ trait ValidatesInput
         return ! $this->hasRuleFor($dotNotatedProperty);
     }
 
+    public function withValidator($callback) : self
+    {
+        $this->withValidatorCallback = $callback;
+
+        return $this;
+    }
+
     public function validate($rules = null, $messages = [], $attributes = [])
     {
         [$rules, $messages, $attributes] = $this->providedOrGlobalRulesMessagesAndAttributes($rules, $messages, $attributes);
@@ -158,8 +167,8 @@ trait ValidatesInput
 
         $validator = Validator::make($data, $rules, $messages, $attributes);
 
-        if (method_exists($this, 'withValidator')) {
-            $this->withValidator($validator);
+        if ($this->withValidatorCallback) {
+            call_user_func($this->withValidatorCallback, $validator);
         }
 
         $this->shortenModelAttributesInsideValidator($ruleKeysToShorten, $validator);

--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -158,6 +158,10 @@ trait ValidatesInput
 
         $validator = Validator::make($data, $rules, $messages, $attributes);
 
+        if (method_exists($this, 'withValidator')) {
+            $this->withValidator($validator);
+        }
+
         $this->shortenModelAttributesInsideValidator($ruleKeysToShorten, $validator);
 
         $validatedData = $validator->validate();
@@ -193,7 +197,7 @@ trait ValidatesInput
             })->toArray();
 
         $ruleKeysForField = array_keys($rulesForField);
-        
+
         $data = $this->prepareForValidation(
             $this->getDataForValidation($rules)
         );

--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -169,6 +169,8 @@ trait ValidatesInput
 
         if ($this->withValidatorCallback) {
             call_user_func($this->withValidatorCallback, $validator);
+
+            $this->withValidatorCallback = null;
         }
 
         $this->shortenModelAttributesInsideValidator($ruleKeysToShorten, $validator);
@@ -219,6 +221,8 @@ trait ValidatesInput
 
         if ($this->withValidatorCallback) {
             call_user_func($this->withValidatorCallback, $validator);
+
+            $this->withValidatorCallback = null;
         }
 
         $this->shortenModelAttributesInsideValidator($ruleKeysToShorten, $validator);

--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -146,7 +146,7 @@ trait ValidatesInput
         return ! $this->hasRuleFor($dotNotatedProperty);
     }
 
-    public function withValidator($callback) : self
+    public function withValidator($callback)
     {
         $this->withValidatorCallback = $callback;
 
@@ -216,6 +216,10 @@ trait ValidatesInput
         $data = $this->unwrapDataForValidation($data);
 
         $validator = Validator::make($data, $rulesForField, $messages, $attributes);
+
+        if ($this->withValidatorCallback) {
+            call_user_func($this->withValidatorCallback, $validator);
+        }
 
         $this->shortenModelAttributesInsideValidator($ruleKeysToShorten, $validator);
 

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -390,6 +390,12 @@ class ValidationTest extends TestCase
 
         $component = Livewire::test(WithValidationMethod::class);
         $component->assertSet('count', 0)->call('runValidationWithThisMethod')->assertSet('count', 1);
+
+        $component = Livewire::test(WithValidationMethod::class);
+        $component->assertSet('count', 0)->call('runValidateOnlyWithClosure')->assertSet('count', 1);
+
+        $component = Livewire::test(WithValidationMethod::class);
+        $component->assertSet('count', 0)->call('runValidateOnlyWithThisMethod')->assertSet('count', 1);
     }
 }
 
@@ -587,9 +593,27 @@ class WithValidationMethod extends Component
         ]);
     }
 
+    public function runValidateOnlyWithClosure()
+    {
+        $this->withValidator(function ($validator) {
+            $validator->after(function ($validator) {
+                $this->count++;
+            });
+        })->validateOnly('foo', [
+            'foo' => 'required',
+        ]);
+    }
+
     public function runValidationWithThisMethod()
     {
         $this->withValidator([$this, 'doSomethingWithValidator'])->validate([
+            'foo' => 'required',
+        ]);
+    }
+
+    public function runValidateOnlyWithThisMethod()
+    {
+        $this->withValidator([$this, 'doSomethingWithValidator'])->validateOnly('foo', [
             'foo' => 'required',
         ]);
     }

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -396,6 +396,12 @@ class ValidationTest extends TestCase
 
         $component = Livewire::test(WithValidationMethod::class);
         $component->assertSet('count', 0)->call('runValidateOnlyWithThisMethod')->assertSet('count', 1);
+
+        $component = Livewire::test(WithValidationMethod::class);
+        $component->assertSet('count', 0)->call('clearWithValidatorAfterRunningValidateMethod')->assertSet('count', 1);
+
+        $component = Livewire::test(WithValidationMethod::class);
+        $component->assertSet('count', 0)->call('clearWithValidatorAfterRunningValidateOnlyMethod')->assertSet('count', 1);
     }
 }
 
@@ -616,6 +622,32 @@ class WithValidationMethod extends Component
         $this->withValidator([$this, 'doSomethingWithValidator'])->validateOnly('foo', [
             'foo' => 'required',
         ]);
+    }
+
+    public function clearWithValidatorAfterRunningValidateMethod()
+    {
+        $this->withValidator(function ($validator) {
+            $validator->after(function ($validator) {
+                $this->count++;
+            });
+        })->validate([
+            'foo' => 'required',
+        ]);
+
+        $this->validate(['foo' => 'required']);
+    }
+
+    public function clearWithValidatorAfterRunningValidateOnlyMethod()
+    {
+        $this->withValidator(function ($validator) {
+            $validator->after(function ($validator) {
+                $this->count++;
+            });
+        })->validateOnly('foo', [
+            'foo' => 'required',
+        ]);
+
+        $this->validateOnly('foo', ['foo' => 'required']);
     }
 
     protected function doSomethingWithValidator($validator)

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ViewErrorBag;
 use Livewire\Component;
@@ -380,6 +381,14 @@ class ValidationTest extends TestCase
 
         $component->call('failFooOnCustomValidator')->assertHasErrors('plop');
     }
+
+    /** @test */
+    public function can_use_withvalidator_method()
+    {
+        $component = Livewire::test(HasWithValidationMethod::class);
+
+        $component->assertSet('count', 0)->call('runValidation')->assertSet('count', 1);
+    }
 }
 
 class ForValidation extends Component
@@ -556,5 +565,31 @@ class ValueEqualsFoobar implements Rule
     public function message()
     {
         return '';
+    }
+}
+
+class HasWithValidationMethod extends Component
+{
+    public $foo = 'bar';
+
+    public $count = 0;
+
+    public function runValidation()
+    {
+        $this->validate([
+            'foo' => 'required',
+        ]);
+    }
+
+    protected function withValidator(ValidatorContract $validator)
+    {
+        $validator->after(function ($validator) {
+            $this->count++;
+        });
+    }
+
+    public function render()
+    {
+        return app('view')->make('dump-errors');
     }
 }


### PR DESCRIPTION
Laravel's FormRequest has the option to [define a 'withValidator' method](https://laravel.com/docs/8.x/validation#adding-after-hooks-to-form-requests). This PR makes it possible to access the validator instance before the validation is run, so you can call any of its methods, just like the 'withValidator' method of Laravel's FormRequest.


```php
class FooBar extends Component
{
    protected function save(Validator $validator)
    {
        $this->withValidator(function (Validator $validator) {
            // acccess the validator instance

            // e.g. $validator->after(...);
            // e.g. $validator->sometimes(...)
        })->validate();
    }
}
```