### PR TITLE
[V3] Remove excess #[On('echo:orders,OrderShipped')] from events docs

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -343,7 +343,6 @@ class OrderTracker extends Component
         ];
     }
 
-    #[On('echo:orders,OrderShipped')]
     public function notifyShipped()
     {
         $this->showOrderShippedNotification = true;


### PR DESCRIPTION
This might be a tiny detail, but since `notifyShipped` is registered in `getListeners` method, it should not be registered again in `#[On]` attribute.