### PR TITLE
[v3] Fix links to the plugins and arranged alphabetically

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -214,12 +214,12 @@ If you include Alpine into your application via a script tag like the following,
 
 Livewire 3 now ships with the following Alpine plugins out-of-the-box:
 
-* [Intersect](https://alpinejs.dev/docs/plugins/intersect)
-* [Collapse](https://alpinejs.dev/docs/plugins/collapse)
-* [Persist](https://alpinejs.dev/docs/plugins/persist)
-* [Morph](https://alpinejs.dev/docs/plugins/morph)
-* [Focus](https://alpinejs.dev/docs/plugins/focus)
-* [Mask](https://alpinejs.dev/docs/plugins/mask)
+* [Collapse](https://alpinejs.dev/plugins/collapse)
+* [Focus](https://alpinejs.dev/plugins/focus)
+* [Intersect](https://alpinejs.dev/plugins/intersect)
+* [Mask](https://alpinejs.dev/plugins/mask)
+* [Morph](https://alpinejs.dev/plugins/morph)
+* [Persist](https://alpinejs.dev/plugins/persist)
 
 If you have already included any of these in your application via `<script>` tags like below, you can remove them along with Alpine's core:
 


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
I believe its needed as the current links are not working, but no discussion
2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
yes
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
no
4️⃣ Does it include tests? (Required)
no
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

The current links for the plugins on the [docs ](https://livewire.laravel.com/docs/upgrading#including-plugins-via-a-script-tag) are not working and the correct links are without the [docs in them](https://alpinejs.dev/plugins/collapse).
I also arranged them alphabetically, but I can revert that if its not needed. 
Cheers

