### PR TITLE
[V3] Updating the Upgrade Guide: Reinforcing Instructions to the Breeze & JetStream

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -260,7 +260,7 @@ Alpine.start()
 You can remove them entirely because Livewire includes Alpine and many popular Alpine plugins by default.
 
 > [!warning] "Livewire V3 (beta) with Laravel Breeze or Laravel Jetstream"
-> If you are trying to try Livewire V3 beta with solutions like Laravel Breeze or Laravel JetStream, you will need to offload Alpine as demonstrated above. Also, you can remove Alpine from your NPM dependencies as well. The Laravel Breeze and Laravel JetStream are not ready for Livewire V3 yet by default.
+> If you are trying the Livewire V3 beta with the Laravel Breeze or Laravel JetStream, you will need to unload the Alpine as demonstrated above. Also, you can remove Alpine and any other Alpine plugins from your NPM dependencies as well. The Laravel Breeze and Laravel JetStream are not ready for Livewire V3 yet by default.
 
 #### Accessing Alpine via JS bundle
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -259,6 +259,9 @@ Alpine.start()
 
 You can remove them entirely because Livewire includes Alpine and many popular Alpine plugins by default.
 
+> [!warning] "Livewire V3 (beta) with Laravel Breeze or Laravel Jetstream"
+> If you are trying to try Livewire V3 beta with solutions like Laravel Breeze or Laravel JetStream, you will need to offload Alpine as demonstrated above. Also, you can remove Alpine from your NPM dependencies as well. The Laravel Breeze and Laravel JetStream are not ready for Livewire V3 yet by default.
+
 #### Accessing Alpine via JS bundle
 
 If you are registering custom Alpine plugins or components inside your application's JavaScript bundle like so:


### PR DESCRIPTION
# The problem

Two days ago I started experimenting with Livewire V3 and I found something that for me was a bug: I couldn't reset the property on the client side, **visually**. For example, resetting the value of `$title` back to empty within the input after it was used to create something like a todo.

# The report

👉  https://github.com/livewire/livewire/discussions/5797

**For these cases of test I was using Laravel Breeze**. After a while I discovered that carelessly I had not removed the Alpine loaded via `app.js` that is **delivered by default from Laravel Breeze and Laravel JetStream.**

# The solution

I decided to write one more point in the specific upgrade guide of the Livewire V3 for anyone trying to use Livewire V3 with these solutions, Breeze or JetStream.

## Definitive Solutions, in Breeze or JetStream

The Laravel team will adapt the Breeze and JetStream to the Livewire V3 when it officially released.