### PR TITLE
Fix invalid array key for validate only

### DIFF
--- a/src/ComponentConcerns/ValidatesInput.php
+++ b/src/ComponentConcerns/ValidatesInput.php
@@ -310,7 +310,7 @@ trait ValidatesInput
                 }
             } else {
                 // Otherwise filter collection down to a specific key
-                $keyData = $data[$fieldKey];
+                $keyData = $data[$fieldKey] ?? null;
 
                 if ($ruleKey == '*') {
                     $data = [];

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -167,6 +167,17 @@ class ValidationTest extends TestCase
     }
 
     /** @test */
+    public function validating_only_a_specific_field_wont_throw_an_error_if_the_array_key_doesnt_exist()
+    {
+        $component = Livewire::test(ForValidation::class);
+
+        $component
+            ->set('items', [])
+            ->call('runDeeplyNestedValidationOnly', 'items.0.baz')
+            ->assertSee('items.0.baz field is required');
+    }
+
+    /** @test */
     public function can_validate_only_a_specific_field_with_custom_message_property()
     {
         $component = Livewire::test(ForValidation::class);


### PR DESCRIPTION
Hello, i got the same error mentioned in this discussion #4782, if you use `validateOnly()` to check a key that doesn't exist in the array it will produce the error.

There is a simple example, assuming we want to validate the 'test' key of the array:
```
class Manage extends Component
{
    public $myArray = [];

    public function updatedMyArray()
    {
        //assuming $myArray === [];
        $this->validateOnly('myArray.test');
    }
}
```
