### PR TITLE
Adds prefix to the `payload id`

### DIFF
--- a/src/Testing/Concerns/MakesCallsToComponent.php
+++ b/src/Testing/Concerns/MakesCallsToComponent.php
@@ -139,6 +139,10 @@ trait MakesCallsToComponent
     {
         $payload['id'] = Str::random(4);
 
+        if (array_key_exists('method', $payload)) {
+            $payload['id'] = $payload['method'] . '-' . $payload['id'];
+        }
+
         $this->lastResponse = $this->pretendWereSendingAComponentUpdateRequest($message, $payload);
 
         if (! $this->lastResponse->exception) {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yes - No

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

I have test macros that check the return values of the methods. After this #3510 change it was not possible to test the return values. If the prefix is added, it will be easy to parse.

This PR makes it possible to find the names of the methods.
