### PR TITLE
[2.x] Fixes the way Livewire sets the session on Livewire internal requests

### DIFF
--- a/src/Controllers/HttpConnectionHandler.php
+++ b/src/Controllers/HttpConnectionHandler.php
@@ -65,7 +65,7 @@ class HttpConnectionHandler extends ConnectionHandler
         $request = Request::create($url, $method);
 
         if (request()->hasSession()) {
-            $request->setLaravelSession(request()->getSession());
+            $request->setLaravelSession(request()->session());
         }
 
         $request->setUserResolver(request()->getUserResolver());

--- a/tests/Unit/SessionTest.php
+++ b/tests/Unit/SessionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Livewire;
+use Livewire\Component;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Session\Store;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Livewire\Controllers\HttpConnectionHandler;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class SessionTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('model_for_sessions', function ($table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+        });
+    }
+
+    /** @test */
+    public function sets_laravel_session()
+    {
+        $model = ModelForSession::create();
+
+        Route::get('/', function () {
+            return 'Hello World';
+        })->middleware(['web', AuthenticateSession::class]);
+
+        $this->withoutExceptionHandling()->actingAs($model)->get('/');
+
+        $handler = new Handler();
+        $request = $handler->makeRequestFromUrlAndMethod('/');
+
+        $this->assertTrue($request->hasSession());
+        $this->assertInstanceOf(Store::class, $request->session());
+
+        Str::startsWith($this->app->version(), '9.')
+            ? $this->assertInstanceOf(SessionInterface::class, $request->getSession())
+            : $this->assertInstanceOf(Store::class, $request->getSession());
+    }
+}
+
+class ModelForSession extends Authenticatable
+{
+    protected $connection = 'testbench';
+    protected $guarded = [];
+}
+
+class Handler extends HttpConnectionHandler
+{
+    public function makeRequestFromUrlAndMethod($url, $method = 'GET')
+    {
+        return parent::makeRequestFromUrlAndMethod($url, $method);
+    }
+}


### PR DESCRIPTION
This pull requests fixes the way Livewire sets the current Laravel 9.x session on internal requests. Added a test, to ensure we cover this in the future.