### PR TITLE
Allow mixed parameters in only and except methods

### DIFF
--- a/src/ComponentConcerns/InteractsWithProperties.php
+++ b/src/ComponentConcerns/InteractsWithProperties.php
@@ -3,6 +3,7 @@
 namespace Livewire\ComponentConcerns;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use function Livewire\str;
 
 trait InteractsWithProperties
@@ -182,20 +183,20 @@ trait InteractsWithProperties
         $this->reset($keysToReset);
     }
 
-    public function only($properties)
+    public function only(...$properties)
     {
         $results = [];
 
-        foreach ($properties as $property) {
+        foreach (Arr::flatten($properties) as $property) {
             $results[$property] = $this->hasProperty($property) ? $this->getPropertyValue($property) : null;
         }
 
         return $results;
     }
     
-    public function except($properties)
+    public function except(...$properties)
     {
-        return array_diff_key($this->all(), array_flip($properties));
+        return array_diff_key($this->all(), array_flip(Arr::flatten($properties)));
     }
 
     public function all()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
I want it, no discussion was made.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes, its on `patch-1`

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

4️⃣ Does it include tests? (Required)
No. It's just a couple of changed lines, will work with existing tests.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Allow us to specify `only` and `except` properties the same way we can with Eloquent `only`, either mixed or as an array.

With this PR the following will work the same:

```php
$properties1 = $this->only('name', 'email');
$properties2 = $this->only(['name', 'email']);
```

It just makes the API a bit nicer and more flexible.
