### PR TITLE
[3.x] Fixes integration with Octane

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -5,6 +5,7 @@ namespace Livewire\Mechanisms\FrontendAssets;
 use Livewire\Drawer\Utils;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Blade;
+use function Livewire\on;
 
 class FrontendAssets
 {
@@ -29,6 +30,13 @@ class FrontendAssets
         Blade::directive('livewireScripts', [static::class, 'livewireScripts']);
         Blade::directive('livewireScriptConfig', [static::class, 'livewireScriptConfig']);
         Blade::directive('livewireStyles', [static::class, 'livewireStyles']);
+
+        on('flush-state', function () {
+            $instance = app(static::class);
+
+            $instance->hasRenderedScripts = false;
+            $instance->hasRenderedStyles = false;
+        });
     }
 
     function useScriptTagAttributes($attributes)

--- a/src/Mechanisms/FrontendAssets/UnitTest.php
+++ b/src/Mechanisms/FrontendAssets/UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Livewire\Mechanisms\FrontendAssets;
+
+use function Livewire\trigger;
+
+class UnitTest extends \Tests\TestCase
+{
+    /** @test */
+    public function styles()
+    {
+        $assets = app(FrontendAssets::class);
+
+        $this->assertFalse($assets->hasRenderedStyles);
+
+        $this->assertStringStartsWith('<!-- Livewire Styles -->', $assets->styles());
+
+        $this->assertTrue($assets->hasRenderedStyles);
+    }
+
+    /** @test */
+    public function scripts()
+    {
+        $assets = app(FrontendAssets::class);
+
+        $this->assertFalse($assets->hasRenderedScripts);
+
+        $this->assertStringStartsWith('<script src="', $assets->scripts());
+
+        $this->assertTrue($assets->hasRenderedScripts);
+    }
+
+    /** @test */
+    public function flush_state_event_resets_has_rendered()
+    {
+        $assets = app(FrontendAssets::class);
+
+        $assets->styles();
+        $assets->scripts();
+
+        $this->assertTrue($assets->hasRenderedStyles);
+        $this->assertTrue($assets->hasRenderedScripts);
+
+        trigger('flush-state');
+
+        $this->assertFalse($assets->hasRenderedScripts);
+        $this->assertFalse($assets->hasRenderedStyles);
+    }
+}


### PR DESCRIPTION
This pull request fixes using Livewire 3 with Octane, simply by telling Livewire to reset both "hasRenderedScripts", and "hasRenderedStyles" when the state should be flushed.

```
// Before:
200    GET /counter ... Working good - because styles and scripts were injected...
200    GET /counter ... Not working - because styles and scripts are missing...
200    GET /counter ... Not working - because styles and scripts are missing...

// After
200    GET /counter ... Working good - because styles and scripts were injected...
200    GET /counter ... Working good - because styles and scripts were injected...
200    GET /counter ... Working good - because styles and scripts were injected...
```