### PR TITLE
[V3] Pagination with customizable default page name

### DIFF
--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -117,6 +117,13 @@ In addition to `$this->resetPage()`, Livewire provides other useful methods for 
 | `$this->nextPage()`    | Go to the next page |
 | `$this->previousPage()`    | Go to the previous page |
 
+## Default page name
+The default parameter used to track current page is 'page' but it can be changed by setting the $pageName property.
+
+```blade
+protected $pageName = 'customPage';
+```
+
 ## Multiple paginators
 
 Because both Laravel and Livewire use URL query string parameters to store and track the current page number, if a single page contains multiple paginators, it's important to assign them different names.

--- a/src/Features/SupportPagination/HandlesPagination.php
+++ b/src/Features/SupportPagination/HandlesPagination.php
@@ -4,6 +4,7 @@ namespace Livewire\Features\SupportPagination;
 
 trait HandlesPagination
 {
+    protected $pageName = 'page';
     public $paginators = [];
 
     public function queryStringHandlesPagination()
@@ -13,32 +14,32 @@ trait HandlesPagination
         })->toArray();
     }
 
-    public function getPage($pageName = 'page')
+    public function getPage($pageName = null)
     {
-        return $this->paginators[$pageName] ?? 1;
+        return $this->paginators[($pageName ?: $this->pageName)] ?? 1;
     }
 
-    public function previousPage($pageName = 'page')
+    public function previousPage($pageName = null)
     {
-        $this->setPage(max(($this->paginators[$pageName] ?? 1) - 1, 1), $pageName);
+        $this->setPage(max(($this->paginators[($pageName ?: $this->pageName)] ?? 1) - 1, 1), ($pageName ?: $this->pageName));
     }
 
-    public function nextPage($pageName = 'page')
+    public function nextPage($pageName = null)
     {
-        $this->setPage(($this->paginators[$pageName] ?? 1) + 1, $pageName);
+        $this->setPage(($this->paginators[($pageName ?: $this->pageName)] ?? 1) + 1, ($pageName ?: $this->pageName));
     }
 
-    public function gotoPage($page, $pageName = 'page')
+    public function gotoPage($page, $pageName = null)
     {
-        $this->setPage($page, $pageName);
+        $this->setPage($page, ($pageName ?: $this->pageName));
     }
 
-    public function resetPage($pageName = 'page')
+    public function resetPage($pageName = null)
     {
-        $this->setPage(1, $pageName);
+        $this->setPage(1, ($pageName ?: $this->pageName));
     }
 
-    public function setPage($page, $pageName = 'page')
+    public function setPage($page, $pageName = null)
     {
         if (is_numeric($page)) {
             $page = (int) ($page <= 0 ? 1 : $page);
@@ -47,21 +48,21 @@ trait HandlesPagination
         $beforePaginatorMethod = 'updatingPaginators';
         $afterPaginatorMethod = 'updatedPaginators';
 
-        $beforeMethod = 'updating' . $pageName;
-        $afterMethod = 'updated' . $pageName;
+        $beforeMethod = 'updating' . ($pageName ?: $this->pageName);
+        $afterMethod = 'updated' . ($pageName ?: $this->pageName);
 
         if (method_exists($this, $beforePaginatorMethod)) {
-            $this->{$beforePaginatorMethod}($page, $pageName);
+            $this->{$beforePaginatorMethod}($page, ($pageName ?: $this->pageName));
         }
 
         if (method_exists($this, $beforeMethod)) {
             $this->{$beforeMethod}($page, null);
         }
 
-        $this->paginators[$pageName] = $page;
+        $this->paginators[($pageName ?: $this->pageName)] = $page;
 
         if (method_exists($this, $afterPaginatorMethod)) {
-            $this->{$afterPaginatorMethod}($page, $pageName);
+            $this->{$afterPaginatorMethod}($page, ($pageName ?: $this->pageName));
         }
 
         if (method_exists($this, $afterMethod)) {


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Now, when it's needed to use a custom page name in a component, we have to pass the custom pageName to all the methods and we can't set a default one
2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
4️⃣ Does it include tests? (Required)
No, it doesn't need new tests because the old ones are good enough
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
We can set a default pageName with a property called $pageName without passing it manually everytime to all methods
