### PR TITLE
Fix route matching issues

### DIFF
--- a/src/Controllers/HttpConnectionHandler.php
+++ b/src/Controllers/HttpConnectionHandler.php
@@ -33,7 +33,7 @@ class HttpConnectionHandler extends ConnectionHandler
             );
         } catch (NotFoundHttpException $e) {
             $request = $this->makeRequestFromUrlAndMethod(
-                Str::replaceFirst(request('fingerprint')['locale'].'/', '', Livewire::originalUrl()),
+                Str::replaceFirst('/'.request('fingerprint')['locale'], '', Livewire::originalUrl()),
                 Livewire::originalMethod()
             );
         }

--- a/src/Controllers/HttpConnectionHandler.php
+++ b/src/Controllers/HttpConnectionHandler.php
@@ -62,7 +62,11 @@ class HttpConnectionHandler extends ConnectionHandler
 
     protected function makeRequestFromUrlAndMethod($url, $method = 'GET')
     {
-        $request = Request::create($url, $method);
+        // Ensure the original script paths are passed into the fake request incase Laravel is running in a subdirectory
+        $request = Request::create($url, $method, [], [], [], [
+            'SCRIPT_FILENAME' => request()->server->get('SCRIPT_FILENAME'),
+            'PHP_SELF' => request()->server->get('PHP_SELF'),
+        ]);
 
         if (request()->hasSession()) {
             $request->setLaravelSession(request()->session());

--- a/src/Controllers/HttpConnectionHandler.php
+++ b/src/Controllers/HttpConnectionHandler.php
@@ -29,6 +29,9 @@ class HttpConnectionHandler extends ConnectionHandler
         try {
             $originalUrl = Livewire::originalUrl();
 
+            // If the original path was the root route, updated the original URL to have
+            // a suffix of '/' to ensure that the route matching works correctly when
+            // a prefix is used (such as running Laravel in a subdirectory).
             if (Livewire::originalPath() == '/') {
                 $originalUrl .= '/';
             }
@@ -41,6 +44,9 @@ class HttpConnectionHandler extends ConnectionHandler
 
             $originalUrl = Str::replaceFirst('/'.request('fingerprint')['locale'], '', Livewire::originalUrl());
 
+            // If the original path was the root route, updated the original URL to have
+            // a suffix of '/' to ensure that the route matching works correctly when
+            // a prefix is used (such as running Laravel in a subdirectory).
             if (Livewire::originalPath() == request('fingerprint')['locale']) {
                 $originalUrl .= '/';
             }

--- a/src/Controllers/HttpConnectionHandler.php
+++ b/src/Controllers/HttpConnectionHandler.php
@@ -27,13 +27,26 @@ class HttpConnectionHandler extends ConnectionHandler
     public function applyPersistentMiddleware()
     {
         try {
+            $originalUrl = Livewire::originalUrl();
+
+            if (Livewire::originalPath() == '/') {
+                $originalUrl .= '/';
+            }
+
             $request = $this->makeRequestFromUrlAndMethod(
-                Livewire::originalUrl(),
+                $originalUrl,
                 Livewire::originalMethod()
             );
         } catch (NotFoundHttpException $e) {
+
+            $originalUrl = Str::replaceFirst('/'.request('fingerprint')['locale'], '', Livewire::originalUrl());
+
+            if (Livewire::originalPath() == request('fingerprint')['locale']) {
+                $originalUrl .= '/';
+            }
+
             $request = $this->makeRequestFromUrlAndMethod(
-                Str::replaceFirst('/'.request('fingerprint')['locale'], '', Livewire::originalUrl()),
+                $originalUrl,
                 Livewire::originalMethod()
             );
         }
@@ -64,6 +77,7 @@ class HttpConnectionHandler extends ConnectionHandler
     {
         // Ensure the original script paths are passed into the fake request incase Laravel is running in a subdirectory
         $request = Request::create($url, $method, [], [], [], [
+            'SCRIPT_NAME' => request()->server->get('SCRIPT_NAME'),
             'SCRIPT_FILENAME' => request()->server->get('SCRIPT_FILENAME'),
             'PHP_SELF' => request()->server->get('PHP_SELF'),
         ]);


### PR DESCRIPTION
Fixes #5462, #5467, #5471, #5466, #5470, #5464 and comments on PR #4570.

## The original bug

This issue originally started when the persistant middleware feature was added to Livewire.

When this was added, Livewire support for locale prefixes broke, as it was trying to match routes based on the `/` root path. But localised applications may have a prefix like `/en` in the path.

A 404 is triggered when the route cannot be matched.

<img width="1728" alt="Pasted image 20230106133835" src="https://user-images.githubusercontent.com/882837/210925482-e6619c10-5bd3-44c8-8773-323768964ce2.png">

This was fixed in [v2.3.14](https://github.com/livewire/livewire/commit/3ead3ff1342d9b17c7fd3559fd1a5f880cf78f28), by first trying to match the root route, and if that doesn't work then it gets the locale from the fingerprint, removes it from the path and tries again.

## The bug that was recently fixed

But it still didn't completely fix the issue, due to a bug with the `Str::replaceFirst()` parameter order, causing it to always return a URL of an empty string "" which is essentially the root URL.

If the root route has authentication on it, and the user isn't logged in, it actually triggers a redirect to the login page, causing Livewire to break completely, as the response is the HTML for the login page.

<img width="641" alt="Pasted image 20230106133703" src="https://user-images.githubusercontent.com/882837/210925540-d3a41f02-32ae-4ebd-b93f-7987da682cec.png">

If there is no authentication though, there are other instances where a `NotFoundHttpException` can occur (such as if there is no root route), triggering the 404 modal.

You can see an example of this bug in the below screenshot (see `ReplaceFirst with bug` output).

It takes the current url `http://livewire-httpconnectionhandler-demo.test/en/welcome` and returns an empty URL.

<img width="587" alt="Pasted image 20230106133145" src="https://user-images.githubusercontent.com/882837/210925664-cc7f2be5-91b8-42c7-9184-fbe554890a7b.png">

A fix was recently merged for this in [PR #4570](https://github.com/livewire/livewire/pull/4570) that swapped the order of the parameters in `Str::replaceFirst()` and the result is shown above (see `ReplaceFirst with fix`), where the URL correctly has the locale removed.

The above fix works great for anyone using packages like [mcamara/laravel-localization](https://github.com/mcamara/laravel-localization) so that localisation is handled correctly.

## The latest bugs

The fix which corrected the parameter order of `Str::ReplaceFirst` has uncovered two new bugs, one of which is when running a Laravel/Livewire app in a sub directory, and the other is when using localisation on the root route. 

### Localisation on the root route

For an app that uses localisation on the root route, it would have a URL like `http://livewire-httpconnectionhandler-demo.test/en`. This URL currently triggers a 404 with the fix from PR#4570 due to it trying to match the locale and then a forward slash.

This can be fixed by ensuring the forward slash is before the locale instead of after, as [noted here](https://github.com/livewire/livewire/pull/4570#issuecomment-1363572394).

### Hosting in a subdirectory

In the scenario where a Laravel/Livewire application is hosted in a subdirectory, currently the latest release of Livewire (v2.10.8) breaks all Livewire components when a subsequent request is triggered.

First question is, why are people hosting them in subdirectories? As it turns out, there are quite a lot of people who still use Apache, and only have a single web root folder configured on their local machines. Therefore then run all they're apps out of subdirectories. So this issue is mainly impacting their local development environment. But when the deploy their app to a proper domain, it is fine.

So what is happening is, if running an application using a URL such as `http://localhost/myapp/mycomponent`, any subsequent Livewire requests return a 404, as the route that is trying to be matched is `/myapp/mycomponent` instead of the path relative to the project of `/mycomponent`.

Now as to why this bug has started happening.

The reason for this is, now that the `Str::replaceFirst()` is actually returning a full URL (instead of an empty string), Livewire is making use of this URL to match it against any available routes to try and find the original route (for the persistent middleware feature).

To determine the original route and its assigned middleware, Livewire generates a fake request using the URL and method provided. This request is then used to match against routes in Laravel's router.

But the faked request that gets generated isn't aware of the projects true base path being inside a subdirectory in the main web root folder, as such believes it's base path is the web root folder, causing to try and match the full URI (`/myapp/mycomponent`) as explained above.

To fix this, we can make use of the real request to Livewire's endpoint to determine the projects actual path and pass these details into the faked request, allowing it to run the match correctly.

## Conclusion

This PR fixes both of the above issues. I have tested it locally using a repo that has localisation and another repo being hosted in a subdirectory, ensuring that the bugs do actually occur and that applying this PR fixes them.

I've also made sure persistent middleware still all works as expected.

These issues are related but also distinct, so if required, I can split into two PRs, but felt it was easier just to give all the context in one PR.

I have no idea how to test this, as such haven't added tests to this PR.

Hope this helps!