### PR TITLE
Fix - Use alias for page, if defined

### DIFF
--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -122,6 +122,6 @@ trait WithPagination
         // The "page" query string item should only be available
         // from within the original component mount run.
         // Avoid cast to integer to prevent hydrate error
-        return request()->query('page', $this->page);
+        return request()->query(data_get($this->queryString, 'page.as', 'page'), $this->page);
     }
 }

--- a/tests/Browser/Pagination/PaginationComponentWithQueryStringAliasForPage.php
+++ b/tests/Browser/Pagination/PaginationComponentWithQueryStringAliasForPage.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Browser\Pagination;
+
+use Tests\Browser\Pagination\Post;
+use Illuminate\Support\Facades\View;
+use Livewire\Component as BaseComponent;
+use Livewire\WithPagination;
+
+class PaginationComponentWithQueryStringAliasForPage extends BaseComponent
+{
+    use WithPagination;
+
+    protected $queryString = [
+        'page' => ['as' => 'p']
+    ];
+
+    public function render()
+    {
+        return View::file(__DIR__.'/view.blade.php', [
+            'posts' => Post::paginate(3),
+        ]);
+    }
+}

--- a/tests/Browser/Pagination/Test.php
+++ b/tests/Browser/Pagination/Test.php
@@ -485,4 +485,29 @@ class Test extends TestCase
             ;
         });
     }
+
+    /** @test */
+    public function pagination_trait_resolves_query_string_alias_for_page_from_component()
+    {
+        $this->browse(function ($browser) {
+            Livewire::visit($browser, PaginationComponentWithQueryStringAliasForPage::class, '?p=2')
+                /**
+                 * Test a deeplink to page 2 with "p" from the query string shows the second page.
+                 */
+                ->assertDontSee('Post #3')
+                ->assertSee('Post #4')
+                ->assertSee('Post #5')
+                ->assertSee('Post #6')
+                ->assertQueryStringHas('p', '2')
+
+                ->waitForLivewire()->click('@previousPage.before')
+
+                ->assertDontSee('Post #4')
+                ->assertSee('Post #1')
+                ->assertSee('Post #2')
+                ->assertSee('Post #3')
+                ->assertQueryStringHas('p', '1')
+            ;
+        });
+    }
 }


### PR DESCRIPTION
Since we are allowed to [define an alias](https://laravel-livewire.com/docs/2.x/query-string#query-string-aliases) for the page query string parameter, the `resolvePage` method should consider this for resolving the current page from request.

Before this fix, deeplinking / reloading would not recognize the alias and would show the first page instead.

Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
