### PR TITLE
[v3] Fix layout path in docs

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -384,12 +384,12 @@ Now, when you visit the `/posts/create` path in your browser, the `CreatePost` c
 
 ### Layout files
 
-Remember that full-page components will use your application's layout, typically defined in the `resources/views/components/layout.blade.php` file.
+Remember that full-page components will use your application's layout, typically defined in the `resources/views/components/layouts/app.blade.php` file.
 
 Ensure you have created a Blade file at this location and included a `{{ $slot }}` placeholder:
 
 ```blade
-<!-- resources/views/components/layout.blade.php -->
+<!-- resources/views/components/layouts/app.blade.php -->
 
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -97,7 +97,7 @@ Now, our _counter_ component is assigned to the `/counter` route, so that when a
 
 ## Create a template layout
 
-Before you can visit `/counter` in the browser, we need an HTML layout for our component to render inside. By default, Livewire will automatically look for a layout file named: `resources/views/components/layout.blade.php`
+Before you can visit `/counter` in the browser, we need an HTML layout for our component to render inside. By default, Livewire will automatically look for a layout file named: `resources/views/components/layouts/app.blade.php`
 
 You may create this file if it doesn't already exist by running the following command:
 
@@ -105,7 +105,7 @@ You may create this file if it doesn't already exist by running the following co
 php artisan livewire:layout
 ```
 
-This command will generate a file called `resources/views/components/layout.blade.php` with the following contents:
+This command will generate a file called `resources/views/components/layouts/app.blade.php` with the following contents:
 
 ```blade
 <!DOCTYPE html>


### PR DESCRIPTION
Congrats on v3 Launch! 🎉

Noticed that the layout paths in the docs are not what Livewire v3 expects as the default full page component layout path.

Cheers! 