### PR TITLE
[V3] Toggleable query string

### DIFF
--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -375,3 +375,9 @@ As you can see, you can use Livewire's page navigation helpers like `$this->next
 </div>
 ```
 
+### Disable query string pagination
+
+You can disable query string functionality for pagination and variables with Url attribute.
+<br>
+<a href='https://livewire.laravel.com/docs/url#disable-query-string'>Check how from URL Query Parameters</a>
+

--- a/docs/url.md
+++ b/docs/url.md
@@ -146,7 +146,7 @@ To force Livewire to use `history.pushState` when updating the URL, you can prov
 
 ```php
 use Livewire\Component;
-use Livewire\With\Url;
+use Livewire\Attributes\Url;
 
 class ShowUsers extends Component
 {
@@ -167,4 +167,20 @@ When you pass this parameter you're disabling the query string functionality for
 
 ```blade
 <livewire:show-users :query-string="false" />
+```
+
+You can also change the default use of query string with the `QueryString` attribute and override it to `true` where needed.
+
+```php
+use Livewire\Component;
+use Livewire\Attributes\QueryString;
+
+#[QueryString(enabled: false)]
+class ShowUsers extends Component
+{
+}
+```
+
+```blade
+<livewire:show-users :query-string="true" />
 ```

--- a/docs/url.md
+++ b/docs/url.md
@@ -158,3 +158,13 @@ class ShowUsers extends Component
 ```
 
 In the example above, when a user changes the search value from "bob" to "frank" and then clicks the browser's back button, the search value (and the URL) will be set back to "bob" instead of navigating to the previously visited page.
+
+## Disable query string
+
+If you need to disable query string functionality somewhere because you're reusing your components for something like a dashboard you can use `:query-string="false"`.
+<br>
+When you pass this parameter you're disabling the query string functionality for your variables(with Url attribute) but also for pagination.
+
+```blade
+<livewire:show-users :query-string="false" />
+```

--- a/src/Attributes/QueryString.php
+++ b/src/Attributes/QueryString.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Livewire\Features\SupportQueryString\BaseQueryString;
+
+#[\Attribute]
+class QueryString extends BaseQueryString
+{
+    //
+}

--- a/src/Features/SupportPagination/BrowserTest.php
+++ b/src/Features/SupportPagination/BrowserTest.php
@@ -832,7 +832,7 @@ class BrowserTest extends BrowserTestCase
     }
 
     /** @test */
-    public function test_disable_urls_change()
+    public function test_url_disabled_by_query_string_param_change()
     {
         Livewire::visit([new class extends Component {
             public function render() { return <<<HTML
@@ -868,7 +868,7 @@ class BrowserTest extends BrowserTestCase
     }
 
     /** @test */
-    public function test_disable_urls_init()
+    public function test_url_disabled_by_query_string_param_init()
     {
         Livewire::withQueryParams(['page' => '2'])->visit([new class extends Component {
             public function render() { return <<<HTML
@@ -903,6 +903,156 @@ class BrowserTest extends BrowserTestCase
             ->assertSee('Post #2')
             ->assertSee('Post #3')
             ->assertDontSee('Post #4')
+        ;
+    }
+
+    /** @test */
+    public function test_url_disabled_by_query_string_attribute_change()
+    {
+        Livewire::visit([new class extends Component {
+            public function render() { return <<<HTML
+            <div>
+                <livewire:child />
+            </div>
+            HTML; }
+        }, 'child' => new #[\Livewire\Attributes\QueryString(false)] class extends Component {
+            use WithPagination;
+
+            public function render()
+            {
+                return Blade::render(
+                    <<< 'HTML'
+                    <div>
+                        @foreach ($posts as $post)
+                            <h1 wire:key="post-{{ $post->id }}">{{ $post->title }}</h1>
+                        @endforeach
+
+                        {{ $posts->links() }}
+                    </div>
+                    HTML,
+                    [
+                        'posts' => Post::paginate(3),
+                    ]
+                );
+            }
+        }])
+            // Test that going to page 2 doesn't change the query string.
+            ->waitForLivewire()->click('@nextPage.before')
+            ->assertQueryStringMissing('page')
+        ;
+    }
+
+    /** @test */
+    public function test_url_disabled_by_query_string_attribute_init()
+    {
+        Livewire::withQueryParams(['page' => '2'])->visit([new class extends Component {
+            public function render() { return <<<HTML
+            <div>
+                <livewire:child />
+            </div>
+            HTML; }
+        }, 'child' => new #[\Livewire\Attributes\QueryString(false)] class extends Component {
+            use WithPagination;
+
+            public function render()
+            {
+                return Blade::render(
+                    <<< 'HTML'
+                    <div>
+                        @foreach ($posts as $post)
+                            <h1 wire:key="post-{{ $post->id }}">{{ $post->title }}</h1>
+                        @endforeach
+
+                        {{ $posts->links() }}
+                    </div>
+                    HTML,
+                    [
+                        'posts' => Post::paginate(3),
+                    ]
+                );
+            }
+        }])
+            // Test that query param page isn't used if disabled.
+            ->assertQueryStringHas('page', '2')
+            ->assertSee('Post #1')
+            ->assertSee('Post #2')
+            ->assertSee('Post #3')
+            ->assertDontSee('Post #4')
+        ;
+    }
+
+    /** @test */
+    public function test_url_enabled_by_query_string_param_override_change()
+    {
+        Livewire::visit([new class extends Component {
+            public function render() { return <<<HTML
+            <div>
+                <livewire:child :query-string='true' />
+            </div>
+            HTML; }
+        }, 'child' => new #[\Livewire\Attributes\QueryString(false)] class extends Component {
+            use WithPagination;
+
+            public function render()
+            {
+                return Blade::render(
+                    <<< 'HTML'
+                    <div>
+                        @foreach ($posts as $post)
+                            <h1 wire:key="post-{{ $post->id }}">{{ $post->title }}</h1>
+                        @endforeach
+
+                        {{ $posts->links() }}
+                    </div>
+                    HTML,
+                    [
+                        'posts' => Post::paginate(3),
+                    ]
+                );
+            }
+        }])
+            // Test that going to page 2 doesn't change the query string.
+            ->waitForLivewire()->click('@nextPage.before')
+            ->assertQueryStringHas('page', '2')
+        ;
+    }
+
+    /** @test */
+    public function test_url_enabled_by_query_string_param_override_init()
+    {
+        Livewire::withQueryParams(['page' => '2'])->visit([new class extends Component {
+            public function render() { return <<<HTML
+            <div>
+                <livewire:child :query-string='true' />
+            </div>
+            HTML; }
+        }, 'child' => new #[\Livewire\Attributes\QueryString(false)] class extends Component {
+            use WithPagination;
+
+            public function render()
+            {
+                return Blade::render(
+                    <<< 'HTML'
+                    <div>
+                        @foreach ($posts as $post)
+                            <h1 wire:key="post-{{ $post->id }}">{{ $post->title }}</h1>
+                        @endforeach
+
+                        {{ $posts->links() }}
+                    </div>
+                    HTML,
+                    [
+                        'posts' => Post::paginate(3),
+                    ]
+                );
+            }
+        }])
+            // Test that query param page isn't used if disabled.
+            ->assertQueryStringHas('page', '2')
+            ->assertSee('Post #4')
+            ->assertSee('Post #5')
+            ->assertSee('Post #6')
+            ->assertDontSee('Post #3')
         ;
     }
 }

--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -26,7 +26,7 @@ class SupportPagination extends ComponentHook
     }
 
     protected $restoreOverriddenPaginationViews;
-    protected $disableUrls = false;
+    protected $useQueryString = true;
 
     function boot()
     {
@@ -37,8 +37,8 @@ class SupportPagination extends ComponentHook
 
     function mount($params)
     {
-        if($params['disableUrls'] ?? false) {
-            $this->disableUrls = true;
+        if(!($params['queryString'] ?? true)) {
+            $this->useQueryString = false;
         }
     }
 
@@ -100,13 +100,13 @@ class SupportPagination extends ComponentHook
 
     protected function resolvePage($alias, $default)
     {
-        if($this->disableUrls) return $default;
+        if(!$this->useQueryString) return $default;
         return request()->query($alias, $default);
     }
 
     protected function addUrlHook($pageName, $queryStringDetails)
     {
-        if($this->disableUrls) return;
+        if(!$this->useQueryString) return;
         $key = 'paginators.' . $pageName;
         $alias = $queryStringDetails['as'];
         $history = $queryStringDetails['history'];

--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -26,12 +26,20 @@ class SupportPagination extends ComponentHook
     }
 
     protected $restoreOverriddenPaginationViews;
+    protected $disableUrls = false;
 
     function boot()
     {
         $this->setPageResolvers();
 
         $this->overrideDefaultPaginationViews();
+    }
+
+    function mount($params)
+    {
+        if($params['disableUrls'] ?? false) {
+            $this->disableUrls = true;
+        }
     }
 
     function destroy()
@@ -92,11 +100,13 @@ class SupportPagination extends ComponentHook
 
     protected function resolvePage($alias, $default)
     {
+        if($this->disableUrls) return $default;
         return request()->query($alias, $default);
     }
 
     protected function addUrlHook($pageName, $queryStringDetails)
     {
+        if($this->disableUrls) return;
         $key = 'paginators.' . $pageName;
         $alias = $queryStringDetails['as'];
         $history = $queryStringDetails['history'];

--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -16,9 +16,9 @@ class SupportPagination extends ComponentHook
     static function provide()
     {
         app('livewire')->provide(function () {
-            $this->loadViewsFrom(__DIR__.'/views', 'livewire');
+            $this->loadViewsFrom(__DIR__ . '/views', 'livewire');
 
-            $paths = [__DIR__.'/views' => resource_path('views/vendor/livewire')];
+            $paths = [__DIR__ . '/views' => resource_path('views/vendor/livewire')];
 
             $this->publishes($paths, 'livewire');
             $this->publishes($paths, 'livewire:pagination');
@@ -37,9 +37,15 @@ class SupportPagination extends ComponentHook
 
     function mount($params)
     {
-        if(!($params['queryString'] ?? true)) {
-            $this->useQueryString = false;
+        $useQueryString = $params['queryString'] ?? null;
+        if ($useQueryString === null) {
+            $queryStringAttribute = (new \ReflectionClass($this->component))->getAttributes(\Livewire\Attributes\QueryString::class)[0] ?? null;
+            if ($queryStringAttribute) {
+                $useQueryString = $queryStringAttribute->getArguments()[0] ?? true;
+            }
         }
+
+        if($useQueryString !== null && !$useQueryString) $this->useQueryString = false;
     }
 
     function destroy()
@@ -72,7 +78,7 @@ class SupportPagination extends ComponentHook
         Paginator::currentPageResolver(function ($pageName) {
             $this->ensurePaginatorIsInitialized($pageName);
 
-            return (int) $this->component->paginators[$pageName];
+            return (int)$this->component->paginators[$pageName];
         });
     }
 
@@ -100,13 +106,13 @@ class SupportPagination extends ComponentHook
 
     protected function resolvePage($alias, $default)
     {
-        if(!$this->useQueryString) return $default;
+        if (!$this->useQueryString) return $default;
         return request()->query($alias, $default);
     }
 
     protected function addUrlHook($pageName, $queryStringDetails)
     {
-        if(!$this->useQueryString) return;
+        if (!$this->useQueryString) return;
         $key = 'paginators.' . $pageName;
         $alias = $queryStringDetails['as'];
         $history = $queryStringDetails['history'];

--- a/src/Features/SupportQueryString/BaseQueryString.php
+++ b/src/Features/SupportQueryString/BaseQueryString.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Livewire\Features\SupportQueryString;
+
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class BaseQueryString extends LivewireAttribute
+{
+    function __construct(
+        public $enabled = true
+    ) {}
+}

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportQueryString;
 
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+use function Livewire\store;
 
 #[\Attribute]
 class BaseUrl extends LivewireAttribute
@@ -13,8 +14,13 @@ class BaseUrl extends LivewireAttribute
         public $keep = false,
     ) {}
 
-    public function mount()
+    public function mount($params)
     {
+        if($params['disableUrls'] ?? false) {
+            store($this->component)->set('disableUrls', true);
+            return;
+        }
+
         $initialValue = request()->query($this->urlName(), 'noexist');
 
         if ($initialValue === 'noexist') return;
@@ -28,7 +34,7 @@ class BaseUrl extends LivewireAttribute
 
     public function dehydrate($context)
     {
-        if (! $context->mounting) return;
+        if (!$context->mounting || store($this->component)->get('disableUrls')) return;
 
         $queryString = [
             'as' => $this->as,

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -16,7 +16,15 @@ class BaseUrl extends LivewireAttribute
 
     public function mount($params)
     {
-        if(!($params['queryString'] ?? true)) {
+        $useQueryString = $params['queryString'] ?? null;
+        if ($useQueryString === null) {
+            $queryStringAttribute = (new \ReflectionClass($this->component))->getAttributes(\Livewire\Attributes\QueryString::class)[0] ?? null;
+            if ($queryStringAttribute) {
+                $useQueryString = $queryStringAttribute->getArguments()[0] ?? true;
+            }
+        }
+
+        if($useQueryString !== null && !$useQueryString) {
             store($this->component)->set('useQueryString', false);
             return;
         }

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -16,8 +16,8 @@ class BaseUrl extends LivewireAttribute
 
     public function mount($params)
     {
-        if($params['disableUrls'] ?? false) {
-            store($this->component)->set('disableUrls', true);
+        if(!($params['queryString'] ?? true)) {
+            store($this->component)->set('useQueryString', false);
             return;
         }
 
@@ -34,7 +34,7 @@ class BaseUrl extends LivewireAttribute
 
     public function dehydrate($context)
     {
-        if (!$context->mounting || store($this->component)->get('disableUrls')) return;
+        if (!$context->mounting || !store($this->component)->get('useQueryString', true)) return;
 
         $queryString = [
             'as' => $this->as,

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace Livewire\Features\SupportQueryString;
+
+use Illuminate\Support\Facades\Blade;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    public function test_url_change()
+    {
+        Livewire::visit(new class extends Component {
+
+            #[Url]
+            public $value = 1;
+
+            public function increment(){
+                $this->value++;
+            }
+
+            public function render()
+            {
+                return Blade::render(
+                    <<< 'HTML'
+                    <div>
+                    <button dusk='increment' wire:click='increment'></button>
+                    </div>
+                    HTML
+                );
+            }
+        })
+
+        ->assertQueryStringMissing('value')
+        ->waitForLivewire()->click('@increment')
+        ->assertQueryStringHas('value', '2');
+    }
+    public function test_url_init()
+    {
+        Livewire::withQueryParams(['value' => '2'])->visit(new class extends Component {
+
+            #[Url]
+            public $value = 1;
+
+            public function render()
+            {
+                return Blade::render(
+                    <<< 'HTML'
+                    <div>{{$value}}</div>
+                    HTML,
+                    [
+                        'value' => $this->value,
+                    ]
+                );
+            }
+        })
+            ->assertSee('2');
+    }
+    public function test_url_disabled_by_query_string_param_change()
+    {
+        Livewire::visit([new class extends Component {
+            public function render() { return <<<HTML
+            <div>
+                <livewire:child :query-string='false' />
+            </div>
+            HTML; }
+        }, 'child' => new class extends Component {
+
+            #[Url]
+            public $value = 1;
+
+            public function increment(){
+                $this->value++;
+            }
+
+            public function render()
+            {
+                return Blade::render(
+                    <<< 'HTML'
+                    <div>
+                    <button dusk='increment' wire:click='increment'></button>
+                    </div>
+                    HTML
+                );
+            }
+        }])
+            ->assertQueryStringMissing('value')
+            ->waitForLivewire()->click('@increment')
+            ->assertQueryStringMissing('value');
+    }
+    public function test_url_disabled_by_query_string_param_init()
+    {
+        Livewire::withQueryParams(['value' => '2'])->visit([new class extends Component {
+            public function render() { return <<<HTML
+            <div>
+                <livewire:child :query-string='false' />
+            </div>
+            HTML; }
+        }, 'child' => new class extends Component {
+
+            #[Url]
+            public $value = 1;
+
+            public function render()
+            {
+                return Blade::render(
+                    <<< 'HTML'
+                    <div>{{$value}}</div>
+                    HTML,
+                    [
+                        'value' => $this->value,
+                    ]
+                );
+            }
+        }])
+            ->assertSee('1');
+    }
+    public function test_url_disabled_by_query_string_attribute_change()
+    {
+        Livewire::visit(new #[\Livewire\Attributes\QueryString(false)] class extends Component {
+
+            #[Url]
+            public $value = 1;
+
+            public function increment(){
+                $this->value++;
+            }
+
+            public function render()
+            {
+                return Blade::render(
+                    <<< 'HTML'
+                    <div>
+                    <button dusk='increment' wire:click='increment'></button>
+                    </div>
+                    HTML
+                );
+            }
+        })
+            ->assertQueryStringMissing('value')
+            ->waitForLivewire()->click('@increment')
+            ->assertQueryStringMissing('value');
+    }
+    public function test_url_disabled_by_query_string_attribute_init()
+    {
+        Livewire::withQueryParams(['value' => '2'])->visit(new #[\Livewire\Attributes\QueryString(false)] class extends Component {
+
+            #[Url]
+            public $value = 1;
+
+            public function render()
+            {
+                return Blade::render(
+                    <<< 'HTML'
+                    <div>{{$value}}</div>
+                    HTML,
+                    [
+                        'value' => $this->value,
+                    ]
+                );
+            }
+        })
+            ->assertSee('1');
+    }
+    public function test_url_enabled_by_query_string_param_override_change()
+    {
+        Livewire::visit([new class extends Component {
+            public function render() { return <<<HTML
+            <div>
+                <livewire:child :query-string='true' />
+            </div>
+            HTML; }
+        }, 'child' => new #[\Livewire\Attributes\QueryString(false)] class extends Component {
+
+            #[Url]
+            public $value = 1;
+
+            public function increment(){
+                $this->value++;
+            }
+
+            public function render()
+            {
+                return Blade::render(
+                    <<< 'HTML'
+                    <div>
+                    <button dusk='increment' wire:click='increment'></button>
+                    </div>
+                    HTML
+                );
+            }
+        }])
+            ->assertQueryStringMissing('value')
+            ->waitForLivewire()->click('@increment')
+            ->assertQueryStringHas('value', '2');
+    }
+    public function test_url_enabled_by_query_string_param_override_init()
+    {
+        Livewire::withQueryParams(['value' => '2'])->visit([new class extends Component {
+            public function render() { return <<<HTML
+            <div>
+                <livewire:child :query-string='true' />
+            </div>
+            HTML; }
+        }, 'child' => new #[\Livewire\Attributes\QueryString(false)] class extends Component {
+
+            #[Url]
+            public $value = 1;
+
+            public function render()
+            {
+                return Blade::render(
+                    <<< 'HTML'
+                    <div>{{$value}}</div>
+                    HTML,
+                    [
+                        'value' => $this->value,
+                    ]
+                );
+            }
+        }])
+            ->assertSee('2');
+    }
+}


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
In V2 was possibile to override the getQueryString() function and with that we were able to pass to our components a prop to disable the use of query string (pagination, etc) so in a dashboard page we could reuse our components multiple times without them influencing the query string (otherwise when the dashboard was reloaded with page refresh, all the components used the same page)
2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
4️⃣ Does it include tests? (Required)
Yes
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

We used a custom prop with the getQueryString() override in V2 to disable the use of query string on our components when needed in some pages like dashboards to avoid them influencing the query string and go all to the same page after page refresh.
Now I tried that and it isn't working anymore in V3, so I created a custom param named "query-string" and a custom Attribute to define default use of query string in components (default true) so when someone needs to use a component in a dashboard page or similar we can pass the :query-string="false" to disable it for Url Attributes and Pagination.
We can also define #[QueryString(false)] in the component class and use :query-string="true" only when we need it.

I already updated the docs, also, if you don't like this implementation for me it's ok to change it but we need this or something similar to replicate what we did in V2.

Thank you!
