### PR TITLE
[v3] Repeatable `#[Rule]`

### DIFF
--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -23,17 +23,17 @@ trait HandlesValidation
 
     public function addRulesFromOutside($rules)
     {
-        $this->rulesFromOutside = array_merge($this->rulesFromOutside, $rules);
+        $this->rulesFromOutside = array_merge_recursive($this->rulesFromOutside, $rules);
     }
 
     public function addMessagesFromOutside($messages)
     {
-        $this->messagesFromOutside = array_merge($this->messagesFromOutside, $messages);
+        $this->messagesFromOutside = array_merge_recursive($this->messagesFromOutside, $messages);
     }
 
     public function addValidationAttributesFromOutside($validationAttributes)
     {
-        $this->validationAttributesFromOutside = array_merge($this->validationAttributesFromOutside, $validationAttributes);
+        $this->validationAttributesFromOutside = array_merge_recursive($this->validationAttributesFromOutside, $validationAttributes);
     }
 
     public function getErrorBag()

--- a/src/Features/SupportValidation/Rule.php
+++ b/src/Features/SupportValidation/Rule.php
@@ -2,11 +2,12 @@
 
 namespace Livewire\Features\SupportValidation;
 
+use Attribute;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
 use function Livewire\wrap;
 
-#[\Attribute]
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_ALL)]
 class Rule extends LivewireAttribute
 {
     // @todo: support custom messages...

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -136,7 +136,7 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    public function rule_attributes_can_contain_multiple_rules()
+    public function rule_attributes_can_contain_rules_for_multiple_properties()
     {
         Livewire::test(new class extends TestComponent {
             #[Rule(['foo' => 'required', 'bar' => 'required'])]
@@ -159,6 +159,54 @@ class UnitTest extends \Tests\TestCase
                 'foo' => 'required',
                 'bar' => 'required',
             ]);
+    }
+
+    /** @test */
+    public function rule_attributes_can_contain_multiple_rules()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Rule(['required', 'min:2', 'max:3'])]
+            public $foo = '';
+        })
+            ->set('foo', '')
+            ->assertHasErrors(['foo' => 'required'])
+            ->set('foo', '1')
+            ->assertHasErrors(['foo' => 'min'])
+            ->set('foo', '12345')
+            ->assertHasErrors(['foo' => 'max'])
+            ->set('foo', 'ok')
+            ->assertHasNoErrors()
+        ;
+    }
+
+    /** @test */
+    public function rule_attributes_can_be_repeated()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Rule('required')]
+            #[Rule('min:2')]
+            #[Rule('max:3')]
+            public $foo = '';
+
+            #[
+                Rule('sometimes'),
+                Rule('max:1')
+            ]
+            public $bar = '';
+        })
+            ->set('foo', '')
+            ->assertHasErrors(['foo' => 'required'])
+            ->set('foo', '1')
+            ->assertHasErrors(['foo' => 'min'])
+            ->set('foo', '12345')
+            ->assertHasErrors(['foo' => 'max'])
+            ->set('foo', 'ok')
+            ->assertHasNoErrors()
+            ->set('bar', '12')
+            ->assertHasErrors(['bar' => 'max'])
+            ->set('bar', '1')
+            ->assertHasNoErrors()
+        ;
     }
 
     /** @test */


### PR DESCRIPTION
maybe `array_merge_recursive` isn't the best solution but for now it works.

```php
// Style A
#[Rule(['required', 'min:2', 'max:3'])]
public $foo = '';

// Style B
#[Rule('required')]
#[Rule('min:2')]
#[Rule('max:3')]
public $foo = '';

// Style C
#[
    Rule('required'),
    Rule('min:2'),
    Rule('max:3'),
]
public $foo = '';
```

what styles should be documented?

---
Fixes https://github.com/livewire/livewire/discussions/5873