### PR TITLE
Allows using dot notation in query string

### DIFF
--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -40,7 +40,7 @@ class SupportBrowserHistory
                     ? json_decode(json_encode($fromQueryString), true)
                     : json_decode($fromQueryString, true);
 
-                $component->$property = $decoded === null ? $fromQueryString : $decoded;
+                data_set($component, $property, $decoded === null ? $fromQueryString : $decoded);
             }
         });
 
@@ -194,7 +194,7 @@ class SupportBrowserHistory
                 $key = is_string($key) ? $key : $value;
                 $alias = $value['as'] ?? $key;
 
-                return [$alias => $component->{$key}];
+                return [$alias => data_get($component, $key)];
             });
     }
 

--- a/tests/Browser/QueryString/ComponentWithDotNotation.php
+++ b/tests/Browser/QueryString/ComponentWithDotNotation.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Browser\QueryString;
+
+use Illuminate\Support\Facades\View;
+use Livewire\WithPagination;
+use Tests\Browser\Pagination\Post;
+
+class ComponentWithDotNotation extends Component
+{
+    use WithPagination;
+    use WithSearch;
+
+    public $filters = [];
+
+    protected $queryString = [
+        'page' => ['except' => 1, 'as' => 'p'],
+        'filters.title' => ['except' => '', 'as' => 'title']
+    ];
+
+    public function changePostTitle()
+    {
+        $this->filters = [
+            'title' => 'Post #2'
+        ];
+    }
+
+    public function mount()
+    {
+        $this->filters = [
+            'title' => 'Post'
+        ];
+    }
+
+    public function render()
+    {
+        return View::file(__DIR__.'/dot-notation.blade.php', [
+            'posts' => Post::query()
+                ->when($this->filters['title'], function ($query, $filter) {
+                    $query->where('title', 'LIKE', "%$filter%");
+                })
+                ->paginate(3),
+        ]);
+    }
+}

--- a/tests/Browser/QueryString/Test.php
+++ b/tests/Browser/QueryString/Test.php
@@ -325,4 +325,22 @@ class Test extends TestCase
             ;
         });
     }
+
+    public function test_query_string_aliases_set_intial_property_values_1()
+    {
+        $this->browse(function (Browser $browser) {
+            Livewire::visit($browser, ComponentWithDotNotation::class, '?title=Post')
+                ->assertInputValue('@title', 'Post')
+                ->assertQueryStringHas('title', 'Post')
+
+                /*
+                 * Ensures that if changing the value the queryString will work as expected
+                 */
+                ->waitForLivewire()->click('@changePostTitle')
+                ->assertInputValue('@title', 'Post #2')
+                ->assertQueryStringHas('title', 'Post #2')
+                ->assertSee('Post #2')
+            ;
+        });
+    }
 }

--- a/tests/Browser/QueryString/dot-notation.blade.php
+++ b/tests/Browser/QueryString/dot-notation.blade.php
@@ -1,0 +1,14 @@
+<div>
+
+    <input wire:model="filters.title" type="text" dusk="title">
+
+    @foreach ($posts as $post)
+        <h1 wire:key="post-{{ $post->id }}">{{ $post->title }}</h1>
+    @endforeach
+
+    <button wire:click="changePostTitle" dusk="changePostTitle">Change Title</button>
+    <p>
+        {{ json_encode($filters)  }}
+    </p>
+    {{ $posts->links() }}
+</div>


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
https://github.com/livewire/livewire/discussions/2036
2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
**Yes**
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
**No**
4️⃣ Does it include tests? (Required)
**Yes**
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Be able to interpret the queryString using dot notation

**Necessity**
→ We have an array called $filters and it has all the information that will be used for filtering in the database later in a dynamic livewire component

**Note**
→ Must be used together with an alias to not break the url (dot notation only).

To add this possibility I used the `data_get` and `data_set` functions to manipulate the class data.

```php
public $filters = [
	'input_text' => [
	     'dishes' => [
		'name' => 'Pastel de Nata',
	     ]
	]
];

public function getQueryString(): array
{
    return [
	'search' => ['except' => 1],
        'page' => ['except' => 1],
        'filters.input_text.dishes.name' => ['as' => 'name', 'except' => ''], // <- fix this
    ];
}
```

Thanks for contributing! 🙌
