### PR TITLE
[V3] Fix TemporaryUploadedFile::dimensions return type

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -74,11 +74,11 @@ class TemporaryUploadedFile extends UploadedFile
         return $this->extractOriginalNameFromFilePath($this->path);
     }
 
-    public function dimensions(): ?array
+    public function dimensions(): null|array|bool
     {
         stream_copy_to_stream($this->storage->readStream($this->path), $tmpFile = tmpfile());
 
-        return @getimagesize(stream_get_meta_data($tmpFile)['uri']);;
+        return @getimagesize(stream_get_meta_data($tmpFile)['uri']);
     }
 
     public function temporaryUrl()

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -74,7 +74,7 @@ class TemporaryUploadedFile extends UploadedFile
         return $this->extractOriginalNameFromFilePath($this->path);
     }
 
-    public function dimensions(): null|array|bool
+    public function dimensions()
     {
         stream_copy_to_stream($this->storage->readStream($this->path), $tmpFile = tmpfile());
 

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -309,7 +309,7 @@ class UnitTest extends \Tests\TestCase
     {
         Storage::fake('avatars');
 
-        $file = UploadedFile::fake()->image('avatar.png', 100, 200);
+        $file = UploadedFile::fake()->image('avatar.pdf', 100, 200);
 
         Livewire::test(FileUploadComponent::class)
             ->set('photo', $file)
@@ -317,6 +317,22 @@ class UnitTest extends \Tests\TestCase
             ->assertHasErrors(['photo' => 'dimensions']);
 
         Storage::disk('avatars')->assertMissing('uploaded-avatar.png');
+    }
+
+    /** @test */
+    public function pdf_dimensions_cannot_be_validated()
+    {
+        Storage::fake('avatars');
+
+        $file = UploadedFile::fake()
+            ->create('not-a-png-image.pdf', 512, 512);
+
+        Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->call('validateUploadWithDimensions')
+            ->assertHasErrors(['photo' => 'dimensions']);
+
+        Storage::disk('avatars')->assertMissing('uploaded-not-a-png-image.png');
     }
 
     /** @test */

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -309,7 +309,7 @@ class UnitTest extends \Tests\TestCase
     {
         Storage::fake('avatars');
 
-        $file = UploadedFile::fake()->image('avatar.pdf', 100, 200);
+        $file = UploadedFile::fake()->image('avatar.png', 100, 200);
 
         Livewire::test(FileUploadComponent::class)
             ->set('photo', $file)

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -320,7 +320,7 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    public function pdf_dimensions_cannot_be_validated()
+    public function invalid_file_extension_can_validate_dimensions()
     {
         Storage::fake('avatars');
 


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
https://github.com/livewire/livewire/discussions/6426
2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
4️⃣ Does it include tests? (Required)
Yes
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This PR corrects only the type of return that prevents other validations such as pdf, image, etc.

Thanks for contributing! 🙌
