### PR TITLE
Fix Calling reset() on an object is deprecated

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -81,7 +81,7 @@ class LivewireServiceProvider extends ServiceProvider
                 // If the app overrode "TrimStrings".
                 \App\Http\Middleware\TrimStrings::class,
             ]);
-        }   
+        }
     }
 
     protected function registerLivewireSingleton()
@@ -243,7 +243,7 @@ class LivewireServiceProvider extends ServiceProvider
         // Early versions of Laravel 7.x don't have this method.
         if (method_exists(ComponentAttributeBag::class, 'macro')) {
             ComponentAttributeBag::macro('wire', function ($name) {
-                $entries = head($this->whereStartsWith('wire:'.$name));
+                $entries = head((array) $this->whereStartsWith('wire:'.$name));
 
                 $directive = head(array_keys($entries));
                 $value = head(array_values($entries));


### PR DESCRIPTION
The Laravel `head()` helper is an alias of PHP `reset()`, after upgrading to PHP 8.1, Ray keeps showing depreciation notice:

```
reset(): Calling reset() on an object is deprecated in .../vendor/laravel/framework/src/Illuminate/Collections/helpers.php on line 158
```

This fix ensures that `ComponentAttributeBag` is treated as an `array` to remove the deprecation notice.