### PR TITLE
Use urls generated by Laravel UrlGenerator instead of custom logic

### DIFF
--- a/js/connection/index.js
+++ b/js/connection/index.js
@@ -31,10 +31,12 @@ export default class Connection {
         let payload = message.payload()
         let csrfToken = getCsrfToken()
         let socketId = this.getSocketId()
-        let appUrl = window.livewire_app_url
+        let appUrl = window.livewire_message_url.replace('$name$', payload.fingerprint.name)
 
         if (this.shouldUseLocalePrefix(payload)) {
-            appUrl = `${appUrl}/${payload.fingerprint.locale}`
+            appUrl = window.livewire_message_url_localized
+                .replace('$name$', payload.fingerprint.name)
+                .replace('$locale$', payload.fingerprint.locale)
         }
 
 
@@ -44,7 +46,7 @@ export default class Connection {
 
         // Forward the query string for the ajax requests.
         fetch(
-            `${appUrl}/livewire/message/${payload.fingerprint.name}`,
+            appUrl,
             {
                 method: 'POST',
                 body: JSON.stringify(payload),

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -248,10 +248,8 @@ HTML;
 
         $assetsUrl = config('livewire.asset_url') ?: rtrim($options['asset_url'] ?? '', '/');
 
-        $appUrl = config('livewire.app_url')
-            ?: rtrim($options['app_url'] ?? '', '/')
-            ?: $assetsUrl;
-
+        $messageUrl = route('livewire.message', ['name' => '$name$']);
+        $messageUrlLocalized = route('livewire.message-localized', ['name' => '$name$', 'locale' => '$locale$']);
         $jsLivewireToken = app()->has('session.store') ? "'" . csrf_token() . "'" : 'null';
 
         $manifest = json_decode(file_get_contents(__DIR__.'/../dist/manifest.json'), true);
@@ -318,7 +316,8 @@ HTML;
     window.livewire = new Livewire({$jsonEncodedOptions});
     {$devTools}
     window.Livewire = window.livewire;
-    window.livewire_app_url = '{$appUrl}';
+    window.livewire_message_url = '{$messageUrl}';
+    window.livewire_message_url_localized = '{$messageUrlLocalized}';
     window.livewire_token = {$jsLivewireToken};
 
 	{$windowAlpineCheck}


### PR DESCRIPTION
We are building an application where we use transparent session ids. We have a custom UrlGenerator implementation that adds the session id to the query string for every request. Because Livewire is not using the UrlGenerator the create the URL to the messages routes, it is not adding the transparent session id. Instead of manually constructing the URL, I believe Livewire should rely on the default implementation from Laravel.

I am unsure about this approach because it makes the config property `livewire.app_url` obsolete. Is there a specific reason to have it instead of using the registered routes?

Once we agree on whether it makes sense, I will update the tests accordingly.