### PR TITLE
Use waitForTextIn() instead of assertSeeIn() to make browser test reliable

### DIFF
--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -332,22 +332,22 @@ class BrowserTest extends \Tests\BrowserTestCase
                 ->assertSeeNothingIn('@text-child')
                 ->assertSeeNothingIn('@text-parent')
                 ->waitForLivewire()->type('@text-input', 'test')
-                ->assertSeeIn('@text-child', 'test')
-                ->assertSeeIn('@text-parent', 'test')
+                ->waitForTextIn('@text-child', 'test')
+                ->waitForTextIn('@text-parent', 'test')
 
                 ->waitForNavigate()->click('@home-link')
                 ->assertSeeNothingIn('@text-child')
                 ->assertSeeNothingIn('@text-parent')
                 ->waitForLivewire()->type('@text-input', 'testing')
-                ->assertSeeIn('@text-child', 'testing')
-                ->assertSeeIn('@text-parent', 'testing')
+                ->waitForTextIn('@text-child', 'testing')
+                ->waitForTextIn('@text-parent', 'testing')
 
                 ->back()
-                ->assertSeeIn('@text-child', 'test')
-                ->assertSeeIn('@text-parent', 'test')
+                ->waitForTextIn('@text-child', 'test')
+                ->waitForTextIn('@text-parent', 'test')
                 ->waitForLivewire()->type('@text-input', 'testing')
-                ->assertSeeIn('@text-child', 'testing')
-                ->assertSeeIn('@text-parent', 'testing')
+                ->waitForTextIn('@text-child', 'testing')
+                ->waitForTextIn('@text-parent', 'testing')
                 ;
         });
     }


### PR DESCRIPTION
### Problem

Livewire's browser tests are flaky. Some of them randomly fail some of the time, which makes it hard to know if test failures are due to a bad code change or due to a random failure.

### Solution

Identify the browser tests that randomly fail, and make necessary changes to them to become reliable.

This is the first PR to advance that goal.

In this case a race condition was causing the test to look for an element that might not yet be fully rendered.

I used this code to run the test 100 times, and it failed 11% of the time:

```bash
count=0
failures=0

while [ $count -lt 100 ]; do
  ./vendor/bin/phpunit --filter events_from_child_components_still_function_after_navigation
  if [ $? -ne 0 ]; then
    ((failures++))
  fi
  ((count++))
done

echo "Total Failures: $failures"
```

The fix is to use `waitForTextIn()` which will wait until that text appears, instead of expecting it to be there immediately. After making that change and re-running the test 100 times, it had zero failures.

Note that the tests are going to fail for this PR until #6375 is merged (and might still fail because of other flaky browser tests).