### PR TITLE
[v3] Fix Reactive Attribute Browser test

### DIFF
--- a/src/Features/SupportReactiveProps/BrowserTest.php
+++ b/src/Features/SupportReactiveProps/BrowserTest.php
@@ -8,53 +8,6 @@ use Livewire\Component;
 class BrowserTest extends \Tests\BrowserTestCase
 {
     /** @test */
-    public function can_throw_exception_cannot_mutate_reactive_prop()
-    {
-        Livewire::visit([
-            new class extends Component {
-                public $count = 0;
-
-                public function inc() { $this->count++; }
-
-                public function render() { return <<<'HTML'
-                    <div>
-                        <h1>Parent count: <span dusk="parent.count">{{ $count }}</span>
-
-                        <button wire:click="inc" dusk="parent.inc">inc</button>
-
-                        <livewire:child :$count />
-                    </div>
-                    HTML;
-                }
-            },
-            'child' => new class extends Component {
-                #[Reactive]
-                public $count;
-
-                public function inc() { $this->count++; }
-
-                public function render() { return <<<'HTML'
-                    <div>
-                        <h1>Child count: <span dusk="child.count">{{ $count }}</span>
-                        <button wire:click="inc" dusk="child.inc">inc</button>
-                    </div>
-                    HTML;
-                }
-            }
-        ])
-        ->assertSeeIn('@parent.count', 0)
-        ->assertSeeIn('@child.count', 0)
-        ->waitForLivewire()->click('@parent.inc')
-        ->assertSeeIn('@parent.count', 1)
-        ->assertSeeIn('@child.count', 1)
-        ->waitForLivewire()->click('@child.inc')
-        ->waitFor('#livewire-error')
-        ->click('#livewire-error')
-        ->assertSeeIn('@parent.count', 1)
-        ->assertSeeIn('@child.count', 1);
-    }
-
-    /** @test */
     public function can_pass_a_reactive_property_from_parent_to_child()
     {
         Livewire::visit([
@@ -116,6 +69,53 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->waitForLivewire()->click('@parent.inc')
             ->assertSeeIn('@parent.count', 0)
             ->assertSeeIn('@child.count', 0);
+    }
+
+    /** @test */
+    public function can_throw_exception_cannot_mutate_reactive_prop()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public $count = 0;
+
+                public function inc() { $this->count++; }
+
+                public function render() { return <<<'HTML'
+                    <div>
+                        <h1>Parent count: <span dusk="parent.count">{{ $count }}</span>
+
+                        <button wire:click="inc" dusk="parent.inc">inc</button>
+
+                        <livewire:child :$count />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                #[Reactive]
+                public $count;
+
+                public function inc() { $this->count++; }
+
+                public function render() { return <<<'HTML'
+                    <div>
+                        <h1>Child count: <span dusk="child.count">{{ $count }}</span>
+                        <button wire:click="inc" dusk="child.inc">inc</button>
+                    </div>
+                    HTML;
+                }
+            }
+        ])
+        ->assertSeeIn('@parent.count', 0)
+        ->assertSeeIn('@child.count', 0)
+        ->waitForLivewire()->click('@parent.inc')
+        ->assertSeeIn('@parent.count', 1)
+        ->assertSeeIn('@child.count', 1)
+        ->waitForLivewire()->click('@child.inc')
+        ->waitFor('#livewire-error')
+        ->click('#livewire-error')
+        ->assertSeeIn('@parent.count', 1)
+        ->assertSeeIn('@child.count', 1);
     }
 
     /** @test */

--- a/src/Features/SupportReactiveProps/BrowserTest.php
+++ b/src/Features/SupportReactiveProps/BrowserTest.php
@@ -63,9 +63,13 @@ class BrowserTest extends \Tests\BrowserTestCase
 
                 public function inc() { $this->count++; }
 
+                public function dec() { $this->count--; }
+
                 public function render() { return <<<'HTML'
                     <div>
                         <h1>Parent count: <span dusk="parent.count">{{ $count }}</span>
+
+                        <button wire:click="dec" dusk="parent.dec">dec</button>
 
                         <button wire:click="inc" dusk="parent.inc">inc</button>
 
@@ -78,12 +82,9 @@ class BrowserTest extends \Tests\BrowserTestCase
                 #[Reactive]
                 public $count;
 
-                public function inc() { $this->count++; }
-
                 public function render() { return <<<'HTML'
                     <div>
                         <h1>Child count: <span dusk="child.count">{{ $count }}</span>
-                        <button wire:click="inc" dusk="child.inc">inc</button>
                     </div>
                     HTML;
                 }
@@ -91,13 +92,30 @@ class BrowserTest extends \Tests\BrowserTestCase
         ])
             ->assertSeeIn('@parent.count', 0)
             ->assertSeeIn('@child.count', 0)
+
             ->waitForLivewire()->click('@parent.inc')
             ->assertSeeIn('@parent.count', 1)
             ->assertSeeIn('@child.count', 1)
-            ->waitForLivewire()->click('@child.inc')
+
+            ->waitForLivewire()->click('@parent.inc')
+            ->assertSeeIn('@parent.count', 2)
+            ->assertSeeIn('@child.count', 2)
+
+            ->waitForLivewire()->click('@parent.dec')
             ->assertSeeIn('@parent.count', 1)
             ->assertSeeIn('@child.count', 1)
-        ;
+
+            ->waitForLivewire()->click('@parent.dec')
+            ->assertSeeIn('@parent.count', 0)
+            ->assertSeeIn('@child.count', 0)
+
+            ->waitForLivewire()->click('@parent.dec')
+            ->assertSeeIn('@parent.count', -1)
+            ->assertSeeIn('@child.count', -1)
+
+            ->waitForLivewire()->click('@parent.inc')
+            ->assertSeeIn('@parent.count', 0)
+            ->assertSeeIn('@child.count', 0);
     }
 
     /** @test */

--- a/src/Features/SupportReactiveProps/BrowserTest.php
+++ b/src/Features/SupportReactiveProps/BrowserTest.php
@@ -8,7 +8,7 @@ use Livewire\Component;
 class BrowserTest extends \Tests\BrowserTestCase
 {
     /** @test */
-    public function can_pass_a_reactive_property_from_parent_to_child()
+    public function can_throw_exception_cannot_mutate_reactive_prop()
     {
         Livewire::visit([
             new class extends Component {
@@ -48,8 +48,55 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertSeeIn('@parent.count', 1)
         ->assertSeeIn('@child.count', 1)
         ->waitForLivewire()->click('@child.inc')
+        ->waitFor('#livewire-error')
+        ->click('#livewire-error')
         ->assertSeeIn('@parent.count', 1)
-        ->assertSeeIn('@child.count', 1)
+        ->assertSeeIn('@child.count', 1);
+    }
+
+    /** @test */
+    public function can_pass_a_reactive_property_from_parent_to_child()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public $count = 0;
+
+                public function inc() { $this->count++; }
+
+                public function render() { return <<<'HTML'
+                    <div>
+                        <h1>Parent count: <span dusk="parent.count">{{ $count }}</span>
+
+                        <button wire:click="inc" dusk="parent.inc">inc</button>
+
+                        <livewire:child :$count />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                #[Reactive]
+                public $count;
+
+                public function inc() { $this->count++; }
+
+                public function render() { return <<<'HTML'
+                    <div>
+                        <h1>Child count: <span dusk="child.count">{{ $count }}</span>
+                        <button wire:click="inc" dusk="child.inc">inc</button>
+                    </div>
+                    HTML;
+                }
+            }
+        ])
+            ->assertSeeIn('@parent.count', 0)
+            ->assertSeeIn('@child.count', 0)
+            ->waitForLivewire()->click('@parent.inc')
+            ->assertSeeIn('@parent.count', 1)
+            ->assertSeeIn('@child.count', 1)
+            ->waitForLivewire()->click('@child.inc')
+            ->assertSeeIn('@parent.count', 1)
+            ->assertSeeIn('@child.count', 1)
         ;
     }
 


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
No
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
4️⃣ Does it include tests? (Required)
Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

---

This PR fixes the test name in the first browser test and improves the reactivity check in another test.

The first should check if the CannotMutateReactivePropException exception was thrown.

The second test verifies the reactivity.

Thanks for contributing! 🙌
