### PR TITLE
Fix morph marker injection to handle @empty inside of @forelse

### DIFF
--- a/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
+++ b/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
@@ -42,7 +42,6 @@ class SupportMorphAwareIfStatement extends ComponentHook
             '@unless' => '@endunless',
             '@error' => '@enderror',
             '@isset' => '@endisset',
-            '@empty' => '@endempty',
             '@auth' => '@endauth',
             '@guest' => '@endguest',
             '@switch' => '@endswitch',

--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -284,6 +284,18 @@ class UnitTest extends \Tests\TestCase
                 <div something="here" @if ($object->method() && $object->method()) foo="bar" @endif something="here"></div>
                 HTML
             ],
+            19 => [
+                1,
+                <<<'HTML'
+                <div>
+                    @forelse($posts as $post)
+                        ...
+                    @empty
+                        ...
+                    @endforelse
+                </div>
+                HTML
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR fixes a problem with morph marker injection where it trips up when using `@empty` inside a `@forelse`