### PR TITLE
Fixes session on with L9

### DIFF
--- a/src/Controllers/HttpConnectionHandler.php
+++ b/src/Controllers/HttpConnectionHandler.php
@@ -64,8 +64,8 @@ class HttpConnectionHandler extends ConnectionHandler
     {
         $request = Request::create($url, $method);
 
-        if ($session = request()->getSession()) {
-            $request->setLaravelSession($session);
+        if (request()->hasSession()) {
+            $request->setLaravelSession(request()->getSession());
         }
 
         $request->setUserResolver(request()->getUserResolver());


### PR DESCRIPTION
It's unclear to me what branch adds L9 support to Livewire (if develop, https://github.com/livewire/livewire/pull/4544, or other). Yet, the changes in this pull request are required for getting Livewire work with L9, as `getSession` may raise an `SessionNotFoundException` if there is no current session.