### PR TITLE
[Feature] Query string aliases

### DIFF
--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -178,6 +178,7 @@ class SupportBrowserHistory
                 return isset($value['except']);
             })
             ->mapWithKeys(function ($value, $key) {
+                $key = $value['as'] ?? $key;
                 return [$key => $value['except']];
             });
     }
@@ -186,9 +187,13 @@ class SupportBrowserHistory
     {
         return collect($component->getQueryString())
             ->mapWithKeys(function($value, $key) use ($component) {
-                $key = is_string($key) ? $key : $value;
+                if (is_string($key)) {
+                    $alias = $value['as'] ?? null;
+                } else {
+                    $key = $value;
+                }
 
-                return [$key => $component->{$key}];
+                return [($alias ?? $key) => $component->{$key}];
             });
     }
 

--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -187,13 +187,10 @@ class SupportBrowserHistory
     {
         return collect($component->getQueryString())
             ->mapWithKeys(function($value, $key) use ($component) {
-                if (is_string($key)) {
-                    $alias = $value['as'] ?? null;
-                } else {
-                    $key = $value;
-                }
+                $key = is_string($key) ? $key : $value;
+                $alias = $value['as'] ?? $key;
 
-                return [($alias ?? $key) => $component->{$key}];
+                return [$alias => $component->{$key}];
             });
     }
 

--- a/tests/Browser/QueryString/ComponentWithAliases.php
+++ b/tests/Browser/QueryString/ComponentWithAliases.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests\Browser\QueryString;
+
+class ComponentWithAliases extends ComponentWithTraits
+{
+    protected $queryString = [
+        'page' => ['except' => 1, 'as' => 'p'],
+        'search' => ['except' => '', 'as' => 's'],
+    ];
+}

--- a/tests/Browser/QueryString/Test.php
+++ b/tests/Browser/QueryString/Test.php
@@ -269,4 +269,29 @@ class Test extends TestCase
             ;
         });
     }
+
+    public function test_query_string_aliases()
+    {
+        $this->browse(function (Browser $browser) {
+            Livewire::visit($browser, ComponentWithAliases::class)
+                ->assertQueryStringMissing('p')
+                ->assertQueryStringMissing('s')
+                // Search for posts where title contains "1".
+                ->waitForLivewire()->type('@search', '1')
+                ->assertQueryStringMissing('p')
+                ->assertQueryStringHas('s', '1')
+                ->assertInputValue('@search', '1')
+                // Navigate to page 2.
+                ->waitForLivewire()->click('@nextPage.before')
+                ->assertQueryStringHas('p', 2)
+                ->assertQueryStringHas('s', '1')
+                ->assertInputValue('@search', '1')
+                // Search for posts where title contains "qwerty".
+                ->waitForLivewire()->type('@search', 'qwerty')
+                ->assertQueryStringMissing('p')
+                ->assertQueryStringHas('s', 'qwerty')
+                ->assertInputValue('@search', 'qwerty')
+            ;
+        });
+    }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
This was discussed in #2496, #2036 and #3305.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

This PR gives developer the ability to alias (customize/rename) query strings in URL with `as` modifier.

I can think of 3 valid reasons why this is useful.

1. Shortening the URL.

```php
class LivewireComponent extends Component
{
    protected $queryString = [
        'page' => ['except' => 1, 'as' => 'p'],
        'search' => ['except' => '', 'as' => 's'],
    ];
}
```
```
?p=2&s=qwerty
```

2. Completely renaming for semantic purposes.

```php
class LivewireComponent extends Component
{
    public $user;

    protected $queryString = [
        'user' => ['as' => 'user_id'],
    ];
}
```
```
?user_id=42
```

3. Following your standards. For example we can make properties appear in snake case although they are defined in camel case inside the component.

```php
class LivewireComponent extends Component
{
    public $userId;

    protected $queryString = [
        'userId' => ['as' => 'user_id'],
    ];
}
```
```
?user_id=7
```

5️⃣ Thanks for contributing! 🙌
🙌

Let me know if I have missed something. Cheers.