### PR TITLE
Use array for only method

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -23,7 +23,7 @@ class CreatePost extends Component
     public function save()
     {
         Post::create(
-            $this->only('title', 'content')
+            $this->only(['title', 'content'])
         );
 
         return $this->redirect('/posts')


### PR DESCRIPTION
This PR fixes a code example from the docs where the array syntax is missing for the `only` method on the form page.
