### PR TITLE
[V3] Fix typo in emitUp step of upgrade tool

### DIFF
--- a/stubs/ReplaceEmitWithDispatch.php
+++ b/stubs/ReplaceEmitWithDispatch.php
@@ -113,7 +113,7 @@ class ReplaceEmitWithDispatch extends UpgradeStep
 
         $this->manualUpgradeWarning(
             console: $console,
-            warning: 'The concept of `emitUp` has been removed entirely. Events are not dispatched as actual browser events and therefore "bubble up" by default.',
+            warning: 'The concept of `emitUp` has been removed entirely. Events are now dispatched as actual browser events and therefore "bubble up" by default.',
             before: ['$this->emitUp(\'post-created\');', '$emitUp(\'post-created\', 1)'],
             after: ['<removed>', '<removed>'],
         );


### PR DESCRIPTION
The typo inferred that Livewire 3 does NOT use browser events, when in fact it does.

`s/not/now`