### PR TITLE
Set initial property values from query string aliases

### DIFF
--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -25,8 +25,8 @@ class SupportBrowserHistory
 
             $queryParams = request()->query();
 
-            foreach ($properties as $property) {
-                $fromQueryString = Arr::get($queryParams, $property);
+            foreach ($component->getQueryString() ?? [] as $property => $options) {
+                $fromQueryString = Arr::get($queryParams, $options['as'] ?? $property);
 
                 if ($fromQueryString === null) {
                     continue;

--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -26,6 +26,10 @@ class SupportBrowserHistory
             $queryParams = request()->query();
 
             foreach ($component->getQueryString() ?? [] as $property => $options) {
+                if (!is_array($options)) {
+                    $property = $options;
+                }
+
                 $fromQueryString = Arr::get($queryParams, $options['as'] ?? $property);
 
                 if ($fromQueryString === null) {

--- a/tests/Browser/QueryString/Test.php
+++ b/tests/Browser/QueryString/Test.php
@@ -308,4 +308,16 @@ class Test extends TestCase
             ;
         });
     }
+
+    public function test_query_string_aliases_set_intial_property_values()
+    {
+        $this->browse(function (Browser $browser) {
+            Livewire::visit($browser, ComponentWithAliases::class, '?s=test')
+                /*
+                 * Check that the intial property value is set from the query string aliases.
+                 */
+                ->assertInputValue('@search', 'test')
+            ;
+        });
+    }
 }

--- a/tests/Browser/QueryString/Test.php
+++ b/tests/Browser/QueryString/Test.php
@@ -312,11 +312,16 @@ class Test extends TestCase
     public function test_query_string_aliases_set_intial_property_values()
     {
         $this->browse(function (Browser $browser) {
-            Livewire::visit($browser, ComponentWithAliases::class, '?s=test')
+            Livewire::visit($browser, ComponentWithAliases::class, '?s=1')
                 /*
                  * Check that the intial property value is set from the query string aliases.
                  */
-                ->assertInputValue('@search', 'test')
+                ->assertInputValue('@search', '1')
+
+                // Navigate to page 2.
+                ->waitForLivewire()->click('@nextPage.before')
+                ->assertQueryStringHas('p', 2)
+                ->assertQueryStringHas('s', '1')
             ;
         });
     }


### PR DESCRIPTION
This is a bug myself and a colleague found while using the query string aliases. If query string aliases params are set during an initial request then they don't set their respective properties unless done manually in the mount function. This pr will fix that:)