### PR TITLE
[v3] Small documentation typos

### DIFF
--- a/docs/morph.md
+++ b/docs/morph.md
@@ -147,7 +147,7 @@ Here's an example of the previous Blade template but with Livewire's injected ma
     @if ($errors->has('title'))
         <div>Error: {{ $errors->first('title') }}</div>
     @endif
-    <!-- ENDBLOCK --> <!-- [tl! highlight] -->
+    <!-- __ENDBLOCK__ --> <!-- [tl! highlight] -->
 
     <div>
         <button>Save</button>

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -492,7 +492,7 @@ $this->setPage(2);
 
 ### `wire:click.prefetch`
 
-Livewire's prefetching feature (`wire:click.prefetching`) has been removed entirely. If you depended on this feature, your application will still work, it will just be slightly less performant in the instances where you were previously benefiting from `.prefetch`.
+Livewire's prefetching feature (`wire:click.prefetch`) has been removed entirely. If you depended on this feature, your application will still work, it will just be slightly less performant in the instances where you were previously benefiting from `.prefetch`.
 
 ```html
 <button wire:click.prefetch=""> <!-- [tl! remove] -->


### PR DESCRIPTION
`wire:click.prefetching` → `wire:click.prefetch`

`<!-- ENDBLOCK -->` → `<!-- __ENDBLOCK__ -->`