### PR TITLE
[Failing Test] File download from event not working

### DIFF
--- a/src/ComponentConcerns/ReceivesEvents.php
+++ b/src/ComponentConcerns/ReceivesEvents.php
@@ -3,6 +3,7 @@
 namespace Livewire\ComponentConcerns;
 
 use Livewire\Event;
+use Livewire\Livewire;
 
 trait ReceivesEvents
 {
@@ -67,10 +68,12 @@ trait ReceivesEvents
         return array_keys($this->getEventsAndHandlers());
     }
 
-    public function fireEvent($event, $params)
+    public function fireEvent($event, $params, $id)
     {
         $method = $this->getEventsAndHandlers()[$event];
 
-        $this->callMethod($method, $params);
+        $this->callMethod($method, $params, function ($returned) use ($event, $id) {
+            Livewire::dispatch('action.returned', $this, $event, $returned, $id);
+        });
     }
 }

--- a/src/HydrationMiddleware/PerformEventEmissions.php
+++ b/src/HydrationMiddleware/PerformEventEmissions.php
@@ -13,10 +13,11 @@ class PerformEventEmissions implements HydrationMiddleware
             foreach ($request->updates as $update) {
                 if ($update['type'] !== 'fireEvent') continue;
 
+                $id = $update['payload']['id'];
                 $event = $update['payload']['event'];
                 $params = $update['payload']['params'];
 
-                $unHydratedInstance->fireEvent($event, $params);
+                $unHydratedInstance->fireEvent($event, $params, $id);
             }
         } catch (ValidationException $e) {
             Livewire::dispatch('failed-validation', $e->validator);

--- a/tests/Browser/FileDownloads/Component.php
+++ b/tests/Browser/FileDownloads/Component.php
@@ -8,6 +8,10 @@ use Livewire\Component as BaseComponent;
 
 class Component extends BaseComponent
 {
+    protected $listeners = [
+        'download'
+    ];
+
     public function download()
     {
         config()->set('filesystems.disks.dusk-tmp', [

--- a/tests/Browser/FileDownloads/Test.php
+++ b/tests/Browser/FileDownloads/Test.php
@@ -189,4 +189,23 @@ class Test extends TestCase
             );
         });
     }
+    
+    /** @test */
+    public function trigger_downloads_from_event_listener()
+    {
+        $this->onlyRunOnChrome();
+
+        $this->browse(function ($browser) {
+            Livewire::visit($browser, Component::class)
+                ->waitForLivewire()->click('@emit-download')
+                ->waitUsing(5, 75, function () {
+                    return Storage::disk('dusk-downloads')->exists('download-target.txt');
+                });
+
+            $this->assertStringContainsString(
+                'I\'m the file you should download.',
+                Storage::disk('dusk-downloads')->get('download-target.txt')
+            );
+        });
+    }
 }

--- a/tests/Browser/FileDownloads/view.blade.php
+++ b/tests/Browser/FileDownloads/view.blade.php
@@ -1,4 +1,5 @@
 <div>
+    <button wire:click="$emit('download')" dusk="emit-download">Emit Download</button>
     <button wire:click="download" dusk="download">Download</button>
     <button wire:click="downloadFromResponse" dusk="download-from-response">Download</button>
     <button wire:click="downloadQuotedContentDispositionFilename" dusk="download-quoted-disposition-filename">Download</button>


### PR DESCRIPTION
File downloads that are triggered from a frontend event (`$emit`) are no longer working since 2.6, see discussion #3790 for details.

The file download `Features/SupportFileDownloads` actually depends on the `action.returned` internal event, which was removed from the `callMethod` function as part of PR #3510 in this commit here 

https://github.com/livewire/livewire/commit/854416a07aac67992c8a8590433b0023a896d561#diff-407939fdc8fd9ff8f7aca791faec0a01792b72a9f10ffc2bf215b2fa508fde46L151

As such, the event is no longer being fired when triggered through an event listener.

This is due to the `callMethod` needing a new closure to be passed through, as demonstrated here, that triggers the event.

https://github.com/livewire/livewire/blob/b39f9d9dcbf92ce920fe84262392a259d59b0e7f/src/HydrationMiddleware/PerformActionCalls.php#L36-L38

---

To fix, I believe that the closure that was added to `PerformActionCalls` needs to be added here to `ReceivesEvents` as well
 https://github.com/livewire/livewire/blob/b39f9d9dcbf92ce920fe84262392a259d59b0e7f/src/ComponentConcerns/ReceivesEvents.php#L74

And then the event listener in `SupportFileDownload` will also need to be updated with the new event signature (added ID parameter) here 

https://github.com/livewire/livewire/blob/b39f9d9dcbf92ce920fe84262392a259d59b0e7f/src/Features/SupportFileDownloads.php#L18

I'm happy to fix, but what I'm not sure about is whether an ID should be generated for the file response to use or not.

Hope this helps!