### PR TITLE
More robustly handle resetting properties that are unset by default

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -52,14 +52,20 @@ trait InteractsWithProperties
         $freshInstance = new static;
 
         foreach ($properties as $property) {
-            // Handle uninitialized properties differently to avoid an error being thrown.
-            if (! isset($freshInstance->{$property})) {
-                unset($this->{$property});
+            $defaultValue = data_get($freshInstance, $property);
 
-                continue;
+            // Handle unsetting properties that are unset by default.
+            if (!$defaultValue) {
+                // Generate a unique handle so we can distinguish between falsey and unset properties.
+                $notSet = uniqid($property);
+                if ($notSet === data_get($freshInstance, $property, $notSet)) {
+                    // The property's default is unset.
+                    data_forget($this, $property);
+                    continue;
+                }
             }
 
-            data_set($this, $property, data_get($freshInstance, $property));
+            data_set($this, $property, $defaultValue);
         }
     }
 

--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -53,16 +53,13 @@ trait InteractsWithProperties
 
         foreach ($properties as $property) {
             $defaultValue = data_get($freshInstance, $property);
+            $unset = '__unset__';
+            $unsetByDefault = !$defaultValue && $unset === data_get($freshInstance, $property, $unset);
 
-            // Handle unsetting properties that are unset by default.
-            if (!$defaultValue) {
-                // Generate a unique handle so we can distinguish between falsey and unset properties.
-                $notSet = uniqid($property);
-                if ($notSet === data_get($freshInstance, $property, $notSet)) {
-                    // The property's default is unset.
-                    data_forget($this, $property);
-                    continue;
-                }
+            // Handle resetting properties that are unset by default.
+            if ($unsetByDefault) {
+                data_forget($this, $property);
+                continue;
             }
 
             data_set($this, $property, $defaultValue);

--- a/src/Drawer/BaseUtils.php
+++ b/src/Drawer/BaseUtils.php
@@ -40,7 +40,7 @@ class BaseUtils
                 if (method_exists($property, 'isInitialized') && !$property->isInitialized($target)) {
                     // If a type of `array` is given with no value, let's assume users want
                     // it prefilled with an empty array...
-                    $value = (method_exists($property->getType(), 'getName') && $property->getType()->getName() === 'array')
+                    $value = (method_exists($property, 'getType') && $property->getType() && method_exists($property->getType(), 'getName') && $property->getType()->getName() === 'array')
                         ? [] : null;
                 } else {
                     $value = $property->getValue($target);


### PR DESCRIPTION
#6345 introduced a test failure.

```
❯ ./vendor/bin/phpunit --filter can_reset_form_object_property
PHPUnit 9.6.10 by Sebastian Bergmann and contributors.

F                                                                   1 / 1 (100%)

Time: 00:00.093, Memory: 48.50 MB

There was 1 failure:

1) Livewire\Features\SupportFormObjects\UnitTest::can_reset_form_object_property
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-''
+'Some Title'

/Users/mark/git/livewire/src/Features/SupportTesting/MakesAssertions.php:93
```

This happened because it's doing `isset($freshInstance->{$property})` and `unset($this->{$property})` but `$property` could be using dot notation, like... `form.title` in the test.

https://github.com/livewire/livewire/blob/8f3511589cf0148943bab54334f5934ce565883b/src/Concerns/InteractsWithProperties.php#L56-L60

This PR uses `data_forget()` and makes the checking for unset-by-default properties more robust. It also beefs up `getPublicProperties()` to not blindly call `->getType()` on values that can sometimes be null.
