### PR TITLE
Ci test hardening

### DIFF
--- a/src/Macros/DuskBrowserMacros.php
+++ b/src/Macros/DuskBrowserMacros.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Macros;
 
+use Illuminate\Support\Str;
 use function Livewire\str;
 use Facebook\WebDriver\WebDriverBy;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -131,7 +132,7 @@ class DuskBrowserMacros
     {
         return function ($callback = null) {
             /** @var \Laravel\Dusk\Browser $this */
-            $id = rand(100, 1000);
+            $id = Str::random();
 
             $this->script([
                 "window.duskIsWaitingForLivewireRequest{$id} = true",

--- a/src/Macros/DuskBrowserMacros.php
+++ b/src/Macros/DuskBrowserMacros.php
@@ -147,7 +147,7 @@ class DuskBrowserMacros
                 // Wait a quick sec for Livewire to hear a click and send a request.
                 $this->pause(25);
 
-                return $this->waitUsing(5, 50, function () use ($id) {
+                return $this->waitUsing(5, 25, function () use ($id) {
                     return $this->driver->executeScript("return window.duskIsWaitingForLivewireRequest{$id} === undefined");
                 }, 'Livewire request was never triggered');
             }

--- a/src/Macros/DuskBrowserMacros.php
+++ b/src/Macros/DuskBrowserMacros.php
@@ -121,7 +121,7 @@ class DuskBrowserMacros
     {
         return function () {
             /** @var \Laravel\Dusk\Browser $this */
-            return $this->waitUsing(5, 75, function () {
+            return $this->waitUsing(6, 25, function () {
                 return $this->driver->executeScript("return !! window.Livewire.components.initialRenderIsFinished");
             });
         };
@@ -143,7 +143,7 @@ class DuskBrowserMacros
             if ($callback) {
                 $callback($this);
 
-                return $this->waitUsing(5, 25, function () use ($id) {
+                return $this->waitUsing(6, 25, function () use ($id) {
                     return $this->driver->executeScript("return window.duskIsWaitingForLivewireRequest{$id} === undefined");
                 }, 'Livewire request was never triggered');
             }
@@ -155,7 +155,7 @@ class DuskBrowserMacros
                 public function __call($method, $params)
                 {
                     return tap($this->browser->{$method}(...$params), function ($browser) {
-                        $browser->waitUsing(5, 25, function () use ($browser) {
+                        $browser->waitUsing(6, 25, function () use ($browser) {
                             return $browser->driver->executeScript("return window.duskIsWaitingForLivewireRequest{$this->id} === undefined");
                         }, 'Livewire request was never triggered');
                     });

--- a/src/Macros/DuskBrowserMacros.php
+++ b/src/Macros/DuskBrowserMacros.php
@@ -144,9 +144,6 @@ class DuskBrowserMacros
             if ($callback) {
                 $callback($this);
 
-                // Wait a quick sec for Livewire to hear a click and send a request.
-                $this->pause(25);
-
                 return $this->waitUsing(5, 25, function () use ($id) {
                     return $this->driver->executeScript("return window.duskIsWaitingForLivewireRequest{$id} === undefined");
                 }, 'Livewire request was never triggered');

--- a/src/Macros/DuskBrowserMacros.php
+++ b/src/Macros/DuskBrowserMacros.php
@@ -2,7 +2,6 @@
 
 namespace Livewire\Macros;
 
-use Illuminate\Support\Str;
 use function Livewire\str;
 use Facebook\WebDriver\WebDriverBy;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -132,7 +131,7 @@ class DuskBrowserMacros
     {
         return function ($callback = null) {
             /** @var \Laravel\Dusk\Browser $this */
-            $id = Str::random();
+            $id = str()->random();
 
             $this->script([
                 "window.duskIsWaitingForLivewireRequest{$id} = true",


### PR DESCRIPTION
* removed `pause` because `waitUsing` will run every 25ms for 5s so there is no need to initially wait
* check every 25ms instead of 50ms so we check more frequently if we received a livewire response
* replaced random value from a random number between 0 and 1000 to a random string with 16 chars (so the chances are super low to overlap)