### PR TITLE
[POC] Encrypt dataMeta model

### DIFF
--- a/src/HydrationMiddleware/HydratePublicProperties.php
+++ b/src/HydrationMiddleware/HydratePublicProperties.php
@@ -20,6 +20,7 @@ use DateTimeImmutable;
 use Carbon\Carbon;
 use DateTime;
 use DateTimeInterface;
+use Illuminate\Support\Facades\Crypt;
 use stdClass;
 use Normalizer;
 
@@ -147,6 +148,8 @@ class HydratePublicProperties implements HydrationMiddleware
 
     protected static function hydrateModel($serialized, $property, $request, $instance)
     {
+        $serialized = Crypt::decrypt($serialized);
+        
         if (isset($serialized['id'])) {
             $model = (new static)->getRestoredPropertyValue(
                 new ModelIdentifier($serialized['class'], $serialized['id'], $serialized['relations'], $serialized['connection'])
@@ -217,6 +220,8 @@ class HydratePublicProperties implements HydrationMiddleware
         $serializedModel = $value instanceof QueueableEntity && ! $value->exists
             ? ['class' => get_class($value)]
             : (array) (new static)->getSerializedPropertyValue($value);
+
+        $serializedModel = Crypt::encrypt($serializedModel);
 
         // Deserialize the models into the "meta" bag.
         data_set($response, 'memo.dataMeta.models.'.$property, $serializedModel);


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

https://github.com/livewire/livewire/discussions/2627

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

Not yet, I have some questions + it's a POC.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

I really dislike Livewire exposing database connection details. From what I understand  `HydratePublicProperties.php` is responsible for creating the meta bag (including it's hydration and dehydration).

So why not encrypt the models data by default, and return a decrypted form when hydrating the model? :)
I simply added the Crypt classes as POC, and only for one model, but I was just wondering if this could lead to problems or any other issues.

From what I've tested, it works perfectly fine, but I'm not a Livewire expert.

If you could please take a look, and give a bit more inside information, I would be really happy.

Thanks!