### PR TITLE
Account For Varying Emission Params

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -157,7 +157,7 @@ trait MakesAssertions
 
         if (empty($params)) {
             $test = collect(data_get($this->payload, 'effects.emits'))->contains('event', '=', $value);
-        } elseif (! is_string($value) && is_callable($params[0])) {
+        } elseif (! is_string($params[0]) && is_callable($params[0])) {
             $event = collect(data_get($this->payload, 'effects.emits'))->first(function ($item) use ($value) {
                 return $item['event'] === $value;
             });

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -157,7 +157,7 @@ trait MakesAssertions
 
         if (empty($params)) {
             $test = collect(data_get($this->payload, 'effects.emits'))->contains('event', '=', $value);
-        } elseif (is_callable($params[0])) {
+        } elseif (! is_string($value) && is_callable($params[0])) {
             $event = collect(data_get($this->payload, 'effects.emits'))->first(function ($item) use ($value) {
                 return $item['event'] === $value;
             });
@@ -168,6 +168,7 @@ trait MakesAssertions
                 return $item['event'] === $value
                     && $item['params'] === $params;
             });
+            
             $encodedParams = json_encode($params);
             $assertionSuffix = " with parameters: {$encodedParams}";
         }

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -148,6 +148,12 @@ class LivewireTestingTest extends TestCase
             ->assertEmitted('foo')
             ->call('emitFooWithParam', 'bar')
             ->assertEmitted('foo', 'bar')
+            ->call('emitFooWithParam', 'info')
+            ->assertEmitted('foo', 'info')
+            ->call('emitFooWithParam', 'last')
+            ->assertEmitted('foo', 'last')
+            ->call('emitFooWithParam', 'retry')
+            ->assertEmitted('foo', 'retry')
             ->call('emitFooWithParam', 'baz')
             ->assertEmitted('foo', function ($event, $params) {
                 return $event === 'foo' && $params === ['baz'];


### PR DESCRIPTION
1️⃣  Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yes! & No.

2️⃣  Does it contain multiple, unrelated changes?
Nope!

3️⃣  Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
Yes!

4️⃣  Please include a thorough description of the improvement and reasons why it's useful.

In our project we have an enum with the value "info" which is one of the parameters for one of our Livewire emitters.

This function thinks that "info" is a callable because PHP has a built-in function `info()` and therefore our tests for it fail.

A simple `! is_string()` check should suffice!

5️⃣  Thanks for contributing! 🙌