### PR TITLE
Add failing lifecycle test when using synths

### DIFF
--- a/src/BootTest/BrowserTest.php
+++ b/src/BootTest/BrowserTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Livewire\BootTest;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use Livewire\Wireable;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    /** @test */
+    public function test_component_booth_method_is_called_before_running_synths()
+    {
+        Livewire::visit(new class extends Component {
+
+            public SomeObject $someObject;
+
+            public function boot()
+            {
+                SomeOtherObjectWithStaticProperty::$someValue = 'valueSetByComponentBoot';
+            }
+
+            public function mount()
+            {
+                $this->someObject = new SomeObject('test');
+            }
+
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <div dusk="value">{{ $someObject->bar }}</div>
+                    <button dusk="button" wire:click="$refresh">Click</button>
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewire()
+            ->click('@button')
+            ->waitForLivewire()
+            ->assertSeeIn('@value', 'valueSetByComponentBoot')
+            ->pause(5000)
+            ;
+    }
+}
+
+class SomeObject implements Wireable {
+    public function __construct(public $foo, public $bar = null)
+    {
+    }
+
+    public function toLivewire()
+    {
+        return [
+            'foo' => $this->foo,
+            'bar' => $this->bar,
+        ];
+    }
+
+    public static function fromLivewire($value)
+    {
+        return new static($value['foo'], SomeOtherObjectWithStaticProperty::$someValue);
+    }
+}
+
+class SomeOtherObjectWithStaticProperty {
+    public static $someValue = 'defaultValue';
+}

--- a/src/Features/SupportLifecycleHooks/BrowserTest.php
+++ b/src/Features/SupportLifecycleHooks/BrowserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Livewire\BootTest;
+namespace Livewire\Features\SupportLifecycleHooks;
 
 use Livewire\Component;
 use Livewire\Livewire;
@@ -13,7 +13,6 @@ class BrowserTest extends BrowserTestCase
     public function test_component_booth_method_is_called_before_running_synths()
     {
         Livewire::visit(new class extends Component {
-
             public SomeObject $someObject;
 
             public function boot()
@@ -34,13 +33,11 @@ class BrowserTest extends BrowserTestCase
                     <button dusk="button" wire:click="$refresh">Click</button>
                 </div>
                 HTML;
-            }
-        })
+            }})
             ->waitForLivewire()
             ->click('@button')
             ->waitForLivewire()
             ->assertSeeIn('@value', 'valueSetByComponentBoot')
-            ->pause(5000)
             ;
     }
 }


### PR DESCRIPTION
This might be an edge case and very specific to my use case, but in v2, the boot method of a component is triggered before calling the `fromLivewire` methods on any `Wirable` objects.

In v2 I have a collection that looks something like this (simplified):
```php
class MyCustomCollection extends Collection implements Wireable
{
    //...

    public static function fromLivewire($values)
    {
        $values = collect($values)
            ->map(function ($value) {
                return collect(MyServiceProvider::$foobar)
                    ->firstWhere('type', '=', $value['type'])
                    ->fill(...$value);
            })->toArray();

        return new static($values);
    }
}

class MyComponent extends Component {
    public function boot()
    {
        // Calls a bunch of dynamic callbacks, which boils down 
        // to building various objects and storing them on a static property; simple example:
        MyServiceProvider::$foobar = [new Something(['type' => 'test']);
    }
}
```

The `fromLivewire` attempts to get a static property `MyServiceProvider::$foobar`, which contains the array of resolved objects. This static value is set every time using the boot method. Now in v3, `MyServiceProvider::$foobar` is `null` when you try to access this inside the `fromLivewire` method. 

The boot method, in v3, seems to be called **after** calling the `fromLivewire method, while in v2, it was done before.

I wasn't sure where to place the test, so these still need to be put in the correct place if this is a correct failing test.
