### PR TITLE
[V2] Add failing tests for `TestableLivewire`

### DIFF
--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -259,4 +259,9 @@ class TestableLivewire
         
         return $this;
     }
+
+    public function __destruct()
+    {
+        unset(self::$instancesById[$this->id()]);
+    }
 }

--- a/tests/Unit/TestableLivewireClearsInstancesTest.php
+++ b/tests/Unit/TestableLivewireClearsInstancesTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Livewire\Component as BaseComponent;
+use Livewire\Livewire;
+use Livewire\Testing\TestableLivewire;
+use Tests\Unit\TestCase;
+
+class TestableLivewireClearsInstancesTest extends TestCase
+{
+    /** @test */
+    public function previous_test()
+    {
+        Livewire::test(Component::class)->assertSuccessful();
+    }
+
+    /** @test */
+    public function it_clears_instances()
+    {
+        $this->assertCount(0, (new ReflectionClass(TestableLivewire::class))->getStaticPropertyValue('instancesById'));
+    }
+}
+
+class Component extends BaseComponent
+{
+    protected $shouldSkipRender = true;
+}


### PR DESCRIPTION
Firstly not sure if v2 is being maintained due to v3 being released only some hours ago – great timing on my part.

Found a memory leak when running multiple Livewire tests in succession. This could be somehow by design but the static `$instancesById` array property on `TestableLivewire` is never reset back to empty, meaning that it continues to grow throughout the test suite.

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Pretty sure it's needed. Haven't made a discussion.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
As above.

Thanks for contributing! 🙌
