### PR TITLE
Add multipart upload to Livewire's FileUpload

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -62,6 +62,7 @@ return [
             'jpg', 'jpeg', 'mpga', 'webp', 'wma',
         ],
         'max_upload_time' => 5, // Max duration (in minutes) before an upload is invalidated...
+        'max_upload_part_size' => 2 * 1024 * 1024, // Max upload part size (in Mb) before the file splitted...
     ],
 
     /*

--- a/js/features/supportFileUploads.js
+++ b/js/features/supportFileUploads.js
@@ -145,6 +145,20 @@ class UploadManager {
         if ('Host' in headers) delete headers.Host
         let url = payload.url
 
+        if (payload.upload_id) {
+            this.makeRequest(name, formData, 'put', url, headers, response => {
+                if (payload.next_part == payload.parts_count) {
+                    return [this.component.$wire.call('completeMultipartUpload', name, payload.upload_id).location];
+                }
+                return undefined;
+            })
+
+            if (payload.next_part < payload.parts_count) {
+                this.component.$wire.call('uploadMultipart', name, payload.upload_id, payload.next_part);
+                return;
+            }
+        }
+
         this.makeRequest(name, formData, 'put', url, headers, response => {
             return [payload.path]
         })
@@ -169,7 +183,9 @@ class UploadManager {
             if ((request.status+'')[0] === '2') {
                 let paths = retrievePaths(request.response && JSON.parse(request.response))
 
-                this.component.$wire.call('finishUpload', name, paths, this.uploadBag.first(name).multiple)
+                if (paths) {
+                    this.component.$wire.call('finishUpload', name, paths, this.uploadBag.first(name).multiple)
+                }
 
                 return
             }

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -105,4 +105,12 @@ class FileUploadConfiguration
     {
         return config('livewire.temporary_file_upload.max_upload_time') ?: 5;
     }
+
+    public static function maxUploadPartSize()
+    {
+        return config('livewire.temporary_file_upload.max_upload_part_size')
+            ?? static::isUsingS3()
+                ? 5 * 2 ** 30 // 5 Gb, AWS limit
+                : 5 * 2 ** 10; // 5 Mb
+    }
 }

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -23,6 +23,26 @@ trait WithFileUploads
         $this->dispatch('upload:generatedSignedUrl', name: $name, url: GenerateSignedUploadUrl::forLocal())->self();
     }
 
+    public function uploadMultipart($name, $fileHashName, $uploadId, $partNumber, $partsCount)
+    {
+        $this->dispatch(
+            'upload:generatedSignedUrlForS3',
+            name: $name,
+            payload: GenerateSignedUploadUrl::forMultipartUpload(
+                $fileHashName, $uploadId, $partNumber, $partsCount
+            ),
+        )->self();
+    }
+
+    public function completeMultipartUpload($name, $uploadId)
+    {
+        return $this->dispatch(
+            'upload:generatedSignedUrlForS3',
+            name: $name,
+            payload: GenerateSignedUploadUrl::completeMultipartUpload($uploadId),
+        )->self();
+    }
+
     public function finishUpload($name, $tmpPath, $isMultiple)
     {
         $this->cleanupOldUploads();
@@ -113,4 +133,3 @@ trait WithFileUploads
         }
     }
 }
-


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
https://github.com/livewire/livewire/discussions/5917

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
no

4️⃣ Does it include tests? (Required)
WIP

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
There are times when developers are required to handle file upload with big size (> 5 GB), and how to handle that are often make some headache because there seems no one true way to implement this.

It feels like no one have handled this case, or simply no published "best practice" yet on implementing this.

Livewire has handled nicely for uploading files, especially on how to deliver the file from client side to server side. However, there still like bottleneck if we want to upload big files. Especially when our servers capacity are capped and we don't have controls to set the server.

This PR will help devs to finally feel confident to tackle this challenge, without having a headache.

Thanks for contributing! 🙌
