### PR TITLE
Rename base attribute classes

### DIFF
--- a/src/Attributes/Computed.php
+++ b/src/Attributes/Computed.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Attributes;
 
-use Livewire\Features\SupportComputed\Computed as BaseComputed;
+use Livewire\Features\SupportComputed\BaseComputed;
 
 #[\Attribute]
 class Computed extends BaseComputed

--- a/src/Attributes/Js.php
+++ b/src/Attributes/Js.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Attributes;
 
-use Livewire\Features\SupportJsEvaluation\Js as BaseJs;
+use Livewire\Features\SupportJsEvaluation\BaseJs;
 
 #[\Attribute]
 class Js extends BaseJs

--- a/src/Attributes/Layout.php
+++ b/src/Attributes/Layout.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Attributes;
 
-use Livewire\Features\SupportPageComponents\Layout as BaseLayout;
+use Livewire\Features\SupportPageComponents\BaseLayout;
 
 #[\Attribute]
 class Layout extends BaseLayout

--- a/src/Attributes/Locked.php
+++ b/src/Attributes/Locked.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Attributes;
 
-use Livewire\Features\SupportLockedProperties\Locked as BaseLocked;
+use Livewire\Features\SupportLockedProperties\BaseLocked;
 
 #[\Attribute]
 class Locked extends BaseLocked

--- a/src/Attributes/Modelable.php
+++ b/src/Attributes/Modelable.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Attributes;
 
-use Livewire\Features\SupportWireModelingNestedComponents\Modelable as BaseModelable;
+use Livewire\Features\SupportWireModelingNestedComponents\BaseModelable;
 
 #[\Attribute]
 class Modelable extends BaseModelable

--- a/src/Attributes/On.php
+++ b/src/Attributes/On.php
@@ -3,7 +3,7 @@
 namespace Livewire\Attributes;
 
 use Attribute;
-use Livewire\Features\SupportEvents\On as BaseOn;
+use Livewire\Features\SupportEvents\BaseOn;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
 class On extends BaseOn

--- a/src/Attributes/Reactive.php
+++ b/src/Attributes/Reactive.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Attributes;
 
-use Livewire\Features\SupportReactiveProps\Reactive as BaseReactive;
+use Livewire\Features\SupportReactiveProps\BaseReactive;
 
 #[\Attribute]
 class Reactive extends BaseReactive

--- a/src/Attributes/Renderless.php
+++ b/src/Attributes/Renderless.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Attributes;
 
-use Livewire\Mechanisms\HandleComponents\Renderless as BaseRenderless;
+use Livewire\Mechanisms\HandleComponents\BaseRenderless;
 
 #[\Attribute]
 class Renderless extends BaseRenderless

--- a/src/Attributes/Rule.php
+++ b/src/Attributes/Rule.php
@@ -3,7 +3,7 @@
 namespace Livewire\Attributes;
 
 use Attribute;
-use Livewire\Features\SupportValidation\Rule as BaseRule;
+use Livewire\Features\SupportValidation\BaseRule;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_ALL)]
 class Rule extends BaseRule

--- a/src/Attributes/Title.php
+++ b/src/Attributes/Title.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Attributes;
 
-use Livewire\Features\SupportPageComponents\Title as BaseTitle;
+use Livewire\Features\SupportPageComponents\BaseTitle;
 
 #[\Attribute]
 class Title extends BaseTitle

--- a/src/Attributes/Url.php
+++ b/src/Attributes/Url.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Attributes;
 
-use Livewire\Features\SupportQueryString\Url as BaseUrl;
+use Livewire\Features\SupportQueryString\BaseUrl;
 
 #[\Attribute]
 class Url extends BaseUrl

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -10,7 +10,7 @@ use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
 
 #[\Attribute]
-class Computed extends Attribute
+class BaseComputed extends Attribute
 {
     protected $requestCachedValue;
 

--- a/src/Features/SupportEvents/BaseOn.php
+++ b/src/Features/SupportEvents/BaseOn.php
@@ -8,7 +8,7 @@ use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use function Livewire\store;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
-class On extends LivewireAttribute
+class BaseOn extends LivewireAttribute
 {
     public function __construct(public $event) {}
 

--- a/src/Features/SupportEvents/UnitTest.php
+++ b/src/Features/SupportEvents/UnitTest.php
@@ -13,7 +13,7 @@ class UnitTest extends \Tests\TestCase
         $component = Livewire::test(new class extends Component {
             public $foo = 'bar';
 
-            #[On('bar')]
+            #[BaseOn('bar')]
             public function onBar($param)
             {
                 $this->foo = $param;
@@ -35,7 +35,7 @@ class UnitTest extends \Tests\TestCase
 
             public $foo = 'bar';
 
-            #[On('bar.{post.id}')]
+            #[BaseOn('bar.{post.id}')]
             public function onBar($param)
             {
                 $this->foo = $param;
@@ -55,7 +55,7 @@ class UnitTest extends \Tests\TestCase
         $component = Livewire::test(new class extends Component {
             public $foo = 'bar';
 
-            #[On('bar')]
+            #[BaseOn('bar')]
             public function onBar($name, $game)
             {
                 $this->foo = $name . $game;
@@ -96,7 +96,7 @@ class UnitTest extends \Tests\TestCase
         Livewire::test(new class extends Component {
             public $counter = 0;
 
-            #[On('foo'), On('bar')]
+            #[BaseOn('foo'), BaseOn('bar')]
             public function add(): void
             {
                 $this->counter++;

--- a/src/Features/SupportJsEvaluation/BaseJs.php
+++ b/src/Features/SupportJsEvaluation/BaseJs.php
@@ -5,7 +5,7 @@ namespace Livewire\Features\SupportJsEvaluation;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
 #[\Attribute]
-class Js extends LivewireAttribute
+class BaseJs extends LivewireAttribute
 {
     function dehydrate($context)
     {

--- a/src/Features/SupportJsEvaluation/BrowserTest.php
+++ b/src/Features/SupportJsEvaluation/BrowserTest.php
@@ -13,7 +13,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             new class extends \Livewire\Component {
                 public $show = false;
 
-                #[Js]
+                #[BaseJs]
                 function toggle()
                 {
                     return <<<'JS'

--- a/src/Features/SupportLockedProperties/BaseLocked.php
+++ b/src/Features/SupportLockedProperties/BaseLocked.php
@@ -5,7 +5,7 @@ namespace Livewire\Features\SupportLockedProperties;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
 #[\Attribute]
-class Locked extends LivewireAttribute
+class BaseLocked extends LivewireAttribute
 {
     public function update()
     {

--- a/src/Features/SupportLockedProperties/UnitTest.php
+++ b/src/Features/SupportLockedProperties/UnitTest.php
@@ -15,7 +15,7 @@ class UnitTest extends \Tests\TestCase
         );
 
         Livewire::test(new class extends Component {
-            #[Locked]
+            #[BaseLocked]
             public $count = 1;
 
             function increment() { $this->count++; }

--- a/src/Features/SupportPageComponents/BaseLayout.php
+++ b/src/Features/SupportPageComponents/BaseLayout.php
@@ -5,7 +5,7 @@ namespace Livewire\Features\SupportPageComponents;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
 #[\Attribute]
-class Layout extends LivewireAttribute
+class BaseLayout extends LivewireAttribute
 {
     function __construct(
         public $name,

--- a/src/Features/SupportPageComponents/BaseTitle.php
+++ b/src/Features/SupportPageComponents/BaseTitle.php
@@ -5,7 +5,7 @@ namespace Livewire\Features\SupportPageComponents;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
 #[\Attribute]
-class Title extends LivewireAttribute
+class BaseTitle extends LivewireAttribute
 {
     function __construct(
         public $content,

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -82,8 +82,8 @@ class SupportPageComponents extends ComponentHook
         // Only run this handler once for the parent-most component. Otherwise child components
         // will run this handler too and override the configured layout...
         $handler = once(function ($target, $view, $data) use (&$layoutConfig, &$slots) {
-            $layoutAttr = $target->getAttributes()->whereInstanceOf(Layout::class)->first();
-            $titleAttr = $target->getAttributes()->whereInstanceOf(Title::class)->first();
+            $layoutAttr = $target->getAttributes()->whereInstanceOf(BaseLayout::class)->first();
+            $titleAttr = $target->getAttributes()->whereInstanceOf(BaseTitle::class)->first();
 
             if ($layoutAttr) {
                 $view->layout($layoutAttr->name, $layoutAttr->params);

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -619,14 +619,14 @@ class ComponentForRenderLayoutAttribute extends Component
 {
     public $name = 'bob';
 
-    #[Layout('layouts.app-with-bar', ['bar' => 'baz'])]
+    #[BaseLayout('layouts.app-with-bar', ['bar' => 'baz'])]
     public function render()
     {
         return view('show-name');
     }
 }
 
-#[Layout('layouts.app-with-bar', ['bar' => 'baz'])]
+#[BaseLayout('layouts.app-with-bar', ['bar' => 'baz'])]
 class ComponentForClassLayoutAttribute extends Component
 {
     public $name = 'bob';
@@ -641,8 +641,8 @@ class ComponentForTitleAttribute extends Component
 {
     public $name = 'bob';
 
-    #[Title('some-title')]
-    #[Layout('layouts.app-with-title')]
+    #[BaseTitle('some-title')]
+    #[BaseLayout('layouts.app-with-title')]
     public function render()
     {
         return view('show-name');
@@ -664,7 +664,7 @@ class ComponentWithModel extends Component
     public FrameworkModel $framework;
 }
 
-#[Layout('layouts.app-with-title')]
+#[BaseLayout('layouts.app-with-title')]
 class ComponentWithClassBasedComponentTitleAndLayoutAttribute extends Component
 {
     public function render()
@@ -674,7 +674,7 @@ class ComponentWithClassBasedComponentTitleAndLayoutAttribute extends Component
     }
 }
 
-#[Layout('layouts.app-layout-with-stacks')]
+#[BaseLayout('layouts.app-layout-with-stacks')]
 class ComponentWithStacks extends Component
 {
     public function render()

--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -9,7 +9,7 @@ use Illuminate\Pagination\Paginator;
 use Livewire\ComponentHook;
 use Livewire\ComponentHookRegistry;
 use Livewire\Features\SupportQueryString\SupportQueryString;
-use Livewire\Features\SupportQueryString\Url;
+use Livewire\Features\SupportQueryString\BaseUrl;
 
 class SupportPagination extends ComponentHook
 {
@@ -103,7 +103,7 @@ class SupportPagination extends ComponentHook
         $keep = $queryStringDetails['keep'];
 
         // @todo: make this work...
-        $this->component->setPropertyAttribute($key, new Url(as: $alias, history: $history, keep: $keep));
+        $this->component->setPropertyAttribute($key, new BaseUrl(as: $alias, history: $history, keep: $keep));
     }
 
     protected function paginationView()

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -5,7 +5,7 @@ namespace Livewire\Features\SupportQueryString;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
 #[\Attribute]
-class Url extends LivewireAttribute
+class BaseUrl extends LivewireAttribute
 {
     public function __construct(
         public $as = null,

--- a/src/Features/SupportQueryString/SupportQueryString.php
+++ b/src/Features/SupportQueryString/SupportQueryString.php
@@ -22,7 +22,7 @@ class SupportQueryString extends ComponentHook
             $history = $value['history'] ?? true;
             $keep = $value['alwaysShow'] ?? $value['keep'] ?? false;
 
-            $this->component->setPropertyAttribute($key, new Url(as: $alias, history: $history, keep: $keep));
+            $this->component->setPropertyAttribute($key, new BaseUrl(as: $alias, history: $history, keep: $keep));
         }
     }
 

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -11,7 +11,7 @@ class UnitTest extends \Tests\TestCase
     function can_track_properties_in_the_url()
     {
         $component = Livewire::test(new class extends Component {
-            #[Url]
+            #[BaseUrl]
             public $count = 1;
 
             function increment() { $this->count++; }

--- a/src/Features/SupportReactiveProps/BaseReactive.php
+++ b/src/Features/SupportReactiveProps/BaseReactive.php
@@ -6,7 +6,7 @@ use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use function Livewire\store;
 
 #[\Attribute]
-class Reactive extends LivewireAttribute
+class BaseReactive extends LivewireAttribute
 {
     function __construct() {}
 

--- a/src/Features/SupportReactiveProps/BrowserTest.php
+++ b/src/Features/SupportReactiveProps/BrowserTest.php
@@ -32,7 +32,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
             'child' => new class extends Component {
-                #[Reactive]
+                #[BaseReactive]
                 public $count;
 
                 public function render() { return <<<'HTML'
@@ -92,7 +92,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
             'child' => new class extends Component {
-                #[Reactive]
+                #[BaseReactive]
                 public $count;
 
                 public function render() { return <<<'HTML'
@@ -105,7 +105,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
             'nestedchild' => new class extends Component {
-                #[Reactive]
+                #[BaseReactive]
                 public $count;
 
                 public function render() { return <<<'HTML'
@@ -152,7 +152,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
             'child' => new class extends Component {
-                #[Reactive]
+                #[BaseReactive]
                 public $count;
 
                 public function inc() { $this->count++; }
@@ -199,7 +199,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
             'child' => new class extends Component {
-                #[Reactive]
+                #[BaseReactive]
                 public $count;
 
                 public function inc() { $this->count++; }

--- a/src/Features/SupportValidation/BaseRule.php
+++ b/src/Features/SupportValidation/BaseRule.php
@@ -8,7 +8,7 @@ use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use function Livewire\wrap;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_ALL)]
-class Rule extends LivewireAttribute
+class BaseRule extends LivewireAttribute
 {
     // @todo: support custom messages...
     function __construct(

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -17,10 +17,10 @@ class UnitTest extends \Tests\TestCase
     public function update_triggers_rule_attribute()
     {
         Livewire::test(new class extends TestComponent {
-            #[Rule('required')]
+            #[BaseRule('required')]
             public $foo = '';
 
-            #[Rule('required')]
+            #[BaseRule('required')]
             public $bar = '';
 
             function clear() { $this->clearValidation(); }
@@ -43,10 +43,10 @@ class UnitTest extends \Tests\TestCase
     public function realtime_validation_can_be_opted_out_of()
     {
         Livewire::test(new class extends TestComponent {
-            #[Rule('required|min:3', onUpdate: false)]
+            #[BaseRule('required|min:3', onUpdate: false)]
             public $foo = '';
 
-            #[Rule('required|min:3')]
+            #[BaseRule('required|min:3')]
             public $bar = '';
 
             function clear() { $this->clearValidation(); }
@@ -68,7 +68,7 @@ class UnitTest extends \Tests\TestCase
     public function rule_attribute_supports_custom_attribute()
     {
         Livewire::test(new class extends TestComponent {
-            #[Rule('required|min:3', attribute: 'The Foo')]
+            #[BaseRule('required|min:3', attribute: 'The Foo')]
             public $foo = '';
 
             function clear() { $this->clearValidation(); }
@@ -93,7 +93,7 @@ class UnitTest extends \Tests\TestCase
     public function rule_attribute_supports_custom_attribute_as_alias()
     {
         Livewire::test(new class extends TestComponent {
-            #[Rule('required|min:3', as: 'The Foo')]
+            #[BaseRule('required|min:3', as: 'The Foo')]
             public $foo = '';
 
             function clear() { $this->clearValidation(); }
@@ -118,7 +118,7 @@ class UnitTest extends \Tests\TestCase
     public function rule_attribute_supports_custom_messages()
     {
         Livewire::test(new class extends TestComponent {
-            #[Rule('min:5', message: 'Your foo is too short.')]
+            #[BaseRule('min:5', message: 'Your foo is too short.')]
             public $foo = '';
 
             function clear() { $this->clearValidation(); }
@@ -139,7 +139,7 @@ class UnitTest extends \Tests\TestCase
     public function rule_attributes_can_contain_rules_for_multiple_properties()
     {
         Livewire::test(new class extends TestComponent {
-            #[Rule(['foo' => 'required', 'bar' => 'required'])]
+            #[BaseRule(['foo' => 'required', 'bar' => 'required'])]
             public $foo = '';
 
             public $bar = '';
@@ -165,7 +165,7 @@ class UnitTest extends \Tests\TestCase
     public function rule_attributes_can_contain_multiple_rules()
     {
         Livewire::test(new class extends TestComponent {
-            #[Rule(['required', 'min:2', 'max:3'])]
+            #[BaseRule(['required', 'min:2', 'max:3'])]
             public $foo = '';
         })
             ->set('foo', '')
@@ -203,14 +203,14 @@ class UnitTest extends \Tests\TestCase
     public function rule_attributes_can_be_repeated()
     {
         Livewire::test(new class extends TestComponent {
-            #[Rule('required')]
-            #[Rule('min:2')]
-            #[Rule('max:3')]
+            #[BaseRule('required')]
+            #[BaseRule('min:2')]
+            #[BaseRule('max:3')]
             public $foo = '';
 
             #[
-                Rule('sometimes'),
-                Rule('max:1')
+                BaseRule('sometimes'),
+                BaseRule('max:1')
             ]
             public $bar = '';
         })

--- a/src/Features/SupportWireModelingNestedComponents/BaseModelable.php
+++ b/src/Features/SupportWireModelingNestedComponents/BaseModelable.php
@@ -6,7 +6,7 @@ use function Livewire\store;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
 #[\Attribute]
-class Modelable extends LivewireAttribute
+class BaseModelable extends LivewireAttribute
 {
     public function mount($params, $parent)
     {

--- a/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
+++ b/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
@@ -30,7 +30,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 HTML; }
             },
             'child' => new class extends \Livewire\Component {
-                #[Modelable]
+                #[BaseModelable]
                 public $bar;
 
                 public function render() { return <<<'HTML'
@@ -81,7 +81,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
             'child' => new class extends \Livewire\Component {
-                #[Modelable]
+                #[BaseModelable]
                 public $bar;
 
                 public function render()
@@ -141,7 +141,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
             'child' => new class extends \Livewire\Component {
-                #[Modelable]
+                #[BaseModelable]
                 public $bar;
 
                 public function render()

--- a/src/Mechanisms/HandleComponents/BaseRenderless.php
+++ b/src/Mechanisms/HandleComponents/BaseRenderless.php
@@ -5,7 +5,7 @@ namespace Livewire\Mechanisms\HandleComponents;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
 #[\Attribute]
-class Renderless extends LivewireAttribute
+class BaseRenderless extends LivewireAttribute
 {
     function call()
     {


### PR DESCRIPTION
Before this PR, every Livewire attribute (Rule, Url, etc.) had two files of the exact same name:

```php
Livewire\Attributes\Rule; // Vanity namespace for userland consumption...
Livewire\Features\SupportValidation\Rule; // Deeper core source code namespace...
```

After this PR, the deeper ones are renamed to `Base[Attribute Name]` as to not confuse users about which ones to use:

```php
Livewire\Attributes\Rule;
Livewire\Features\SupportValidation\BaseRule;
```
