### PR TITLE
Avoid 500 server error when component gets request with empty body

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -369,7 +369,7 @@ HTML;
                 return str(request('fingerprint')['url'])->after(request()->root());
             }
 
-            return request('fingerprint')['path'];
+            return request('fingerprint.path');
         }
 
         return request()->path();
@@ -386,7 +386,7 @@ HTML;
                 return 'GET';
             }
 
-            return request('fingerprint')['method'];
+            return request('fingerprint.method', 'POST');
         }
 
         return request()->method();


### PR DESCRIPTION
Avoid 500 server error when component gets request with empty body 
https://github.com/livewire/livewire/discussions/4262