### PR TITLE
flaky-test: Use waitForText() and waitUntilMissingText() instead of manual pause()

### DIFF
--- a/src/Features/SupportJsEvaluation/BrowserTest.php
+++ b/src/Features/SupportJsEvaluation/BrowserTest.php
@@ -31,12 +31,13 @@ class BrowserTest extends \Tests\BrowserTestCase
                 </div>
                 HTML; }
         })
+        ->waitUntilMissingText('Toggle Me!')
         ->assertDontSee('Toggle Me!')
         ->click('@toggle')
-        ->pause(100)
+        ->waitForText('Toggle Me!')
         ->assertSee('Toggle Me!')
         ->click('@toggle')
-        ->pause(100)
+        ->waitUntilMissingText('Toggle Me!')
         ->assertDontSee('Toggle Me!')
         ;
     }


### PR DESCRIPTION
This test was failing ~3% of the time. It was using a manual `pause(100)` which was sometimes not long enough. By changing to `waitForText()` and `waitUntilMissingText()`, we can let Dusk take care of re-polling the DOM.

As a bonus, it might end up being faster, because if ~3% of the time 100ms isn't long enough, then ~97% of the time, 100ms is more than is needed!