### PR TITLE
[Feature] Add support to arrays as parameters in the `assertSeeHtml` and `assertDontSeeHtml` methods

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -82,22 +82,26 @@ trait MakesAssertions
         return $this;
     }
 
-    public function assertSeeHtml($value)
+    public function assertSeeHtml($values)
     {
-        PHPUnit::assertStringContainsString(
-            $value,
-            $this->stripOutInitialData($this->lastRenderedDom)
-        );
+        foreach (Arr::wrap($values) as $value) {
+            PHPUnit::assertStringContainsString(
+                $value,
+                $this->stripOutInitialData($this->lastRenderedDom)
+            );
+        }
 
         return $this;
     }
 
-    public function assertDontSeeHtml($value)
+    public function assertDontSeeHtml($values)
     {
-        PHPUnit::assertStringNotContainsString(
-            $value,
-            $this->stripOutInitialData($this->lastRenderedDom)
-        );
+        foreach (Arr::wrap($values) as $value) {
+            PHPUnit::assertStringNotContainsString(
+                $value,
+                $this->stripOutInitialData($this->lastRenderedDom)
+            );
+        }
 
         return $this;
     }


### PR DESCRIPTION
It makes the `assertSeeHtml` and `assertDontSeeHtml` methods accept arrays, just as `assertSee` does, using `Arr::wrap` to handle non-array values and performing the assertions over them in a for loop.

It's a simple change, but I think it will help devs who need to cover unordered HTML code pieces.

Thank you!
