### PR TITLE
fix: Call to undefined method ReflectionUnionType::getName() on multiple-types property

### DIFF
--- a/src/Mechanisms/HandleComponents/BrowserTest.php
+++ b/src/Mechanisms/HandleComponents/BrowserTest.php
@@ -92,6 +92,32 @@ class BrowserTest extends \Tests\BrowserTestCase
     }
 
     /** @test */
+    public function it_uses_the_synthesizers_for_multiple_types_property_updates()
+    {
+        Livewire::visit(new class extends \Livewire\Component {
+            public string|int $localValue = 15;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" dusk="localInput" wire:model.live.debounce.100ms="localValue">
+
+                    <span dusk="localValue">{{ $localValue }}</span>
+                </div>
+                HTML;
+            }
+        })
+        ->waitForText(15)
+        ->assertSee(15)
+
+        ->type('@localInput', 25)
+        ->waitForText(25)
+        ->assertSee(25)
+        ;
+    }
+
+    /** @test */
     public function it_uses_the_synthesizers_for_enum_property_updates_when_initial_state_is_null()
     {
         Livewire::visit(new class extends \Livewire\Component {

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -7,6 +7,7 @@ use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Drawer\Utils;
 use Illuminate\Support\Facades\View;
+use ReflectionUnionType;
 
 class HandleComponents
 {
@@ -342,9 +343,13 @@ class HandleComponents
         if ($parent && is_object($parent) && property_exists($parent, $childKey) && Utils::propertyIsTyped($parent, $childKey)) {
             $type = Utils::getProperty($parent, $childKey)->getType();
 
-            $synth = $this->getSynthesizerByType($type->getName(), $context, $path);
+            $types = $type instanceof ReflectionUnionType ? $type->getTypes() : [$type];
 
-            if ($synth) return $synth->hydrateFromType($type->getName(), $value);
+            foreach ($types as $type) {
+                $synth = $this->getSynthesizerByType($type->getName(), $context, $path);
+
+                if ($synth) return $synth->hydrateFromType($type->getName(), $value);
+            }
         }
 
         return $value;


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

#6361

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

no

4️⃣ Does it include tests? (Required)

absolutely

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
