### PR TITLE
$validationCustomValues added to components

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -100,6 +100,14 @@ trait ValidatesInput
         return [];
     }
 
+    protected function getValidationCustomValues()
+    {
+        if (method_exists($this, 'validationCustomValues')) return $this->validationCustomValues();
+        if (property_exists($this, 'validationCustomValues')) return $this->validationCustomValues;
+
+        return [];
+    }
+
     public function rulesForModel($name)
     {
         if (empty($this->getRules())) return collect();
@@ -175,6 +183,11 @@ trait ValidatesInput
 
         $this->shortenModelAttributesInsideValidator($ruleKeysToShorten, $validator);
 
+        $customValues = $this->getValidationCustomValues();
+        if (!empty($customValues)) {
+            $validator->addCustomValues($customValues);
+        }
+
         $validatedData = $validator->validate();
 
         $this->resetErrorBag();
@@ -226,6 +239,11 @@ trait ValidatesInput
         }
 
         $this->shortenModelAttributesInsideValidator($ruleKeysToShorten, $validator);
+
+        $customValues = $this->getValidationCustomValues();
+        if (!empty($customValues)) {
+            $validator->addCustomValues($customValues);
+        }
 
         try {
             $result = $validator->validate();

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -63,6 +63,16 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
+    public function validate_component_properties_with_custom_value_property()
+    {
+        $component = Livewire::test(ForValidation::class);
+
+        $component->runAction('runValidationWithCustomValuesProperty');
+
+        $this->assertStringContainsString('The bar field is required when foo is my custom value.', $component->payload['effects']['html']);
+    }
+
+    /** @test */
     public function validate_nested_component_properties()
     {
         $component = Livewire::test(ForValidation::class);
@@ -526,6 +536,21 @@ class ForValidation extends Component
         $this->validate([
             'bar' => 'required',
         ], [], ['bar' => 'foobar']);
+    }
+
+    public function runValidationWithCustomValuesProperty()
+    {
+        $this->foo = 'my';
+
+        $this->validationCustomValues = [
+            'foo' => [
+                'my' => 'my custom value',
+            ],
+        ];
+
+        $this->validate([
+            'bar' => 'required_if:foo,my',
+        ]);
     }
 
     public function runNestedValidation()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yes: https://github.com/livewire/livewire/discussions/4151

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
A $validationCustomValues property can be added to Livewire components to have the validation values also translated.

5️⃣ Thanks for contributing! 🙌