### PR TITLE
[V3] Give wireable synth higher priority over other synths

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -103,7 +103,6 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
             \Livewire\Features\SupportPagination\SupportPagination::class,
             \Livewire\Features\SupportValidation\SupportValidation::class,
             \Livewire\Features\SupportRedirects\SupportRedirects::class,
-            \Livewire\Features\SupportWireables\SupportWireables::class,
             \Livewire\Features\SupportStreaming\SupportStreaming::class,
             \Livewire\Features\SupportNavigate\SupportNavigate::class,
             \Livewire\Features\SupportEntangle\SupportEntangle::class,
@@ -115,6 +114,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
             // Some features we want to have priority over others...
             \Livewire\Features\SupportLifecycleHooks\SupportLifecycleHooks::class,
             \Livewire\Features\SupportLegacyModels\SupportLegacyModels::class,
+            \Livewire\Features\SupportWireables\SupportWireables::class,
         ] as $feature) {
             app('livewire')->componentHook($feature);
         }


### PR DESCRIPTION
In V2 wireables had priority over all over types. This PR make anything with the wireable trait use wireable synth over the defined type, see discussion #6346.

Hope this helps!
