### PR TITLE
[Fix] Add flush state and feature listeners to support Octane

### DIFF
--- a/src/Features/OptimizeRenderedDom.php
+++ b/src/Features/OptimizeRenderedDom.php
@@ -29,5 +29,9 @@ class OptimizeRenderedDom
                 $response->effects['html'] = null;
             }
         });
+
+        Livewire::listen('flush-state', function() {
+            $this->htmlHashesByComponent = [];
+        });
     }
 }

--- a/src/Features/Placeholder.php
+++ b/src/Features/Placeholder.php
@@ -17,5 +17,9 @@ class Placeholder
         Livewire::listen('component.dehydrate', function ($component, $response) {
             //
         });
+
+        Livewire::listen('flush-state', function() {
+            //
+        });
     }
 }

--- a/src/Features/SupportActionReturns.php
+++ b/src/Features/SupportActionReturns.php
@@ -28,6 +28,10 @@ class SupportActionReturns
 
             $response->effects['returns'] = $this->returnsByIdAndAction[$component->id];
         });
+
+        Livewire::listen('flush-state', function() {
+            $this->returnsByIdAndAction = [];
+        });
     }
 
     function valueIsntAFileResponse($value)

--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -57,6 +57,10 @@ class SupportBrowserHistory
 
             $this->getPathFromReferer($referer, $component, $response);
         });
+
+        Livewire::listen('flush-state', function() {
+            $this->mergedQueryParamsFromDehydratedComponents = [];
+        });
     }
 
     protected function getRouteFromReferer($referer)

--- a/src/Features/SupportComponentTraits.php
+++ b/src/Features/SupportComponentTraits.php
@@ -90,5 +90,9 @@ class SupportComponentTraits
                 ImplicitlyBoundMethod::call(app(), $method);
             }
         });
+
+        Livewire::listen('flush-state', function() {
+            $this->componentIdMethodMap = [];
+        });
     }
 }

--- a/src/Features/SupportFileDownloads.php
+++ b/src/Features/SupportFileDownloads.php
@@ -44,6 +44,10 @@ class SupportFileDownloads
 
             $response->effects['download'] = $download;
         });
+
+        Livewire::listen('flush-state', function() {
+            $this->downloadsById = [];
+        });
     }
 
     function valueIsntAFileResponse($value)

--- a/src/Features/SupportRedirects.php
+++ b/src/Features/SupportRedirects.php
@@ -47,5 +47,9 @@ class SupportRedirects
                 return;
             }
         });
+
+        Livewire::listen('flush-state', function() {
+            static::$redirectorCacheStack = [];
+        });
     }
 }

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -448,4 +448,11 @@ HTML;
     {
         return $this->shouldDisableBackButtonCache;
     }
+
+    public function flushState()
+    {
+        $this->shouldDisableBackButtonCache = false;
+
+        $this->dispatch('flush-state');
+    }
 }


### PR DESCRIPTION
Currently some of Livewire's feature classes are retaining state between requests when using Octane, see #2859,#3492, #3509.

This PR adds a method to the `LivewireManager` class called `flushState` that fires an internal Livewire event, that the feature classes can listen to and reset their own state.

A corresponding PR will be submitted to Octane, with an Octane listener that triggers this `flushState` method as required to prepare for new requests.

This will allow us to add new features to Livewire without needing to add a corresponding PR to Octane.

Hope this helps!

Edit: Here is the Octane PR https://github.com/laravel/octane/pull/400