### PR TITLE
[V3][Docs] Change Extends from Controller to Component

### DIFF
--- a/docs/properties.md
+++ b/docs/properties.md
@@ -128,7 +128,7 @@ namespace App\Livewire;
 
 use Livewire\Component;
 
-class ManageTodos extends Controller
+class ManageTodos extends Component
 {
     public $todos = [];
 


### PR DESCRIPTION
This PR aims to change the "extends" of one of the examples from Controller, that's wrong for Livewire components, to Component.