### PR TITLE
[V3] failing test: Conditional markers containing @ with property-based co…

### DIFF
--- a/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
+++ b/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
@@ -19,7 +19,7 @@ class SupportMorphAwareIfStatement extends ComponentHook
     static function registerPrecompilers($precompile)
     {
         $outsideOfHtmlTag = function ($directive) {
-            $htmlTag = '<[^>]*("[^"]*"|\'[^\']*\'|\{\{[^}]*\}\}|@class[^[]*\[(?:[^[\]]++|(?R))*]|@if[^(]*\([^)]*\)[^@]*@endif|@foreach[^(]*\([^)]*\)[^@]*@endforeach|[^>])*?>';
+            $htmlTag = '<[^>]*("[^"]*"|\'[^\']*\'|\{\{[^}]*\}\}|@class[^[]*\[(?:[^[\]]++|(?R))*]|@if[^(]*\(([^)]*|->)*\)[^>]*|@foreach[^(]*\(([^)]*|->)*\)[^>]*|[^>])*?>';
             $bladeEchoExpression = '\{\{[^}]*\}\}';
             $bladeParameters = '\([^)]*\)';
             $ignoreIfInsideHtmlTagOrExpression = "({$htmlTag}|{$bladeEchoExpression}|{$bladeParameters})(*SKIP)(*FAIL)|";

--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -48,24 +48,17 @@ class UnitTest extends \Tests\TestCase
     /** @test */
     public function it_only_adds_conditional_markers_to_any_if_that_is_not_inside_a_html_tag_with_property_condition_containing_at_symbol()
     {
-        $output = $this->compile(<<<HTML
-            <div
-                @if (\$foo->bar)
-                    @click="baz"
-                @endif
-            >
-                @if (true)
-                    foo
-                @endif
-
-                @if (true)
-                    bar
-                @endif
-            </div>
+        $output = $this->compile(<<<'HTML'
+        <div
+            @if ($foo->bar)
+                @click="baz"
+            @endif
+        >
+        </div>
         HTML);
 
-        $this->assertOccurrences(2, '__BLOCK__', $output);
-        $this->assertOccurrences(2, '__ENDBLOCK__', $output);
+        $this->assertOccurrences(0, '__BLOCK__', $output);
+        $this->assertOccurrences(0, '__ENDBLOCK__', $output);
     }
 
     /** @test */

--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -46,6 +46,29 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    public function it_only_adds_conditional_markers_to_any_if_that_is_not_inside_a_html_tag_with_property_condition_containing_at_symbol()
+    {
+        $output = $this->compile(<<<HTML
+            <div
+                @if (\$foo->bar)
+                    @click="baz"
+                @endif
+            >
+                @if (true)
+                    foo
+                @endif
+
+                @if (true)
+                    bar
+                @endif
+            </div>
+        HTML);
+
+        $this->assertOccurrences(2, '__BLOCK__', $output);
+        $this->assertOccurrences(2, '__ENDBLOCK__', $output);
+    }
+
+    /** @test */
     public function it_adds_conditional_markers_correctly_after_class_directive_containing_parentheses()
     {
         $output = $this->compile(<<<HTML


### PR DESCRIPTION
I did try hard to fix the regex but I just couldn't get it to play ball. I have narrowed it down quite far:

`>` from `$foo->bar` seems to incorrectly match the end of that tag

and then `@` inside that condition is not being matched anywhere?

The result here is that the first `@endif` has a marker, even though it's inside the html tag