### PR TITLE
change blade to uppercase so vscode recognizes the syntax

### DIFF
--- a/src/Commands/livewire.inline.stub
+++ b/src/Commands/livewire.inline.stub
@@ -8,10 +8,10 @@ class [class] extends Component
 {
     public function render()
     {
-        return <<<'blade'
+        return <<<'BLADE'
             <div>
                 {{-- [quote] --}}
             </div>
-        blade;
+        BLADE;
     }
 }


### PR DESCRIPTION
this PR changes the blade heredoc to use BLADE uppercased so that vscode recognizes the syntax

