### PR TITLE
[v3] Carbon replace deprecated format

### DIFF
--- a/src/Mechanisms/HandleComponents/Synthesizers/CarbonSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CarbonSynth.php
@@ -29,7 +29,7 @@ class CarbonSynth extends Synth {
 
     function dehydrate($target) {
         return [
-            $target->format(DateTimeInterface::ISO8601),
+            $target->format(DateTimeInterface::ATOM),
             ['type' => array_search(get_class($target), static::$types)],
         ];
     }


### PR DESCRIPTION
`DateTimeInterface::ISO8601` is deprecated `DateTimeInterface::ATOM` is nearly identical and works perfect for our use-case

```php
now()->format(DateTimeInterface::ISO8601); // 2023-07-22T10:03:42+0200
now()->format(DateTimeInterface::ATOM);    // 2023-07-22T10:03:42+02:00

new DateTime('2023-07-22T10:03:42+02:00') // works
// all other classes are based on DateTime::class
```

