### PR TITLE
Support multiple middleware on File Upload route

### DIFF
--- a/src/Features/SupportFileUploads/FileUploadController.php
+++ b/src/Features/SupportFileUploads/FileUploadController.php
@@ -8,10 +8,10 @@ class FileUploadController
 {
     public function getMiddleware()
     {
-        return [[
-            'middleware' => FileUploadConfiguration::middleware(),
+        return array_map(fn($middleware) => [
+            'middleware' => $middleware,
             'options' => [],
-        ]];
+        ], (array) FileUploadConfiguration::middleware());
     }
 
     public function handle()

--- a/src/Features/SupportFileUploads/FileUploadController.php
+++ b/src/Features/SupportFileUploads/FileUploadController.php
@@ -8,10 +8,18 @@ class FileUploadController
 {
     public function getMiddleware()
     {
-        return array_map(fn($middleware) => [
-            'middleware' => $middleware,
-            'options' => [],
-        ], (array) FileUploadConfiguration::middleware());
+        /**
+         * Laravel requires the returned array to contain an array for each
+         * middleware with `middleware` and `options` keys. So we'll map
+         * through the file upload config middleware and format them.
+         */
+        return array_map(
+            fn($middleware) => [
+                'middleware' => $middleware,
+                'options' => [],
+            ],
+            (array) FileUploadConfiguration::middleware()
+        );
     }
 
     public function handle()

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -418,7 +418,22 @@ class UnitTest extends \Tests\TestCase
         try {
             $this->withoutExceptionHandling()->post($url);
         } catch (\Throwable $th) {
-            $this->assertEquals('Middleware was hit!', $th->getMessage());
+            $this->assertStringContainsString(DummyMiddleware::class, $th->getMessage());
+        }
+    }
+
+    /** @test */
+    public function the_global_upload_route_middleware_supports_multiple_middleware()
+    {
+        config()->set('livewire.temporary_file_upload.middleware', ['throttle:60,1', DummyMiddleware::class]);
+
+        $url = GenerateSignedUploadUrl::forLocal();
+
+        try {
+            $this->withoutExceptionHandling()->post($url);
+        } catch (\Throwable $th) {
+            $this->assertStringContainsString('throttle:60,1', $th->getMessage());
+            $this->assertStringContainsString(DummyMiddleware::class, $th->getMessage());
         }
     }
 
@@ -665,7 +680,7 @@ class DummyMiddleware
 {
     public function handle($request, $next)
     {
-        throw new \Exception('Middleware was hit!');
+        throw new \Exception(implode(',', $request->route()->computedMiddleware));
     }
 }
 


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
No

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This solves a problem where I have to add multiple middleware to the `livewire.upload-file` route to make Livewire V3 work on my multitenant application. I tried to use the pipe separated notation, which didn't work and has been deprecated for a long while anyways. The new code now supports passing an array to the `livewire.temporary_file_upload.middleware` config. 

I've also made some small changes to how the other middleware test worked to prevent creating extra dummy classes to make the new test working.
