### PR TITLE
Add support for custom query string

### DIFF
--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -37,7 +37,7 @@ class SupportBrowserHistory
                 }
 
                 if(method_exists($component, 'formatQueryParameter')) {
-                    $fromQueryString = $component->formatQueryParameter($fromQueryString);
+                    $fromQueryString = $component->formatQueryParameter($property, $fromQueryString);
                 }
 
                 $decoded = is_array($fromQueryString)

--- a/src/WithCustomizedQueryString.php
+++ b/src/WithCustomizedQueryString.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Livewire;
+
+trait WithCustomizedQueryString
+{
+    /**
+     * Should return a php array when there is an array in the fromQueryString
+     * If fromQueryString is not an array this should return a string
+     *
+     * @param string $fromQueryString
+     * @return array|string
+     */
+    abstract public function formatQueryParameter($fromQueryString);
+
+    /**
+     * Format the query string
+     *
+     * @param $queryParams
+     * @return string
+     */
+    abstract public function formatQueryString($queryParams): string;
+}

--- a/src/WithCustomizedQueryString.php
+++ b/src/WithCustomizedQueryString.php
@@ -8,10 +8,11 @@ trait WithCustomizedQueryString
      * Should return a php array when there is an array in the fromQueryString
      * If fromQueryString is not an array this should return a string
      *
+     * @param string $property
      * @param string $fromQueryString
      * @return array|string
      */
-    abstract public function formatQueryParameter($fromQueryString);
+    abstract public function formatQueryParameter(string $property, string $fromQueryString);
 
     /**
      * Format the query string

--- a/tests/Browser/CustomQueryString/Component.php
+++ b/tests/Browser/CustomQueryString/Component.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Browser\CustomQueryString;
+
+use Illuminate\Support\Facades\View;
+use Livewire\Component as BaseComponent;
+use Livewire\WithCustomizedQueryString;
+
+class Component extends BaseComponent
+{
+    use WithCustomizedQueryString;
+
+    protected $queryString = [
+        'a' => ['except' => [], 'as' => 'a'],
+        'b' => ['except' => [], 'as' => 'b'],
+    ];
+
+    public $a = [];
+    public $b = '';
+    public $output = '';
+
+    public function render()
+    {
+        return View::file(__DIR__.'/view.blade.php');
+    }
+
+    public function setOutputToA() {
+        $this->output = implode(',', $this->a);
+    }
+
+    public function setOutputToB() {
+        $this->output = $this->b;
+    }
+
+    public function formatQueryParameter(string $property, string $fromQueryString)
+    {
+        if (gettype($this->{$property}) == 'array') {
+            return explode(',', $fromQueryString);
+        }
+
+        return $fromQueryString;
+    }
+
+    public function formatQueryString($queryParams): string
+    {
+        if ($queryParams->isEmpty()) {
+            return '';
+        }
+
+        $build = '';
+
+        $i = 0;
+        foreach ($queryParams->toArray() as $key => $value) {
+            if ($i > 0) {
+                $build .= '&';
+            }
+
+            $build .= $key . '=';
+
+            if (is_array($value)) {
+                $j = 0;
+
+                foreach ($value as $item) {
+                    if ($j > 0) {
+                        $build .= ',';
+                    }
+
+                    $build .= $item;
+
+                    $j++;
+                }
+            } else {
+                $build .= $value;
+            }
+
+            $i++;
+        }
+
+        return '?' . $build;
+    }
+}

--- a/tests/Browser/CustomQueryString/Test.php
+++ b/tests/Browser/CustomQueryString/Test.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Browser\CustomQueryString;
+
+use Livewire\Livewire;
+use Tests\Browser\TestCase;
+
+class Test extends TestCase
+{
+    /** @test */
+    public function can_change_query_string() {
+        $this->browse(function ($browser) {
+            $queryString = '?' . http_build_query([
+                'a' => '1,2,3,4',
+                'b' => 'test'
+            ]);
+
+            Livewire::visit($browser, Component::class, $queryString)
+                /**
+                 * Basic action (click).
+                 */
+                ->waitForLivewire()->click('@setA')
+                ->assertSeeIn('@output', '1,2,3,4')
+                ->assertDontSeeIn('@output', ',1,2,3,4')
+                ->assertDontSeeIn('@output', '1,2,3,4,')
+                ->assertDontSeeIn('@output', ',1,2,3,4,')
+                ->assertDontSeeIn('@output', '')
+
+                /**
+                 * Basic action (click).
+                 */
+                ->waitForLivewire()->click('@setB')
+                ->assertSeeIn('@output', 'test')
+                ->assertDontSeeIn('@output', '');
+        });
+    }
+}

--- a/tests/Browser/CustomQueryString/view.blade.php
+++ b/tests/Browser/CustomQueryString/view.blade.php
@@ -1,0 +1,5 @@
+<div>
+    <button type="button" wire:click="setOutputToA" dusk="setA">setA</button>
+    <button type="button" wire:click="setOutputToB" dusk="setB">setB</button>
+    <span dusk="output">{{ $output }}</span>
+</div>


### PR DESCRIPTION
**Description**

I did not create a discussion thread about this but it's a feature I would like to have within livewire. With this change it possible to change the way the querystring works using a trait.

I've made changes to the SupportBrowserHistory class in which it checks if the component has access to the methods in the trait. If not, the standard will be used.

It does not include tests an extension within livewire which does nothing on itself.

**How to use this?**

In your component you include the WithCustomizedQueryString trait. This trait ensures your component inherits 2 functions: 
![image](https://user-images.githubusercontent.com/5661837/160408143-f7abd8f9-4604-49a3-a1b7-65bc24c50ded.png)
With these functions you are able to compose the url pushed to the browser (formatQueryString) and with the other function (formatQueryParameter) you are able to format the values of the query parameters to a usable string or array.

That works as following.
Normally a queryString URL looks like: ?array[0]=123&array[1]=456&string=abc
Now I want that same URL to look like this:  ?array=1,2,3&string=abc
In my Component class I added the WithCustomizedQueryStringTrait and filled the functions like this:

![image](https://user-images.githubusercontent.com/5661837/160408881-74955b10-a01f-40d8-bf95-190598aa2c43.png)

![image](https://user-images.githubusercontent.com/5661837/160408944-75211697-836c-48df-bafd-f12b61ff04fc.png)

Now the URL formatting is like I would like to have it without changing the functionality within livewire.

I hope this is something other members/users also like to use. I thought of this as a usable and optional way of implementing this.
