### PR TITLE
[V3] Updated code in a quotation block installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ If you want more control over this behavior, you can manually include the assets
 By including these assets manually on a page, Livewire knows not to inject the assets automatically.
 
 > [!warning] AlpineJS is bundled with Livewire
-> Because Alpine is bundled with Livewire's JavaScript assets, you must include `@livewireScripts` on every page you wish to use Alpine. Even if you're not using Livewire on that page.
+> Because Alpine is bundled with Livewire's JavaScript assets, you must include <code>@livewireScripts</code> on every page you wish to use Alpine. Even if you're not using Livewire on that page.
 
 Though rarely required, you may disable Livewire's auto-injecting asset behavior by updating the `inject_assets` [configuration option](#publishing-config) in your application's `config/livewire.php` file:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ If you want more control over this behavior, you can manually include the assets
 By including these assets manually on a page, Livewire knows not to inject the assets automatically.
 
 > [!warning] AlpineJS is bundled with Livewire
-> Because Alpine is bundled with Livewire's JavaScript assets, you must include <code>@livewireScripts</code> on every page you wish to use Alpine. Even if you're not using Livewire on that page.
+> Because Alpine is bundled with Livewire's JavaScript assets, you must include `@verbatim@livewireScripts@endverbatim` on every page you wish to use Alpine. Even if you're not using Livewire on that page.
 
 Though rarely required, you may disable Livewire's auto-injecting asset behavior by updating the `inject_assets` [configuration option](#publishing-config) in your application's `config/livewire.php` file:
 


### PR DESCRIPTION
This is a proposed fix to the issue mentioned in https://github.com/livewire/livewire/discussions/6526

In the quotation block the code is not visible on the docs site. Converting ```   to `<code>` might fix this. 
