### PR TITLE
Add $wire.errors() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Contribute to the docs here: https://github.com/livewire/docs
 * Refine the "asset_url" config. Potentially change to "app_url" (https://github.com/livewire/livewire/pull/1693)
 * Support multiple pagination (https://github.com/livewire/livewire/pull/1997)
 * A CSP-safe mode for Livewire (https://github.com/livewire/livewire/pull/2485#issuecomment-784355989)
-* Add `$wire.errors()` type deal
 
 ## License
 

--- a/js/component/index.js
+++ b/js/component/index.js
@@ -636,6 +636,10 @@ export default class Component {
         )
     }
 
+    errors() {
+        return this.serverMemo.errors
+    }
+
     get $wire() {
         if (this.dollarWireProxy) return this.dollarWireProxy
 
@@ -671,6 +675,7 @@ export default class Component {
                         'upload',
                         'uploadMultiple',
                         'removeUpload',
+                        'errors'
                     ].includes(property)
                 ) {
                     // Forward public API methods right away.


### PR DESCRIPTION
Hey,
This small pr only adds the errors function to the js livewire component.
The function only returns the equvilant of $wire.__instance.serverMemo.errors