### PR TITLE
DisableBrowserCache support symfony response & skip otherwise

### DIFF
--- a/src/DisableBrowserCache.php
+++ b/src/DisableBrowserCache.php
@@ -18,11 +18,13 @@ class DisableBrowserCache
         $response = $next($request);
 
         if (Livewire::shouldDisableBackButtonCache()){
-            return $response->withHeaders([
-                "Pragma" => "no-cache",
-                "Expires" => "Fri, 01 Jan 1990 00:00:00 GMT",
-                "Cache-Control" => "no-cache, must-revalidate, no-store, max-age=0, private",
-            ]);
+            if ($response instanceof \Symfony\Component\HttpFoundation\Response) {
+                $response->headers->add([
+                    "Pragma" => "no-cache",
+                    "Expires" => "Fri, 01 Jan 1990 00:00:00 GMT",
+                    "Cache-Control" => "no-cache, must-revalidate, no-store, max-age=0, private",
+                ]);
+            }
         }
 
         return $response;

--- a/src/DisableBrowserCache.php
+++ b/src/DisableBrowserCache.php
@@ -3,6 +3,7 @@
 namespace Livewire;
 
 use Closure;
+use Symfony\Component\HttpFoundation\Response;
 
 class DisableBrowserCache
 {
@@ -17,14 +18,12 @@ class DisableBrowserCache
     {
         $response = $next($request);
 
-        if (Livewire::shouldDisableBackButtonCache()){
-            if ($response instanceof \Symfony\Component\HttpFoundation\Response) {
-                $response->headers->add([
-                    "Pragma" => "no-cache",
-                    "Expires" => "Fri, 01 Jan 1990 00:00:00 GMT",
-                    "Cache-Control" => "no-cache, must-revalidate, no-store, max-age=0, private",
-                ]);
-            }
+        if ($response instanceof Response && Livewire::shouldDisableBackButtonCache()){
+            $response->headers->add([
+                "Pragma" => "no-cache",
+                "Expires" => "Fri, 01 Jan 1990 00:00:00 GMT",
+                "Cache-Control" => "no-cache, must-revalidate, no-store, max-age=0, private",
+            ]);
         }
 
         return $response;


### PR DESCRIPTION
Right now `DisableBrowserCache` throw an exception if `$response` is not an instance of `Illuminate\Http\Response`.

With this change it also support the base `\Symfony\Component\HttpFoundation\Response` and it will skip the headers set if the response is something else.