### PR TITLE
Add exception if parameters is not array or traversable

### DIFF
--- a/src/Features/SupportEvents/SupportEvents.php
+++ b/src/Features/SupportEvents/SupportEvents.php
@@ -22,6 +22,10 @@ class SupportEvents extends ComponentHook
 
             $method = static::getListenerMethodName($this->component, $name);
 
+            if (! is_array($params) && ! is_iterable($params)) {
+                throw new \Exception('EventParametersNotIterable');
+            }
+
             $returnEarly(
                 wrap($this->component)->$method(...$params)
             );


### PR DESCRIPTION
Just for know whats wrong when send data like
```js
Livewire.dispatch('something-here', 1); // user id "1"
```

otherwise, developers never know what's wrong on his code, In docs i can see sending parameters in V3 is with javascript object

```js
// In Livewire V2, works
Livewire.emit('something-here', 1); // user id "1"
```

But in upgrade to V3, is needed change too from code above to

```js
Livewire.dispatch('something-here', {id: 1}); // user id "1"
```

Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
