### PR TITLE
Deduplicate content in docs/nesting.md

### DIFF
--- a/docs/nesting.md
+++ b/docs/nesting.md
@@ -125,14 +125,15 @@ Boolean values may be provided to components by only specifying the key. For exa
 <livewire:todo-count :todos="$todos" inline />
 ```
 
-> [!tip]
-> If the name of the property and variable you are passing into the child component match, you can use the following shorter, alternative syntax:
->
-> ```blade
-> <livewire:todo-count :todos="$todos" /> <!-- [tl! remove] -->
->
-> <livewire:todo-count :$todos /> <!-- [tl! add] -->
-> ```
+### Shortened attribute syntax
+
+When passing PHP variables into a component, the variable name and the prop name are often the same. To avoid writing the name twice, Livewire allows you to simply prefix the variable with a colon:
+
+```blade
+<livewire:todo-count :todos="$todos" /> <!-- [tl! remove] -->
+
+<livewire:todo-count :$todos /> <!-- [tl! add] -->
+```
 
 ## Rendering children in a loop
 
@@ -156,16 +157,6 @@ As you can see, each child component will have a unique key set to the ID of eac
 
 > [!warning] Keys aren't optional
 > If you have used frontend frameworks like Vue or Alpine, you are familiar with adding a key to a nested element in a loop. However, in those frameworks, a key isn't _mandatory_, meaning the items will render, but a re-order might not be tracked properly. However, Livewire relies more heavily on keys and will behave incorrectly without them.
-
-### Shortened attribute syntax
-
-When passing PHP variables into a component, the variable name and the prop name are often the same. To avoid writing the name twice, Livewire allows you to simply prefix the variable with a colon:
-
-```blade
-<livewire:todo-item :todo="$todo" /> <!-- [tl! remove] -->
-
-<livewire:todo-item :$todo /> <!-- [tl! add] -->
-```
 
 ## Reactive props
 


### PR DESCRIPTION
In https://github.com/livewire/livewire/edit/main/docs/nesting.md, the shortened attribute syntax (i.e. `<livewire-foo :$bar />`) is explained two times right after each other and the second time it's under a heading it does not belong.