### PR TITLE
Validate only fix

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -200,10 +200,27 @@ trait ValidatesInput
     public function validateOnly($field, $rules = null, $messages = [], $attributes = [])
     {
         [$rules, $messages, $attributes] = $this->providedOrGlobalRulesMessagesAndAttributes($rules, $messages, $attributes);
+        
+        $rulesForField = collect($rules)
+            ->filter(function($value, $rule) use ($field) {
+                if(! str($field)->is($rule)) {
+                    return false;
+                }
 
-        $rulesForField = collect($rules)->filter(function ($rule, $fullFieldKey) use ($field) {
-            return str($field)->is($fullFieldKey) || str($fullFieldKey)->startsWith($field);
-        })->toArray();
+                $fieldArray = str($field)->explode('.');
+                $ruleArray = str($rule)->explode('.');
+                
+                for($i = 0; $i < count($fieldArray); $i++) {
+                    if(isset($ruleArray[$i]) && $ruleArray[$i] === '*') {
+                        $ruleArray[$i] = $fieldArray[$i];
+                    }
+                }
+
+                $rule = $ruleArray->join('.');
+
+                return $field === $rule;
+            })
+            ->toArray();
 
         $ruleKeysForField = array_keys($rulesForField);
         

--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -239,7 +239,7 @@ trait ValidatesInput
             $ruleArray = str($ruleForField)->explode('.');
             $fieldArray = str($field)->explode('.');
 
-            $data = $this->filterData($data, $ruleArray, $fieldArray);
+            $data = $this->filterCollectionDataDownToSpecificKeys($data, $ruleArray, $fieldArray);
         }
 
         $validator = Validator::make($data, $rulesForField, $messages, $attributes);
@@ -278,7 +278,7 @@ trait ValidatesInput
         return $result;
     }
 
-    protected function filterData($data, $ruleKeys, $fieldKeys)
+    protected function filterCollectionDataDownToSpecificKeys($data, $ruleKeys, $fieldKeys)
     {
         if (count($ruleKeys)) {
             $ruleKey = $ruleKeys->shift();
@@ -286,7 +286,7 @@ trait ValidatesInput
 
             if ($fieldKey == '*') {
                 foreach ($data as $key => $value) {
-                    $data[$key] = $this->filterData($value, $ruleKeys, $fieldKeys);
+                    $data[$key] = $this->filterCollectionDataDownToSpecificKeys($value, $ruleKeys, $fieldKeys);
                 }
             } else {
                 $keyData = $data[$fieldKey];
@@ -295,7 +295,7 @@ trait ValidatesInput
                     $data = [];
                 }
 
-                $data[$fieldKey] = $this->filterData($keyData, $ruleKeys, $fieldKeys);
+                $data[$fieldKey] = $this->filterCollectionDataDownToSpecificKeys($keyData, $ruleKeys, $fieldKeys);
             }
         }
 

--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -282,13 +282,19 @@ trait ValidatesInput
             $ruleKey = $ruleKeys->shift();
             $fieldKey = $fieldKeys->shift();
 
-            $keyData = $data[$fieldKey];
+            if ($fieldKey == '*') {
+                foreach ($data as $key => $value) {
+                    $data[$key] = $this->filterData($value, $ruleKeys, $fieldKeys);
+                }
+            } else {
+                $keyData = $data[$fieldKey];
 
-            if($ruleKey == '*') {
-                $data = [];
+                if ($ruleKey == '*') {
+                    $data = [];
+                }
+
+                $data[$fieldKey] = $this->filterData($keyData, $ruleKeys, $fieldKeys);
             }
-
-            $data[$fieldKey] = $this->filterData($keyData, $ruleKeys, $fieldKeys);
         }
 
         return $data;

--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -235,10 +235,12 @@ trait ValidatesInput
 
         $data = $this->unwrapDataForValidation($data);
 
-        $ruleArray = str($ruleForField)->explode('.');
-        $fieldArray = str($field)->explode('.');
+        if ($ruleForField) {
+            $ruleArray = str($ruleForField)->explode('.');
+            $fieldArray = str($field)->explode('.');
 
-        $data = $this->filterData($data, $ruleArray, $fieldArray);
+            $data = $this->filterData($data, $ruleArray, $fieldArray);
+        }
 
         $validator = Validator::make($data, $rulesForField, $messages, $attributes);
 

--- a/tests/Unit/EloquentModelValidationTest.php
+++ b/tests/Unit/EloquentModelValidationTest.php
@@ -190,27 +190,33 @@ class EloquentModelValidationTest extends TestCase
 
     /** @test */
     public function collection_model_property_validation_only_includes_relevant_error()
-    {   $test = Livewire::test(ComponentForEloquentModelCollectionHydrationMiddleware::class, [
-        'foos' => collect()->pad(3, Foo::first())]);
-        $test  ->call('performValidateOnly', 'foos.0.bar_baz')
+    {   
+        Livewire::test(ComponentForEloquentModelCollectionHydrationMiddleware::class, [
+            'foos' => collect()->pad(3, Foo::first()),
+        ])
+            ->call('performValidateOnly', 'foos.0.bar_baz')
             ->assertHasErrors('foos.0.bar_baz')
             ->assertHasNoErrors('foos.1.bar_baz');
     }
 
     /** @test */
     public function collection_model_property_validation_includes_all_errors_when_using_base_wildcard()
-    {   $test = Livewire::test(ComponentForEloquentModelCollectionHydrationMiddleware::class, [
-        'foos' => collect()->pad(3, Foo::first())]);
-        $test  ->call('performValidateOnly', 'foos.*')
+    {   
+        Livewire::test(ComponentForEloquentModelCollectionHydrationMiddleware::class, [
+                'foos' => collect()->pad(3, Foo::first())
+        ])
+            ->call('performValidateOnly', 'foos.*')
             ->assertHasErrors('foos.0.bar_baz')
             ->assertHasErrors('foos.1.bar_baz');
     }
 
     /** @test */
     public function collection_model_property_validation_only_includes_all_errors_when_using_wildcard()
-    {   $test = Livewire::test(ComponentForEloquentModelCollectionHydrationMiddleware::class, [
-        'foos' => collect()->pad(3, Foo::first())]);
-        $test  ->call('performValidateOnly', 'foos.*.bar_baz')
+    {   
+        Livewire::test(ComponentForEloquentModelCollectionHydrationMiddleware::class, [
+            'foos' => collect()->pad(3, Foo::first())
+        ])
+            ->call('performValidateOnly', 'foos.*.bar_baz')
             ->assertHasErrors('foos.0.bar_baz')
             ->assertHasErrors('foos.1.bar_baz');
     }

--- a/tests/Unit/EloquentModelValidationTest.php
+++ b/tests/Unit/EloquentModelValidationTest.php
@@ -200,17 +200,6 @@ class EloquentModelValidationTest extends TestCase
     }
 
     /** @test */
-    public function collection_model_property_validation_includes_all_errors_when_using_base_wildcard()
-    {   
-        Livewire::test(ComponentForEloquentModelCollectionHydrationMiddleware::class, [
-                'foos' => collect()->pad(3, Foo::first())
-        ])
-            ->call('performValidateOnly', 'foos.*')
-            ->assertHasErrors('foos.0.bar_baz')
-            ->assertHasErrors('foos.1.bar_baz');
-    }
-
-    /** @test */
     public function collection_model_property_validation_only_includes_all_errors_when_using_wildcard()
     {   
         Livewire::test(ComponentForEloquentModelCollectionHydrationMiddleware::class, [

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -735,9 +735,9 @@ class WithValidationMethod extends Component
 
 class ValidatesOnlyTestComponent extends Component
 {
-    public string $image = '';
-    public string $image_alt = '';
-    public string $image_url = '';
+    public $image = '';
+    public $image_alt = '';
+    public $image_url = '';
 
     public $rules = [
         'image' => 'required_without:image_url|string',

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -429,6 +429,18 @@ class ValidationTest extends TestCase
         $component = Livewire::test(WithValidationMethod::class);
         $component->assertSet('count', 0)->call('clearWithValidatorAfterRunningValidateOnlyMethod')->assertSet('count', 1);
     }
+
+    /** @test */
+    public function a_set_of_items_will_validate_individually()
+    {
+        Livewire::test(ValidatesOnlyTestComponent::class, ['image' => 'image', 'imageAlt' => 'This is an image'])
+            ->call('runValidateOnly', 'image_alt')
+            ->assertHasNoErrors(['image_alt', 'image_url', 'image'])
+            ->call('runValidateOnly', 'image_url')
+            ->assertHasNoErrors(['image', 'image_url', 'image_alt'])
+            ->call('runValidateOnly', 'image')
+            ->assertHasNoErrors(['image', 'image_url', 'image_alt']);
+    }
 }
 
 class ForValidation extends Component
@@ -718,5 +730,45 @@ class WithValidationMethod extends Component
     public function render()
     {
         return app('view')->make('dump-errors');
+    }
+}
+
+class ValidatesOnlyTestComponent extends Component
+{
+    public string $image = '';
+    public string $image_alt = '';
+    public string $image_url = '';
+
+    public $rules = [
+        'image' => 'required_without:image_url|string',
+        'image_alt' => 'required|string',
+        'image_url' => 'required_without:image|string'
+    ];
+
+    public function mount($image, $imageAlt, $imageUrl = '')
+    {
+        $this->image = $image;
+        $this->image_alt = $imageAlt;
+        $this->image_url = $imageUrl;
+    }
+
+    public function runValidation()
+    {
+        $this->validate();
+    }
+
+    public function runValidateOnly($propertyName)
+    {
+        $this->validateOnly($propertyName);
+    }
+
+    public function runResetValidation()
+    {
+        $this->resetValidation();
+    }
+
+    public function render()
+    {
+        return view('null-view');
     }
 }


### PR DESCRIPTION
This PR fixes an issue with validateOnly where validation rules that depend on other data wasn't working due to having filtered that other data out, see #4278 (specifically [this comment](https://github.com/livewire/livewire/discussions/4278#discussioncomment-1696770)) for more details.

To fix this I've changed it so only the specific rule that matches the field passed into `validateOnly` is used and for the data, the only data that is filtered down is collections if the field being validated is a part of a collection.

I also removed a test that was failing after this fix, due to it trying to test cascading rules, which I think isn't correct.

I believe that test was added as part of the original `validateOnly` changes which due to the way validateOnly was working was allowing the cascade to pass.

I reverted back to 2.5.5 (before the original fix) to see if rules cascaded and they don't. I copied the test into it and ran it and it failed then too, so in my opinion this test can be safely removed.

Hope this helps!