### PR TITLE
Docs Fix - Code example bug about property visibility

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -288,7 +288,7 @@ use App\Models\Post;
 
 class PostForm extends Form
 {
-    public ?Post $post;
+    protected ?Post $post;
 
     #[Rule('required|min:5')]
     public $title = '';

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -307,7 +307,7 @@ class PostForm extends Form
 
     public function store()
     {
-        Post::create($this->all());
+        Post::create($this->only(['title', 'content']));
     }
 
     public function update()

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -288,7 +288,7 @@ use App\Models\Post;
 
 class PostForm extends Form
 {
-    protected ?Post $post;
+    public ?Post $post;
 
     #[Rule('required|min:5')]
     public $title = '';


### PR DESCRIPTION
This PR fixes a code example about form objects. I'm pretty sure this model property needs to be `protected`, because when `public` it will be used for the `$this->all()` method which tries to fill a column on the model that does not exist.

![CleanShot 2023-07-29 at 17 26 19@2x](https://github.com/livewire/livewire/assets/1394539/693b0baa-1205-461d-9cc7-652db8ff2976)
