### PR TITLE
Allow validation data to be set from the validate/validateOnly methods

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -163,12 +163,12 @@ trait ValidatesInput
         return $this;
     }
 
-    public function validate($rules = null, $messages = [], $attributes = [])
+    public function validate($rules = null, $messages = [], $attributes = [], $data = null)
     {
         [$rules, $messages, $attributes] = $this->providedOrGlobalRulesMessagesAndAttributes($rules, $messages, $attributes);
 
         $data = $this->prepareForValidation(
-            $this->getDataForValidation($rules)
+            $data ?? $this->getDataForValidation($rules)
         );
 
         $ruleKeysToShorten = $this->getModelAttributeRuleKeysToShorten($data, $rules);
@@ -197,7 +197,7 @@ trait ValidatesInput
         return $validatedData;
     }
 
-    public function validateOnly($field, $rules = null, $messages = [], $attributes = [])
+    public function validateOnly($field, $rules = null, $messages = [], $attributes = [], $data = null)
     {
         [$rules, $messages, $attributes] = $this->providedOrGlobalRulesMessagesAndAttributes($rules, $messages, $attributes);
 
@@ -230,7 +230,7 @@ trait ValidatesInput
 
         $ruleKeysForField = array_keys($rulesForField);
 
-        $data = $this->getDataForValidation($rules);
+        $data = $data ?? $this->getDataForValidation($rules);
 
         $ruleKeysToShorten = $this->getModelAttributeRuleKeysToShorten($data, $rules);
 

--- a/tests/Unit/EloquentModelValidationTest.php
+++ b/tests/Unit/EloquentModelValidationTest.php
@@ -223,6 +223,18 @@ class EloquentModelValidationTest extends TestCase
 
         $this->assertEquals('sparkling', $cart->fresh()->items[0]->title);
     }
+
+    /** @test */
+    public function validate_message_doesnt_contain_base_property()
+    {
+        Livewire::test(ComponentWithoutModelBaseProperty::class, [
+            'state' => [],
+        ])
+            ->set('state.bar', '')
+            ->call('save')
+            ->assertHasErrors('bar', 'required')
+            ->assertSee('The bar field is required.');
+    }
 }
 
 class Foo extends Model
@@ -381,6 +393,25 @@ class ComponentForEloquentModelNestedHydrationMiddleware extends Component
         $this->validate();
 
         $this->cart->items->each->save();
+    }
+
+    public function render()
+    {
+        return view('dump-errors');
+    }
+}
+
+class ComponentWithoutModelBaseProperty extends Component
+{
+    public $state;
+
+    protected $rules = [
+        'bar' => 'required'
+    ];
+
+    public function save()
+    {
+        $this->validate(null, [], [], $this->state);
     }
 
     public function render()


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Yes, #4459.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

4️⃣ Does it include tests? (Required, where possible)
Yes, but a bunch of unrelated tests fail locally. Hoping they don't fail when Github Actions run, since I don't know why they fail.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
This PR adds an additional, optional, parameter to pass data directly to the validate functions.

For normal validation, I can just use [Custom Validators](https://laravel-livewire.com/docs/2.x/input-validation#custom-validators). As far as I know, however, if I want to use real-time validation I would have to pluck the attribute's validation rules from the array and pass that to the `Validator::make` method (while also providing any messages and attributes - if applicable). While this is not necessarily the wrong way to do things, I feel that it duplicates code that the `validate()` and `validateOnly()` methods provide.

Thanks for contributing! 🙌