### PR TITLE
Change from nowdoc to heredoc on asset warning output

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -248,7 +248,7 @@ HTML;
             $fullAssetPath = ($this->isRunningServerless() ? config('app.asset_url') : $assetsUrl).'/vendor/livewire'.$versionedFileName;
 
             if ($manifest !== $publishedManifest) {
-                $assetWarning = <<<'HTML'
+                $assetWarning = <<<HTML
 <script {$nonce}>
     console.warn("Livewire: The published Livewire assets are out of date\n See: https://laravel-livewire.com/docs/installation/")
 </script>


### PR DESCRIPTION
Currently the asset warning script `$nonce` variable isn't being evaluated due to nowdoc syntax, as such that breaks turbolinks/turbo.

Currently when it renders, it looks like this:

![Screen Shot 2022-08-10 at 8 49 26 am](https://user-images.githubusercontent.com/882837/183775528-6e339cad-003f-48c9-bb5a-d370c1d73f24.png)

Which causes this error in turbolinks:

![image](https://user-images.githubusercontent.com/882837/183775591-87b2631f-5da7-46c0-a45a-872283ad70e4.png)

So have changed it to heredoc, so when the nonce is empty is doesn't render anything:

![Screen Shot 2022-08-10 at 8 49 44 am](https://user-images.githubusercontent.com/882837/183775681-f94b2106-056c-4ca3-98f6-84ae3b57edd5.png)

Hope this helps!