### PR TITLE
Allow Livewire to work from a subdirectory

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -223,10 +223,10 @@ HTML;
     {
         $jsonEncodedOptions = $options ? json_encode($options) : '';
 
-        $assetsUrl = config('livewire.asset_url') ?: rtrim($options['asset_url'] ?? '', '/');
+        $assetsUrl = config('livewire.asset_url') ?: rtrim($options['asset_url'] ?? url(''), '/');
 
         $appUrl = config('livewire.app_url')
-            ?: rtrim($options['app_url'] ?? '', '/')
+            ?: rtrim($options['app_url'] ?? url(''), '/')
             ?: $assetsUrl;
 
         $jsLivewireToken = app()->has('session.store') ? "'" . csrf_token() . "'" : 'null';


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Yes

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
I don't think it needs a test

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
I'm running my Laravel app from a subdirectory on my domain so the Livewire javascript file doesn't load. please check the before and after code

before
`<script src="/livewire/livewire.js?id=940557fc56b15ccb9a2d" data-turbo-eval="false" data-turbolinks-eval="false" ></script>`

after
`<script src="https://example.com/subdirectory/livewire/livewire.js?id=940557fc56b15ccb9a2d" data-turbo-eval="false" data-turbolinks-eval="false" ></script>`

if the Laravel app is placed on the main domain then the code will be
`<script src="https://example.com/livewire/livewire.js?id=940557fc56b15ccb9a2d" data-turbo-eval="false" data-turbolinks-eval="false" ></script>`


