### PR TITLE
Attempt at fixing the safari special character encoding checksum issue

### DIFF
--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -91,9 +91,11 @@ class HydratePublicProperties implements HydrationMiddleware
         array_walk($publicData, function ($value, $key) use ($instance, $response) {
             if (
                 // The value is a supported type, set it in the data, if not, throw an exception for the user.
-                is_bool($value) || is_null($value) || is_array($value) || is_numeric($value) || is_string($value)
+                is_bool($value) || is_null($value) || is_array($value) || is_numeric($value)
             ) {
                 data_set($response, 'memo.data.'.$key, $value);
+            }else if(is_string($value)) {
+                data_set($response, 'memo.data.'.$key, \Normalizer::normalize($value));
             } else if ($value instanceof Wireable && version_compare(PHP_VERSION, '7.4', '>=')) {
                 $response->memo['dataMeta']['wireables'][] = $key;
 
@@ -237,7 +239,7 @@ class HydratePublicProperties implements HydrationMiddleware
 
     public static function processRules($rules) {
         $rules = Collection::wrap($rules);
-        
+
         $rules = $rules
             ->mapInto(Stringable::class);
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
see https://github.com/livewire/livewire/discussions/3018

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
I did, this time :)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required, where possible)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Out of curiosity I went down the rabbit hole of why Safair/Ios causes a corrupt data error. I found out that safari encodes (if that is the right word here) special characters differently from chrome. 

I saw a suggestion somewhere in and old issue https://github.com/livewire/livewire/issues/1356 that this could be solved by normalizing the data. So I gave it a go. 

It solved the problem for me for safari on a mac.

Don't know if this is the correct solution, but hopefully a step in the right direction.

Thanks for contributing! 🙌
Thank you for Livewire!