### PR TITLE
js() helper for blade component $attributes

### DIFF
--- a/src/LivewireBladeDirectives.php
+++ b/src/LivewireBladeDirectives.php
@@ -20,17 +20,7 @@ EOT;
 
     public static function js($expression)
     {
-        return <<<EOT
-<?php
-    if (is_object({$expression}) || is_array({$expression})) {
-        echo "JSON.parse(atob('".base64_encode(json_encode({$expression}))."'))";
-    } elseif (is_string({$expression})) {
-        echo "'".str_replace("'", "\'", {$expression})."'";
-    } else {
-        echo json_encode({$expression});
-    }
-?>
-EOT;
+        return '{!! Livewire\js('.$expression.') !!}';
     }
 
     public static function livewireStyles($expression)

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -16,3 +16,18 @@ if (! function_exists('Livewire\str')) {
         return Str::of($string);
     }
 }
+
+if (! function_exists('Livewire\js')) {
+    function js($expression, $options = null, $depth = 512): string
+    {
+        if (is_object($expression) || is_array($expression)) {
+            $base64 = base64_encode(json_encode($expression, trim($options), trim($depth)));
+            return "JSON.parse(atob('$base64'))";
+        }
+        if (is_string($expression)) {
+            $string = str_replace("'", "\'", $expression);
+            return "'$string'";
+        }
+        return json_encode($expression, trim($options), trim($depth));
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -18,14 +18,6 @@ if (! function_exists('Livewire\str')) {
 }
 
 if (! function_exists('Livewire\js')) {
-    /**
-     * base64 encode an expression and compile it into 'JSON.parse(atob($base64))' string.
-     *
-     * @param $expression
-     * @param int|null $options
-     * @param int $depth
-     * @return string
-     */
     function js($expression, $options = null, $depth = 512): string
     {
         if (is_object($expression) || is_array($expression)) {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -22,12 +22,15 @@ if (! function_exists('Livewire\js')) {
     {
         if (is_object($expression) || is_array($expression)) {
             $base64 = base64_encode(json_encode($expression, $options, $depth));
+            
             return "JSON.parse(atob('$base64'))";
         }
         if (is_string($expression)) {
             $string = str_replace("'", "\'", $expression);
+            
             return "'$string'";
         }
+        
         return json_encode($expression, $options, $depth);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -18,16 +18,24 @@ if (! function_exists('Livewire\str')) {
 }
 
 if (! function_exists('Livewire\js')) {
+    /**
+     * base64 encode an expression and compile it into 'JSON.parse(atob($base64))' string.
+     *
+     * @param $expression
+     * @param int|null $options
+     * @param int $depth
+     * @return string
+     */
     function js($expression, $options = null, $depth = 512): string
     {
         if (is_object($expression) || is_array($expression)) {
-            $base64 = base64_encode(json_encode($expression, trim($options), trim($depth)));
+            $base64 = base64_encode(json_encode($expression, $options, $depth));
             return "JSON.parse(atob('$base64'))";
         }
         if (is_string($expression)) {
             $string = str_replace("'", "\'", $expression);
             return "'$string'";
         }
-        return json_encode($expression, trim($options), trim($depth));
+        return json_encode($expression, $options, $depth);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -22,15 +22,16 @@ if (! function_exists('Livewire\js')) {
     {
         if (is_object($expression) || is_array($expression)) {
             $base64 = base64_encode(json_encode($expression, $options, $depth));
-            
+
             return "JSON.parse(atob('$base64'))";
         }
+
         if (is_string($expression)) {
             $string = str_replace("'", "\'", $expression);
-            
+
             return "'$string'";
         }
-        
+
         return json_encode($expression, $options, $depth);
     }
 }

--- a/tests/Unit/LivewireJsDirectiveTest.php
+++ b/tests/Unit/LivewireJsDirectiveTest.php
@@ -14,6 +14,11 @@ class LivewireJsDirectiveTest extends TestCase
             'string' => "@js('hey')",
         ])
             ->assertSee("'hey'", false);
+
+        Livewire::test(ComponentForTestingJsFunction::class, [
+            'data' => 'hey',
+        ])
+            ->assertSee("'hey'");
     }
 
     /** @test */
@@ -42,6 +47,11 @@ class LivewireJsDirectiveTest extends TestCase
             'data' => ['hey' => 'there'],
         ])
             ->assertSee("JSON.parse(atob('eyJoZXkiOiJ0aGVyZSJ9'))", false);
+
+        Livewire::test(ComponentForTestingJsFunction::class, [
+            'data' => ['hey' => 'there'],
+        ])
+            ->assertSee("JSON.parse(atob('eyJoZXkiOiJ0aGVyZSJ9'))");
     }
 
     /** @test */
@@ -52,6 +62,11 @@ class LivewireJsDirectiveTest extends TestCase
             'data' => ['hey', 'there'],
         ])
             ->assertSee("JSON.parse(atob('WyJoZXkiLCJ0aGVyZSJd'))", false);
+
+        Livewire::test(ComponentForTestingJsFunction::class, [
+            'data' => ['hey', 'there'],
+        ])
+            ->assertSee("JSON.parse(atob('WyJoZXkiLCJ0aGVyZSJd'))");
     }
 }
 
@@ -70,5 +85,22 @@ class ComponentForTestingJsDirective extends Component
     public function render()
     {
         return '<div>'.$this->expression.'</div>';
+    }
+}
+
+class ComponentForTestingJsFunction extends Component
+{
+    public $data = [];
+
+    public function mount($data = null)
+    {
+        $this->data = $data;
+    }
+
+    public function render()
+    {
+        return <<<'BLADE'
+<button x-on:click="$dispatch('notify-errors', {{ Livewire\js($data) }} )"></button>
+BLADE;
     }
 }


### PR DESCRIPTION
Using the `@js` directives within component tags is not supported by Laravel. 
For example, `<x-alert :errors="@js($errors->all())"/>` will not be compiled.
This PR adds a `js()` helper to use in blade components or anywhere in php.

### Why we need this:

Lets say we have a blade component; button.blade.php
```blade
<button {{ $attributes->merge(['class' => 'classes']) }}>
{{ $slot }}
</button>
```

If we want to add Alpine interactivity we cannot use the Livewire `@js` directive, it won't compile.
```blade
<x-button x-data
   x-on:click="$dispatch( 'notify-errors', @js($errors->all()) )"
   type="submit"> Submit </x-button>
```

With the `js()` helper we will be able to work around it.
```blade
<x-button x-data
   x-on:click="$dispatch( 'notify-errors', {{ Livewire\js($errors->all()) }} )"
   type="submit"> Submit </x-button>
```

I added `$options` and `$depth`, following the Laravel `@json()` directive. Adds usability that the Livewire `@js()` directive is missing.

Use the `@js()` blade directive with _optional_ flags and depth
```blade
<div 
    x-data="{ config: @js( $complexNestedArray, JSON_NUMERIC_CHECK | JSON_FORCE_OBJECT, 8 ) }" 
></div>
```

Where it is not possible to use the directive, we use the new `js()` method.
```blade
<x-foo 
    x-data="{ config: {{ Livewire\js( $complexNestedArray, JSON_NUMERIC_CHECK | JSON_FORCE_OBJECT, 8 ) }} }" 
></x-foo>
```

I like to keep the namespace `Livewire\js` to make it clear where the helper comes from and to avoid naming conflicts.

Discussed in #4083 
