### PR TITLE
[v3] Add —run-only option to upgrade command

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/UpgradeStep.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/UpgradeStep.php
@@ -3,6 +3,8 @@
 namespace Livewire\Features\SupportConsoleCommands\Commands\Upgrade;
 
 use Arr;
+use Closure;
+use Illuminate\Console\Command;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Storage;
 
@@ -32,14 +34,19 @@ abstract class UpgradeStep
         return false;
     }
 
-    public function interactiveReplacement($console, $title, $before, $after, $pattern, $replacement, $directories = ['resources/views'])
+    public function interactiveReplacement(Command $console, $title, $before, $after, $pattern, $replacement, $directories = ['resources/views'])
     {
         $console->line("<fg=#FB70A9;bg=black;options=bold,reverse> {$title} </>");
         $console->newLine();
+        $console->line('Please review the example below and confirm if you would like to apply this change.');
+        $console->newLine();
 
-        $console->line("This means all <options=underscore>{$before}</> directives must be changed to <options=underscore>{$after}</>.");
+        $console->table(['Example of the change that will be made:'], [
+            ["<fg=red>- {$before} </>"],
+            ["<fg=green>+ {$after} </>"],
+        ]);
 
-        $confirm = $console->confirm("Would you like to change all occurrences of {$before} to {$after}?", true);
+        $confirm = $console->confirm("Would you like to apply these changes?", true);
 
         if ($confirm) {
             $console->line("Changing all occurrences of <options=underscore>{$before}</> to <options=underscore>{$after}</>.");
@@ -90,7 +97,7 @@ abstract class UpgradeStep
         }
 
         return $files->map(function($file) use ($pattern, $replacement) {
-            if($replacement instanceof \Closure) {
+            if($replacement instanceof Closure) {
                 $file['content'] = preg_replace_callback($pattern, $replacement, $file['content'], -1, $count);
             } else {
                 $file['content'] = preg_replace($pattern, $replacement, $file['content'], -1, $count);

--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/UpgradeStep.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/UpgradeStep.php
@@ -49,7 +49,6 @@ abstract class UpgradeStep
         $confirm = $console->confirm("Would you like to apply these changes?", true);
 
         if ($confirm) {
-            $console->line("Changing all occurrences of <options=underscore>{$before}</> to <options=underscore>{$after}</>.");
             $console->newLine();
 
             $replacements = $this->patternReplacement($pattern, $replacement, $directories);

--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/UpgradeStep.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/UpgradeStep.php
@@ -41,7 +41,7 @@ abstract class UpgradeStep
         $console->line('Please review the example below and confirm if you would like to apply this change.');
         $console->newLine();
 
-        $console->table(['Example of the change that will be made:'], [
+        $console->table(['Before/After Example'], [
             ["<fg=red>- {$before} </>"],
             ["<fg=green>+ {$after} </>"],
         ]);

--- a/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
@@ -25,7 +25,7 @@ use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeIntroductio
 
 class UpgradeCommand extends Command
 {
-    protected $signature = 'livewire:upgrade';
+    protected $signature = 'livewire:upgrade {--run-only=}';
 
     protected $description = 'Interactive upgrade helper to migrate from v2 to v3';
 
@@ -33,7 +33,7 @@ class UpgradeCommand extends Command
 
     public function handle()
     {
-        app(Pipeline::class)->send($this)->through([
+        app(Pipeline::class)->send($this)->through(collect([
             UpgradeIntroduction::class,
 
             // Automated steps
@@ -50,16 +50,19 @@ class UpgradeCommand extends Command
             RepublishNavigation::class,
             ChangeTestAssertionMethods::class,
 
-            // Third-party steps
-            ... static::$thirdPartyUpgradeSteps,
-
             // Manual steps
             UpgradeConfigInstructions::class,
             UpgradeAlpineInstructions::class,
             UpgradeEmitInstructions::class,
 
+            // Third-party steps
+            ... static::$thirdPartyUpgradeSteps,
+
             ClearViewCache::class,
-        ])->thenReturn();
+        ])->when($this->option('run-only'), function($collection) {
+            return $collection->filter(fn($step) => str($step)->afterLast('\\')->kebab()->is($this->option('run-only')));
+        })->toArray())
+        ->thenReturn();
     }
 
     public static function addThirdPartyUpgradeStep($step)


### PR DESCRIPTION
Added an option to run only a specific upgrade command, which is helpful if you don't want to run the entire upgrade command again and go through each step. It uses a kebab case to filter.

```shell
php artisan livewire:upgrade --run-only upgrade-introduction

# Will run only the following step:
# Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeIntroduction
```

I've also moved down the third-party steps to be ran after the official steps are done.