### PR TITLE
[Fix] Override `getPath` to return temp path set by Livewire

### DIFF
--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -52,7 +52,7 @@ class FileUploadConfiguration
         return config('filesystems.disks.'.strtolower($diskBeforeTestFake).'.driver') === 'gcs';
     }
 
-    protected static function directory()
+    public static function directory()
     {
         return Util::normalizeRelativePath(config('livewire.temporary_file_upload.directory') ?: 'livewire-tmp');
     }

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -23,6 +23,11 @@ class TemporaryUploadedFile extends UploadedFile
         parent::__construct(stream_get_meta_data($tmpFile)['uri'], $this->path);
     }
 
+    public function getPath()
+    {
+        return $this->storage->path(FileUploadConfiguration::directory());
+    }
+
     public function isValid()
     {
         return true;

--- a/tests/Unit/FileUploadsTest.php
+++ b/tests/Unit/FileUploadsTest.php
@@ -612,6 +612,23 @@ class FileUploadsTest extends TestCase
         $this->assertStringStartsWith('livewire-file:', $component->get('obj.file_uploads'));
     }
 
+    /** @test */
+    public function it_returns_temporary_path_set_by_livewire()
+    {
+        Storage::fake('avatars');
+
+        $file = UploadedFile::fake()->image($fileName = 'avatar.jpg');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->call('upload', $fileName)
+            ->viewData('photo');
+
+        $this->assertEquals(
+            FileUploadConfiguration::storage()->path(FileUploadConfiguration::directory()),
+            $photo->getPath()
+        );
+    }
 }
 
 class DummyMiddleware


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
I do believe it is needed since Livewire overrides temp path but method `getPath` returns path set by system.
No but other devs have raised concerns in #3055 and #3064.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

When working with file uploads in Livewire we should be able to return file paths with `getPath`.

When instantiating `TemporaryUploadedFile` we are creating a temporary file then giving it's path to the parent constructor, which goes all the way to the first ancestor `SplFileInfo`. Now the object has path defined as the default temporary path defined by the system.

https://github.com/livewire/livewire/blob/ba99d0d17267f22bdee34a159a6921c772ef5820/src/TemporaryUploadedFile.php#L15-L24

Livewire does a good job of overriding tons of other methods, but `getPath` is left hanging, which is IMHO very useful as tons of third-party packages rely on it.

One example from the top of my head being [laravel-medialibrary](https://github.com/spatie/laravel-medialibrary) where you can upload files by just passing an `\Symfony\Component\HttpFoundation\File\UploadedFile` instance (which extends `SplFileInfo`, extended by `TemporaryUploadedFile`) into it's `addMedia` method.

```php
class Form extends Component
{
    use WithFileUploads;

    public $avatar;
    
    public function saveAvatar()
    {
        Auth::user()->addMedia($this->avatar)->toMediaCollection('avatars');
    }
    
    public function render()
    {
        return view('livewire.form');
    }
}
```
```html
<form wire:submit.prevent="saveAvatar">
    <input type="file" wire:model="avatar">

    <button type="submit">Save</button>
</form>
```

This little snippet will not work in the latest release, but this PR fixes it.

P.S. I exposed `FileUploadConfiguration::directory()` as a public method since my fix relies on it but if you have any better way to do this that I missed let me know.

5️⃣ Thanks for contributing! 🙌
🙌