### PR TITLE
Fix morph markers on long content without html tags

### DIFF
--- a/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
+++ b/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
@@ -54,7 +54,7 @@ class SupportMorphAwareIfStatement extends ComponentHook
                         [^<]                      # All non "<" characters
                         |                         # OR
                         (?!<[a-zA-Z\/])<          # A "<" character without a forward slash or letter after it
-                    )*                            # As many characters as it can until ">" is reached
+                    ){0,1000}                     # As many characters as it can until ">" is reached (limited to 1000 characters for performance reasons)
                     (?<![?=-])                    # Ignore "?>", "->", and "=>"
                     >                             # A ">" character
                 )

--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -347,6 +347,22 @@ class UnitTest extends \Tests\TestCase
                 </div>
                 HTML
             ],
+            25 => [
+                1,
+                '@if(true) ' . str_repeat('a', 6126) . ' @endif',
+            ],
+            26 => [
+                1,
+                '@if(true) ' . str_repeat('a', 6127) . ' @endif',
+            ],
+            27 => [
+                1,
+                '@if(true) ' . str_repeat('a', 6126) . ' @endif <div></div>',
+            ],
+            28 => [
+                1,
+                '@if(true) <div></div> ' . str_repeat('a', 6127) . ' @endif',
+            ],
         ];
     }
 


### PR DESCRIPTION
This only affects the current "main" branch, because issue has been introduced [on a change not released yet](https://github.com/livewire/livewire/commit/6c865772d85990f3debaa8cd86a320551b14e229)!

I do not fully understand the reason behind this error but it looks for me like a weird combination between the updated regex with the newly introduced `negative lookahead` and a limitation on PHP preg functions.

Given a matching directive like `@if` followed by long content (~> 6150 characters) not containing a `<` will lead to an unexpected behaviour in the `preg_replace_callback` statement: It returns an empty string.
Which ultimately results in this exception:
```
Livewire\Exceptions\RootTagMissingFromViewException: Livewire encountered a missing root tag when trying to render a component. 
 When rendering a Blade view, make sure it contains a root HTML tag.
 ```

The tests added may look a bit silly, but here is what happens:
```php
'@if(true) ' . str_repeat('a', 6126) . ' @endif', // Here the preg replace works as expected

'@if(true) ' . str_repeat('a', 6127) . ' @endif', // Here it returns am empty string

'@if(true) ' . str_repeat('a', 6126) . ' @endif <div></div>', // same here, because the < from the div is too far away from the @if

'@if(true) <div></div> ' . str_repeat('a', 6127) . ' @endif', // But this one does work again because of the < on the div
```

And here is a little snippet with a simplified regex (only `@if`):

```php
$pattern = '/@if(?![a-zA-Z])(?!([^<]|(?!<[a-zA-Z\/])<)*(?<![?=-])>)/';

preg_replace($pattern, 'REPLACE', '@if(' . str_repeat('a', 6141)); // returns null !!!

preg_replace($pattern, 'REPLACE', '@if(' . str_repeat('a', 6140)); // returns the expected string
```

Hope this helps to find the root cause of the issue 😅