### PR TITLE
[v3] Add failing test for lazy nested components calling boot method twice

### DIFF
--- a/src/Features/SupportNestingComponents/BrowserTest.php
+++ b/src/Features/SupportNestingComponents/BrowserTest.php
@@ -180,6 +180,7 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertNotPresent('@child-one');
     }
     
+    /** @test */
     public function lazy_nested_components_do_not_call_boot_method_twice()
     {
         Livewire::visit([

--- a/src/Features/SupportNestingComponents/BrowserTest.php
+++ b/src/Features/SupportNestingComponents/BrowserTest.php
@@ -179,6 +179,19 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->waitForLivewire()->click('@delete-one')
         ->assertNotPresent('@child-one');
     }
+    
+    public function lazy_nested_components_do_not_call_boot_method_twice()
+    {
+        Livewire::visit([
+            BootPage::class,
+            'nested-boot-component' => NestedBootComponent::class,
+        ])
+            ->assertSee('Page')
+            ->pause(500)
+            ->assertDontSee('Boot count: 2')
+            ->assertSee('Boot count: 1');
+        ;
+    }
 }
 
 class Page extends Component
@@ -242,5 +255,39 @@ class ThirdComponent extends Component
     public function render()
     {
         return '<div>Third Component Rendered</div>';
+    }
+}
+
+class BootPage extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <div>Page</div>
+
+            <livewire:nested-boot-component lazy/>
+        </div>
+        HTML;
+    }
+}
+
+class NestedBootComponent extends Component
+{
+    public $bootCount = 0;
+
+    public function boot()
+    {
+        $this->increment();
+    }
+
+    public function increment()
+    {
+        $this->bootCount ++;
+    }
+
+    public function render()
+    {
+        return '<div>Boot count: {{ $bootCount }}</div>';
     }
 }


### PR DESCRIPTION
Issue: Nested components that use `lazy` call the boot method twice when initially loaded. In scenarios where the boot method is used to render additional content, this content is then duplicated on the page. 

Removing `lazy` prevents this from happening. 

Expected: The boot method would only be called once.