### PR TITLE
prevent error when assets are out of date

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -254,7 +254,7 @@ HTML;
             if ($manifest !== $publishedManifest) {
                 $assetWarning = <<<HTML
 <script {$nonce}>
-    console.warn("Livewire: The published Livewire assets are out of date\n See: https://laravel-livewire.com/docs/installation/")
+    console.warn("Livewire: The published Livewire assets are out of date. See: https://laravel-livewire.com/docs/installation/")
 </script>
 HTML;
             }

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -254,7 +254,7 @@ HTML;
             if ($manifest !== $publishedManifest) {
                 $assetWarning = <<<HTML
 <script {$nonce}>
-    console.warn("Livewire: The published Livewire assets are out of date. See: https://laravel-livewire.com/docs/installation/")
+    console.warn("Livewire: The published Livewire assets are out of date. \\n See: https://laravel-livewire.com/docs/installation/")
 </script>
 HTML;
             }


### PR DESCRIPTION
Fix: When published Livewire assets are out of date, the warn message causes an error instead of displaying the message.
