### PR TITLE
[V3] Fix example in docs 📚

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -321,11 +321,12 @@ use App\Models\Order;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
 class OrderShipped implements ShouldBroadcast
 {
-    use InteractsWithSockets, SerializesModels;
+    use Dispatchable, InteractsWithSockets, SerializesModels;
 
     public Order $order;
 


### PR DESCRIPTION
Fixes the example in `events.md` docs.

Newcomers will avoid this error trying to reproduce the example:

```
Call to undefined method App\Events\OrderShipped::dispatch()
```