### PR TITLE
bugfix/paginatio-type :bug: Changes the page type from int to double.

### DIFF
--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -36,7 +36,7 @@ trait WithPagination
                 $this->paginators[$pageName] = request()->query($pageName, 1);
             }
 
-            return (double) $this->paginators[$pageName];
+            return (int) $this->paginators[$pageName];
         });
 
         Paginator::defaultView($this->paginationView());
@@ -75,6 +75,8 @@ trait WithPagination
 
     public function setPage($page, $pageName = 'page')
     {
+        $page = intval($page);
+        $page = $page <= 0 ? 1 : $page ;
         $beforePaginatorMethod = 'updatingPaginators';
         $afterPaginatorMethod = 'updatedPaginators';
 
@@ -106,6 +108,7 @@ trait WithPagination
     {
         // The "page" query string item should only be available
         // from within the original component mount run.
-        return (double) request()->query('page', $this->page);
+        // Avoid cast to integer to prevent hydrate error
+        return request()->query('page', $this->page);
     }
 }

--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -36,7 +36,7 @@ trait WithPagination
                 $this->paginators[$pageName] = request()->query($pageName, 1);
             }
 
-            return (int) $this->paginators[$pageName];
+            return (double) $this->paginators[$pageName];
         });
 
         Paginator::defaultView($this->paginationView());
@@ -106,6 +106,6 @@ trait WithPagination
     {
         // The "page" query string item should only be available
         // from within the original component mount run.
-        return (int) request()->query('page', $this->page);
+        return (double) request()->query('page', $this->page);
     }
 }

--- a/tests/Unit/ComponentPaginationTest.php
+++ b/tests/Unit/ComponentPaginationTest.php
@@ -61,6 +61,7 @@ class ComponentPaginationTest extends TestCase
 class ComponentWithPaginationStub extends Component
 {
     use WithPagination;
+    
     public function render()
     {
         return view('show-name', ['name' => 'example']);

--- a/tests/Unit/ComponentPaginationTest.php
+++ b/tests/Unit/ComponentPaginationTest.php
@@ -40,12 +40,28 @@ class ComponentPaginationTest extends TestCase
             ->call('previousPage')
             ->assertSet('page', 1);
     }
+
+    /** @test */
+    public function double_page_value_should_be_casted_to_int()
+    {
+        Livewire::test(ComponentWithPaginationStub::class)
+            ->call('gotoPage', 2.5)
+            ->assertSet('page', 2);
+    }
+
+    /** @test */
+    public function string_page_value_should_be_reset()
+    {
+        Livewire::test(ComponentWithPaginationStub::class)
+            ->call('gotoPage', "M")
+            ->assertSet('page', 1);
+    }
 }
 
 class ComponentWithPaginationStub extends Component
 {
     use WithPagination;
-    
+
     public function render()
     {
         return view('show-name', ['name' => 'example']);

--- a/tests/Unit/ComponentPaginationTest.php
+++ b/tests/Unit/ComponentPaginationTest.php
@@ -61,7 +61,6 @@ class ComponentPaginationTest extends TestCase
 class ComponentWithPaginationStub extends Component
 {
     use WithPagination;
-
     public function render()
     {
         return view('show-name', ['name' => 'example']);


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
It's a very small change, if in the PR discussion the most of you guys consider the change is not required, the PR can be rejected.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, It doesn't.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

Some tests have been added to ComponentPaginationTest.php. 

`vendor/bin/phpunit tests/Unit/ComponentPaginationTest.php`

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
When the user tries to paginate a component using an integer overflow value livewire returns a 500 error in the pagination response.

Example: 
http://localhost/my-component-with-pagination?page=9223372036854775807
Returns error 500

Values equal to **999999999999999999** or lower works perfectly.

Taking into account the final user is able to change the page param value in the browser URL, livewire should catch this error.

5️⃣ Thanks for contributing! 🙌