### PR TITLE
Add "HMR"/Live reload

### DIFF
--- a/src/ComponentConcerns/ReceivesEvents.php
+++ b/src/ComponentConcerns/ReceivesEvents.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\ComponentConcerns;
 
+use Illuminate\Support\Facades\File;
 use Livewire\Event;
 use Livewire\Livewire;
 
@@ -12,7 +13,13 @@ trait ReceivesEvents
     protected $listeners = [];
 
     protected function getListeners() {
-        return $this->listeners;
+        $listeners = $this->listeners;
+
+        if (config('app.debug') && File::exists(public_path('hot'))) {
+            $listeners['hmr'] = '$refresh';
+        }
+
+        return $listeners;
     }
 
     public function emit($event, ...$params)

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -182,7 +182,6 @@ class LivewireManager
         // HTML Label.
         $html = $debug ? ['<!-- Livewire Scripts -->'] : [];
 
-
         // JavaScript assets.
         $html[] = $debug ? $scripts : $this->minify($scripts);
 

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -193,7 +193,8 @@ class LivewireManager
         return implode("\n", $html);
     }
 
-    protected function getHmrScript(): string {
+    protected function getHmrScript(): string
+    {
         if (File::exists(public_path('hot'))) {
             $websocketUrl = str_replace(['http://', 'https://'], 'ws://', trim(File::get(public_path('hot'))) . '/ws');
 

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -196,7 +196,11 @@ class LivewireManager
     protected function getHmrScript(): string
     {
         if (File::exists(public_path('hot'))) {
-            $websocketUrl = str_replace(['http://', 'https://'], 'ws://', trim(File::get(public_path('hot'))) . '/ws');
+            $websocketUrl = str_replace(
+                ['http://', 'https://'],
+                request()->secure() ? 'wss://' : 'ws://',
+                trim(File::get(public_path('hot'))) . '/ws'
+            );
 
             return <<<HTML
 <script>


### PR DESCRIPTION
Hey,

This small pr (needs docs update as well) enables the usage of HMR with Laravel livewire.

It relies on Laravel mix/webpack.

The strategy is simple. When you run `npm run mix watch--hot` a `hot` file is created in `public` and also on the webpack js side a new function comes available.

We listen on the websocket, which is only injected with debug mode.

This greatly improves the workflow as you no longer need to refresh and go through steps again in some cases.

Then every time a hmr happens (for example when tailwind reparses), the event is emitted and will refresh all livewire components and keep its state.

![Screen Recording 2022-05-12 at 08 52 10](https://user-images.githubusercontent.com/866743/168013631-f2c8411f-8a88-477a-93cd-1d09ecb9707a.gif)

This is of course only active with debug mode on. And will not trigger if webpack is not in hot reload mode.
