### PR TITLE
[Failing Test] Duplicate `wire:key` issues

### DIFF
--- a/tests/Browser/Morphdom/ChildComponent.php
+++ b/tests/Browser/Morphdom/ChildComponent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Browser\Morphdom;
+
+use Livewire\Component as BaseComponent;
+
+class ChildComponent extends BaseComponent
+{
+    public $numbers = [
+        1,
+        2,
+    ];
+
+    public function addNumber()
+    {
+        $this->numbers[] = end($this->numbers) + 1;
+
+        $this->emit('numbersUpdated', $this->numbers);
+    }
+
+    public function render()
+    {
+        return <<< 'HTML'
+<div>
+    <div dusk="child-numbers">
+        @foreach($numbers as $number)
+            <div wire:key="{{ $number }}" dusk="child-{{ $number }}">{{ $number }}</div>
+        @endforeach
+    </div>
+
+    <button type="button" wire:click="addNumber" dusk="add-number">Add Number</button>
+</div>
+HTML;
+    }
+}

--- a/tests/Browser/Morphdom/ParentComponent.php
+++ b/tests/Browser/Morphdom/ParentComponent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Browser\Morphdom;
+
+use Livewire\Component as BaseComponent;
+
+class ParentComponent extends BaseComponent
+{
+    public $numbers = [
+        1,
+        2,
+        3,
+        4,
+    ];
+
+    protected $listeners = [
+        'numbersUpdated'
+    ];
+
+    public function numbersUpdated($numbers)
+    {
+        $this->numbers = $numbers;
+    }
+
+    public function render()
+    {
+        return <<< 'HTML'
+<div>
+    <div dusk="parent-numbers">
+        @foreach($numbers as $number)
+            <div wire:key="{{ $number }}" @dusk="parent-{{ $number }}">{{ $number }}</div>
+        @endforeach
+    </div>
+
+    @livewire(Tests\Browser\Morphdom\ChildComponent::class)
+</div>
+HTML;
+    }
+}

--- a/tests/Browser/Morphdom/Test.php
+++ b/tests/Browser/Morphdom/Test.php
@@ -57,4 +57,24 @@ class Test extends TestCase
             ;
         });
     }
+
+    /** @test */
+    public function it_does_not_move_elements_from_a_child_component()
+    {
+        $this->browse(function ($browser) {
+            Livewire::visit($browser, ParentComponent::class)
+                ->assertSeeIn('@parent-numbers', 1)
+                ->assertSeeIn('@child-numbers', 1)
+                ->assertSeeIn('@parent-numbers', 2)
+                ->assertSeeIn('@child-numbers', 2)
+                ->waitForLivewire()->click('@add-number')
+                ->assertSeeIn('@parent-numbers', 1)
+                ->assertSeeIn('@child-numbers', 1)
+                ->assertSeeIn('@parent-numbers', 2)
+                ->assertSeeIn('@child-numbers', 2)
+                ->assertSeeIn('@parent-numbers', 3)
+                ->assertSeeIn('@child-numbers', 3)
+                ;
+        });
+    }
 }


### PR DESCRIPTION
This adds a failing tests for the scenario where there are two lists on a page with each element using the same `wire:key` structure like `$loop->index`.

If a new element is added to one list with the same `wire:key` as an element in the other list, when morphdom tries to morph them, it moves the existing one instead of creating a new one.

See screen capture below, where there are two components each displaying the same list. If we add a new user to the child component and refresh the parent, we can see the new user gets moved.

 I've added a sleep to the parent component so we can clearly see the user in the child list before the parent refreshes.

I suspect it has to do with Livewire's custom morphdom look ahead.

Hope this helps!

![recording (46)](https://user-images.githubusercontent.com/882837/137715811-c2c17b76-a299-420b-a2ec-e8b2e21e10fd.gif)


