### PR TITLE
[v3] Add beta warning to quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,4 +1,7 @@
-To begin your Livewire journey, we will create a simple "counter" component and render it in the browser. This example is a great way to experience Livewire for the first time as it demonstrates Livewire's _liveness_ in the simplest way possible
+> [!warning] Livewire 3 is still in beta
+> While we attempt to keep breaking changes to a minimum, they are still possible while Livewire 3 remains in beta. Therefore, we recommend testing your application thoroughly before using Livewire 3 in production.
+
+To begin your Livewire journey, we will create a simple "counter" component and render it in the browser. This example is a great way to experience Livewire for the first time as it demonstrates Livewire's _liveness_ in the simplest way possible.
 
 ## Prerequisites
 


### PR DESCRIPTION
The beta warning is now only shown on the upgrade guide. This PR will add the warning to the default documentation page (quickstart) as well to manage expectations. 