### PR TITLE
`imageSize` method on TemporaryUploadedFile to support `dimensions` validation rule

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -74,6 +74,13 @@ class TemporaryUploadedFile extends UploadedFile
         return $this->extractOriginalNameFromFilePath($this->path);
     }
 
+    public function imageSize(): ?array
+    {
+        stream_copy_to_stream($this->storage->readStream($this->path), $tmpFile = tmpfile());
+
+        return @getimagesize(stream_get_meta_data($tmpFile)['uri']);;
+    }
+
     public function temporaryUrl()
     {
         if ((FileUploadConfiguration::isUsingS3() or FileUploadConfiguration::isUsingGCS()) && ! app()->runningUnitTests()) {


### PR DESCRIPTION
Currently a test exists already that tests the use of `dimensions` rule, but that test only is successful because a real local path is provided to the `getimagesize()` method used by Laravel. In a real application, that path is a remote path on some bucket, so then the rule currently does not work. I won't know how can I make sure the test checks this.
https://github.com/livewire/livewire/blob/019b1e69d8cd8c7e749eba7a38e4fa69ecbc8f74/tests/Unit/FileUploadsTest.php#L310-L323

The `imageSize` method on `UploadedFile` was added in https://github.com/laravel/framework/pull/46912