### PR TITLE
[V2] Fix extension

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -152,11 +152,9 @@ class TemporaryUploadedFile extends UploadedFile
         $hash = str()->random(30);
         $meta = str('-meta'.base64_encode($file->getClientOriginalName()).'-')->replace('/', '_');
 
-        $extension = rescue(function() use ($file) {
-            return $file->clientExtension();
-        }, null, false);
+        $extension = $file->getClientOriginalExtension();
 
-        if ($extension === null) {
+        if ($extension === null || $extension === '') {
             $extension = $file->guessExtension();
         }
 


### PR DESCRIPTION
See https://github.com/livewire/livewire/pull/6011#issuecomment-1672525845

i think the best solution is to just use the extension from the client filename and in case there is non we detect base on the mimetype.