### PR TITLE
Fix localised route paths

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -356,6 +356,13 @@ HTML;
         return request()->hasHeader('X-Livewire');
     }
 
+    public function getPayloadLocale()
+    {
+        $fingerprint = request()->only('fingerprint')['fingerprint'] ?? [];
+
+        return data_get($fingerprint, 'locale');
+    }
+
     public function originalUrl()
     {
         if ($this->isDefinitelyLivewireRequest()) {

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -138,6 +138,7 @@ class LivewireServiceProvider extends ServiceProvider
         $locale = Livewire::getPayloadLocale();
 
         if (isset($locale)) {
+            // `app()->setLocale()` can't be called here as the translator doesn't exist yet.
             config()->set('app.locale', $locale);
         }
     }

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -67,6 +67,7 @@ class LivewireServiceProvider extends ServiceProvider
         $this->registerTestMacros();
         $this->registerLivewireSingleton();
         $this->registerComponentAutoDiscovery();
+        $this->registerLocale();
     }
 
     public function boot()
@@ -128,6 +129,17 @@ class LivewireServiceProvider extends ServiceProvider
     protected function registerConfig()
     {
         $this->mergeConfigFrom(__DIR__.'/../config/livewire.php', 'livewire');
+    }
+
+    protected function registerLocale()
+    {
+        if (! Livewire::isLivewireRequest()) return;
+
+        $locale = Livewire::getPayloadLocale();
+
+        if (isset($locale)) {
+            config()->set('app.locale', $locale);
+        }
     }
 
     protected function registerViews()


### PR DESCRIPTION
This PR fixes an issue raised in discussion [#5526](https://github.com/livewire/livewire/discussions/5526), relating to Livewire's persistent middleware route matching not being able to match routes with localised paths. For context on the route matching, see the previous [PR #5490](https://github.com/livewire/livewire/pull/5490).

The previous PR fixed issues with localisation when it came to the locale prefix and the root route (without a locale).

One scenario that still hasn't been working though is when route paths are localised.

For example, with the below route definition, we can see that there is a route group with a locale prefix and there is a route `'favourites'` that can be translated into other locales.

```php
Route::prefix(LaravelLocalization::setLocale())->group(function () {
	Route::get(__('favourites'), MyComponent::class);
});
```

If we have language files set up to support both English and Dutch, then when the favourites route is loaded, it can be loaded through the English translations `'/en/favourites'` or `'/favourites'`, or another locale (if configured), such as Dutch, using `'/nl/favorieten'`.

Accessing the `'/nl/favorieten'` route works without any issue for the initial page load. But when a subsequent Livewire request is made, a `404` is returned as the route cannot be matched.

The reason the route cannot be matched is that when Livewire's endpoint is hit, the app, routes, and everything load, depending on the parameters in Livewire's request. Due to this, the app's default locale is used (such as `en`).

As such, Laravel's router has reference to the English translations of all the routes, such as `'/favourites'`. This means that when Livewire tries to do a route match with the original route path `'/nl/favorieten'`, it fails with a `404`.

The way it does the matching is, it first looks for a route with the path `'/nl/favorieten'`. If that path cannot be found, it removes the locale prefix and tries to match again using the path `'/favorieten'`. Which, if it also cannot be found, as the route is stored in the router as `'/favourites'`, it then triggers the `404` response.

Livewire tracks details of the original route, including its path and locale, as part of the component payload.

So what we need is to take the locale from Livewire's component payload and apply it to the app, before the router and all the routes are loaded, to ensure that the routes are all translated into the correct locale before Livewire tries to do the route match.

**HttpConnectionHandler experiment**
I experimented with applying the locale to the app within the `Livewire\Controllers\HttpConnectionHandler`. Due to Livewire having already hit the `'/livewire/messages'` route, the router and routes have already been loaded in English, so applying the locale here had no effect.

**Custom middleware experiment**
I then experimented with adding a locale middleware as a permanent middleware that gets applied to Livewire's endpoints for all Livewire requests. Again though, this was too late in the lifecycle, as Laravel's router and routes get loaded in the `RouteServiceProvider::boot()` method and were already translated into English.

**The fix**
Finally, I source-dove Laravel's core, to find out what exactly the order of operations were and discovered that the `Request` object is bound to the container before any of the service providers have been loaded or either of their `register()` or `boot()` methods have been called.

This insight allowed me to come up with the implementation submitted in this PR, which is to retrieve the component payload locale from the request in Livewire's service provider's `register()` method, and if it's a Livewire request, then update the app's locale to match.

This ensures that the app's configured locale is the same as the one in the original request. So by the time the router and the routes are loaded in the `RouteServiceProvider::boot()` method, Laravel can correctly use the new app locale to translate the routes to the same locale as the original request.

Now when Livewire tries to match the path `'/nl/favorieten'`, it can correctly find the same route stored in the router.

I then tested this fix with a couple of repo's that I had been provided that demonstrated this issue, one using `mcamara/laravel-localisation` package and the other using a custom localisation implementation. Both of the repos were able to successfully match the translated routes when using this fix, allowing Livewire's request to finish properly instead of returning a `404`.

Hope this helps!