### PR TITLE
feature: Implicit enum binding

### DIFF
--- a/src/ImplicitlyBoundMethod.php
+++ b/src/ImplicitlyBoundMethod.php
@@ -2,6 +2,7 @@
 
 namespace Livewire;
 
+use BackedEnum;
 use Illuminate\Container\BoundMethod;
 use Illuminate\Contracts\Routing\UrlRoutable as ImplicitlyBindable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -92,6 +93,10 @@ class ImplicitlyBoundMethod extends BoundMethod
 
     protected static function getImplicitBinding($container, $className, $value)
     {
+        if (in_array(BackedEnum::class, class_implements($className))) {
+            return $className::tryFrom($value);
+        }
+
         $model = $container->make($className)->resolveRouteBinding($value);
 
         if (! $model) {
@@ -118,6 +123,8 @@ class ImplicitlyBoundMethod extends BoundMethod
 
     public static function implementsInterface($parameter)
     {
-        return (new ReflectionClass($parameter->getType()->getName()))->implementsInterface(ImplicitlyBindable::class);
+        $type = new ReflectionClass($parameter->getType()->getName());
+
+        return $type->implementsInterface(ImplicitlyBindable::class) || $type->implementsInterface(BackedEnum::class);
     }
 }

--- a/src/ImplicitlyBoundMethod.php
+++ b/src/ImplicitlyBoundMethod.php
@@ -125,6 +125,14 @@ class ImplicitlyBoundMethod extends BoundMethod
     {
         $type = new ReflectionClass($parameter->getType()->getName());
 
-        return $type->implementsInterface(ImplicitlyBindable::class) || $type->implementsInterface(BackedEnum::class);
+        if ($type->implementsInterface(ImplicitlyBindable::class)) {
+            return true;
+        }
+
+        if (! interface_exists(BackedEnum::class)) {
+            return false;
+        }
+
+        return $type->implementsInterface(BackedEnum::class);
     }
 }


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Many other areas of the Laravel framework support enum bindings, such as in route binding and Eloquent casts.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Just like you can with models, you may now implicitly bind [PHP 8.1 Enums](https://www.php.net/manual/en/language.types.enumerations.php) as parameters to Livewire actions:

```php
public function setExpenseHandler(
    ExpensableItem $expensableItem, // Eloquent model binding
    ?ExpensableItemHandler $handler, // Enum binding
): void
{
    $expensableItem->handled_by = $handler; // Eloquent enum casting
    $expensableItem->save();
}
```

Without this change, you need to implement the `UrlRoutable` on the Enum, which does not make sense since this interface also requires an many other methods that are not used in Livewire's implicit binding.

Thanks for contributing! 🙌
