### PR TITLE
Allow only/except to be called without an array

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -81,7 +81,7 @@ trait InteractsWithProperties
     {
         $results = [];
 
-        foreach ($properties as $property) {
+        foreach (is_array($properties) ? $properties : func_get_args() as $property) {
             $results[$property] = $this->hasProperty($property) ? $this->getPropertyValue($property) : null;
         }
 
@@ -90,7 +90,7 @@ trait InteractsWithProperties
 
     public function except($properties)
     {
-        if (! is_array($properties)) $properties = [$properties];
+        $properties = is_array($properties) ? $properties : func_get_args();
 
         return array_diff_key($this->all(), array_flip($properties));
     }

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -85,7 +85,7 @@ class Form implements Arrayable
     {
         $results = [];
 
-        foreach ($properties as $property) {
+        foreach (is_array($properties) ? $properties : func_get_args() as $property) {
             $results[$property] = $this->hasProperty($property) ? $this->getPropertyValue($property) : null;
         }
 
@@ -94,7 +94,7 @@ class Form implements Arrayable
 
     public function except($properties)
     {
-        if (! is_array($properties)) $properties = [$properties];
+        $properties = is_array($properties) ? $properties : func_get_args();
 
         return array_diff_key($this->all(), array_flip($properties));
     }

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -205,6 +205,29 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    function can_get_only_specific_properties()
+    {
+        $component = new class extends Component {};
+
+        $form = new PostFormStub($component, 'foobar');
+
+        $this->assertEquals(
+            ['title' => ''],
+            $form->only('title')
+        );
+
+        $this->assertEquals(
+            ['content' => ''],
+            $form->except(['title'])
+        );
+
+        $this->assertEquals(
+            ['title' => '', 'content' => ''],
+            $form->only('title', 'content')
+        );
+    }
+
+    /** @test */
     function can_get_properties_except()
     {
         $component = new class extends Component {};
@@ -212,13 +235,18 @@ class UnitTest extends \Tests\TestCase
         $form = new PostFormStub($component, 'foobar');
 
         $this->assertEquals(
-            ["content" => ""],
+            ['content' => ''],
             $form->except('title')
         );
 
         $this->assertEquals(
-            ["content" => ""],
+            ['content' => ''],
             $form->except(['title'])
+        );
+
+        $this->assertEquals(
+            [],
+            $form->except('title', 'content')
         );
     }
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
I did not - but I felt it was worthy for consideration so that `only` and `except` work in a similar manner to those in Laravel.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Sure did.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No - all related.

4️⃣ Does it include tests? (Required)
I updated the relevant (and added new tests) for the form objects.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
When using `only`/`except` on the HTTP request in standalone Laravel you have the option to pass a single key, an array, or multiple keys as arguments and it works regardless.

```php
Request::only('foo');
Request::only('foo', 'bar');
Request::only(['foo', 'bar']);
```

However, the `only` method in Livewire currently only supports an array as an argument, and `except` supports a single argument or an array. [You can view Laravel's `InteractsWithInput` to see the inspiration for this change](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Http/Concerns/InteractsWithInput.php#L424-L464).

With this change, the following should all work identically.

```php
$this->only('foo');
$this->only('foo', 'bar');
$this->only(['foo', 'bar']);

$this->except('foo');
$this->except('foo', 'bar');
$this->except(['foo', 'bar']);
```