### PR TITLE
remove word be from upgrade guide documentation page

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -6,7 +6,7 @@
 
 To save you time upgrading, we've included an Artisan command to automate as many parts of the upgrade process as possible.
 
-After [installing Livewire version 3](/docs/upgrading#update-livewire-to-version-3), run the following command and you will be receive prompts to upgrade each breaking change automatically:
+After [installing Livewire version 3](/docs/upgrading#update-livewire-to-version-3), run the following command and you will receive prompts to upgrade each breaking change automatically:
 
 ```shell
 php artisan livewire:upgrade
@@ -624,4 +624,3 @@ Route::group(['prefix' => LaravelLocalization::setLocale()], function ()
 ```
 
 For more information, please consult our documentation on [configuring Livewire's update endpoint](/docs/installation#configuring-livewires-update-endpoint).
-


### PR DESCRIPTION
The text on upgrade guide is "After [installing Livewire version 3](https://livewire.laravel.com/docs/upgrading#update-livewire-to-version-3), run the following command and you will **be** receive prompts to upgrade each breaking change automatically:". Here the word "be" should be removed. Or it will also be correct if we change it to "you will be receiving prompts...".