### PR TITLE
Fix for TypeError in invokable components

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -52,7 +52,7 @@ abstract class Component
         // For some reason Octane doesn't play nice with the injected $route.
         // We need to override it here. However, we can't remove the actual
         // param from the method signature as it would break inheritance.
-        $route = request()->route();
+        $route = request()->route() ?? $route;
 
         try {
             $componentParams = (new ImplicitRouteBinding($container))

--- a/tests/Unit/RouteRegistrationTest.php
+++ b/tests/Unit/RouteRegistrationTest.php
@@ -19,6 +19,20 @@ class RouteRegistrationTest extends TestCase
     }
 
     /** @test */
+    public function can_handle_requests_after_application_is_created()
+    {
+        Livewire::component(ComponentForRouteRegistration::class);
+
+        Route::get('/foo', ComponentForRouteRegistration::class);
+
+        // After application is created,
+        // request()->route() is null
+        $this->createApplication();
+
+        $this->withoutExceptionHandling()->get('/foo')->assertSee('baz');
+    }
+
+    /** @test */
     public function component_uses_alias_instead_of_full_name_if_registered()
     {
         Livewire::component('component-alias', ComponentForRouteRegistration::class);


### PR DESCRIPTION
When testing invokable components with PHPUnit (for example, `$this->createApplication(); $this->actingAs($user)->get(route('component'))`), a `TypeError` occurs.
This is because `request()->route()` is `null`.

To fix this, we override `$route` only if `request()->route()` is not null