### PR TITLE
Query string sorting

### DIFF
--- a/tests/Browser/QueryString/ComponentWithSort.php
+++ b/tests/Browser/QueryString/ComponentWithSort.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace QueryString;
+
+use Tests\Browser\QueryString\ComponentWithTraits;
+
+class ComponentWithSort extends ComponentWithTraits
+{
+    protected $queryString = [
+        'page' => ['sort' => 2],
+        'search' => ['sort' => 1],
+    ];
+}

--- a/tests/Browser/QueryString/ComponentWithSort.php
+++ b/tests/Browser/QueryString/ComponentWithSort.php
@@ -1,13 +1,20 @@
 <?php
 
-namespace QueryString;
+namespace Tests\Browser\QueryString;
 
-use Tests\Browser\QueryString\ComponentWithTraits;
+use Illuminate\Support\Facades\View;
+use Livewire\Component as BaseComponent;
 
-class ComponentWithSort extends ComponentWithTraits
+class ComponentWithSort extends BaseComponent
 {
+    public $page = 1;
+    public $search = '';
     protected $queryString = [
         'page' => ['sort' => 2],
         'search' => ['sort' => 1],
     ];
+    public function render()
+    {
+        return '<input wire:model="search" type="text" dusk="search">';
+    }
 }

--- a/tests/Browser/QueryString/Test.php
+++ b/tests/Browser/QueryString/Test.php
@@ -4,6 +4,7 @@ namespace Tests\Browser\QueryString;
 
 use Livewire\Livewire;
 use Laravel\Dusk\Browser;
+use QueryString\ComponentWithSort;
 use Tests\Browser\TestCase;
 
 class Test extends TestCase
@@ -323,6 +324,15 @@ class Test extends TestCase
                 ->assertQueryStringHas('p', 2)
                 ->assertQueryStringHas('s', '1')
             ;
+        });
+    }
+
+
+    public function test_query_string_sort_params()
+    {
+        $this->browse(function (Browser $browser) {
+            Livewire::visit($browser, ComponentWithSort::class, '?page=2&search=1')
+                ->assertScript('return !! window.location.search.match(/search=1&page=2/)');
         });
     }
 }

--- a/tests/Browser/QueryString/Test.php
+++ b/tests/Browser/QueryString/Test.php
@@ -4,7 +4,7 @@ namespace Tests\Browser\QueryString;
 
 use Livewire\Livewire;
 use Laravel\Dusk\Browser;
-use QueryString\ComponentWithSort;
+use Tests\Browser\QueryString\ComponentWithSort;
 use Tests\Browser\TestCase;
 
 class Test extends TestCase
@@ -332,7 +332,9 @@ class Test extends TestCase
     {
         $this->browse(function (Browser $browser) {
             Livewire::visit($browser, ComponentWithSort::class, '?page=2&search=1')
-                ->assertScript('return !! window.location.search.match(/search=1&page=2/)');
+                ->waitForLivewire()
+                ->type('@search','p')
+                ->assertScript('return !! window.location.search.match(/search=p&page=2/)');
         });
     }
 }


### PR DESCRIPTION
As described here https://github.com/livewire/livewire/discussions/2722 for SEO reasons we must force a sorting for the query params. 

I've introduced a `sort` option for the QueryParams that will set the order of the queryParams.

here is an example:
```
    protected $queryString = [
        'page' => ['sort' => 2],
        'search' => ['sort' => 1],
    ];
```

The only problem I have is that in the initial request, it's not updating the URL to the correct order but when you update the value of one queryParams it will enforce the order based on the sort option.

I am not that familiar with browser testing and it might work in the initial request too but I couldn't write a test that passes on initial request