### PR TITLE
Add missing use notation for Modelable attribute

### DIFF
--- a/docs/nesting.md
+++ b/docs/nesting.md
@@ -281,6 +281,7 @@ Below is the `TodoInput` component with the `#[Modelable]` attribute added above
 namespace App\Livewire;
 
 use Livewire\Component;
+use Livewire\Attributes\Modelable;
 
 class TodoInput extends Component
 {


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

I found that `docs/nesting.md` has missed `use` notation:

```php
use Livewire\Attributes\Modelable;
```

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes, I created branch `fix-nesting-docs`.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No, just fix for 1 md file.

4️⃣ Does it include tests? (Required)

No, I did not find tests for docs.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

```php
namespace App\Livewire;

use Livewire\Component;
use Livewire\Attributes\Modelable; // Missed line

class TodoInput extends Component
{
```

Thanks for contributing! 🙌
