### PR TITLE
fix: Ensure component directory exists when discovering components

### DIFF
--- a/src/LivewireComponentsFinder.php
+++ b/src/LivewireComponentsFinder.php
@@ -64,6 +64,10 @@ class LivewireComponentsFinder
 
     public function getClassNames()
     {
+        if (! $this->files->exists($this->path)) {
+            return collect();
+        }
+
         return collect($this->files->allFiles($this->path))
             ->map(function (SplFileInfo $file) {
                 return app()->getNamespace().

--- a/tests/Unit/DiscoverCommandTest.php
+++ b/tests/Unit/DiscoverCommandTest.php
@@ -70,4 +70,14 @@ EOT
 
         $this->assertTrue(File::exists($manifestPath));
     }
+
+    /** @test */
+    public function no_exception_is_thrown_when_the_class_directory_does_not_exist()
+    {
+        File::deleteDirectory($this->livewireClassesPath());
+
+        Artisan::call('livewire:discover');
+
+        $this->assertTrue(File::exists(app()->bootstrapPath('cache/livewire-components.php')));
+    }
 }


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

#3820, laravel-filament/filament#1009, #3415

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Sometimes, your project only contains Livewire components that are registered in service providers using `Livewire::component()`. For instance, some people use Filament's Livewire components to build their entire application, so they don't need an `app/Http/Livewire` directory.

When `app/Http/Livewire` does not exist, an exception is thrown when `livewire:discover` is run. This PR adds a simple directory existence check beforehand to ensure that the exception is not thrown.

Thanks for contributing! 🙌
