### PR TITLE
Add missing inline-flex to wire:loading

### DIFF
--- a/js/component/LoadingStates.js
+++ b/js/component/LoadingStates.js
@@ -244,7 +244,7 @@ function startLoading(els) {
 }
 
 function getDisplayProperty(directive) {
-    return (['inline', 'block', 'table', 'flex', 'grid']
+    return (['inline', 'block', 'table', 'flex', 'grid', 'inline-flex']
         .filter(i => directive.modifiers.includes(i))[0] || 'inline-block')
 }
 


### PR DESCRIPTION
When you are trying to inline-flex a loading element, just like for instance you want to center the loading message inside a table's `td`, you need it to be inline-flex.