### PR TITLE
Add assertions for FileDownloaded contents

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -400,4 +400,28 @@ trait MakesAssertions
 
         return $this;
     }
+    
+    public function assertFileDownloadedContains($content)
+    {
+        $downloadedContent = data_get($this->lastResponse, 'original.effects.download.content');
+
+        PHPUnit::assertStringContainsString(
+            $content,
+            base64_decode($downloadedContent)
+        );
+
+        return $this;
+    }
+    
+    public function assertFileDownloadedNotContains($content)
+    {
+        $downloadedContent = data_get($this->lastResponse, 'original.effects.download.content');
+
+        PHPUnit::assertStringNotContainsString(
+            $content,
+            base64_decode($downloadedContent)
+        );
+
+        return $this;
+    }
 }

--- a/tests/Unit/FileDownloadsTest.php
+++ b/tests/Unit/FileDownloadsTest.php
@@ -73,6 +73,22 @@ class FileDownloadsTest extends TestCase
             ->assertFileDownloaded()
             ->assertSeeText('Thanks!');
     }
+    
+    /** @test */
+    public function can_check_a_downloaded_file_contains()
+    {
+        Livewire::test(FileDownloadComponent::class)
+                ->call('streamDownload', 'download.txt')
+                ->assertFileDownloadedContains('alpine');
+    }
+    
+    /** @test */
+    public function can_check_a_downloaded_file_does_not_contain()
+    {
+        Livewire::test(FileDownloadComponent::class)
+                ->call('streamDownload', 'download.txt')
+                ->assertFileDownloadedNotContains('vuejs');
+    }
 }
 
 class FileDownloadComponent extends Component


### PR DESCRIPTION
@joshhanley here's the PR for #4981

This adds:
- an assertion `assertFileDownloadedContains `to check for some specific partial content in the downloaded file.
- an assertion `assertFileDownloadedNotContains `to check for missing specific partial content in the downloaded file.
