### PR TITLE
Fix for model properties set to an empty array returning NULL after a request

### DIFF
--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -175,7 +175,7 @@ class HydratePublicProperties implements HydrationMiddleware
 
     public static function setDirtyData($model, $data) {
         foreach ($data as $key => $value) {
-            if (is_array($value)) {
+            if (is_array($value) && !empty($value)) {
                 $existingData = data_get($model, $key);
 
                 if (is_array($existingData)) {

--- a/tests/Unit/PublicPropertyHydrationAndDehydrationTest.php
+++ b/tests/Unit/PublicPropertyHydrationAndDehydrationTest.php
@@ -91,6 +91,20 @@ class PublicPropertyHydrationAndDehydrationTest extends TestCase
     }
 
     /** @test */
+    public function an_eloquent_model_with_a_properties_dirty_data_set_to_an_empty_array_gets_hydrated_properly()
+    {
+        $model = new Author();
+
+        $dirtyData = [
+            'name' => [],
+        ];
+
+        HydratePublicProperties::setDirtyData($model, $dirtyData);
+
+        $this->assertEquals([], $model->name);
+    }
+
+    /** @test */
     public function rules_get_extracted_properly()
     {
         $rules = [


### PR DESCRIPTION
Fixes #3840 

If you have an eloquent model and set one of its properties to an empty array, on the next request it was being hydrated as null instead of the empty array.

```php
$model = new Model();
$model->list = [];  // After a request this was returning NULL
```

Hope this helps!
