### PR TITLE
Support loading validation rules from traits.

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -77,36 +77,43 @@ trait ValidatesInput
         );
     }
 
+    protected function loadConfig(string $field)
+    {
+        $config = [];
+
+        foreach (class_uses_recursive($class = static::class) as $trait) {
+            if (method_exists($class, $method = $field . class_basename($trait))) {
+                $config = array_merge($config, $this->{$method}());
+            }
+            if (property_exists($class, $property = $field . class_basename($trait))) {
+                $config = array_merge($config, $this->{$property});
+            }
+        }
+
+        if (method_exists($this, $field)) $config = array_merge($config, $this->{$field}());
+        elseif (property_exists($this, $field)) $config = array_merge($config, $this->{$field});
+
+        return $config;
+    }
+
     protected function getRules()
     {
-        if (method_exists($this, 'rules')) return $this->rules();
-        if (property_exists($this, 'rules')) return $this->rules;
-
-        return [];
+        return $this->loadConfig('rules');
     }
 
     protected function getMessages()
     {
-        if (method_exists($this, 'messages')) return $this->messages();
-        if (property_exists($this, 'messages')) return $this->messages;
-
-        return [];
+        return $this->loadConfig('messages');
     }
 
     protected function getValidationAttributes()
     {
-        if (method_exists($this, 'validationAttributes')) return $this->validationAttributes();
-        if (property_exists($this, 'validationAttributes')) return $this->validationAttributes;
-
-        return [];
+        return $this->loadConfig('validationAttributes');
     }
 
     protected function getValidationCustomValues()
     {
-        if (method_exists($this, 'validationCustomValues')) return $this->validationCustomValues();
-        if (property_exists($this, 'validationCustomValues')) return $this->validationCustomValues;
-
-        return [];
+        return $this->loadConfig('validationCustomValues');
     }
 
     public function rulesForModel($name)


### PR DESCRIPTION
:wave:

Traits are a great (and recommended) way to introduce some reusability into your livewire components.

To use lifecycle hooks inside your traits, but still be able to use them in your component, you can suffix them with the traits name as such:

```php
trait IsAnExample
{
    public function mountIsAnExample()
   {
       // Do stuff in addition to what is done in mount() in the component
   }
}
```

Hooks for query strings are also supported:

```php
trait IsAnExample
{
    protected $queryStringIsAnExample = [
        'example'
    ];
 
    // or as a method
 
    public function queryStringIsAnExample()
    {
        return ['example'];
    }
}
```

This PR adds the same functionality for validation rules. I use this for traits that extracts common functionality shared among a bunch of similar (but different :) ) forms.

```php
trait HasUsername
{
    protected ?string $username = null;

    public function rulesHasUsername()
    {
        return [
            'username' => 'required|email',
        ];
    }
}
```

If there is any interest in this I will:

* Add support for `protected $rulesIsAnExample`.
* Add support for validation messages.
* Add documentation.
* Add more tests?

Please let me know if you would be willing to accept this, if I work on it further.

