### PR TITLE
Allow Responsable objects download

### DIFF
--- a/src/Features/SupportFileDownloads.php
+++ b/src/Features/SupportFileDownloads.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features;
 
+use Illuminate\Contracts\Support\Responsable;
 use Livewire\Livewire;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -16,6 +17,10 @@ class SupportFileDownloads
     function __construct()
     {
         Livewire::listen('action.returned', function ($component, $action, $returned) {
+            if($returned instanceof Responsable){
+                $returned = $returned->toResponse(request());
+            }
+
             if ($this->valueIsntAFileResponse($returned)) return;
 
             $response = $returned;

--- a/tests/Unit/FileDownloadsTest.php
+++ b/tests/Unit/FileDownloadsTest.php
@@ -92,6 +92,7 @@ class FileDownloadComponent extends Component
 class DownloadableResponse implements Responsable
 {
     public function toResponse($request)
-    {   return  Storage::disk('unit-downloads')->download('download.txt');
+    {
+        return  Storage::disk('unit-downloads')->download('download.txt');
     }
 }

--- a/tests/Unit/FileDownloadsTest.php
+++ b/tests/Unit/FileDownloadsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use Illuminate\Contracts\Support\Responsable;
 use Livewire\Livewire;
 use Livewire\Component;
 use Illuminate\Support\Facades\Storage;
@@ -23,6 +24,13 @@ class FileDownloadsTest extends TestCase
         Livewire::test(FileDownloadComponent::class)
                 ->call('streamDownload', 'download.txt')
                 ->assertFileDownloaded('download.txt', 'alpinejs');
+    }
+
+    public function can_download_a_responsable(){
+        Livewire::test(FileDownloadComponent::class)
+            ->call('responsableDownload')
+            ->assertFileDownloaded()
+            ->assertFileDownloaded('download.txt', 'I\'m the file you should download.', 'text/plain');
     }
 
     /** @test */
@@ -73,5 +81,17 @@ class FileDownloadComponent extends Component
         }, $filename, $headers);
     }
 
+    public function responsableDownload()
+    {
+        return new DownloadableResponse();
+    }
+
     public function render() { return app('view')->make('null-view'); }
+}
+
+class DownloadableResponse implements Responsable
+{
+    public function toResponse($request)
+    {   return  Storage::disk('unit-downloads')->download('download.txt');
+    }
 }


### PR DESCRIPTION
Hi all!

this PR will add support for Responsable objects download

my main concern is to be able handle a download from a Responsable object like this one (it may be, for example, a **spatie/media-library Media** object)

```php
class DownloadableResponse implements Responsable
{
    public function toResponse($request)
    {   
        return  Storage::download('test-file.txt');
    }
}
```

as for now, in order to allow the download, the Livewire component method should be 

```php
 public function download()
{
    $response = new DownloadableResponse();

    return $response->toResponse(request());
}
```


with this PR, you will be able to do:


```php
 public function download()
{
    return new DownloadableResponse();
}
```

and the `->toResponse()` conversion will be handled in SupportFileDownloads Trait