### PR TITLE
Declare properties in classes to avoid having problems with dynamic properties

### DIFF
--- a/src/Commands/ComponentParser.php
+++ b/src/Commands/ComponentParser.php
@@ -14,6 +14,12 @@ class ComponentParser
     protected $component;
     protected $componentClass;
     protected $directories;
+    protected $baseClassNamespace;
+    protected $baseTestNamespace;
+    protected $baseClassPath;
+    protected $baseViewPath;
+    protected $baseTestPath;
+    protected $stubDirectory;
 
     public function __construct($classNamespace, $viewPath, $rawCommand, $stubSubDirectory = '')
     {

--- a/src/Commands/CopyCommand.php
+++ b/src/Commands/CopyCommand.php
@@ -9,6 +9,7 @@ class CopyCommand extends FileManipulationCommand
     protected $signature = 'livewire:copy {name} {new-name} {--inline} {--force} {--test}';
 
     protected $description = 'Copy a Livewire component';
+    private $newParser;
 
     public function handle()
     {

--- a/src/Commands/MoveCommand.php
+++ b/src/Commands/MoveCommand.php
@@ -9,6 +9,7 @@ class MoveCommand extends FileManipulationCommand
     protected $signature = 'livewire:move {name} {new-name} {--force} {--inline}';
 
     protected $description = 'Move a Livewire component';
+    private $newParser;
 
     public function handle()
     {
@@ -80,7 +81,7 @@ class MoveCommand extends FileManipulationCommand
         if (!File::exists($oldTestPath) || File::exists($newTestPath)) {
             return false;
         }
-        
+
         $this->ensureDirectoryExists($newTestPath);
         File::move($oldTestPath, $newTestPath);
         return $newTestPath;

--- a/src/Macros/ViewMacros.php
+++ b/src/Macros/ViewMacros.php
@@ -6,6 +6,8 @@ use Illuminate\View\AnonymousComponent;
 
 class ViewMacros
 {
+    public $livewireLayout;
+
     public function extends()
     {
         return function ($view, $params = []) {

--- a/src/ObjectPrybar.php
+++ b/src/ObjectPrybar.php
@@ -7,6 +7,7 @@ use ReflectionClass;
 class ObjectPrybar
 {
     protected $obj;
+    public $reflected;
 
     public function __construct($obj)
     {

--- a/src/Redirector.php
+++ b/src/Redirector.php
@@ -6,6 +6,8 @@ use Illuminate\Routing\Redirector as BaseRedirector;
 
 class Redirector extends BaseRedirector
 {
+    public $component;
+
     public function to($path, $status = 302, $headers = [], $secure = null)
     {
         $this->component->redirect($this->generator->to($path, [], $secure));

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -12,6 +12,7 @@ class TemporaryUploadedFile extends UploadedFile
 {
     protected $storage;
     protected $path;
+    public $disk;
 
     public function __construct($path, $disk)
     {

--- a/src/WireDirective.php
+++ b/src/WireDirective.php
@@ -8,6 +8,10 @@ use Illuminate\View\ComponentAttributeBag;
 
 class WireDirective implements Htmlable, Stringable
 {
+    public $name;
+    public $directive;
+    public $value;
+
     public function __construct($name, $directive, $value)
     {
         $this->name = $name;

--- a/tests/Unit/ComponentPropertyBindingsStubs.php
+++ b/tests/Unit/ComponentPropertyBindingsStubs.php
@@ -62,6 +62,8 @@ class ComponentWithPropBindingsAndMountMethod extends Component
 
     public $parent;
 
+    public $name;
+
     public function mount(PropBoundModel $parent)
     {
         $this->parent = $parent;

--- a/tests/Unit/DirectlyAssignComponentParametersAsPropertiesTest.php
+++ b/tests/Unit/DirectlyAssignComponentParametersAsPropertiesTest.php
@@ -42,6 +42,8 @@ class ComponentWithDirectlyAssignedPropertiesAndMountMethod extends \Livewire\Co
 {
     public $foo;
     public $baz;
+    public $fooFromMount;
+    public $bazFromMount;
 
     public function mount($foo, $baz)
     {

--- a/tests/Unit/ImplicitlyBoundMethodTest.php
+++ b/tests/Unit/ImplicitlyBoundMethodTest.php
@@ -429,6 +429,8 @@ class ImplicitlyBoundMethodTester extends ImplicitlyBoundMethod
 
 class ContainerTestModel extends \Illuminate\Database\Eloquent\Model
 {
+    public $value;
+
     public function __construct()
     {
         $this->value = func_get_args();
@@ -443,6 +445,8 @@ class ContainerTestModel extends \Illuminate\Database\Eloquent\Model
 
 class NullContainerTestModel extends \Illuminate\Database\Eloquent\Model
 {
+    public $value;
+
     public function __construct()
     {
         $this->value = func_get_args();

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -493,9 +493,6 @@ class ForValidation extends Component
     ];
     public $password = '';
     public $passwordConfirmation = '';
-    public $messages;
-    public $validationAttributes;
-    public $validationCustomValues;
 
     public function runValidation()
     {

--- a/tests/Unit/ValidationTest.php
+++ b/tests/Unit/ValidationTest.php
@@ -493,6 +493,9 @@ class ForValidation extends Component
     ];
     public $password = '';
     public $passwordConfirmation = '';
+    public $messages;
+    public $validationAttributes;
+    public $validationCustomValues;
 
     public function runValidation()
     {


### PR DESCRIPTION
Dynamic properties are going to be deprecated in 8.2

Relevant RFC: https://wiki.php.net/rfc/deprecate_dynamic_properties

The only changes are the properties added. There is no change in functionality.  It just declares properties I found that were dynamically created.

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Discussion here: https://github.com/livewire/livewire/discussions/5168

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No, just the properties.
