### PR TITLE
[V3] Fix documentation about assertHasErrors and assertHasNoErrors

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -386,10 +386,10 @@ class CreatePostTest extends TestCase
 }
 ```
 
-If you want to test that a specific validation rule has failed, you can pass an array of rules as a second argument to `assertHasErrors()`:
+If you want to test that a specific validation rule has failed, you can pass an array of rules:
 
 ```php
-$this->assertHasErrors('title', ['required']);
+$this->assertHasErrors(['title', ['required']]);
 ```
 
 ### Authorization
@@ -598,35 +598,35 @@ Livewire provides many more testing utilities. Below is a comprehensive list of 
 | `dispatch('post-created', postId: $post->id)`                      | Dispatch the `post-created` event with `$post->id` as an additional parameter (`$event.detail` from Alpine) |
 
 ### Assertions
-| Method                                                  | Description                                                                                                      |
-|---------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
-| `assertSet('title', '...')`                      | Assert that the `title` property is set to the provided value |
-| `assertNotSet('title', '...')`                   | Assert that the `title` property is not set to the provided value |
-| `assertCount('posts', 3)`                    | Assert that the `posts` property is an array-like value with `3` items in it |
-| `assertSnapshotSet('date', '08/26/1990')`               | Assert that the `date` property's raw / dehydrated value (from JSON) is set to `08/26/1990`. Alternative to asserting against the hydrated `DateTime` instance in the case of `date` |
-| `assertSnapshotNotSet('date', '08/26/1990')`            | Assert that `date`'s raw / dehydrated value is not equal to the provided value |
-| `assertSee($post->title)`                                    | Assert that the rendered HTML of the component contains the provided value |
-| `assertDontSee($post->title)`                                | Assert that the rendered HTML does not contain the provided value |
-| `assertSeeHtml('<div>...</div>')`          | Assert the provided string literal is contained in the rendered HTML without escaping the HTML characters (unlike `assertSee`, which does escape the provided characters by default)  |
-| `assertDontSeeHtml('<div>...</div>')`                            | Assert the provided string is contained in the rendered HTML |
-| `assertSeeInOrder(['...', '...'])`       | Assert that the provided strings appear in order in the rendered HTML output of the component |
-| `assertSeeHtmlInOrder([$firstString, $secondString])`   | Assert that the provided HTML strings appear in order in the rendered output of the component |
-| `assertDispatched('post-created')`              | Assert that the given event has been dispatched by the component |
-| `assertNotDispatched('post-created')`              | Assert that the given event has not been dispatched by the component |
-| `assertHasErrors('title')`                        | Assert that validation has failed for the `title` property |
-| `assertHasErrors('title', ['required', 'min:6'])` | Assert that the provided validation rules failed for the `title` property |
-| `assertHasNoErrors('title')`                      | Assert that there are no validation errors for the `title` property |
-| `assertHasNoErrors('title', ['required', 'min:6'])`| Assert that the provided validation rules haven't failed for the `title` property |
-| `assertRedirect()`                                      | Assert that a redirect has been triggered from within the component |
-| `assertRedirect('/posts')`                                  | Assert the component triggered a redirect to the `/posts` endpoint |
-| `assertRedirect(ShowPosts::class)`               | Assert that the component triggered a redirect to the `ShowPosts` component |
+| Method                                                | Description                                                                                                      |
+|-------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| `assertSet('title', '...')`                           | Assert that the `title` property is set to the provided value |
+| `assertNotSet('title', '...')`                        | Assert that the `title` property is not set to the provided value |
+| `assertCount('posts', 3)`                             | Assert that the `posts` property is an array-like value with `3` items in it |
+| `assertSnapshotSet('date', '08/26/1990')`             | Assert that the `date` property's raw / dehydrated value (from JSON) is set to `08/26/1990`. Alternative to asserting against the hydrated `DateTime` instance in the case of `date` |
+| `assertSnapshotNotSet('date', '08/26/1990')`          | Assert that `date`'s raw / dehydrated value is not equal to the provided value |
+| `assertSee($post->title)`                             | Assert that the rendered HTML of the component contains the provided value |
+| `assertDontSee($post->title)`                         | Assert that the rendered HTML does not contain the provided value |
+| `assertSeeHtml('<div>...</div>')`                     | Assert the provided string literal is contained in the rendered HTML without escaping the HTML characters (unlike `assertSee`, which does escape the provided characters by default)  |
+| `assertDontSeeHtml('<div>...</div>')`                 | Assert the provided string is contained in the rendered HTML |
+| `assertSeeInOrder(['...', '...'])`                    | Assert that the provided strings appear in order in the rendered HTML output of the component |
+| `assertSeeHtmlInOrder([$firstString, $secondString])` | Assert that the provided HTML strings appear in order in the rendered output of the component |
+| `assertDispatched('post-created')`                    | Assert that the given event has been dispatched by the component |
+| `assertNotDispatched('post-created')`                 | Assert that the given event has not been dispatched by the component |
+| `assertHasErrors('title')`                            | Assert that validation has failed for the `title` property |
+| `assertHasErrors(['title', ['required', 'min:6']])`   | Assert that the provided validation rules failed for the `title` property |
+| `assertHasNoErrors('title')`                          | Assert that there are no validation errors for the `title` property |
+| `assertHasNoErrors(['title', ['required', 'min:6']])` | Assert that the provided validation rules haven't failed for the `title` property |
+| `assertRedirect()`                                    | Assert that a redirect has been triggered from within the component |
+| `assertRedirect('/posts')`                            | Assert the component triggered a redirect to the `/posts` endpoint |
+| `assertRedirect(ShowPosts::class)`                    | Assert that the component triggered a redirect to the `ShowPosts` component |
 | `assertNoRedirect()`                                  | Assert that no redirect has been triggered |
-| `assertViewHas('posts')`                           | Assert that the `render()` method has passed a `posts` item to the view data |
-| `assertViewHas('postCount', 3)`           | Assert that a `postCount` variable has been passed to the view with a value of `3` |
-| `assertViewHas('posts', function ($posts) { ... })` | Assert that `postCount` view data exists and that it passes any assertions declared in the provided callback |
-| `assertViewIs('livewire.show-posts')`     | Assert that the component's render method returned the provided view name |
-| `assertFileDownloaded()`             | Assert that a file download has been triggered |
-| `assertFileDownloaded($filename)`             | Assert that a file download matching the provided file name has been triggered |
-| `assertUnauthorized()`             | Assert that an authorization exception has been thrown within the component (status code: 401) |
-| `assertForbidden()`             | Assert that an error response was triggered with the status code: 403 |
-| `assertStatus(500)`             | Assert that the latest response matches the provided status code |
+| `assertViewHas('posts')`                              | Assert that the `render()` method has passed a `posts` item to the view data |
+| `assertViewHas('postCount', 3)`                       | Assert that a `postCount` variable has been passed to the view with a value of `3` |
+| `assertViewHas('posts', function ($posts) { ... })`   | Assert that `postCount` view data exists and that it passes any assertions declared in the provided callback |
+| `assertViewIs('livewire.show-posts')`                 | Assert that the component's render method returned the provided view name |
+| `assertFileDownloaded()`                              | Assert that a file download has been triggered |
+| `assertFileDownloaded($filename)`                     | Assert that a file download matching the provided file name has been triggered |
+| `assertUnauthorized()`                                | Assert that an authorization exception has been thrown within the component (status code: 401) |
+| `assertForbidden()`                                   | Assert that an error response was triggered with the status code: 403 |
+| `assertStatus(500)`                                   | Assert that the latest response matches the provided status code |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -598,35 +598,35 @@ Livewire provides many more testing utilities. Below is a comprehensive list of 
 | `dispatch('post-created', postId: $post->id)`                      | Dispatch the `post-created` event with `$post->id` as an additional parameter (`$event.detail` from Alpine) |
 
 ### Assertions
-| Method                                                | Description                                                                                                      |
-|-------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
-| `assertSet('title', '...')`                           | Assert that the `title` property is set to the provided value |
-| `assertNotSet('title', '...')`                        | Assert that the `title` property is not set to the provided value |
-| `assertCount('posts', 3)`                             | Assert that the `posts` property is an array-like value with `3` items in it |
+| Method                                                | Description                                                                                                                                                                          |
+|-------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `assertSet('title', '...')`                           | Assert that the `title` property is set to the provided value                                                                                                                        |
+| `assertNotSet('title', '...')`                        | Assert that the `title` property is not set to the provided value                                                                                                                    |
+| `assertCount('posts', 3)`                             | Assert that the `posts` property is an array-like value with `3` items in it                                                                                                         |
 | `assertSnapshotSet('date', '08/26/1990')`             | Assert that the `date` property's raw / dehydrated value (from JSON) is set to `08/26/1990`. Alternative to asserting against the hydrated `DateTime` instance in the case of `date` |
-| `assertSnapshotNotSet('date', '08/26/1990')`          | Assert that `date`'s raw / dehydrated value is not equal to the provided value |
-| `assertSee($post->title)`                             | Assert that the rendered HTML of the component contains the provided value |
-| `assertDontSee($post->title)`                         | Assert that the rendered HTML does not contain the provided value |
-| `assertSeeHtml('<div>...</div>')`                     | Assert the provided string literal is contained in the rendered HTML without escaping the HTML characters (unlike `assertSee`, which does escape the provided characters by default)  |
-| `assertDontSeeHtml('<div>...</div>')`                 | Assert the provided string is contained in the rendered HTML |
-| `assertSeeInOrder(['...', '...'])`                    | Assert that the provided strings appear in order in the rendered HTML output of the component |
-| `assertSeeHtmlInOrder([$firstString, $secondString])` | Assert that the provided HTML strings appear in order in the rendered output of the component |
-| `assertDispatched('post-created')`                    | Assert that the given event has been dispatched by the component |
-| `assertNotDispatched('post-created')`                 | Assert that the given event has not been dispatched by the component |
-| `assertHasErrors('title')`                            | Assert that validation has failed for the `title` property |
-| `assertHasErrors(['title', ['required', 'min:6']])`   | Assert that the provided validation rules failed for the `title` property |
-| `assertHasNoErrors('title')`                          | Assert that there are no validation errors for the `title` property |
-| `assertHasNoErrors(['title', ['required', 'min:6']])` | Assert that the provided validation rules haven't failed for the `title` property |
-| `assertRedirect()`                                    | Assert that a redirect has been triggered from within the component |
-| `assertRedirect('/posts')`                            | Assert the component triggered a redirect to the `/posts` endpoint |
-| `assertRedirect(ShowPosts::class)`                    | Assert that the component triggered a redirect to the `ShowPosts` component |
-| `assertNoRedirect()`                                  | Assert that no redirect has been triggered |
-| `assertViewHas('posts')`                              | Assert that the `render()` method has passed a `posts` item to the view data |
-| `assertViewHas('postCount', 3)`                       | Assert that a `postCount` variable has been passed to the view with a value of `3` |
-| `assertViewHas('posts', function ($posts) { ... })`   | Assert that `postCount` view data exists and that it passes any assertions declared in the provided callback |
-| `assertViewIs('livewire.show-posts')`                 | Assert that the component's render method returned the provided view name |
-| `assertFileDownloaded()`                              | Assert that a file download has been triggered |
-| `assertFileDownloaded($filename)`                     | Assert that a file download matching the provided file name has been triggered |
-| `assertUnauthorized()`                                | Assert that an authorization exception has been thrown within the component (status code: 401) |
-| `assertForbidden()`                                   | Assert that an error response was triggered with the status code: 403 |
-| `assertStatus(500)`                                   | Assert that the latest response matches the provided status code |
+| `assertSnapshotNotSet('date', '08/26/1990')`          | Assert that `date`'s raw / dehydrated value is not equal to the provided value                                                                                                       |
+| `assertSee($post->title)`                             | Assert that the rendered HTML of the component contains the provided value                                                                                                           |
+| `assertDontSee($post->title)`                         | Assert that the rendered HTML does not contain the provided value                                                                                                                    |
+| `assertSeeHtml('<div>...</div>')`                     | Assert the provided string literal is contained in the rendered HTML without escaping the HTML characters (unlike `assertSee`, which does escape the provided characters by default) |
+| `assertDontSeeHtml('<div>...</div>')`                 | Assert the provided string is contained in the rendered HTML                                                                                                                         |
+| `assertSeeInOrder(['...', '...'])`                    | Assert that the provided strings appear in order in the rendered HTML output of the component                                                                                        |
+| `assertSeeHtmlInOrder([$firstString, $secondString])` | Assert that the provided HTML strings appear in order in the rendered output of the component                                                                                        |
+| `assertDispatched('post-created')`                    | Assert that the given event has been dispatched by the component                                                                                                                     |
+| `assertNotDispatched('post-created')`                 | Assert that the given event has not been dispatched by the component                                                                                                                 |
+| `assertHasErrors('title')`                            | Assert that validation has failed for the `title` property                                                                                                                           |
+| `assertHasErrors(['title', ['required', 'min:6']])`   | Assert that the provided validation rules failed for the `title` property                                                                                                            |
+| `assertHasNoErrors('title')`                          | Assert that there are no validation errors for the `title` property                                                                                                                  |
+| `assertHasNoErrors(['title', ['required', 'min:6']])` | Assert that the provided validation rules haven't failed for the `title` property                                                                                                    |
+| `assertRedirect()`                                    | Assert that a redirect has been triggered from within the component                                                                                                                  |
+| `assertRedirect('/posts')`                            | Assert the component triggered a redirect to the `/posts` endpoint                                                                                                                   |
+| `assertRedirect(ShowPosts::class)`                    | Assert that the component triggered a redirect to the `ShowPosts` component                                                                                                          |
+| `assertNoRedirect()`                                  | Assert that no redirect has been triggered                                                                                                                                           |
+| `assertViewHas('posts')`                              | Assert that the `render()` method has passed a `posts` item to the view data                                                                                                         |
+| `assertViewHas('postCount', 3)`                       | Assert that a `postCount` variable has been passed to the view with a value of `3`                                                                                                   |
+| `assertViewHas('posts', function ($posts) { ... })`   | Assert that `postCount` view data exists and that it passes any assertions declared in the provided callback                                                                         |
+| `assertViewIs('livewire.show-posts')`                 | Assert that the component's render method returned the provided view name                                                                                                            |
+| `assertFileDownloaded()`                              | Assert that a file download has been triggered                                                                                                                                       |
+| `assertFileDownloaded($filename)`                     | Assert that a file download matching the provided file name has been triggered                                                                                                       |
+| `assertUnauthorized()`                                | Assert that an authorization exception has been thrown within the component (status code: 401)                                                                                       |
+| `assertForbidden()`                                   | Assert that an error response was triggered with the status code: 403                                                                                                                |
+| `assertStatus(500)`                                   | Assert that the latest response matches the provided status code                                                                                                                     |

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -461,7 +461,7 @@ public function cant_create_post_with_title_shorter_than_3_characters()
         ->set('title', 'Sa')
         ->set('content', 'Sample content...')
         ->call('save')
-        ->assertHasErrors('title', ['min:3']);
+        ->assertHasErrors(['title', ['min:3']]);
 }
 ```
 


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Yes. The docs need a little fix. Discussion about it can be found over [here](https://github.com/livewire/livewire/discussions/6184)

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
No, because docs need no tests right?

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Have a look at ```assertHasErrors``` and ```assertHasNoErrors``` in the [sourcecode](https://github.com/livewire/livewire/blob/main/src/Features/SupportValidation/TestsValidation.php).

They both accept 1 parameter called ```$keys```. Yet the documentation over [here](https://github.com/livewire/livewire/blob/main/docs/testing.md) and [here](https://github.com/livewire/livewire/blob/main/docs/validation.md), states that i can receive 2 arguments in some cases.


Thanks for contributing! 🙌
