### PR TITLE
Suppress type warning

### DIFF
--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -127,7 +127,7 @@ class SupportBrowserHistory
     {
         if (empty($referer = request()->header('Referer'))) return [];
 
-        parse_str(parse_url($referer, PHP_URL_QUERY), $refererQueryString);
+        parse_str((string) parse_url($referer, PHP_URL_QUERY), $refererQueryString);
 
         return $refererQueryString;
     }


### PR DESCRIPTION
I'm not sure that this is the best solution, but since `parse_str()` expects a string, it made sense to me to cast whatever **this particular call to** `parse_url()` returns to a string.

It seems that `parse_url()`, when specifying the `PHP_URL_QUERY` component, will always return a string or `null`.  So, this seems like a safe solution.

FYI...this is only generating a warning:
```bash
parse_str(): Passing null to parameter #1 ($string) of type string is deprecated in /path/to/vendor/livewire/livewire/src/Features/SupportBrowserHistory.php on line 130
```

So, it's not fixing anything that's broken, but just silencing some of the noise. 🤓 

Please let me know if anyone has any questions/concerns.

Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required, where possible)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
