### PR TITLE
docs: remove unnecessary .prevent modifier

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -422,7 +422,7 @@ class UpdatePost extends Component
 ```
 
 ```blade
-<form wire:submit.prevent>
+<form wire:submit>
     <input type="text" wire:model.blur="title">
     <div>
         @error('title') <span class="error">{{ $message }}</span> @enderror


### PR DESCRIPTION
`wire:submit` does `.prevent` by default now, so we can omit it from this place in the docs.