### PR TITLE
[V3] Add add error api to forms

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -302,7 +302,7 @@ Below are all the available methods for manipulating the validation errors in yo
 
 Method | Description
 --- | ---
-`$this->addError([key], [message])` | Manually add a validation message to the error bag
+`$this->addError([key], [message])` | Manually add a validation message to the error bag (when used in forms, key will be prefixed with 'form.')
 `$this->resetValidation([?key])` | Reset the validation errors for the provided key, or reset all errors if no key is supplied
 `$this->getErrorBag()` | Retrieve the underlying Laravel error bag used in the Livewire component
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -302,9 +302,12 @@ Below are all the available methods for manipulating the validation errors in yo
 
 Method | Description
 --- | ---
-`$this->addError([key], [message])` | Manually add a validation message to the error bag (when used in forms, key will be prefixed with 'form.')
+`$this->addError([key], [message])` | Manually add a validation message to the error bag
 `$this->resetValidation([?key])` | Reset the validation errors for the provided key, or reset all errors if no key is supplied
 `$this->getErrorBag()` | Retrieve the underlying Laravel error bag used in the Livewire component
+
+> [!info] Using `$this->addError()` with Form Objects
+> When manually adding errors using `$this->addError` inside of a form object the key will automatically be prefixed with the name of the property the form is assigned to in the parent component. For example, if in your Component you assign the form to a property called `$data`, key will become `data.key`. 
 
 ## Accessing the validator instance
 

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -34,6 +34,11 @@ class Form implements Arrayable
         $this->component->addRulesFromOutside($rulesWithPrefixedKeys);
     }
 
+    public function addError($key, $message)
+    {
+        $this->component->addError($this->propertyName . '.' . $key, $message);
+    }
+
     public function validate()
     {
         $rules = $this->component->getRules();

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -51,6 +51,28 @@ class UnitTest extends \Tests\TestCase
         ;
     }
 
+    function can_manually_add_errors_to_the_error_bag()
+    {
+        Livewire::test(new class extends Component {
+            public PostFormValidateStub $form;
+
+            function save()
+            {
+                $this->addError('status', 'An error message...');
+            }
+
+            public function render() {
+                return '<div></div>';
+            }
+        })
+        ->assertSet('form.title', '')
+        ->assertSet('form.content', '')
+        ->assertHasNoErrors()
+        ->call('save')
+        ->assertHasErrors('form.status')
+        ;
+    }
+
     /** @test */
     function can_validate_a_form_object_using_rule_attributes()
     {


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

- Yes ✔, see discussion: https://github.com/livewire/livewire/discussions/5891

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

- Yes ✔

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

- No ✔

4️⃣ Does it include tests? (Required)

- Yes ✔

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

- This is more of a nice to have DX improvement, the same thing can be accomplished right now using the second syntax shown. 
- This brings the `$this->addError()` API to the new Form components added to V3. 

```php
// New usage
$this->addError('key', 'message');

// Existing method to accomplish
$this->component->addError('key', 'message');
```
