### PR TITLE
Fix PHP7.2 syntax error

### DIFF
--- a/src/LivewireBladeDirectives.php
+++ b/src/LivewireBladeDirectives.php
@@ -76,9 +76,11 @@ EOT;
     }
 
     public static function stack($name, $default = '') {
+        $expression = rtrim("{$name}, {$default}", ', ');
+
         return "
             <template livewire-stack=\"<?php echo {$name}; ?>\"></template>
-            <?php echo \$__env->yieldPushContent({$name}, ${default}); ?>
+            <?php echo \$__env->yieldPushContent($expression); ?>
             <template livewire-end-stack=\"<?php echo {$name}; ?>\"></template>
         ";
     }
@@ -102,11 +104,13 @@ EOT;
     }
 
     public static function push($name, $content = '') {
+        $expression = rtrim("{$name}, {$content}", ', ');
+
         return "<?php
             if (isset(\$_instance)) {
                 \$_key = isset(\$_started_once) ? \$_instance->getName() : \$_instance->id;
 
-                \$__env->startPush({$name}, {$content});
+                \$__env->startPush({$expression});
 
                 \$_push_name = {$name};
 
@@ -116,17 +120,19 @@ EOT;
 
                 unset(\$_key);
             } else {
-                \$__env->startPush({$name}, {$content});
+                \$__env->startPush({$expression});
             }
         ?>";
     }
 
     public static function prepend($name, $content = '') {
+        $expression = rtrim("{$name}, {$content}", ', ');
+
         return "<?php
             if (isset(\$_instance)) {
                 \$_key = isset(\$_started_once) ? \$_instance->getName() : \$_instance->id;
 
-                \$__env->startPrepend({$name}, {$content});
+                \$__env->startPrepend({$expression});
 
                 \$_push_name = {$name};
 
@@ -136,7 +142,7 @@ EOT;
 
                 unset(\$_key);
             } else {
-                \$__env->startPrepend({$name}, {$content});
+                \$__env->startPrepend({$expression});
             }
         ?>";
     }
@@ -145,9 +151,9 @@ EOT;
         return "<?php
             if (isset(\$_instance)) {
                 \$__contents = ob_get_clean();
-                
+
                 \$_key = isset(\$_started_once) ? \$_instance->getName() : null;
-                
+
                 \$_instance->addToStack(\$_push_name, 'push', \$__contents, \$_key);
 
                 echo \$__contents;
@@ -167,9 +173,9 @@ EOT;
         return "<?php
             if (isset(\$_instance)) {
                 \$__contents = ob_get_clean();
-                
+
                 \$_key = isset(\$_started_once) ? \$_instance->getName() : null;
-                
+
                 \$_instance->addToStack(\$_push_name, 'prepend', \$__contents, \$_key);
 
                 echo \$__contents;

--- a/src/LivewireBladeDirectives.php
+++ b/src/LivewireBladeDirectives.php
@@ -150,8 +150,6 @@ EOT;
             if (isset(\$_instance)) {
                 \$__contents = ob_get_clean();
 
-
-
                 \$_instance->addToStack(\$__stack_name, 'push', \$__contents, \$__stack_item_key);
 
                 echo \$__contents;
@@ -171,8 +169,6 @@ EOT;
         return "<?php
             if (isset(\$_instance)) {
                 \$__contents = ob_get_clean();
-
-
 
                 \$_instance->addToStack(\$__stack_name, 'prepend', \$__contents, \$__stack_item_key);
 


### PR DESCRIPTION
The new push feature uses trailing commas in function calls which is not a thing in PHP7.2
![image](https://user-images.githubusercontent.com/13331388/137263367-7cc2fb62-3b8e-4038-b2b5-7009ae086694.png)

this PR fixes it - so CI should turn green again