### PR TITLE
change public to private in the sample code for making dangerous methods private

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -858,7 +858,7 @@ class BrowsePosts extends Component
         $this->delete($id); // [tl! highlight]
     }
 
-    public function delete($postId)  // [tl! highlight:5]
+    private function delete($postId)  // [tl! highlight:5]
     {
         $post = Post::find($postId);
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -840,7 +840,7 @@ Every public method inside your Livewire component is callable from the client. 
 Consider the `BrowsePosts` example that we previously discussed, where users can view all posts in your application, but only administrators can delete posts. In the [Always authorize server-side](/docs/actions#always-authorize-server-side) section, we made the action secure by adding server-side authorization. Now imagine we refactor the actual deletion of the post into a dedicated method like you might do in order to simplify your code:
 
 ```php
-// Warning: this is an example of what not to do
+// Warning: This snippet demonstrates what NOT to do...
 <?php
 
 namespace App\Livewire;

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -840,6 +840,7 @@ Every public method inside your Livewire component is callable from the client. 
 Consider the `BrowsePosts` example that we previously discussed, where users can view all posts in your application, but only administrators can delete posts. In the [Always authorize server-side](/docs/actions#always-authorize-server-side) section, we made the action secure by adding server-side authorization. Now imagine we refactor the actual deletion of the post into a dedicated method like you might do in order to simplify your code:
 
 ```php
+// Warning: this is an example of what not to do
 <?php
 
 namespace App\Livewire;
@@ -858,7 +859,7 @@ class BrowsePosts extends Component
         $this->delete($id); // [tl! highlight]
     }
 
-    private function delete($postId)  // [tl! highlight:5]
+    public function delete($postId)  // [tl! highlight:5]
     {
         $post = Post::find($postId);
 


### PR DESCRIPTION
Edit: Initially I thought this code is a mistake by the author of the docs.
But then I realised it's an intentional demonstration of a possible mistake by developers. So I changed my PR from a change in the code, to a "warning" comment at the top of the code.
