### PR TITLE
[v3] Added additional information on #[Modelable] attribute 

### DIFF
--- a/docs/nesting.md
+++ b/docs/nesting.md
@@ -302,6 +302,10 @@ class TodoInput extends Component
 
 Now the parent `TodoList` component can treat `TodoInput` like any other input element and bind directly to its value using `wire:model`.
 
+> [!warning]
+> Currently Livewire only support a single `#[Modelable]` attribute, only the first one will be bound.
+
+
 ## Listening for events from children
 
 Another powerful parent-child component communication technique is Livewire's event system, which allows you to dispatch an event on the server or client that can be intercepted by other components.


### PR DESCRIPTION
When reading I asked myself if there was any way to have multiple `#[Modelable]` attributes.
I checked `SupportWireModelingNestedComponents` and find out the answer, so it seemed a good idea to share it with others.