### PR TITLE
Move from 'use Arr' to 'use Illuminate\Support\Arr'

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/UpgradeStep.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/UpgradeStep.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Features\SupportConsoleCommands\Commands\Upgrade;
 
-use Arr;
+use Illuminate\Support\Arr;
 use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\FilesystemAdapter;


### PR DESCRIPTION
I tried to run `php artisan livewire:upgrade` on my machine and got a weird message about `Arr` not being defined - but `Illuminate\Support\Arr` was. At least in Tinker, that works better (at least in my project). Totally fine if the problem is on my end, I'm not particularly attached to this PR, just trying to help :)

```
uberbrady@GrokBook-Air snipe-it % php artisan tinker
Psy Shell v0.11.19 (PHP 8.1.21 — cli) by Justin Hileman
> \Arr::wrap()

   Error  Class "Arr" not found.

> ^D

   INFO  Ctrl+D.

uberbrady@GrokBook-Air snipe-it % php artisan tinker
Psy Shell v0.11.19 (PHP 8.1.21 — cli) by Justin Hileman
> use Illuminate\Support\Arr;
> Arr::wrap()

   ArgumentCountError  Too few arguments to function Illuminate\Support\Arr::wrap(), 0 passed in /Users/uberbrady/Documents/grokability/snipe-iteval()'d code on line 1 and exactly 1 expected.

> 
```

As you can see, the second example seems to at least be calling the right function (though I sent it bad arguments).