### PR TITLE
[Fix] Added app_url config value - fixing CDN url problem

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -58,20 +58,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Livewire App URL
-    |--------------------------------------------------------------------------
-    |
-    | This value should be used if livewire assets are served from CDN.
-    | Livewire will communicate with an app through this url.
-    |
-    | Examples: "https://my-app.com", "myurl.com/app".
-    |
-    */
-
-    'app_url' => null,
-
-    /*
-    |--------------------------------------------------------------------------
     | Livewire Endpoint Middleware Group
     |--------------------------------------------------------------------------
     |

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -58,6 +58,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Livewire App URL
+    |--------------------------------------------------------------------------
+    |
+    | This value should be used if livewire assets are served from CDN.
+    | Livewire will communicate with an app through this url.
+    |
+    | Examples: "https://my-app.com", "myurl.com/app".
+    |
+    */
+
+    'app_url' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Livewire Endpoint Middleware Group
     |--------------------------------------------------------------------------
     |

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -219,7 +219,8 @@ HTML;
     {
         $jsonEncodedOptions = $options ? json_encode($options) : '';
 
-        $appUrl = config('app.url') ?: rtrim($options['app_url'] ?? '', '/');;
+        $appUrl = (config('livewire.app_url') ?? config('livewire.asset_url'))
+            ?: rtrim($options['app_url'] ?? '', '/');;
 
         $assetsUrl = config('livewire.asset_url') ?: rtrim($options['asset_url'] ?? '', '/');
 

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -221,7 +221,7 @@ HTML;
 
         $assetsUrl = config('livewire.asset_url') ?: rtrim($options['asset_url'] ?? '', '/');
 
-        $appUrl = config('app.url')
+        $appUrl = config('livewire.app_url')
             ?: rtrim($options['app_url'] ?? '', '/')
             ?: $assetsUrl;
 

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -221,7 +221,7 @@ HTML;
 
         $assetsUrl = config('livewire.asset_url') ?: rtrim($options['asset_url'] ?? '', '/');
 
-        $appUrl = config('livewire.app_url')
+        $appUrl = config('app.url')
             ?: rtrim($options['app_url'] ?? '', '/')
             ?: $assetsUrl;
 

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -219,7 +219,7 @@ HTML;
     {
         $jsonEncodedOptions = $options ? json_encode($options) : '';
 
-        $appUrl = config('app.url');
+        $appUrl = config('app.url') ?: rtrim($options['app_url'] ?? '', '/');;
 
         $assetsUrl = config('livewire.asset_url') ?: rtrim($options['asset_url'] ?? '', '/');
 

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -219,7 +219,9 @@ HTML;
     {
         $jsonEncodedOptions = $options ? json_encode($options) : '';
 
-        $appUrl = config('livewire.asset_url') ?: rtrim($options['asset_url'] ?? '', '/');
+        $appUrl = config('app.url');
+
+        $assetsUrl = config('livewire.asset_url') ?: rtrim($options['asset_url'] ?? '', '/');
 
         $jsLivewireToken = app()->has('session.store') ? "'" . csrf_token() . "'" : 'null';
 
@@ -227,7 +229,7 @@ HTML;
         $versionedFileName = $manifest['/livewire.js'];
 
         // Default to dynamic `livewire.js` (served by a Laravel route).
-        $fullAssetPath = "{$appUrl}/livewire{$versionedFileName}";
+        $fullAssetPath = "{$assetsUrl}/livewire{$versionedFileName}";
         $assetWarning = null;
 
         $nonce = isset($options['nonce']) ? "nonce=\"{$options['nonce']}\"" : '';
@@ -237,7 +239,7 @@ HTML;
             $publishedManifest = json_decode(file_get_contents(public_path('vendor/livewire/manifest.json')), true);
             $versionedFileName = $publishedManifest['/livewire.js'];
 
-            $fullAssetPath = ($this->isRunningServerless() ? config('app.asset_url') : $appUrl).'/vendor/livewire'.$versionedFileName;
+            $fullAssetPath = ($this->isRunningServerless() ? config('app.asset_url') : $assetsUrl).'/vendor/livewire'.$versionedFileName;
 
             if ($manifest !== $publishedManifest) {
                 $assetWarning = <<<'HTML'

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -219,10 +219,11 @@ HTML;
     {
         $jsonEncodedOptions = $options ? json_encode($options) : '';
 
-        $appUrl = (config('livewire.app_url') ?? config('livewire.asset_url'))
-            ?: rtrim($options['app_url'] ?? '', '/');;
-
         $assetsUrl = config('livewire.asset_url') ?: rtrim($options['asset_url'] ?? '', '/');
+
+        $appUrl = config('livewire.app_url')
+            ?: rtrim($options['app_url'] ?? '', '/')
+            ?: $assetsUrl;
 
         $jsLivewireToken = app()->has('session.store') ? "'" . csrf_token() . "'" : 'null';
 

--- a/tests/Unit/LivewireAssetsDirectiveTest.php
+++ b/tests/Unit/LivewireAssetsDirectiveTest.php
@@ -18,7 +18,7 @@ class LivewireAssetsDirectiveTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            "window.livewire_app_url = '';",
+            "window.livewire_app_url = 'http://localhost';",
             Livewire::scripts()
         );
     }
@@ -32,7 +32,7 @@ class LivewireAssetsDirectiveTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            "window.livewire_app_url = '';",
+            "window.livewire_app_url = 'http://localhost';",
             Livewire::scripts()
         );
     }
@@ -40,20 +40,24 @@ class LivewireAssetsDirectiveTest extends TestCase
     /** @test */
     public function livewire_js_calls_reference_configured_asset_url()
     {
+        config()->set('app.url', null);
+
         $this->assertStringContainsString(
             '<script src="https://foo.com/assets/livewire/livewire.js?',
             Livewire::scripts(['asset_url' => 'https://foo.com/assets'])
         );
 
         $this->assertStringContainsString(
-            "window.livewire_app_url = 'https://foo.com/assets';",
-            Livewire::scripts(['asset_url' => 'https://foo.com/assets'])
+            "window.livewire_app_url = 'https://foo-bar.com/path';",
+            Livewire::scripts(['app_url' => 'https://foo-bar.com/path'])
         );
     }
 
     /** @test */
     public function asset_url_trailing_slashes_are_trimmed()
     {
+        config()->set('app.url', null);
+
         $this->assertStringContainsString(
             '<script src="https://foo.com/assets/livewire/livewire.js?',
             Livewire::scripts(['asset_url' => 'https://foo.com/assets/'])
@@ -61,15 +65,17 @@ class LivewireAssetsDirectiveTest extends TestCase
 
         $this->assertStringContainsString(
             "window.livewire_app_url = 'https://foo.com/assets';",
-            Livewire::scripts(['asset_url' => 'https://foo.com/assets/'])
+            Livewire::scripts(['app_url' => 'https://foo.com/assets/'])
         );
     }
 
     /** @test */
     public function asset_url_passed_into_blade_assets_directive()
     {
+        config()->set('app.url', null);
+
         $output = View::make('assets-directive', [
-            'options' => ['asset_url' => 'https://foo.com/assets/'],
+            'options' => ['asset_url' => 'https://foo.com/assets/', 'app_url' => 'https://bar.com/'],
         ])->render();
 
         $this->assertStringContainsString(
@@ -78,7 +84,7 @@ class LivewireAssetsDirectiveTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            "window.livewire_app_url = 'https://foo.com/assets';",
+            "window.livewire_app_url = 'https://bar.com';",
             $output
         );
     }

--- a/tests/Unit/LivewireAssetsDirectiveTest.php
+++ b/tests/Unit/LivewireAssetsDirectiveTest.php
@@ -18,7 +18,23 @@ class LivewireAssetsDirectiveTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            "window.livewire_app_url = 'http://localhost';",
+            "window.livewire_app_url = '';",
+            Livewire::scripts()
+        );
+    }
+
+    public function livewire_js_should_use_configured_app_url()
+    {
+        config()->set('app.debug', true);
+        config()->set('livewire.app_url', 'https://foo.com');
+
+        $this->assertStringContainsString(
+            '<script src="/livewire/livewire.js?',
+            Livewire::scripts()
+        );
+
+        $this->assertStringContainsString(
+            "window.livewire_app_url = 'https://foo.com';",
             Livewire::scripts()
         );
     }
@@ -32,7 +48,7 @@ class LivewireAssetsDirectiveTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            "window.livewire_app_url = 'http://localhost';",
+            "window.livewire_app_url = '';",
             Livewire::scripts()
         );
     }
@@ -40,8 +56,6 @@ class LivewireAssetsDirectiveTest extends TestCase
     /** @test */
     public function livewire_js_calls_reference_configured_asset_url()
     {
-        config()->set('app.url', null);
-
         $this->assertStringContainsString(
             '<script src="https://foo.com/assets/livewire/livewire.js?',
             Livewire::scripts(['asset_url' => 'https://foo.com/assets'])
@@ -56,8 +70,6 @@ class LivewireAssetsDirectiveTest extends TestCase
     /** @test */
     public function asset_url_trailing_slashes_are_trimmed()
     {
-        config()->set('app.url', null);
-
         $this->assertStringContainsString(
             '<script src="https://foo.com/assets/livewire/livewire.js?',
             Livewire::scripts(['asset_url' => 'https://foo.com/assets/'])
@@ -72,8 +84,6 @@ class LivewireAssetsDirectiveTest extends TestCase
     /** @test */
     public function asset_url_passed_into_blade_assets_directive()
     {
-        config()->set('app.url', null);
-
         $output = View::make('assets-directive', [
             'options' => ['asset_url' => 'https://foo.com/assets/', 'app_url' => 'https://bar.com/'],
         ])->render();

--- a/tests/Unit/LivewireAssetsDirectiveTest.php
+++ b/tests/Unit/LivewireAssetsDirectiveTest.php
@@ -26,7 +26,7 @@ class LivewireAssetsDirectiveTest extends TestCase
     public function livewire_js_should_use_configured_app_url()
     {
         config()->set('app.debug', true);
-        config()->set('app.url', 'https://foo.com');
+        config()->set('livewire.app_url', 'https://foo.com');
 
         $this->assertStringContainsString(
             '<script src="/livewire/livewire.js?',

--- a/tests/Unit/LivewireAssetsDirectiveTest.php
+++ b/tests/Unit/LivewireAssetsDirectiveTest.php
@@ -18,7 +18,7 @@ class LivewireAssetsDirectiveTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            "window.livewire_app_url = '';",
+            "window.livewire_app_url = 'http://localhost';",
             Livewire::scripts()
         );
     }
@@ -48,7 +48,7 @@ class LivewireAssetsDirectiveTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            "window.livewire_app_url = '';",
+            "window.livewire_app_url = 'http://localhost';",
             Livewire::scripts()
         );
     }
@@ -56,6 +56,8 @@ class LivewireAssetsDirectiveTest extends TestCase
     /** @test */
     public function livewire_js_calls_reference_configured_asset_url()
     {
+        config()->set('app.url', null);
+
         $this->assertStringContainsString(
             '<script src="https://foo.com/assets/livewire/livewire.js?',
             Livewire::scripts(['asset_url' => 'https://foo.com/assets'])
@@ -70,6 +72,8 @@ class LivewireAssetsDirectiveTest extends TestCase
     /** @test */
     public function asset_url_trailing_slashes_are_trimmed()
     {
+        config()->set('app.url', null);
+
         $this->assertStringContainsString(
             '<script src="https://foo.com/assets/livewire/livewire.js?',
             Livewire::scripts(['asset_url' => 'https://foo.com/assets/'])
@@ -84,6 +88,8 @@ class LivewireAssetsDirectiveTest extends TestCase
     /** @test */
     public function asset_url_passed_into_blade_assets_directive()
     {
+        config()->set('app.url', null);
+
         $output = View::make('assets-directive', [
             'options' => ['asset_url' => 'https://foo.com/assets/', 'app_url' => 'https://bar.com/'],
         ])->render();

--- a/tests/Unit/LivewireAssetsDirectiveTest.php
+++ b/tests/Unit/LivewireAssetsDirectiveTest.php
@@ -26,7 +26,7 @@ class LivewireAssetsDirectiveTest extends TestCase
     public function livewire_js_should_use_configured_app_url()
     {
         config()->set('app.debug', true);
-        config()->set('livewire.app_url', 'https://foo.com');
+        config()->set('app.url', 'https://foo.com');
 
         $this->assertStringContainsString(
             '<script src="/livewire/livewire.js?',

--- a/tests/Unit/LivewireAssetsDirectiveTest.php
+++ b/tests/Unit/LivewireAssetsDirectiveTest.php
@@ -18,7 +18,7 @@ class LivewireAssetsDirectiveTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            "window.livewire_app_url = 'http://localhost';",
+            "window.livewire_app_url = '';",
             Livewire::scripts()
         );
     }
@@ -48,7 +48,7 @@ class LivewireAssetsDirectiveTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            "window.livewire_app_url = 'http://localhost';",
+            "window.livewire_app_url = '';",
             Livewire::scripts()
         );
     }
@@ -56,8 +56,6 @@ class LivewireAssetsDirectiveTest extends TestCase
     /** @test */
     public function livewire_js_calls_reference_configured_asset_url()
     {
-        config()->set('app.url', null);
-
         $this->assertStringContainsString(
             '<script src="https://foo.com/assets/livewire/livewire.js?',
             Livewire::scripts(['asset_url' => 'https://foo.com/assets'])
@@ -72,8 +70,6 @@ class LivewireAssetsDirectiveTest extends TestCase
     /** @test */
     public function asset_url_trailing_slashes_are_trimmed()
     {
-        config()->set('app.url', null);
-
         $this->assertStringContainsString(
             '<script src="https://foo.com/assets/livewire/livewire.js?',
             Livewire::scripts(['asset_url' => 'https://foo.com/assets/'])
@@ -88,8 +84,6 @@ class LivewireAssetsDirectiveTest extends TestCase
     /** @test */
     public function asset_url_passed_into_blade_assets_directive()
     {
-        config()->set('app.url', null);
-
         $output = View::make('assets-directive', [
             'options' => ['asset_url' => 'https://foo.com/assets/', 'app_url' => 'https://bar.com/'],
         ])->render();


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

I think yes, it fixes problem with app url when serving livewire scripts from CDN.
https://github.com/livewire/livewire/discussions/3928
https://github.com/livewire/livewire/discussions/3108

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

It includes required changes in existing tests and one new test case.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Like described in point 1 - without this fix livewire served from CDN tries to communicate with application (ex POST requests) using CDN url instead of app url.

5️⃣ Thanks for contributing! 🙌