### PR TITLE
Laravel v10 Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,17 +13,25 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
-        laravel: [7.*, 8.*, 9.*]
+        php: [7.2, 7.3, 7.4, '8.0', 8.1, 8.2]
+        laravel: [7.*, 8.*, 9.*, 10.*]
         exclude:
           - php: 7.2
             laravel: 9.*
+          - php: 7.2
+            laravel: 10.*
           - php: 7.3
             laravel: 9.*
+          - php: 7.3
+            laravel: 10.*
           - php: 7.4
             laravel: 9.*
+          - php: 7.4
+            laravel: 10.*
           - php: 7.2
             laravel: 8.*
+          - php: '8.0'
+            laravel: 10.*
           - php: 8.1
             laravel: 7.*
           - php: 8.2

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     "require": {
         "php": "^7.2.5|^8.0",
         "symfony/http-kernel": "^5.0|^6.0",
-        "illuminate/support": "^7.0|^8.0|^9.0",
-        "illuminate/database": "^7.0|^8.0|^9.0",
-        "illuminate/validation": "^7.0|^8.0|^9.0",
+        "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
+        "illuminate/database": "^7.0|^8.0|^9.0|^10.0",
+        "illuminate/validation": "^7.0|^8.0|^9.0|^10.0",
         "league/mime-type-detection": "^1.9"
     },
     "require-dev": {
@@ -21,8 +21,8 @@
         "mockery/mockery": "^1.3.1",
         "phpunit/phpunit": "^8.4|^9.0",
         "laravel/framework": "^7.0|^8.0|^9.0",
-        "orchestra/testbench": "^5.0|^6.0|^7.0",
-        "orchestra/testbench-dusk": "^5.2|^6.0|^7.0",
+        "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0",
+        "orchestra/testbench-dusk": "^5.2|^6.0|^7.0|^8.0",
         "calebporzio/sushi": "^2.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "psy/psysh": "@stable",
         "mockery/mockery": "^1.3.1",
         "phpunit/phpunit": "^8.4|^9.0",
-        "laravel/framework": "^7.0|^8.0|^9.0",
+        "laravel/framework": "^7.0|^8.0|^9.0|^10.0",
         "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0",
         "orchestra/testbench-dusk": "^5.2|^6.0|^7.0|^8.0",
         "calebporzio/sushi": "^2.1"

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -125,7 +125,7 @@ class TemporaryUploadedFile extends UploadedFile
         return $this->storage->delete($this->path);
     }
 
-    public function storeAs($path, $name, $options = [])
+    public function storeAs($path, $name = null, $options = [])
     {
         $options = $this->parseOptions($options);
 

--- a/tests/Unit/ModelAttributesCanBeCastTest.php
+++ b/tests/Unit/ModelAttributesCanBeCastTest.php
@@ -171,16 +171,16 @@ class ModelAttributesCanBeCastTest extends TestCase
             ->call('validateAttribute', 'model.decimal_with_one_digit')
             ->assertHasNoErrors('model.decimal_with_one_digit');
 
-        if (version_compare(app()->version(), '9.46.0', '<')) {
+        if (version_compare(app()->version(), '9.46.0', '>=') && version_compare(app()->version(), '9.48.0', '<')) {
                 // Laravel 9.46 changed how decimal property rounding is handled,
                 // where rounding up will no longer be applied laravel/framework PR#45492
             $component
-                ->assertSet('model.decimal_with_one_digit', 5.6)
-                ->assertPayloadSet('model.decimal_with_one_digit', 5.6);
-        } else {
-            $component
                 ->assertSet('model.decimal_with_one_digit', 5.5)
                 ->assertPayloadSet('model.decimal_with_one_digit', 5.5);
+        } else {
+            $component
+                ->assertSet('model.decimal_with_one_digit', 5.6)
+                ->assertPayloadSet('model.decimal_with_one_digit', 5.6);
         }
     }
 
@@ -195,7 +195,7 @@ class ModelAttributesCanBeCastTest extends TestCase
             ->call('validateAttribute', 'model.decimal_with_two_digits')
             ->assertHasNoErrors('model.decimal_with_two_digits');
 
-        if (version_compare(app()->version(), '9.46.0', '>=')) {
+        if (version_compare(app()->version(), '9.46.0', '>=') && version_compare(app()->version(), '9.48.0', '<')) {
                 // Laravel 9.46 changed how decimal property rounding is handled,
                 // where rounding up will no longer be applied laravel/framework PR#45492
             $component

--- a/tests/Unit/SessionTest.php
+++ b/tests/Unit/SessionTest.php
@@ -42,7 +42,7 @@ class SessionTest extends TestCase
         $this->assertTrue($request->hasSession());
         $this->assertInstanceOf(Store::class, $request->session());
 
-        Str::startsWith($this->app->version(), '9.')
+        version_compare($this->app->version(), '9', '>=')
             ? $this->assertInstanceOf(SessionInterface::class, $request->getSession())
             : $this->assertInstanceOf(Store::class, $request->getSession());
     }


### PR DESCRIPTION
This PR adds Laravel v10 support. We'll need this to update Jetstream: https://github.com/laravel/jetstream/pull/1216

Depends on:

- [x] https://github.com/calebporzio/sushi/pull/109