### PR TITLE
[V3] Docs: fix `composer require` commands

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@ Livewire is a Laravel package, so you will need to have a Laravel application up
 To install Livewire, open your terminal and navigate to your Laravel application directory, then run the following command:
 
 ```shell
-composer require livewire/livewire:^3.0@beta
+composer require livewire/livewire "^3.0@beta"
 ```
 
 That's it — really. If you want more customization options, keep reading. Otherwise, you can jump right into using Livewire.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,7 @@ Before we start, make sure you have the following installed:
 From the root directory of your Laravel app, run the following [Composer](https://getcomposer.org/) command:
 
 ```shell
-composer require livewire/livewire:^3.0@beta
+composer require livewire/livewire "^3.0@beta"
 ```
 
 ## Create a Livewire component

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -26,13 +26,13 @@ Livewire now requires that your application is running on PHP version 8.1 or gre
 Run the following composer command to upgrade your application's Livewire dependency from version 2 to 3:
 
 ```shell
-composer require livewire/livewire:3.0.0-beta.1
+composer require livewire/livewire "3.0.0-beta.4"
 ```
 
 The above command will lock you to the current beta version. If you want to receive more frequent updates, you can switch to the more flexible version constraint:
 
 ```shell
-composer require livewire/livewire:^3.0@beta
+composer require livewire/livewire "^3.0@beta"
 ```
 
 <!-- @todo after launch:

--- a/docs/volt.md
+++ b/docs/volt.md
@@ -27,8 +27,8 @@ $increment = fn () => $this->count++;
 To get started, install Volt into your project using the Composer package manager:
 
 ```bash
-composer require livewire/livewire:^3.0@beta # Or ensure Livewire v3.x is installed...
-composer require livewire/volt:^1.0@beta
+composer require livewire/livewire "^3.0@beta" # Or ensure Livewire v3.x is installed...
+composer require livewire/volt "^1.0@beta"
 ```
 
 After installing Volt, you may execute the `volt:install` Artisan command, which will install Volt's service provider file into your application. This service provider specifies the mounted directories in which Volt will search for single file components:


### PR DESCRIPTION
It seems that Windows machines have difficulties with the current `composer require` commands, because they contain a `^`.
With the current commands, it causes errors while installing, like:

![afbeelding](https://github.com/livewire/livewire/assets/11609290/4884bb5d-ba51-4309-a38a-eb1a45d915d1)

Could be resolved when the version parameter is [enclosed by double quotes](https://stackoverflow.com/questions/72877159/using-composer-require-without-quotes/72904848#72904848):

![afbeelding](https://github.com/livewire/livewire/assets/11609290/975aed39-b275-4426-a10b-a176405137d3)
