### PR TITLE
Remove dot from command description

### DIFF
--- a/src/Commands/S3CleanupCommand.php
+++ b/src/Commands/S3CleanupCommand.php
@@ -11,7 +11,7 @@ class S3CleanupCommand extends Command
 {
     protected $signature = 'livewire:configure-s3-upload-cleanup';
 
-    protected $description = 'Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs.';
+    protected $description = 'Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs';
 
     public function handle()
     {


### PR DESCRIPTION
A command (`S3CleanupCommand`) has been added since my last PR (#967).

This PR simply removes the ending dot, to follow Laravel's artisan conventions.