### PR TITLE
[V3] Upgrade Computed Properties

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/ChangeComputedProperties.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/ChangeComputedProperties.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Livewire\Features\SupportConsoleCommands\Commands\Upgrade;
+
+use Livewire\Features\SupportConsoleCommands\Commands\UpgradeCommand;
+
+class ChangeComputedProperties extends UpgradeStep
+{
+    public function handle(UpgradeCommand $console, \Closure $next)
+    {
+        $this->interactiveReplacement(
+            console: $console,
+            title: 'The getComputedProperty gets replaced by property name with attribute.',
+            before: 'public function getFooBarProperty()',
+            after: "#[\Livewire\Attributes\Computed]\n  public function fooBar()",
+            pattern: '/(.*)public function get(.+)Property\(\)/',
+            replacement: fn ($matches) => isset($matches[2])
+                ? "{$matches[1]}#[\Livewire\Attributes\Computed]\n{$matches[1]}public function ".str($matches[2])->lcfirst().'()'
+                : $matches[0],
+            directories: 'app',
+        );
+
+        return $next($console);
+    }
+}

--- a/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Pipeline\Pipeline;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\AddLiveModifierToEntangleDirectives;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\AddLiveModifierToWireModelDirectives;
+use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ChangeComputedProperties;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ChangeDefaultLayoutView;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ChangeDefaultNamespace;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ChangeLazyToBlurModifierOnWireModelDirectives;
@@ -51,6 +52,7 @@ class UpgradeCommand extends Command
             RepublishNavigation::class,
             ChangeTestAssertionMethods::class,
             ChangeForgetComputedToUnset::class,
+            ChangeComputedProperties::class,
 
             // Partially automated steps
             ReplaceEmitWithDispatch::class,


### PR DESCRIPTION
This PR brings the option to replace computed properties during the upgrade to V3.
It handles single word or multiple words, converting the first letter to lower case.


It would convert any of the following scenarios:
```php
    public function getComputedNameProperty(): Collection
    {
        //
    }

    public function getOtherComputedNameProperty()
    {
        //
    }

    public function getComputedProperty(): Collection
    {
        //
    }

    public function getOtherComputedProperty()
    {
        //
    }
```

Into this:
```php
   #[\Livewire\Attributes\Computed]
    public function computedName(): Collection
    {
        //
    }

    #[\Livewire\Attributes\Computed]
    public function otherComputedName()
    {
        //
    }

    #[\Livewire\Attributes\Computed]
    public function computed(): Collection
    {
        //
    }

    #[\Livewire\Attributes\Computed]
    public function otherComputed()
    {
        //
    }
```