### PR TITLE
Do not disable caching of pages that do not use livewire

### DIFF
--- a/src/DisableBrowserCache.php
+++ b/src/DisableBrowserCache.php
@@ -18,6 +18,10 @@ class DisableBrowserCache
     {
         $response = $next($request);
 
+        if (!$request->routeIs('livewire.')) {
+            return $response;
+        }
+
         if ($response instanceof Response && Livewire::shouldDisableBackButtonCache()){
             $response->headers->add([
                 "Pragma" => "no-cache",

--- a/src/DisableBrowserCache.php
+++ b/src/DisableBrowserCache.php
@@ -18,7 +18,7 @@ class DisableBrowserCache
     {
         $response = $next($request);
 
-        if (!$request->routeIs('livewire.')) {
+        if (!$request->isMethodCacheable() || !$request->routeIs('livewire.')) {
             return $response;
         }
 


### PR DESCRIPTION
When using livewire in only a small part of a project, the middleware that is being used prevents the whole project from being cached. For example this will not work:

```php
Route::middleware('cache.headers:public;max_age=2628000;etag')
    ->group(function (){
        Route::get('/', 'HomeController@index')->name('home');
    });
```

This change suggests limiting caching to only routes with the mask `livewire.`


I'm also curious if it's possible to transfer the registration of this middleware from the global level, to the configuration file.