### PR TITLE
[v3] Add failing test for automatic route property binding

### DIFF
--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -65,13 +65,19 @@ class ImplicitRouteBinding
         return $this->getPublicPropertyTypes($component)
             ->intersectByKeys($route->parametersWithoutNulls())
             ->map(function ($className, $propName) use ($route) {
-                $resolved = $this->resolveParameter($route, $propName, $className);
+                // If typed public property, resolve the class
+                if($className) {
+                    $resolved = $this->resolveParameter($route, $propName, $className);
 
-                // We'll also pass the resolved model back to the route
-                // so that it can be used for any depending bindings
-                $route->setParameter($propName, $resolved);
+                    // We'll also pass the resolved model back to the route
+                    // so that it can be used for any depending on bindings
+                    $route->setParameter($propName, $resolved);
 
-                return $resolved;
+                    return $resolved;
+                }
+
+                // Otherwise, just return the route parameter
+                return $route->parameter($propName);
             });
     }
 
@@ -84,8 +90,7 @@ class ImplicitRouteBinding
         return collect(Utils::getPublicPropertiesDefinedOnSubclass($component))
             ->map(function ($value, $name) use ($component) {
                 return Reflector::getParameterClassName(new \ReflectionProperty($component, $name));
-            })
-            ->filter();
+            });
     }
 
     protected function resolveParameter($route, $parameterName, $parameterClassName)

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -420,6 +420,54 @@ class UnitTest extends \Tests\TestCase
             ->assertSee('I am a script 1')
             ->assertDontSee('I am a script 2');
     }
+
+    /** @test */
+    public function can_access_route_parameters_without_mount_method()
+    {
+        Route::get('/route-with-params/{myId}', ComponentForRouteWithoutMountParametersTest::class);
+
+        $this->get('/route-with-params/123')->assertSeeText('123');
+    }
+
+    /** @test */
+    public function can_access_route_parameters_with_mount_method()
+    {
+        Route::get('/route-with-params/{myId}', ComponentForRouteWithMountParametersTest::class);
+
+        $this->get('/route-with-params/123')->assertSeeText('123');
+    }
+}
+
+class ComponentForRouteWithoutMountParametersTest extends Component
+{
+    public $myId;
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            {{ $myId }}
+        </div>
+        HTML;
+    }
+}
+
+class ComponentForRouteWithMountParametersTest extends Component
+{
+    public $myId;
+
+    public function mount()
+    {
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            {{ $myId }}
+        </div>
+        HTML;
+    }
 }
 
 class ComponentForConfigurableLayoutTest extends Component


### PR DESCRIPTION
In the [docs](https://livewire.laravel.com/docs/components#using-route-model-binding) the following is mentioned:

> Livewire knows to use "route model binding" because the Post type-hint is prepended to the $post parameter in mount().
> Like before, you can reduce boilerplate by omitting the mount() method

When you remove the mount method, the binding will no longer work. If you add the `mount` method without any properties it will work again.

```php
// Works
class Component {
    public $post;

    public function mount($post) 
    {
        $this->post = $post;
    }
}

// Works
class Component {
    public $post;

    public function mount() 
    {
    }
}

// Fails
class Component {
    public $post;
}
```

It seems to be related to https://github.com/livewire/livewire/blob/11c75143c19d4f4559d0cf67e27f458cbd0c154e/src/Drawer/ImplicitRouteBinding.php#L84-L88

This will only resolve properties if they have a type-hint:

```php
// Works
class Component {
    public Post $post;
}

// Fails
class Component {
    public $post;
}
```

Shouldn't the route property binding always bind regardless of whether the property is type-hinted? I believe this is how it worked in v2.