### PR TITLE
Fix snake case attributes when using the Attribute casting

### DIFF
--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -241,6 +241,8 @@ class HydratePublicProperties implements HydrationMiddleware
     }
 
     public static function filterData($instance, $property) {
+        Model::cacheMutatedAttributes(get_class($instance->$property));
+
         $cacheSnakeAttributes = Model::$snakeAttributes;
         Model::$snakeAttributes = false;
 

--- a/tests/Browser/DataBinding/Models/Test.php
+++ b/tests/Browser/DataBinding/Models/Test.php
@@ -152,7 +152,7 @@ if(class_exists(Attribute::class)) {
             return $this->hasMany(OtherComment::class);
         }
 
-        public function firstName(): Attribute
+        public function firstName()
         {
             return Attribute::make(
                 function() {
@@ -161,7 +161,7 @@ if(class_exists(Attribute::class)) {
             );
         }
 
-        public function lastName(): Attribute
+        public function lastName()
         {
             return Attribute::make(
                 function() {

--- a/tests/Browser/DataBinding/Models/Test.php
+++ b/tests/Browser/DataBinding/Models/Test.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Browser\DataBinding\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use Livewire\Livewire;
 use Sushi\Sushi;
@@ -16,13 +18,13 @@ class Test extends TestCase
         $this->browse(function (Browser $browser) {
             Livewire::visit($browser, Component::class)
                 // ->tinker()
-                ->assertValue('@author.name', 'Bob')
+                ->assertValue('@author.name', 'Bob Doe')
                 ->assertValue('@author.email', 'bob@bob.com')
                 ->assertValue('@author.posts.0.title', 'Post 1')
                 ->assertValue('@author.posts.0.comments.0.comment', 'Comment 1')
-                ->assertValue('@author.posts.0.comments.0.author.name', 'Bob')
+                ->assertValue('@author.posts.0.comments.0.author.name', 'Bob Doe')
                 ->assertValue('@author.posts.0.comments.1.comment', 'Comment 2')
-                ->assertValue('@author.posts.0.comments.1.author.name', 'John')
+                ->assertValue('@author.posts.0.comments.1.author.name', 'John Doe')
                 ->assertValue('@author.posts.1.title', 'Post 2')
                 ;
         });
@@ -57,10 +59,10 @@ class Test extends TestCase
         $this->assertEquals('Mike', $author->posts[0]->comments[1]->author->name);
 
         // Reset back after finished.
-        $author->name = 'Bob';
+        $author->name = 'Bob Doe';
         $author->posts[0]->title = 'Post 1';
         $author->posts[0]->comments[0]->comment = 'Comment 1';
-        $author->posts[0]->comments[1]->author->name = 'John';
+        $author->posts[0]->comments[1]->author->name = 'John Doe';
         $author->push();
     }
 
@@ -70,9 +72,9 @@ class Test extends TestCase
         $this->browse(function (Browser $browser) {
             Livewire::visit($browser, Component::class)
                 ->assertValue('@author.posts.0.otherComments.0.comment', 'Other Comment 1')
-                ->assertValue('@author.posts.0.otherComments.0.author.name', 'Bob')
+                ->assertValue('@author.posts.0.otherComments.0.author.name', 'Bob Doe')
                 ->assertValue('@author.posts.0.otherComments.1.comment', 'Other Comment 2')
-                ->assertValue('@author.posts.0.otherComments.1.author.name', 'John')
+                ->assertValue('@author.posts.0.otherComments.1.author.name', 'John Doe')
 
                 ->waitForLivewire()->type('@author.posts.0.otherComments.0.comment', 'Other Message 1')
                 ->assertSeeIn('@output.author.posts.0.otherComments.0.comment', 'Other Message 1')
@@ -91,35 +93,124 @@ class Test extends TestCase
 
         // Reset back after finished.
         $author->posts[0]->otherComments[0]->comment = 'Other Comment 1';
-        $author->posts[0]->otherComments[1]->author->name = 'John';
+        $author->posts[0]->otherComments[1]->author->name = 'John Doe';
+        $author->push();
+    }
+
+    /** @test */
+    public function it_supports_attribute_casts()
+    {
+        $this->browse(function (Browser $browser) {
+            Livewire::visit($browser, Component::class)
+                ->waitForLivewire()->type('@author.name', 'Steve Doe')
+                ->assertSeeIn('@output.author.name', 'Steve Doe')
+
+                ->waitForLivewire()->click('@save')
+            ;
+        });
+
+        $author = Author::first();
+
+        $this->assertEquals('Steve', $author->first_name);
+        $this->assertEquals('Doe', $author->last_name);
+
+        // Reset back after finished.
+        $author->name = 'John Doe';
         $author->push();
     }
 }
 
-class Author extends Model
-{
-    use Sushi;
-
-    protected $guarded = [];
-
-    protected $rows = [
-        ['id' => 1, 'name' => 'Bob', 'email' => 'bob@bob.com'],
-        ['id' => 2, 'name' => 'John', 'email' => 'john@john.com']
-    ];
-
-    public function posts()
+if(class_exists(Attribute::class)) {
+    class Author extends Model
     {
-        return $this->hasMany(Post::class);
+        use Sushi;
+
+        protected $guarded = [];
+
+        protected $rows = [
+            ['id' => 1, 'name' => 'Bob Doe', 'email' => 'bob@bob.com'],
+            ['id' => 2, 'name' => 'John Doe', 'email' => 'john@john.com']
+        ];
+
+        protected $appends = [
+            'first_name',
+            'last_name'
+        ];
+
+        public function posts()
+        {
+            return $this->hasMany(Post::class);
+        }
+
+        public function comments()
+        {
+            return $this->hasMany(Comment::class);
+        }
+
+        public function otherComments()
+        {
+            return $this->hasMany(OtherComment::class);
+        }
+
+        public function firstName(): Attribute
+        {
+            return Attribute::make(
+                function() {
+                    return Str::before($this->name, ' ');
+                }
+            );
+        }
+
+        public function lastName(): Attribute
+        {
+            return Attribute::make(
+                function() {
+                    return Str::after($this->name, ' ');
+                }
+            );
+        }
     }
-
-    public function comments()
+} else {
+    class Author extends Model
     {
-        return $this->hasMany(Comment::class);
-    }
+        use Sushi;
 
-    public function otherComments()
-    {
-        return $this->hasMany(OtherComment::class);
+        protected $guarded = [];
+
+        protected $rows = [
+            ['id' => 1, 'name' => 'Bob Doe', 'email' => 'bob@bob.com'],
+            ['id' => 2, 'name' => 'John Doe', 'email' => 'john@john.com']
+        ];
+
+        protected $appends = [
+            'first_name',
+            'last_name'
+        ];
+
+        public function posts()
+        {
+            return $this->hasMany(Post::class);
+        }
+
+        public function comments()
+        {
+            return $this->hasMany(Comment::class);
+        }
+
+        public function otherComments()
+        {
+            return $this->hasMany(OtherComment::class);
+        }
+
+        public function getFirstNameAttribute()
+        {
+            return Str::before($this->name, ' ');
+        }
+
+        public function getLastNameAttribute()
+        {
+            return Str::after($this->name, ' ');
+        }
     }
 }
 


### PR DESCRIPTION
Issue is described in #5535 and was introduced in #5525.

This PR had an unintentional knock-on effect with snake case attributes that are appended to the model json when serializing. [This behaviour is documented in the latest version of Laravel](https://laravel.com/docs/9.x/eloquent-serialization#appending-values-to-json).

I've proposed a solution that caches the model attributes before disabling snake case attributes. #5525 disables snake case so the relations can be properly accessed by Livewire, this aims to keep the fixes introduced in that PR, whilst also keeping support for snake case attributes.

Additionally, I have added a test for this, but since snake case attributes were introduced in Laravel 8+ they're only added if the `Attribute` class exists, though I have also added the fallback methods in older versions.