### PR TITLE
Skip @js Blade directive registration if already defined

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -57,7 +57,7 @@ class LivewireServiceProvider extends ServiceProvider
      *
      * @var string[][]
      */
-    static $bladeDirectivesToRegisterIfMissing = [
+    protected $bladeDirectivesToRegisterIfMissing = [
         'js' => [LivewireBladeDirectives::class, 'js'],
     ];
 
@@ -293,7 +293,7 @@ class LivewireServiceProvider extends ServiceProvider
 
     protected function registerBladeDirectives()
     {
-        foreach (static::$bladeDirectivesToRegisterIfMissing as $name => $callable) {
+        foreach ($this->bladeDirectivesToRegisterIfMissing as $name => $callable) {
             $this->registerBladeDirectiveIfNotRegistered($name, $callable);
         }
 

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -51,6 +51,16 @@ use Livewire\HydrationMiddleware\{
 
 class LivewireServiceProvider extends ServiceProvider
 {
+
+    /**
+     * Specify Blade directives that should never be overwritten.
+     *
+     * @var string[][]
+     */
+    static $bladeDirectivesToRegisterIfMissing = [
+        'js' => [LivewireBladeDirectives::class, 'js'],
+    ];
+
     public function register()
     {
         $this->registerConfig();
@@ -283,11 +293,7 @@ class LivewireServiceProvider extends ServiceProvider
 
     protected function registerBladeDirectives()
     {
-        $bladeDirectivesToRegisterIfMissing = [
-            'js' => [LivewireBladeDirectives::class, 'js'],
-        ];
-
-        foreach ($bladeDirectivesToRegisterIfMissing as $name => $callable) {
+        foreach (static::$bladeDirectivesToRegisterIfMissing as $name => $callable) {
             $this->registerBladeDirectiveIfNotRegistered($name, $callable);
         }
 
@@ -458,10 +464,6 @@ class LivewireServiceProvider extends ServiceProvider
 
     protected function bladeDirectiveAlreadyRegistered(string $name): bool
     {
-        if ($this->app->environment('testing')) {
-            return false;
-        }
-
         if (method_exists(BladeCompiler::class, Str::start($name, 'compile')))
         {
             return true;

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -446,6 +446,6 @@ class LivewireServiceProvider extends ServiceProvider
     protected function shouldRegisterJsDirective(): bool
     {
         return $this->app->environment('testing')
-            || version_compare($this->app->version(), '8.71.0') === -1;
+            || version_compare($this->app->version(), '8.71.0', '<');
     }
 }

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -456,7 +456,7 @@ class LivewireServiceProvider extends ServiceProvider
         }
     }
 
-    protected function bladeDirectiveAlreadyRegistered(string $name)
+    protected function bladeDirectiveAlreadyRegistered(string $name): bool
     {
         if ($this->app->environment('testing')) {
             return false;

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -281,7 +281,10 @@ class LivewireServiceProvider extends ServiceProvider
 
     protected function registerBladeDirectives()
     {
-        Blade::directive('js', [LivewireBladeDirectives::class, 'js']);
+        if ($this->shouldRegisterJsDirective()) {
+            Blade::directive('js', [LivewireBladeDirectives::class, 'js']);
+        }
+
         Blade::directive('this', [LivewireBladeDirectives::class, 'this']);
         Blade::directive('entangle', [LivewireBladeDirectives::class, 'entangle']);
         Blade::directive('livewire', [LivewireBladeDirectives::class, 'livewire']);
@@ -438,5 +441,11 @@ class LivewireServiceProvider extends ServiceProvider
         foreach ((array) $groups as $group) {
             $this->publishes($paths, $group);
         }
+    }
+
+    protected function shouldRegisterJsDirective(): bool
+    {
+        return $this->app->environment('testing')
+            || version_compare($this->app->version(), '8.71.0') === -1;
     }
 }

--- a/tests/Unit/LivewireJsDirectiveTest.php
+++ b/tests/Unit/LivewireJsDirectiveTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit;
 use Illuminate\Support\Facades\Blade;
 use Livewire\Livewire;
 use Livewire\Component;
-use Livewire\LivewireServiceProvider;
+use Livewire\LivewireBladeDirectives;
 
 class LivewireJsDirectiveTest extends TestCase
 {
@@ -13,9 +13,8 @@ class LivewireJsDirectiveTest extends TestCase
     {
         parent::setUp();
 
-        foreach (LivewireServiceProvider::$bladeDirectivesToRegisterIfMissing as $name => $callable) {
-            Blade::directive($name, $callable);
-        }
+        // Register the @js directive to force replacement of the directive introduced in Laravel 8.71.0
+        Blade::directive('js', [LivewireBladeDirectives::class, 'js']);
     }
 
     /** @test */

--- a/tests/Unit/LivewireJsDirectiveTest.php
+++ b/tests/Unit/LivewireJsDirectiveTest.php
@@ -2,11 +2,22 @@
 
 namespace Tests\Unit;
 
+use Illuminate\Support\Facades\Blade;
 use Livewire\Livewire;
 use Livewire\Component;
+use Livewire\LivewireServiceProvider;
 
 class LivewireJsDirectiveTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (LivewireServiceProvider::$bladeDirectivesToRegisterIfMissing as $name => $callable) {
+            Blade::directive($name, $callable);
+        }
+    }
+
     /** @test */
     public function single_quotes()
     {


### PR DESCRIPTION
As discussed in https://github.com/livewire/livewire/discussions/4875, this PR skips registration of the @js custom blade directive unless the framework version is < 8.71.0 or running in the testing environment.

I am not a big fan of conditional execution based on the testing environment, but in the current case I don't see an option that will make sure that the tests will still always cover the custom implementation of the directive.

Also, I do not see an easy way to test the conditional registration itself, as this would require bootstrapping with a mocked App::version(). Not sure we want to go down that rabbit hole. Let me know if you think otherwise.