### PR TITLE
Fix custom key of pagination undefined

### DIFF
--- a/src/WithPagination.php
+++ b/src/WithPagination.php
@@ -66,11 +66,17 @@ trait WithPagination
 
     public function previousPage($pageName = 'page')
     {
+        if (!isset($this->paginators[$pageName]) && isset($this->$pageName)) {
+            $this->paginators[$pageName] = $this->{$pageName};
+        }
         $this->setPage(max($this->paginators[$pageName] - 1, 1), $pageName);
     }
 
     public function nextPage($pageName = 'page')
     {
+        if (!isset($this->paginators[$pageName]) && isset($this->$pageName)) {
+            $this->paginators[$pageName] = $this->{$pageName};
+        }
         $this->setPage($this->paginators[$pageName] + 1, $pageName);
     }
 


### PR DESCRIPTION
As I explain in [discussions/5752](https://github.com/livewire/livewire/discussions/5752) when you have a custom key to paginate and click on previous or next button throw an ```ErrorException```.
So I make a validation before call the key of array and if not exist is created

Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
yes is needed when you have custom paginators.
and yes [a discussion](https://github.com/livewire/livewire/discussions/5752) was created before

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
no

4️⃣ Does it include tests? (Required)
no

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

a validation on Trait WithPagination.php was added in the functions previousPage and nextPage
```php
if (!isset($this->paginators[$pageName]) && isset($this->$pageName)) {
    $this->paginators[$pageName] = $this->{$pageName};
}
```

Problem:

When you have a diferent name of page using pagination and try to use the left or right buttons apears an exception
Example:
```php
public $page_example = 1;
protected $queryString = [
        'page_example' => ['except' => 1]
];
```

in the view if you click on buttons prev or next will show an ```ErrorException```
```php 
Undefined array key "page_example" 
```

But, if you have a pagination with pages, ```1```,```2```,```3```,```4```,```5``` and click one of those buttons will work, and magically the prev and next button will work, at least until reload page.

Thanks for contributing! 🙌
