### PR TITLE
Update volt.md

### DIFF
--- a/docs/volt.md
+++ b/docs/volt.md
@@ -269,7 +269,7 @@ $delete = function (PostRepository $posts) {
 
 ### Renderless actions
 
-In some cases, your component might declare an action that does not perform any operations that would cause the component's rendered Blade template to change. If that's the case, you can [skip the rendering phase](docs/actions#skipping-re-renders) of Livewire's lifecycle by encapsulating the action within the `action` function and chaining the `renderless` method onto its definition:
+In some cases, your component might declare an action that does not perform any operations that would cause the component's rendered Blade template to change. If that's the case, you can [skip the rendering phase](/docs/actions#skipping-re-renders) of Livewire's lifecycle by encapsulating the action within the `action` function and chaining the `renderless` method onto its definition:
 
 ```php
 use function Livewire\Volt\{action};


### PR DESCRIPTION
Link currently redirects to `https://livewire.laravel.com/docs/docs/actions#skipping-re-renders`. (`docs` twice)