### PR TITLE
Fix wireable order validation

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -371,8 +371,8 @@ trait ValidatesInput
     protected function unwrapDataForValidation($data)
     {
         return collect($data)->map(function ($value) {
-            if ($value instanceof Collection || $value instanceof EloquentCollection || $value instanceof Model) return $value->toArray();
-            else if ($value instanceof Wireable) return $value->toLivewire();
+            if ($value instanceof Wireable) return $value->toLivewire();
+            else if ($value instanceof Collection || $value instanceof EloquentCollection || $value instanceof Model) return $value->toArray();
 
             return $value;
         })->all();

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -466,7 +466,7 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
-    public function an_object_with_wireable_on_it_gets_validated()
+    public function when_unwrapping_data_for_validation_an_object_is_checked_if_it_is_wireable_first()
     {
         Livewire::test(ValidatesWireableProperty::class)
             ->call('runValidation')

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -468,6 +468,10 @@ class ValidationTest extends TestCase
     /** @test */
     public function when_unwrapping_data_for_validation_an_object_is_checked_if_it_is_wireable_first()
     {
+        if (version_compare(PHP_VERSION, '7.4', '<')) {
+            $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
+        }
+
         Livewire::test(ValidatesWireableProperty::class)
             ->call('runValidation')
             ->assertHasErrors('customCollection.0.amount')

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -4,12 +4,10 @@ namespace Tests\Unit;
 
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ViewErrorBag;
 use Livewire\Component;
 use Livewire\Livewire;
-use Livewire\Wireable;
 
 use function PHPUnit\Framework\assertTrue;
 
@@ -472,6 +470,8 @@ class ValidationTest extends TestCase
             $this->markTestSkipped('Typed Property Initialization not supported prior to PHP 7.4');
         }
 
+        require_once __DIR__.'/WireablesCanBeSetAsPublicPropertiesStubs.php';
+
         Livewire::test(ValidatesWireableProperty::class)
             ->call('runValidation')
             ->assertHasErrors('customCollection.0.amount')
@@ -864,73 +864,5 @@ class ValidatesComputedProperty extends Component
     public function render()
     {
         return view('null-view');
-    }
-}
-
-class ValidatesWireableProperty extends Component
-{
-    public CustomWireableCollection $customCollection;
-
-    public $rules = [
-        'customCollection.*.amount' => 'required|gt:100'
-    ];
-
-    public function mount()
-    {
-        $this->customCollection = new CustomWireableCollection([
-            new CustomWireableDTO(50),
-        ]);
-    }
-
-    public function runValidation()
-    {
-        $this->validate();
-    }
-
-    public function render()
-    {
-        return view('null-view');
-    }
-}
-
-class CustomWireableCollection extends Collection implements Wireable
-{
-    public function toLivewire()
-    {
-        return $this->mapWithKeys(function($dto, $key) {
-            return [$key => $dto instanceof CustomWireableDTO ? $dto->toLivewire() : $dto];
-        })->all();
-    }
-
-    public static function fromLivewire($value)
-    {
-        return static::wrap($value)
-        ->mapWithKeys(function ($dto, $key) {
-            return [$key => CustomWireableDTO::fromLivewire($dto)];
-        });
-    }
-}
-
-class CustomWireableDTO implements Wireable
-{
-    public $amount;
-
-    public function __construct($amount)
-    {
-        $this->amount = $amount;
-    }
-
-    public function toLivewire()
-    {
-        return [
-            'amount' => $this->amount
-        ];
-    }
-
-    public static function fromLivewire($value)
-    {
-        return new static(
-            $value['amount']
-        );
     }
 }


### PR DESCRIPTION
To validate data, Livewire converts objects (like collections and models) to arrays first, so that way it can be validated.

But if you have a custom collection (say that contains DTOs) that implements the `Wireable` interface, currently it won't validate properly as calling `toArray` on the custom collection won't return the correct data structure.

To fix this, this PR changes the order that `upwrapDataForValidation` checks what data type the object is, nows checks if the object implements the `Wireable` interface first and if so, uses that method.

This also makes it consistent with the dehydration process in `HydratesPublicProperties`, which checks whether an object implements `Wireable` first and uses that method if it does.

https://github.com/livewire/livewire/blob/98b83e96128c30956edc8bd032270b7b7c605f35/src/HydrationMiddleware/HydratePublicProperties.php#L100-L103

To add the test for this, I had to add an example custom collection and custom DTO (mainly as that what how I found this issue). If you can think of a simpler way to test this change, I'd be happy to refine it.

Hope this helps!