### PR TITLE
created 2 new assertions, assertEmittedTo() and assertEmittedUp()

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -151,6 +151,26 @@ trait MakesAssertions
         return $this;
     }
 
+    public function assertEmittedTo($target, $value, ...$params)
+    {
+        $this->assertEmitted($value, ...$params);
+        $result = $this->testEmittedTo($target, $value);
+
+        PHPUnit::assertTrue($result, "Failed asserting that an event [{$value}] was fired to {$target}.");
+
+        return $this;
+    }
+
+    public function assertEmittedUp($value, ...$params)
+    {
+        $this->assertEmitted($value, ...$params);
+        $result = $this->testEmittedUp($value);
+
+        PHPUnit::assertTrue($result, "Failed asserting that an event [{$value}] was fired up.");
+
+        return $this;
+    }
+
     protected function testEmitted($value, $params)
     {
         $assertionSuffix = '.';
@@ -168,7 +188,7 @@ trait MakesAssertions
                 return $item['event'] === $value
                     && $item['params'] === $params;
             });
-            
+
             $encodedParams = json_encode($params);
             $assertionSuffix = " with parameters: {$encodedParams}";
         }
@@ -177,6 +197,23 @@ trait MakesAssertions
             'test'            => $test,
             'assertionSuffix' => $assertionSuffix,
         ];
+    }
+
+    protected function testEmittedTo($target, $value)
+    {
+        return (bool) collect(data_get($this->payload, 'effects.emits'))->first(function ($item) use ($target, $value) {
+            return $item['event'] === $value
+                && $item['to'] === $target;
+        });
+
+    }
+
+    protected function testEmittedUp($value)
+    {
+        return (bool) collect(data_get($this->payload, 'effects.emits'))->first(function ($item) use ($value) {
+            return $item['event'] === $value
+                && $item['ancestorsOnly'] === true;
+        });
     }
 
     public function assertDispatchedBrowserEvent($name, $data = null)

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -161,6 +161,24 @@ class LivewireTestingTest extends TestCase
     }
 
     /** @test */
+    public function assert_emitted_to()
+    {
+        Livewire::test(EmitsEventsComponentStub::class)
+            ->call('emitFooToBar')
+            ->assertEmittedTo('some-component', 'foo')
+        ;
+    }
+
+    /** @test */
+    public function assert_emitted_up()
+    {
+        Livewire::test(EmitsEventsComponentStub::class)
+            ->call('emitFooUp')
+            ->assertEmittedUp('foo')
+        ;
+    }
+
+    /** @test */
     public function assert_not_emitted()
     {
         Livewire::test(EmitsEventsComponentStub::class)
@@ -285,6 +303,16 @@ class EmitsEventsComponentStub extends Component
     public function emitFooWithParam($param)
     {
         $this->emit('foo', $param);
+    }
+
+    public function emitFooToBar()
+    {
+        $this->emitTo('some-component','foo');
+    }
+
+    public function emitFooUp()
+    {
+        $this->emitUp('foo');
     }
 
     public function render()

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -164,8 +164,14 @@ class LivewireTestingTest extends TestCase
     public function assert_emitted_to()
     {
         Livewire::test(EmitsEventsComponentStub::class)
-            ->call('emitFooToBar')
+            ->call('emitFooToSomeComponent')
             ->assertEmittedTo('some-component', 'foo')
+            ->call('emitFooToSomeComponentWithParam', 'bar')
+            ->assertEmittedTo('some-component', 'foo', 'bar')
+            ->call('emitFooToSomeComponentWithParam', 'bar')
+            ->assertEmittedTo('some-component','foo', function ($event, $params) {
+                return $event === 'foo' && $params === ['bar'];
+            })
         ;
     }
 
@@ -175,6 +181,12 @@ class LivewireTestingTest extends TestCase
         Livewire::test(EmitsEventsComponentStub::class)
             ->call('emitFooUp')
             ->assertEmittedUp('foo')
+            ->call('emitFooUpWithParam', 'bar')
+            ->assertEmittedUp('foo', 'bar')
+            ->call('emitFooUpWithParam', 'bar')
+            ->assertEmittedUp('foo', function ($event, $params) {
+                return $event === 'foo' && $params === ['bar'];
+            })
         ;
     }
 
@@ -305,14 +317,24 @@ class EmitsEventsComponentStub extends Component
         $this->emit('foo', $param);
     }
 
-    public function emitFooToBar()
+    public function emitFooToSomeComponent()
     {
         $this->emitTo('some-component','foo');
+    }
+
+    public function emitFooToSomeComponentWithParam($param)
+    {
+        $this->emitTo('some-component','foo', $param);
     }
 
     public function emitFooUp()
     {
         $this->emitUp('foo');
+    }
+
+    public function emitFooUpWithParam($param)
+    {
+        $this->emitUp('foo', $param);
     }
 
     public function render()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
yes, even requested by the magnificent Josh Hanley:
https://github.com/livewire/livewire/discussions/4298

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
nope

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
yes!

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
There was no way of asserting that an event was emitted to a specific component or up.

5️⃣ Thanks for contributing! 🙌
Thank you!