### PR TITLE
add method to get the preRenderedView

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -156,6 +156,11 @@ abstract class Component
             ->toArray();
     }
 
+    public function getPreRenderedView()
+    {
+        return $this->preRenderedView;
+    }
+
     public function skipRender()
     {
         $this->shouldSkipRender = true;
@@ -274,7 +279,7 @@ abstract class Component
     {
         return $this->forStack;
     }
-    
+
     function __isset($property)
     {
         try {

--- a/tests/Unit/ComponentGetPreRenderedViewTest.php
+++ b/tests/Unit/ComponentGetPreRenderedViewTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class ComponentGetPreRenderedViewTest extends TestCase
+{
+    /** @test */
+    public function it_should_get_the_pre_rendered_view()
+    {
+        $component = new ComponentExample('fake-id');
+
+        $component->renderToView();
+
+        $this->assertNotNull($component->getPreRenderedView());
+        $this->assertInstanceOf(View::class, $component->getPreRenderedView());
+    }
+}
+
+class ComponentExample extends Component
+{
+    public function render()
+    {
+        return view('null-view');
+    }
+}


### PR DESCRIPTION
1️⃣ **Is this something that is wanted/needed? Did you create a discussion about it first?**
Yes, I want to modify the livewire behavior, but I need access to the rendered view in many cases
https://github.com/livewire/livewire/discussions/5190

2️⃣ **Did you create a branch for your fix/feature? (Master branch PR's will be closed)**
Yes

3️⃣ **Does it contain multiple, unrelated changes? Please separate the PRs out.**
No

4️⃣ **Does it include tests? (Required)**
Yes

5️⃣ **Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.**
It will be really useful if we can get access to the preRenderedView property in the livewire component, I need to use a trait to expose it.

Thanks for contributing! 🙌
