### PR TITLE
[V3] Docs - Fixes forms code example

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -82,8 +82,10 @@ class CreatePost extends Component
 
     public function save()
     {
+        $this->validate(); // [tl! highlight]
+
         Post::create(
-            $this->only('title', 'content')
+            $this->only(['title', 'content'])
         );
 
         return $this->redirect('/posts');
@@ -803,4 +805,3 @@ If you are using a "multiple" select menu, Livewire works as expected. In this e
     ...
 </select>
 ```
-


### PR DESCRIPTION
This pr fixes the code sample and aligns it with the expectations.

The docs describe that a user who tries to submit the form without filling in any of the fields will see the validation messages. This is not true, as these messages will only appear if an user adjusts a field. A `$this->validate();` line will fix this. Also adds the missing brackets in `$this->only();`