### PR TITLE
Add booted method

### DIFF
--- a/src/Features/SupportBootMethod.php
+++ b/src/Features/SupportBootMethod.php
@@ -2,8 +2,9 @@
 
 namespace Livewire\Features;
 
-use Livewire\Livewire;
 use Illuminate\Support\Facades\App;
+use Livewire\ImplicitlyBoundMethod;
+use Livewire\Livewire;
 
 class SupportBootMethod
 {
@@ -13,6 +14,12 @@ class SupportBootMethod
     {
         Livewire::listen('component.boot', function ($component) {
             $component->bootIfNotBooted();
+        });
+
+        Livewire::listen('component.booted', function ($component, $request) {
+            if (method_exists($component, $method = 'booted')) {
+                ImplicitlyBoundMethod::call(app(), [$component, $method], [$request]); 
+            }
         });
     }
 }

--- a/src/Features/SupportComponentTraits.php
+++ b/src/Features/SupportComponentTraits.php
@@ -19,6 +19,7 @@ class SupportComponentTraits
                     'boot',
                     'hydrate',
                     'mount',
+                    'booted',
                     'updating',
                     'updated',
                     'rendering',
@@ -57,6 +58,14 @@ class SupportComponentTraits
 
             foreach ($methods as $method) {
                 ImplicitlyBoundMethod::call(app(), $method, $params);
+            }
+        });
+
+        Livewire::listen('component.booted', function ($component, $request) {
+            $methods = $this->componentIdMethodMap[$component->id]['booted'] ?? [];
+
+            foreach ($methods as $method) {
+                ImplicitlyBoundMethod::call(app(), $method, [$request]);
             }
         });
 

--- a/src/HydrationMiddleware/CallHydrationHooks.php
+++ b/src/HydrationMiddleware/CallHydrationHooks.php
@@ -12,6 +12,8 @@ class CallHydrationHooks implements HydrationMiddleware
         Livewire::dispatch('component.hydrate.subsequent', $instance, $request);
 
         $instance->hydrate($request);
+
+        Livewire::dispatch('component.booted', $instance, $request);
     }
 
     public static function dehydrate($instance, $response)

--- a/src/LifecycleManager.php
+++ b/src/LifecycleManager.php
@@ -121,6 +121,8 @@ class LifecycleManager
 
         Livewire::dispatch('component.mount', $this->instance, $params);
 
+        Livewire::dispatch('component.booted', $this->instance, $this->request);
+
         return $this;
     }
 

--- a/tests/Unit/BootComponentTest.php
+++ b/tests/Unit/BootComponentTest.php
@@ -12,27 +12,27 @@ class BootComponentTest extends TestCase
     public function boot_method_is_called_on_mount_and_on_subsequent_updates()
     {
         Livewire::test(ComponentWithBootMethod::class)
-            ->assertSet('memo', 'bootmount')
+            ->assertSet('memo', 'bootmountbooted')
             ->call('$refresh')
-            ->assertSet('memo', 'boothydrate');
+            ->assertSet('memo', 'boothydratebooted');
     }
 
     /** @test */
     public function boot_method_can_be_added_to_trait()
     {
         Livewire::test(ComponentWithBootTrait::class)
-            ->assertSet('memo', 'boottraitinitializemount')
+            ->assertSet('memo', 'boottraitboottraitinitializemountbootedtraitbooted')
             ->call('$refresh')
-            ->assertSet('memo', 'boottraitinitializehydrate');
+            ->assertSet('memo', 'boottraitboottraitinitializehydratebootedtraitbooted');
     }
 
     /** @test */
     public function boot_method_supports_dependency_injection()
     {
         Livewire::test(ComponentWithBootMethodDI::class)
-            ->assertSet('memo', 'boottrait')
+            ->assertSet('memo', 'boottraitbootbootedtraitbooted')
             ->call('$refresh')
-            ->assertSet('memo', 'boottrait');
+            ->assertSet('memo', 'boottraitbootbootedtraitbooted');
     }
 }
 
@@ -56,6 +56,11 @@ class ComponentWithBootMethod extends Component
     public function hydrate()
     {
         $this->_memo .= 'hydrate';
+    }
+
+    public function booted()
+    {
+        $this->_memo .= 'booted';
     }
 
     public function render()
@@ -90,9 +95,15 @@ class ComponentWithBootTrait extends Component
         $this->_memo .= 'hydrate';
     }
 
+    public function booted()
+    {
+        $this->_memo .= 'booted';
+    }
+
     public function render()
     {
         $this->memo = $this->_memo;
+
         return view('null-view');
     }
 }
@@ -101,12 +112,17 @@ trait BootMethodTrait
 {
     public function bootBootMethodTrait()
     {
-        $this->_memo .= 'trait';
+        $this->_memo .= 'traitboot';
     }
 
     public function initializeBootMethodTrait()
     {
-        $this->_memo .= 'initialize';
+        $this->_memo .= 'traitinitialize';
+    }
+
+    public function bootedBootMethodTrait()
+    {
+        $this->_memo .= 'traitbooted';
     }
 }
 
@@ -114,7 +130,12 @@ trait BootMethodTraitWithDI
 {
     public function bootBootMethodTraitWithDI(Stringable $string)
     {
-        $this->_memo .= $string->append('trait');
+        $this->_memo .= $string->append('traitboot');
+    }
+
+    public function bootedBootMethodTraitWithDI(Stringable $string)
+    {
+        $this->_memo .= $string->append('traitbooted');
     }
 }
 
@@ -132,9 +153,15 @@ class ComponentWithBootMethodDI extends Component
         $this->_memo .= $string->append('boot');
     }
 
+    public function booted(Stringable $string)
+    {
+        $this->_memo .= $string->append('booted');
+    }
+
     public function render()
     {
         $this->memo = $this->_memo;
+
         return view('null-view');
     }
 }


### PR DESCRIPTION
This PR adds support for a `booted` lifecycle hook method which fires after `mount` on an initial request, and after all `hydrate` methods on a subsequent request (but before any updates are processed).

Currently, the `boot` method runs before `mount` and `hydrate` so if you need access to the mounted/hydrated data, it won't be available in `boot`.

By adding this lifecycle hook, it allows use to use the component data in a single method that will run on all requests.
This should save needing to duplicate code in `mount` and `hydrate`.

Hope this helps!