### PR TITLE
Support anonymous class component registration

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -42,7 +42,6 @@ class LivewireManager
             $viewClass = $viewClass::class;
         }
 
-
         $this->componentAliases[$alias] = $viewClass;
     }
 

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -39,7 +39,7 @@ class LivewireManager
         }
 
         if (is_object($viewClass)) {
-            $viewClass = $viewClass::class;
+            $viewClass = get_class($viewClass);
         }
 
         $this->componentAliases[$alias] = $viewClass;

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -27,7 +27,7 @@ class LivewireManager
     ];
 
     public static $isLivewireRequestTestingOverride = false;
-    
+
     public static $currentCompilingViewPath;
     public static $currentCompilingChildCounter;
 
@@ -37,6 +37,11 @@ class LivewireManager
             $viewClass = $alias;
             $alias = $viewClass::getName();
         }
+
+        if (is_object($viewClass)) {
+            $viewClass = $viewClass::class;
+        }
+
 
         $this->componentAliases[$alias] = $viewClass;
     }
@@ -462,7 +467,7 @@ HTML;
         static::$isLivewireRequestTestingOverride = false;
         static::$currentCompilingChildCounter = null;
         static::$currentCompilingViewPath = null;
-        
+
         $this->shouldDisableBackButtonCache = false;
 
         $this->dispatch('flush-state');

--- a/tests/Unit/AnonymousClassComponentsTest.php
+++ b/tests/Unit/AnonymousClassComponentsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+
+class AnonymousClassComponentsTest extends TestCase
+{
+    /** @test */
+    public function can_register_anonymous_class_as_component()
+    {
+        Livewire::component('foo', new class extends \Livewire\Component {
+            public $count = 0;
+
+            function inc()
+            {
+                $this->count++;
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    <span>Count: {{ $count }}</span>
+                    <button wire:click="inc">inc</button>
+                </div>
+                HTML;
+            }
+        });
+
+        $component = Livewire::test('foo')
+            ->assertSee('Count: 0')
+            ->call('inc')
+            ->assertSee('Count: 1');
+    }
+}


### PR DESCRIPTION
This PR makes the following possible:

```php
// In something like a service provider:

Livewire::component('foo', new class extends \Livewire\Component {
    // ....
});
```

Now you can use the component as normal:

```html
<livewire:foo />
```
