### PR TITLE
Rewrite morph marker injection system

### DIFF
--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -22,270 +22,269 @@ class UnitTest extends \Tests\TestCase
             <livewire:foo />
         ');
 
-        $this->assertCount(3, explode('__BLOCK__', $output));
-        $this->assertCount(3, explode('__ENDBLOCK__', $output));
+        $this->assertCount(2, explode('__BLOCK__', $output));
+        $this->assertCount(2, explode('__ENDBLOCK__', $output));
     }
 
     /** @test */
-    public function it_only_adds_conditional_markers_to_any_if_that_is_not_inside_a_html_tag()
+    public function handles_custom_blade_conditional_directives()
     {
-        $output = $this->compile(<<<HTML
-        <div @if (true) other @endif>
-            @if (true)
-                foo
-            @endif
-
-            @if (true)
-                bar
-            @endif
-        </div>
-        HTML);
-
-        $this->assertOccurrences(2, '__BLOCK__', $output);
-        $this->assertOccurrences(2, '__ENDBLOCK__', $output);
-    }
-
-    /** @test */
-    public function it_only_adds_conditional_markers_to_any_if_that_is_not_inside_a_html_tag_with_property_condition_containing_at_symbol()
-    {
-        $output = $this->compile(<<<'HTML'
-        <div
-            @if ($foo->bar)
-                @click="baz"
-            @endif
-        >
-        </div>
-        HTML);
-
-        $this->assertOccurrences(0, '__BLOCK__', $output);
-        $this->assertOccurrences(0, '__ENDBLOCK__', $output);
-    }
-
-    /** @test */
-    public function it_adds_conditional_markers_correctly_after_class_directive_containing_parentheses()
-    {
-        $output = $this->compile(<<<HTML
-        <div>
-            <div @class(['foo(bar)'])></div>
-
-            <div>
-                @if (true)
-                    <div foo="{
-                        'bar': 'baz',
-                    }"></div>
-                @endif
-            </div>
-        </div>
-        HTML);
-
-        $this->assertOccurrences(1, '__BLOCK__', $output);
-        $this->assertOccurrences(1, '__ENDBLOCK__', $output);
-    }
-
-    /** @test */
-    public function it_adds_conditional_markers_correctly_after_class_directive_containing_square_brackets()
-    {
-        $output = $this->compile(<<<HTML
-        <div>
-            <div @class(['foo[bar]'])></div>
-
-            <div>
-                @if (true)
-                    <div foo="{
-                        'bar': 'baz',
-                    }"></div>
-                @endif
-            </div>
-        </div>
-        HTML);
-
-        $this->assertOccurrences(1, '__BLOCK__', $output);
-        $this->assertOccurrences(1, '__ENDBLOCK__', $output);
-    }
-
-    /** @test */
-    public function it_only_adds_conditional_markers_to_any_for_each_that_is_not_inside_a_html_tag()
-    {
-        $output = $this->compile(<<<'HTML'
-        <div @foreach(range(1,4) as $key => $value) {{ $key }}="{{ $value }}" @endforeach>
-            @foreach(range(1,4) as $key => $value)
-                {{ $key }}="{{ $value }}"
-            @endforeach
-
-            @foreach(range(1,4) as $key => $value)
-                {{ $key }}="{{ $value }}"
-            @endforeach
-        </div>
-        HTML);
-
-        $this->assertOccurrences(2, '__BLOCK__', $output);
-        $this->assertOccurrences(2, '__ENDBLOCK__', $output);
-    }
-
-    /** @test */
-    public function it_does_not_add_conditional_markers_around_an_attribute_name_containing_a_greater_than_symbol()
-    {
-        $output = $this->compile(<<<'HTML'
-        <div
-            @if ($foo)
-                {{ $foo->bar }}
-            @endif
-
-            @if ($foo)
-                {{ $foo=>bar }}="bar"
-            @endif
-        >
-        </div>
-        HTML);
-
-        $this->assertOccurrences(0, '__BLOCK__', $output);
-        $this->assertOccurrences(0, '__ENDBLOCK__', $output);
-    }
-
-    /** @test */
-    public function it_does_not_add_conditional_markers_around_an_attribute_value_containing_a_greater_than_symbol()
-    {
-        $output = $this->compile(<<<'HTML'
-        <div
-            @if ($foo)
-                foo="{{ $foo->bar }}"
-            @endif
-
-            @if ($foo)
-                foo="{{ $foo=>bar }}"
-            @endif
-        >
-        </div>
-        HTML);
-
-        $this->assertOccurrences(0, '__BLOCK__', $output);
-        $this->assertOccurrences(0, '__ENDBLOCK__', $output);
-    }
-
-    /** @test */
-    public function it_does_not_add_conditional_markers_around_an_condition_containing_a_greater_than_symbol()
-    {
-        $output = $this->compile(<<<'HTML'
-        <div
-            @if ($foo->bar)
-                foo="bar"
-            @endif
-
-            @if ($foo=>bar)
-                foo="bar"
-            @endif
-        >
-        </div>
-        HTML);
-
-        $this->assertOccurrences(0, '__BLOCK__', $output);
-        $this->assertOccurrences(0, '__ENDBLOCK__', $output);
-    }
-
-    /** @test */
-    public function it_still_adds_conditional_markers_if_there_is_a_blade_expression_before_it_that_contains_a_less_than_symbol()
-    {
-        $output = $this->compile(<<<'HTML'
-        <div>
-            {{ 1 < 5 ? "true" : "false" }}
-
-            @foreach(range(1,4) as $key => $value)
-                {{ $key }}="{{ $value }}"
-            @endforeach
-
-            @foreach(range(1,4) as $key => $value)
-                {{ $key }}="{{ $value }}"
-            @endforeach
-        </div>
-        HTML);
-
-        $this->assertOccurrences(2, '__BLOCK__', $output);
-        $this->assertOccurrences(2, '__ENDBLOCK__', $output);
-    }
-
-    /** @test */
-    public function conditional_markers_do_not_remove_nested_endif_statements_without_a_parent_tag()
-    {
-        Livewire::component('foo', new class extends \Livewire\Component {
-            public function render() {
-                return '<div> @if (true) @if (true) <div></div> @endif @endif </div>';
-            }
+        Blade::if('foo', function () {
+            return '...';
         });
 
-        $output = Blade::render('
-            <livewire:foo />
-        ');
-
-        $this->assertOccurrences(2, '__BLOCK__', $output);
-        $this->assertOccurrences(2, '__ENDBLOCK__', $output);
-    }
-
-    /** @test */
-    public function it_does_not_add_conditional_markers_around_an_attribute_if_a_class_helper_with_conditions_appears()
-    {
-        $output = $this->compile(<<<'BLADE'
-            <div
-                @class([
-                    'flex',
-                ])
-
-                @if(true)
-                    data-no-block
-                @endif
-            >
-                @if(true)
-                    <span>foo</span>
-                @endif
-            </div>
-        BLADE);
-
-
-        $this->assertOccurrences(1, '__BLOCK__', $output);
-        $this->assertOccurrences(1, '__ENDBLOCK__', $output);
-
-        $output = $this->compile(<<<'BLADE'
-            <div
-                @class([
-                    'flex' => true,
-                ])
-
-                @if(true)
-                    data-no-block
-                @endif
-            >
-                @if(true)
-                    <span>foo</span>
-                @endif
-            </div>
-        BLADE);
-
+        $output = $this->compile(<<<'HTML'
+        <div>
+            @foo (true)
+                ...
+            @endfoo
+        </div>
+        HTML);
 
         $this->assertOccurrences(1, '__BLOCK__', $output);
         $this->assertOccurrences(1, '__ENDBLOCK__', $output);
     }
 
-    /** @test */
-    public function supports_two_in_a_row()
+    /**
+     * @test
+     * @dataProvider templatesProvider
+     **/
+    function foo($occurances, $template)
     {
-        $compiled = $this->compile('<div>
-    @if (true)
-        Dispatch up worked!
-    @endif
+        $compiled = $this->compile($template);
 
-    @if (true)
-        Dispatch to worked!
-    @endif
-</div>');
+        $this->assertOccurrences($occurances, '__BLOCK__', $compiled);
+        $this->assertOccurrences($occurances, '__ENDBLOCK__', $compiled);
+    }
 
-        $this->assertEquals('<div>
-    <!-- __BLOCK__ --><?php if(true): ?>
-        Dispatch up worked!
-    <?php endif; ?> <!-- __ENDBLOCK__ -->
+    public function templatesProvider()
+    {
+        return [
+            0 => [
+                2,
+                <<<'HTML'
+                <div @if (true) other @endif>
+                    @if (true)
+                        foo
+                    @endif
 
-    <!-- __BLOCK__ --><?php if(true): ?>
-        Dispatch to worked!
-    <?php endif; ?> <!-- __ENDBLOCK__ -->
-</div>', $compiled);
+                    @if (true)
+                        bar
+                    @endif
+                </div>
+                HTML
+            ],
+            1 => [
+                0,
+                <<<'HTML'
+                <div
+                    @if ($foo->bar)
+                        @click="baz"
+                    @endif
+                >
+                </div>
+                HTML
+            ],
+            2 => [
+                1,
+                <<<'HTML'
+                <div>
+                    <div @class(['foo(bar)'])></div>
+
+                    <div>
+                        @if (true)
+                            <div foo="{
+                                'bar': 'baz',
+                            }"></div>
+                        @endif
+                    </div>
+                </div>
+                HTML
+            ],
+            3 => [
+                1,
+                <<<'HTML'
+                <div>
+                    <div @class(['foo[bar]'])></div>
+
+                    <div>
+                        @if (true)
+                            <div foo="{
+                                'bar': 'baz',
+                            }"></div>
+                        @endif
+                    </div>
+                </div>
+                HTML
+            ],
+            4 => [
+                2,
+                <<<'HTML'
+                <div @foreach(range(1,4) as $key => $value) {{ $key }}="{{ $value }}" @endforeach>
+                    @foreach(range(1,4) as $key => $value)
+                        {{ $key }}="{{ $value }}"
+                    @endforeach
+
+                    @foreach(range(1,4) as $key => $value)
+                        {{ $key }}="{{ $value }}"
+                    @endforeach
+                </div>
+                HTML
+            ],
+            5 => [
+                0,
+                <<<'HTML'
+                <div
+                    @if ($foo)
+                        {{ $foo->bar }}
+                    @endif
+
+                    @if ($foo)
+                        {{ $foo=>bar }}="bar"
+                    @endif
+                >
+                </div>
+                HTML
+            ],
+            6 => [
+                0,
+                <<<'HTML'
+                <div
+                    @if ($foo)
+                        foo="{{ $foo->bar }}"
+                    @endif
+
+                    @if ($foo)
+                        foo="{{ $foo=>bar }}"
+                    @endif
+                >
+                </div>
+                HTML
+            ],
+            7 => [
+                0,
+                <<<'HTML'
+                <div
+                    @if ($foo->bar)
+                        foo="bar"
+                    @endif
+
+                    @if ($foo=>bar)
+                        foo="bar"
+                    @endif
+                >
+                </div>
+                HTML
+            ],
+            8 => [
+                2,
+                <<<'HTML'
+                <div>
+                    {{ 1 < 5 ? "true" : "false" }}
+
+                    @foreach(range(1,4) as $key => $value)
+                        {{ $key }}="{{ $value }}"
+                    @endforeach
+
+                    @foreach(range(1,4) as $key => $value)
+                        {{ $key }}="{{ $value }}"
+                    @endforeach
+                </div>
+                HTML
+            ],
+            9 => [
+                2,
+                <<<'HTML'
+                <div> @if (true) @if (true) <div></div> @endif @endif </div>
+                HTML
+            ],
+            10 => [
+                1,
+                <<<'HTML'
+                <div
+                    @class([
+                        'flex',
+                    ])
+
+                    @if(true)
+                        data-no-block
+                    @endif
+                >
+                    @if(true)
+                        <span>foo</span>
+                    @endif
+                </div>
+                HTML
+            ],
+            11 => [
+                1,
+                <<<'HTML'
+                <div
+                    @class([
+                        'flex' => true,
+                    ])
+
+                    @if(true)
+                        data-no-block
+                    @endif
+                >
+                    @if(true)
+                        <span>foo</span>
+                    @endif
+                </div>
+                HTML
+            ],
+            12 => [
+                2,
+                <<<'HTML'
+                <div>
+                    @if (true)
+                        Dispatch up worked!
+                    @endif
+
+                    @if (true)
+                        Dispatch to worked!
+                    @endif
+                </div>
+                HTML
+            ],
+            13 => [
+                0,
+                <<<'HTML'
+                <div {{ $object->method("test {$foo}") }} @if (true) bar="bob" @endif></div>
+                HTML
+            ],
+            14 => [
+                0,
+                <<<'HTML'
+                <div {{ $object->method("test {$foo}") }} @if (true) bar="bob" @endif></div>
+                HTML
+            ],
+            15 => [
+                0,
+                <<<'HTML'
+                <div @if ($object->method() && $object->property) foo="bar" @endif something="here"></div>
+                HTML
+            ],
+            16 => [
+                0,
+                <<<'HTML'
+                <div something="here" @if ($object->method() && $object->property) foo="bar" @endif something="here"></div>
+                HTML
+            ],
+            17 => [
+                0,
+                <<<'HTML'
+                <div @if ($object->method() && $object->method()) foo="bar" @endif something="here"></div>
+                HTML
+            ],
+            18 => [
+                0,
+                <<<'HTML'
+                <div something="here" @if ($object->method() && $object->method()) foo="bar" @endif something="here"></div>
+                HTML
+            ],
+        ];
     }
 
     protected function compile($string)

--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -22,8 +22,8 @@ class UnitTest extends \Tests\TestCase
             <livewire:foo />
         ');
 
-        $this->assertCount(2, explode('__BLOCK__', $output));
-        $this->assertCount(2, explode('__ENDBLOCK__', $output));
+        $this->assertCount(3, explode('__BLOCK__', $output));
+        $this->assertCount(3, explode('__ENDBLOCK__', $output));
     }
 
     /** @test */

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -47,9 +47,9 @@ class LivewireManager
         app(ExtendBlade::class)->livewireOnlyDirective($name, $callback);
     }
 
-    function precompiler($pattern, $callback)
+    function precompiler($callback)
     {
-        app(ExtendBlade::class)->livewireOnlyPrecompiler($pattern, $callback);
+        app(ExtendBlade::class)->livewireOnlyPrecompiler($callback);
     }
 
     function new($name, $id = null)

--- a/src/Mechanisms/ExtendBlade/ExtendBlade.php
+++ b/src/Mechanisms/ExtendBlade/ExtendBlade.php
@@ -78,13 +78,9 @@ class ExtendBlade
         $this->directives[$name] = $handler;
     }
 
-    function livewireOnlyPrecompiler($pattern, $handler)
+    function livewireOnlyPrecompiler($handler)
     {
-        $this->precompilers[] = function ($string) use ($pattern, $handler) {
-            return preg_replace_callback($pattern, function ($matches) use ($handler, $string) {
-                return $handler($matches, $string);
-            }, $string);
-        };
+        $this->precompilers[] = $handler;
     }
 
     function livewireifyBladeCompiler() {

--- a/src/Mechanisms/ExtendBlade/UnitTest.php
+++ b/src/Mechanisms/ExtendBlade/UnitTest.php
@@ -36,8 +36,10 @@ class UnitTest extends \Tests\TestCase
     /** @test */
     public function livewire_only_precompilers_apply_to_livewire_components_and_not_normal_blade()
     {
-        Livewire::precompiler('/@foo/sm', function ($matches) {
-            return 'bar';
+        Livewire::precompiler(function ($string) {
+            return preg_replace_callback('/@foo/sm',  function ($matches) {
+                return 'bar';
+            }, $string);
         });
 
         $output = Blade::render('


### PR DESCRIPTION
The previous system was too complex and slow.

This is a rewrite to make the regex much simpler, much faster, and much more comprehensive.

Now, markers will be injected around all Blade control directives (@ if, foreach, forelse, error, guest, admin, etc..) including custom registered `Blade::if()` directives in people's apps.