### PR TITLE
Adding assertion to test that an event was emitted to self

### DIFF
--- a/src/Testing/Concerns/MakesAssertions.php
+++ b/src/Testing/Concerns/MakesAssertions.php
@@ -176,6 +176,16 @@ trait MakesAssertions
         return $this;
     }
 
+    public function assertEmittedSelf($value, ...$params)
+    {
+        $this->assertEmitted($value, ...$params);
+        $result = $this->testEmittedSelf($value);
+
+        PHPUnit::assertTrue($result, "Failed asserting that an event [{$value}] was fired to itself.");
+
+        return $this;
+    }
+
     protected function testEmitted($value, $params)
     {
         $assertionSuffix = '.';
@@ -222,6 +232,15 @@ trait MakesAssertions
         return (bool) collect(data_get($this->payload, 'effects.emits'))->first(function ($item) use ($value) {
             return $item['event'] === $value
                 && $item['ancestorsOnly'] === true;
+        });
+    }
+
+
+    protected function testEmittedSelf($value)
+    {
+        return (bool) collect(data_get($this->payload, 'effects.emits'))->first(function ($item) use ($value) {
+            return $item['event'] === $value
+                && $item['selfOnly'] === true;
         });
     }
 

--- a/tests/Unit/LivewireTestingTest.php
+++ b/tests/Unit/LivewireTestingTest.php
@@ -217,6 +217,21 @@ class LivewireTestingTest extends TestCase
     }
 
     /** @test */
+    public function assert_emitted_self()
+    {
+        Livewire::test(EmitsEventsComponentStub::class)
+            ->call('emitFooSelf')
+            ->assertEmittedSelf('foo')
+            ->call('emitFooSelfWithParam', 'bar')
+            ->assertEmittedSelf('foo', 'bar')
+            ->call('emitFooSelfWithParam', 'bar')
+            ->assertEmittedSelf('foo', function ($event, $params) {
+                return $event === 'foo' && $params === ['bar'];
+            })
+        ;
+    }
+
+    /** @test */
     public function assert_not_emitted()
     {
         Livewire::test(EmitsEventsComponentStub::class)
@@ -386,6 +401,16 @@ class EmitsEventsComponentStub extends Component
     public function emitFooUpWithParam($param)
     {
         $this->emitUp('foo', $param);
+    }
+
+    public function emitFooSelf()
+    {
+        $this->emitSelf('foo');
+    }
+
+    public function emitFooSelfWithParam($param)
+    {
+        $this->emitSelf('foo', $param);
     }
 
     public function render()


### PR DESCRIPTION
As per title and discussion #5455. Simple assertion to `assertEmittedSelf($value, ...$params)`.

As a related issue/request/offer to PR, I would like to add `assertNotEmittedSelf` as well as other "negatives" for "to" and "up". We have `assertNotEmitted` so the others would be handy also. There may be some instances where these may be useful.
