### PR TITLE
Fix typo in documenation for Morphing and Javscript

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -190,7 +190,7 @@ let $wire = {
     $parent,
 
     // Get the value of a property by name...
-    // Usage: $wire.$set('count')
+    // Usage: $wire.$get('count')
     $get(name) { ... },
 
     // Set a property on the component by name...

--- a/docs/morph.md
+++ b/docs/morph.md
@@ -125,7 +125,7 @@ Fortunately, Livewire has worked hard to mitigate these problems using the follo
 
 Livewire has an additional step in its morphing algorithm that checks subsequent elements and their contents before changing an element.
 
-The prevents the above scenario from happening in many cases.
+This prevents the above scenario from happening in many cases.
 
 Here is a visualization of the "look-ahead" algorithm in action:
 


### PR DESCRIPTION
While going through the documentation, I  found these which seems to be typos.
This PR does not impact the existing version, however it is nice to  have typo free documentation.
Files with changes:

- `javascript.md`
- `morph.md`


Apologies in advance If I have missed the PR guidelines.


Thanks