### PR TITLE
[v3] Fixes stubs namespace generation

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/livewire.attribute.stub
+++ b/src/Features/SupportConsoleCommands/Commands/livewire.attribute.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Livewire\Attributes;
+namespace DummyNamespace;
 
 use Livewire\Attribute as LivewireAttribute;
 

--- a/src/Features/SupportConsoleCommands/Commands/livewire.form.stub
+++ b/src/Features/SupportConsoleCommands/Commands/livewire.form.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Livewire\Forms;
+namespace DummyNamespace;
 
 use Livewire\Attributes\Rule;
 use Livewire\Form;

--- a/src/Features/SupportConsoleCommands/Tests/AttributeCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/AttributeCommandUnitTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Livewire\Features\SupportConsoleCommands\Tests;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Artisan;
+
+class AttributeCommandUnitTest extends \Tests\TestCase
+{
+    /** @test */
+    public function attribute_is_created_by_attribute_command()
+    {
+        Artisan::call('livewire:attribute', ['name' => 'SampleAttribute']);
+
+        $filePath = $this->livewireClassesPath('Attributes/SampleAttribute.php');
+
+        $this->assertTrue(File::exists($filePath));
+
+        $this->assertTrue(str(File::get($filePath))->contains('namespace App\Livewire\Attributes;'));
+    }
+
+
+    /** @test */
+    public function attribute_is_created_in_subdirectory_by_attribute_command()
+    {
+        Artisan::call('livewire:attribute', ['name' => 'Auth/SampleAttribute']);
+
+        $filePath = $this->livewireClassesPath('Attributes/Auth/SampleAttribute.php');
+
+        $this->assertTrue(File::exists($filePath));
+
+        $this->assertTrue(str(File::get($filePath))->contains('namespace App\Livewire\Attributes\Auth;'));
+    }
+}

--- a/src/Features/SupportConsoleCommands/Tests/FormCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/FormCommandUnitTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Livewire\Features\SupportConsoleCommands\Tests;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Artisan;
+
+class FormCommandUnitTest extends \Tests\TestCase
+{
+    /** @test */
+    public function form_object_is_created_by_form_command()
+    {
+        Artisan::call('livewire:form', ['name' => 'SampleForm']);
+
+        $filePath = $this->livewireClassesPath('Forms/SampleForm.php');
+
+        $this->assertTrue(File::exists($filePath));
+
+        $this->assertTrue(str(File::get($filePath))->contains('namespace App\Livewire\Forms;'));
+    }
+
+
+    /** @test */
+    public function form_object_is_created_in_subdirectory_by_form_command()
+    {
+        Artisan::call('livewire:form', ['name' => 'Auth/SampleForm']);
+
+        $filePath = $this->livewireClassesPath('Forms/Auth/SampleForm.php');
+
+        $this->assertTrue(File::exists($filePath));
+
+        $this->assertTrue(str(File::get($filePath))->contains('namespace App\Livewire\Forms\Auth;'));
+    }
+}


### PR DESCRIPTION
Fixes the issue with wrong namespace generation for forms and attributes, as they were hard coded. For example, `artisan livewire:form Auth/LoginForm` and `artisan livewire:attribute Auth/Content` will ignore the `Auth` part completely. This fixes the issue.