### PR TITLE
Discover index components in subfolders

### DIFF
--- a/src/LivewireComponentsFinder.php
+++ b/src/LivewireComponentsFinder.php
@@ -23,7 +23,9 @@ class LivewireComponentsFinder
 
     public function find($alias)
     {
-        return $this->getManifest()[$alias] ?? null;
+        $manifest = $this->getManifest();
+
+        return $manifest[$alias] ?? $manifest["{$alias}.index"] ?? null;
     }
 
     public function getManifest()

--- a/tests/Unit/LivewireDirectivesTest.php
+++ b/tests/Unit/LivewireDirectivesTest.php
@@ -190,6 +190,22 @@ class LivewireDirectivesTest extends TestCase
     }
 
     /** @test */
+    public function can_assert_see_livewire_on_test_view_refering_by_subfolder_without_dot_index()
+    {
+        if(! class_exists(TestView::class)) {
+            self::markTestSkipped('Need Laravel >= 8');
+        }
+
+        Artisan::call('make:livewire', ['name' => 'foo.index']);
+
+        $testView = new TestView(view('render-component', [
+            'component' => 'foo',
+        ]));
+
+        $testView->assertSeeLivewire('foo');
+    }
+
+    /** @test */
     public function can_assert_dont_see_livewire_on_test_view()
     {
         if(! class_exists(TestView::class)) {


### PR DESCRIPTION
This PR adds the functionality to discover `index` components in sub-folders if the initial `$alias` for the component could not be resolved. It follows the same logic as Laravel does for finding [Anonymous Index Components](https://laravel.com/docs/8.x/blade#anonymous-index-components).

## Use Case
We have a `Registration` component folder, because in this case a registration consist of multiple steps (username & password in step 1, address data in step 2, etc.). With the current implementation we would have to reference the specific registration component with `registration.index` with this PR we can reference the component by `registration` and also place the related steps (components) inside the same folder.

```blade
<!-- before -->
<livewire:registration.index />

<!-- after -->
<livewire:registration />
```

```php
namespace App\Http\Livewire\Registration;

use Livewire\Component;

class Index extends Component
{
    public function render()
    {
        return view('livewire.registration.index');
    }
}
```

## Advantages
Grouping components that belong to the an "index" component together in a folder without referencing it with a ".index" suffix.

## Tests
I've not added any tests because I am not sure if the idea of this PR is acceptable nor where to place the tests for this small feature. If you point me to a specific file I ll gladly add the missing tests.