### PR TITLE
Pass the component class name to `assertEmittedTo`

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Testing\Constraints\SeeInOrder;
+use Livewire\Component;
 use Livewire\Features\SupportRootElementTracking;
 use PHPUnit\Framework\Assert as PHPUnit;
 
@@ -205,6 +206,10 @@ trait MakesAssertions
 
     protected function testEmittedTo($target, $value)
     {
+        $target = is_subclass_of($target, Component::class)
+            ? $target::getName()
+            : $target;
+
         return (bool) collect(data_get($this->payload, 'effects.emits'))->first(function ($item) use ($target, $value) {
             return $item['event'] === $value
                 && $item['to'] === $target;

--- a/tests/Unit/Components/ComponentWhichReceivesEvent.php
+++ b/tests/Unit/Components/ComponentWhichReceivesEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Unit\Components;
+
+use Livewire\Component;
+
+class ComponentWhichReceivesEvent extends Component
+{
+    public function render()
+    {
+        return view("null-view");
+    }
+}

--- a/tests/Unit/Components/ComponentWhichReceivesEvent.php
+++ b/tests/Unit/Components/ComponentWhichReceivesEvent.php
@@ -6,8 +6,5 @@ use Livewire\Component;
 
 class ComponentWhichReceivesEvent extends Component
 {
-    public function render()
-    {
-        return view("null-view");
-    }
+
 }

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -6,6 +6,7 @@ use Livewire\Component;
 use Livewire\Livewire;
 use PHPUnit\Framework\AssertionFailedError;
 use Illuminate\Support\Facades\Route;
+use Tests\Unit\Components\ComponentWhichReceivesEvent;
 
 class LivewireTestingTest extends TestCase
 {
@@ -189,6 +190,8 @@ class LivewireTestingTest extends TestCase
         Livewire::test(EmitsEventsComponentStub::class)
             ->call('emitFooToSomeComponent')
             ->assertEmittedTo('some-component', 'foo')
+            ->call('emitFooToAComponentAsAModel')
+            ->assertEmittedTo(ComponentWhichReceivesEvent::class, 'foo')
             ->call('emitFooToSomeComponentWithParam', 'bar')
             ->assertEmittedTo('some-component', 'foo', 'bar')
             ->call('emitFooToSomeComponentWithParam', 'bar')
@@ -368,6 +371,11 @@ class EmitsEventsComponentStub extends Component
     public function emitFooToSomeComponentWithParam($param)
     {
         $this->emitTo('some-component','foo', $param);
+    }
+
+    public function emitFooToAComponentAsAModel()
+    {
+        $this->emitTo(ComponentWhichReceivesEvent::class,'foo');
     }
 
     public function emitFooUp()


### PR DESCRIPTION
Currently you must pass the component name in `assertEmittedTo`:

```php
Livewire::test(EmitsEventsComponentStub::class)
    ->call('emitFooToSomeComponent')
    ->assertEmittedTo('some-component', 'foo')
```

This PR lets you pass the component class name:

```php
Livewire::test(EmitsEventsComponentStub::class)
    ->call('emitFooToAComponentAsAModel')
    ->assertEmittedTo(ComponentWhichReceivesEvent::class, 'foo')
```