### PR TITLE
remove test flag from MoveCommand

### DIFF
--- a/src/Commands/MoveCommand.php
+++ b/src/Commands/MoveCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\File;
 
 class MoveCommand extends FileManipulationCommand
 {
-    protected $signature = 'livewire:move {name} {new-name} {--force} {--inline} {--test}';
+    protected $signature = 'livewire:move {name} {new-name} {--force} {--inline}';
 
     protected $description = 'Move a Livewire component';
 
@@ -30,10 +30,7 @@ class MoveCommand extends FileManipulationCommand
         $class = $this->renameClass();
         if (! $inline) $view = $this->renameView();
 
-        $test = $this->option('test');
-        if ($test) {
-            $test = $this->renameTest();
-        }
+        $test = $this->renameTest();
         $this->refreshComponentAutodiscovery();
 
         $this->line("<options=bold,reverse;fg=green> COMPONENT MOVED </> 🤙\n");
@@ -77,14 +74,15 @@ class MoveCommand extends FileManipulationCommand
 
     protected function renameTest()
     {
+        $oldTestPath = $this->parser->testPath();
         $newTestPath = $this->newParser->testPath();
-        if (File::exists($newTestPath)) {
-            $this->line("<fg=red;options=bold>Test already exists:</> {$this->newParser->relativeViewPath()}");
 
+        if (!File::exists($oldTestPath) || File::exists($newTestPath)) {
             return false;
         }
+        
         $this->ensureDirectoryExists($newTestPath);
-        File::move($this->parser->testPath(), $newTestPath);
+        File::move($oldTestPath, $newTestPath);
         return $newTestPath;
     }
 }

--- a/src/Commands/MvCommand.php
+++ b/src/Commands/MvCommand.php
@@ -4,7 +4,7 @@ namespace Livewire\Commands;
 
 class MvCommand extends MoveCommand
 {
-    protected $signature = 'livewire:mv {name} {new-name} {--inline} {--force} {--test}';
+    protected $signature = 'livewire:mv {name} {new-name} {--inline} {--force}';
 
     protected function configure()
     {

--- a/tests/Unit/MoveCommandTest.php
+++ b/tests/Unit/MoveCommandTest.php
@@ -48,7 +48,7 @@ class MoveCommandTest extends TestCase
         $this->assertTrue(File::exists($this->livewireViewsPath('bob.blade.php')));
         $this->assertTrue(File::exists($this->livewireTestsPath('BobTest.php')));
 
-        Artisan::call('livewire:move', ['name' => 'bob', 'new-name' => 'lob','--test'=>true]);
+        Artisan::call('livewire:move', ['name' => 'bob', 'new-name' => 'lob']);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Lob.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('lob.blade.php')));
@@ -85,7 +85,7 @@ class MoveCommandTest extends TestCase
         $this->assertTrue(File::exists($this->livewireViewsPath('bob/lob.blade.php')));
         $this->assertTrue(File::exists($this->livewireTestsPath('Bob/LobTest.php')));
 
-        Artisan::call('livewire:move', ['name' => 'bob.lob', 'new-name' => 'bob.lob.law','--test'=>true]);
+        Artisan::call('livewire:move', ['name' => 'bob.lob', 'new-name' => 'bob.lob.law']);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Bob/Lob/Law.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('bob/lob/law.blade.php')));
@@ -106,7 +106,7 @@ class MoveCommandTest extends TestCase
         $this->assertTrue(File::exists($this->livewireViewsPath('bob-lob.blade.php')));
         $this->assertTrue(File::exists($this->livewireTestsPath('BobLobTest.php')));
 
-        Artisan::call('livewire:move', ['name' => 'bob-lob', 'new-name' => 'lob-law','--test'=>true]);
+        Artisan::call('livewire:move', ['name' => 'bob-lob', 'new-name' => 'lob-law']);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('/LobLaw.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('lob-law.blade.php')));
@@ -127,7 +127,7 @@ class MoveCommandTest extends TestCase
         $this->assertTrue(File::exists($this->livewireViewsPath('bob-lob/bob-lob.blade.php')));
         $this->assertTrue(File::exists($this->livewireTestsPath('BobLob/BobLobTest.php')));
 
-        Artisan::call('livewire:move', ['name' => 'BobLob.BobLob', 'new-name' => 'LobLaw.LobLaw','--test'=>true]);
+        Artisan::call('livewire:move', ['name' => 'BobLob.BobLob', 'new-name' => 'LobLaw.LobLaw']);
 
         $this->assertFalse(File::exists($this->livewireClassesPath('BobLob/BobLob.php')));
         $this->assertFalse(File::exists($this->livewireViewsPath('bob-lob/bob-lob.blade.php')));


### PR DESCRIPTION
This PR removes the `--test` flag from the `livewire:move` command. As discussed in #4820 we will now check whether a test file is present and if it is rename the test.

```php
php artisan livewire:make Foo --test

// moving with tests before
php artisan livewire:move Foo Bar --test
`
// moving with tests now
php artisan livewire:move Foo Bar
```