### PR TITLE
[V2] Add config option to disable s3 direct download links

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -106,6 +106,7 @@ return [
             'jpg', 'jpeg', 'mpga', 'webp', 'wma',
         ],
         'max_upload_time' => 5, // Max duration (in minutes) before an upload gets invalidated.
+        's3_direct_url' => true,
     ],
 
     /*

--- a/src/Controllers/CanPretendToBeAFile.php
+++ b/src/Controllers/CanPretendToBeAFile.php
@@ -4,10 +4,9 @@ namespace Livewire\Controllers;
 
 trait CanPretendToBeAFile
 {
-    public function pretendResponseIsFile($file, $mimeType = 'application/javascript')
+    public function pretendResponseIsFile($file, $lastModified, $mimeType = 'application/javascript')
     {
         $expires = strtotime('+1 year');
-        $lastModified = filemtime($file);
         $cacheControl = 'public, max-age=31536000';
 
         if ($this->matchesCache($lastModified)) {
@@ -17,7 +16,7 @@ trait CanPretendToBeAFile
             ]);
         }
 
-        return response()->file($file, [
+        return response()->make($file, 200, [
             'Content-Type' => "$mimeType; charset=utf-8",
             'Expires' => $this->httpDate($expires),
             'Cache-Control' => $cacheControl,

--- a/src/Controllers/FilePreviewHandler.php
+++ b/src/Controllers/FilePreviewHandler.php
@@ -12,8 +12,10 @@ class FilePreviewHandler
     {
         abort_unless(request()->hasValidSignature(), 401);
 
+        $file = FileUploadConfiguration::path($filename);
         return $this->pretendResponseIsFile(
-            FileUploadConfiguration::storage()->path(FileUploadConfiguration::path($filename)),
+            FileUploadConfiguration::storage()->get($file),
+            FileUploadConfiguration::storage()->lastModified($file),
             FileUploadConfiguration::mimeType($filename)
         );
     }

--- a/src/Controllers/LivewireJavaScriptAssets.php
+++ b/src/Controllers/LivewireJavaScriptAssets.php
@@ -8,11 +8,13 @@ class LivewireJavaScriptAssets
 
     public function source()
     {
-        return $this->pretendResponseIsFile(__DIR__.'/../../dist/livewire.js');
+        $path = __DIR__.'/../../dist/livewire.js';
+        return $this->pretendResponseIsFile(file_get_contents($path), filemtime($path));
     }
 
     public function maps()
     {
-        return $this->pretendResponseIsFile(__DIR__.'/../../dist/livewire.js.map');
+        $path = __DIR__.'/../../dist/livewire.js.map';
+        return $this->pretendResponseIsFile(file_get_contents($path), filemtime($path));
     }
 }

--- a/src/FileUploadConfiguration.php
+++ b/src/FileUploadConfiguration.php
@@ -46,6 +46,11 @@ class FileUploadConfiguration
         return config('filesystems.disks.'.strtolower($diskBeforeTestFake).'.driver') === 's3';
     }
 
+    public static function isUsingS3DirectURL()
+    {
+        return self::isUsingS3() && config('livewire.temporary_file_upload.s3_direct_url');
+    }
+
     public static function isUsingGCS()
     {
         $diskBeforeTestFake = config('livewire.temporary_file_upload.disk') ?: config('filesystems.default');

--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -83,7 +83,7 @@ class TemporaryUploadedFile extends UploadedFile
 
     public function temporaryUrl()
     {
-        if ((FileUploadConfiguration::isUsingS3() or FileUploadConfiguration::isUsingGCS()) && ! app()->runningUnitTests()) {
+        if ((FileUploadConfiguration::isUsingS3DirectURL() or FileUploadConfiguration::isUsingGCS()) && ! app()->runningUnitTests()) {
             return $this->storage->temporaryUrl(
                 $this->path,
                 now()->addDay(),

--- a/src/WithFileUploads.php
+++ b/src/WithFileUploads.php
@@ -11,7 +11,7 @@ trait WithFileUploads
 {
     public function startUpload($name, $fileInfo, $isMultiple)
     {
-        if (FileUploadConfiguration::isUsingS3()) {
+        if (FileUploadConfiguration::isUsingS3DirectURL()) {
             throw_if($isMultiple, S3DoesntSupportMultipleFileUploads::class);
 
             $file = UploadedFile::fake()->create($fileInfo[0]['name'], $fileInfo[0]['size'] / 1024, $fileInfo[0]['type']);


### PR DESCRIPTION
The S3 direct download feature is always enabled, if the disk driver is s3. This PR introduces an option that allows to disable direct download, so that down and uploads always go through the livewire controllers.

This feature allows to use s3 or an s3 compatible system like minio, without exposing it to the user. It's useful when for example the minio storage is in the internal network behind a firewall.

If this is accepted, I can also port this to livewire 3.x