### PR TITLE
Add assertBrowserEventIsNotDispatched() method.

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -245,6 +245,20 @@ trait MakesAssertions
 
         return $this;
     }
+    
+    public function assertBrowserEventIsNotDispatched($name)
+    {
+        if (! array_key_exists('dispatches', $this->payload['effects'])){
+            $test = false;
+        } else {
+            $test = collect($this->payload['effects']['dispatches'])->contains('event', '=', $name);
+        }
+
+        PHPUnit::assertFalse($test, "Failed asserting that an event [{$name}] was not fired");
+
+        return $this;
+    }
+
 
     public function assertHasErrors($keys = [])
     {


### PR DESCRIPTION
There are some situations which we need to check the browser event isn't dispatched in our tests.

With this method, it will be accessible.