### PR TITLE
Fix persistent middleware redirect issue

### DIFF
--- a/src/Controllers/HttpConnectionHandler.php
+++ b/src/Controllers/HttpConnectionHandler.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Controllers;
 
+use Illuminate\Http\Response;
 use Livewire\Livewire;
 use Illuminate\Support\Str;
 use Illuminate\Pipeline\Pipeline;
@@ -75,7 +76,7 @@ class HttpConnectionHandler extends ConnectionHandler
             ->send($request)
             ->through($filteredMiddleware)
             ->then(function() {
-                return response()->noContent();
+                return new Response();
             });
     }
 

--- a/tests/Unit/RedirectTest.php
+++ b/tests/Unit/RedirectTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Unit;
 
+use Illuminate\Contracts\Routing\ResponseFactory;
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
 use Livewire\Component;
 use Livewire\Livewire;
-use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Redirect;
 
 class RedirectTest extends TestCase
 {
@@ -163,6 +165,14 @@ class RedirectTest extends TestCase
         $this->assertNull($component->payload['effects']['html']);
     }
 
+    /** @test */
+    public function it_redirects_properly_even_if_persistent_middleware_feature_returns_an_empty_response()
+    {
+        Livewire::test(RedirectFromActionComponent::class)
+            ->call('runAction')
+            ->assertRedirect('/home');
+    }
+
     protected function registerNamedRoute()
     {
         Route::get('foo', function () {
@@ -281,5 +291,33 @@ class RenderOnRedirectWithSkipRenderMethod extends Component
     Render has run
 </div>
 HTML;
+    }
+}
+
+class RedirectFromActionComponent extends Component
+{
+    public function runAction()
+    {
+        return app(RedirectAction::class);
+    }
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class RedirectAction implements Responsable
+{
+    protected $response;
+
+    public function __construct(ResponseFactory $response)
+    {
+        $this->response = $response;
+    }
+
+    public function toResponse($request)
+    {
+        return $this->response->redirectTo('/home');
     }
 }


### PR DESCRIPTION
Due to the recent change in Laravel 10 of adding types, Livewire's persistent middleware broke when a middleware was applied that required a return type of `Symfony\Component\HttpFoundation\Response`, such as the `guest` middleware.

The reason this broke was due to Livewire's fake request pipeline, in the persistent middleware feature, had no return and as such was returning `null`, causing a type error.

This has been recently fixed in [PR #5561](https://github.com/livewire/livewire/pull/5561) and released in v2.11.3.

But this PR has caused a new issue, see [discussion #5568](https://github.com/livewire/livewire/discussions/5568). What is happening is if an action class, such as those used in Jetstream, initiates a redirect response then Livewire is no longer handling the redirect using its redirect mechanisms. As such the redirects no longer work.

This is an example of such an action.

```php
use Illuminate\Contracts\Routing\ResponseFactory;
use Illuminate\Http\RedirectResponse;
use Laravel\Fortify\Contracts\VerifyEmailResponse;
use Livewire\Redirector;

class RedirectToHome implements VerifyEmailResponse
{
    public function __construct(
        private ResponseFactory $response,
    ) {}

    public function toResponse($request): RedirectResponse|Redirector
    {
        return $this->response->redirectToRoute('home');
    }
}
```

Digging into why this is happening, the fix in the PR above was to add `return response()->noContent()` to the end of the fake request pipeline, to satisfy the `Response` return type required by middleware.

But the problem with that is the `response()` helper actually retrieves an instance of the `ResponseFactory` from Laravel's container. As this is the first time it has been accessed, Laravel creates a new singleton instance and applies Laravel's `Redirector` class. 

See the `ResponseFactory` singleton registration here.

https://github.com/laravel/framework/blob/8dac049d27ee126c10a1fec9eda6d76cc560f94f/src/Illuminate/Routing/RoutingServiceProvider.php#L171-L176

This happens because the persistent middleware feature is run before any of Livewire's other features. As such, Livewire hasn't yet replaced the `Redirector` in the container, which happens later during component hydration.

See Livewire's replacement of the `Redirector` here.

https://github.com/livewire/livewire/blob/9da51085a7b02a8512a9d4c525d5ea96e8f52aa0/src/Features/SupportRedirects.php#L20-L27

Finally, when the action class is created by Laravel's container, the `ResponseFactory` is injected into it, which due to it being a singleton, still has a reference to Laravel's `Redirector` even though Livewire had replaced it.

This causes the redirect response to be a default Laravel redirect instead of a Livewire redirect, causing the redirect to fail.

This PR changes the persistent middleware feature to just manually instantiate a new `Response` object as it's not actually used for anything, therefore doesn't need to be built up using the `ResponseFactory`.

I've pushed a failing test first, and will push the fix once the tests have run.

Hope this helps!