### PR TITLE
Fixes bug where null computed property is considered set

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -274,15 +274,17 @@ abstract class Component
     {
         return $this->forStack;
     }
-    
+
     function __isset($property)
     {
         try {
-            $this->__get($property);
-            return true;
-        } catch(PropertyNotFoundException $ex) {
-            return false;
-        }
+            $value = $this->__get($property);
+
+            if (isset($value)) {
+                return true;
+            }
+        } catch(PropertyNotFoundException $ex) {}
+
         return false;
     }
 

--- a/tests/Unit/ComputedPropertiesTest.php
+++ b/tests/Unit/ComputedPropertiesTest.php
@@ -58,6 +58,13 @@ class ComputedPropertiesTest extends TestCase
         Livewire::test(FalseIssetComputedPropertyStub::class)
             ->assertSee('false');
     }
+
+    /** @test */
+    public function isset_is_false_on_null_computed_property()
+    {
+        Livewire::test(NullIssetComputedPropertyStub::class)
+            ->assertSee('false');
+    }
 }
 
 class ComputedPropertyStub extends Component
@@ -155,3 +162,18 @@ class FalseIssetComputedPropertyStub extends Component{
         return view('isset-foo');
     }
 }
+
+class NullIssetComputedPropertyStub extends Component{
+    public $upperCasedFoo = 'FOO_BAR';
+
+    public function getFooProperty()
+    {
+        return null;
+    }
+
+    public function render()
+    {
+        return view('isset-foo');
+    }
+}
+


### PR DESCRIPTION
This pull request fixes a bug where a null return from a computed property is considered set. This is because no check was actually performed on the computed property value, but instead it was just checking if the computed property value could be retrieved.