### PR TITLE
[V3] Enhance docs on the `set()` Testable

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -592,6 +592,7 @@ Livewire provides many more testing utilities. Below is a comprehensive list of 
 | Method                                                  | Description                                                                                                      |
 |---------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
 | `set('title', '...')`                      | Set the `title` property to the provided value |
+| `set(['title' => '...', ...])`                      | Set multiple component properties using an associative array |
 | `toggle('sortAsc')`                      | Toggle the `sortAsc` property between `true` and `false`  |
 | `call('save')`                      | Call the `save` action / method |
 | `call('remove', $post->id)`                      | Call the `remove` method and pass the `$post->id` as the first parameter (Accepts subsequent parameters as well) |


### PR DESCRIPTION
Not sure if you like the docs to be formatted like this, but I was planning to add a `setMultiple` method to allow for setting multiple component properties at once. And found this was already supported by the `set()` method, but just not in the documentation :).