### PR TITLE
Publish less files to packagist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,10 @@
 /tests              export-ignore
 /.editorconfig      export-ignore
 /github_banner.png  export-ignore
+/.github            export-ignore
+/babel.config.js    export-ignore
+/jest.config.js     export-ignore
+/rollup.config.js   export-ignore
+/.prettierrc        export-ignore
+/.all-contributorsrc export-ignore
+/squishy            export-ignore


### PR DESCRIPTION
I noticed that there are some files published to Packagist, that are only needed while developing locally. This results in e.g. every developer downloading the `.github/` folder, which is not necessary.

These are the files/folders downloaded after a fresh install:
```
ls -alh vendor/livewire/livewire
total 608
drwxr-xr-x  19 niclasvaneyk  staff   608B Jun 19 04:54 .
drwxr-xr-x   3 niclasvaneyk  staff    96B Jul 18 18:41 ..
-rw-r--r--   1 niclasvaneyk  staff    18K Jun 19 04:54 .all-contributorsrc
drwxr-xr-x   7 niclasvaneyk  staff   224B Jun 19 04:54 .github
-rw-r--r--   1 niclasvaneyk  staff    93B Jun 19 04:54 .prettierrc
-rw-r--r--   1 niclasvaneyk  staff   1.0K Jun 19 04:54 LICENSE.md
-rw-r--r--   1 niclasvaneyk  staff   1.2K Jun 19 04:54 README.md
-rw-r--r--   1 niclasvaneyk  staff   655B Jun 19 04:54 babel.config.js
-rw-r--r--   1 niclasvaneyk  staff   1.4K Jun 19 04:54 composer.json
drwxr-xr-x   3 niclasvaneyk  staff    96B Jun 19 04:54 config
drwxr-xr-x   5 niclasvaneyk  staff   160B Jun 19 04:54 dist
-rw-r--r--   1 niclasvaneyk  staff   239B Jun 19 04:54 jest.config.js
drwxr-xr-x  16 niclasvaneyk  staff   512B Jun 19 04:54 js
-rw-r--r--   1 niclasvaneyk  staff   244K Jun 19 04:54 package-lock.json
-rw-r--r--   1 niclasvaneyk  staff   876B Jun 19 04:54 package.json
-rw-r--r--   1 niclasvaneyk  staff   1.5K Jun 19 04:54 rollup.config.js
-rwxr-xr-x   1 niclasvaneyk  staff   1.4K Jun 19 04:54 squishy
drwxr-xr-x  41 niclasvaneyk  staff   1.3K Jun 19 04:54 src
drwxr-xr-x   5 niclasvaneyk  staff   160B Jun 19 04:54 stubs
```

This PR ensures that the following files won't end up in the `vendor/` folder:

- the `.github/` directory. This is also done by [all of spaties packages](https://github.com/spatie/package-skeleton-laravel/blob/main/.gitattributes#L5) and only contains files required by GitHub
- the `{babel,rollup,jest}.config.js`. They are only needed while building/developing JS locally, so there is no need to distribute them to the end user
- the `squishy` script, which is also only needed while developing locally
- the `.prettierrc` for similar reasons as the two above
- the `.all-contributorsrc` file. A really nice concept (did not know about the project before!), but I don't think this file needs to be downloaded for all users of Livewire

After applying these changes, exporting using `git export`, then extracting the archive, this is the new result:

```
@NiclasvanEyk ➜ /workspaces/livewire/latest (publish-less-files-to-packagist ✗) $ ls -alh
total 292K
drwxrwxrwx+  7 codespace codespace 4.0K Aug  2 22:01 .
drwxrwxrwx+ 11 codespace root      4.0K Aug  2 22:00 ..
-rw-rw-r--   1 codespace codespace 1.5K Aug  2 21:29 composer.json
drwxrwxr-x+  2 codespace codespace 4.0K Aug  2 21:29 config
drwxrwxr-x+  2 codespace codespace 4.0K Aug  2 21:29 dist
drwxrwxr-x+  7 codespace codespace 4.0K Aug  2 21:29 js
-rw-rw-r--   1 codespace codespace 1.1K Aug  2 21:29 LICENSE.md
-rw-rw-r--   1 codespace codespace  876 Aug  2 21:29 package.json
-rw-rw-r--   1 codespace codespace 245K Aug  2 21:29 package-lock.json
-rw-rw-r--   1 codespace codespace 1.3K Aug  2 21:29 README.md
drwxrwxr-x+ 12 codespace codespace 4.0K Aug  2 21:29 src
drwxrwxr-x+  2 codespace codespace 4.0K Aug  2 21:29 stubs
```

This results in developers having to download less files. It may not seem like much, but if every vendor slims down their download size it adds up. Especially for a project with this many installs!

Very nice contribution guidelines at https://laravel-livewire.com/docs/2.x/contribution-guide btw! I have never seen such an elaborate one before.
