### PR TITLE
[V3] Fixed typo in lazy loading documentation

### DIFF
--- a/docs/lazy.md
+++ b/docs/lazy.md
@@ -207,4 +207,4 @@ If you want to set a default placeholder view for all your components you can do
 'lazy_placeholder' => 'livewire.placeholder',
 ```
 
-Now, when a component is lazy-loaded and no `placeholder()` is definied, Livewire will use the configured Blade view (`livewire.placeholder` in this case.)
+Now, when a component is lazy-loaded and no `placeholder()` is defined, Livewire will use the configured Blade view (`livewire.placeholder` in this case.)


### PR DESCRIPTION
Fixed a typo in the lazy loading documentation, right at the [bottom](https://livewire.laravel.com/docs/lazy#default-placeholder-view) of the page.