### PR TITLE
[V3] Add failing test for using assertViewIs

### DIFF
--- a/src/Features/SupportTesting/InitialRender.php
+++ b/src/Features/SupportTesting/InitialRender.php
@@ -37,6 +37,9 @@ class InitialRender extends Render
 
         $html = $response->getContent();
 
+        // Set "original" to Blade view for assertions like "assertViewIs()"...
+        $response->original = $componentView;
+
         $snapshot = Utils::extractAttributeDataFromHtml($html, 'wire:snapshot');
         $effects = Utils::extractAttributeDataFromHtml($html, 'wire:effects');
 

--- a/src/Features/SupportTesting/SubsequentRender.php
+++ b/src/Features/SupportTesting/SubsequentRender.php
@@ -41,6 +41,9 @@ class SubsequentRender extends Render
 
         $json = $response->json();
 
+        // Set "original" to Blade view for assertions like "assertViewIs()"...
+        $response->original = $componentView;
+
         $componentResponsePayload = $json['components'][0];
 
         $snapshot = json_decode($componentResponsePayload['snapshot'], true);

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanAssertViewIsUnitTest.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanAssertViewIsUnitTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Livewire\Features\SupportTesting\Tests;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class TestableLivewireCanAssertViewIsUnitTest extends \Tests\TestCase
+{
+    /** @test */
+    function can_assert_view_is()
+    {
+        Livewire::test(ViewComponent::class)
+            ->assertViewIs('null-view');
+    }
+}
+
+class ViewComponent extends Component
+{
+    function render()
+    {
+        return view('null-view');
+    }
+}


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes - bug reported as #6212 - was asked to open PR with failing test.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

4️⃣ Does it include tests? (Required)

Yes -the PR is a test case.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

`assertViewIs` doesn't appear to work in V3. I checked, and it is stilled listed as an available assertion in the docs. 

See original discussion for a real world example on a fresh Laravel & Livewire installation: https://github.com/livewire/livewire/discussions/6212