### PR TITLE
[Fix] PHP 8.1 compatibility

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -243,7 +243,7 @@ class LivewireServiceProvider extends ServiceProvider
         // Early versions of Laravel 7.x don't have this method.
         if (method_exists(ComponentAttributeBag::class, 'macro')) {
             ComponentAttributeBag::macro('wire', function ($name) {
-                $entries = head($this->whereStartsWith('wire:'.$name));
+                $entries = $this->whereStartsWith('wire:'.$name)->first();
 
                 $directive = head(array_keys($entries));
                 $value = head(array_values($entries));

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -243,13 +243,12 @@ class LivewireServiceProvider extends ServiceProvider
         // Early versions of Laravel 7.x don't have this method.
         if (method_exists(ComponentAttributeBag::class, 'macro')) {
             ComponentAttributeBag::macro('wire', function ($name) {
-                $entries = iterator_to_array($this->whereStartsWith('wire:'.$name));
+                foreach ($this->whereStartsWith('wire:'.$name) as $directive => $value) {
+                    return new WireDirective($name, $directive, $value);
+                }
 
-                $directive = head(array_keys($entries));
-                $value = head(array_values($entries));
-
-                return new WireDirective($name, $directive, $value);
-            });
+                throw new InvalidArgument('Missing wire:'.$name.' attribute');
+            });;
         }
 
         View::mixin(new ViewMacros);

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -248,7 +248,7 @@ class LivewireServiceProvider extends ServiceProvider
                 }
 
                 throw new InvalidArgument('Missing wire:'.$name.' attribute');
-            });;
+            });
         }
 
         View::mixin(new ViewMacros);

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -243,7 +243,7 @@ class LivewireServiceProvider extends ServiceProvider
         // Early versions of Laravel 7.x don't have this method.
         if (method_exists(ComponentAttributeBag::class, 'macro')) {
             ComponentAttributeBag::macro('wire', function ($name) {
-                $entries = $this->whereStartsWith('wire:'.$name)->first();
+                $entries = iterator_to_array($this->whereStartsWith('wire:'.$name));
 
                 $directive = head(array_keys($entries));
                 $value = head(array_values($entries));


### PR DESCRIPTION
reset() on object is deprecated (so is head())

1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
I guess being PHP 8.1 compatible before it's released as stable is a must-have.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Single change.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Behavior does not change, maybe in a different PR, PHP 8.1 should be enabled for CI.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Running this provider with PHP 8.1 output:
```
reset(): Calling reset() on an object is deprecated
```
and it's indeed ambigous, here we're not actually picking the "head" of the object.

`iterator_to_array()` would be a relevant alternative.

5️⃣ Thanks for contributing! 🙌
You're welcome.