### PR TITLE
[V2] Fix timeouts from cleanup files

### DIFF
--- a/src/Commands/CleanupCommand.php
+++ b/src/Commands/CleanupCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Livewire\Commands;
+
+use Illuminate\Console\Command;
+use Livewire\FileUploadConfiguration;
+use Livewire\Jobs\CleanupUploadedFilesJob;
+
+class CleanupCommand extends Command
+{
+    protected $signature = 'livewire:upload-cleanup';
+
+    protected $description = 'Dispatch job to delete files older than 24 hours';
+
+    public function handle()
+    {
+        if ( FileUploadConfiguration::isUsingS3()) {
+            $this->error("This command is not to be used with S3 driver.");
+
+            return;
+        }
+
+        CleanupUploadedFilesJob::dispatch();
+
+        $this->info('Dispatched CleanupUploadedFilesJob job');
+    }
+}

--- a/src/Jobs/CleanupUploadedFilesJob.php
+++ b/src/Jobs/CleanupUploadedFilesJob.php
@@ -4,11 +4,10 @@ namespace Livewire\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Livewire\FileUploadConfiguration;
 
-class CleanupUploadedFilesJob implements ShouldQueue, ShouldBeUnique
+class CleanupUploadedFilesJob implements ShouldQueue
 {
     use Dispatchable;
     use Queueable;

--- a/src/Jobs/CleanupUploadedFilesJob.php
+++ b/src/Jobs/CleanupUploadedFilesJob.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Livewire\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Livewire\FileUploadConfiguration;
+
+class CleanupUploadedFilesJob implements ShouldQueue, ShouldBeUnique
+{
+    use Dispatchable;
+    use Queueable;
+
+    public $tries = 1;
+    public $timeout = 600;
+
+    public function handle()
+    {
+        $storage = FileUploadConfiguration::storage();
+
+        foreach ($storage->allFiles(FileUploadConfiguration::path()) as $filePathname) {
+            // On busy websites, this cleanup code can run in multiple threads causing part of the output
+            // of allFiles() to have already been deleted by another thread.
+            if (! $storage->exists($filePathname)) continue;
+
+            $yesterdaysStamp = now()->subDay()->timestamp;
+            if ($yesterdaysStamp > $storage->lastModified($filePathname)) {
+                $storage->delete($filePathname);
+            }
+        }
+    }
+
+    public function uniqueId()
+    {
+        return self::class;
+    }
+}

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -32,8 +32,8 @@ use Livewire\Commands\{
     ComponentParser,
     DiscoverCommand,
     S3CleanupCommand,
-    MakeLivewireCommand,
-};
+    CleanupCommand,
+    MakeLivewireCommand};
 use Livewire\Macros\ViewMacros;
 use Livewire\HydrationMiddleware\{
     RenderView,
@@ -179,6 +179,7 @@ class LivewireServiceProvider extends ServiceProvider
             StubsCommand::class,        // livewire:stubs
             DiscoverCommand::class,     // livewire:discover
             S3CleanupCommand::class,    // livewire:configure-s3-upload-cleanup
+            CleanupCommand::class,      // livewire:upload-cleanup
             PublishCommand::class,      // livewire:publish
         ]);
     }

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -33,7 +33,8 @@ use Livewire\Commands\{
     DiscoverCommand,
     S3CleanupCommand,
     CleanupCommand,
-    MakeLivewireCommand};
+    MakeLivewireCommand
+};
 use Livewire\Macros\ViewMacros;
 use Livewire\HydrationMiddleware\{
     RenderView,

--- a/src/WithFileUploads.php
+++ b/src/WithFileUploads.php
@@ -103,7 +103,6 @@ trait WithFileUploads
             return;
         }
 
-        CleanupUploadedFilesJob::dispatch()
-            ->delay(600);
+        CleanupUploadedFilesJob::dispatch();
     }
 }


### PR DESCRIPTION
The problem
We are using livewire in a high traffic site with GCS as a temp folder for uploads. Currently the clearing of files older than 24 hours is being done in sync which causes file uploads to timeout, even by just going through the tmp folder.

Solution
Added a unique job that gets dispatched after 10 minutes (Just to group cleanups)* for systems that don't use S3 or GCS. I also added a command to dispatch that job manually if the gcs users choose to do so (or any other filesystem for that matter).

I hope this helps, thanks for the hard work, hoping for a quick response 😅

*(Forgot laravel 7 doesn't provide unique jobs)

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
