### PR TITLE
[V3] Move auto-injected livewire styles to end of head tag

### DIFF
--- a/src/Features/SupportAutoInjectedAssets/BrowserTest.php
+++ b/src/Features/SupportAutoInjectedAssets/BrowserTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Livewire\Features\SupportAutoInjectedAssets;
+
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    /** @test */
+    public function livewire_styles_take_preference_over_other_styles()
+    {
+        Livewire::visit(new class extends Component {
+            #[Layout('layouts.app-with-styles')]
+            function render()
+            {
+
+                return <<<'HTML'
+                <div>
+                    <div wire:loading class="show" dusk="loading">Loading</div>
+
+                    <button type="button" wire:click="$refresh" dusk="refresh">Refresh</button>
+                </div>
+                HTML;
+            }
+        })
+        ->assertNotVisible('@loading')
+        ->waitForLivewire()->click('@refresh')
+        ->assertNotVisible('@loading')
+        ;
+    }
+}

--- a/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
+++ b/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
@@ -48,7 +48,7 @@ class SupportAutoInjectedAssets extends ComponentHook
 
         $html = str($html);
 
-        if ($html->test('/<\s*head(?:\s|\s[^>])*>/i') && $html->test('/<\s*\/\s*body\s*>/i')) {
+        if ($html->test('/<\s*\/\s*head\s*>/i') && $html->test('/<\s*\/\s*body\s*>/i')) {
             return $html
                 ->replaceMatches('/(<\s*\/\s*head\s*>)/i', $livewireStyles.'$1')
                 ->replaceMatches('/(<\s*\/\s*body\s*>)/i', $livewireScripts.'$1')

--- a/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
+++ b/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
@@ -50,7 +50,7 @@ class SupportAutoInjectedAssets extends ComponentHook
 
         if ($html->test('/<\s*head(?:\s|\s[^>])*>/i') && $html->test('/<\s*\/\s*body\s*>/i')) {
             return $html
-                ->replaceMatches('/(<\s*head(?:\s|\s[^>])*>)/i', '$1'.$livewireStyles)
+                ->replaceMatches('/(<\s*\/\s*head\s*>)/i', $livewireStyles.'$1')
                 ->replaceMatches('/(<\s*\/\s*body\s*>)/i', $livewireScripts.'$1')
                 ->toString();
         }

--- a/src/Features/SupportAutoInjectedAssets/UnitTest.php
+++ b/src/Features/SupportAutoInjectedAssets/UnitTest.php
@@ -82,10 +82,10 @@ class UnitTest extends TestCase
                 lang="en"
             >
                 <head
-                >$livewireStyles
+                >
                     <meta charset="utf-8"/>
                     <title></title>
-                </head>
+                $livewireStyles</head>
                 <body>
                 $livewireScripts</body
                 >
@@ -120,10 +120,10 @@ class UnitTest extends TestCase
                 lang="en"
             >
                 <Head
-                >$livewireStyles
+                >
                     <meta charset="utf-8"/>
                     <title></title>
-                </Head>
+                $livewireStyles</Head>
                 <bOdY>
                     <header class=""></header>
                 $livewireScripts</bOdY

--- a/src/Features/SupportAutoInjectedAssets/UnitTest.php
+++ b/src/Features/SupportAutoInjectedAssets/UnitTest.php
@@ -29,10 +29,10 @@ class UnitTest extends TestCase
         HTML, <<<HTML
             <!doctype html>
             <html>
-                <head>$livewireStyles
+                <head>
                     <meta charset="utf-8"/>
                     <title></title>
-                </head>
+                $livewireStyles</head>
                 <body>
                 $livewireScripts</body>
             </html>

--- a/tests/views/layouts/app-with-styles.blade.php
+++ b/tests/views/layouts/app-with-styles.blade.php
@@ -1,0 +1,17 @@
+<html>
+<head>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <style>
+        .show {
+            display: block;
+        }
+    </style>
+</head>
+<body>
+    {{ $slot }}
+
+    @stack('scripts')
+</body>
+</html>
+
+


### PR DESCRIPTION
There is an issue #6040 with `wire:loading` elements not disappearing after loading is finished if the element has another class that sets the display value. This is because the auto-injected styles are injected at the beginning of the `<head>` tag instead of before the closing `</head>` tag. So Livewire's styles are not being given priority over any other styles.

This PR moves the auto-injected styles to the end of the head tag.

Having Livewire styles after all other styles was actually something I used to recommend to people in V2.

Hope this helps!