### PR TITLE
Add support for named error bags

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -216,10 +216,10 @@ abstract class Component
         $previouslySharedErrors = app('view')->getShared()['errors'] ?? new ViewErrorBag;
         $previouslySharedInstance = app('view')->getShared()['_instance'] ?? null;
 
-        $errors = (new ViewErrorBag)->put('default', $errorBag);
+        $errors = (new ViewErrorBag)->put($this->errorBagKey, $errorBag);
 
-        $errors->getBag('default')->merge(
-            $previouslySharedErrors->getBag('default')
+        $errors->getBag($this->errorBagKey)->merge(
+            $previouslySharedErrors->getBag($this->errorBagKey)
         );
 
         $view->with([

--- a/src/Component.php
+++ b/src/Component.php
@@ -6,13 +6,11 @@ use Illuminate\View\View;
 use BadMethodCallException;
 use Illuminate\Support\Str;
 use Illuminate\Routing\Route;
-use Livewire\ImplicitlyBoundMethod;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Container\Container;
 use Livewire\Exceptions\PropertyNotFoundException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Livewire\Exceptions\CannotUseReservedLivewireComponentProperties;
 
 abstract class Component
@@ -274,7 +272,7 @@ abstract class Component
     {
         return $this->forStack;
     }
-    
+
     function __isset($property)
     {
         try {

--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -20,6 +20,8 @@ trait ValidatesInput
 {
     protected $errorBag;
 
+    protected $errorBagKey = 'default';
+
     protected $withValidatorCallback;
 
     public function getErrorBag()
@@ -37,6 +39,11 @@ trait ValidatesInput
         return $this->errorBag = $bag instanceof MessageBag
             ? $bag
             : new MessageBag($bag);
+    }
+
+    public function setErrorBagKey($key)
+    {
+        $this->errorBagKey = $key;
     }
 
     public function resetErrorBag($field = null)
@@ -238,7 +245,7 @@ trait ValidatesInput
         $data = $this->unwrapDataForValidation($data);
 
         // If a matching rule is found, then filter collections down to keys specified in the field,
-        // while leaving all other data intact. If a key isn't specified and instead there is a 
+        // while leaving all other data intact. If a key isn't specified and instead there is a
         // wildcard '*' then leave that whole collection intact. This ensures that any rules
         // that depend on other fields/ properties still work.
         if ($ruleForField) {

--- a/src/HydrationMiddleware/PerformActionCalls.php
+++ b/src/HydrationMiddleware/PerformActionCalls.php
@@ -40,6 +40,7 @@ class PerformActionCalls implements HydrationMiddleware
         } catch (ValidationException $e) {
             Livewire::dispatch('failed-validation', $e->validator, $unHydratedInstance);
 
+            $unHydratedInstance->setErrorBagKey($e->errorBag);
             $unHydratedInstance->setErrorBag($e->validator->errors());
         }
     }

--- a/src/HydrationMiddleware/PerformEventEmissions.php
+++ b/src/HydrationMiddleware/PerformEventEmissions.php
@@ -22,6 +22,7 @@ class PerformEventEmissions implements HydrationMiddleware
         } catch (ValidationException $e) {
             Livewire::dispatch('failed-validation', $e->validator, $unHydratedInstance);
 
+            $unHydratedInstance->setErrorBagKey($e->errorBag);
             $unHydratedInstance->setErrorBag($e->validator->errors());
         }
     }

--- a/tests/Unit/views/dump-errors.blade.php
+++ b/tests/Unit/views/dump-errors.blade.php
@@ -1,7 +1,7 @@
 <div>
-    @json($errors->toArray())
+    @json($errors->getBag($bag ?? 'default')->toArray())
 
-    @error('test') @enderror
+    @error('test', $bag ?? 'default') @enderror
 
     @component('dump-errors-nested-component')@endcomponent
 </div>


### PR DESCRIPTION
For every bit of relevant context and why this is needed, please see https://github.com/livewire/livewire/discussions/2585#discussioncomment-2282452 first.

---

This PR allows the use of the `Validator`'s error isolation feature using `validateWithBag`.

Remarks:

- I am not sure about the new property's name suffixed with "Key" because `errorBag` is already in use. Perhaps the current property should be renamed to `errors` / `messages`.
- I have deliberately omitted `PerformDataBindingUpdates` because that should always be the `default` error bag (I think?).
- Not sure if tests are sufficient, or in the right place. Corrections definitely welcome.

Thanks 🙏