### PR TITLE
Fix assertion with validation

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -276,6 +276,10 @@ trait MakesAssertions
                 $rules = array_keys(Arr::get($failed, $key, []));
 
                 foreach ((array) $value as $rule) {
+                    if (Str::contains($rule, ':')){
+                        $rule = Str::before($rule, ':');
+                    }
+
                     PHPUnit::assertContains(Str::studly($rule), $rules, "Component has no [{$rule}] errors for [{$key}] attribute.");
                 }
             }
@@ -304,6 +308,10 @@ trait MakesAssertions
                 $rules = array_keys(Arr::get($failed, $key, []));
 
                 foreach ((array) $value as $rule) {
+                    if (Str::contains($rule, ':')){
+                        $rule = Str::before($rule, ':');
+                    }
+
                     PHPUnit::assertNotContains(Str::studly($rule), $rules, "Component has [{$rule}] errors for [{$key}] attribute.");
                 }
             }


### PR DESCRIPTION
In some cases, we may pass validation rules with some parameters.
For example, I have this $rules property in my component:
```php
protected $rules = [
    'name' => 'min:8'
];
```

If I assert that in my tests:
```php
Livewire::test(Create::class)
    ->set('name', 'x')
    ->call('create')
    ->assertHasErrors(['route' => 'min:8']);
```

My tests will fail, but there is nothing wrong with my code and in lots of people's opinions this problem comes from their tests and they may not figure out how to fix it out!

With these changes, this problem will be fixed and params will be ignored.

Also, we can make it sensitive and restrict by params but it is much better for now, because already if we pass any params it will fail.