### PR TITLE
Fix flaky loading test

### DIFF
--- a/tests/Browser/Loading/Test.php
+++ b/tests/Browser/Loading/Test.php
@@ -16,6 +16,7 @@ class Test extends TestCase
                 ->waitForLivewire(function (Browser $browser) {
                     $browser->click('@button');
 
+                    $browser->pause(1);
                     $browser->assertVisible('@show');
                     $browser->assertNotVisible('@hide');
 
@@ -39,7 +40,7 @@ class Test extends TestCase
                 ->waitForLivewire(function (Browser $browser) {
                     $browser->click('@button');
 
-                    $browser->pause(100);
+                    $browser->pause(101);
 
                     $browser->assertNotVisible('@show-w-delay');
                 })
@@ -47,7 +48,7 @@ class Test extends TestCase
                 ->waitForLivewire(function (Browser $browser) {
                     $browser->click('@button');
 
-                    $browser->pause(200);
+                    $browser->pause(201);
 
                     $browser->assertVisible('@show-w-delay');
                 })
@@ -90,6 +91,7 @@ class Test extends TestCase
                 ->waitForLivewire(function (Browser $browser) {
                     $browser->click('@error-button');
 
+                    $browser->pause(1);
                     $browser->assertNotVisible('@hide');
                     $browser->assertVisible('@show');
 
@@ -153,7 +155,7 @@ class Test extends TestCase
                 ->waitForLivewire(function (Browser $browser) {
                     $browser->click('@load');
 
-                    $browser->pause(50);
+                    $browser->pause(51);
 
                     $browser->assertVisible('@delay-shortest');
                     $browser->assertNotVisible('@delay-shorter');
@@ -167,7 +169,7 @@ class Test extends TestCase
                 ->waitForLivewire(function (Browser $browser) {
                     $browser->click('@load');
                     
-                    $browser->pause(100);
+                    $browser->pause(101);
 
                     $browser->assertVisible('@delay-shortest');
                     $browser->assertVisible('@delay-shorter');
@@ -181,7 +183,7 @@ class Test extends TestCase
                 ->waitForLivewire(function (Browser $browser) {
                     $browser->click('@load');
                     
-                    $browser->pause(150);
+                    $browser->pause(151);
 
                     $browser->assertVisible('@delay-shortest');
                     $browser->assertVisible('@delay-shorter');
@@ -195,7 +197,7 @@ class Test extends TestCase
                 ->waitForLivewire(function (Browser $browser) {
                     $browser->click('@load');
                     
-                    $browser->pause(200);
+                    $browser->pause(201);
 
                     $browser->assertVisible('@delay-shortest');
                     $browser->assertVisible('@delay-shorter');
@@ -209,7 +211,7 @@ class Test extends TestCase
                 ->waitForLivewire(function (Browser $browser) {
                     $browser->click('@load');
                     
-                    $browser->pause(300);
+                    $browser->pause(301);
 
                     $browser->assertVisible('@delay-shortest');
                     $browser->assertVisible('@delay-shorter');
@@ -223,7 +225,7 @@ class Test extends TestCase
                 ->waitForLivewire(function (Browser $browser) {
                     $browser->click('@load');
                     
-                    $browser->pause(500);
+                    $browser->pause(501);
 
                     $browser->assertVisible('@delay-shortest');
                     $browser->assertVisible('@delay-shorter');
@@ -237,7 +239,7 @@ class Test extends TestCase
                 ->waitForLivewire(function (Browser $browser) {
                     $browser->click('@load');
                     
-                    $browser->pause(1000);
+                    $browser->pause(1001);
 
                     $browser->assertVisible('@delay-shortest');
                     $browser->assertVisible('@delay-shorter');


### PR DESCRIPTION
This PR fixes flaky loading tests by just adding some extra time to allow the browser to act