### PR TITLE
[V3] Add Windows PowerShell warning to docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,6 +6,9 @@ To install Livewire, open your terminal and navigate to your Laravel application
 composer require livewire/livewire "^3.0@beta"
 ```
 
+> [!warning] PowerShell for Windows
+> The `^` operator causes issues for installing the beta when using PowerShell for Windows. See [Composer docs](https://getcomposer.org/doc/articles/versions.md#caret-version-range-) for more details.
+
 That's it — really. If you want more customization options, keep reading. Otherwise, you can jump right into using Livewire.
 
 ## Publishing the configuration file

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,6 +18,9 @@ From the root directory of your Laravel app, run the following [Composer](https:
 composer require livewire/livewire "^3.0@beta"
 ```
 
+> [!warning] PowerShell for Windows
+> The `^` operator causes issues for installing the beta when using PowerShell for Windows. See [Composer docs](https://getcomposer.org/doc/articles/versions.md#caret-version-range-) for more details.
+
 ## Create a Livewire component
 
 Livewire provides a convenient Artisan command to generate new components quickly. Run the following command to make a new `Counter` component:


### PR DESCRIPTION
There are issues (#5775, #6189)  installing the beta when trying to it using PowerShell for Windows. This is due to an incompatibility with the `^` and is noted in the composer documentation.

This PR adds a warning to the quickstart and installation docs for Powershell users linking to the composer docs.

See https://github.com/livewire/livewire/pull/6076#issuecomment-1656336235 for confirmation.