### PR TITLE
[V3] Fixed incorrect directive in documentation ( actions.md )

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -218,8 +218,6 @@ Livewire provides a `wire:loading` directive that makes it trivial to show and h
 
 ```blade
 <form wire:submit="save">
-    <input wire:model="title">
-
     <textarea wire:model="content"></textarea>
 
     <button type="submit">Save</button>

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -218,7 +218,9 @@ Livewire provides a `wire:loading` directive that makes it trivial to show and h
 
 ```blade
 <form wire:submit="save">
-    <textarea wire:submit="content"></textarea>
+    <input wire:model="title">
+
+    <textarea wire:model="content"></textarea>
 
     <button type="submit">Save</button>
 


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes. Because the documentation isn't correct. I did not create a discussion because I think it is such small change that it would be overkill.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

4️⃣ Does it include tests? (Required)

No. Not applicable.


5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

While reviewing the Laravel Livewire 3.x documentation, I noticed an incorrect directive used in an example:

Original:
```html
<textarea wire:submit="content"></textarea>
```

Corrected:
```html
<textarea wire:model="content"></textarea>
```

This PR corrects this typo to ensure accuracy in the documentation.

Thanks for contributing! 🙌
