### PR TITLE
[V3] Document the deprecation of @this.on()

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -606,6 +606,10 @@ Livewire.hook('commit', ({ component, commit, respond, succeed, fail }) => { // 
 
 You may consult the new [JavaScript hook documentation](/docs/javascript) for a more thorough understanding of the new hook system.
 
+### @this.on() deprecated
+
+While in Livewire 2 you could register JavaScript callbacks for component events using `@this.on('event-name', callbackFn)` in your Blade template, in Livewire 3 this has been deprecated. Instead, you should take advantage of Alpine's inclusion, and use the `x-on:event-name="callbackCode"` pattern.
+
 ## Localization
 
 If your application uses a locale prefix in the URI such as `https://example.com/en/...`, Livewire 2 automatically preserved this URL prefix when making component updates via `https://example.com/en/livewire/update`.


### PR DESCRIPTION
See discussion at https://github.com/livewire/livewire/discussions/5892

`@this.on('event-name', callbackFn)` could be used in Livewire 2 inside Blade (frequently in an `x-init`) to tell Livewire to run a JavaScript function upon a component action being triggered.

In Livewire 3, this does not work, and instead Livewire tries to call a non-existent `on()` method on the component, which fails.

Since Alpine is now included, this syntax works:

`x-on:event-name="callbackCode"`

This PR documents that change in the upgrade docs.