### PR TITLE
[v3] Rename duplicate Suit enum in test

### DIFF
--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -100,12 +100,12 @@ class UnitTest extends \Tests\TestCase
     public function it_uses_the_synthesizers_for_enum_property_updates_when_initial_state_is_null()
     {
         Livewire::test(new class extends \Livewire\Component {
-            public ?Suit $selected;
+            public ?UnitSuit $selected;
 
             #[\Livewire\Attributes\Computed]
             public function cases()
             {
-                return Suit::cases();
+                return UnitSuit::cases();
             }
 
             public function render()
@@ -125,7 +125,7 @@ class UnitTest extends \Tests\TestCase
         })
         ->assertSet('selected', null)
         ->set('selected', 'D')
-        ->assertSet('selected', Suit::Diamonds)
+        ->assertSet('selected', UnitSuit::Diamonds)
         ->set('selected', null)
         ->assertSet('selected', null)
         ;
@@ -234,7 +234,7 @@ class ComponentWithStringPropertiesStub extends Component
     }
 }
 
-enum Suit: string
+enum UnitSuit: string
 {
     case Hearts = 'H';
 
@@ -252,5 +252,5 @@ class CountForm extends Form
 
 class SuitForm extends Form
 {
-    public Suit $selected;
+    public UnitSuit $selected;
 }


### PR DESCRIPTION
This prevented PHPUnit from running.

![CleanShot 2023-08-11 at 14 10 00@2x](https://github.com/livewire/livewire/assets/353790/0ad5125f-98c2-4705-989d-b440740d873a)

There were two enums named Suit in the same namespace.

Instead of referencing the one from the other test, I just renamed the Unit test one to UnitSuit. I feel like tests shouldn't depend on assets from other tests.