### PR TITLE
[FIX] Check all the values in dehydratePropertyFromWithFileUploads before calling serializeMultipleForLivewireResponse

### DIFF
--- a/src/Features/SupportFileUploads.php
+++ b/src/Features/SupportFileUploads.php
@@ -45,8 +45,19 @@ class SupportFileUploads
             return  $value->serializeForLivewireResponse();
         }
 
-        if (is_array($value) && isset(array_values($value)[0]) && array_values($value)[0] instanceof TemporaryUploadedFile && is_numeric(key($value))) {
-            return array_values($value)[0]::serializeMultipleForLivewireResponse($value);
+        if (is_array($value) && isset(array_values($value)[0])) {
+            $isValid = true;
+
+            foreach (array_values($value) as $key => $arrayValue) {
+                if (!($arrayValue instanceof TemporaryUploadedFile) || !is_numeric($key)) {
+                    $isValid = false;
+                    break;
+                }
+            }
+
+            if ($isValid) {
+                return array_values($value)[0]::serializeMultipleForLivewireResponse($value);
+            }
         }
 
         if (is_array($value)) {

--- a/tests/Unit/DehydratePropertyFromWithFileUploadsTest.php
+++ b/tests/Unit/DehydratePropertyFromWithFileUploadsTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Support\Facades\Storage;
+use Livewire\Features\SupportFileUploads;
+use Illuminate\Http\UploadedFile;
+use Livewire\TemporaryUploadedFile;
+use Livewire\Wireable;
+
+class DehydratePropertyFromWithFileUploadsTest extends TestCase
+{
+    /** @test */
+    public function a_text_variable_should_return_with_no_changes()
+    {
+        if (version_compare(PHP_VERSION, '7.4', '<')) {
+            $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
+        }
+
+        $uploader = SupportFileUploads::init();
+        $inputValue = 'File Upload';
+        $outputValue = $uploader->dehydratePropertyFromWithFileUploads($inputValue);
+        $this->assertTrue($inputValue === $outputValue);
+    }
+
+    /** @test */
+    public function an_image_should_return_a_serialized_version_of_itself()
+    {
+        Storage::fake('tmp-for-tests');
+
+        if (version_compare(PHP_VERSION, '7.4', '<')) {
+            $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
+        }
+
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        $uploader = SupportFileUploads::init();
+        $tempFile = TemporaryUploadedFile::createFromLivewire($file->path());
+        $outputFile = $uploader->dehydratePropertyFromWithFileUploads($tempFile);
+        $this->assertTrue(str_contains($outputFile, 'livewire-file:'));
+    }
+
+    /** @test */
+    public function an_array_should_serialize_all_images_within_it()
+    {
+        Storage::fake('tmp-for-tests');
+
+        if (version_compare(PHP_VERSION, '7.4', '<')) {
+            $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
+        }
+
+        $file1 = UploadedFile::fake()->image('avatar.jpg');
+        $file2 = UploadedFile::fake()->image('avatar.jpg');
+
+        $uploader = SupportFileUploads::init();
+        $tmpFileArray = [
+            TemporaryUploadedFile::createFromLivewire($file1->path()),
+            TemporaryUploadedFile::createFromLivewire($file2->path())
+        ];
+
+        $outputFileStr = $uploader->dehydratePropertyFromWithFileUploads($tmpFileArray);
+        $imageListArr = explode(',', str_replace(array('livewire-files:','[', ']'), '', $outputFileStr));
+
+        $this->assertTrue(str_contains($outputFileStr, 'livewire-files:'));
+        $this->assertTrue(count($imageListArr) === count($tmpFileArray));
+    }
+
+    /** @test */
+    public function a_wireable_object_serialize_all_images_within_it()
+    {
+        Storage::fake('tmp-for-tests');
+
+        if (version_compare(PHP_VERSION, '7.4', '<')) {
+            $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
+        }
+
+        $file1 = UploadedFile::fake()->image('avatar.jpg');
+        $file2 = UploadedFile::fake()->image('avatar.jpg');
+        $file3 = UploadedFile::fake()->image('avatar.jpg');
+
+        $uploader = SupportFileUploads::init();
+
+        $tmpFile = TemporaryUploadedFile::createFromLivewire($file1->path());
+        $tmpFileArray = [
+            TemporaryUploadedFile::createFromLivewire($file2->path()),
+            TemporaryUploadedFile::createFromLivewire($file3->path())
+        ];
+
+        $wireableInput = new DehydrateTestWireable($tmpFile, $tmpFileArray, 'test string', 1);
+
+        $wireableOutput = $uploader->dehydratePropertyFromWithFileUploads($wireableInput);
+        $imageListArr = explode(',', str_replace(array('livewire-files:','[', ']'), '', $wireableOutput->imageList));
+
+
+        $this->assertTrue(str_contains($wireableOutput->image, 'livewire-file:'));
+        $this->assertTrue(str_contains($wireableOutput->imageList, 'livewire-files:'));
+        $this->assertTrue(count($imageListArr) === count($tmpFileArray));
+        $this->assertTrue($wireableOutput->text === 'test string');
+        $this->assertTrue($wireableOutput->number === 1);
+    }
+}
+
+class DehydrateTestWireable implements Wireable
+{
+    public $image;
+    public $imageList;
+    public $text;
+    public $number;
+
+    public function __construct($image, $imageList, $text, $number)
+    {
+        $this->image = $image;
+        $this->imageList = $imageList;
+        $this->text = $text;
+        $this->number = $number;
+    }
+
+    public function toLivewire()
+    {
+        return [
+            'image' => $this->image,
+            'imageList' => $this->imageList,
+            'text' => $this->text,
+            'number' => $this->number
+        ];
+    }
+
+    public static function fromLivewire($value)
+    {
+        return new static($value['image'], $value['imageList'], $value['text'], $value['number']);
+    }
+}
+
+

--- a/tests/Unit/DehydratePropertyFromWithFileUploadsTest.php
+++ b/tests/Unit/DehydratePropertyFromWithFileUploadsTest.php
@@ -13,10 +13,6 @@ class DehydratePropertyFromWithFileUploadsTest extends TestCase
     /** @test */
     public function a_text_variable_should_return_with_no_changes()
     {
-        if (version_compare(PHP_VERSION, '7.4', '<')) {
-            $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
-        }
-
         $uploader = SupportFileUploads::init();
         $inputValue = 'File Upload';
         $outputValue = $uploader->dehydratePropertyFromWithFileUploads($inputValue);
@@ -27,10 +23,6 @@ class DehydratePropertyFromWithFileUploadsTest extends TestCase
     public function an_image_should_return_a_serialized_version_of_itself()
     {
         Storage::fake('tmp-for-tests');
-
-        if (version_compare(PHP_VERSION, '7.4', '<')) {
-            $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
-        }
 
         $file = UploadedFile::fake()->image('avatar.jpg');
 
@@ -44,10 +36,6 @@ class DehydratePropertyFromWithFileUploadsTest extends TestCase
     public function an_array_should_serialize_all_images_within_it()
     {
         Storage::fake('tmp-for-tests');
-
-        if (version_compare(PHP_VERSION, '7.4', '<')) {
-            $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
-        }
 
         $file1 = UploadedFile::fake()->image('avatar.jpg');
         $file2 = UploadedFile::fake()->image('avatar.jpg');
@@ -69,10 +57,6 @@ class DehydratePropertyFromWithFileUploadsTest extends TestCase
     public function a_wireable_object_serialize_all_images_within_it()
     {
         Storage::fake('tmp-for-tests');
-
-        if (version_compare(PHP_VERSION, '7.4', '<')) {
-            $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
-        }
 
         $file1 = UploadedFile::fake()->image('avatar.jpg');
         $file2 = UploadedFile::fake()->image('avatar.jpg');
@@ -104,10 +88,6 @@ class DehydratePropertyFromWithFileUploadsTest extends TestCase
     public function serialize_mixed_arrays_with_uploaded_files()
     {
         Storage::fake('tmp-for-tests');
-
-        if (version_compare(PHP_VERSION, '7.4', '<')) {
-            $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
-        }
 
         $file = UploadedFile::fake()->image('avatar.jpg');
 


### PR DESCRIPTION
Referring to this issue: https://github.com/livewire/livewire/discussions/2243

I'm using a file upload (using Livewire fileuploads) functionality with sorting (using Livewire/sortable). I ran into the same issue as the creator of the issue mentioned above. Once you start dragging a freshly added image to the first position in the list an error pops up. There's [a video](https://drive.google.com/file/d/10sVkwguH_b0xWuzdpPNvwqeaCof_8rJp/view) in the mentioned issue that shows you how to reproduce this bug.

This issue only happens when a newly uploaded image gets dragged to the first position. This is because the $value array would look like this:

![image](https://user-images.githubusercontent.com/90309934/136432334-65e9c159-22b3-40e4-b66c-9d11a4ba1f5d.png)

The _dehydratePropertyFromWithFileUploads_ function only checks in the third if-statement if the first item of this array is an instance of _TemporaryUploadedFile_ while that doesn't necessarily mean that this is a valid array.

The _serializeMultipleForLivewireResponse_ calls the _getFilename_ on all of the items in the array, which will fail for items that aren't an instance of _TemporaryUploadedFile_. 

This pull request fixes this issue by not allowing invalid arrays to call the _serializeMultipleForLivewireResponse_ function, but instead let's them pass on to the fourth if-statement of the _dehydratePropertyFromWithFileUploads_ function. An invalid array meaning that not all items in the array are an instance of _TemporaryUploadedFile_

