### PR TITLE
Add BackedEnum as possible type for property

### DIFF
--- a/src/Exceptions/PublicPropertyTypeNotAllowedException.php
+++ b/src/Exceptions/PublicPropertyTypeNotAllowedException.php
@@ -9,7 +9,7 @@ class PublicPropertyTypeNotAllowedException extends \Exception
     public function __construct($componentName, $key, $value)
     {
         parent::__construct(
-            "Livewire component's [{$componentName}] public property [{$key}] must be of type: [numeric, string, array, null, or boolean].\n".
+            "Livewire component's [{$componentName}] public property [{$key}] must be of type: [numeric, string, array, null, boolean, or BackedEnum].\n".
             "Only protected or private properties can be set as other types because JavaScript doesn't need to access them."
         );
     }

--- a/tests/Unit/PublicPropertiesAreCastToJavaScriptUsableTypesTest.php
+++ b/tests/Unit/PublicPropertiesAreCastToJavaScriptUsableTypesTest.php
@@ -87,6 +87,16 @@ class PublicPropertiesAreCastToJavaScriptUsableTypesTest extends TestCase
         Livewire::test(ComponentWithPropertiesStub::class, ['foo' => $orderedNumericArray])
             ->assertSet('foo', [[0 => 'bar', 1 => 'foo']]);
     }
+
+    /** @test */
+    public function exception_throw_mention_backed_enum_as_possible_type()
+    {
+        $this->expectException(PublicPropertyTypeNotAllowedException::class);
+        $this->expectDeprecationMessageMatches('/BackedEnum/');
+        Livewire::component('foo', ComponentWithPropertiesStub::class);
+
+        View::make('render-component', ['component' => 'foo', 'params' => ['foo' => new \StdClass]])->render();
+    }
 }
 
 class ComponentWithPropertiesStub extends Component


### PR DESCRIPTION
Since backed enums can be used as a type since commit 8dd340ea07da5c5eb33afa3fce258046b4a6938a, is good to have it mentioned on PublicPropertyTypeNotAllowedException.

I was misled thinking that enums were not supported since I didn't see enums on the list provided in the exception message, but the problem was just that my enums were not backed.