### PR TITLE
Make assertSet() and assertNotSet() more strict

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -11,30 +11,24 @@ use PHPUnit\Framework\Assert as PHPUnit;
 
 trait MakesAssertions
 {
-    public function assertSet($name, $value)
+    public function assertSet($name, $value, $strict = false)
     {
-        $actualValue = $this->get($name);
+        $actual = $this->get($name);
 
         if (! is_string($value) && is_callable($value)) {
-            PHPUnit::assertTrue($value($actualValue));
-        } elseif (is_object($actualValue)) {
-            PHPUnit::assertEquals($value, $actualValue);
+            PHPUnit::assertTrue($value($actual));
         } else {
-            PHPUnit::assertSame($value, $actualValue);
+            $strict ? PHPUnit::assertSame($value, $actual) : PHPUnit::assertEquals($value, $actual);
         }
 
         return $this;
     }
 
-    public function assertNotSet($name, $value)
+    public function assertNotSet($name, $value, $strict = false)
     {
-        $actualValue = $this->get($name);
+        $actual = $this->get($name);
 
-        if (is_object($actualValue)) {
-            PHPUnit::assertNotEquals($value, $actualValue);
-        } else {
-            PHPUnit::assertNotSame($value, $actualValue);
-        }
+        $strict ? PHPUnit::assertNotSame($value, $actual) : PHPUnit::assertNotEquals($value, $actual);
 
         return $this;
     }

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -13,10 +13,14 @@ trait MakesAssertions
 {
     public function assertSet($name, $value)
     {
+        $actualValue = $this->get($name);
+
         if (! is_string($value) && is_callable($value)) {
-            PHPUnit::assertTrue($value($this->get($name)));
+            PHPUnit::assertTrue($value($actualValue));
+        } elseif (is_object($actualValue)) {
+            PHPUnit::assertEquals($value, $actualValue);
         } else {
-            PHPUnit::assertSame($value, $this->get($name));
+            PHPUnit::assertSame($value, $actualValue);
         }
 
         return $this;
@@ -24,7 +28,13 @@ trait MakesAssertions
 
     public function assertNotSet($name, $value)
     {
-        PHPUnit::assertNotSame($value, $this->get($name));
+        $actualValue = $this->get($name);
+
+        if (is_object($actualValue)) {
+            PHPUnit::assertNotEquals($value, $actualValue);
+        } else {
+            PHPUnit::assertNotSame($value, $actualValue);
+        }
 
         return $this;
     }

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -24,11 +24,25 @@ trait MakesAssertions
         return $this;
     }
 
+    public function assertSetStrict($name, $value)
+    {
+        $this->assertSet($name, $value, true);
+
+        return $this;
+    }
+
     public function assertNotSet($name, $value, $strict = false)
     {
         $actual = $this->get($name);
 
         $strict ? PHPUnit::assertNotSame($value, $actual) : PHPUnit::assertNotEquals($value, $actual);
+
+        return $this;
+    }
+
+    public function assertNotSetStrict($name, $value)
+    {
+        $this->assertNotSet($name, $value, true);
 
         return $this;
     }

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -24,25 +24,11 @@ trait MakesAssertions
         return $this;
     }
 
-    public function assertSetStrict($name, $value)
-    {
-        $this->assertSet($name, $value, true);
-
-        return $this;
-    }
-
     public function assertNotSet($name, $value, $strict = false)
     {
         $actual = $this->get($name);
 
         $strict ? PHPUnit::assertNotSame($value, $actual) : PHPUnit::assertNotEquals($value, $actual);
-
-        return $this;
-    }
-
-    public function assertNotSetStrict($name, $value)
-    {
-        $this->assertNotSet($name, $value, true);
 
         return $this;
     }

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -16,7 +16,7 @@ trait MakesAssertions
         if (! is_string($value) && is_callable($value)) {
             PHPUnit::assertTrue($value($this->get($name)));
         } else {
-            PHPUnit::assertEquals($value, $this->get($name));
+            PHPUnit::assertSame($value, $this->get($name));
         }
 
         return $this;
@@ -24,7 +24,7 @@ trait MakesAssertions
 
     public function assertNotSet($name, $value)
     {
-        PHPUnit::assertNotEquals($value, $this->get($name));
+        PHPUnit::assertNotSame($value, $this->get($name));
 
         return $this;
     }

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -50,7 +50,13 @@ class LivewireTestingTest extends TestCase
             ->set('name', 'info')
             ->assertSet('name', 'info')
             ->set('name', 'is_array')
-            ->assertSet('name', 'is_array');
+            ->assertSet('name', 'is_array')
+            ->assertSet(
+                'name',
+                function ($propertyValue) {
+                    return $propertyValue === 'is_array';
+                }
+            );
 
         $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
 

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -53,7 +53,7 @@ class LivewireTestingTest extends TestCase
             ->assertSet('name', 'is_array')
             ->set('name', 0)
             ->assertSet('name', null)
-            ->assertSetStrict('name', 0)
+            ->assertSet('name', 0, true)
             ->assertSet(
                 'name',
                 function ($propertyValue) {
@@ -63,7 +63,7 @@ class LivewireTestingTest extends TestCase
 
         $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
 
-        $component->assertSetStrict('name', null);
+        $component->assertSet('name', null, true);
     }
 
     /** @test */
@@ -72,10 +72,10 @@ class LivewireTestingTest extends TestCase
         $component = Livewire::test(HasMountArguments::class, ['name' => 'bar'])
             ->assertNotSet('name', 'foo')
             ->set('name', 100)
-            ->assertNotSetStrict('name', "1e2")
+            ->assertNotSet('name', "1e2", true)
             ->set('name', 0)
-            ->assertNotSetStrict('name', false)
-            ->assertNotSetStrict('name', null);
+            ->assertNotSet('name', false, true)
+            ->assertNotSet('name', null, true);
 
         $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
 

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -45,19 +45,27 @@ class LivewireTestingTest extends TestCase
     /** @test */
     public function assert_set()
     {
-        Livewire::test(HasMountArguments::class, ['name' => 'foo'])
+        $livewire = Livewire::test(HasMountArguments::class, ['name' => 'foo'])
             ->assertSet('name', 'foo')
             ->set('name', 'info')
             ->assertSet('name', 'info')
             ->set('name', 'is_array')
             ->assertSet('name', 'is_array');
+
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+
+        $livewire->set('name', 0)->assertSet('name', null);
     }
 
     /** @test */
     public function assert_not_set()
     {
-        Livewire::test(HasMountArguments::class, ['name' => 'bar'])
-            ->assertNotSet('name', 'foo');
+        Livewire::test(HasMountArguments::class, ['name' => null])
+            ->assertNotSet('name', false)
+            ->assertNotSet('name', '')
+            ->assertNotSet('name', 0)
+            ->set('name', 100)
+            ->assertNotSet('name', "1e2");
     }
 
     /** @test */

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -53,7 +53,7 @@ class LivewireTestingTest extends TestCase
             ->assertSet('name', 'is_array')
             ->set('name', 0)
             ->assertSet('name', null)
-            ->assertSet('name', 0, true)
+            ->assertSetStrict('name', 0)
             ->assertSet(
                 'name',
                 function ($propertyValue) {
@@ -63,7 +63,7 @@ class LivewireTestingTest extends TestCase
 
         $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
 
-        $component->assertSet('name', null, true);
+        $component->assertSetStrict('name', null);
     }
 
     /** @test */
@@ -72,10 +72,10 @@ class LivewireTestingTest extends TestCase
         $component = Livewire::test(HasMountArguments::class, ['name' => 'bar'])
             ->assertNotSet('name', 'foo')
             ->set('name', 100)
-            ->assertNotSet('name', "1e2", true)
+            ->assertNotSetStrict('name', "1e2")
             ->set('name', 0)
-            ->assertNotSet('name', false, true)
-            ->assertNotSet('name', null, true);
+            ->assertNotSetStrict('name', false)
+            ->assertNotSetStrict('name', null);
 
         $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
 

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -51,27 +51,35 @@ class LivewireTestingTest extends TestCase
             ->assertSet('name', 'info')
             ->set('name', 'is_array')
             ->assertSet('name', 'is_array')
+            ->set('name', 0)
+            ->assertSet('name', null)
+            ->assertSet('name', 0, true)
             ->assertSet(
                 'name',
                 function ($propertyValue) {
-                    return $propertyValue === 'is_array';
+                    return $propertyValue === 0;
                 }
             );
 
         $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
 
-        $component->set('name', 0)->assertSet('name', null);
+        $component->assertSet('name', null, true);
     }
 
     /** @test */
     public function assert_not_set()
     {
-        Livewire::test(HasMountArguments::class, ['name' => null])
-            ->assertNotSet('name', false)
-            ->assertNotSet('name', '')
-            ->assertNotSet('name', 0)
+        $component = Livewire::test(HasMountArguments::class, ['name' => 'bar'])
+            ->assertNotSet('name', 'foo')
             ->set('name', 100)
-            ->assertNotSet('name', "1e2");
+            ->assertNotSet('name', "1e2", true)
+            ->set('name', 0)
+            ->assertNotSet('name', false, true)
+            ->assertNotSet('name', null, true);
+
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+
+        $component->assertNotSet('name', null);
     }
 
     /** @test */

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -45,7 +45,7 @@ class LivewireTestingTest extends TestCase
     /** @test */
     public function assert_set()
     {
-        $livewire = Livewire::test(HasMountArguments::class, ['name' => 'foo'])
+        $component = Livewire::test(HasMountArguments::class, ['name' => 'foo'])
             ->assertSet('name', 'foo')
             ->set('name', 'info')
             ->assertSet('name', 'info')
@@ -60,7 +60,7 @@ class LivewireTestingTest extends TestCase
 
         $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
 
-        $livewire->set('name', 0)->assertSet('name', null);
+        $component->set('name', 0)->assertSet('name', null);
     }
 
     /** @test */

--- a/tests/Unit/ModelAttributesCanBeCastTest.php
+++ b/tests/Unit/ModelAttributesCanBeCastTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use Carbon\Carbon;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
@@ -158,19 +159,19 @@ class ModelAttributesCanBeCastTest extends TestCase
     public function can_cast_decimal_attributes_with_one_digit_from_model_casts_definition()
     {
         Livewire::test(ComponentForModelAttributeCasting::class)
-            ->assertSet('model.decimal_with_one_digit', 5.0)
+            ->assertSet('model.decimal_with_one_digit', '5.0')
             ->assertPayloadSet('model.decimal_with_one_digit', 5.0)
 
             ->set('model.decimal_with_one_digit', 5.120983)
             ->call('validateAttribute', 'model.decimal_with_one_digit')
             ->assertHasNoErrors('model.decimal_with_one_digit')
-            ->assertSet('model.decimal_with_one_digit', 5.1)
+            ->assertSet('model.decimal_with_one_digit', '5.1')
             ->assertPayloadSet('model.decimal_with_one_digit', 5.1)
 
             ->set('model.decimal_with_one_digit', '5.55')
             ->call('validateAttribute', 'model.decimal_with_one_digit')
             ->assertHasNoErrors('model.decimal_with_one_digit')
-            ->assertSet('model.decimal_with_one_digit', 5.6)
+            ->assertSet('model.decimal_with_one_digit', '5.6')
             ->assertPayloadSet('model.decimal_with_one_digit', 5.6);
     }
 
@@ -178,19 +179,19 @@ class ModelAttributesCanBeCastTest extends TestCase
     public function can_cast_decimal_attributes_with_two_digits_from_model_casts_definition()
     {
         Livewire::test(ComponentForModelAttributeCasting::class)
-            ->assertSet('model.decimal_with_two_digits', 6.0)
+            ->assertSet('model.decimal_with_two_digits', '6.00')
             ->assertPayloadSet('model.decimal_with_two_digits', 6.0)
 
             ->set('model.decimal_with_two_digits', 6.4567)
             ->call('validateAttribute', 'model.decimal_with_two_digits')
             ->assertHasNoErrors('model.decimal_with_two_digits')
-            ->assertSet('model.decimal_with_two_digits', 6.46)
+            ->assertSet('model.decimal_with_two_digits', '6.46')
             ->assertPayloadSet('model.decimal_with_two_digits', 6.46)
 
             ->set('model.decimal_with_two_digits', '6.212')
             ->call('validateAttribute', 'model.decimal_with_two_digits')
             ->assertHasNoErrors('model.decimal_with_two_digits')
-            ->assertSet('model.decimal_with_two_digits', 6.21)
+            ->assertSet('model.decimal_with_two_digits', '6.21')
             ->assertPayloadSet('model.decimal_with_two_digits', 6.21);
     }
 

--- a/tests/Unit/ModelAttributesCanBeCastTest.php
+++ b/tests/Unit/ModelAttributesCanBeCastTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Unit;
 
-use Carbon\Carbon;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;

--- a/tests/Unit/ModelAttributesCanBeCastTest.php
+++ b/tests/Unit/ModelAttributesCanBeCastTest.php
@@ -158,19 +158,19 @@ class ModelAttributesCanBeCastTest extends TestCase
     public function can_cast_decimal_attributes_with_one_digit_from_model_casts_definition()
     {
         Livewire::test(ComponentForModelAttributeCasting::class)
-            ->assertSet('model.decimal_with_one_digit', '5.0')
+            ->assertSet('model.decimal_with_one_digit', 5.0)
             ->assertPayloadSet('model.decimal_with_one_digit', 5.0)
 
             ->set('model.decimal_with_one_digit', 5.120983)
             ->call('validateAttribute', 'model.decimal_with_one_digit')
             ->assertHasNoErrors('model.decimal_with_one_digit')
-            ->assertSet('model.decimal_with_one_digit', '5.1')
+            ->assertSet('model.decimal_with_one_digit', 5.1)
             ->assertPayloadSet('model.decimal_with_one_digit', 5.1)
 
             ->set('model.decimal_with_one_digit', '5.55')
             ->call('validateAttribute', 'model.decimal_with_one_digit')
             ->assertHasNoErrors('model.decimal_with_one_digit')
-            ->assertSet('model.decimal_with_one_digit', '5.6')
+            ->assertSet('model.decimal_with_one_digit', 5.6)
             ->assertPayloadSet('model.decimal_with_one_digit', 5.6);
     }
 
@@ -178,19 +178,19 @@ class ModelAttributesCanBeCastTest extends TestCase
     public function can_cast_decimal_attributes_with_two_digits_from_model_casts_definition()
     {
         Livewire::test(ComponentForModelAttributeCasting::class)
-            ->assertSet('model.decimal_with_two_digits', '6.00')
+            ->assertSet('model.decimal_with_two_digits', 6.0)
             ->assertPayloadSet('model.decimal_with_two_digits', 6.0)
 
             ->set('model.decimal_with_two_digits', 6.4567)
             ->call('validateAttribute', 'model.decimal_with_two_digits')
             ->assertHasNoErrors('model.decimal_with_two_digits')
-            ->assertSet('model.decimal_with_two_digits', '6.46')
+            ->assertSet('model.decimal_with_two_digits', 6.46)
             ->assertPayloadSet('model.decimal_with_two_digits', 6.46)
 
             ->set('model.decimal_with_two_digits', '6.212')
             ->call('validateAttribute', 'model.decimal_with_two_digits')
             ->assertHasNoErrors('model.decimal_with_two_digits')
-            ->assertSet('model.decimal_with_two_digits', '6.21')
+            ->assertSet('model.decimal_with_two_digits', 6.21)
             ->assertPayloadSet('model.decimal_with_two_digits', 6.21);
     }
 


### PR DESCRIPTION
1️⃣  **Is this something that is wanted/needed? Did you create an issue / discussion about it first?**
Yes! 
And No.

2️⃣  **Does it contain multiple, unrelated changes? Please separate the PRs out.**
Nope!

3️⃣  **Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)**
Yes!

4️⃣  **Please include a thorough description of the improvement and reasons why it's useful.**
There are some properties in a few of our tests that we want to assert have been set `false`, `0`, `null`, or `''`.
Currently the code is using `assertEquals()` which is somewhat equivalent to using `==`, whereas using `assertSame()` is equivalent to using `===`, which is much more useful when deciding what a property is truly set to.
Currently `$property` could quite literally be set to `100` and doing `assertSet('property', '1e2')` would pass.

Testing the difference between the two is much more apparent when using `assertNotSet()` because the test would instead fail.

After applying the changes in this PR, the behavior between the two tests would be the reverse, of course.

One good example is, let's say, the property has been set to zero and we want to assert that the property isn't null.

Making this change would allow tests to be more tight-knit.
We have opted for using `PHPUnit::assertSame($livewire->get('property'), $expectedValue)` in the meantime.

5️⃣  **Thanks for contributing!** 🙌
Thank you!

P.S. Let me know if the `expectException()` isn't needed! :) 
(assertNotSet is technically checking it)