### PR TITLE
add command shortcuts

### DIFF
--- a/src/Commands/CopyCommand.php
+++ b/src/Commands/CopyCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\File;
 
 class CopyCommand extends FileManipulationCommand
 {
-    protected $signature = 'livewire:copy {name} {new-name} {--inline} {--force} {--test}';
+    protected $signature = 'livewire:copy {name} {new-name} {--i|--inline} {--f|--force} {--t|--test}';
 
     protected $description = 'Copy a Livewire component';
 

--- a/src/Commands/CpCommand.php
+++ b/src/Commands/CpCommand.php
@@ -4,7 +4,7 @@ namespace Livewire\Commands;
 
 class CpCommand extends CopyCommand
 {
-    protected $signature = 'livewire:cp {name} {new-name} {--inline} {--force} {--test}';
+    protected $signature = 'livewire:cp {name} {new-name} {--i|--inline} {--f|--force} {--t|--test}';
 
     protected function configure()
     {

--- a/src/Commands/DeleteCommand.php
+++ b/src/Commands/DeleteCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\File;
 
 class DeleteCommand extends FileManipulationCommand
 {
-    protected $signature = 'livewire:delete {name} {--inline} {--force} {--test}';
+    protected $signature = 'livewire:delete {name} {--i|--inline} {--f|--force} {--t|--test}';
 
     protected $description = 'Delete a Livewire component';
 

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\File;
 
 class MakeCommand extends FileManipulationCommand
 {
-    protected $signature = 'livewire:make {name} {--force} {--inline} {--test} {--stub= : If you have several stubs, stored in subfolders }';
+    protected $signature = 'livewire:make {name} {--f|--force} {--i|--inline} {--t|--test} {--s|--stub= : If you have several stubs, stored in subfolders }';
 
     protected $description = 'Create a new Livewire component';
 

--- a/src/Commands/MakeLivewireCommand.php
+++ b/src/Commands/MakeLivewireCommand.php
@@ -4,5 +4,5 @@ namespace Livewire\Commands;
 
 class MakeLivewireCommand extends MakeCommand
 {
-    protected $signature = 'make:livewire {name} {--force} {--inline} {--test} {--stub=}';
+    protected $signature = 'make:livewire {name} {--f|--force} {--i|--inline} {--t|--test} {--s|--stub=}';
 }

--- a/src/Commands/MoveCommand.php
+++ b/src/Commands/MoveCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\File;
 
 class MoveCommand extends FileManipulationCommand
 {
-    protected $signature = 'livewire:move {name} {new-name} {--force} {--inline} {--test}';
+    protected $signature = 'livewire:move {name} {new-name} {--f|--force} {--i|--inline} {--t|--test}';
 
     protected $description = 'Move a Livewire component';
 

--- a/src/Commands/MvCommand.php
+++ b/src/Commands/MvCommand.php
@@ -4,7 +4,7 @@ namespace Livewire\Commands;
 
 class MvCommand extends MoveCommand
 {
-    protected $signature = 'livewire:mv {name} {new-name} {--inline} {--force} {--test}';
+    protected $signature = 'livewire:mv {name} {new-name} {--i|--inline} {--f|--force} {--t|--test}';
 
     protected function configure()
     {

--- a/src/Commands/RmCommand.php
+++ b/src/Commands/RmCommand.php
@@ -4,7 +4,7 @@ namespace Livewire\Commands;
 
 class RmCommand extends DeleteCommand
 {
-    protected $signature = 'livewire:rm {name} {--inline} {--force} {--test}';
+    protected $signature = 'livewire:rm {name} {--i|--inline} {--f|--force} {--t|--test}';
 
     protected function configure()
     {

--- a/src/Commands/TouchCommand.php
+++ b/src/Commands/TouchCommand.php
@@ -4,7 +4,7 @@ namespace Livewire\Commands;
 
 class TouchCommand extends MakeCommand
 {
-    protected $signature = 'livewire:touch {name} {--force} {--inline} {--test} {--stub=default}';
+    protected $signature = 'livewire:touch {name} {--f|--force} {--i|--inline} {--t|--test} {--s|--stub=default}';
 
     protected function configure()
     {


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

it's something i find useful

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

i forked and made a pr from my repo

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

no, all changes relate to updating command shortcuts all together

4️⃣ Does it include tests? (Required, where possible)

n/a

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

this pr simply adds command shortcuts for livewire commands arguments

for example, instead of typing `php artisan make:livewire --inline` we can just do `php artisan make:livewire -i`. this is especially useful for using several arguments at once, e.g. `php artisan make:livewire -ift`

Thanks for contributing! 🙌

🚀 