### PR TITLE
[V3] Make sure `orchestra/testbench-dusk` is installed

### DIFF
--- a/src/Features/SupportTesting/DuskTestable.php
+++ b/src/Features/SupportTesting/DuskTestable.php
@@ -44,7 +44,7 @@ class DuskTestable
             static::$currentTestCase = null;
         });
 
-        if (isset($_SERVER['CI'])) {
+        if (isset($_SERVER['CI']) && class_exists(\Orchestra\Testbench\Dusk\Options::class)) {
             \Orchestra\Testbench\Dusk\Options::withoutUI();
         }
 


### PR DESCRIPTION
When running tests on CI without having `orchestra/testbench-dusk` installed, the CI will crash because the `\Orchestra\Testbench\Dusk\Options` is not found.

This PR adds a check if the classes of this package exist before using them.