### PR TITLE
Fix Livewire requests across load balancers

### DIFF
--- a/src/LivewireBladeDirectives.php
+++ b/src/LivewireBladeDirectives.php
@@ -52,7 +52,7 @@ EOT;
         // Livewire children are properly tracked across load balancers.
         if (LivewireManager::$currentCompilingViewPath !== null) {
             // $cachedKey = '[hash of Blade view path]-[current @livewire directive count]'
-            $cachedKey = "'" . crc32(LivewireManager::$currentCompilingViewPath) . "-" . LivewireManager::$currentCompilingChildCounter . "'";
+            $cachedKey = "'l" . crc32(LivewireManager::$currentCompilingViewPath) . "-" . LivewireManager::$currentCompilingChildCounter . "'";
 
             // We'll increment count, so each cache key inside a compiled view is unique.
             LivewireManager::$currentCompilingChildCounter++;

--- a/src/LivewireBladeDirectives.php
+++ b/src/LivewireBladeDirectives.php
@@ -47,6 +47,17 @@ EOT;
     {
         $cachedKey = "'" . Str::random(7) . "'";
 
+        // If we are inside a Livewire component, we know we're rendering a child.
+        // Therefore, we must create a more deterministic view cache key so that
+        // Livewire children are properly tracked across load balancers.
+        if (LivewireManager::$currentCompilingViewPath !== null) {
+            // $cachedKey = '[hash of Blade view path]-[current @livewire directive count]'
+            $cachedKey = "'" . crc32(LivewireManager::$currentCompilingViewPath) . "-" . LivewireManager::$currentCompilingChildCounter . "'";
+
+            // We'll increment count, so each cache key inside a compiled view is unique.
+            LivewireManager::$currentCompilingChildCounter++;
+        } 
+
         $pattern = "/,\s*?key\(([\s\S]*)\)/"; //everything between ",key(" and ")"
         $expression = preg_replace_callback($pattern, function ($match) use (&$cachedKey) {
             $cachedKey = trim($match[1]) ?: $cachedKey;

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -27,6 +27,9 @@ class LivewireManager
     ];
 
     public static $isLivewireRequestTestingOverride = false;
+    
+    public static $currentCompilingViewPath;
+    public static $currentCompilingChildCounter;
 
     public function component($alias, $viewClass = null)
     {

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -459,6 +459,9 @@ HTML;
 
     public function flushState()
     {
+        static::$currentCompilingChildCounter = null;
+        static::$currentCompilingViewPath = null;
+        
         $this->shouldDisableBackButtonCache = false;
 
         $this->dispatch('flush-state');

--- a/tests/Unit/WorksOnLoadBalancersTest.php
+++ b/tests/Unit/WorksOnLoadBalancersTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Livewire;
+use Livewire\Component;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\File;
+
+class WorksOnLoadBalancersTest extends TestCase
+{
+    /** @test */
+    public function livewire_renders_chidren_properly_across_load_balancers()
+    {
+        Livewire::component('parent', LoadBalancerParentComponent::class);
+        Livewire::component('child', LoadBalancerChildComponent::class);
+
+        $component = Livewire::test('parent');
+
+        $component->assertSee('child-content-1');
+        $component->assertSee('child-content-2');
+
+        // Nuke the view cache to simulate two different servers serving the same
+        // livewire page for different requests.
+        File::cleanDirectory(__DIR__.'/../../vendor/orchestra/testbench-core/laravel/storage/framework/views');
+
+        $component->call('$refresh');
+
+        $component->assertDontSee('child-content-1');
+        $component->assertDontSee('child-content-2');
+    }
+}
+
+class LoadBalancerParentComponent extends Component
+{
+    public function render()
+    {
+        return view('load-balancer-parent');
+    }
+}
+
+class LoadBalancerChildComponent extends Component
+{
+    public $number;
+
+    public function render()
+    {
+        return view('load-balancer-child');
+    }
+}

--- a/tests/Unit/views/load-balancer-child.blade.php
+++ b/tests/Unit/views/load-balancer-child.blade.php
@@ -1,0 +1,3 @@
+<div>
+    child-content-{{ $number }}
+</div>

--- a/tests/Unit/views/load-balancer-parent.blade.php
+++ b/tests/Unit/views/load-balancer-parent.blade.php
@@ -1,0 +1,6 @@
+<div>
+    Parent
+
+    @livewire('child', ['number' => 1])
+    @livewire('child', ['number' => 2])
+</div>


### PR DESCRIPTION
# The Problem:

Currently, if a Livewire app is served across load balancers, the following situation may occur:
* A user loads a page with a Livewire component (that contains child Livewire components) on it
* That user does something on the page that triggers a new request to the server
* The load balancer picks up the request and routes it to a DIFFERENT server than the one that originated the page load
* The child components that were rendered on the page are re-rendered (and potentially other odd behavior occurs)

The reason this happens is because Livewire uses Laravel's view cache files as a sort of backend store to set unique keys on each child component in a Blade view. These "unique keys" are generated as random strings. This is how Livewire tracks whether to render, or leave alone a child Livewire component on subsequent renders. In a load-balancer situation, there are two different sets of Blade view cache files, and therefore two totally different sets of keys, creating a mis-match.

## The Solution:

The solution is to deterministically generate those keys for tracking child components rather than randomly generate them. This way, they will be the same across different application instances (across servers in this case).

The new strategy for key generation is this:
-> `[a hash generated from the blade view path]-[a counter that is incremented every time @livewire appears in a view]`

Because the blade files are the same across app instances, these keys will be deterministic.

## Notes:
It's actually fairly tough to get access to the current Blade view path from a custom Blade directive (@livewire), so I had to overload a core function in Laravel's compiler engine: `->get()`.

I don't think this method changes very much so we should be safe, but just to be sure, I forward the method calls to the parent when not inside a Livewire component, so the effects of this change should be minimal outside Livewire components in people's apps. Not my favorite thing to do, but I don't see another, simpler, way.
