### PR TITLE
[V3] Can reset unset properties

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -52,6 +52,12 @@ trait InteractsWithProperties
         $freshInstance = new static;
 
         foreach ($properties as $property) {
+            if (! isset($freshInstance->{$property})) {
+                unset($this->{$property});
+
+                continue;
+            }
+
             data_set($this, $property, data_get($freshInstance, $property));
         }
     }

--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -52,6 +52,7 @@ trait InteractsWithProperties
         $freshInstance = new static;
 
         foreach ($properties as $property) {
+            // Handle uninitialized properties differently to avoid an error being thrown.
             if (! isset($freshInstance->{$property})) {
                 unset($this->{$property});
 

--- a/src/Concerns/Tests/ResetPropertiesUnitTest.php
+++ b/src/Concerns/Tests/ResetPropertiesUnitTest.php
@@ -70,13 +70,29 @@ class ResetPropertiesUnitTest extends \Tests\TestCase
             ->assertSet('bob', 'law')
             ->assertSet('mwa', 'hah');
     }
+
+    /** @test */
+    public function can_reset_unset_properties()
+    {
+        $component = Livewire::test(ResetPropertiesComponent::class)
+            ->set('notSet', 1)
+            ->assertSet('notSet', 1)
+            // Reset only notSet.
+            ->call('resetKeys', 'notSet');
+
+        $this->assertFalse(isset($component->notSet));
+    }
 }
 
 class ResetPropertiesComponent extends Component
 {
     public $foo = 'bar';
+
     public $bob = 'lob';
+
     public $mwa = 'hah';
+
+    public int $notSet;
 
     public function resetAll()
     {


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

I ran into an issue trying to reset a property with no default value.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

You can now call `reset` when there are typed properties that have no default values

Thanks for contributing! 🙌
