### PR TITLE
[bug] Octane has issues with injecting $route

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -42,7 +42,7 @@ abstract class Component
         Livewire::setBackButtonCache();
     }
 
-    public function __invoke(Container $container, Route $route)
+    public function __invoke(Container $container)
     {
         // For some reason Octane doesn't play nice with the injected $route.
         // We need to override it here. However, we can't remove the actual

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -86,7 +86,7 @@ class LivewireServiceProvider extends ServiceProvider
 
     protected function registerLivewireSingleton()
     {
-        $this->app->bind(LivewireManager::class);
+        $this->app->singleton(LivewireManager::class);
 
         $this->app->alias(LivewireManager::class, 'livewire');
     }
@@ -102,12 +102,12 @@ class LivewireServiceProvider extends ServiceProvider
             ? '/tmp/storage/bootstrap/cache/livewire-components.php'
             : app()->bootstrapPath('cache/livewire-components.php');
 
-        $this->app->bind(LivewireComponentsFinder::class, function ($app) use ($defaultManifestPath) {
+        $this->app->singleton(LivewireComponentsFinder::class, function () use ($defaultManifestPath) {
             return new LivewireComponentsFinder(
                 new Filesystem,
-                $app['config']->get('livewire.manifest_path') ?: $defaultManifestPath,
+                config('livewire.manifest_path') ?: $defaultManifestPath,
                 ComponentParser::generatePathFromNamespace(
-                    $app['config']->get('livewire.class_namespace')
+                    config('livewire.class_namespace')
                 )
             );
         });

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -81,12 +81,12 @@ class LivewireServiceProvider extends ServiceProvider
                 // If the app overrode "TrimStrings".
                 \App\Http\Middleware\TrimStrings::class,
             ]);
-        }   
+        }
     }
 
     protected function registerLivewireSingleton()
     {
-        $this->app->singleton(LivewireManager::class);
+        $this->app->bind(LivewireManager::class);
 
         $this->app->alias(LivewireManager::class, 'livewire');
     }
@@ -102,12 +102,12 @@ class LivewireServiceProvider extends ServiceProvider
             ? '/tmp/storage/bootstrap/cache/livewire-components.php'
             : app()->bootstrapPath('cache/livewire-components.php');
 
-        $this->app->singleton(LivewireComponentsFinder::class, function () use ($defaultManifestPath) {
+        $this->app->bind(LivewireComponentsFinder::class, function ($app) use ($defaultManifestPath) {
             return new LivewireComponentsFinder(
                 new Filesystem,
-                config('livewire.manifest_path') ?: $defaultManifestPath,
+                $app['config']->get('livewire.manifest_path') ?: $defaultManifestPath,
                 ComponentParser::generatePathFromNamespace(
-                    config('livewire.class_namespace')
+                    $app['config']->get('livewire.class_namespace')
                 )
             );
         });


### PR DESCRIPTION
I have a component that got updated and on the next request, the following error was thrown:

```
Unresolvable dependency resolving [Parameter #0 [ <required> $methods ]] in class Illuminate\Routing\Route
```

There are a [lot of references](https://github.com/livewire/livewire/search?q=Octane), but it seems like [one commit removed the binding](https://github.com/livewire/livewire/commit/da335efeb41c004411685709d7733303177ac88e), but [it got reverted](https://github.com/livewire/livewire/commit/ad9af07a9c623c1aefbbcfcbd178adcac8ebb8ac).

There are injection issues in general with Octane if you're not careful, and even if it is useless, should not be injected. 🐱 

References: https://github.com/livewire/livewire/issues/2878, https://github.com/livewire/livewire/pull/3495
