### PR TITLE
[V3] Add Method: `resetSafe`

### DIFF
--- a/docs/properties.md
+++ b/docs/properties.md
@@ -167,7 +167,7 @@ class ManageTodos extends Component
 
     public function addTodo()
     {
-        [$title] = $this->resetSafe('todo'); // [tl! highlight]
+        $title = $this->resetSafe('todo'); // [tl! highlight]
         
         $this->todos[] = $title;
     }

--- a/docs/properties.md
+++ b/docs/properties.md
@@ -128,7 +128,7 @@ namespace App\Livewire;
 
 use Livewire\Component;
 
-class ManageTodos extends Controller
+class ManageTodos extends Component
 {
     public $todos = [];
 
@@ -150,6 +150,31 @@ In the above example, after a user clicks "Add Todo", the input field holding th
 > [!warning] `reset()` won't work on values set in `mount()`
 > `reset()` will reset a property to its state before the `mount` method was called. If you initialized the property in `mount()` to a different value, you will need to reset the property manually.
 
+Since `reset` permanently resets the property, you can use `resetSafe` to reset properties while also getting the current values of the properties before they were reset:
+
+```php
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class ManageTodos extends Component
+{
+    public $todos = [];
+
+    public $todo = '';
+
+    public function addTodo()
+    {
+        [$title] = $this->resetSafe('todo'); // [tl! highlight]
+        
+        $this->todos[] = $title;
+    }
+
+    // ...
+}
+```
 
 ## Supported property types
 

--- a/docs/properties.md
+++ b/docs/properties.md
@@ -128,7 +128,7 @@ namespace App\Livewire;
 
 use Livewire\Component;
 
-class ManageTodos extends Component
+class ManageTodos extends Controller
 {
     public $todos = [];
 

--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -75,6 +75,10 @@ trait InteractsWithProperties
 
         $this->reset($properties);
 
+        if (count($values) === 1) {
+            return array_values($values)[0];
+        }
+
         return [...array_values($values)];
     }
 

--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -59,6 +59,25 @@ trait InteractsWithProperties
         }
     }
 
+    public function resetSafety(...$properties)
+    {
+        if (count($properties) && is_array($properties[0])) {
+            $properties = $properties[0];
+        }
+
+        $keys = array_intersect_key($this->all(), array_flip($properties));
+
+        $values = [];
+
+        foreach ($keys as $key => $value) {
+            $values[$key] = $value;
+        }
+
+        $this->reset($properties);
+
+        return [...array_values($values)];
+    }
+
     protected function resetExcept(...$properties)
     {
         if (count($properties) && is_array($properties[0])) {

--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -75,11 +75,13 @@ trait InteractsWithProperties
 
         $this->reset($properties);
 
+        $values = array_values($values);
+
         if (count($values) === 1) {
-            return array_values($values)[0];
+            return $values[0];
         }
 
-        return [...array_values($values)];
+        return [...$values];
     }
 
     protected function resetExcept(...$properties)

--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -59,7 +59,7 @@ trait InteractsWithProperties
         }
     }
 
-    public function resetSafety(...$properties)
+    public function resetSafe(...$properties)
     {
         if (count($properties) && is_array($properties[0])) {
             $properties = $properties[0];

--- a/src/Concerns/Tests/ResetPropertiesTest.php
+++ b/src/Concerns/Tests/ResetPropertiesTest.php
@@ -72,13 +72,35 @@ class ResetPropertiesTest extends \Tests\TestCase
     }
 
     /** @test */
-    public function can_reset_safe_properties()
+    public function can_reset_safe_single_property()
     {
         Livewire::test(ResetPropertiesComponent::class)
             ->assertSet('foo', 'bar')
             ->assertSet('bob', 'lob')
             ->assertSet('mwa', 'hah')
-            ->assertSet('safe', [])
+            ->assertSet('safe', '')
+            ->set('foo', 'baz')
+            ->set('bob', 'law')
+            ->set('mwa', 'aha')
+            ->assertSet('foo', 'baz')
+            ->assertSet('bob', 'law')
+            ->assertSet('mwa', 'aha')
+            // Reset foo and bob safety.
+            ->call('resetKeysSafe', ['foo'])
+            ->assertSet('foo', 'bar')
+            ->assertSet('bob', 'law')
+            ->assertSet('mwa', 'aha')
+            ->assertSet('safe', 'baz');
+    }
+
+    /** @test */
+    public function can_reset_safe_multiples_properties()
+    {
+        Livewire::test(ResetPropertiesComponent::class)
+            ->assertSet('foo', 'bar')
+            ->assertSet('bob', 'lob')
+            ->assertSet('mwa', 'hah')
+            ->assertSet('safe', '')
             ->set('foo', 'baz')
             ->set('bob', 'law')
             ->set('mwa', 'aha')
@@ -103,7 +125,7 @@ class ResetPropertiesComponent extends Component
     public $bob = 'lob';
     public $mwa = 'hah';
 
-    public $safe = [];
+    public $safe = '';
 
     public function resetAll()
     {

--- a/src/Concerns/Tests/ResetPropertiesTest.php
+++ b/src/Concerns/Tests/ResetPropertiesTest.php
@@ -70,6 +70,30 @@ class ResetPropertiesTest extends \Tests\TestCase
             ->assertSet('bob', 'law')
             ->assertSet('mwa', 'hah');
     }
+
+    /** @test */
+    public function can_reset_safety_properties()
+    {
+        Livewire::test(ResetPropertiesComponent::class)
+            ->assertSet('foo', 'bar')
+            ->assertSet('bob', 'lob')
+            ->assertSet('mwa', 'hah')
+            ->set('foo', 'baz')
+            ->set('bob', 'law')
+            ->set('mwa', 'aha')
+            ->assertSet('foo', 'baz')
+            ->assertSet('bob', 'law')
+            ->assertSet('mwa', 'aha')
+            // Reset foo and bob safety.
+            ->call('resetPropertiesSafety', ['foo', 'bob'])
+            ->assertSet('foo', 'bar')
+            ->assertSet('bob', 'lob')
+            ->assertSet('mwa', 'aha')
+            ->assertSet('safety', [
+                'baz',
+                'law',
+            ]);
+    }
 }
 
 class ResetPropertiesComponent extends Component
@@ -77,6 +101,8 @@ class ResetPropertiesComponent extends Component
     public $foo = 'bar';
     public $bob = 'lob';
     public $mwa = 'hah';
+
+    public $safety = [];
 
     public function resetAll()
     {
@@ -91,6 +117,11 @@ class ResetPropertiesComponent extends Component
     public function resetKeysExcept($keys)
     {
         $this->resetExcept($keys);
+    }
+
+    public function resetPropertiesSafety($keys)
+    {
+        $this->safety = $this->resetSafety($keys);
     }
 
     public function render()

--- a/src/Concerns/Tests/ResetPropertiesTest.php
+++ b/src/Concerns/Tests/ResetPropertiesTest.php
@@ -72,12 +72,13 @@ class ResetPropertiesTest extends \Tests\TestCase
     }
 
     /** @test */
-    public function can_reset_safety_properties()
+    public function can_reset_safe_properties()
     {
         Livewire::test(ResetPropertiesComponent::class)
             ->assertSet('foo', 'bar')
             ->assertSet('bob', 'lob')
             ->assertSet('mwa', 'hah')
+            ->assertSet('safe', [])
             ->set('foo', 'baz')
             ->set('bob', 'law')
             ->set('mwa', 'aha')
@@ -85,11 +86,11 @@ class ResetPropertiesTest extends \Tests\TestCase
             ->assertSet('bob', 'law')
             ->assertSet('mwa', 'aha')
             // Reset foo and bob safety.
-            ->call('resetPropertiesSafety', ['foo', 'bob'])
+            ->call('resetKeysSafe', ['foo', 'bob'])
             ->assertSet('foo', 'bar')
             ->assertSet('bob', 'lob')
             ->assertSet('mwa', 'aha')
-            ->assertSet('safety', [
+            ->assertSet('safe', [
                 'baz',
                 'law',
             ]);
@@ -102,7 +103,7 @@ class ResetPropertiesComponent extends Component
     public $bob = 'lob';
     public $mwa = 'hah';
 
-    public $safety = [];
+    public $safe = [];
 
     public function resetAll()
     {
@@ -119,9 +120,9 @@ class ResetPropertiesComponent extends Component
         $this->resetExcept($keys);
     }
 
-    public function resetPropertiesSafety($keys)
+    public function resetKeysSafe($keys)
     {
-        $this->safety = $this->resetSafety($keys);
+        $this->safe = $this->resetSafe($keys);
     }
 
     public function render()


### PR DESCRIPTION
# The Problem

Most of the time when we're working with Livewire, we need to get the value of the properties to perform an operation and then it's important to reset the properties so that they go back to their original states 👇 

```php
public $title = '';

// ...

public function create()
{
    $todo = new Todo();

    // binding $title with front-end and edit it...

    $todo->title = $this->title;

    $todo->save();

    $this->reset();
}
```

OK! That works, but having to use the property and then reset it can be a bit exhausting, no? 🤔 So this PR aims to "solve" this problem by adding the `resetSafe` method 👇 

# Solution

The `resetSafe` method allows us to reset the properties, BUT before the reset is actually performed we can capture the current values of the properties:

### Single Property

```php
public $title = '';

// ...

public function create()
{
    // binding $title with front-end and edit it...

    $todo = new Todo();

    $todo->title = $this->resetSafe('todo')

    $todo->save();

    // $this->reset(); // 👈 This is not necessary here since `resetSafe` already does it.
}
```

### Multiple Properties

```php
public $todo = '';

public $description = '';

// ...

public function create()
{
    // binding $title and $description with front-end and edit it...

    [$title, $description] = $this->resetSafe('todo', 'description');

    $todo = new Todo();

    $todo->title = $title;

    $todo->description = $description;

    $todo->save();

    // $this->reset(); // 👈 This is not necessary here since `resetSafe` already does it.
}
```

---

Hope this help,

Thanks. ❤️ 
