### PR TITLE
[Feature] Allow filling a model using a factory when testing

### DIFF
--- a/src/Testing/Concerns/MakesCallsToComponent.php
+++ b/src/Testing/Concerns/MakesCallsToComponent.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Testing\Concerns;
 
+use Illuminate\Support\Arr;
 use function Livewire\str;
 use Illuminate\Support\Str;
 use Illuminate\Http\UploadedFile;
@@ -46,6 +47,17 @@ trait MakesCallsToComponent
     {
         foreach ($values as $name => $value) {
             $this->set($name, $value);
+        }
+
+        return $this;
+    }
+
+    public function fillFactory($modelFactory, $prefix, $except = [])
+    {
+        $factory = Arr::except($modelFactory->toArray(), $except);
+
+        foreach ($factory as $name => $value) {
+            $this->set("$prefix.$name", $value);
         }
 
         return $this;

--- a/tests/Unit/ComponentCanBeFilledFromFactoryTest.php
+++ b/tests/Unit/ComponentCanBeFilledFromFactoryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class ComponentCanBeFilledFromFactoryTest extends TestCase
+{
+    /** @test */
+    public function can_fill_from_factory()
+    {
+        $userFactory = User::factory()->make();
+        $component = Livewire::test(ComponentWithFactoryFillableProperties::class);
+
+        $component->fillFactory($userFactory, 'user', ['password']);
+
+        $component->assertSet('user.name', 'Caleb');
+        $component->assertSet('user.email', 'example@laravel-livewire.com');
+        $component->assertNotSet('user.password', 'test');
+    }
+}
+
+class UserFactory extends Factory {
+    protected $model = User::class;
+
+    public function definition()
+    {
+        return [
+            'name' => 'Caleb',
+            'email' => 'example@laravel-livewire.com',
+            'password' => 'test',
+        ];
+    }
+}
+
+class User extends Model {
+    use HasFactory;
+
+    protected static function newFactory()
+    {
+        return UserFactory::new();
+    }
+}
+
+class ComponentWithFactoryFillableProperties extends Component
+{
+    public User $user;
+
+    protected $rules = [
+        'user.name' => 'required',
+        'user.email' => 'required|email',
+    ];
+
+    public function mount()
+    {
+        $this->user = new User;
+    }
+
+    public function render()
+    {
+        return app('view')->make('null-view');
+    }
+}

--- a/tests/Unit/ComponentCanBeFilledFromFactoryTest.php
+++ b/tests/Unit/ComponentCanBeFilledFromFactoryTest.php
@@ -10,13 +10,18 @@ use Livewire\Livewire;
 
 class ComponentCanBeFilledFromFactoryTest extends TestCase
 {
-    /** @test */
-    public function can_fill_from_factory()
+    public function setUp(): void
     {
+        parent::setUp();
+
         if(! class_exists(Factory::class)) {
             $this->markTestSkipped('Need Laravel >= 8');
         }
+    }
 
+    /** @test */
+    public function can_fill_from_factory()
+    {
         $userFactory = User::factory()->make();
         $component = Livewire::test(ComponentWithFactoryFillableProperties::class);
 

--- a/tests/Unit/ComponentCanBeFilledFromFactoryTest.php
+++ b/tests/Unit/ComponentCanBeFilledFromFactoryTest.php
@@ -10,19 +10,14 @@ use Livewire\Livewire;
 
 class ComponentCanBeFilledFromFactoryTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        if(! class_exists(Factory::class)) {
-            $this->markTestSkipped('Need Laravel >= 8');
-        }
-    }
-
     /** @test */
     public function can_fill_from_factory()
     {
-        $userFactory = User::factory()->make();
+        if(! class_exists(Factory::class)) {
+            $this->markTestSkipped('Need Laravel >= 8');
+        }
+
+        $userFactory = ExampleUser::factory()->make();
         $component = Livewire::test(ComponentWithFactoryFillableProperties::class);
 
         $component->fillFactory($userFactory, 'user', ['password']);
@@ -33,44 +28,48 @@ class ComponentCanBeFilledFromFactoryTest extends TestCase
     }
 }
 
-class UserFactory extends Factory {
-    protected $model = User::class;
-
-    public function definition()
+if(class_exists(Factory::class)) {
+    class UserFactory extends Factory
     {
-        return [
-            'name' => 'Caleb',
-            'email' => 'example@laravel-livewire.com',
-            'password' => 'test',
+        protected $model = ExampleUser::class;
+
+        public function definition()
+        {
+            return [
+                'name' => 'Caleb',
+                'email' => 'example@laravel-livewire.com',
+                'password' => 'test',
+            ];
+        }
+    }
+
+    class ExampleUser extends Model
+    {
+        use HasFactory;
+
+        protected static function newFactory()
+        {
+            return UserFactory::new();
+        }
+    }
+
+    class ComponentWithFactoryFillableProperties extends Component
+    {
+        public $user;
+
+        protected $rules = [
+            'user.name' => 'required',
+            'user.email' => 'required|email',
         ];
-    }
-}
 
-class User extends Model {
-    use HasFactory;
+        public function mount()
+        {
+            $this->user = new ExampleUser;
+        }
 
-    protected static function newFactory()
-    {
-        return UserFactory::new();
-    }
-}
-
-class ComponentWithFactoryFillableProperties extends Component
-{
-    public $user;
-
-    protected $rules = [
-        'user.name' => 'required',
-        'user.email' => 'required|email',
-    ];
-
-    public function mount()
-    {
-        $this->user = new User;
-    }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
+        public function render()
+        {
+            return app('view')->make('null-view');
+        }
     }
 }

--- a/tests/Unit/ComponentCanBeFilledFromFactoryTest.php
+++ b/tests/Unit/ComponentCanBeFilledFromFactoryTest.php
@@ -13,6 +13,10 @@ class ComponentCanBeFilledFromFactoryTest extends TestCase
     /** @test */
     public function can_fill_from_factory()
     {
+        if(! class_exists(Factory::class)) {
+            $this->markTestSkipped('Need Laravel >= 8');
+        }
+
         $userFactory = User::factory()->make();
         $component = Livewire::test(ComponentWithFactoryFillableProperties::class);
 
@@ -48,7 +52,7 @@ class User extends Model {
 
 class ComponentWithFactoryFillableProperties extends Component
 {
-    public User $user;
+    public $user;
 
     protected $rules = [
         'user.name' => 'required',


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
I created a discussion about this. The idea is to make it easier to use factories to populate many properties from a factory at the same time for testing. 
https://github.com/livewire/livewire/discussions/3892

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Single change

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes, single test

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Rather than having to set each property manually you can fill the model properties with a single `fillFactory()` call.

```php
//Before
$user = User::factory()->make();

Livewire::test(MyComponent::class)
   ->set('user.name', $user->name),
   ->set('user.email', $user->email);

//After
$user = User::factory()->make();

Livewire::test(MyComponent::class)
   ->fillFactory($user, 'user');
```

It also offers the ability to specify fields you don't want to exclude from the factory, by passing in a third argument (an array).
```php
$user = User::factory()->make();

Livewire::test(MyComponent::class)
   ->fillFactory($user, 'user', ['password'])
   ->assertNotSet('user.password');
```

5️⃣ Thanks for contributing! 🙌