### PR TITLE
[V3] Fix a minor bug by adding a null check for S3 filesystem disk root to `FileUploadConfiguration`

### DIFF
--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -64,15 +64,11 @@ class FileUploadConfiguration
 
     protected static function s3Root()
     {
-        if(!static::isUsingS3()){
-            return '';
-        }
+        if (! static::isUsingS3()) return '';
 
         $diskConfig = static::diskConfig();
-        
-        if(!is_array($diskConfig)){
-            return '';
-        }
+
+        if (! is_array($diskConfig)) return '';
 
         $root = $diskConfig['root'] ?? null;
 

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -64,9 +64,19 @@ class FileUploadConfiguration
 
     protected static function s3Root()
     {
-        return static::isUsingS3() && is_array(static::diskConfig()) && array_key_exists('root', static::diskConfig())
-            ? static::normalizeRelativePath(static::diskConfig()['root'])
-            : '';
+        if(!static::isUsingS3()){
+            return '';
+        }
+
+        $diskConfig = static::diskConfig();
+        
+        if(!is_array($diskConfig)){
+            return '';
+        }
+
+        $root = $diskConfig['root'] ?? null;
+
+        return $root !== null ? static::normalizeRelativePath($root) : '';
     }
 
     public static function path($path = '', $withS3Root = true)


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
https://github.com/livewire/livewire/discussions/5715

The original function made an assumption that the root would be never null if available in the config, but Laravel's Filesystem implementation allows for an empty root, and transforms it to an empty string later on.

This should enable having a nullable root and assign it properly to an empty string.

The use case for this, is that I have the same application deployed on multiple environments, and the root is variable between a string and a null value

Thanks for contributing! 🙌