### PR TITLE
Add new computed property declaration

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -303,7 +303,7 @@ abstract class Component
         if (method_exists($this, $computedMethodName = Str::camel($studlyProperty))
             && ($returnType = (new ReflectionMethod($this, $computedMethodName))->getReturnType())
             && $returnType instanceof ReflectionNamedType
-            && $returnType->getName() === ComputedProperty::class) {
+            && $returnType->getName() === Property::class) {
             if (isset($this->computedPropertyCache[$property])) {
                 return $this->computedPropertyCache[$property];
             }

--- a/src/ComputedProperty.php
+++ b/src/ComputedProperty.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Livewire;
+
+class ComputedProperty
+{
+    public $get;
+
+    public function __construct(callable $get = null)
+    {
+        $this->get = $get;
+    }
+
+    public static function get(callable $get)
+    {
+        return new static($get);
+    }
+}

--- a/src/Property.php
+++ b/src/Property.php
@@ -2,7 +2,7 @@
 
 namespace Livewire;
 
-class ComputedProperty
+class Property
 {
     public $get;
 

--- a/tests/Unit/ComputedPropertiesTest.php
+++ b/tests/Unit/ComputedPropertiesTest.php
@@ -64,7 +64,7 @@ class ComputedPropertiesTest extends TestCase
     public function new_computed_property_is_accessable_within_blade_view()
     {
         Livewire::test(NewComputedPropertyStub::class)
-                ->assertSee('foo');
+                ->assertSee('foo_bar');
     }
 
     /** @test */

--- a/tests/Unit/ComputedPropertiesTest.php
+++ b/tests/Unit/ComputedPropertiesTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use Livewire\Component;
+use Livewire\ComputedProperty;
 use Livewire\Livewire;
 
 class ComputedPropertiesTest extends TestCase
@@ -57,6 +58,20 @@ class ComputedPropertiesTest extends TestCase
     {
         Livewire::test(FalseIssetComputedPropertyStub::class)
             ->assertSee('false');
+    }
+
+    /** @test */
+    public function new_computed_property_is_accessable_within_blade_view()
+    {
+        Livewire::test(NewComputedPropertyStub::class)
+                ->assertSee('foo');
+    }
+
+    /** @test */
+    public function new_computed_property_without_type_hint_is_not_found()
+    {
+        Livewire::test(NewComputedPropertyWithoutReturnTypeStub::class)
+                ->assertSee('false');
     }
 }
 
@@ -153,5 +168,35 @@ class FalseIssetComputedPropertyStub extends Component{
     public function render()
     {
         return view('isset-foo');
+    }
+}
+
+class NewComputedPropertyStub extends Component
+{
+    public $upperCasedFoo = 'FOO_BAR';
+
+    public function fooBar(): ComputedProperty
+    {
+        return new ComputedProperty(function() { return strtolower($this->upperCasedFoo); });
+    }
+
+    public function render()
+    {
+        return view('var-dump-foo-bar');
+    }
+}
+
+class NewComputedPropertyWithoutReturnTypeStub extends Component
+{
+    public $upperCasedFoo = 'FOO_BAR';
+
+    public function fooBar()
+    {
+        return 'something';
+    }
+
+    public function render()
+    {
+        return view('isset-foo-bar');
     }
 }

--- a/tests/Unit/ComputedPropertiesTest.php
+++ b/tests/Unit/ComputedPropertiesTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Unit;
 
 use Livewire\Component;
-use Livewire\ComputedProperty;
+use Livewire\Property;
 use Livewire\Livewire;
 
 class ComputedPropertiesTest extends TestCase
@@ -175,9 +175,9 @@ class NewComputedPropertyStub extends Component
 {
     public $upperCasedFoo = 'FOO_BAR';
 
-    public function fooBar(): ComputedProperty
+    public function fooBar(): Property
     {
-        return new ComputedProperty(function() { return strtolower($this->upperCasedFoo); });
+        return new Property(function() { return strtolower($this->upperCasedFoo); });
     }
 
     public function render()


### PR DESCRIPTION
This PR adds a new method to declare computed properties for livewire components.

Old way:
```php
    public function getFooBarProperty()
    {
        return strtolower($this->upperCasedFoo);
    }
```
New way:
```php
    public function fooBar(): Property
    {
        return new Property(fn() => strtolower($this->upperCasedFoo));
    }
```
or

```php
    public function fooBar(): Property
    {
        return Property::get(fn() => strtolower($this->upperCasedFoo));
    }
```

This is the same approach which laravel takes with the new Attribute Accessor/Mutator ( https://laravel.com/docs/9.x/eloquent-mutators#defining-an-accessor )

I like this approach, because I don't have to write a function like `get{Attribute}Property` and with the return type, it is clear that this is an computed property.

This feature can be taken as an additional method and is not meant to be a replacement.