### PR TITLE
[v3] Remove unused precompiler

### DIFF
--- a/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
+++ b/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
@@ -12,12 +12,10 @@ class SupportMorphAwareIfStatement extends ComponentHook
     {
         if (! config('livewire.inject_morph_markers', true)) return;
 
-        static::registerPrecompilers(
-            app('livewire')->precompiler(...)
-        );
+        static::registerPrecompilers();
     }
 
-    static function registerPrecompilers($precompile)
+    static function registerPrecompilers()
     {
         $generatePattern = function ($directives) {
             $directivesPattern = '('


### PR DESCRIPTION
`$precompile` is unsued because the facade is called directly
https://github.com/livewire/livewire/blob/c534fca8e219d807b2a3228a0fe75b69182df4f9/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php#L57