### PR TITLE
[v3] Fix/Cleanup dynamic component

### DIFF
--- a/src/Mechanisms/CompileLivewireTags.php
+++ b/src/Mechanisms/CompileLivewireTags.php
@@ -78,8 +78,7 @@ class CompileLivewireTags extends ComponentTagCompiler
                 // Does not need quotes as resolved with quotes already.
                 $component = $attributes['component'] ?? $attributes['is'];
 
-                unset($attributes['component']);
-                unset($attributes['is']);
+                unset($attributes['component'], $attributes['is']);
             } else {
                 // Add single quotes to the component name to compile it as string in quotes
                 $component = "'{$component}'";

--- a/src/Mechanisms/CompileLivewireTags.php
+++ b/src/Mechanisms/CompileLivewireTags.php
@@ -62,11 +62,11 @@ class CompileLivewireTags extends ComponentTagCompiler
             if ($component === 'styles') return '@livewireStyles';
             if ($component === 'scripts') return '@livewireScripts';
             if ($component === 'dynamic-component' || $component === 'is') {
-                if(! (isset($attributes['component']) || isset($attributes['is']))) {
                     $dynamicComponentExists = rescue(function() use ($component, $attributes) {
                         // Need to run this in rescue otherwise running this during a test causes Livewire directory not found exception
                         return $component === 'dynamic-component' && app('livewire')->getClass('dynamic-component');
                     });
+                if (! isset($attributes['component']) && ! isset($attributes['is'])) {
 
                     if ($dynamicComponentExists) {
                         return $this->componentString("'{$component}'", $attributes);

--- a/src/Mechanisms/CompileLivewireTags.php
+++ b/src/Mechanisms/CompileLivewireTags.php
@@ -29,8 +29,9 @@ class CompileLivewireTags extends ComponentTagCompiler
 
             $keys = array_keys($attributes);
             $values = array_values($attributes);
+            $attributesCount = count($attributes);
 
-            for ($i=0; $i < count($keys); $i++) {
+            for ($i=0; $i < $attributesCount; $i++) {
                 if ($keys[$i] === ':' && $values[$i] === 'true') {
                     if (isset($values[$i + 1]) && $values[$i + 1] === 'true') {
                         $attributes[$keys[$i + 1]] = '$'.$keys[$i + 1];

--- a/src/Mechanisms/CompileLivewireTags.php
+++ b/src/Mechanisms/CompileLivewireTags.php
@@ -62,11 +62,10 @@ class CompileLivewireTags extends ComponentTagCompiler
             if ($component === 'styles') return '@livewireStyles';
             if ($component === 'scripts') return '@livewireScripts';
             if ($component === 'dynamic-component' || $component === 'is') {
-                    $dynamicComponentExists = rescue(function() use ($component, $attributes) {
-                        // Need to run this in rescue otherwise running this during a test causes Livewire directory not found exception
-                        return $component === 'dynamic-component' && app('livewire')->getClass('dynamic-component');
-                    });
                 if (! isset($attributes['component']) && ! isset($attributes['is'])) {
+                    // Check if 'dynamic-component' or 'is' is an actual livewire component
+                    // Need to run this in rescue otherwise running this during a test causes Livewire directory not found exception
+                    $dynamicComponentExists = rescue(fn() => app(ComponentRegistry::class)->getClass($component));
 
                     if ($dynamicComponentExists) {
                         return $this->componentString("'{$component}'", $attributes);


### PR DESCRIPTION
* replaced the dead `app('livewire')->getClass()`
* optimized for loop (count in condition runs on each step in the loop so we count before)
* fixed the check if there is a component named "is"or "dynamic-component" if there are no arguments provided @calebporzio wouldn't it be time to just make check in the component registry and throw there an error that its not allowed to use those component names?