### PR TITLE
Add custom exception handling when performing actions calls

### DIFF
--- a/src/HydrationMiddleware/PerformActionCalls.php
+++ b/src/HydrationMiddleware/PerformActionCalls.php
@@ -3,6 +3,7 @@
 namespace Livewire\HydrationMiddleware;
 
 use Livewire\Livewire;
+use Throwable;
 use function Livewire\str;
 
 use Illuminate\Validation\ValidationException;
@@ -41,6 +42,14 @@ class PerformActionCalls implements HydrationMiddleware
             Livewire::dispatch('failed-validation', $e->validator, $unHydratedInstance);
 
             $unHydratedInstance->setErrorBag($e->validator->errors());
+        } catch (Throwable $e) {
+            $exceptionClassName = str(get_class($e))->split('/\\\/')->last();
+
+            if (method_exists($unHydratedInstance, $method = "handle$exceptionClassName")) {
+                $unHydratedInstance->$method($e);
+            } else {
+                throw $e;
+            }
         }
     }
 

--- a/tests/Unit/ComponentCanHandleCustomAppExceptionsTest.php
+++ b/tests/Unit/ComponentCanHandleCustomAppExceptionsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit;
+
+use Exception;
+use Livewire\Component;
+use Livewire\Livewire;
+use Throwable;
+
+class ComponentCanHandleCustomAppExceptionsTest extends TestCase
+{
+    /** @test */
+    public function a_livewire_component_can_handle_custom_application_exceptions()
+    {
+        Livewire::test(ComponentWithExcceptionHandling::class)
+            ->call('doSomething');
+
+    }
+
+    /** @test */
+    public function a_livewire_component_can_throws_custom_application_exceptions()
+    {
+        $this->expectException(AppHandledException::class);
+        Livewire::test(ComponentWithoutExcceptionHandling::class)
+            ->call('doSomething');
+
+    }
+}
+
+class ComponentWithoutExcceptionHandling extends Component
+{
+    public function render()
+    {
+        return view('null-view');
+    }
+
+    public function doSomething()
+    {
+        throw new AppHandledException('Some handled error');
+    }
+}
+
+class ComponentWithExcceptionHandling extends ComponentWithoutExcceptionHandling
+{
+    public function handleAppHandledException(Throwable $e)
+    {
+        // eg: add a custom validation error to the bag
+        //$this->getErrorBag()->add('custom-error-key', $e->getMessage());
+    }
+}
+
+class AppHandledException extends Exception
+{
+}


### PR DESCRIPTION
In a traditional Laravel application if the flow is broken by throwing an exception, you can react to this by rendering an appropriate response to the exception type and request type(html or json) when using the App\Exceptions\Handler class, but in Livewire there is no equivalent, when a call to a component method fails, unless it is a ValidationException it is thrown, and in the front end there is no way to capture the message and type of error to show something more suitable to the user. It is desirable to have this functionality to be able to react to exceptions in personalized ways and not just as it is currently default in Livewire.

**Example:**

When in a hypothetical component "Checkout", some class method is called that makes an http request to the payment gateway, if this request fails, you do not want to show any dialog to the user saying that there was a generic error, what you really want is to show a message saying that:
"_Communication with the payment processor failed, try again later, or contact the email: support@example.com_"
 and in addition to that send the failure to the application's error reporting system(eg: Bugsnag), the part of sending the failure and the writing of the message can be done in the nested class, no matter the depth, and the message is sent upwards by throwing a custom exception class, and the Livewire component must be able to display the message, but for that instead of having a try catch block for each possible custom exception, you could add methods in the component or in a trait to handle each type of exception that you want to handle, and show the user the appropriate message for each failure.
