### PR TITLE
[V3] Add --pest command to Artisan commands

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,6 +9,8 @@ artisan make:livewire create-post --test
 
 In addition to generating the component files themselves, the above command will generate the following test file `tests/Feature/Livewire/CreatePostTest.php`:
 
+If you would like to create a [Pest PHP](https://pestphp.com/) test, you may provide the `--pest` option to the make:livewire command:
+
 ```php
 <?php
 

--- a/src/Features/SupportConsoleCommands/Commands/ComponentParser.php
+++ b/src/Features/SupportConsoleCommands/Commands/ComponentParser.php
@@ -186,9 +186,9 @@ class ComponentParser
         return str($this->testPath())->replaceFirst(base_path().'/', '');
     }
 
-    public function testContents()
+    public function testContents($testType = 'phpunit')
     {
-        $stubName = 'livewire.test.stub';
+        $stubName = $testType === 'pest' ? 'livewire.pest.stub' : 'livewire.test.stub';
 
         if(File::exists($stubPath = base_path($this->stubDirectory.$stubName))) {
             $template = file_get_contents($stubPath);

--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\File;
 
 class MakeCommand extends FileManipulationCommand
 {
-    protected $signature = 'livewire:make {name} {--force} {--inline} {--test} {--stub= : If you have several stubs, stored in subfolders }';
+    protected $signature = 'livewire:make {name} {--force} {--inline} {--test} {--pest} {--stub= : If you have several stubs, stored in subfolders }';
 
     protected $description = 'Create a new Livewire component';
 
@@ -35,7 +35,8 @@ class MakeCommand extends FileManipulationCommand
 
         $force = $this->option('force');
         $inline = $this->option('inline');
-        $test = $this->option('test');
+        $test = $this->option('test') || $this->option('pest');
+        $testType = $this->option('test') ? 'phpunit' : 'pest';
 
         $showWelcomeMessage = $this->isFirstTimeMakingAComponent();
 
@@ -43,7 +44,7 @@ class MakeCommand extends FileManipulationCommand
         $view = $this->createView($force, $inline);
 
         if ($test) {
-            $test = $this->createTest($force);
+            $test = $this->createTest($force, $testType);
         }
 
         if($class || $view) {
@@ -102,7 +103,7 @@ class MakeCommand extends FileManipulationCommand
         return $viewPath;
     }
 
-    protected function createTest($force = false)
+    protected function createTest($force = false, $testType = 'phpunit')
     {
         $testPath = $this->parser->testPath();
 
@@ -115,7 +116,7 @@ class MakeCommand extends FileManipulationCommand
 
         $this->ensureDirectoryExists($testPath);
 
-        File::put($testPath, $this->parser->testContents());
+        File::put($testPath, $this->parser->testContents($testType));
 
         return $testPath;
     }

--- a/src/Features/SupportConsoleCommands/Commands/MakeLivewireCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeLivewireCommand.php
@@ -4,5 +4,5 @@ namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 class MakeLivewireCommand extends MakeCommand
 {
-    protected $signature = 'make:livewire {name} {--force} {--inline} {--test} {--stub=}';
+    protected $signature = 'make:livewire {name} {--force} {--inline} {--test} {--pest} {--stub=}';
 }

--- a/src/Features/SupportConsoleCommands/Commands/StubsCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/StubsCommand.php
@@ -39,6 +39,11 @@ class StubsCommand extends Command
             file_get_contents(__DIR__.'/livewire.test.stub')
         );
 
+        file_put_contents(
+            $stubsPath.'/livewire.pest.stub',
+            file_get_contents(__DIR__.'/livewire.pest.stub')
+        );
+
         $this->info('Stubs published successfully.');
     }
 }

--- a/src/Features/SupportConsoleCommands/Commands/TouchCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/TouchCommand.php
@@ -4,7 +4,7 @@ namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 class TouchCommand extends MakeCommand
 {
-    protected $signature = 'livewire:touch {name} {--force} {--inline} {--test} {--stub=default}';
+    protected $signature = 'livewire:touch {name} {--force} {--inline} {--test} {--pest} {--stub=default}';
 
     protected function configure()
     {

--- a/src/Features/SupportConsoleCommands/Commands/livewire.pest.stub
+++ b/src/Features/SupportConsoleCommands/Commands/livewire.pest.stub
@@ -1,0 +1,9 @@
+<? php
+
+use [classwithnamespace];
+use Livewire\Livewire;
+
+it('renders successfully', function () {
+    Livewire::test([class]::class)
+        ->assertStatus(200);
+});

--- a/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
@@ -37,6 +37,22 @@ class MakeCommandUnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    public function component_pest_test_is_created_by_make_command_with_pest_option()
+    {
+        Artisan::call('make:livewire', ['name' => 'foo', '--pest' => true]);
+
+        $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
+        $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('FooTest.php')));
+
+        $file = File::get($this->livewireTestsPath('FooTest.php'));
+
+        $this->assertStringContainsString('use App\Livewire\Foo;', $file);
+        $this->assertStringContainsString('use Livewire\Livewire;', $file);
+        $this->assertStringContainsString('it(\'renders successfully\', function () {', $file);
+    }
+
+    /** @test */
     public function component_is_created_by_livewire_make_command()
     {
         Artisan::call('livewire:make', ['name' => 'foo', '--test' => true]);

--- a/src/Features/SupportConsoleCommands/Tests/StubCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/StubCommandUnitTest.php
@@ -16,6 +16,7 @@ class StubCommandUnitTest extends \Tests\TestCase
         $this->assertTrue(File::exists($this->stubsPath('livewire.inline.stub')));
         $this->assertTrue(File::exists($this->stubsPath('livewire.view.stub')));
         $this->assertTrue(File::exists($this->stubsPath('livewire.test.stub')));
+        $this->assertTrue(File::exists($this->stubsPath('livewire.pest.stub')));
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds a `--pest` flag to the Artisan commands when creating a Livewire component to also create a Pest PHP test.

```shell
artisan make:livewire create-post --pest
```

It also handles copying and deleting the Pest files when the respective commands are run.

A new `livewire.pest.stub` was created for the Pest tests and it also gets published when publishing the stubs.
