### PR TITLE
[FIX] Check all the values in dehydratePropertyFromWithFileUploads before calling serializeMultipleForLivewireResponse

### DIFF
--- a/src/Features/SupportFileUploads.php
+++ b/src/Features/SupportFileUploads.php
@@ -45,8 +45,19 @@ class SupportFileUploads
             return  $value->serializeForLivewireResponse();
         }
 
-        if (is_array($value) && isset(array_values($value)[0]) && array_values($value)[0] instanceof TemporaryUploadedFile && is_numeric(key($value))) {
-            return array_values($value)[0]::serializeMultipleForLivewireResponse($value);
+        if (is_array($value) && isset(array_values($value)[0])) {
+            $isValid = true;
+
+            foreach (array_values($value) as $key => $arrayValue) {
+                if (!($arrayValue instanceof TemporaryUploadedFile) || !is_numeric($key)) {
+                    $isValid = false;
+                    break;
+                }
+            }
+
+            if ($isValid) {
+                return array_values($value)[0]::serializeMultipleForLivewireResponse($value);
+            }
         }
 
         if (is_array($value)) {


### PR DESCRIPTION
Referring to this issue: https://github.com/livewire/livewire/discussions/2243

I'm using a file upload (using Livewire fileuploads) functionality with sorting (using Livewire/sortable). I ran into the same issue as the creator of the issue mentioned above. Once you start dragging a freshly added image to the first position in the list an error pops up. There's [a video](https://drive.google.com/file/d/10sVkwguH_b0xWuzdpPNvwqeaCof_8rJp/view) in the mentioned issue that shows you how to reproduce this bug.

This issue only happens when a newly uploaded image gets dragged to the first position. This is because the $value array would look like this:

![image](https://user-images.githubusercontent.com/90309934/136432334-65e9c159-22b3-40e4-b66c-9d11a4ba1f5d.png)

The _dehydratePropertyFromWithFileUploads_ function only checks in the third if-statement if the first item of this array is an instance of _TemporaryUploadedFile_ while that doesn't necessarily mean that this is a valid array.

The _serializeMultipleForLivewireResponse_ calls the _getFilename_ on all of the items in the array, which will fail for items that aren't an instance of _TemporaryUploadedFile_. 

This pull request fixes this issue by not allowing invalid arrays to call the _serializeMultipleForLivewireResponse_ function, but instead let's them pass on to the fourth if-statement of the _dehydratePropertyFromWithFileUploads_ function. An invalid array meaning that not all items in the array are an instance of _TemporaryUploadedFile_

