### PR TITLE
[v3] Fix upgrade command bug that would prevent it from moving to the next step 

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/ChangeDefaultLayoutView.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/ChangeDefaultLayoutView.php
@@ -39,6 +39,7 @@ class ChangeDefaultLayoutView extends UpgradeStep
 
             $this->patternReplacement('/layouts\.app/', 'components.layouts.app', 'config');
         }
+
         return $next($console);
     }
 

--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/ChangeDefaultNamespace.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/ChangeDefaultNamespace.php
@@ -72,9 +72,9 @@ class ChangeDefaultNamespace extends UpgradeStep
             $console->table(
                 ['Status', 'Component', 'Remark'], $results
             );
-
-            return $next($console);
         }
+
+        return $next($console);
     }
 
     protected function hasOldNamespace()

--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/RepublishNavigation.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/RepublishNavigation.php
@@ -24,7 +24,6 @@ class RepublishNavigation extends UpgradeStep
             }
         }
 
-
         return $next($console);
     }
 }


### PR DESCRIPTION
Found a small little bug that would stop the command after the introduction if it didn't detect the old namespace.