### PR TITLE
Pass layout data to layout component constructor

### DIFF
--- a/src/Macros/ViewMacros.php
+++ b/src/Macros/ViewMacros.php
@@ -27,7 +27,7 @@ class ViewMacros
             unset($params['attributes']);
 
             if (is_subclass_of($view, \Illuminate\View\Component::class)) {
-                $layout = new $view();
+                $layout = app()->makeWith($view, $params);
                 $view = $layout->resolveView()->name();
             } else {
                 $layout = new AnonymousComponent($view, $params);

--- a/tests/AppLayoutWithConstructor.php
+++ b/tests/AppLayoutWithConstructor.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\View\Component;
+
+class AppLayoutWithConstructor extends Component
+{
+    public $foo;
+
+    public function __construct($foo = 'bar')
+    {
+        $this->foo = $foo;
+    }
+
+    public function render()
+    {
+        return view('layouts.app-from-class-component');
+    }
+}

--- a/tests/Unit/ComponentLayoutTest.php
+++ b/tests/Unit/ComponentLayoutTest.php
@@ -61,6 +61,18 @@ class ComponentLayoutTest extends TestCase
     }
 
     /** @test */
+    public function can_show_params_set_in_the_constructor_of_a_custom_class_based_component_layout()
+    {
+        Livewire::component(ComponentWithClassBasedComponentLayoutAndParams::class);
+
+        Route::get('/foo', ComponentWithClassBasedComponentLayoutAndParams::class);
+
+        $this->withoutExceptionHandling()->get('/foo')
+            ->assertSee('bar')
+            ->assertSee('baz');
+    }
+
+    /** @test */
     public function can_show_attributes_with_a_custom_class_based_component_layout()
     {
         Livewire::component(ComponentWithClassBasedComponentLayoutAndAttributes::class);
@@ -163,6 +175,16 @@ class ComponentWithClassBasedComponentLayout extends Component
     public function render()
     {
         return view('null-view')->layout(\Tests\AppLayout::class, [
+            'bar' => 'baz'
+        ]);
+    }
+}
+
+class ComponentWithClassBasedComponentLayoutAndParams extends Component
+{
+    public function render()
+    {
+        return view('null-view')->layout(\Tests\AppLayoutWithConstructor::class, [
             'bar' => 'baz'
         ]);
     }


### PR DESCRIPTION
When rendering full-page components that use a layout component class, the data passed as the second argument to the layout function is not passed along to the layout component's constructor. For example:

```
public function render()
{
    return view( 'livewire.my-component' )
        ->layout(\App\Views\Components\AppLayout::class, [
            'title' => 'Meta Title Set Here',
            'heading' => 'Page Title Here',
        ]);
}
```

In the `layout` function defined in `Livewire\Macros\ViewMacros`, notice that when the layout component is instantiated, `$layout = new $view();`, the data in the `$params` variable is not passed to the layout constructor. This PR fixes that by using the `makeWith` function from Laravel's service container to create the layout instance and pass along the arguments in the `$params` variable to the constructor of the layout component class.

This is useful for cases where layout components manipulate or initialize data based on other arguments in their constructor. Consider this simple example where the AppLayout component constructor sets `$title` to the value of `$heading` if not explicitly set.
```
public function __construct($title = null, $heading = null)
{
    $this->title = $title ?? $heading;
    $this->heading = $heading;
}
```
