### PR TITLE
Rename other Suit reference to fix unit tests

### DIFF
--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -148,7 +148,7 @@ class UnitTest extends \Tests\TestCase
         })
         ->assertSet('form.selected', null)
         ->set('form.selected', 'D')
-        ->assertSet('form.selected', Suit::Diamonds)
+        ->assertSet('form.selected', UnitSuit::Diamonds)
         ->set('form.selected', null)
         ->assertSet('form.selected', null)
         ;


### PR DESCRIPTION
I could have sworn I confirmed the unit tests before submitting #6323, but I missed one `Suit` => `UnitSuit` reference. Sorry about that.