### PR TITLE
Make empty() and isset() work on computed properties

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -272,6 +272,17 @@ abstract class Component
     {
         return $this->forStack;
     }
+    
+    function __isset($property)
+    {
+        try {
+            $this->__get($property);
+            return true;
+        } catch(PropertyNotFoundException $ex) {
+            return false;
+        }
+        return false;
+    }
 
     public function __get($property)
     {

--- a/tests/Unit/ComputedPropertiesTest.php
+++ b/tests/Unit/ComputedPropertiesTest.php
@@ -44,6 +44,20 @@ class ComputedPropertiesTest extends TestCase
             ->call('callForgetComputedWithTwoArgs', 'bar', 'foo')
             ->assertSee('int(11)');
     }
+
+    /** @test */
+    public function isset_is_true_on_existing_computed_property()
+    {
+        Livewire::test(IssetComputedPropertyStub::class)
+            ->assertSee('true');
+    }
+
+    /** @test */
+    public function isset_is_false_on_non_existing_computed_property()
+    {
+        Livewire::test(FalseIssetComputedPropertyStub::class)
+            ->assertSee('false');
+    }
 }
 
 class ComputedPropertyStub extends Component
@@ -111,5 +125,33 @@ class MemoizedComputedPropertyStub extends Component
         $this->foo;
 
         return view('var-dump-foo');
+    }
+}
+
+class IssetComputedPropertyStub extends Component{
+    public $upperCasedFoo = 'FOO_BAR';
+
+    public function getFooBarProperty()
+    {
+        return strtolower($this->upperCasedFoo);
+    }
+
+    public function render()
+    {
+        return view('isset-foo-bar');
+    }
+}
+
+class FalseIssetComputedPropertyStub extends Component{
+    public $upperCasedFoo = 'FOO_BAR';
+
+    public function getFooBarProperty()
+    {
+        return strtolower($this->upperCasedFoo);
+    }
+
+    public function render()
+    {
+        return view('isset-foo');
     }
 }

--- a/tests/Unit/views/isset-foo-bar.blade.php
+++ b/tests/Unit/views/isset-foo-bar.blade.php
@@ -1,0 +1,3 @@
+<div>
+    {{ var_dump(isset($this->foo_bar)) }}
+</div>

--- a/tests/Unit/views/isset-foo.blade.php
+++ b/tests/Unit/views/isset-foo.blade.php
@@ -1,0 +1,3 @@
+<div>
+    {{ var_dump(isset($this->foo)) }}
+</div>


### PR DESCRIPTION
isset() and empty() were not working for me on computed component properties, like getSomeNameProperty()

```php
    public function doSomething()
    {
        // Always returned true even if getSomeNameProperty() was set
        if (empty($this->someName)) {
            ...


```

This implements the magic __isset($property) on the component to make that work.

My use case was a trait that did not know if a certain dynamic property was existent on the component it was used on.

Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required, where possible)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
