### PR TITLE
[v3] Show livewire version from about command

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace Livewire;
+use Composer\InstalledVersions;
+use Illuminate\Foundation\Console\AboutCommand;
 
 class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
 {
@@ -65,6 +67,12 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
 
     protected function bootMechanisms()
     {
+        if (class_exists(AboutCommand::class) && class_exists(InstalledVersions::class)) {
+            AboutCommand::add('Livewire', [
+                'Livewire' => InstalledVersions::getPrettyVersion('livewire/livewire'),
+            ]);
+        }
+        
         foreach ($this->getMechanisms() as $mechanism) {
             (new $mechanism)->boot($this);
         }


### PR DESCRIPTION
I added these lines of code to quickly check the livewire version from laravel's `php artisan about` command. I feel like this could be a good enhancement. 