### PR TITLE
[v3] Fix asset auto injection (miss matches)

### DIFF
--- a/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
+++ b/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
@@ -40,16 +40,16 @@ class SupportAutoInjectedAssets extends ComponentHook
 
         $html = str($html);
 
-        if ($html->test('/<\s*head[^>]*>/') && $html->test('/<\s*body[^>]*>/')) {
+        if ($html->test('/<\s*head(?:\s|\s[^>])*>/i') && $html->test('/<\s*\/\s*body\s*>/i')) {
             return $html
-                ->replaceMatches('/(<\s*head[^>]*>)/', '$1'.$livewireStyles)
-                ->replaceMatches('/(<\s*\/\s*body\s*>)/', $livewireScripts.'$1')
+                ->replaceMatches('/(<\s*head(?:\s|\s[^>])*>)/i', '$1'.$livewireStyles)
+                ->replaceMatches('/(<\s*\/\s*body\s*>)/i', $livewireScripts.'$1')
                 ->toString();
         }
 
         return $html
-            ->replaceMatches('/(<\s*html[^>]*>)/', '$1'.$livewireStyles)
-            ->replaceMatches('/(<\s*\/\s*html\s*>)/', $livewireScripts.'$1')
+            ->replaceMatches('/(<\s*html(?:\s[^>])*>)/i', '$1'.$livewireStyles)
+            ->replaceMatches('/(<\s*\/\s*html\s*>)/i', $livewireScripts.'$1')
             ->toString();
     }
 }

--- a/src/Features/SupportAutoInjectedAssets/UnitTest.php
+++ b/src/Features/SupportAutoInjectedAssets/UnitTest.php
@@ -91,6 +91,45 @@ class UnitTest extends TestCase
     }
 
     /** @test */
+    public function it_injects_livewire_assets_html_with_header(): void
+    {
+        $livewireStyles = FrontendAssets::styles();
+        $livewireScripts = FrontendAssets::scripts();
+
+        $this->compare(<<<'HTML'
+            <!doctype html>
+            <HTML
+                lang="en"
+            >
+                <Head
+                >
+                    <meta charset="utf-8"/>
+                    <title></title>
+                </Head>
+                <bOdY>
+                    <header class=""></header>
+                </bOdY
+                >
+            </HTML>
+        HTML, <<<HTML
+            <!doctype html>
+            <HTML
+                lang="en"
+            >
+                <Head
+                >$livewireStyles
+                    <meta charset="utf-8"/>
+                    <title></title>
+                </Head>
+                <bOdY>
+                    <header class=""></header>
+                $livewireScripts</bOdY
+                >
+            </HTML>
+        HTML);
+    }
+
+    /** @test */
     public function can_disable_auto_injection_using_global_method(): void
     {
         $this->markTestIncomplete();


### PR DESCRIPTION
- compare and replace `case-insensitive`
- ensure only `html` `head` and `body` are matching - not `header` or anything else