### PR TITLE
[V3] Reenable failing test as it covers a navigate bug

### DIFF
--- a/legacy_tests/Browser/Redirects/Test.php
+++ b/legacy_tests/Browser/Redirects/Test.php
@@ -15,8 +15,6 @@ class Test extends TestCase
     /** @test */
     public function it_correctly_shows_flash_messages_before_and_after_direct()
     {
-        $this->markTestSkipped(); // @flaky
-
         $this->browse(function ($browser) {
             $this->visitLivewireComponent($browser, Component::class)
                 /*


### PR DESCRIPTION
This test is failing due to navigate being enabled on page load.

Navigate is taking control and redirecting it internally. The alpine:navigated event is firing, so isNavigating is being set to true in the below snippet, hence navigate is handling the redirect.

https://github.com/livewire/livewire/blob/04298292a365841879d64c13881d5499517bb597/js/features/supportNavigate.js#L5-L6

`alpine:navigated` is firing on page load as a replacement for `DOMContentLoaded` which won't fire if a page has been loaded using navigate.

https://github.com/alpinejs/alpine/blob/394edf0057495fe005f3977d1eae7cc697c0ab3b/packages/navigate/src/index.js#L108-L111