### PR TITLE
[v3] Fix reset all

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -44,6 +44,11 @@ trait InteractsWithProperties
             ? $properties[0]
             : $properties;
 
+        // Reset all
+        if (empty($properties)) {
+            $properties = array_keys($this->all());
+        }
+
         $freshInstance = new static;
 
         foreach ($properties as $property) {


### PR DESCRIPTION
In v2 when calling `$this->reset();` without any parameters, all properties were reset, but in v3 none of the properties are reset.

I guess this is a bug, because there is already a test file with a failing test: [src/Concerns/Tests/ResetPropertiesTest.php](https://github.com/livewire/livewire/blob/e3a1a5a70aa037276b98e8d69f19ff194240cb89/src/Concerns/Tests/ResetPropertiesTest.php#L25)
But this test file is not executed when running the PHPUnit test suite nor is it run in the testing pipeline.

This PR brings this behaviour back but does not update the PHPUnit configuration.