### PR TITLE
[V3] Use route-key

### DIFF
--- a/src/Features/SupportModels/ModelSynth.php
+++ b/src/Features/SupportModels/ModelSynth.php
@@ -24,11 +24,11 @@ class ModelSynth extends Synth {
         // If no alias is found, this just returns the class name
         $alias = $target->getMorphClass();
 
-        $serializedModel = (array) $this->getSerializedPropertyValue($target);
+        $key = $target->getRouteKey();
 
         return [
             null,
-            ['class' => $alias, 'key' => $serializedModel['id']],
+            ['class' => $alias, 'key' => $key],
         ];
     }
 
@@ -43,7 +43,11 @@ class ModelSynth extends Synth {
             $class = $aliasClass;
         }
 
-        $model = (new $class)->newQueryForRestoration($key)->useWritePdo()->firstOrFail();
+        $model = (new $class)
+            ->newQueryWithoutScopes()
+            ->where((new $class)->getRouteKeyName(), $key)
+            ->useWritePdo()
+            ->firstOrFail();
 
         return $model;
     }


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

https://github.com/livewire/livewire/discussions/6334

The main issue is exposing database details, e.g. of user-ids:
- 1
- 2
- 3
- ..

Someone could guess the number of active users (or any other models).
It's pretty easy, just do `window.livewire.all()` in a console window.

Also it can be confusing, as I'm talking to the API over prefixed ID's, instead of actual model-ids.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No (not yet).

It doesn't change collection model id's yet.

4️⃣ Does it include tests? (Required)

No, because I would like to gain some feedback first.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

```json
{
    "data": {
        "book": [
            null,
            {
                "class": "book",
                "key": "book-gxMRBP0zzh", // <-- this value
                "s": "mdl"
            }
        ]
    },
    "memo": {
        "id": "Um0csVv3RF021PpgJVjM",
        "name": "books.book-show-controller",
        "path": "books\\/book-gxMRBP0zzh",
        "method": "GET",
        "children": [],
        "lazyLoaded": false,
        "errors": [],
        "locale": "en"
    },
    "checksum": ".."
}
```
As you can see, the `key` is now the route-key, instead of the current model id.

It would be great if class could be hidden as well, but it seems to be used in two locations/keys.

Thanks!