### PR TITLE
Set array input one by one in tests

### DIFF
--- a/src/Testing/Concerns/MakesCallsToComponent.php
+++ b/src/Testing/Concerns/MakesCallsToComponent.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Testing\Concerns;
 
+use Illuminate\Support\Arr;
 use function Livewire\str;
 use Illuminate\Support\Str;
 use Illuminate\Http\UploadedFile;
@@ -64,7 +65,7 @@ trait MakesCallsToComponent
     public function updateProperty($name, $value = null)
     {
         if (is_array($name)) {
-            foreach ($name as $key => $value) {
+            foreach (Arr::dot($name) as $key => $value) {
                 $this->syncInput($key, $value);
             }
 

--- a/tests/Unit/DataBindingTest.php
+++ b/tests/Unit/DataBindingTest.php
@@ -4,6 +4,8 @@ namespace Tests\Unit;
 
 use Livewire\Component;
 use Livewire\Livewire;
+use Livewire\TemporaryUploadedFile;
+use Livewire\WithFileUploads;
 
 class DataBindingTest extends TestCase
 {
@@ -43,6 +45,33 @@ class DataBindingTest extends TestCase
 
         $this->assertEquals('baz', $component->foo);
         $this->assertContains('foo', $component->payload['effects']['dirty']);
+    }
+
+    /** @test */
+    public function update_component_data_with_custom_files_structure()
+    {
+        $component = Livewire::test(DataBindingStub::class);
+
+        $component->updateProperty([
+            'files' => [
+                'type_1' => [
+                    TemporaryUploadedFile::fake()->image('sample.jpg', 521, 732),
+                    TemporaryUploadedFile::fake()->image('sample2.png', 1001, 1702),
+                    TemporaryUploadedFile::fake()->image('sample3.png', 1510, 1920),
+                ],
+                'type_2' => [],
+            ],
+        ]);
+
+        $filesProperty = $component->files;
+
+        $this->assertIsArray($filesProperty);
+
+        $this->assertArrayHasKey('type_1', $filesProperty);
+        $this->assertArrayHasKey('type_2', $filesProperty);
+        $this->assertIsString( $filesProperty['type_1']);
+        $this->assertStringStartsWith('livewire-files:[', $filesProperty['type_1']);
+        $this->assertSame([], $filesProperty['type_2']);
     }
 
     /** @test */
@@ -86,8 +115,11 @@ class DataBindingTest extends TestCase
 
 class DataBindingStub extends Component
 {
+    use WithFileUploads;
+
     public $foo;
     public $bar;
+    public $files;
     public $propertyWithHook;
     public $arrayProperty = ['foo', 'bar'];
 


### PR DESCRIPTION
Today I've encountered the following problem in tests:

```
 Livewire::test(SomeComponent::class)
        ->set([
                'files' => [
                    'type_1' => [
                         TemporaryUploadedFile::fake()->image('sample.jpg', 521, 732),
                         TemporaryUploadedFile::fake()->image('sample2.png', 1001, 1702),
                         TemporaryUploadedFile::fake()->image('sample3.png', 1510, 1920),
                      
                    'type_2' => [],
                ],
                'settings' => [
                    'some_setting' => 'setting value',
                ],
            ])

```

In Blade templates I had usage of `$file->temporaryUrl()` that failed (no method found) and when I commented using this method in Blade I got:

```
InvalidArgumentException : Type is not supported
 /usr/share/nginx/html/vendor/laravel/framework/src/Illuminate/Http/JsonResponse.php:88

```

The problem is that `syncInput` makes changes for UploadedFile using some assumptions and is not implemented to handle above case. Implementation of it looks like this:

```
    public function syncInput($name, $value)
    {
        if ($value instanceof UploadedFile) {
            return $this->syncUploadedFiles($name, [$value]);
        } elseif (is_array($value) && isset($value[0]) && $value[0] instanceof UploadedFile) {
            return $this->syncUploadedFiles($name, $value, $isMultiple = true);
        }

        return $this->sendMessage('syncInput', [
            'name' => $name,
            'value' => $value,
        ]);
    }
```

For above array it wouldn't sync uploaded files and it finally causes problem because probably json_encode is not able to deal with uploaded files. Probably `syncInput` method (used for tests) could be also refactored (now value should not be array anymore) but for now I think it's safer to leave it without change.


Just in case, there is possible workaround to make this working (without any Livewire code changes), when in tests you use:

```
    ->set('files.type_1.0', TemporaryUploadedFile::fake()->image('sample.jpg', 521, 732))
    ->set('files.type_1.1', TemporaryUploadedFile::fake()->image('sample2.png', 1001, 1702))
    ->set('files.type_1.2', TemporaryUploadedFile::fake()->image('sample3.png', 1510, 1920))
```

then everything is working as expected
