### PR TITLE
Add `assertReturned` method to test return value of a method

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -400,4 +400,15 @@ trait MakesAssertions
 
         return $this;
     }
+
+    public function assertReturned($value)
+    {
+        if (is_callable($value)) {
+            PHPUnit::assertTrue($value(array_values(data_get($this->lastResponse, 'effects.returns'))[0]));
+        } else {
+            PHPUnit::assertEquals($value, array_values(data_get($this->lastResponse, 'effects.returns'))[0]);
+        }
+
+        return $this;
+    }
 }

--- a/tests/Unit/TestableLivewireCanAssertReturnedValueTest.php
+++ b/tests/Unit/TestableLivewireCanAssertReturnedValueTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use Livewire\LivewireManager;
+
+class TestableLivewireCanAssertReturnedValueTest extends TestCase
+{
+    /** @test */
+    public function can_assert_return_value_of_called_method()
+    {
+        $component = Livewire::test(AssertReturnedValueOfMethodComponent::class);
+
+        $component->call('someMethod')->assertReturned('foo');
+    }
+
+    /** @test */
+    public function can_assert_invalid_return_value_of_called_method()
+    {
+        $component = Livewire::test(AssertReturnedValueOfMethodComponent::class);
+
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+
+        $component->call('someMethod')->assertReturned('bar');
+    }
+
+    /** @test */
+    public function can_assert_return_value_of_called_method_using_closure()
+    {
+        $component = Livewire::test(AssertReturnedValueOfMethodComponent::class);
+
+        $component->call('someMethod')->assertReturned(fn ($value) => $value === 'foo');
+    }
+
+    /** @test */
+    public function can_assert_invalid_return_value_of_called_method_using_closure()
+    {
+        $component = Livewire::test(AssertReturnedValueOfMethodComponent::class);
+
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+
+        $component->call('someMethod')->assertReturned(fn ($value) => $value !== 'foo');
+    }
+}
+
+class AssertReturnedValueOfMethodComponent extends Component
+{
+    public function someMethod()
+    {
+        return 'foo';
+    }
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}

--- a/tests/Unit/TestableLivewireCanAssertReturnedValueTest.php
+++ b/tests/Unit/TestableLivewireCanAssertReturnedValueTest.php
@@ -31,7 +31,9 @@ class TestableLivewireCanAssertReturnedValueTest extends TestCase
     {
         $component = Livewire::test(AssertReturnedValueOfMethodComponent::class);
 
-        $component->call('someMethod')->assertReturned(fn ($value) => $value === 'foo');
+        $component->call('someMethod')->assertReturned(function ($value) {
+            return $value === 'foo';
+        });
     }
 
     /** @test */
@@ -41,7 +43,9 @@ class TestableLivewireCanAssertReturnedValueTest extends TestCase
 
         $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
 
-        $component->call('someMethod')->assertReturned(fn ($value) => $value !== 'foo');
+        $component->call('someMethod')->assertReturned(function ($value) {
+            return $value !== 'foo';
+        });
     }
 }
 


### PR DESCRIPTION
Currently there is no easy way to assert the return value of method:

```php
class SomeComponent extends Component
{
    public function someMethod()
    {
        return 'foo'; // How to test that 'foo' is returned when this method is called?
    }
}
```
This PR adds an   `assertReturned` method to make that possible.
```php
Livewire::test(SomeComponent::class)
   ->call('someMethod')
   ->assertReturned('foo'); //  OR  ->assertReturned(fn ($value) => $value === 'foo');
```