### PR TITLE
[V3] Fixes Lazy Load By Default Exception - Undefined array key "lazy"

### DIFF
--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -102,7 +102,7 @@ class SupportLazyLoading extends ComponentHook
             ->placeholder();
 
         $html = Utils::insertAttributesIntoHtmlRoot($placeholder, [
-            ($params['lazy'] === 'on-load' ? 'x-init' : 'x-intersect') => '$wire.__lazyLoad(\''.$encoded.'\')',
+            ((isset($params['lazy']) and $params['lazy'] === 'on-load') ? 'x-init' : 'x-intersect') => '$wire.__lazyLoad(\''.$encoded.'\')',
         ]);
 
         return $html;


### PR DESCRIPTION
This PR fixes Lazy Loading throwing an exception under a certain use case.

According to the [Docs](https://livewire.laravel.com/docs/lazy#lazy-load-by-default) you can use Lazy Loading by default, and it implies you can omit the `lazy` parameter from your Blade View after defining the `#[Lazy]` attribute.

Unfortunately doing so will result in an error throwing `Undefined array key "lazy"` when it does the check to see if the lazy load should be an `intersect` or `init` event.

This simply adds a check to make sure the array key is indeed set and the value is `on-load` before using `x-init`.

The current **work-around** is to do the following redundant declaration:
```php
#[Lazy]
class Revenue extends Component
{
    // ...
}
```
```blade
<livewire:revenue lazy />
```