### PR TITLE
Failing test for Form Object Validation uninitialized properties

### DIFF
--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -6,6 +6,7 @@ use Livewire\Attributes\Rule;
 use Livewire\Component;
 use Livewire\Form;
 use Livewire\Livewire;
+use PHPUnit\Framework\Assert;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -205,6 +206,32 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    function all_properties_are_available_in_rules_method()
+    {
+        Livewire::test(new class extends Component {
+            public PostFormWithRulesStub $form;
+
+            public function mount()
+            {
+                $this->form->setPost(42);
+            }
+
+            function save() {
+                $this->form->validate();
+            }
+
+            function render() {
+                return '<div></div>';
+            }
+        })
+        ->assertSet('form.post', 42)
+        ->call('save')
+        ->assertSet('form.post', 42)
+        ->assertHasErrors()
+        ;
+    }
+
+    /** @test */
     function can_get_properties_except()
     {
         $component = new class extends Component {};
@@ -319,6 +346,28 @@ class PostFormStub extends Form
     public $title = '';
 
     public $content = '';
+}
+
+class PostFormWithRulesStub extends Form
+{
+    public ?int $post = null;
+    public $title = '';
+    public $content = '';
+
+    public function setPost($model)
+    {
+        $this->post = $model;
+    }
+
+    public function rules()
+    {
+        Assert::assertEquals(42, $this->post, 'post should be available to run more complex rules');
+
+        return [
+            'title' => 'required',
+            'content' => 'required',
+        ];
+    }
 }
 
 class PostFormValidateStub extends Form


### PR DESCRIPTION
for my buddy @austenc 

given the following code
```php
class ClientForm extends Form
{
    public ?Client $client = null; // this is set in the component mount

    #[Rule('required')]
    public $name;

    #[Rule(['required', 'email:rfc,filter'])]
    public $email;

    public function rules()
    {
        dd($this->client); // will be null

        return [
            'email' => collect([])->when($this->client,
                fn ($rules) => $rules->push(ValidationRule::unique('clients', 'email')->ignore($this->client->id)),
                fn ($rules) => $rules->push(ValidationRule::unique('clients', 'email'))
            )->toArray(),
        ];
    }
}
```