### PR TITLE
[v3] Fix route caching

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -22,8 +22,8 @@ class FrontendAssets
 
     public function boot()
     {
-        app($this::class)->setScriptRoute(function ($handle) {
-            return Route::get('/livewire/livewire.js', $handle);
+        app($this::class)->setScriptRoute(function () {
+            return Route::get('/livewire/livewire.js', [self::class, 'returnJavaScriptAsFile']);
         });
 
         Blade::directive('livewireScripts', [static::class, 'livewireScripts']);
@@ -38,9 +38,7 @@ class FrontendAssets
 
     function setScriptRoute($callback)
     {
-        $route = $callback(function () {
-            return $this->returnJavaScriptAsFile();
-        });
+        $route = $callback();
 
         $this->javaScriptRoute = $route;
     }

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -17,8 +17,8 @@ class HandleRequests
 
     function boot()
     {
-        app($this::class)->setUpdateRoute(function ($handle) {
-            return Route::post('/livewire/update', $handle)->middleware('web');
+        app($this::class)->setUpdateRoute(function () {
+            return Route::post('/livewire/update', [self::class, 'handleUpdate'])->middleware('web');
         });
 
         $this->skipRequestPayloadTamperingMiddleware();
@@ -42,9 +42,7 @@ class HandleRequests
 
     function setUpdateRoute($callback)
     {
-        $route = $callback(function () {
-            return $this->handleUpdate();
-        });
+        $route = $callback();
 
         // Append `livewire.update` to the existing name, if any.
         $route->name('livewire.update');

--- a/src/Tests/LivewireRouteCachingTest.php
+++ b/src/Tests/LivewireRouteCachingTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Livewire\Tests;
+
+use Error;
+use Exception;
+use Illuminate\Routing\Route;
+use Tests\TestCase;
+
+class LivewireRouteCachingTest extends TestCase
+{
+    /** @test */
+    public function livewire_script_route_is_cacheable(): void
+    {
+        $route = $this->getRoute('livewire/livewire.js');
+
+        $this->cacheRoute($route, 'Livewire\Mechanisms\FrontendAssets\FrontendAssets@returnJavaScriptAsFile', "Failed to cache route 'livewire/livewire.js'");
+    }
+
+    /** @test */
+    public function livewire_update_route_is_cacheable(): void
+    {
+        $route = $this->getRoute('livewire/update');
+
+        $this->cacheRoute($route, 'Livewire\Mechanisms\HandleRequests\HandleRequests@handleUpdate', "Failed to cache route 'livewire/update'");
+    }
+
+    protected function getRoute(string $uri): Route
+    {
+        $route = collect(\Illuminate\Support\Facades\Route::getRoutes())
+            ->firstWhere(fn(Route $route) => $route->uri() === $uri);
+
+        if ($route === null) {
+            $this->fail("Route '$uri' not found.");
+        }
+
+        return $route;
+    }
+
+    protected function cacheRoute(Route $route, string $expectedHandle, string $message): void
+    {
+        try {
+            $route->prepareForSerialization();
+
+            $this->assertStringContainsString($expectedHandle, $route->getAction('uses'));
+        } catch (Error|Exception) {
+            $this->fail($message);
+        }
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
This PR fixes Laravel route caching. This problem has been mentioned in https://github.com/livewire/livewire/discussions/5910 and https://github.com/livewire/livewire/pull/6000

Test implementation taken from here and sightly modified: https://github.com/livewire/livewire/pull/5910

To be honest I am not sure why the routes were created with this `$handle` closure. But in my case it works perfectly fine without.