### PR TITLE
Extend events

### DIFF
--- a/src/ComponentConcerns/ReceivesEvents.php
+++ b/src/ComponentConcerns/ReceivesEvents.php
@@ -74,6 +74,11 @@ trait ReceivesEvents
 
     public function fireEvent($event, $params, $id)
     {
+        if($event instanceof Event){
+            $params = $event->getParams();
+            $event = $event->getName();
+        }
+
         $method = $this->getEventsAndHandlers()[$event];
 
         $this->callMethod($method, $params, function ($returned) use ($event, $id) {

--- a/src/ComponentConcerns/ReceivesEvents.php
+++ b/src/ComponentConcerns/ReceivesEvents.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\ComponentConcerns;
 
-use Livewire\LivewireEvent;
+use Livewire\Event;
 use Livewire\Livewire;
 
 trait ReceivesEvents
@@ -17,8 +17,8 @@ trait ReceivesEvents
 
     public function emit($event, ...$params)
     {
-        if(!$event instanceof LivewireEvent){
-            $event = new LivewireEvent($event, $params);
+        if(!$event instanceof Event){
+            $event = new Event($event, $params);
         }
 
         return $this->eventQueue[] = $event;
@@ -74,7 +74,7 @@ trait ReceivesEvents
 
     public function fireEvent($event, $params, $id)
     {
-        if($event instanceof LivewireEvent){
+        if($event instanceof Event){
             $params = $event->getParams();
             $event = $event->getName();
         }

--- a/src/ComponentConcerns/ReceivesEvents.php
+++ b/src/ComponentConcerns/ReceivesEvents.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\ComponentConcerns;
 
-use Livewire\Event;
+use Livewire\LivewireEvent;
 use Livewire\Livewire;
 
 trait ReceivesEvents
@@ -17,8 +17,8 @@ trait ReceivesEvents
 
     public function emit($event, ...$params)
     {
-        if(!$event instanceof Event){
-            $event = new Event($event, $params);
+        if(!$event instanceof LivewireEvent){
+            $event = new LivewireEvent($event, $params);
         }
 
         return $this->eventQueue[] = $event;
@@ -74,7 +74,7 @@ trait ReceivesEvents
 
     public function fireEvent($event, $params, $id)
     {
-        if($event instanceof Event){
+        if($event instanceof LivewireEvent){
             $params = $event->getParams();
             $event = $event->getName();
         }

--- a/src/ComponentConcerns/ReceivesEvents.php
+++ b/src/ComponentConcerns/ReceivesEvents.php
@@ -17,7 +17,11 @@ trait ReceivesEvents
 
     public function emit($event, ...$params)
     {
-        return $this->eventQueue[] = new Event($event, $params);
+        if(!$event instanceof Event){
+            $event = new Event($event, $params);
+        }
+
+        return $this->eventQueue[] = $event;
     }
 
     public function emitUp($event, ...$params)

--- a/src/Event.php
+++ b/src/Event.php
@@ -57,4 +57,14 @@ class Event
 
         return $output;
     }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getParams()
+    {
+        return array_values($this->params);
+    }
 }

--- a/src/Event.php
+++ b/src/Event.php
@@ -2,7 +2,7 @@
 
 namespace Livewire;
 
-class LivewireEvent
+class Event
 {
     protected $name;
     protected $params;

--- a/src/LivewireEvent.php
+++ b/src/LivewireEvent.php
@@ -2,7 +2,7 @@
 
 namespace Livewire;
 
-class Event
+class LivewireEvent
 {
     protected $name;
     protected $params;

--- a/tests/Unit/ComponentEventInstanceTest.php
+++ b/tests/Unit/ComponentEventInstanceTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Unit;
 
 use Livewire\Component;
-use Livewire\LivewireEvent;
+use Livewire\Event;
 use Livewire\Livewire;
 use Livewire\LivewireManager;
 
@@ -14,14 +14,14 @@ class ComponentEventInstanceTest extends TestCase
     {
         $component = Livewire::test(ReceivesCustomClassEvents::class);
 
-        $component->emit(new CustomLivewireEvent('baz'));
+        $component->emit(new CustomEvent('baz'));
 
 
         $this->assertEquals($component->get('foo'), 'baz');
     }
 }
 
-class CustomLivewireEvent extends LivewireEvent
+class CustomEvent extends Event
 {
     public function __construct($param)
     {
@@ -33,7 +33,7 @@ class ReceivesCustomClassEvents extends Component
 {
     public $foo;
 
-    protected $listeners = [CustomLivewireEvent::class => 'onCustomEvent'];
+    protected $listeners = [CustomEvent::class => 'onCustomEvent'];
 
     public function onCustomEvent($value)
     {

--- a/tests/Unit/ComponentEventInstanceTest.php
+++ b/tests/Unit/ComponentEventInstanceTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Unit;
 
 use Livewire\Component;
-use Livewire\Event;
+use Livewire\LivewireEvent;
 use Livewire\Livewire;
 use Livewire\LivewireManager;
 
@@ -12,16 +12,16 @@ class ComponentEventInstanceTest extends TestCase
     /** @test */
     public function reieves_event_with_custom_class_name()
     {
-        $component = Livewire::test(ReceivesEvents::class);
+        $component = Livewire::test(ReceivesCustomClassEvents::class);
 
-        $component->emit(new CustomEvent('baz'));
+        $component->emit(new CustomLivewireEvent('baz'));
 
 
         $this->assertEquals($component->get('foo'), 'baz');
     }
 }
 
-class CustomEvent extends Event
+class CustomLivewireEvent extends LivewireEvent
 {
     public function __construct($param)
     {
@@ -29,11 +29,11 @@ class CustomEvent extends Event
     }
 }
 
-class ReceivesEvents extends Component
+class ReceivesCustomClassEvents extends Component
 {
     public $foo;
 
-    protected $listeners = [CustomEvent::class => 'onCustomEvent'];
+    protected $listeners = [CustomLivewireEvent::class => 'onCustomEvent'];
 
     public function onCustomEvent($value)
     {

--- a/tests/Unit/ComponentEventInstanceTest.php
+++ b/tests/Unit/ComponentEventInstanceTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Component;
+use Livewire\Event;
+use Livewire\Livewire;
+use Livewire\LivewireManager;
+
+class ComponentEventInstanceTest extends TestCase
+{
+    /** @test */
+    public function reieves_event_with_custom_class_name()
+    {
+        $component = Livewire::test(ReceivesEvents::class);
+
+        $component->emit(new CustomEvent('baz'));
+
+
+        $this->assertEquals($component->get('foo'), 'baz');
+    }
+}
+
+class CustomEvent extends Event
+{
+    public function __construct($param)
+    {
+        parent::__construct(self::class, compact('param'));
+    }
+}
+
+class ReceivesEvents extends Component
+{
+    public $foo;
+
+    protected $listeners = [CustomEvent::class => 'onCustomEvent'];
+
+    public function onCustomEvent($value)
+    {
+        $this->foo = $value;
+    }
+
+    public function render()
+    {
+        return app('view')->make('null-view');
+    }
+}


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes. Discussion link: https://github.com/livewire/livewire/discussions/4580#discussioncomment-2170018

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No. The code is backward compatible.

4️⃣ Does it include tests? (Required, where possible)

Yes. New `ComponentEventInstanceTest.php` test file presented.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This code is most useful to be more strict with events using class names. 
Eventually when my page components are listening to global events of other components, instead of remembering the string representation of the event - I can use the event's class name.

Livewire `Event.php` class was renamed as proposed in the discussion.

Thanks for contributing! 🙌
