### PR TITLE
[V3] Multiple messages/As translation fix on rule attribute

### DIFF
--- a/src/Features/SupportValidation/BaseRule.php
+++ b/src/Features/SupportValidation/BaseRule.php
@@ -50,7 +50,13 @@ class BaseRule extends LivewireAttribute
 
         if ($this->as) {
             if (is_array($this->as)) {
-                $this->component->addValidationAttributesFromOutside($this->translate ? trans($this->as) : $this->as);
+                $multipleAs = $this->as;
+                if($this->translate){
+                    foreach ($multipleAs as &$as){
+                        $as = trans($as);
+                    }
+                }
+                $this->component->addValidationAttributesFromOutside($multipleAs);
             } else {
                 $this->component->addValidationAttributesFromOutside([$this->getName() => $this->translate ? trans($this->as) : $this->as]);
             }

--- a/src/Features/SupportValidation/BaseRule.php
+++ b/src/Features/SupportValidation/BaseRule.php
@@ -58,7 +58,13 @@ class BaseRule extends LivewireAttribute
 
         if ($this->message) {
             if (is_array($this->message)) {
-                $this->component->addMessagesFromOutside($this->translate ? trans($this->message) : $this->message);
+                $messages = $this->message;
+                if($this->translate){
+                    foreach ($messages as &$message){
+                        $message = trans($message);
+                    }
+                }
+                $this->component->addMessagesFromOutside($messages);
             } else {
                 $this->component->addMessagesFromOutside([$this->getName() => $this->translate ? trans($this->message) : $this->message]);
             }

--- a/src/Features/SupportValidation/BaseRule.php
+++ b/src/Features/SupportValidation/BaseRule.php
@@ -50,13 +50,11 @@ class BaseRule extends LivewireAttribute
 
         if ($this->as) {
             if (is_array($this->as)) {
-                $multipleAs = $this->as;
-                if($this->translate){
-                    foreach ($multipleAs as &$as){
-                        $as = trans($as);
-                    }
-                }
-                $this->component->addValidationAttributesFromOutside($multipleAs);
+                $as = $this->translate
+                    ? array_map(fn ($i) => trans($i), $this->as)
+                    : $this->as;
+
+                $this->component->addValidationAttributesFromOutside($as);
             } else {
                 $this->component->addValidationAttributesFromOutside([$this->getName() => $this->translate ? trans($this->as) : $this->as]);
             }
@@ -64,12 +62,10 @@ class BaseRule extends LivewireAttribute
 
         if ($this->message) {
             if (is_array($this->message)) {
-                $messages = $this->message;
-                if($this->translate){
-                    foreach ($messages as &$message){
-                        $message = trans($message);
-                    }
-                }
+                $messages = $this->translate
+                    ? array_map(fn ($i) => trans($i), $this->message)
+                    : $this->message;
+
                 $this->component->addMessagesFromOutside($messages);
             } else {
                 $this->component->addMessagesFromOutside([$this->getName() => $this->translate ? trans($this->message) : $this->message]);

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -128,6 +128,25 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    public function rule_attribute_alias_is_translatable_with_array()
+    {
+        Lang::addLines(['translatable.foo' => 'Translated Foo'], App::currentLocale());
+
+        Livewire::test(new class extends TestComponent {
+            #[BaseRule('required|min:3', as: ['foo' => 'translatable.foo'])]
+            public $foo = '';
+        })
+            ->set('foo', 'te')
+            ->assertHasErrors()
+            ->tap(function ($component) {
+                $messages = $component->errors()->getMessages();
+
+                $this->assertEquals('The Translated Foo field must be at least 3 characters.', $messages['foo'][0]);
+            })
+        ;
+    }
+
+    /** @test */
     public function rule_attribute_alias_translation_can_be_opted_out()
     {
         Lang::addLines(['translatable.foo' => 'Translated Foo'], App::currentLocale());
@@ -165,6 +184,44 @@ class UnitTest extends \Tests\TestCase
                 $this->assertEquals('Your foo is too short.', $messages['foo'][0]);
             })
             ;
+    }
+
+    /** @test */
+    public function rule_attribute_message_is_translatable()
+    {
+        Lang::addLines(['translatable.foo' => 'Your foo is too short.'], App::currentLocale());
+
+        Livewire::test(new class extends TestComponent {
+            #[BaseRule('min:5', message: 'translatable.foo')]
+            public $foo = '';
+        })
+            ->set('foo', 'te')
+            ->assertHasErrors()
+            ->tap(function ($component) {
+                $messages = $component->errors()->getMessages();
+
+                $this->assertEquals('Your foo is too short.', $messages['foo'][0]);
+            })
+        ;
+    }
+
+    /** @test */
+    public function rule_attribute_message_is_translatable_with_array()
+    {
+        Lang::addLines(['translatable.foo' => 'Your foo is too short.'], App::currentLocale());
+
+        Livewire::test(new class extends TestComponent {
+            #[BaseRule('min:5', message: ['min' => 'translatable.foo'])]
+            public $foo = '';
+        })
+            ->set('foo', 'te')
+            ->assertHasErrors()
+            ->tap(function ($component) {
+                $messages = $component->errors()->getMessages();
+
+                $this->assertEquals('Your foo is too short.', $messages['foo'][0]);
+            })
+        ;
     }
 
     /** @test */


### PR DESCRIPTION
Hello,
if you pass an array of messages or As to a Rule attribute with translate enabled it won't work, this PR fixes the problem.