### PR TITLE
Add vercel.json to disable builds and comments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,6 @@
 {
   "git": {
-    "deploymentEnabled": {
-      "main": false
-    },
+    "deploymentEnabled": false,
     "silent": true
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    },
+    "silent": true
+  }
+}


### PR DESCRIPTION
Vercel bot has started running builds and adding comments because someone else has linked Livewire to their Vercel account. This file disables them.

Hope this helps!