### PR TITLE
[V3] Make \Livewire\Livewire::forceAssetInjection() override config livewire.asset_injection = false

### DIFF
--- a/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
+++ b/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
@@ -20,9 +20,8 @@ class SupportAutoInjectedAssets extends ComponentHook
             static::$forceAssetInjection = false;
         });
 
-        if (config('livewire.inject_assets', true) === false) return;
-
         app('events')->listen(RequestHandled::class, function ($handled) {
+            if (config('livewire.inject_assets', true) === false) return;
             if (! str($handled->response->headers->get('content-type'))->contains('text/html')) return;
             if (! method_exists($handled->response, 'status') || $handled->response->status() !== 200) return;
             if ((! static::$hasRenderedAComponentThisRequest) && (! static::$forceAssetInjection)) return;

--- a/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
+++ b/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
@@ -21,7 +21,7 @@ class SupportAutoInjectedAssets extends ComponentHook
         });
 
         app('events')->listen(RequestHandled::class, function ($handled) {
-            if (config('livewire.inject_assets', true) === false) return;
+            if (! static::$forceAssetInjection && config('livewire.inject_assets', true) === false) return;
             if (! str($handled->response->headers->get('content-type'))->contains('text/html')) return;
             if (! method_exists($handled->response, 'status') || $handled->response->status() !== 200) return;
             if ((! static::$hasRenderedAComponentThisRequest) && (! static::$forceAssetInjection)) return;

--- a/src/Features/SupportAutoInjectedAssets/UnitTest.php
+++ b/src/Features/SupportAutoInjectedAssets/UnitTest.php
@@ -141,7 +141,18 @@ class UnitTest extends TestCase
     /** @test */
     public function can_disable_auto_injection_using_config(): void
     {
-        $this->markTestIncomplete();
+        config()->set('livewire.inject_assets', false);
+
+        Route::get('/with-livewire', function () {
+            return (new class Extends TestComponent {})();
+        });
+
+        Route::get('/without-livewire', function () {
+            return Blade::render('<html></html>');
+        });
+
+        $this->get('/without-livewire')->assertDontSee('/livewire/livewire.js');
+        $this->get('/with-livewire')->assertDontSee('/livewire/livewire.js');
     }
 
     /** @test */

--- a/src/Features/SupportAutoInjectedAssets/UnitTest.php
+++ b/src/Features/SupportAutoInjectedAssets/UnitTest.php
@@ -156,6 +156,27 @@ class UnitTest extends TestCase
     }
 
     /** @test */
+    public function can_force_injection_over_config(): void
+    {
+        config()->set('livewire.inject_assets', false);
+
+        Route::get('/with-livewire', function () {
+            return (new class Extends TestComponent {})();
+        });
+
+        Route::get('/without-livewire', function () {
+            return '<html></html>';
+        });
+
+        \Livewire\Livewire::forceAssetInjection();
+        $this->get('/with-livewire')->assertSee('/livewire/livewire.js');
+
+        \Livewire\Livewire::flushState();
+        \Livewire\Livewire::forceAssetInjection();
+        $this->get('/without-livewire')->assertSee('/livewire/livewire.js');
+    }
+
+    /** @test */
     public function only_auto_injects_when_a_livewire_component_was_rendered_on_the_page(): void
     {
         Route::get('/with-livewire', function () {

--- a/src/Features/SupportAutoInjectedAssets/UnitTest.php
+++ b/src/Features/SupportAutoInjectedAssets/UnitTest.php
@@ -226,6 +226,7 @@ class UnitTest extends TestCase
     public function makeACleanSlate()
     {
         \Livewire\Livewire::flushState();
+
         parent::makeACleanSlate();
     }
 }

--- a/src/Features/SupportAutoInjectedAssets/UnitTest.php
+++ b/src/Features/SupportAutoInjectedAssets/UnitTest.php
@@ -222,4 +222,10 @@ class UnitTest extends TestCase
     {
         $this->assertEquals($expected, SupportAutoInjectedAssets::injectAssets($original));
     }
+
+    public function makeACleanSlate()
+    {
+        \Livewire\Livewire::flushState();
+        parent::makeACleanSlate();
+    }
 }

--- a/src/Features/SupportAutoInjectedAssets/UnitTest.php
+++ b/src/Features/SupportAutoInjectedAssets/UnitTest.php
@@ -187,8 +187,8 @@ class UnitTest extends TestCase
             return '<html></html>';
         });
 
-        $this->get('/with-livewire')->assertSee('/livewire/livewire.js');
         $this->get('/without-livewire')->assertDontSee('/livewire/livewire.js');
+        $this->get('/with-livewire')->assertSee('/livewire/livewire.js');
     }
 
     /** @test */
@@ -202,8 +202,8 @@ class UnitTest extends TestCase
             return '<html></html>';
         });
 
-        $this->get('/with-persist')->assertSee('/livewire/livewire.js');
         $this->get('/without-persist')->assertDontSee('/livewire/livewire.js');
+        $this->get('/with-persist')->assertSee('/livewire/livewire.js');
     }
 
     /** @test */


### PR DESCRIPTION
This PR improves the tests for SupportAutoInjectedAssets and fixes the problem where \Livewire\Livewire::forceAssetInjection() would be overridden by the config property 'asset_injection' being set to false.

Discussion: #6355