### PR TITLE
[v3] fix facade alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "Livewire\\LivewireServiceProvider"
       ],
       "aliases": {
-        "Livewire": "Livewire\\LivewireManager"
+        "Livewire": "Livewire\\Livewire"
       }
     }
   },


### PR DESCRIPTION
all options should work but the alias points to the `\Livewire\LivewireManager::class` and not to `\Livewire\Livewire::class` the `Facade`

```php
app('livewire')->isRunningServerless();
\Livewire\Livewire::isRunningServerless();
\Livewire::isRunningServerless(); // <-- this is broken
```

----
Fixes #5835, https://github.com/livewire/next/issues/65, https://github.com/livewire/livewire/discussions/5772