### PR TITLE
[V3] Fix EloquentCollectionSynth: Undefined array key "class"

### DIFF
--- a/src/Features/SupportLegacyModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentCollectionSynth.php
@@ -38,7 +38,7 @@ class EloquentCollectionSynth extends Synth
 
         $rules = $this->getRules($this->context);
 
-        if (empty($rules)) return [[], []];
+        if (empty($rules)) return [[], $meta];
 
         $data = $this->getDataFromCollection($target, $rules);
 

--- a/src/Features/SupportLegacyModels/Tests/EloquentCollectionsBrowserTest.php
+++ b/src/Features/SupportLegacyModels/Tests/EloquentCollectionsBrowserTest.php
@@ -71,7 +71,7 @@ class EloquentCollectionsBrowserTest extends TestCase
     }
 
     /** @test */
-    public function it_displays_all_nested_data_2()
+    public function it_hydrate_work_property_without_rules()
     {
         $this->browse(function (Browser $browser) {
             $this->visitLivewireComponent($browser, EloquentCollectionsWithoutRulesComponent::class)

--- a/src/Features/SupportLegacyModels/Tests/EloquentCollectionsBrowserTest.php
+++ b/src/Features/SupportLegacyModels/Tests/EloquentCollectionsBrowserTest.php
@@ -69,6 +69,17 @@ class EloquentCollectionsBrowserTest extends TestCase
         $author->posts[0]->comments[1]->author->name = 'John';
         $author->push();
     }
+
+    /** @test */
+    public function it_displays_all_nested_data_2()
+    {
+        $this->browse(function (Browser $browser) {
+            $this->visitLivewireComponent($browser, EloquentCollectionsWithoutRulesComponent::class)
+                ->waitForLivewire()->click('@something')
+                ->assertSeeIn('@output', 'Ok!');
+            ;
+        });
+    }
 }
 
 class EloquentCollectionsComponent extends BaseComponent
@@ -146,6 +157,36 @@ class EloquentCollectionsComponent extends BaseComponent
     <button wire:click="save" type="button" dusk="save">Save</button>
 </div>
 HTML;
+    }
+}
+
+
+class EloquentCollectionsWithoutRulesComponent extends EloquentCollectionsComponent
+{
+    public $output;
+
+    protected $rules = [];
+
+    public function something()
+    {
+        $this->output = 'Ok!';
+    }
+
+    public function render()
+    {
+        return
+        <<<'HTML'
+<div>
+      <div>
+          @foreach($authors as $author)
+              <p>{{ $author->name }}</p>
+          @endforeach
+      </div>
+      <span dusk='output'>{{ $output }}</span>
+      <button dusk='something' wire:click='something'>something</button>
+</div>
+HTML;
+
     }
 }
 


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
https://github.com/livewire/livewire/discussions/6391
2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
4️⃣ Does it include tests? (Required)
Yes
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌

---

This Pull Request fixes the "`Undefined array key "class"`" bug when using collection interaction with validation.

The initial problem was when trying to hydrate by starting a new instance `$meta['class']` which is not defined in the dehydrator.

I tried to address both options: removing the $rules line or adding the `$meta`. I followed by adding the $meta variable to be similar to EloquentModelSynth.

To reproduce the issue just follow the guide in the discussion, also added a test