### PR TITLE
[v3] assign classname from laravel morph map

### DIFF
--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Schema;
 use Livewire\Livewire;
-use Sushi\Sushi;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -14,36 +13,11 @@ class UnitTest extends \Tests\TestCase
     {
         parent::setUp();
 
-        Schema::create('authors', function ($table) {
-            $table->bigIncrements('id');
-            $table->string('title');
-            $table->string('name');
-            $table->string('email');
-            $table->timestamps();
-        });
-
         Schema::create('posts', function ($table) {
             $table->bigIncrements('id');
             $table->string('title');
             $table->string('description');
             $table->string('content');
-            $table->foreignId('author_id')->nullable();
-            $table->timestamps();
-        });
-
-        Schema::create('comments', function ($table) {
-            $table->bigIncrements('id');
-            $table->string('comment');
-            $table->foreignId('post_id');
-            $table->foreignId('author_id');
-            $table->timestamps();
-        });
-
-        Schema::create('other_comments', function ($table) {
-            $table->bigIncrements('id');
-            $table->string('comment');
-            $table->foreignId('post_id');
-            $table->foreignId('author_id');
             $table->timestamps();
         });
     }
@@ -180,17 +154,12 @@ class UnitTest extends \Tests\TestCase
             ->call('$refresh')
             ->assertSet('post', $post);
     }
+
 }
 
 #[\Attribute]
 class Lazy {
     //
-}
-
-class Post extends Model
-{
-    protected $connection = 'testbench';
-    protected $guarded = [];
 }
 
 class PostComponent extends \Livewire\Component
@@ -208,4 +177,9 @@ class PostComponent extends \Livewire\Component
         <div></div>
         HTML;
     }
+}
+class Post extends Model
+{
+    protected $connection = 'testbench';
+    protected $guarded = [];
 }

--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -4,30 +4,14 @@ namespace Livewire\Features\SupportModels;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Facades\Schema;
 use Livewire\Livewire;
+use Sushi\Sushi;
 
 class UnitTest extends \Tests\TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        Schema::create('posts', function ($table) {
-            $table->bigIncrements('id');
-            $table->string('title');
-            $table->string('description');
-            $table->string('content');
-            $table->timestamps();
-        });
-    }
-
     /** @test */
     public function model_properties_are_persisted()
     {
-        Post::create(['id' => 1, 'title' => 'Post 1', 'description' => 'Post 1 Description', 'content' => 'Post 1 Content']);
-        Post::create(['id' => 2, 'title' => 'Post 2', 'description' => 'Post 2 Description', 'content' => 'Post 2 Content']);
-
         (new Post)::resolveConnection()->enableQueryLog();
 
         Livewire::test(new class extends \Livewire\Component {
@@ -41,9 +25,9 @@ class UnitTest extends \Tests\TestCase
                 <div>{{ $post->title }}</div>
             HTML; }
         })
-        ->assertSee('Post 1')
+        ->assertSee('First')
         ->call('$refresh')
-        ->assertSee('Post 1');
+        ->assertSee('First');
 
         $this->assertCount(2, Post::resolveConnection()->getQueryLog());
     }
@@ -51,9 +35,6 @@ class UnitTest extends \Tests\TestCase
     /** @test */
     public function cant_update_a_model_property()
     {
-        Post::create(['id' => 1, 'title' => 'Post 1', 'description' => 'Post 1 Description', 'content' => 'Post 1 Content']);
-        Post::create(['id' => 2, 'title' => 'Post 2', 'description' => 'Post 2 Description', 'content' => 'Post 2 Content']);
-
         $this->expectExceptionMessage("Can't set model properties directly");
 
         Livewire::test(new class extends \Livewire\Component {
@@ -67,16 +48,13 @@ class UnitTest extends \Tests\TestCase
                 <div>{{ $post->title }}</div>
             HTML; }
         })
-        ->assertSee('Post 1')
+        ->assertSee('First')
         ->set('post.title', 'bar');
     }
 
     /** @test */
     public function cant_view_model_data_in_javascript()
     {
-        Post::create(['id' => 1, 'title' => 'Post 1', 'description' => 'Post 1 Description', 'content' => 'Post 1 Content']);
-        Post::create(['id' => 2, 'title' => 'Post 2', 'description' => 'Post 2 Description', 'content' => 'Post 2 Content']);
-
         $data = Livewire::test(new class extends \Livewire\Component {
             public Post $post;
 
@@ -96,9 +74,6 @@ class UnitTest extends \Tests\TestCase
     public function model_properties_are_lazy_loaded()
     {
         $this->markTestSkipped(); // @todo: probably not going to go this route...
-        Post::create(['id' => 1, 'title' => 'Post 1', 'description' => 'Post 1 Description', 'content' => 'Post 1 Content']);
-        Post::create(['id' => 2, 'title' => 'Post 2', 'description' => 'Post 2 Description', 'content' => 'Post 2 Content']);
-
         (new Post)::resolveConnection()->enableQueryLog();
 
         Livewire::test(new class extends \Livewire\Component {
@@ -128,8 +103,6 @@ class UnitTest extends \Tests\TestCase
     /** @test */
     public function it_uses_laravels_morph_map_instead_of_class_name_if_available_when_dehydrating()
     {
-        $post = Post::create(['id' => 1, 'title' => 'Post 1', 'description' => 'Post 1 Description', 'content' => 'Post 1 Content']);
-
         Relation::morphMap([
             'post' => Post::class,
         ]);
@@ -142,9 +115,7 @@ class UnitTest extends \Tests\TestCase
     /** @test */
     public function it_uses_laravels_morph_map_instead_of_class_name_if_available_when_hydrating()
     {
-        $post = Post::create(['id' => 1, 'title' => 'Post 1', 'description' => 'Post 1 Description', 'content' => 'Post 1 Content']);
-
-        $post = $post->fresh();
+        $post = Post::first();
 
         Relation::morphMap([
             'post' => Post::class,
@@ -180,6 +151,10 @@ class PostComponent extends \Livewire\Component
 }
 class Post extends Model
 {
-    protected $connection = 'testbench';
-    protected $guarded = [];
+    use Sushi;
+
+    protected $rows = [
+        ['title' => 'First'],
+        ['title' => 'Second'],
+    ];
 }


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first? ⚠️ 
It did not open any discussion but it is supposed to be according to [docs: properties expose system information to the browser](https://livewire.laravel.com/docs/properties#properties-expose-system-information-to-the-browser)
also there are some old discussions about it on V2, #4074 #3812 

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed) ✅ 

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out. ❌ 

4️⃣ Does it include tests? (Required) ✅ 

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌

## Context
According to [docs: properties expose system information to the browser](https://livewire.laravel.com/docs/properties#properties-expose-system-information-to-the-browser) class names exposed to JS through snapshot `component.snapshot.data.model[1].class` property can be overridden by Laravel default `Relation::morphMap()` which is not working with Livewire V3,

Meanwhile, it is still possible to do so if the `legacy_model_binding` is turned on in the config which will change the behavior of livewire toward model binding according to the [docs: eloquent model binding](https://livewire.laravel.com/docs/upgrading#eloquent-model-binding)