### PR TITLE
Fix boot so it runs before all mount and hydrate methods

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -66,6 +66,7 @@ abstract class Component
         }
 
         $manager = LifecycleManager::fromInitialInstance($instance)
+            ->boot()
             ->initialHydrate()
             ->mount($componentParams)
             ->renderToView();
@@ -104,10 +105,6 @@ abstract class Component
     public function initializeTraits()
     {
         foreach (class_uses_recursive($class = static::class) as $trait) {
-            if (method_exists($class, $method = 'boot'.class_basename($trait))) {
-                ImplicitlyBoundMethod::call(app(), [$this, $method]); 
-            }
-
             if (method_exists($class, $method = 'initialize'.class_basename($trait))) {
                 $this->{$method}();
             }

--- a/src/Connection/ConnectionHandler.php
+++ b/src/Connection/ConnectionHandler.php
@@ -9,6 +9,7 @@ abstract class ConnectionHandler
     public function handle($payload)
     {
         return LifecycleManager::fromSubsequentRequest($payload)
+            ->boot()
             ->hydrate()
             ->renderToView()
             ->dehydrate()

--- a/src/Features/SupportBootMethod.php
+++ b/src/Features/SupportBootMethod.php
@@ -11,7 +11,7 @@ class SupportBootMethod
 
     function __construct()
     {
-        Livewire::listen('component.hydrate', function ($component, $response) {
+        Livewire::listen('component.boot', function ($component) {
             $component->bootIfNotBooted();
         });
     }

--- a/src/Features/SupportComponentTraits.php
+++ b/src/Features/SupportComponentTraits.php
@@ -13,11 +13,10 @@ class SupportComponentTraits
 
     function __construct()
     {
-        Livewire::listen('component.hydrate', function ($component) {
-            $component->initializeTraits();
-
+        Livewire::listen('component.boot', function ($component) {
             foreach (class_uses_recursive($component) as $trait) {
                 $hooks = [
+                    'boot',
                     'hydrate',
                     'mount',
                     'updating',
@@ -35,6 +34,16 @@ class SupportComponentTraits
                     }
                 }
             }
+
+            $methods = $this->componentIdMethodMap[$component->id]['boot'] ?? [];
+
+            foreach ($methods as $method) {
+                ImplicitlyBoundMethod::call(app(), $method);
+            }
+        });
+
+        Livewire::listen('component.hydrate', function ($component) {
+            $component->initializeTraits();
 
             $methods = $this->componentIdMethodMap[$component->id]['hydrate'] ?? [];
 

--- a/src/LifecycleManager.php
+++ b/src/LifecycleManager.php
@@ -76,6 +76,13 @@ class LifecycleManager
         static::$initialDehydrationMiddleware += $callables;
     }
 
+    public function boot()
+    {
+        Livewire::dispatch('component.boot', $this->instance);
+
+        return $this;
+    }
+
     public function hydrate()
     {
         foreach (static::$hydrationMiddleware as $class) {

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -99,6 +99,7 @@ class LivewireManager
         }
 
         return LifecycleManager::fromInitialRequest($name, $id)
+            ->boot()
             ->initialHydrate()
             ->mount($params)
             ->renderToView()

--- a/tests/Unit/BootComponentTest.php
+++ b/tests/Unit/BootComponentTest.php
@@ -14,7 +14,7 @@ class BootComponentTest extends TestCase
         Livewire::test(ComponentWithBootMethod::class)
             ->assertSet('memo', 'bootmount')
             ->call('$refresh')
-            ->assertSet('memo', 'bootmountboothydrate');
+            ->assertSet('memo', 'boothydrate');
     }
 
     /** @test */
@@ -23,7 +23,7 @@ class BootComponentTest extends TestCase
         Livewire::test(ComponentWithBootTrait::class)
             ->assertSet('memo', 'boottraitinitializemount')
             ->call('$refresh')
-            ->assertSet('memo', 'boottraitinitializemountboottraitinitializehydrate');
+            ->assertSet('memo', 'boottraitinitializehydrate');
     }
 
     /** @test */
@@ -32,31 +32,36 @@ class BootComponentTest extends TestCase
         Livewire::test(ComponentWithBootMethodDI::class)
             ->assertSet('memo', 'boottrait')
             ->call('$refresh')
-            ->assertSet('memo', 'boottraitboottrait');
+            ->assertSet('memo', 'boottrait');
     }
 }
 
 class ComponentWithBootMethod extends Component
 {
+    // Use protected property to record all memo's
+    // as hydrating memo wipes out changes from boot
+    protected $_memo = '';
     public $memo = '';
+
+    public function boot()
+    {
+        $this->_memo .= 'boot';
+    }
 
     public function mount()
     {
-        $this->memo .= 'mount';
+        $this->_memo .= 'mount';
     }
 
     public function hydrate()
     {
-        $this->memo .= 'hydrate';
-    }
-
-    public function boot()
-    {
-        $this->memo .= 'boot';
+        $this->_memo .= 'hydrate';
     }
 
     public function render()
     {
+        $this->memo = $this->_memo;
+
         return view('null-view');
     }
 }
@@ -65,45 +70,51 @@ class ComponentWithBootTrait extends Component
 {
     use BootMethodTrait;
 
+    // Use protected property to record all memo's
+    // as hydrating memo wipes out changes from boot
+    protected $_memo = '';
     public $memo = '';
+
+    public function boot()
+    {
+        $this->_memo .= 'boot';
+    }
 
     public function mount()
     {
-        $this->memo .= 'mount';
+        $this->_memo .= 'mount';
     }
 
     public function hydrate()
     {
-        $this->memo .= 'hydrate';
-    }
-
-    public function boot()
-    {
-        $this->memo .= 'boot';
+        $this->_memo .= 'hydrate';
     }
 
     public function render()
     {
+        $this->memo = $this->_memo;
         return view('null-view');
     }
 }
 
-trait BootMethodTrait {
+trait BootMethodTrait
+{
     public function bootBootMethodTrait()
     {
-        $this->memo .= 'trait';
+        $this->_memo .= 'trait';
     }
 
     public function initializeBootMethodTrait()
     {
-        $this->memo .= 'initialize';
+        $this->_memo .= 'initialize';
     }
 }
 
-trait BootMethodTraitWithDI {
+trait BootMethodTraitWithDI
+{
     public function bootBootMethodTraitWithDI(Stringable $string)
     {
-        $this->memo .= $string->append('trait');
+        $this->_memo .= $string->append('trait');
     }
 }
 
@@ -111,15 +122,19 @@ class ComponentWithBootMethodDI extends Component
 {
     use BootMethodTraitWithDI;
 
+    // Use protected property to record all memo's
+    // as hydrating memo wipes out changes from boot
+    protected $_memo = '';
     public $memo = '';
 
     public function boot(Stringable $string)
     {
-        $this->memo .= $string->append('boot');
+        $this->_memo .= $string->append('boot');
     }
 
     public function render()
     {
+        $this->memo = $this->_memo;
         return view('null-view');
     }
 }


### PR DESCRIPTION
Currently on the initial request the `boot` method runs before `mount`. But on a subsequent request, it runs after `hydrateFoo` but before `hydrate`. See discussion #3875 for details.

This PR fixes the boot method to ensure it runs first before any `mount`, `hydrate`, `hydrateFoo`, etc. methods.

There was an issue with the tests, where component property hydration was wiping out any changes pushed into the test `$memo` property by the boot method (but that's a good thing as it now means it's working as it should 😁). 

So made a protected `$_memo` to build up the string before assigning to the public property in render to enable checks to be run against it. I've added comments into the test components that explains that.

As such it means the protected `$_memo` is empty at the beginning of each request, allowing me to explicitly check results only from that request instead of a full string of from the initial request too.

Hope this helps!