### PR TITLE
Missing dispatched events with assertDispatchedBrowserEvent() returns in undefined array key

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -225,15 +225,15 @@ trait MakesAssertions
         $assertionSuffix = '.';
 
         if (is_null($data)) {
-            $test = collect($this->payload['effects']['dispatches'] ?? [])->contains('event', '=', $name);
+            $test = collect(data_get($this->payload, 'effects.dispatches'))->contains('event', '=', $name);
         } elseif (is_callable($data)) {
-            $event = collect($this->payload['effects']['dispatches'] ?? [])->first(function ($item) use ($name) {
+            $event = collect(data_get($this->payload, 'effects.dispatches'))->first(function ($item) use ($name) {
                 return $item['event'] === $name;
             });
 
             $test = $event && $data($event['event'], $event['data']);
         } else {
-            $test = (bool) collect($this->payload['effects']['dispatches'] ?? [])->first(function ($item) use ($name, $data) {
+            $test = (bool) collect(data_get($this->payload, 'effects.dispatches'))->first(function ($item) use ($name, $data) {
                 return $item['event'] === $name
                     && $item['data'] === $data;
             });

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -225,15 +225,15 @@ trait MakesAssertions
         $assertionSuffix = '.';
 
         if (is_null($data)) {
-            $test = collect($this->payload['effects']['dispatches'])->contains('event', '=', $name);
+            $test = collect($this->payload['effects']['dispatches'] ?? [])->contains('event', '=', $name);
         } elseif (is_callable($data)) {
-            $event = collect($this->payload['effects']['dispatches'])->first(function ($item) use ($name) {
+            $event = collect($this->payload['effects']['dispatches'] ?? [])->first(function ($item) use ($name) {
                 return $item['event'] === $name;
             });
 
             $test = $event && $data($event['event'], $event['data']);
         } else {
-            $test = (bool) collect($this->payload['effects']['dispatches'])->first(function ($item) use ($name, $data) {
+            $test = (bool) collect($this->payload['effects']['dispatches'] ?? [])->first(function ($item) use ($name, $data) {
                 return $item['event'] === $name
                     && $item['data'] === $data;
             });

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use Livewire\Component;
 use Livewire\Livewire;
+use PHPUnit\Framework\AssertionFailedError;
 use Illuminate\Support\Facades\Route;
 
 class LivewireTestingTest extends TestCase
@@ -234,7 +235,7 @@ class LivewireTestingTest extends TestCase
     }
 
     /** @test */
-    public function assert_dispatched()
+    public function assert_dispatched_browser_event()
     {
         Livewire::test(DispatchesBrowserEventsComponentStub::class)
             ->call('dispatchFoo')
@@ -245,6 +246,15 @@ class LivewireTestingTest extends TestCase
             ->assertDispatchedBrowserEvent('foo', function ($event, $data) {
                 return $event === 'foo' && $data === ['bar' => 'baz'];
             });
+    }
+
+    /** @test */
+    public function assert_dispatched_browser_event_fails()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        Livewire::test(DispatchesBrowserEventsComponentStub::class)
+            ->assertDispatchedBrowserEvent('foo');
     }
 
     /** @test */


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first? 

Probably so - helps with assertion testing.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No, one singular change.

4️⃣ Does it include tests? (Required, where possible)

Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This PR resolves a small bug with `assertDispatchedBrowserEvent()`. If you return a component with no dispatched events, an Error Exception from the framework will occur (vs. a failed PHPUnit assertion)
```
ErrorException: Undefined array key "dispatches"

src/Testing/Concerns/MakesAssertions.php:228
```

If other browser events are fired, this will be fine, but this PR allows the failed assertion to return.
