### PR TITLE
[v3] Fix route caching

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -38,9 +38,7 @@ class FrontendAssets
 
     function setScriptRoute($callback)
     {
-        $route = $callback(function () {
-            return $this->returnJavaScriptAsFile();
-        });
+        $route = $callback([self::class, 'returnJavaScriptAsFile']);
 
         $this->javaScriptRoute = $route;
     }

--- a/src/Mechanisms/HandleRequests/BrowserTest.php
+++ b/src/Mechanisms/HandleRequests/BrowserTest.php
@@ -12,7 +12,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     {
         Livewire::setUpdateRoute(function ($handle) {
             return Route::post('/custom/update', function () use ($handle) {
-                $response = $handle();
+                $response = app(HandleRequests::class)->handleUpdate();
 
                 // Override normal Livewire and force the updated count to be "5" instead of 2...
                 $response['components'][0]['effects']['html'] = (string) str($response['components'][0]['effects']['html'])->replace(

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -42,9 +42,7 @@ class HandleRequests
 
     function setUpdateRoute($callback)
     {
-        $route = $callback(function () {
-            return $this->handleUpdate();
-        });
+        $route = $callback([self::class, 'handleUpdate']);
 
         // Append `livewire.update` to the existing name, if any.
         $route->name('livewire.update');

--- a/src/Tests/LivewireRouteCachingTest.php
+++ b/src/Tests/LivewireRouteCachingTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Livewire\Tests;
+
+use Error;
+use Exception;
+use Illuminate\Routing\Route;
+use Tests\TestCase;
+
+class LivewireRouteCachingTest extends TestCase
+{
+    /** @test */
+    public function livewire_script_route_is_cacheable(): void
+    {
+        $route = $this->getRoute('livewire/livewire.js');
+
+        $this->cacheRoute($route, 'Livewire\Mechanisms\FrontendAssets\FrontendAssets@returnJavaScriptAsFile', "Failed to cache route 'livewire/livewire.js'");
+    }
+
+    /** @test */
+    public function livewire_update_route_is_cacheable(): void
+    {
+        $route = $this->getRoute('livewire/update');
+
+        $this->cacheRoute($route, 'Livewire\Mechanisms\HandleRequests\HandleRequests@handleUpdate', "Failed to cache route 'livewire/update'");
+    }
+
+    protected function getRoute(string $uri): Route
+    {
+        $route = collect(\Illuminate\Support\Facades\Route::getRoutes())
+            ->firstWhere(fn(Route $route) => $route->uri() === $uri);
+
+        if ($route === null) {
+            $this->fail("Route '$uri' not found.");
+        }
+
+        return $route;
+    }
+
+    protected function cacheRoute(Route $route, string $expectedHandle, string $message): void
+    {
+        try {
+            $route->prepareForSerialization();
+
+            $this->assertStringContainsString($expectedHandle, $route->getAction('uses'));
+        } catch (Error|Exception $e) {
+            dd($e);
+            $this->fail($message);
+        }
+
+        $this->assertTrue(true);
+    }
+}

--- a/src/Tests/LivewireRouteCachingTest.php
+++ b/src/Tests/LivewireRouteCachingTest.php
@@ -43,8 +43,7 @@ class LivewireRouteCachingTest extends TestCase
             $route->prepareForSerialization();
 
             $this->assertStringContainsString($expectedHandle, $route->getAction('uses'));
-        } catch (Error|Exception $e) {
-            dd($e);
+        } catch (Error|Exception) {
             $this->fail($message);
         }
 


### PR DESCRIPTION
This PR fixes Laravel route caching. This problem has been mentioned in https://github.com/livewire/livewire/pull/5910 and https://github.com/livewire/livewire/discussions/6000

Test implementation taken from here and sightly modified: https://github.com/livewire/livewire/pull/5910