### PR TITLE
[V3] Custom Validator Facade correction path

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -391,7 +391,8 @@ If you wish to use your own validation system in Livewire, that isn't a problem.
 Below is an example of the `CreatePost` component, but instead of using Livewire's validation features, a completely custom validator is being created and applied to the component properties:
 
 ```php
-use Illuminate\Validation\Validator;
+use Illuminate\Support\Facades\Validatorgit add .
+;
 use Livewire\Component;
 use App\Models\Post;
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -391,8 +391,7 @@ If you wish to use your own validation system in Livewire, that isn't a problem.
 Below is an example of the `CreatePost` component, but instead of using Livewire's validation features, a completely custom validator is being created and applied to the component properties:
 
 ```php
-use Illuminate\Support\Facades\Validatorgit add .
-;
+use Illuminate\Support\Facades\Validator;
 use Livewire\Component;
 use App\Models\Post;
 


### PR DESCRIPTION
This PR corrects an incorrect path in the validation.md file located in the docs folder of the Livewire repository. 
The incorrect path references Illuminate\Validation\Validator, while the correct path should be Illuminate\Support\Facades\Validator.

By updating it to the correct path, we ensure the best DX experience throughout docs.

Related Issue:
[6213](https://github.com/livewire/livewire/issues/6213)
