### PR TITLE
Fix file is deleted but property still references deleted file if filename mismatches.

### DIFF
--- a/src/WithFileUploads.php
+++ b/src/WithFileUploads.php
@@ -87,12 +87,12 @@ trait WithFileUploads
 
                 return true;
             })));
-        } elseif ($uploads instanceof TemporaryUploadedFile) {
+        } elseif ($uploads instanceof TemporaryUploadedFile && $uploads->getFilename() === $tmpFilename) {
             $uploads->delete();
 
             $this->emit('upload:removed', $name, $tmpFilename)->self();
 
-            if ($uploads->getFilename() === $tmpFilename) $this->syncInput($name, null);
+            $this->syncInput($name, null);
         }
     }
 

--- a/tests/Unit/FileUploadsTest.php
+++ b/tests/Unit/FileUploadsTest.php
@@ -69,6 +69,21 @@ class FileUploadsTest extends TestCase
     }
 
     /** @test */
+    public function cant_remove_file_with_mismatched_filename_provided()
+    {
+
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        $component = Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file);
+
+        $component->call('removeUpload', 'photo', 'mismatched-filename.png')
+            ->assertNotEmitted('upload:removed', 'photo', 'mismatched-filename.png')
+            ->assertNotSet('photo', null);
+
+    }
+
+    /** @test */
     public function can_remove_a_file_from_an_array_of_files_property()
     {
         $file1 = UploadedFile::fake()->image('avatar1.jpg');

--- a/tests/Unit/FileUploadsTest.php
+++ b/tests/Unit/FileUploadsTest.php
@@ -69,7 +69,7 @@ class FileUploadsTest extends TestCase
     }
 
     /** @test */
-    public function cant_remove_file_with_mismatched_filename_provided()
+    public function cant_remove_a_file_property_with_mismatched_filename_provided()
     {
 
         $file = UploadedFile::fake()->image('avatar.jpg');


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
No, I did not create any discussion about it.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes: fix-remove-upload

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
I need to explore how to code tests first...

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

If we were to trigger the upload:remove event to a property with a different filename, the file is deleted however it is still being referenced. This will throw exceptions if we were to use the value.

I'm still not sure whether it's better to match both property name and filename as my PR or ignore filename entirely if it's a single file.


Thanks for contributing! 🙌
