### PR TITLE
Add `StringNormalization` support to arrays and collections to fix Safari checksum issues

### DIFF
--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -98,9 +98,11 @@ class HydratePublicProperties implements HydrationMiddleware
             ) {
                 data_set($response, 'memo.data.'.$key, $value);
             } else if(is_array($value)) {
+                // The data here needs to be normalised, so that Safari handles special charaters properly without throwing a checksum exception.
                 data_set($response, 'memo.data.'.$key, static::normalizeArray($value));
             } else if(is_string($value)) {
                 data_set($response, 'memo.data.'.$key, \Normalizer::normalize($value));
+                // The data here needs to be normalised, so that Safari handles special charaters properly without throwing a checksum exception.
             } else if ($value instanceof Wireable && version_compare(PHP_VERSION, '7.4', '>=')) {
                 $response->memo['dataMeta']['wireables'][] = $key;
 
@@ -112,6 +114,7 @@ class HydratePublicProperties implements HydrationMiddleware
             } else if ($value instanceof Collection) {
                 $response->memo['dataMeta']['collections'][] = $key;
 
+                // The data here needs to be normalised, so that Safari handles special charaters properly without throwing a checksum exception.
                 data_set($response, 'memo.data.'.$key, static::normalizeCollection($value)->toArray());
             } else if ($value instanceof DateTimeInterface) {
                 if ($value instanceof IlluminateCarbon) {

--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -94,13 +94,14 @@ class HydratePublicProperties implements HydrationMiddleware
         array_walk($publicData, function ($value, $key) use ($instance, $response) {
             if (
                 // The value is a supported type, set it in the data, if not, throw an exception for the user.
-                is_bool($value) || is_null($value) || is_array($value) || is_numeric($value)
+                is_bool($value) || is_null($value) || is_numeric($value)
             ) {
                 data_set($response, 'memo.data.'.$key, $value);
+            } else if(is_array($value)) {
+                data_set($response, 'memo.data.'.$key, static::normalizeArray($value));
             } else if(is_string($value)) {
                 data_set($response, 'memo.data.'.$key, \Normalizer::normalize($value));
-            }
-              else if ($value instanceof Wireable && version_compare(PHP_VERSION, '7.4', '>=')) {
+            } else if ($value instanceof Wireable && version_compare(PHP_VERSION, '7.4', '>=')) {
                 $response->memo['dataMeta']['wireables'][] = $key;
 
                 data_set($response, 'memo.data.'.$key, $value->toLivewire());
@@ -111,7 +112,7 @@ class HydratePublicProperties implements HydrationMiddleware
             } else if ($value instanceof Collection) {
                 $response->memo['dataMeta']['collections'][] = $key;
 
-                data_set($response, 'memo.data.'.$key, $value->toArray());
+                data_set($response, 'memo.data.'.$key, static::normalizeCollection($value)->toArray());
             } else if ($value instanceof DateTimeInterface) {
                 if ($value instanceof IlluminateCarbon) {
                     $response->memo['dataMeta']['dates'][$key] = 'illuminate';
@@ -316,5 +317,43 @@ class HydratePublicProperties implements HydrationMiddleware
         }
 
         return $filteredData;
+    }
+
+    protected static function normalizeArray($value)
+    {
+        return array_map(function ($item) {
+            if (is_string($item)) {
+                return \Normalizer::normalize($item);
+            }
+
+            if (is_array($item)) {
+                return static::normalizeArray($item);
+            }
+
+            if ($item instanceof Collection) {
+                return static::normalizeCollection($item);
+            }
+
+            return $item;
+        }, $value);
+    }
+
+    protected static function normalizeCollection($value)
+    {
+        return $value->map(function ($item) {
+            if (is_string($item)) {
+                return \Normalizer::normalize($item);
+            }
+
+            if (is_array($item)) {
+                return static::normalizeArray($item);
+            }
+
+            if ($item instanceof Collection) {
+                return static::normalizeCollection($item);
+            }
+
+            return $item;
+        });
     }
 }

--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -21,6 +21,7 @@ use Carbon\Carbon;
 use DateTime;
 use DateTimeInterface;
 use stdClass;
+use Normalizer;
 
 class HydratePublicProperties implements HydrationMiddleware
 {
@@ -101,8 +102,8 @@ class HydratePublicProperties implements HydrationMiddleware
                 // The data here needs to be normalised, so that Safari handles special charaters properly without throwing a checksum exception.
                 data_set($response, 'memo.data.'.$key, static::normalizeArray($value));
             } else if(is_string($value)) {
-                data_set($response, 'memo.data.'.$key, \Normalizer::normalize($value));
                 // The data here needs to be normalised, so that Safari handles special charaters properly without throwing a checksum exception.
+                data_set($response, 'memo.data.'.$key, Normalizer::normalize($value));
             } else if ($value instanceof Wireable && version_compare(PHP_VERSION, '7.4', '>=')) {
                 $response->memo['dataMeta']['wireables'][] = $key;
 
@@ -326,7 +327,7 @@ class HydratePublicProperties implements HydrationMiddleware
     {
         return array_map(function ($item) {
             if (is_string($item)) {
-                return \Normalizer::normalize($item);
+                return Normalizer::normalize($item);
             }
 
             if (is_array($item)) {
@@ -345,7 +346,7 @@ class HydratePublicProperties implements HydrationMiddleware
     {
         return $value->map(function ($item) {
             if (is_string($item)) {
-                return \Normalizer::normalize($item);
+                return Normalizer::normalize($item);
             }
 
             if (is_array($item)) {

--- a/tests/Browser/StringNormalization/Component.php
+++ b/tests/Browser/StringNormalization/Component.php
@@ -9,6 +9,7 @@ class Component extends BaseComponent
 {
     public $string = 'â';
     public $number = 0;
+    public $array = ['â'];
 
     public function render()
     {

--- a/tests/Browser/StringNormalization/Component.php
+++ b/tests/Browser/StringNormalization/Component.php
@@ -13,11 +13,15 @@ class Component extends BaseComponent
     public $recursiveArray = ['â', ['â']];
     public $collection;
     public $recursiveCollection;
+    public $model;
+    public $modelCollection;
 
     public function mount()
     {
         $this->collection = collect(['â']);
         $this->recursiveCollection = collect(['â', ['â']]);
+        $this->model = Model::find(1);
+        $this->modelCollection = Model::all();
     }
 
     public function render()

--- a/tests/Browser/StringNormalization/Component.php
+++ b/tests/Browser/StringNormalization/Component.php
@@ -10,6 +10,15 @@ class Component extends BaseComponent
     public $string = 'â';
     public $number = 0;
     public $array = ['â'];
+    public $recursiveArray = ['â', ['â']];
+    public $collection;
+    public $recursiveCollection;
+
+    public function mount()
+    {
+        $this->collection = collect(['â']);
+        $this->recursiveCollection = collect(['â', ['â']]);
+    }
 
     public function render()
     {

--- a/tests/Browser/StringNormalization/Model.php
+++ b/tests/Browser/StringNormalization/Model.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Browser\StringNormalization;
+
+use Illuminate\Database\Eloquent\Model as BaseModel;
+use Sushi\Sushi;
+
+class Model extends BaseModel
+{
+    use Sushi;
+
+    protected $rows = [
+        [
+            'id' => 1,
+            'name' => 'â'
+        ]
+    ];
+}

--- a/tests/Browser/StringNormalization/view.blade.php
+++ b/tests/Browser/StringNormalization/view.blade.php
@@ -5,5 +5,7 @@
     <pre>{{ print_r($recursiveArray, true) }}</pre>
     <pre>{{ print_r($collection->toArray(), true) }}</pre>
     <pre>{{ print_r($recursiveCollection->toArray(), true) }}</pre>
+    <pre>{{ print_r($model->name, true) }}</pre>
+    <pre>{{ print_r($modelCollection->toArray(), true) }}</pre>
     <button id="add_number" wire:click="addNumber">Add Number</button>
 </div>

--- a/tests/Browser/StringNormalization/view.blade.php
+++ b/tests/Browser/StringNormalization/view.blade.php
@@ -1,5 +1,6 @@
 <div>
     <div>{{ $string }}</div>
     <div>{{ $number }}</div>
+    <div>{{ $array[0] }}</div>
     <button id="add_number" wire:click="addNumber">Add Number</button>
 </div>

--- a/tests/Browser/StringNormalization/view.blade.php
+++ b/tests/Browser/StringNormalization/view.blade.php
@@ -1,6 +1,9 @@
 <div>
     <div>{{ $string }}</div>
     <div>{{ $number }}</div>
-    <div>{{ $array[0] }}</div>
+    <pre>{{ print_r($array, true) }}</pre>
+    <pre>{{ print_r($recursiveArray, true) }}</pre>
+    <pre>{{ print_r($collection->toArray(), true) }}</pre>
+    <pre>{{ print_r($recursiveCollection->toArray(), true) }}</pre>
     <button id="add_number" wire:click="addNumber">Add Number</button>
 </div>

--- a/tests/Browser/TestCase.php
+++ b/tests/Browser/TestCase.php
@@ -32,7 +32,7 @@ class TestCase extends BaseTestCase
 {
     use SupportsSafari;
 
-    public static $useSafari = true;
+    public static $useSafari = false;
     public static $useAlpineV3 = false;
 
     public function setUp(): void

--- a/tests/Browser/TestCase.php
+++ b/tests/Browser/TestCase.php
@@ -32,7 +32,7 @@ class TestCase extends BaseTestCase
 {
     use SupportsSafari;
 
-    public static $useSafari = false;
+    public static $useSafari = true;
     public static $useAlpineV3 = false;
 
     public function setUp(): void


### PR DESCRIPTION
Update `StringNormalization` test to prove that special chars are not normalized and break Safari checksum.  
https://github.com/livewire/livewire/pull/4942 don't fix all cases.
