### PR TITLE
[V3] Fix navigate test to detect OS and determine which key to press

### DIFF
--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -344,7 +344,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     /** @test */
     public function navigate_is_not_triggered_on_cmd_click()
     {
-        $key = PHP_OS_FAMILY === 'Darwin' ? \Facebook\WebDriver\WebDriverKeys::META : \Facebook\WebDriver\WebDriverKeys::CONTROL;
+        $key = PHP_OS_FAMILY === 'Darwin' ? \Facebook\WebDriver\WebDriverKeys::COMMAND : \Facebook\WebDriver\WebDriverKeys::CONTROL;
 
         $this->browse(function (Browser $browser) use ($key) {
             $browser

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -344,18 +344,20 @@ class BrowserTest extends \Tests\BrowserTestCase
     /** @test */
     public function navigate_is_not_triggered_on_cmd_click()
     {
-        $this->browse(function (Browser $browser) {
+        $key = PHP_OS_FAMILY === 'Darwin' ? \Facebook\WebDriver\WebDriverKeys::META : \Facebook\WebDriver\WebDriverKeys::CONTROL;
+
+        $this->browse(function (Browser $browser) use ($key) {
             $browser
                 ->visit('/first')
                 ->tap(fn ($b) => $b->script('window._lw_dusk_test = true'))
                 ->assertScript('return window._lw_dusk_test')
                 ->assertSee('On first')
-                ->tap(function ($browser) {
-                    $browser->driver->getKeyboard()->pressKey(\Facebook\WebDriver\WebDriverKeys::META);
+                ->tap(function ($browser) use ($key) {
+                    $browser->driver->getKeyboard()->pressKey($key);
                 })
                 ->click('@link.to.second')
-                ->tap(function ($browser) {
-                    $browser->driver->getKeyboard()->releaseKey(\Facebook\WebDriver\WebDriverKeys::META);
+                ->tap(function ($browser) use ($key) {
+                    $browser->driver->getKeyboard()->releaseKey($key);
                 })
                 ->pause(500) // Let navigate run if it was going to (it should not)
                 ->assertSee('On first')


### PR DESCRIPTION
Navigate test for cmd + click is failing in CI due to it being a linux environment. Have added a check to determine what OS is being used and to use the appropriate key. Have tested it locally on a mac and it passes.