### PR TITLE
[Feature] Adds $readOnly reserved property

### DIFF
--- a/src/ComponentConcerns/HandlesActions.php
+++ b/src/ComponentConcerns/HandlesActions.php
@@ -24,6 +24,8 @@ trait HandlesActions
             ($this->{$propertyName} instanceof Model || $this->{$propertyName} instanceof EloquentCollection) && $this->missingRuleFor($name),
             new CannotBindToModelDataWithoutValidationRuleException($name, $this::getName())
         );
+        
+        if (isset($this->readOnly) && in_array($propertyName, $this->readOnly)) return;
 
         $this->callBeforeAndAfterSyncHooks($name, $value, function ($name, $value) use ($propertyName, $rehash) {
             throw_unless(

--- a/tests/Unit/ComponentReadOnlyPropertyTest.php
+++ b/tests/Unit/ComponentReadOnlyPropertyTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Livewire;
+use Livewire\Component;
+
+class ComponentReadOnlyPropertyTest extends TestCase
+{
+    /** @test */
+    public function only_readonly_properties_on_a_livewire_component_cannot_be_set_by_the_client()
+    {
+        Livewire::test(ComponentWithReadOnlyProperty::class)
+            ->set('foo', 'Baz')
+            ->set('bar', 'Foo')
+            ->assertSet('foo', 'Bar')
+            ->assertSet('bar', 'Foo');
+    }
+}
+
+class ComponentWithReadOnlyProperty extends Component
+{
+    protected $readOnly = ['foo'];
+
+    public $foo = 'Bar';
+
+    public $bar = 'Baz';
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}


### PR DESCRIPTION
I quickly discussed this on discord and confirmed no existing method to block client updates to a property exists short of using an updating hook.  At least one other person mentioned having had to use updating hook in the past to accomplish this.

This PR adds the ability to easily define one or more properties which should not be editable by the client and will block requests to do so with a simple conditional early return.

If you have ever wanted to use a property on a Livewire component to store a piece of state between requests that the user should not be able to edit you must block the edits for example by using a 'Updating' lifecycle hook. This adds the ability to instead define an array of properties that should be considered readonly to the client. 

Example usage:

```
    protected $readOnly = ['foo'];
    public $foo = 'Bar';
    public $bar = 'Baz';
```

By using this the client cannot update $foo, even if the user would intentionally send a `$set()` request. It can only be edited in the backend php.

Matching docs PR will be provided to document this new feature.