### PR TITLE
Deterministic "cached keys" for nested components

### DIFF
--- a/src/LivewireBladeDirectives.php
+++ b/src/LivewireBladeDirectives.php
@@ -45,7 +45,7 @@ EOT;
 
     public static function livewire($expression)
     {
-        $cachedKey = "'" . Str::random(7) . "'";
+        $cachedKey = "'" . sha1($expression) . "'";
 
         $pattern = "/,\s*?key\(([\s\S]*)\)/"; //everything between ",key(" and ")"
         $expression = preg_replace_callback($pattern, function ($match) use (&$cachedKey) {

--- a/tests/Unit/NestingComponentsTest.php
+++ b/tests/Unit/NestingComponentsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use Illuminate\Support\Facades\Artisan;
 use Livewire\Component;
 
 class NestingComponentsTest extends TestCase
@@ -25,6 +26,21 @@ class NestingComponentsTest extends TestCase
 
         $this->assertStringContainsString('foo', $component->payload['effects']['html']);
 
+        $component->runAction('$refresh');
+
+        $this->assertStringNotContainsString('foo', $component->payload['effects']['html']);
+    }
+
+    /** @test */
+    public function parent_renders_stub_element_in_place_of_child_on_subsequent_renders_even_if_view_cache_cleared()
+    {
+        app('livewire')->component('parent', ParentComponentForNestingChildStub::class);
+        app('livewire')->component('child', ChildComponentForNestingStub::class);
+        $component = app('livewire')->test('parent');
+
+        $this->assertStringContainsString('foo', $component->payload['effects']['html']);
+
+        Artisan::call('view:clear');
         $component->runAction('$refresh');
 
         $this->assertStringNotContainsString('foo', $component->payload['effects']['html']);

--- a/tests/Unit/views/show-duplicate-children.blade.php
+++ b/tests/Unit/views/show-duplicate-children.blade.php
@@ -1,0 +1,4 @@
+<div>
+    @livewire('child', ['name' => $childName])
+    @livewire('child', ['name' => $childName])
+</div>


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
No issue or discussion, but this is an issue I ran into personally, [as have a few other people](https://twitter.com/cssgareth/status/1391473632627642369?s=20).

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope, one single change

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes, this includes a test that fails without this change

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
Currently, rendering nested Livewire components when running multiple instances of a Laravel app behind a load balancer can cause Livewire to lose track of the state of all child components.

This is caused by Livewire using random strings to track each child component and storing this string in Laravel's view cache. Since the view cache isn't typically shared between app instances in this setup, Livewire can end up rendering child components from scratch if requests don't consistently reach the same instance of the app.

By making the generation of these strings deterministic, it doesn't matter if the view cache isn't shared. Each instance of the app will generate the same string for a given child component, so child components will be correctly tracked across app instances.

5️⃣ Thanks for contributing! 🙌
🙇 