### PR TITLE
Fix SupportFileDownloads - Multibyte character support

### DIFF
--- a/src/Features/SupportFileDownloads/SupportFileDownloads.php
+++ b/src/Features/SupportFileDownloads/SupportFileDownloads.php
@@ -70,7 +70,6 @@ class SupportFileDownloads extends ComponentHook
          *
          * Content-Disposition: attachment; filename=filename.jpg
          * Content-Disposition: attachment; filename="test file.jpg"
-         * Content-Disposition: attachment; filename*=utf-8''%E3%83%80%E3%82%A6%E3%83%B3%E3%83%AD%E3%83%BC%E3%83%89%E7%B5%90%E6%9E%9C.csv
          */
         if (preg_match('/filename\*=utf-8\'\'(.+)$/i', $header, $matches)) {
             return rawurldecode($matches[1]);

--- a/src/Features/SupportFileDownloads/SupportFileDownloads.php
+++ b/src/Features/SupportFileDownloads/SupportFileDownloads.php
@@ -71,9 +71,11 @@ class SupportFileDownloads extends ComponentHook
          * Content-Disposition: attachment; filename=filename.jpg
          * Content-Disposition: attachment; filename="test file.jpg"
          */
+
+         // Support foreign-language filenames (japanese, greek, etc..)...
         if (preg_match('/filename\*=utf-8\'\'(.+)$/i', $header, $matches)) {
             return rawurldecode($matches[1]);
-        } 
+        }
 
         if (preg_match('/.*?filename="(.+?)"/', $header, $matches)) {
             return $matches[1];

--- a/src/Features/SupportFileDownloads/SupportFileDownloads.php
+++ b/src/Features/SupportFileDownloads/SupportFileDownloads.php
@@ -70,7 +70,11 @@ class SupportFileDownloads extends ComponentHook
          *
          * Content-Disposition: attachment; filename=filename.jpg
          * Content-Disposition: attachment; filename="test file.jpg"
+         * Content-Disposition: attachment; filename*=utf-8''%E3%83%80%E3%82%A6%E3%83%B3%E3%83%AD%E3%83%BC%E3%83%89%E7%B5%90%E6%9E%9C.csv
          */
+        if (preg_match('/filename\*=utf-8\'\'(.+)$/i', $header, $matches)) {
+            return rawurldecode($matches[1]);
+        } 
 
         if (preg_match('/.*?filename="(.+?)"/', $header, $matches)) {
             return $matches[1];

--- a/src/Features/SupportFileDownloads/UnitTest.php
+++ b/src/Features/SupportFileDownloads/UnitTest.php
@@ -66,6 +66,38 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    public function can_download_with_custom_japanese_filename()
+    {
+        Livewire::test(FileDownloadComponent::class)
+                ->call('download', 'ダウンロード.csv')
+                ->assertFileDownloaded('ダウンロード.csv', 'I\'m the file you should download.');
+    }
+
+    /** @test */
+    public function can_download_a_file_as_stream_with_custom_japanese_filename()
+    {
+        Livewire::test(FileDownloadComponent::class)
+                ->call('streamDownload', 'ダウンロード.csv')
+                ->assertFileDownloaded('ダウンロード.csv', 'alpinejs');
+    }
+
+    /** @test */
+    public function can_download_with_custom_japanese_filename_and_headers()
+    {
+        Livewire::test(FileDownloadComponent::class)
+                ->call('download', 'ダウンロード.csv', ['Content-Type' => 'text/csv'])
+                ->assertFileDownloaded('ダウンロード.csv', 'I\'m the file you should download.', 'text/csv');
+    }
+
+    /** @test */
+    public function can_download_a_file_as_stream_with_custom_japanese_filename_and_headers()
+    {
+        Livewire::test(FileDownloadComponent::class)
+                ->call('streamDownload', 'ダウンロード.csv', ['Content-Type' => 'text/csv'])
+                ->assertFileDownloaded('ダウンロード.csv', 'alpinejs', 'text/csv');
+    }
+
+    /** @test */
     public function it_refreshes_html_after_download()
     {
         Livewire::test(FileDownloadComponent::class)


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first? 
Yes
https://github.com/livewire/livewire/discussions/4946 
This is not a discussion I created, but another person put it up.
2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed) 
Yes
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
4️⃣ Does it include tests? (Required)
Yes
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

```php
if (preg_match('/filename\*=utf-8\'\'(.+)$/i', $header, $matches)) {
    return rawurldecode($matches[1]);
}
```

I added the above code to `livewire/src/Features/SupportFileDownloads.php` above. Currently, there was a problem that file names containing Japanese characters would end up as `______.csv` when trying to download them. We believe this needs to be fixed, especially since Livewire is a very popular library in Japan.
We have improved the problem by adding a decoding process in the case of filename*, and confirmed that it works with UnitTest.


I have tested this modification on Laravel in the following environment
`PHP 8.2.9`
`Laravel 10.22.0`

https://github.com/livewire/livewire/discussions/4946
I tested with `Ελληνικά.xlsx` and Japanese `ダウンロード.csv` in the same situation as

Before the modification, as shown below, `________.xlsx` and `______.csv` with multibyte characters did not download with the correct file name.

[![Image from Gyazo](https://i.gyazo.com/5ff0ee890766bbedcfa6cfe199fe2119.png)](https://gyazo.com/5ff0ee890766bbedcfa6cfe199fe2119)

With this correction, we can confirm that we were able to download the file with the correct file name.
Below is a screenshot of the corrected file.

[![Image from Gyazo](https://i.gyazo.com/fc4f4c53f4ce9bf6e620890c442ad896.png)](https://gyazo.com/fc4f4c53f4ce9bf6e620890c442ad896)
