### PR TITLE
[PHP 8.1] Fix deprecation warning reset(): Calling reset() on an object is deprecated

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -243,7 +243,7 @@ class LivewireServiceProvider extends ServiceProvider
         // Early versions of Laravel 7.x don't have this method.
         if (method_exists(ComponentAttributeBag::class, 'macro')) {
             ComponentAttributeBag::macro('wire', function ($name) {
-                $entries = $this->whereStartsWith('wire:'.$name)->getAttributes();
+                $entries = $this->whereStartsWith('wire:'.$name)->attributes;
 
                 $directive = head(array_keys($entries));
                 $value = head(array_values($entries));

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -243,7 +243,7 @@ class LivewireServiceProvider extends ServiceProvider
         // Early versions of Laravel 7.x don't have this method.
         if (method_exists(ComponentAttributeBag::class, 'macro')) {
             ComponentAttributeBag::macro('wire', function ($name) {
-                $entries = head((array) $this->whereStartsWith('wire:'.$name));
+                $entries = $this->whereStartsWith('wire:'.$name)->getAttributes();
 
                 $directive = head(array_keys($entries));
                 $value = head(array_values($entries));


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
No

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Only this fix

4️⃣ Does it include tests? (Required, where possible)
No tests are needed for deprecation warnings

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌

Hello,

on a PHP 8.1 installation our deprecation.log was spammed by following message:

```bash
reset(): Calling reset() on an object is deprecated in /home/swwv-iob/swwv-iob.test.ecoplan-crm.com/vendor/laravel/framework/src/Illuminate/Collections/helpers.php on line 158
```

Digging deeper into this problem I found the particular code in the *LivewireServiceProvider.php* when the wire *ComponentAttributeBag* macro is registered. I'm not quite sure why this head() helper was used in this case indeed I think it was not necessary because the head() helper is called on the attributes array afterwards. So the result should always be the same.

These deprecation warnings occur every time a livewire component with registered query string vars is rendered.

All unit tests are still passing so I think this fix does not break anything.


