### PR TITLE
[v3] Add support for third-party upgrade commands

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/ThirdPartyUpgradeNotice.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/ThirdPartyUpgradeNotice.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Livewire\Features\SupportConsoleCommands\Commands\Upgrade;
+
+use Illuminate\Console\Command;
+
+class ThirdPartyUpgradeNotice extends UpgradeStep
+{
+    public function handle(Command $console, \Closure $next)
+    {
+        $console->line("<fg=#FB70A9;bg=black;options=bold,reverse> Third-party package upgrade 🚀 </>");
+        $console->newLine();
+        $console->comment('!! Please be aware that the following upgrade steps are registered by third-parties !!');
+        $console->newLine();
+        $console->newLine();
+        $console->line('You can abort this command at any time by pressing ctrl+c.');
+
+        if($console->confirm('Ready to continue?', true))
+        {
+            return $next($console);
+        }
+    }
+}

--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/UpgradeStep.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/UpgradeStep.php
@@ -90,7 +90,11 @@ abstract class UpgradeStep
         }
 
         return $files->map(function($file) use ($pattern, $replacement) {
-            $file['content'] = preg_replace($pattern, $replacement, $file['content'], -1, $count);
+            if($replacement instanceof \Closure) {
+                $file['content'] = preg_replace_callback($pattern, $replacement, $file['content'], -1, $count);
+            } else {
+                $file['content'] = preg_replace($pattern, $replacement, $file['content'], -1, $count);
+            }
             $file['occurrences'] = $count;
 
             return $count > 0 ? $file : null;

--- a/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
@@ -17,6 +17,7 @@ use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RemoveDeferModifie
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RemovePrefetchModifierFromWireClickDirective;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RemovePreventModifierFromWireSubmitDirective;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RepublishNavigation;
+use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ThirdPartyUpgradeNotice;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeAlpineInstructions;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeConfigInstructions;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeEmitInstructions;
@@ -28,9 +29,10 @@ class UpgradeCommand extends Command
 
     protected $description = 'Interactive upgrade helper to migrate from v2 to v3';
 
+    protected static $thirdPartyUpgradeSteps = [];
+
     public function handle()
     {
-
         app(Pipeline::class)->send($this)->through([
             UpgradeIntroduction::class,
 
@@ -48,6 +50,9 @@ class UpgradeCommand extends Command
             RepublishNavigation::class,
             ChangeTestAssertionMethods::class,
 
+            // Third-party steps
+            ... static::$thirdPartyUpgradeSteps,
+
             // Manual steps
             UpgradeConfigInstructions::class,
             UpgradeAlpineInstructions::class,
@@ -55,5 +60,14 @@ class UpgradeCommand extends Command
 
             ClearViewCache::class,
         ])->thenReturn();
+    }
+
+    public static function addThirdPartyUpgradeStep($step)
+    {
+        if(empty(static::$thirdPartyUpgradeSteps)) {
+            static::$thirdPartyUpgradeSteps[] = ThirdPartyUpgradeNotice::class;
+        }
+
+        static::$thirdPartyUpgradeSteps[] = $step;
     }
 }


### PR DESCRIPTION
I've been working on making other packages compatible with v3, like the [modal component](https://github.com/wire-elements/modal). I thought it might be cool to allow other third parties to hook into the upgrade command instead of each having to implement their own logic.

This PR will allow this as follows:

```php
UpgradeCommand::addThirdPartyUpgradeStep(\App\TestCommand::class);
```
At the same time, I'm adding closure support for more advanced replacements.
For example:

```php
// Basic replacement
$this->interactiveReplacement(
    console: $console,
    title: 'assertEmitted is now assertDispatched.',
    before: 'assertEmitted',
    after: 'assertDispatched',
    pattern: '/assertEmitted\((.*)\)/',
    replacement: 'assertDispatched($1)',
    directories: 'tests'
);

// Advanced replacement
$this->interactiveReplacement(
    console: $console,
    title: 'assertEmitted is now assertDispatched.',
    before: 'assertEmitted',
    after: 'assertDispatched',
    pattern: '/assertEmitted\((.*)\)/',
    replacement: function($matches) {
        $value = $matches[1];
        return "assertEmitted('$value')";
    },
    directories: 'tests'
);
```