### PR TITLE
add assertNotEmittedTo method

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -165,6 +165,15 @@ trait MakesAssertions
 
         return $this;
     }
+    public function assertNotEmittedTo($target, $value, ...$params)
+    {
+        $this->assertEmitted($value, ...$params);
+        $result = $this->testNotEmittedTo($target, $value);
+
+        PHPUnit::assertTrue($result, "Failed asserting that an event [{$value}] was not fired to {$target}.");
+
+        return $this;
+    }
 
     public function assertEmittedUp($value, ...$params)
     {
@@ -210,6 +219,19 @@ trait MakesAssertions
             ? $target::getName()
             : $target;
 
+        return (bool) collect(data_get($this->payload, 'effects.emits'))->first(function ($item) use ($target, $value) {
+            return $item['event'] === $value
+                && $item['to'] === $target;
+        });
+
+    }
+
+    protected function testNotEmittedTo($target, $value)
+    {
+        $target = is_subclass_of($target, Component::class)
+            ? $target::getName()
+            : $target;
+        dd($target);
         return (bool) collect(data_get($this->payload, 'effects.emits'))->first(function ($item) use ($target, $value) {
             return $item['event'] === $value
                 && $item['to'] === $target;

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -231,10 +231,10 @@ trait MakesAssertions
         $target = is_subclass_of($target, Component::class)
             ? $target::getName()
             : $target;
-        dd($target);
+
         return (bool) collect(data_get($this->payload, 'effects.emits'))->first(function ($item) use ($target, $value) {
             return $item['event'] === $value
-                && $item['to'] === $target;
+                && $item['to'] != $target;
         });
 
     }

--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -234,7 +234,7 @@ trait MakesAssertions
 
         return (bool) collect(data_get($this->payload, 'effects.emits'))->first(function ($item) use ($target, $value) {
             return $item['event'] === $value
-                && $item['to'] != $target;
+                && $item['to'] !== $target;
         });
 
     }

--- a/tests/Unit/Components/ComponentWhichDoesntEmittedTo.php
+++ b/tests/Unit/Components/ComponentWhichDoesntEmittedTo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Components;
+
+class ComponentWhichDoesntEmittedTo
+{
+
+}

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use Components\ComponentWhichDoesntEmittedTo;
 use Livewire\Component;
 use Livewire\Livewire;
 use PHPUnit\Framework\AssertionFailedError;
@@ -234,6 +235,22 @@ class LivewireTestingTest extends TestCase
             ->call('emitFooWithParam', 'baz')
             ->assertNotEmitted('foo', function ($event, $params) {
                 return $event !== 'foo' && $params !== ['bar'];
+            });
+    }
+
+    /** @test */
+    public function assert_not_emitted_to()
+    {
+        Livewire::test(EmitsEventsComponentStub::class)
+            ->call('emitFooToSomeComponent')
+            ->assertNotEmittedTo('other-component', 'foo')
+            ->call('emitFooToAComponentAsAModel')
+            ->assertNotEmittedTo(ComponentWhichDoesntEmittedTo::class, 'foo')
+            ->call('emitFooToSomeComponentWithParam', 'bar')
+            ->assertNotEmittedTo('other-component', 'foo', 'bar')
+            ->call('emitFooToSomeComponentWithParam', 'bar')
+            ->assertNotEmittedTo('other-component','foo', function ($event, $params) {
+                return $event === 'foo' && $params === ['bar'];
             });
     }
 


### PR DESCRIPTION
[Discussion](https://github.com/livewire/livewire/discussions/5047#discussion-4155783)

### What is the improvement?
- add assertNotEmittedTo function 

### Why is this improvement useful?
- To assert that an event emitted, but NOT emitted to a particular component.
- this would help in cases like the one described in the [discussion](https://github.com/livewire/livewire/discussions/5047#discussion-4155783)

### Sample Code
```
//Emitter Class
public function mount(bool $condition) : void
    {
            $condition? $this->emitTo(ComponentA::class,'testEvent') :  $this->emitTo(ComponentB::class,'testEvent');
    }
//Test function
Livewire::test(Emitter::class,['condition'=>true])
            ->assertEmittedTo(ComponentA::class,'testEvent')
            ->assertNotEmittedTo(ComponentB::class,'testEvent');
```

Let me know please if there are any improvements you would like me to add! 
thank you 💟 


