### PR TITLE
[V3] Livewire page component layout view not found if a component contains nested component

### DIFF
--- a/src/Features/SupportNestingComponents/BrowserTest.php
+++ b/src/Features/SupportNestingComponents/BrowserTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportNestingComponents;
 
+use Livewire\Attributes\Layout;
 use Livewire\Component;
 use Livewire\Livewire;
 
@@ -85,6 +86,46 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->pause(500)
         ->assertPresent('@child')
         ->assertSeeIn('@child', 'Child')
+        ;
+    }
+
+    /** @test */
+    public function nested_components_do_not_error_when_parent_has_custom_layout_and_default_layout_does_not_exist()
+    {
+        config()->set('livewire.layout', '');
+
+        Livewire::visit([
+            new class extends Component {
+                #[Layout('layouts.app')]
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button type="button" wire:click="$refresh" dusk="refresh">
+                            Refresh
+                        </button>
+                        <livewire:child />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div dusk="child">
+                        Child
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->assertPresent('@child')
+            ->assertSeeIn('@child', 'Child')
+            ->waitForLivewire()->click('@refresh')
+            ->pause(500)
+            ->assertPresent('@child')
+            ->assertSeeIn('@child', 'Child')
         ;
     }
 

--- a/src/Features/SupportNestingComponents/BrowserTest.php
+++ b/src/Features/SupportNestingComponents/BrowserTest.php
@@ -123,7 +123,6 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertPresent('@child')
             ->assertSeeIn('@child', 'Child')
             ->waitForLivewire()->click('@refresh')
-            ->pause(500)
             ->assertPresent('@child')
             ->assertSeeIn('@child', 'Child')
         ;

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -2,9 +2,7 @@
 
 namespace Livewire\Features\SupportPageComponents;
 
-use function Livewire\invade;
-use function Livewire\on;
-use function Livewire\off;
+use function Livewire\{invade, on, off, once};
 use Livewire\Drawer\ImplicitRouteBinding;
 use Livewire\ComponentHook;
 use Illuminate\View\View;
@@ -81,7 +79,9 @@ class SupportPageComponents extends ComponentHook
         $layoutConfig = null;
         $slots = [];
 
-        $handler = function ($target, $view, $data) use (&$layoutConfig, &$slots) {
+        // Only run this handler once for the parent-most component. Otherwise child components
+        // will run this handler too and override the configured layout...
+        $handler = once(function ($target, $view, $data) use (&$layoutConfig, &$slots) {
             $layoutAttr = $target->getAttributes()->whereInstanceOf(Layout::class)->first();
             $titleAttr = $target->getAttributes()->whereInstanceOf(Title::class)->first();
 
@@ -100,7 +100,7 @@ class SupportPageComponents extends ComponentHook
                 // to be later forwarded into the layout component itself...
                 $layoutConfig->viewContext = $viewContext;
             };
-        };
+        });
 
         on('render', $handler);
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -61,6 +61,19 @@ function invade($obj)
     };
 }
 
+function once($fn)
+{
+    $hasRun = false;
+
+    return function (...$params) use ($fn, &$hasRun) {
+        if ($hasRun) return;
+
+        $hasRun = true;
+
+        return $fn(...$params);
+    };
+}
+
 function of(...$params)
 {
     return $params;


### PR DESCRIPTION
This adds a failing test for #6281

The exception only happens when you do not have the default livewire layout blade file present and the parent component uses a custom layout.