### PR TITLE
[v3] $wire.toggle: allow deferring 👌

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -195,10 +195,10 @@ let $wire = {
 
     // Set a property on the component by name...
     // Usage: $wire.$set('count', 5)
-    $set(name, value) { ... },
+    $set(name, value, live = true) { ... },
 
     // Toggle the value of a boolean property...
-    $toggle(name) { ... },
+    $toggle(name, live = true) { ... },
 
     // Call the method
     // Usage: $wire.$call('increment')

--- a/js/$wire.js
+++ b/js/$wire.js
@@ -119,8 +119,8 @@ wireProperty('$entangle', (component) => (name, live = false) => {
     return generateEntangleFunction(component)(name, live)
 })
 
-wireProperty('$toggle', (component) => (name) => {
-    return component.$wire.set(name, ! component.$wire.get(name))
+wireProperty('$toggle', (component) => (name, live = true) => {
+    return component.$wire.set(name, ! component.$wire.get(name), live)
 })
 
 wireProperty('$watch', (component) => (path, callback) => {


### PR DESCRIPTION
Currently, `$wire.set` has a 3rd argument `live = true` that allows deferring the update of a property until the next network request. The `$wire.toggle` shortcut doesn't allow deferring so far. I fixed that with this PR.

Given that Caleb highlighted the reduction of unnecessary network requests as one of the big benefits of v3 vs v2, I assume that this is a wanted feature :)

Before:
```html
<!-- sends network request - ugh! -->
<button type="button" @click="$wire.toggle('foo')">...</button>

<!-- reinventing the wheel - ugh! -->
<button type="button" @click="$wire.set('foo', ! $wire.get('foo'), false)">...</button> 
```

After:
```html
<!-- No network request 😍 -->
<button type="button" @click="$wire.toggle('foo', false)">...</button>
```