### PR TITLE
use authorize request trait

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -241,9 +241,12 @@ namespace App\Livewire;
 
 use Livewire\Component;
 use App\Models\Post;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class ShowPosts extends Component
 {
+    use AuthorizesRequests;
+    
     public function delete($id)
     {
         $post = Post::findOrFail($id);
@@ -298,9 +301,12 @@ namespace App\Livewire;
 
 use Livewire\Component;
 use App\Models\Post;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class ShowPosts extends Component
 {
+    use AuthorizesRequests;
+    
     public function delete(Post $post) // [tl! highlight]
     {
         $this->authorize('update', $post);
@@ -729,9 +735,12 @@ namespace App\Livewire;
 
 use Livewire\Component;
 use App\Models\Post;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class ShowPosts extends Component
 {
+    use AuthorizesRequests;
+    
     public function delete($id)
     {
         $post = Post::find($id);


### PR DESCRIPTION
The problem
To Authorize the request  in the component AuthorizeRequests Trait is missing which gets an error
Method App\Http\Livewire\Agent\Settings\ChatSetting::authorize does not exist.

Solution
To use Authorize requests in components  we should use AuthorizeRequests Triat


1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
