### PR TITLE
[Fix] Add fix for skip render on redirect

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -126,4 +126,19 @@ return [
 
     'back_button_cache' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Render On Redirect
+    |--------------------------------------------------------------------------
+    |
+    | This value determines whether Livewire will render before it's redirected
+    | or not. Setting it to "false" (default) will mean the render method is
+    | skipped when redirecting. And "true" will mean the render method is
+    | run before redirecting. Browsers bfcache can store a potentially
+    | stale view if render is skipped on redirect.
+    |
+    */
+
+    'render_on_redirect' => false,
+
 ];

--- a/src/Component.php
+++ b/src/Component.php
@@ -30,7 +30,7 @@ abstract class Component
 
     protected $queryString = [];
     protected $computedPropertyCache = [];
-    protected $shouldSkipRender = false;
+    protected $shouldSkipRender = null;
     protected $preRenderedView;
 
     public function __construct($id = null)

--- a/src/ComponentConcerns/PerformsRedirects.php
+++ b/src/ComponentConcerns/PerformsRedirects.php
@@ -9,15 +9,21 @@ trait PerformsRedirects
     public function redirect($url)
     {
         $this->redirectTo = $url;
+
+        $this->shouldSkipRender = $this->shouldSkipRender ?? ! config('livewire.render_on_redirect', false);
     }
 
     public function redirectRoute($name, $parameters = [], $absolute = true)
     {
         $this->redirectTo = route($name, $parameters, $absolute);
+
+        $this->shouldSkipRender = $this->shouldSkipRender ?? ! config('livewire.render_on_redirect', false);
     }
 
     public function redirectAction($name, $parameters = [], $absolute = true)
     {
         $this->redirectTo = action($name, $parameters, $absolute);
+
+        $this->shouldSkipRender = $this->shouldSkipRender ?? ! config('livewire.render_on_redirect', false);
     }
 }

--- a/tests/Unit/RedirectTest.php
+++ b/tests/Unit/RedirectTest.php
@@ -132,6 +132,37 @@ class RedirectTest extends TestCase
         $this->assertEquals(route('foo'), $component->payload['effects']['redirect']);
     }
 
+    /** @test */
+    public function skip_render_on_redirect_by_default()
+    {
+        $component = Livewire::test(SkipsRenderOnRedirect::class);
+
+        $this->assertEquals('/local', $component->payload['effects']['redirect']);
+        $this->assertNull($component->payload['effects']['html']);
+    }
+
+    /** @test */
+    public function dont_skip_render_on_redirect_if_config_set()
+    {
+        config()->set('livewire.render_on_redirect', true);
+
+        $component = Livewire::test(SkipsRenderOnRedirect::class);
+
+        $this->assertEquals('/local', $component->payload['effects']['redirect']);
+        $this->assertStringContainsString('Render has run', $component->payload['effects']['html']);
+    }
+
+    /** @test */
+    public function manually_override_dont_skip_render_on_redirect_using_skip_render_method()
+    {
+        config()->set('livewire.render_on_redirect', true);
+
+        $component = Livewire::test(RenderOnRedirectWithSkipRenderMethod::class);
+
+        $this->assertEquals('/local', $component->payload['effects']['redirect']);
+        $this->assertNull($component->payload['effects']['html']);
+    }
+
     protected function registerNamedRoute()
     {
         Route::get('foo', function () {
@@ -215,5 +246,40 @@ class TriggersRedirectOnMountStub extends Component
     public function render()
     {
         return app('view')->make('null-view');
+    }
+}
+
+class SkipsRenderOnRedirect extends Component
+{
+    public function mount()
+    {
+        return $this->redirect('/local');
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+<div>
+    Render has run
+</div>
+HTML;
+    }
+}
+
+class RenderOnRedirectWithSkipRenderMethod extends Component
+{
+    public function mount()
+    {
+        $this->skipRender();
+        return $this->redirect('/local');
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+<div>
+    Render has run
+</div>
+HTML;
     }
 }


### PR DESCRIPTION
PR #2747 released in v2.6 allowed the render method to run on redirect, to ensure that browser's bfcache had the latest render before the redirect was performed, so users weren't presented with stale data when they clicked on the back button after a redirect.

But that caused issues with redirecting in mount or an action method if authorisation failed (or something similar) and you don't want the render method to run.

This PR reverts the default back to skipping render on redirect and adds a config option `render_on_redirect` which is set to `false` by default. 

This config option allows developers to set this to `true` if they are concerned about users seeing stale data when they click the back button.

If the config option has been set to `true`, a developer can still tell Livewire to skip render on a specific redirect by calling `$this->skipRender()` right before the redirect call.

```php
public function mount() {
    $this->skipRender();
    return $this->redirect('/some-path');
}
```

Hope this helps!