### PR TITLE
Handle error in XMLHttpRequest and pass to uploadErrored

### DIFF
--- a/js/component/UploadManager.js
+++ b/js/component/UploadManager.js
@@ -103,6 +103,10 @@ class UploadManager {
             request.setRequestHeader(key, value)
         })
 
+        request.addEventListener('error', e => {
+            this.component.call('uploadErrored', name, null, this.uploadBag.first(name).multiple)
+        })
+
         request.upload.addEventListener('progress', e => {
             e.detail = {}
             e.detail.progress = Math.round((e.loaded * 100) / e.total)


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Sorry, I did not start a discussion first, but this is a small PR that should be quick to review.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

4️⃣ Does it include tests? (Required)

It does not, but I didn't see where the upload component was tested in the browser. I would be happy to add tests for this if there is an existing place to add one :).

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This adds an event listener on the XMLHttpRequest for file uploads in UploadManager.js. 

Previously an error thrown here was not propagated up to the component, so the error callback is not triggered for things like CORS errors, aggressive Ad blocking extensions, or 500 errors (which we have encountered uploading directly to Backblaze B2).

In our use case, this results in the state we expose to the user getting stuck in "Uploading", even though the file has failed to upload.

Thanks for considering!

Jesse
