### PR TITLE
[V3] Highlight full methods in synthesizers docs

### DIFF
--- a/docs/synthesizers.md
+++ b/docs/synthesizers.md
@@ -233,8 +233,8 @@ class AddressSynth extends Synth
         return $instance;
     }
 
-    public function get(&$target, $key)
-    { // [tl! highlight:6]
+    public function get(&$target, $key) // [tl! highlight:8]
+    {
         return $target->{$key};
     }
 


### PR DESCRIPTION
Just a small visual fix, as the first method signature and last closing brace are not highlighted