### PR TITLE
Fix validate only custom attributes

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
 use Livewire\Exceptions\MissingRulesException;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Livewire\HydrationMiddleware\HydratePublicProperties;
 
 trait ValidatesInput
 {
@@ -199,34 +200,20 @@ trait ValidatesInput
     {
         [$rules, $messages, $attributes] = $this->providedOrGlobalRulesMessagesAndAttributes($rules, $messages, $attributes);
 
-        // If the field is "items.0.foo", validation rules for "items.*.foo" is applied.
-        // if the field is "items.0", validation rules for "items.*" and "items.*.foo" etc are applied.
-        $rulesForField = collect($rules)
-            ->filter(function ($rule, $fullFieldKey) use ($field) {
-                return str($field)->is($fullFieldKey);
-            })->keys()
-            ->flatMap(function($key) use ($rules) {
-                return collect($rules)->filter(function($rule, $ruleKey) use ($key) {
-                    return str($ruleKey)->is($key);
-                });
-            })->mapWithKeys(function ($value, $key) use ($field) {
-                $fieldArray = str($field)->explode('.');
-                $result = str($key)->explode('.');
-
-                $result->splice(0, $fieldArray->count(), $fieldArray->toArray());
-
-                return [
-                    $result->join('.') => $value,
-                ];
-            })->toArray();
+        $rulesForField = collect($rules)->filter(function ($rule, $fullFieldKey) use ($field) {
+            return str($field)->is($fullFieldKey) || str($fullFieldKey)->startsWith($field);
+        })->toArray();
 
         $ruleKeysForField = array_keys($rulesForField);
-
-        $data = $this->prepareForValidation(
-            $this->getDataForValidation($rules)
-        );
+        
+        $data = $this->getDataForValidation($rules);
 
         $ruleKeysToShorten = $this->getModelAttributeRuleKeysToShorten($data, $rules);
+        
+        $processedRules = HydratePublicProperties::processRules([$field]);
+        $data = HydratePublicProperties::extractData($data, $processedRules, []);
+
+        $data = $this->prepareForValidation($data);
 
         $data = $this->unwrapDataForValidation($data);
 

--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -237,14 +237,23 @@ class HydratePublicProperties implements HydrationMiddleware
 
     public static function processRules($rules) {
         $rules = Collection::wrap($rules);
-
+        
         $rules = $rules
-            ->mapInto(Stringable::class)
-            ->mapToGroups(function($rule) {
+            ->mapInto(Stringable::class);
+
+        [$groupedRules, $singleRules] = $rules->partition(function($rule) {
+            return $rule->contains('.');
+        });
+
+        $singleRules = $singleRules->map(function(Stringable $rule) {
+            return $rule->__toString();
+        });
+
+        $groupedRules = $groupedRules->mapToGroups(function(Stringable $rule) {
                 return [$rule->before('.')->__toString() => $rule->after('.')];
             });
 
-        $rules = $rules->mapWithKeys(function($rules, $group) {
+        $groupedRules = $groupedRules->mapWithKeys(function($rules, $group) {
             // Split rules into collection and model rules.
             [$collectionRules, $modelRules] = $rules
                 ->partition(function($rule) {
@@ -263,10 +272,12 @@ class HydratePublicProperties implements HydrationMiddleware
 
             $modelRules = $modelRules->map->__toString();
 
-            $rules = $modelRules->merge($collectionRules);
+            $rules = $modelRules->union($collectionRules);
 
             return [$group => $rules];
         });
+
+        $rules = $singleRules->union($groupedRules);
 
         return $rules;
     }

--- a/tests/Unit/PublicPropertyHydrationAndDehydrationTest.php
+++ b/tests/Unit/PublicPropertyHydrationAndDehydrationTest.php
@@ -182,6 +182,40 @@ class PublicPropertyHydrationAndDehydrationTest extends TestCase
     }
 
     /** @test */
+    public function single_property_rules_with_specific_instance_get_extracted_properly()
+    {
+        $rules = [
+            'foo',
+            'bar',
+        ];
+
+        $expected = [
+            'foo',
+            'bar',
+        ];
+
+        $this->assertEquals($expected, HydratePublicProperties::processRules($rules)->toArray());
+    }
+
+    /** @test */
+    public function collection_rules_with_specific_instance_get_extracted_properly()
+    {
+        $rules = [
+            'foo.1.bar',
+        ];
+
+        $expected = [
+            'foo' => [
+                1 => [
+                    'bar',
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, HydratePublicProperties::processRules($rules)->toArray());
+    }
+
+    /** @test */
     public function an_eloquent_model_properties_can_be_serialised()
     {
         $model = Author::create(['id' => 1, 'title' => 'foo', 'name' => 'bar', 'email' => 'baz']);

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -50,6 +50,7 @@ class ValidationTest extends TestCase
         $component->runAction('runValidationWithAttributesProperty');
 
         $this->assertStringContainsString('The foobar field is required.', $component->payload['effects']['html']);
+        $this->assertStringContainsString('The Items Baz field is required.', $component->payload['effects']['html']);
     }
 
     /** @test */
@@ -552,10 +553,14 @@ class ForValidation extends Component
 
     public function runValidationWithAttributesProperty()
     {
-        $this->validationAttributes = ['bar' => 'foobar'];
+        $this->validationAttributes = [
+            'bar' => 'foobar',
+            'items.*.baz' => 'Items Baz'
+        ];
 
         $this->validate([
             'bar' => 'required',
+            'items.*.baz' => 'required',
         ]);
     }
 

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -181,6 +181,21 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
+    public function can_validate_only_a_specific_field_with_custom_attributes_property()
+    {
+        $component = Livewire::test(ForValidation::class);
+
+        $component
+            ->call('runValidationOnlyWithAttributesProperty', 'bar')
+            ->assertSee('The foobar field is required.')
+            ->call('runValidationOnlyWithAttributesProperty', 'items.*.baz') // Test wildcard works
+            ->assertSee('The Items Baz field is required.')
+            ->call('runValidationOnlyWithAttributesProperty', 'items.1.baz') // Test specific instance works
+            ->assertSee('The Items Baz field is required.')
+            ;
+    }
+
+    /** @test */
     public function can_validate_only_a_specific_field_with_deeply_nested_array()
     {
         $component = Livewire::test(ForValidation::class);
@@ -491,6 +506,19 @@ class ForValidation extends Component
         $this->validateOnly($field, [
             'foo' => 'required',
             'bar' => 'required',
+        ]);
+    }
+
+    public function runValidationOnlyWithAttributesProperty($field)
+    {
+        $this->validationAttributes = [
+            'bar' => 'foobar',
+            'items.*.baz' => 'Items Baz',
+        ];
+
+        $this->validateOnly($field, [
+            'bar' => 'required',
+            'items.*.baz' => 'required',
         ]);
     }
 


### PR DESCRIPTION
This PR fixes custom validation attribute names (both Livewire ones and Laravel's validation translation file ones), see discussion #3824.

Since 2.6, custom validation attributes were no longer being displayed for nested items when using `validateOnly`.

For example with the following custom attribute

```php
protected $validationAttributes = [
        'users.*.email' => 'email address'
];
```

When running `$this->onlyValidate('users.1.email');`, the error message was still showing "users.1.email" instead of "email address".

The issue was introduced in PR #3596 as that PR was filtering the rules to match the exact property to validate, and changing them from `users.*.email` to `users.1.email`.

The problem with that is the custom attributes still need the rule names to be `users.*.email` to work properly.

To solve this I've change it so it filters which data to pass to the validator and leaves the rules intact.

I started writing the logic for this, then realised we already have it in `HydratePublicProperties`, and so you will notice that I'm making use of the data processing methods from there as it is the same logic. With some small modifications to it, I got it all running.

Not sure if you would prefer to move these methods to another class which then hydrate and validate can make use of.

Hope this helps!