### PR TITLE
[V3] Add `reset` method to Form Object

### DIFF
--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -49,6 +49,24 @@ class Form implements Arrayable
         return $this->component->validate($filteredRules)[$this->propertyName];
     }
 
+    public function reset(...$properties): void
+    {
+        $properties = array_filter($properties, fn ($property) => array_key_exists($property, $this->all()));
+
+        $reset = [];
+
+        $empty = empty($properties);
+        $properties = $properties ?: $this->all();
+
+        foreach ($properties as $key => $value) {
+            if (str($value)->startsWith($this->propertyName . '.')) continue;
+
+            $reset[] = $this->propertyName .'.'. ($empty ? $key : $value);
+        }
+
+        $this->component->reset(...$reset);
+    }
+
     public function all()
     {
         return $this->toArray();

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -51,8 +51,6 @@ class Form implements Arrayable
 
     public function reset(...$properties): void
     {
-        $properties = array_filter($properties, fn ($property) => array_key_exists($property, $this->all()));
-
         $reset = [];
 
         $empty = empty($properties);

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -77,14 +77,14 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    function can_reset_a_form_object_inside_form_object()
+    function can_reset_a_form_object_inside_the_class()
     {
         Livewire::test(new class extends Component {
-            public PostFormValidateStub $form;
+            public PostFormStoreStub $form;
 
             function save()
             {
-                $this->form->reset('title', 'content');
+                $this->form->store();
             }
 
             public function render() {
@@ -101,10 +101,10 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    function can_reset_all_properties_of_form_object_inside_form_object()
+    function can_reset_all_properties_of_form_object_inside_the_class()
     {
         Livewire::test(new class extends Component {
-            public PostFormValidateStub $form;
+            public PostFormStub $form;
 
             function save()
             {
@@ -125,10 +125,10 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    function can_reset_specific_properties_of_form_object_inside_form_object()
+    function can_reset_specific_properties_of_form_object_inside_the_class()
     {
         Livewire::test(new class extends Component {
-            public PostFormValidateStub $form;
+            public PostFormStub $form;
 
             function save()
             {
@@ -182,6 +182,18 @@ class PostFormStub extends Form
     public $title = '';
 
     public $content = '';
+}
+
+class PostFormStoreStub extends Form
+{
+    public $title = '';
+
+    public $content = '';
+
+    public function store()
+    {
+        $this->reset();
+    }
 }
 
 class PostFormValidateStub extends Form

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -77,7 +77,7 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    function can_reset_a_form_object()
+    function can_reset_a_form_object_inside_form_object()
     {
         Livewire::test(new class extends Component {
             public PostFormValidateStub $form;
@@ -101,7 +101,7 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    function can_reset_all_properties_of_form_object()
+    function can_reset_all_properties_of_form_object_inside_form_object()
     {
         Livewire::test(new class extends Component {
             public PostFormValidateStub $form;
@@ -125,7 +125,7 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    function can_reset_specific_properties_of_form_object()
+    function can_reset_specific_properties_of_form_object_inside_form_object()
     {
         Livewire::test(new class extends Component {
             public PostFormValidateStub $form;

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -77,6 +77,78 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    function can_reset_a_form_object()
+    {
+        Livewire::test(new class extends Component {
+            public PostFormValidateStub $form;
+
+            function save()
+            {
+                $this->form->reset('title', 'content');
+            }
+
+            public function render() {
+                return '<div></div>';
+            }
+        })
+        ->set('form.title', 'Some Title')
+        ->set('form.content', 'Some content...')
+        ->assertHasNoErrors()
+        ->call('save')
+        ->assertSet('form.title', '')
+        ->assertSet('form.content', '')
+        ;
+    }
+
+    /** @test */
+    function can_reset_all_properties_of_form_object()
+    {
+        Livewire::test(new class extends Component {
+            public PostFormValidateStub $form;
+
+            function save()
+            {
+                $this->form->reset();
+            }
+
+            public function render() {
+                return '<div></div>';
+            }
+        })
+        ->set('form.title', 'Some Title')
+        ->set('form.content', 'Some content...')
+        ->assertHasNoErrors()
+        ->call('save')
+        ->assertSet('form.title', '')
+        ->assertSet('form.content', '')
+        ;
+    }
+
+    /** @test */
+    function can_reset_specific_properties_of_form_object()
+    {
+        Livewire::test(new class extends Component {
+            public PostFormValidateStub $form;
+
+            function save()
+            {
+                $this->form->reset('title');
+            }
+
+            public function render() {
+                return '<div></div>';
+            }
+        })
+        ->set('form.title', 'Some Title')
+        ->set('form.content', 'Some content...')
+        ->assertHasNoErrors()
+        ->call('save')
+        ->assertSet('form.title', '')
+        ->assertSet('form.content', 'Some content...')
+        ;
+    }
+
+    /** @test */
     function can_validate_a_form_object_using_rule_attributes()
     {
         Livewire::test(new class extends Component {


### PR DESCRIPTION
# Problem

With the release of Form Objects, the main idea is to abstract the logic of a form to a class outside the main scope of the component. Initially, the Form Object was released without the possibility of resetting its properties within the class itself, through a method. This makes it necessary to have **two logics in different places** 👇 

```php
class CreateTodoForm extends Form
{
    #[Rule('required|min:3|max:10')]
    public $title = '';

    #[Rule('required|min:3|max:10')]
    public $description = '';

    public function save(): void
    {
        $this->validate();

        Todo::create($this->all());
    }
}
```

And then...

```php
class Create extends Component
{

    public CreateTodoForm $form;

    // ...

    public function add(): void
    {
        $this->form->save();

        $this->reset('form.title', 'form.description'); // 👈 Two separated logics... ❌
    }
}
```

# Solution

With this PR we concentrated even more the Form Object allowing the reset to also occur within the class itself 👇 

```php
class CreateTodoForm extends Form
{
    #[Rule('required|min:3|max:10')]
    public $title = '';

    #[Rule('required|min:3|max:10')]
    public $description = '';

    public function save(): void
    {
        $this->validate();

        Todo::create($this->all());

        $this->reset(); // all...

        // $this->reset('title'); // single...

        // $this->reset('title', 'description'); // multiples...
    }
}
```

Even knowing that the focus now is the release of the V3, this PR will be of great help to anyone who wants to use Form Objects with a more concentrated logic, like above examples.

---

Hope this help,

Thanks. 🚀 
