### PR TITLE
[v3] Fix stream variable and ob_flush issue

### DIFF
--- a/src/Features/SupportStreaming/HandlesStreaming.php
+++ b/src/Features/SupportStreaming/HandlesStreaming.php
@@ -6,10 +6,10 @@ use Livewire\ComponentHookRegistry;
 
 trait HandlesStreaming
 {
-    function stream($name, $content, $append = false)
+    function stream($name, $content, $replace = false)
     {
         $hook = ComponentHookRegistry::getHook($this, SupportStreaming::class);
 
-        $hook->stream($name, $content, $append);
+        $hook->stream($name, $content, $replace);
     }
 }

--- a/src/Features/SupportStreaming/SupportStreaming.php
+++ b/src/Features/SupportStreaming/SupportStreaming.php
@@ -32,7 +32,11 @@ class SupportStreaming extends ComponentHook
     public static function streamContent($body)
     {
         echo json_encode(['stream' => true, 'body' => $body, 'endStream' => true]);
-        ob_flush();
+
+        if (ob_get_level() > 0) {
+            ob_flush();
+        }
+
         flush();
     }
 }


### PR DESCRIPTION
The 3rd args of the stream method should be $replace, not $append because of its behavior.

Only need ob_flush() if an output buffer is active, so always check it before running ob_flush() to avoid this error:

`ob_flush(): Failed to flush buffer. No buffer to flush`