### PR TITLE
Add warning to docs regarding auto-inject of Alpine.js

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,6 +39,9 @@ If you want more control over this behavior, you can manually include the assets
 
 By including these assets manually on a page, Livewire knows to not inject the assets automatically.
 
+> [!warning] Alpine.js will only work where Livewire is detected
+> Livewire will automatically inject its assets along with Alpine.js only into pages with Livewire components detected, meaning that Alpine.js will not be available on pages that do not utilize Livewire components.
+
 Though rarely required, you may disable Livewire's auto-injecting asset behavior by updating the `inject_assets` [configuration option](#publishing-config) in your application's `config/livewire.php` file:
 
 ```php

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,10 +37,10 @@ If you want more control over this behavior, you can manually include the assets
 </html>
 ```
 
-By including these assets manually on a page, Livewire knows to not inject the assets automatically.
+By including these assets manually on a page, Livewire knows not to inject the assets automatically.
 
-> [!warning] Alpine.js will only work where Livewire is detected
-> Livewire will automatically inject its assets along with Alpine.js only into pages with Livewire components detected, meaning that Alpine.js will not be available on pages that do not utilize Livewire components.
+> [!warning] AlpineJS is bundled with Livewire
+> Because Alpine is bundled with Livewire's JavaScript assets, you must include `@livewireScripts` on every page you wish to use Alpine. Even if you're not using Livewire on that page.
 
 Though rarely required, you may disable Livewire's auto-injecting asset behavior by updating the `inject_assets` [configuration option](#publishing-config) in your application's `config/livewire.php` file:
 


### PR DESCRIPTION
I _**think**_ the docs should _warn_ the users that since livewire's assets and alpine will be auto-injected only to sites that detect livewire, it will also NOT include alpine.js where there is no livewire.
 
Meaning that when you want to use pure alpine.js on a page that does not contain any livewire component, you will not have it at your disposal and will need to import it manually. What do you think?

I put the warning into the installation step, but it could potentionally be in the upgrade guide.