### PR TITLE
[v3] Add failing upload test when using upload as method name

### DIFF
--- a/src/Features/SupportFileUploads/BrowserTest.php
+++ b/src/Features/SupportFileUploads/BrowserTest.php
@@ -61,4 +61,57 @@ class BrowserTest extends \Tests\BrowserTestCase
         })
         ;
     }
+
+    /** @test */
+    public function can_use_method_name_upload()
+    {
+        Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photo;
+
+            function mount()
+            {
+                Storage::disk('tmp-for-tests')->deleteDirectory('photos');
+            }
+
+            function upload()
+            {
+                $this->photo->storeAs('photos', 'photo.png');
+            }
+
+            function render() { return <<<'HTML'
+            <div>
+                <input type="file" wire:model="photo" dusk="upload">
+
+                <div wire:loading wire:target="photo">uploading...</div>
+
+                <button wire:click="$refresh">refresh</button>
+
+                <div>
+                    @if ($photo)
+                        <img src="{{ $photo->temporaryUrl() }}" dusk="preview">
+                    @endif
+                </div>
+
+                <button wire:click="upload" dusk="save">Save</button>
+            </div>
+            HTML; }
+        })
+            ->assertMissing('@preview')
+            ->attach('@upload', __DIR__ . '/browser_test_image.png')
+            ->pause(250)
+            ->assertVisible('@preview')
+            ->tap(function () {
+                Storage::disk('tmp-for-tests')->assertMissing('photos/photo.png');
+            })
+            ->waitForLivewire()
+            ->click('@save')
+            ->tap(function () {
+                Storage::disk('tmp-for-tests')->assertExists('photos/photo.png');
+            })
+        ;
+    }
 }


### PR DESCRIPTION
If you attempt to use a method name called `upload` on your component, the upload will fail.
Happy to PR the docs in case `upload` should be a reserved method name.

```
livewire.js?id=3605227a:845 Alpine Expression Error: Cannot read properties of undefined (reading 'name')

Expression: "$wire.upload"

Uncaught TypeError: Cannot read properties of undefined (reading 'name')
    at livewire.js?id=3605227a:3582:29
    at Array.map (<anonymous>)
    at UploadManager.startUpload (livewire.js?id=3605227a:3581:42)
    at UploadManager.setUpload (livewire.js?id=3605227a:3529:14)
    at UploadManager.upload (livewire.js?id=3605227a:3502:12)
    at upload (livewire.js?id=3605227a:3646:19)
    at Proxy.<anonymous> (livewire.js?id=3605227a:3753:57)
    at runIfTypeOfFunction (livewire.js?id=3605227a:927:26)
    at livewire.js?id=3605227a:915:11
    at tryCatch (livewire.js?id=3605227a:838:14)
```