### PR TITLE
Pass uploaded bytes and total bytes to progress hook

### DIFF
--- a/js/component/FileUploads.js
+++ b/js/component/FileUploads.js
@@ -12,7 +12,7 @@ export default function () {
 
             el.dispatchEvent(
                 new CustomEvent('livewire-upload-progress', {
-                    bubbles: true, detail: { progress: percentCompleted }
+                    bubbles: true, detail: { progress: percentCompleted, loaded: progressEvent.loaded, total: progressEvent.total }
                 })
             )
         }


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
I needed it in a new project of mine where I wanted to calculate the upload speed and the time remaining. Currently the only ifnromation we get in the progress event hook is the progress percentage as an integer and the total file size. With this information it is hard to estimate the upload speed and total estimated time since we can only calculate these things when the value of the progress changes but with large files this can take a while. 

This PR allows us to calculate the precise progress ourselves and allows for further calculations.

I did not create a discussion about this first.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
No new branch was created, I forked this repo and applied the changes I applied in my project aswell.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope

