### PR TITLE
Check success before showing COMPONENT MOVED message

### DIFF
--- a/src/Commands/MoveCommand.php
+++ b/src/Commands/MoveCommand.php
@@ -33,7 +33,7 @@ class MoveCommand extends FileManipulationCommand
         $test = $this->renameTest();
         $this->refreshComponentAutodiscovery();
 
-        $this->line("<options=bold,reverse;fg=green> COMPONENT MOVED </> 🤙\n");
+        if ($class) $this->line("<options=bold,reverse;fg=green> COMPONENT MOVED </> 🤙\n");
         $class && $this->line("<options=bold;fg=green>CLASS:</> {$this->parser->relativeClassPath()} <options=bold;fg=green>=></> {$this->newParser->relativeClassPath()}");
         if (! $inline) $view && $this->line("<options=bold;fg=green>VIEW:</>  {$this->parser->relativeViewPath()} <options=bold;fg=green>=></> {$this->newParser->relativeViewPath()}");
         if ($test) $test && $this->line("<options=bold;fg=green>Test:</>  {$this->parser->relativeTestPath()} <options=bold;fg=green>=></> {$this->newParser->relativeTestPath()}");


### PR DESCRIPTION
I accidentally ran a `livewire:move` twice in a row and noticed that you get both a fail and success messages if files already exist: 
<img width="776" alt="image" src="https://user-images.githubusercontent.com/7386641/195988241-a0f05fc3-f5d6-4238-8d40-dd77eefe7869.png">
This checks that it went well prior to outputting the `COMPONENT MOVED 🤙` message.