### PR TITLE
fix wire:key issue containing commas when using on livewire components

### DIFF
--- a/src/LivewireBladeDirectives.php
+++ b/src/LivewireBladeDirectives.php
@@ -45,10 +45,10 @@ EOT;
 
     public static function livewire($expression)
     {
-        $cachedKey  = "'" . Str::random(7) . "'";
+        $cachedKey = "'" . Str::random(7) . "'";
 
-        $pattren    = "/,\s*?key\(([\s\S]*)\)/"; //everything between ",key(" and ")"
-        $expression = preg_replace_callback($pattren, function ($match) use (&$cachedKey) {
+        $pattern = "/,\s*?key\(([\s\S]*)\)/"; //everything between ",key(" and ")"
+        $expression = preg_replace_callback($pattern, function ($match) use (&$cachedKey) {
             $cachedKey = trim($match[1]) ?: $cachedKey;
             return "";
         }, $expression);

--- a/src/LivewireBladeDirectives.php
+++ b/src/LivewireBladeDirectives.php
@@ -45,16 +45,13 @@ EOT;
 
     public static function livewire($expression)
     {
-        $lastArg = str(last(explode(',', $expression)))->trim();
+        $cachedKey  = "'" . Str::random(7) . "'";
 
-        if ($lastArg->startsWith('key(') && $lastArg->endsWith(')')) {
-            $cachedKey = $lastArg->replaceFirst('key(', '')->replaceLast(')', '');
-            $args = explode(',', $expression);
-            array_pop($args);
-            $expression = implode(',', $args);
-        } else {
-            $cachedKey = "'".str()->random(7)."'";
-        }
+        $pattren    = "/,\s*?key\(([\s\S]*)\)/"; //everything between ",key(" and ")"
+        $expression = preg_replace_callback($pattren, function ($match) use (&$cachedKey) {
+            $cachedKey = trim($match[1]) ?: $cachedKey;
+            return "";
+        }, $expression);
 
         return <<<EOT
 <?php

--- a/tests/Unit/NestingComponentsTest.php
+++ b/tests/Unit/NestingComponentsTest.php
@@ -79,6 +79,24 @@ class NestingComponentsTest extends TestCase
         $this->assertStringNotContainsString('foo', $component->payload['effects']['html']);
         $this->assertStringNotContainsString('bar', $component->payload['effects']['html']);
     }
+
+    /** @test */
+    public function parent_tracks_subsequent_renders_of_children_inside_a_loop_with_colon_wire_key_having_comma()
+    {
+        app('livewire')->component('parent', ParentComponentForNestingChildrenWithWireKeyHavingCommaStub::class);
+        app('livewire')->component('child', ChildComponentForNestingStub::class);
+        $component = app('livewire')->test('parent');
+
+        $this->assertStringContainsString('foo', $component->payload['effects']['html'] );
+
+        $component->runAction('setChildren', ['foo', 'bar']);
+        $this->assertStringNotContainsString('foo', $component->payload['effects']['html']);
+        $this->assertStringContainsString('bar', $component->payload['effects']['html'] );
+
+        $component->runAction('setChildren', ['foo', 'bar']);
+        $this->assertStringNotContainsString('foo', $component->payload['effects']['html']);
+        $this->assertStringNotContainsString('bar', $component->payload['effects']['html']);
+    }
 }
 
 class ParentComponentForNestingChildStub extends Component
@@ -123,6 +141,27 @@ class ParentComponentForNestingChildrenWithWireKeyStub extends Component
             <div>
                 @foreach ($children as $child)
                     <livewire:child :name="$child" :wire:key="$child" />
+                @endforeach
+            </div>
+blade;
+    }
+}
+
+class ParentComponentForNestingChildrenWithWireKeyHavingCommaStub extends Component
+{
+    public $children = ['foo'];
+
+    public function setChildren($children)
+    {
+        $this->children = $children;
+    }
+
+    public function render()
+    {
+        return <<<'blade'
+            <div>
+                @foreach ($children as $child)
+                    <livewire:child :name="$child" :wire:key="str_pad($child, 5, '_', STR_PAD_BOTH)" />
                 @endforeach
             </div>
 blade;


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yes / No 🙊
2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No (Actually I am bad at tests atm, learning though)
4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Current implementation of wire:key extraction based on comma( , ) and causes error when there is comma in key value either explicitly or when using some function/method and passing more than one params like
```php
   @livewire('componen-name',key(some_helper('foo','bar')))
   //Or as in component syntax
   <livewire:component-name wire:key="{{some_helper('foo','bar')}}"
```
Owing to comma inside expression string, it bypasses the current implementation and compiles to 
```php
   key('.e(some_helper('foo','bar')).')
```
This causes following TypeError as `key()` accepts an array
![image](https://user-images.githubusercontent.com/90649496/138615289-4c5f5261-48ca-4a9b-b18d-ec883f86f679.png)


5️⃣ Thanks for contributing! 🙌
Pleasure is always mine. It's in fact my first ever contribution (though a small one) to any OSS and to my luck it is to my favorite one 🎉