### PR TITLE
[V3] Return null on IntSynth when null is passed in

### DIFF
--- a/src/Mechanisms/HandleComponents/Synthesizers/IntSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/IntSynth.php
@@ -15,7 +15,7 @@ class IntSynth extends Synth {
     }
 
     static function hydrateFromType($type, $value) {
-        if ($value === '') return null;
+        if ($value === '' || $value === null) return null;
 
         return (int) $value;
     }

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/IntSynthTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/IntSynthTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\Synthesizers\Tests;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class IntSynthTest extends \Tests\TestCase
+{
+    /**
+     * @test
+     */
+    public function null_value_hydrated_returns_null()
+    {
+        Livewire::test(ComponentWithNullableInt::class)
+            ->set(['intField' => null])
+            ->assertSet('intField', null);
+    }
+}
+
+class ComponentWithNullableInt extends Component
+{
+    public ?int $intField = null;
+
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/IntSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/IntSynthUnitTest.php
@@ -13,8 +13,8 @@ class IntSynthUnitTest extends \Tests\TestCase
     public function null_value_hydrated_returns_null()
     {
         Livewire::test(ComponentWithNullableInt::class)
-            ->set(['intField' => null])
-            ->assertSet('intField', null);
+            ->set('intField', null)
+            ->assertSet('intField', null, true); // Use strict mode
     }
 }
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/IntSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/IntSynthUnitTest.php
@@ -5,7 +5,7 @@ namespace Livewire\Mechanisms\HandleComponents\Synthesizers\Tests;
 use Livewire\Component;
 use Livewire\Livewire;
 
-class IntSynthTest extends \Tests\TestCase
+class IntSynthUnitTest extends \Tests\TestCase
 {
     /**
      * @test


### PR DESCRIPTION
The `IntSynth` in Livewire V3 adds the ability to convert an empty string that's passed into the synth to `null`. This is great on the frontend (since a form input will generally return `''` instead of `null`, but there are still scenarios where `null` might be returned. For example, in a unit test (as demonstrated in the test on this PR), or when updated though Javascipt.

This PR just makes sure we pass though that `null` value in those cases, as opposed to passing it to the `int` cast, which converts it to `0`. 


1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Did not create a discussion, but an explanation is included above.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
The only changes are to the `IntSynth` class, and adding a test for that Synth.

4️⃣ Does it include tests? (Required)
Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
Included above :) 

