### PR TITLE
[v3] Add failing test for rendering and updating components with a root <tr> element

### DIFF
--- a/src/Tests/UpdatingTableRowsTest.php
+++ b/src/Tests/UpdatingTableRowsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Livewire\Tests;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class UpdatingTableRowsTest extends \Tests\BrowserTestCase
+{
+    /** @test */
+    public function component_renders_table_rows_and_updates_properly()
+    {
+        Livewire::visit(new class extends Component {
+            public int $counter = 0;
+
+            public function increment()
+            {
+                $this->counter++;
+            }
+
+            public function render() {
+                return <<<'HTML'
+                    <tr dusk="table-row">
+                        <td>
+                            <button type="button" wire:click="increment" dusk="increment">+</button>
+                        </td>
+                        <td>
+                            <input wire:model="counter" dusk="counter">
+                        </td>
+                    </tr>
+                HTML;
+            }
+        })
+            ->assertVisible('@table-row')
+            ->assertInputValue('@counter', '0')
+            ->click('@increment')
+            ->waitForLivewire()
+            ->assertVisible('@table-row')
+            ->assertInputValue('@counter', '1')
+        ;
+    }
+}

--- a/src/Tests/UpdatingTableRowsTest.php
+++ b/src/Tests/UpdatingTableRowsTest.php
@@ -10,7 +10,18 @@ class UpdatingTableRowsTest extends \Tests\BrowserTestCase
     /** @test */
     public function component_renders_table_rows_and_updates_properly()
     {
-        Livewire::visit(new class extends Component {
+        Livewire::visit([new class extends Component {
+            public function render() {
+                return <<<'HTML'
+                    <table>
+                        <tbody>
+                            <livewire:child />
+                        </tbody>
+                    </table>
+                HTML;
+            }
+        },
+        'child' => new class extends Component {
             public int $counter = 0;
 
             public function increment()
@@ -18,7 +29,8 @@ class UpdatingTableRowsTest extends \Tests\BrowserTestCase
                 $this->counter++;
             }
 
-            public function render() {
+            public function render()
+            {
                 return <<<'HTML'
                     <tr dusk="table-row">
                         <td>
@@ -30,7 +42,7 @@ class UpdatingTableRowsTest extends \Tests\BrowserTestCase
                     </tr>
                 HTML;
             }
-        })
+        }])
             ->assertVisible('@table-row')
             ->assertInputValue('@counter', '0')
             ->click('@increment')

--- a/src/Tests/UpdatingTableRowsTest.php
+++ b/src/Tests/UpdatingTableRowsTest.php
@@ -43,11 +43,13 @@ class UpdatingTableRowsTest extends \Tests\BrowserTestCase
                 HTML;
             }
         }])
-            ->assertVisible('@table-row')
+            ->assertPresent('@table-row')
+            ->assertPresent('@counter')
             ->assertInputValue('@counter', '0')
             ->click('@increment')
             ->waitForLivewire()
-            ->assertVisible('@table-row')
+            ->assertPresent('@table-row')
+            ->assertPresent('@counter')
             ->assertInputValue('@counter', '1')
         ;
     }


### PR DESCRIPTION
see #6247

If your Livewire v3 component has a root element that is a `<tr>` element,  when the component updates, its re-render will "unwrap" instead of re-rendering the `<tr>` element.

In my app where I saw this issue, the `<tr>` rendered correctly, but on update it would "unwrap".