### PR TITLE
spread attributes for dynamic components

### DIFF
--- a/src/LivewireTagCompiler.php
+++ b/src/LivewireTagCompiler.php
@@ -112,6 +112,15 @@ class LivewireTagCompiler extends ComponentTagCompiler
                                 ? "'{$attribute}' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute({$value})"
                                 : "'{$attribute}' => {$value}";
                 })
+                ->when(PHP_VERSION_ID >= 80100, function($collection) {
+                    return $collection->map(function (string $value, string $attribute) {
+                        if(! str($attribute)->startsWith('wire:spread')) {
+                            return $value;
+                        }
+
+                        return str($value)->after('=> ')->prepend('...')->toString();
+                    });
+                })
                 ->implode(',');
     }
 }

--- a/src/LivewireTagCompiler.php
+++ b/src/LivewireTagCompiler.php
@@ -118,7 +118,7 @@ class LivewireTagCompiler extends ComponentTagCompiler
                             return $value;
                         }
 
-                        return str($value)->after('=> ')->prepend('...')->toString();
+                        return (string) str($value)->after('=> ')->prepend('...');
                     });
                 })
                 ->implode(',');

--- a/tests/Unit/TagCompilerTest.php
+++ b/tests/Unit/TagCompilerTest.php
@@ -111,6 +111,42 @@ class TagCompilerTest extends TestCase
     }
 
     /** @test */
+    public function it_compiles_livewire_dynamic_component_and_spread_attributes()
+    {
+        if(PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped();
+        }
+
+        $alertComponent = '<livewire:is component="alert" :wire:spread="$alertAttributes" />';
+        $result = $this->compiler->compile($alertComponent);
+
+        $this->assertEquals('@livewire(\'alert\', [...$alertAttributes])', $result);
+
+        $alertComponent = '<livewire:is component="alert" :wire:spread="[\'type\' => \'warning\']" />';
+        $result = $this->compiler->compile($alertComponent);
+
+        $this->assertEquals("@livewire('alert', [...['type' => 'warning']])", $result);
+    }
+
+    /** @test */
+    public function it_compiles_livewire_dynamic_component_and_not_spread_attributes()
+    {
+        if(PHP_VERSION_ID >= 80100) {
+            $this->markTestSkipped();
+        }
+
+        $alertComponent = '<livewire:is component="alert" :wire:spread="$alertAttributes" />';
+        $result = $this->compiler->compile($alertComponent);
+
+        $this->assertEquals('@livewire(\'alert\', [\'wire:spread\' => $alertAttributes])', $result);
+
+        $alertComponent = '<livewire:is component="alert" :wire:spread="[\'type\' => \'warning\']" />';
+        $result = $this->compiler->compile($alertComponent);
+
+        $this->assertEquals("@livewire('alert', ['wire:spread' => ['type' => 'warning']])", $result);
+    }
+
+    /** @test */
     public function it_uses_existing_dynamic_component_if_one_exists()
     {
         Livewire::component('dynamic-component', DynamicComponent::class);


### PR DESCRIPTION
Currently dynamic-components are not that dynamic as you need to hardcode the attributes
```blade
<livewire:dynamic-component component="alert" :type="$type" :message="$message" />
```

Or pass them via a "magic" attribute
```blade
<livewire:dynamic-component :component="$component" :attributes="$attributes" />
```
But then you have to parse them in the `Component` and assigned them yourself:
```php
public function mount(array $attributes) {
     $this->type = $attributes['type'];
     $this->message = $attributes['message'];
}
```

With this PR we will have `wire:spread`
```blade
<livewire:dynamic-component :component="$component" :wire:spread="$attributes" />
```
so we don't have to monkey around with arrays in mount

This will only be supported if you run PHP 8.1.

Below PHP 8.1 nothing will be manipulated, you could retrieve attributes via `mount`
```php
public function mount() {
     $attributes = func_get_args()[0];
     $this->type = $attributes['type'];
     $this->message = $attributes['message'];
}
```

