### PR TITLE
[V3] Fix Laravel Octane asset loading

### DIFF
--- a/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
+++ b/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
@@ -26,7 +26,6 @@ class SupportAutoInjectedAssets extends ComponentHook
             if (! str($handled->response->headers->get('content-type'))->contains('text/html')) return;
             if (! method_exists($handled->response, 'status') || $handled->response->status() !== 200) return;
             if ((! static::$hasRenderedAComponentThisRequest) && (! static::$forceAssetInjection)) return;
-            if (app(FrontendAssets::class)->hasRenderedScripts) return;
 
             $html = $handled->response->getContent();
 


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

[Yes](https://github.com/livewire/livewire/discussions/6322)

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

No, I don't think you can add tests for Octane?

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

I'm using Laravel Octane, see https://laravel.com/docs/10.x/octane#managing-memory-leaks

The problem is that `app(FrontendAssets::class)->hasRenderedScripts` will always be `true`, even when you (hard) reload the page, as this value is being cached.

I think the only workaround is to remove this line, or use `static::$forceAssetInjection` something like this:
```php
if (! static::$forceAssetInjection && app(FrontendAssets::class)->hasRenderedScripts) return;
```

Thanks