### PR TITLE
Allow response effects html to be an html node

### DIFF
--- a/js/component/index.js
+++ b/js/component/index.js
@@ -288,7 +288,14 @@ export default class Component {
             // If we get HTML from the server, store it for the next time we might not.
             this.lastFreshHtml = response.effects.html
 
-            this.handleMorph(response.effects.html.trim())
+			let html = response.effects.html;
+
+			// If the html is a string trim it, otherwise it should be a html node
+			if (typeof response.effects.html === 'string') {
+				html = response.effects.html.trim();
+			}
+
+            this.handleMorph(html);
         } else {
             // It's important to still "morphdom" even when the server HTML hasn't changed,
             // because Alpine needs to be given the chance to update.


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
It is needed to be able to properly fix Livewire's integration with Vue 3 (separate pull request coming soon on the livewire/vue repo).

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, just a single change.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Sorry no, but all included tests should still work.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
I added a simple condition to check that the `response.effects.html` is a string before running `trim()` on it.  This prevents an error if the `response.effects.html` is an html node - which can happen when the response is hooked into via the `message.received` hook.

Basically, this code should function the same in all use cases except when the `message.received` hook is used to change it to an html node.

5️⃣ Thanks for contributing! 🙌
Thank you for such a great library.  This is my first pull request to Livewire, hopefully many more in the future.