### PR TITLE
Check the class name is valid before creating it

### DIFF
--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -19,9 +19,17 @@ class MakeCommand extends FileManipulationCommand
             $this->option('stub')
         );
 
-        if($this->isReservedClassName($name = $this->parser->className())) {
+        if (!$this->isClassNameValid($name = $this->parser->className())) {
+            $this->line("<options=bold,reverse;fg=red> WHOOPS! </> 😳 \n");
+            $this->line("<fg=red;options=bold>Class is invalid:</> {$name}");
+
+            return;
+        }
+
+        if ($this->isReservedClassName($name)) {
             $this->line("<options=bold,reverse;fg=red> WHOOPS! </> 😳 \n");
             $this->line("<fg=red;options=bold>Class is reserved:</> {$name}");
+
             return;
         }
 
@@ -114,6 +122,11 @@ class MakeCommand extends FileManipulationCommand
         return $testPath;
     }
 
+    public function isClassNameValid($name)
+    {
+        return preg_match("/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/", $name);
+    }
+    
     public function isReservedClassName($name)
     {
         return array_search(strtolower($name), $this->getReservedName()) !== false;

--- a/tests/Unit/MakeCommandTest.php
+++ b/tests/Unit/MakeCommandTest.php
@@ -153,4 +153,18 @@ class MakeCommandTest extends TestCase
         $this->assertFalse(File::exists($this->livewireClassesPath('List.php')));
         $this->assertFalse(File::exists($this->livewireViewsPath('list.blade.php')));
     }
+    /** @test */
+    public function a_component_is_not_created_with_a_invalid_class_name()
+    {
+        Artisan::call('make:livewire', ['name' => '1Class']);
+
+        $this->assertFalse(File::exists($this->livewireClassesPath('1Class.php')));
+        $this->assertFalse(File::exists($this->livewireViewsPath('1Class.blade.php')));
+
+        Artisan::call('make:livewire', ['name' => '!Class']);
+
+        $this->assertFalse(File::exists($this->livewireClassesPath('!Class.php')));
+        $this->assertFalse(File::exists($this->livewireViewsPath('!Class.blade.php')));
+
+    }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first? 

No, just a error I found by been an idiot

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out. 

None, just one command/test

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Tests pass and added test to prove the fix

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Just stops you from running the `livewire:make` command with an invalid class name like **1Class**

5️⃣ Thanks for contributing! 🙌