### PR TITLE
Add ability to exclude querystring using an array of values

### DIFF
--- a/src/Features/SupportBrowserHistory.php
+++ b/src/Features/SupportBrowserHistory.php
@@ -166,7 +166,11 @@ class SupportBrowserHistory
             ->merge($this->mergedQueryParamsFromDehydratedComponents)
             ->merge($this->getQueryParamsFromComponentProperties($component))
             ->reject(function ($value, $key) use ($excepts) {
-                return isset($excepts[$key]) && $excepts[$key] === $value;
+                return isset($excepts[$key])
+                    && (
+                        (is_array($excepts[$key]) && in_array($value, $excepts[$key]))
+                        || $excepts[$key] === $value
+                    );
             })
             ->map(function ($property) {
                 return is_bool($property) ? json_encode($property) : $property;

--- a/tests/Browser/QueryString/ComponentWithArrayExcepts.php
+++ b/tests/Browser/QueryString/ComponentWithArrayExcepts.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Browser\QueryString;
+
+use Illuminate\Support\Facades\View;
+use Livewire\Component as BaseComponent;
+
+class ComponentWithArrayExcepts extends BaseComponent
+{
+    protected $queryString = [
+        'search' => ['except' => ['black', 'white']],
+    ];
+
+    public $search = '';
+
+    public function render()
+    {
+        return View::file(__DIR__.'/array-excepts.blade.php');
+    }
+}
+

--- a/tests/Browser/QueryString/Test.php
+++ b/tests/Browser/QueryString/Test.php
@@ -176,6 +176,31 @@ class Test extends TestCase
         });
     }
 
+    public function test_array_excepts_results()
+    {
+        $this->browse(function (Browser $browser) {
+            Livewire::visit($browser, ComponentWithArrayExcepts::class)
+                ->assertSeeIn('@request', 'Request:#')
+                ->assertSeeIn('@search', 'Search:#')
+                ->waitForLivewire()->type('@input', 'red')
+                ->assertSeeIn('@search', 'Search:red')
+                ->refresh()
+                ->assertSeeIn('@request', 'Request:red')
+                ->waitForLivewire()->type('@input', 'black')
+                ->assertSeeIn('@search', 'Search:black')
+                ->refresh()
+                ->assertSeeIn('@request', 'Request:#')
+                ->waitForLivewire()->type('@input', 'yellow')
+                ->assertSeeIn('@search', 'Search:yellow')
+                ->refresh()
+                ->assertSeeIn('@request', 'Request:yellow')
+                ->waitForLivewire()->type('@input', 'white')
+                ->assertSeeIn('@search', 'Search:white')
+                ->refresh()
+                ->assertSeeIn('@request', 'Request:#');
+        });
+    }
+
     public function test_that_input_values_are_set_after_back_button()
     {
         $this->browse(function (Browser $browser) {

--- a/tests/Browser/QueryString/array-excepts.blade.php
+++ b/tests/Browser/QueryString/array-excepts.blade.php
@@ -1,0 +1,6 @@
+<div>
+    <input wire:model="search" dusk="input" />
+
+    <p dusk="request">Request:{{ request('search') ?: '#' }}</p>
+    <p dusk="search">Search:{{ $search ?: '#' }}</p>
+</div>


### PR DESCRIPTION
Add the ability to filter querystring params by an array of values like so:

```php
protected $queryString = [
    'search' => ['except' => ['black', 'white']],
];
```