### PR TITLE
[v3] Add example for testing a page contains Volt component

### DIFF
--- a/docs/volt.md
+++ b/docs/volt.md
@@ -682,3 +682,25 @@ If your Volt component is nested, you may use "dot" notation to specify the comp
 ```php
 Volt::test('users.stats')
 ```
+
+#### Testing a page contains a Volt component
+
+The simplest way of asserting a given endpoint contains and renders a Volt component is by using `assertSeeVolt`:
+
+```php
+<?php
+
+namespace Tests\Feature\Volt;
+
+use Tests\TestCase;
+
+class CreatePostTest extends TestCase
+{
+    /** @test */
+    public function component_exists_on_the_page()
+    {
+        $this->get('/posts/create')
+            ->assertSeeVolt('create-post');
+    }
+}
+```


### PR DESCRIPTION
This PR adds a small section to the Volt documentation on how to test if a page contains a Volt component. The example might be a bit long character-wise given you need to pass in the path to the component. 🤷‍♂️

AFAIK this is the only way as of now to test for this, so thought it'd be good to have an example of it available.
