### PR TITLE
Add support for after validation hook

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -144,7 +144,7 @@ trait ValidatesInput
         return ! $this->hasRuleFor($dotNotatedProperty);
     }
 
-    public function validate($rules = null, $messages = [], $attributes = [])
+    public function validate($rules = null, $messages = [], $attributes = [], $after = null)
     {
         [$rules, $messages, $attributes] = $this->providedOrGlobalRulesMessagesAndAttributes($rules, $messages, $attributes);
 
@@ -157,6 +157,10 @@ trait ValidatesInput
         $data = $this->unwrapDataForValidation($data);
 
         $validator = Validator::make($data, $rules, $messages, $attributes);
+
+        if ($after) {
+            $validator->after($after);
+        }
 
         $this->shortenModelAttributesInsideValidator($ruleKeysToShorten, $validator);
 
@@ -193,7 +197,7 @@ trait ValidatesInput
             })->toArray();
 
         $ruleKeysForField = array_keys($rulesForField);
-        
+
         $data = $this->prepareForValidation(
             $this->getDataForValidation($rules)
         );

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -380,6 +380,17 @@ class ValidationTest extends TestCase
 
         $component->call('failFooOnCustomValidator')->assertHasErrors('plop');
     }
+
+    /** @test */
+    public function validate_component_with_after()
+    {
+        $component = Livewire::test(ForValidation::class);
+
+        $component->runAction('runValidationWithAfter');
+
+        $this->assertStringNotContainsString('The foo field is required', $component->payload['effects']['html']);
+        $this->assertStringContainsString('Fails after validation!', $component->payload['effects']['html']);
+    }
 }
 
 class ForValidation extends Component
@@ -528,6 +539,15 @@ class ForValidation extends Component
         $this->validate([
             'password' => 'same:passwordConfirmation',
         ]);
+    }
+
+    public function runValidationWithAfter()
+    {
+        $this->validate([
+            'foo' => 'required',
+        ],[],[],function($validator) {
+            $validator->errors()->add('foo','Fails after validation!');
+        });
     }
 
     public function runValidationWithoutAllPublicPropertiesAndReturnValidatedData()


### PR DESCRIPTION
Laravel provides an after hook for validation, that you can use to perform other validation logic outside of the rules. Currently with Livewire's implementation, there is no way to hook into that, since the validate method returns the validatedData but not the validator itself. This extends the validate method to take an optional after argument, which when provided, is sent to the validator after hook. I added an accompanying test as well. 
