### PR TITLE
Throw exception if `lastResponse` contains exception

### DIFF
--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Testing;
 
+use Exception;
 use Mockery;
 use Livewire\Livewire;
 use Illuminate\Routing\Route;
@@ -83,13 +84,18 @@ class TestableLivewire
 
         $this->lastResponse = $this->pretendWereMountingAComponentOnAPage($name, $params, $queryParams);
 
-        if (! $this->lastResponse->exception) {
-            $this->updateComponent([
-                'fingerprint' => $this->rawMountedResponse->fingerprint,
-                'serverMemo' => $this->rawMountedResponse->memo,
-                'effects' => $this->rawMountedResponse->effects,
-            ], $isInitial = true);
+        if($this->lastResponse->exception){
+            /** @var Exception $exception */
+            $exception = $this->lastResponse->exception;
+
+            throw new Exception(sprintf("A %d %s was thrown while mounting %s", $exception->getStatusCode(), $exception::class, $componentClass));
         }
+
+        $this->updateComponent([
+            'fingerprint' => $this->rawMountedResponse->fingerprint,
+            'serverMemo' => $this->rawMountedResponse->memo,
+            'effects' => $this->rawMountedResponse->effects,
+        ], $isInitial = true);
 
         Livewire::flushState();
     }


### PR DESCRIPTION
Currently, if there is an exception when mounting a component for testing, a vague test output is returned:

![image](https://user-images.githubusercontent.com/12905222/233680732-5f155fff-1570-4a87-89a4-481522c961b3.png)

This PR ensures that the test output is much more informative:

![image](https://user-images.githubusercontent.com/12905222/233681037-8c7eebc5-0e2a-4bc2-aae1-1cdf70221331.png)
