### PR TITLE
Update signature for UploadedFile::storeAs to match new Laravel signature

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -125,7 +125,7 @@ class TemporaryUploadedFile extends UploadedFile
         return $this->storage->delete($this->path);
     }
 
-    public function storeAs($path, $name, $options = [])
+    public function storeAs($path, $name = null, $options = [])
     {
         $options = $this->parseOptions($options);
 


### PR DESCRIPTION
This is a fix for the upcoming Laravel 10.x.

Laravel made the path argument optional in UploadedFile::storeAs in https://github.com/laravel/framework/commit/8d4741665f564cc8a3e15d823c0bb025a85324b4 causing errors in the subclass as this method needs the same update.