### PR TITLE
New method "resetExcept"

### DIFF
--- a/src/ComponentConcerns/InteractsWithProperties.php
+++ b/src/ComponentConcerns/InteractsWithProperties.php
@@ -171,6 +171,16 @@ trait InteractsWithProperties
             $this->{$property} = $freshInstance->{$property};
         }
     }
+    
+    protected function resetExcept(...$properties)
+    {
+        if (count($properties) && is_array($properties[0])) {
+            $properties = $properties[0];
+        }
+
+        $keysToReset = array_diff(array_keys($this->getPublicPropertiesDefinedBySubClass()), $properties);
+        $this->reset($keysToReset);
+    }
 
     public function only($properties)
     {

--- a/tests/Unit/ResetPropertiesTest.php
+++ b/tests/Unit/ResetPropertiesTest.php
@@ -45,7 +45,30 @@ class ResetPropertiesTest extends TestCase
             // Reset only foo.
             ->call('resetKeys', 'foo')
             ->assertSet('foo', 'bar')
-            ->assertSet('bob', 'law');
+            ->assertSet('bob', 'law')
+            ->assertSet('mwa', 'aha')
+            ->set('foo', 'baz')
+            ->set('bob', 'law')
+            ->set('mwa', 'aha')
+            ->assertSet('foo', 'baz')
+            ->assertSet('bob', 'law')
+            ->assertSet('mwa', 'aha')
+            // Reset all except foo.
+            ->call('resetKeysExcept', 'foo')
+            ->assertSet('foo', 'baz')
+            ->assertSet('bob', 'lob')
+            ->assertSet('mwa', 'hah')
+            ->set('foo', 'baz')
+            ->set('bob', 'law')
+            ->set('mwa', 'aha')
+            ->assertSet('foo', 'baz')
+            ->assertSet('bob', 'law')
+            ->assertSet('mwa', 'aha')
+            // Reset all except foo and bob.
+            ->call('resetKeysExcept', ['foo', 'bob'])
+            ->assertSet('foo', 'baz')
+            ->assertSet('bob', 'law')
+            ->assertSet('mwa', 'hah');
     }
 }
 
@@ -63,6 +86,11 @@ class ResetPropertiesComponent extends Component
     public function resetKeys($keys)
     {
         $this->reset($keys);
+    }
+    
+    public function resetKeysExcept($keys)
+    {
+        $this->resetExcept($keys);
     }
 
     public function render()


### PR DESCRIPTION
If you have a component with many public properties and want to reset all except some, you would have to write all properties into the reset method - and if you add more public properties, you would always have to remember to add them. This PR makes this a little easier - you can name all the properties you want to keep.

I don't know if that's of use for enough people, but I needed it. I have it in a base component anyway, so no hard feelings if this PR gets rejected :-).

1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
https://github.com/livewire/livewire/discussions/4097

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No, but would be easy to add at `ResetPropertiesTest.php`.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
See above.

5️⃣ Thanks for contributing! 🙌