### PR TITLE
[V3] Added information about $dispatchTo

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -182,6 +182,16 @@ You can dispatch events directly from your Blade templates using the `$dispatch`
 
 In this example, when the button is clicked, the `show-post-modal` event will be dispatched with the specified data.
 
+If you want to dispatch an event directly to another component you can use the `$dispatchTo()` JavaScript function:
+
+```blade
+<button wire:click="$dispatchTo('posts', 'show-post-modal', { id: {{ $post->id }} })">
+    EditPost
+</button>
+```
+
+In this example, when the button is clicked, the `show-post-modal` event will be dispatched directly to the `Posts` component.
+
 ## Testing dispatched events
 
 To test events dispatched by your component, use the `assertDispatched()` method in your Livewire test. This method checks that a specific event has been dispatched during the component's lifecycle:

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -408,6 +408,9 @@ $this->dispatch('post-created', postId: $post->id); // [tl! add]
 <button wire:click="$emit('post-created', 1)">...</button> <!-- [tl! remove] -->
 <button wire:click="$dispatch('post-created', { postId: 1 })">...</button> <!-- [tl! add] -->
 
+<button wire:click="$emitTo('foo', post-created', 1)">...</button> <!-- [tl! remove] -->
+<button wire:click="$dispatchTo('foo', 'post-created', { postId: 1 })">...</button> <!-- [tl! add] -->
+
 <button x-on:click="$wire.emit('post-created', 1)">...</button> <!-- [tl! remove] -->
 <button x-on:click="$dispatch('post-created', { postId: 1 })">...</button> <!-- [tl! add] -->
 ```


### PR DESCRIPTION
I was missing information about directly emitting events to a component from a blade template.
It seems you can use `$dispatchTo` to do this. I've added some information about this to the docs.