### PR TITLE
Only propagate server varaibles that were set in the initial request.

### DIFF
--- a/src/Controllers/HttpConnectionHandler.php
+++ b/src/Controllers/HttpConnectionHandler.php
@@ -83,11 +83,12 @@ class HttpConnectionHandler extends ConnectionHandler
     protected function makeRequestFromUrlAndMethod($url, $method = 'GET')
     {
         // Ensure the original script paths are passed into the fake request incase Laravel is running in a subdirectory
-        $request = Request::create($url, $method, [], [], [], [
-            'SCRIPT_NAME' => request()->server->get('SCRIPT_NAME'),
-            'SCRIPT_FILENAME' => request()->server->get('SCRIPT_FILENAME'),
-            'PHP_SELF' => request()->server->get('PHP_SELF'),
-        ]);
+        $serverVariables = Collection::make(request()->server->all())->only([
+            'SCRIPT_NAME',
+            'SCRIPT_FILENAME',
+            'PHP_SELF',
+        ])->toArray();
+        $request = Request::create($url, $method, [], [], [], $serverVariables);
 
         if (request()->hasSession()) {
             $request->setLaravelSession(request()->session());


### PR DESCRIPTION
When using Bref on AWS Lambda functions where SCRIPT_NAME is not provided the following depreciation notice was being thrown: basename(): Passing null to parameter #1 ($path) of type string is deprecated in /var/task/vendor/symfony/http-foundation/Request.php on line 1748

Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
