### PR TITLE
[V3] Feature Enhancement - Pass component parameters as an argument to placeholder() method

### DIFF
--- a/docs/lazy.md
+++ b/docs/lazy.md
@@ -86,6 +86,19 @@ class Revenue extends Component
 
 Because the above component specifies a "placeholder" by returning HTML from a `placeholder()` method, the user will see an SVG loading spinner on the page until the component is fully loaded.
 
+### Rendering a placeholder via a view
+
+For more complex loaders (such as skeletons) you can return a `view` from the `placeholder()` similar to `render()`. 
+
+```php
+public function placeholder(array $attributes = [])
+{
+    return view('livewire.placeholders.skeleton', $attributes);
+}
+```
+
+Any attributes from the component being lazy loaded will be available as an `attributes` arugment passed to the `placeholder()` method.
+
 ## Lazy loading outside of the viewport
 
 By default, Lazy-loaded components aren't full loaded until they enter the browser's viewport, for example when a user scrolls to one.

--- a/docs/lazy.md
+++ b/docs/lazy.md
@@ -91,13 +91,13 @@ Because the above component specifies a "placeholder" by returning HTML from a `
 For more complex loaders (such as skeletons) you can return a `view` from the `placeholder()` similar to `render()`. 
 
 ```php
-public function placeholder(array $attributes = [])
+public function placeholder(array $params = [])
 {
-    return view('livewire.placeholders.skeleton', $attributes);
+    return view('livewire.placeholders.skeleton', $params);
 }
 ```
 
-Any attributes from the component being lazy loaded will be available as an `attributes` arugment passed to the `placeholder()` method.
+Any parameters from the component being lazy loaded will be available as an `$params` arugment passed to the `placeholder()` method.
 
 ## Lazy loading outside of the viewport
 

--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -263,6 +263,39 @@ class BrowserTest extends BrowserTestCase
         ->assertSee('Count: 3')
         ;
     }
+
+    /** @test */
+    public function can_access_component_attribute_data_in_placeholder_view()
+    {
+        Livewire::visit([new class extends Component {
+            public function render() { return <<<HTML
+            <div>
+                <livewire:child my-attribute="An Attribute Value" lazy />
+            </div>
+            HTML; }
+        }, 'child' => new class extends Component {
+            public function mount() {
+                sleep(1);
+            }
+            public function placeholder(array $attributes = []) { 
+                return view('placeholder', $attributes);
+            }
+            public function render() {
+                return <<<HTML
+                <div id="child">
+                    Child!
+                </div>
+                HTML;
+            }
+        }])
+        ->waitFor('#loading')
+        ->assertSee('An Attribute Value')
+        ->assertDontSee('Child!')
+        ->waitFor('#child')
+        ->assertSee('Child!')
+        ;
+    }
+
 }
 
 class Page extends Component {

--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -265,20 +265,20 @@ class BrowserTest extends BrowserTestCase
     }
 
     /** @test */
-    public function can_access_component_attribute_data_in_placeholder_view()
+    public function can_access_component_parameters_in_placeholder_view()
     {
         Livewire::visit([new class extends Component {
             public function render() { return <<<HTML
             <div>
-                <livewire:child my-attribute="An Attribute Value" lazy />
+                <livewire:child my-parameter="A Parameter Value" lazy />
             </div>
             HTML; }
         }, 'child' => new class extends Component {
             public function mount() {
                 sleep(1);
             }
-            public function placeholder(array $attributes = []) { 
-                return view('placeholder', $attributes);
+            public function placeholder(array $params = []) { 
+                return view('placeholder', $params);
             }
             public function render() {
                 return <<<HTML
@@ -289,7 +289,7 @@ class BrowserTest extends BrowserTestCase
             }
         }])
         ->waitFor('#loading')
-        ->assertSee('An Attribute Value')
+        ->assertSee('A Parameter Value')
         ->assertDontSee('Child!')
         ->waitFor('#child')
         ->assertSee('Child!')

--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -99,7 +99,7 @@ class SupportLazyLoading extends ComponentHook
 
         $placeholder = wrap($this->component)
             ->withFallback($placeholderHtml)
-            ->placeholder();
+            ->placeholder($params);
 
         $html = Utils::insertAttributesIntoHtmlRoot($placeholder, [
             ($params['lazy'] === 'on-load' ? 'x-init' : 'x-intersect') => '$wire.__lazyLoad(\''.$encoded.'\')',

--- a/tests/views/placeholder.blade.php
+++ b/tests/views/placeholder.blade.php
@@ -1,4 +1,4 @@
 <div id="loading">
   Loading...
-  <div>{{ $myAttribute }}</div>
+  <div>{{ $myParameter }}</div>
 </div>

--- a/tests/views/placeholder.blade.php
+++ b/tests/views/placeholder.blade.php
@@ -1,0 +1,4 @@
+<div id="loading">
+  Loading...
+  <div>{{ $myAttribute }}</div>
+</div>


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

**See discussion:** 
https://github.com/livewire/livewire/discussions/6495#discussioncomment-6827650

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

`features/add-component-attributes-to-placeholder`

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Nope

4️⃣ Does it include tests? (Required)

**Added new test:**
```
phpunit --filter can_access_component_parameters_in_placeholder_view ./src/Features/SupportLazyLoading/BrowserTest.php
```

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Having access to the components attribute values inside the placeholder method/view can be helpful when you need to output more than one skeleton loader inside a grid layout and/or adjust layout classes that wrap around each skeleton loader.

Let's assume I have a component that fetches data from a slow API and uses the `lazy` attribute:

```blade
<livewire:article-list 
    lazy
    per-page="4" 
    header-element="h3"
    wrapper-class="g-col-12 g-col-sm-6 g-col-xxl-3"
/>
```

And I want to use the `per-page` and `wrapper-class` attribute values to change the output of the view returned inside my components `placeholder()` method:

```php
// App\Livewire\ArticleList.php
public function placeholder()
{
    return view('livewire.placeholders.article-list');
}
```

There is no current way to access the livewire component parameters inside the `placeholder()` method to do this kind of thing. 

This PR will pass an `$params` argument to the `placeholder()` method which can then be either passed directly to the view or can be accessed and used as needed.

```php
// App\Livewire\ArticleList.php
public function placeholder(array $params = [])
{
    return view('livewire.placeholders.article-list', $params);
}
```

```blade
{{-- resources/views/livewire/placeholders/article-list.blade.php --}}
<div class="grid g-col-12">
  @for ($i = 0; $i < $perPage; $i++)
  <div class="{{ $wrapperClass }}">
    <x-cards.article skeleton />
  </div>
  @endfor
</div>
```

This offers a lot of flexibility for complex layouts that require more than an single placeholder element, and can allow placeholder views to dynamically change based on the main component parameters being passed.