### PR TITLE
fix array on query string

### DIFF
--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -94,6 +94,10 @@ class SupportBrowserHistory
             $path = $this->buildPathFromReferer($referer, $queryParams);
         }
 
+        // Referer query string sent by the browser can have different encoding when parameters are bracket formatted
+        // the query string is rebuilt to avoid pushing undesired entries on the browser history
+        $referer = $this->buildPathFromReferer($referer, collect($this->getQueryParamsFromRefererHeader()));
+
         if ($referer !== $path) {
             $response->effects['path'] = $path;
         }
@@ -204,6 +208,10 @@ class SupportBrowserHistory
             return '';
         }
 
-        return '?'.http_build_query($queryParams->toArray(), '', '&', PHP_QUERY_RFC1738);
+        $httpQuery = http_build_query($queryParams->toArray(), '', '&', PHP_QUERY_RFC1738);
+        
+        // A nested array is not evaluated as empty, but if all values are nullable query string will be empty
+        // Prevent sending back path with an extra '?'
+        return $httpQuery ? '?'.$httpQuery : '';
     }
 }

--- a/tests/Browser/QueryString/ComponentWithArrayOnQueryString.php
+++ b/tests/Browser/QueryString/ComponentWithArrayOnQueryString.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Browser\QueryString;
+
+use Illuminate\Support\Facades\View;
+use Livewire\Component;
+
+class ComponentWithArrayOnQueryString extends Component
+{
+
+    public $notCreateHistoryWhenEmptyArrayMessage = '';
+    public $notCreateHistoryWhenArrayHasSameContentMessage = '';
+
+    public $filters = [
+        'search' => null,
+        'status' => null
+    ];
+
+    protected $queryString = [
+        'filters' => [
+            'search' => null,
+            'status' => null,
+        ] 
+    ];
+
+    public function doNotCreateHistoryWhenEmptyArray()
+    {
+        $this->notCreateHistoryWhenEmptyArrayMessage = 'history-not-created-when-array-is-empty';
+    }
+
+    public function doNotCreateHistoryWhenArrayHasSameContent()
+    {
+        $this->notCreateHistoryWhenArrayHasSameContentMessage = 'history-not-created-when-array-has-same-content';
+    }
+
+    public function render()
+    {
+        return View::file(__DIR__.'/component-with-nullable-array.blade.php');
+    }
+}

--- a/tests/Browser/QueryString/Test.php
+++ b/tests/Browser/QueryString/Test.php
@@ -325,4 +325,89 @@ class Test extends TestCase
             ;
         });
     }
+
+    public function test_query_string_with_empty_array_do_not_write_wrong_history()
+    {
+        $this->browse(function (Browser $browser) {
+            Livewire::visit($browser, ComponentWithArrayOnQueryString::class, '')
+                // the browser history exists and the last url is the test above
+                ->back()
+                ->assertPathIsNot('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->forward()
+                ->assertPathIs('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->assertInputValue('@search', '')
+                ->assertInputValue('@status', '')
+                ->assertDontSeeIn('@empty-array-output', 'history-not-created-when-array-is-empty')
+                ->assertDontSeeIn('@same-content-array-output', 'history-not-created-when-array-has-same-content')
+              
+                // the click on the button must not create a new entry in the browser history
+                ->waitForLivewire()->click('@empty-array-btn')
+                ->assertSeeIn('@empty-array-output', 'history-not-created-when-array-is-empty')
+                ->back()
+                ->assertPathIsNot('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->forward()
+                ->assertPathIs('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->assertQueryStringMissing('filters')
+                ->assertDontSeeIn('@empty-array-output', 'history-not-created-when-array-is-empty')
+
+                // change the input search must create a new entry in the browser history
+                ->type('@search', 'foo')
+                ->waitForLivewire()->click('@submit')
+                ->assertQueryStringHas('filters')
+                ->back()
+                ->assertPathIs('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->assertQueryStringMissing('filters')
+                ->back()
+                ->assertPathIsNot('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->forward()
+                ->forward()
+                ->assertPathIs('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->assertInputValue('@search', 'foo')
+                ->assertInputValue('@status', '')
+
+                // change the input status must create a new entry in the browser history
+                ->type('@status', 'baz')
+                ->waitForLivewire()->click('@submit')
+                ->assertQueryStringHas('filters')
+                ->back()
+                ->assertPathIs('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->assertQueryStringHas('filters')
+                ->assertInputValue('@search', 'foo')
+                ->assertInputValue('@status', '')
+                ->back()
+                ->assertPathIs('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->assertQueryStringMissing('filters')
+                ->back()
+                ->assertPathIsNot('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->forward()
+                ->forward()
+                ->forward()
+                ->assertPathIs('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->assertInputValue('@search', 'foo')
+                ->assertInputValue('@status', 'baz')
+                ->assertDontSeeIn('@same-content-array-output', 'history-not-created-when-array-has-same-content')
+
+                // the click on the button must not create a new entry in the browser history
+                ->waitForLivewire()->click('@same-content-array-btn')
+                ->assertSeeIn('@same-content-array-output', 'history-not-created-when-array-has-same-content')
+                ->back()
+                ->assertPathIs('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->assertQueryStringHas('filters')
+                ->assertInputValue('@search', 'foo')
+                ->assertInputValue('@status', '')
+                ->back()
+                ->assertPathIs('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->assertQueryStringMissing('filters')
+                ->back()
+                ->assertPathIsNot('/livewire-dusk/Tests%5CBrowser%5CQueryString%5CComponentWithArrayOnQueryString')
+                ->forward()
+                ->forward()
+                ->forward()
+                ->assertQueryStringHas('filters')
+                ->assertInputValue('@search', 'foo')
+                ->assertInputValue('@status', 'baz')
+                ->assertDontSeeIn('@empty-array-output', 'history-not-created-when-array-is-empty')
+                ->assertDontSeeIn('@same-content-array-output', 'history-not-created-when-array-has-same-content');
+        });
+    }
 }

--- a/tests/Browser/QueryString/component-with-nullable-array.blade.php
+++ b/tests/Browser/QueryString/component-with-nullable-array.blade.php
@@ -1,0 +1,13 @@
+<div>
+    <input wire:model.defer="filters.search" type="text" dusk="search">
+    <input wire:model.defer="filters.status" type="text" dusk="status">
+    <button wire:click.prevent="$refresh" dusk="submit">Submit</button>
+    <button type="button" wire:click='doNotCreateHistoryWhenEmptyArray' dusk="empty-array-btn">
+        Empty Array
+    </button>
+    <span dusk="empty-array-output">{{ $notCreateHistoryWhenEmptyArrayMessage }}</span>
+    <button type="button" wire:click='doNotCreateHistoryWhenArrayHasSameContent' dusk="same-content-array-btn">
+        Query String Is Not Changed
+    </button>
+    <span dusk="same-content-array-output">{{ $notCreateHistoryWhenArrayHasSameContentMessage }}</span>
+</div>


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Yes, I created a discussion https://github.com/livewire/livewire/discussions/4473
2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
4️⃣ Does it include tests? (Required, where possible)
Yes
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
This PR will fix wrong behaviour on browser history when querystring contains square bracket parameters

Thanks for contributing! 🙌
