### PR TITLE
Fix syntax error in generated pest test file

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/livewire.pest.stub
+++ b/src/Features/SupportConsoleCommands/Commands/livewire.pest.stub
@@ -1,4 +1,4 @@
-<? php
+<?php
 
 use [classwithnamespace];
 use Livewire\Livewire;


### PR DESCRIPTION
# Fix syntax error in generated pest test files  

- The `php artisan livewire:make {Component} --pest` command currently generates pest test files with a syntax error. 

- It generates test files that start with: `<? php`
Instead of the correct syntax: `<?php`

- This causes the pint to fail with a syntax error when running `vendor/bin/pint`:
```console
! tests\Feature\Livewire\CounterTest.php ---------- syntax error
```

This PR fixes the generated test files to use the correct PHP opening tag:

```php
<?php

use App\Livewire\Counter;
use Livewire\Livewire;

it('renders successfully', function () {
    Livewire::test(Counter::class)
        ->assertStatus(200);
});
