### PR TITLE
[v3] Add except method to form

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -80,6 +80,8 @@ trait InteractsWithProperties
 
     public function except($properties)
     {
+        if (! is_array($properties)) $properties = [$properties];
+
         return array_diff_key($this->all(), array_flip($properties));
     }
 

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -15,32 +15,20 @@ class Form implements Arrayable
         $this->addValidationRulesToComponent();
     }
 
-    public function getComponent()
-    {
-        return $this->component;
-    }
-
-    public function getPropertyName()
-    {
-        return $this->propertyName;
-    }
+    public function getComponent() { return $this->component; }
+    public function getPropertyName() { return $this->propertyName; }
 
     public function addValidationRulesToComponent()
     {
         $rules = [];
 
-        if (method_exists($this, 'rules')) {
-            $rules = $this->rules();
-        } else {
-            if (property_exists($this, 'rules')) {
-                $rules = $this->rules;
-            }
-        }
+        if (method_exists($this, 'rules')) $rules = $this->rules();
+        else if (property_exists($this, 'rules')) $rules = $this->rules;
 
         $rulesWithPrefixedKeys = [];
 
         foreach ($rules as $key => $value) {
-            $rulesWithPrefixedKeys[$this->propertyName.'.'.$key] = $value;
+            $rulesWithPrefixedKeys[$this->propertyName . '.' . $key] = $value;
         }
 
         $this->component->addRulesFromOutside($rulesWithPrefixedKeys);
@@ -48,7 +36,7 @@ class Form implements Arrayable
 
     public function addError($key, $message)
     {
-        $this->component->addError($this->propertyName.'.'.$key, $message);
+        $this->component->addError($this->propertyName . '.' . $key, $message);
     }
 
     public function validate()
@@ -58,9 +46,7 @@ class Form implements Arrayable
         $filteredRules = [];
 
         foreach ($rules as $key => $value) {
-            if (!str($key)->startsWith($this->propertyName.'.')) {
-                continue;
-            }
+            if (! str($key)->startsWith($this->propertyName . '.')) continue;
 
             $filteredRules[$key] = $value;
         }
@@ -117,9 +103,7 @@ class Form implements Arrayable
             ? $properties[0]
             : $properties;
 
-        if (empty($properties)) {
-            $properties = array_keys($this->all());
-        }
+        if (empty($properties)) $properties = array_keys($this->all());
 
         $freshInstance = new static($this->getComponent(), $this->getPropertyName());
 

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -72,13 +72,9 @@ class Form implements Arrayable
 
     public function except($properties)
     {
-        $results = $this->all();
+        if (! is_array($properties)) $properties = [$properties];
 
-        foreach ($properties as $property) {
-            unset($results[$property]);
-        }
-
-        return $results;
+        return array_diff_key($this->all(), array_flip($properties));
     }
 
     public function hasProperty($prop)

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -15,20 +15,32 @@ class Form implements Arrayable
         $this->addValidationRulesToComponent();
     }
 
-    public function getComponent() { return $this->component; }
-    public function getPropertyName() { return $this->propertyName; }
+    public function getComponent()
+    {
+        return $this->component;
+    }
+
+    public function getPropertyName()
+    {
+        return $this->propertyName;
+    }
 
     public function addValidationRulesToComponent()
     {
         $rules = [];
 
-        if (method_exists($this, 'rules')) $rules = $this->rules();
-        else if (property_exists($this, 'rules')) $rules = $this->rules;
+        if (method_exists($this, 'rules')) {
+            $rules = $this->rules();
+        } else {
+            if (property_exists($this, 'rules')) {
+                $rules = $this->rules;
+            }
+        }
 
         $rulesWithPrefixedKeys = [];
 
         foreach ($rules as $key => $value) {
-            $rulesWithPrefixedKeys[$this->propertyName . '.' . $key] = $value;
+            $rulesWithPrefixedKeys[$this->propertyName.'.'.$key] = $value;
         }
 
         $this->component->addRulesFromOutside($rulesWithPrefixedKeys);
@@ -36,7 +48,7 @@ class Form implements Arrayable
 
     public function addError($key, $message)
     {
-        $this->component->addError($this->propertyName . '.' . $key, $message);
+        $this->component->addError($this->propertyName.'.'.$key, $message);
     }
 
     public function validate()
@@ -46,7 +58,9 @@ class Form implements Arrayable
         $filteredRules = [];
 
         foreach ($rules as $key => $value) {
-            if (! str($key)->startsWith($this->propertyName . '.')) continue;
+            if (!str($key)->startsWith($this->propertyName.'.')) {
+                continue;
+            }
 
             $filteredRules[$key] = $value;
         }
@@ -65,6 +79,17 @@ class Form implements Arrayable
 
         foreach ($properties as $property) {
             $results[$property] = $this->hasProperty($property) ? $this->getPropertyValue($property) : null;
+        }
+
+        return $results;
+    }
+
+    public function except($properties)
+    {
+        $results = $this->all();
+
+        foreach ($properties as $property) {
+            unset($results[$property]);
         }
 
         return $results;
@@ -92,7 +117,9 @@ class Form implements Arrayable
             ? $properties[0]
             : $properties;
 
-        if (empty($properties)) $properties = array_keys($this->all());
+        if (empty($properties)) {
+            $properties = array_keys($this->all());
+        }
 
         $freshInstance = new static($this->getComponent(), $this->getPropertyName());
 

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -178,6 +178,19 @@ class UnitTest extends \Tests\TestCase
         ->assertSet('form.content', '')
         ;
     }
+
+    /** @test */
+    function can_get_properties_except()
+    {
+        $component = new class extends Component {};
+
+        $form = new PostFormStub($component, 'foobar');
+
+        $this->assertEquals(
+            ["content" => ""],
+            $form->except(["title"])
+        );
+    }
 }
 
 class PostFormStub extends Form

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -188,7 +188,12 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertEquals(
             ["content" => ""],
-            $form->except(["title"])
+            $form->except('title')
+        );
+
+        $this->assertEquals(
+            ["content" => ""],
+            $form->except(['title'])
         );
     }
 }


### PR DESCRIPTION
When using the same Form class for both storing and updating, one might want to get all properties except for the 'Model' property. Currently, this requires utilizing the `->only()` method and individually listing all the other properties.

I propose to add the `->except()` method to make this easier. 

Let me know what you think, happy to make any changes.