### PR TITLE
Undefined array key "value" for syncInput

### DIFF
--- a/src/HydrationMiddleware/PerformDataBindingUpdates.php
+++ b/src/HydrationMiddleware/PerformDataBindingUpdates.php
@@ -14,6 +14,8 @@ class PerformDataBindingUpdates implements HydrationMiddleware
                 if ($update['type'] !== 'syncInput') continue;
 
                 $data = $update['payload'];
+                
+                if (! array_key_exists('value', $data)) continue;
 
                 $unHydratedInstance->syncInput($data['name'], $data['value']);
             }


### PR DESCRIPTION
I had a chat with Josh about this on Discord.

I've had this exception in my error logs across several Livewire sites:

![image](https://user-images.githubusercontent.com/41773797/147657992-05bf8786-639d-4ab1-b080-6b6594642ca6.png)

I've never hit this exception myself before, neither in development nor production.

I checked all instances in the JavaScript codebase where `syncInput` is sent as an update, and both times `value` is sent as a payload item:

<img width="476" alt="Screenshot 2021-12-29 at 11 33 29" src="https://user-images.githubusercontent.com/41773797/147658091-613c74b0-7443-40c9-ba6e-fb306090a389.png">

If I check the request payload, the `value` key is not present:

![](https://media.discordapp.net/attachments/769321943044194404/925710284763562025/Screenshot_2021-12-29_at_11.22.04.png)

I understand that this PR is purely hiding the symptom of a problem, but I don't know how to write a failing test for this internal behaviour, and I can't replicate the issue on my own machine.

## Alternative solution

My immediate thought would be to add `?? null` onto the `$data['value']`, but in this case the value of the property would be completely lost - instead of being retained. If you think this is a better solution, let me know :)