### PR TITLE
Add redirectIntended method to redirect trait

### DIFF
--- a/src/ComponentConcerns/PerformsRedirects.php
+++ b/src/ComponentConcerns/PerformsRedirects.php
@@ -26,4 +26,12 @@ trait PerformsRedirects
 
         $this->shouldSkipRender = $this->shouldSkipRender ?? ! config('livewire.render_on_redirect', false);
     }
+    
+    
+    public function redirectIntended($default)
+    {
+        $this->redirectTo = session()->pull('url.intended', $default);
+
+        $this->shouldSkipRender = $this->shouldSkipRender ?? ! config('livewire.render_on_redirect', false);
+    }
 }

--- a/tests/Unit/RedirectTest.php
+++ b/tests/Unit/RedirectTest.php
@@ -40,6 +40,25 @@ class RedirectTest extends TestCase
         $this->assertEquals('http://localhost/foo', $component->payload['effects']['redirect']);
     }
 
+    /** @test **/
+    public function route_intended_pulls_url_from_session(){
+        session()->put('url.intended', '/foo');
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectIntended', '/baz');
+
+        $this->assertEquals('/foo', $component->payload['effects']['redirect']);
+    }
+
+    /** @test **/
+    public function route_intended_uses_fallback_url_when_session_key_is_empty(){
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectIntended', '/baz');
+
+        $this->assertEquals('/baz', $component->payload['effects']['redirect']);
+    }
+
     /** @test */
     public function action_redirect()
     {
@@ -181,6 +200,11 @@ class TriggersRedirectStub extends Component
     public function triggerRedirect()
     {
         return $this->redirect('/local');
+    }
+
+    public function triggerRedirectIntended($default)
+    {
+        return $this->redirectIntended($default);
     }
 
     public function triggerRedirectRoute()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yes.
2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.
3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No.
4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Add same functionality and expected behaviour as Laravel's Redirector. Pulls an optional url.intended from the session, with a fallback (default) route alternative.

This allows for redirecting back to intended URL, for example after visiting login page through the auth middleware

5️⃣ Thanks for contributing! 🙌