### PR TITLE
Remove test skips for old versions of Laravel

### DIFF
--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -298,10 +298,6 @@ class UnitTest extends \Tests\TestCase
     /** @test */
     public function route_supports_laravels_missing_fallback_function(): void
     {
-        if (! method_exists(\Illuminate\Routing\Route::class, 'missing')) {
-            $this->markTestSkipped('Need Laravel >= 8');
-        }
-
         Route::get('awesome-js/{framework}', ComponentWithModel::class)
              ->missing(function (Request $request) {
                  $this->assertEquals(request(), $request);

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -194,10 +194,6 @@ class UnitTest extends \LegacyTests\Unit\TestCase
     /** @test */
     function can_assert_see_livewire_on_test_view()
     {
-        if(! class_exists(TestView::class)) {
-            self::markTestSkipped('Need Laravel >= 8');
-        }
-
         Artisan::call('make:livewire', ['name' => 'foo']);
 
         $testView = new TestView(view('render-component', [
@@ -210,10 +206,6 @@ class UnitTest extends \LegacyTests\Unit\TestCase
     /** @test */
     function can_assert_see_livewire_on_test_view_refering_by_subfolder_without_dot_index()
     {
-        if(! class_exists(TestView::class)) {
-            self::markTestSkipped('Need Laravel >= 8');
-        }
-
         Artisan::call('make:livewire', ['name' => 'bar.index']);
 
         $testView = new TestView(view('render-component', [
@@ -226,10 +218,6 @@ class UnitTest extends \LegacyTests\Unit\TestCase
     /** @test */
     function can_assert_dont_see_livewire_on_test_view()
     {
-        if(! class_exists(TestView::class)) {
-            self::markTestSkipped('Need Laravel >= 8');
-        }
-
         Artisan::call('make:livewire', ['name' => 'foo']);
 
         $testView = new TestView(view('null-view'));


### PR DESCRIPTION
Livewire now requires Laravel 10, so these are not necessary.
