### PR TITLE
[V3] Make temporary URLs stable over some time to prevent browser cache problems

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -86,7 +86,7 @@ class TemporaryUploadedFile extends UploadedFile
         if ((FileUploadConfiguration::isUsingS3() or FileUploadConfiguration::isUsingGCS()) && ! app()->runningUnitTests()) {
             return $this->storage->temporaryUrl(
                 $this->path,
-                now()->addDay(),
+                now()->addDay()->endOfHour(),
                 ['ResponseContentDisposition' => 'filename="' . $this->getClientOriginalName() . '"']
             );
         }
@@ -97,7 +97,7 @@ class TemporaryUploadedFile extends UploadedFile
         }
 
         return URL::temporarySignedRoute(
-            'livewire.preview-file', now()->addMinutes(30), ['filename' => $this->getFilename()]
+            'livewire.preview-file', now()->addMinutes(30)->endOfHour(), ['filename' => $this->getFilename()]
         );
     }
 

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportFileUploads;
 
+use Carbon\Carbon;
 use Livewire\WithFileUploads;
 use Livewire\Livewire;
 use Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButtonCache;
@@ -659,6 +660,33 @@ class UnitTest extends \Tests\TestCase
             $photo->getPath()
         );
     }
+
+     /** @test */
+     public function preview_url_is_stable_over_some_time()
+     {
+         Storage::fake('avatars');
+
+         $file = UploadedFile::fake()->image('avatar.jpg');
+
+         $photo = Livewire::test(FileUploadComponent::class)
+             ->set('photo', $file)
+             ->viewData('photo');
+
+         // Due to Livewire object still being in memory, we need to
+         // reset the "shouldDisableBackButtonCache" property back to it's default
+         // which is false to ensure it's not applied to the below route
+         Livewire::enableBackButtonCache();
+
+         Carbon::setTestNow(Carbon::today()->setTime(10, 01, 00));
+
+         $first_url = $photo->temporaryUrl();
+
+         Carbon::setTestNow(Carbon::today()->setTime(10, 05, 00));
+
+         $second_url = $photo->temporaryUrl();
+
+         $this->assertEquals($first_url, $second_url);
+     }
 }
 
 class DummyMiddleware

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -661,32 +661,32 @@ class UnitTest extends \Tests\TestCase
         );
     }
 
-     /** @test */
-     public function preview_url_is_stable_over_some_time()
-     {
-         Storage::fake('avatars');
+    /** @test */
+    public function preview_url_is_stable_over_some_time()
+    {
+        Storage::fake('avatars');
 
-         $file = UploadedFile::fake()->image('avatar.jpg');
+        $file = UploadedFile::fake()->image('avatar.jpg');
 
-         $photo = Livewire::test(FileUploadComponent::class)
-             ->set('photo', $file)
-             ->viewData('photo');
+        $photo = Livewire::test(FileUploadComponent::class)
+        ->set('photo', $file)
+        ->viewData('photo');
 
-         // Due to Livewire object still being in memory, we need to
-         // reset the "shouldDisableBackButtonCache" property back to it's default
-         // which is false to ensure it's not applied to the below route
-         Livewire::enableBackButtonCache();
+        // Due to Livewire object still being in memory, we need to
+        // reset the "shouldDisableBackButtonCache" property back to it's default
+        // which is false to ensure it's not applied to the below route
+        Livewire::enableBackButtonCache();
 
-         Carbon::setTestNow(Carbon::today()->setTime(10, 01, 00));
+        Carbon::setTestNow(Carbon::today()->setTime(10, 01, 00));
 
-         $first_url = $photo->temporaryUrl();
+        $first_url = $photo->temporaryUrl();
 
-         Carbon::setTestNow(Carbon::today()->setTime(10, 05, 00));
+        Carbon::setTestNow(Carbon::today()->setTime(10, 05, 00));
 
-         $second_url = $photo->temporaryUrl();
+        $second_url = $photo->temporaryUrl();
 
-         $this->assertEquals($first_url, $second_url);
-     }
+        $this->assertEquals($first_url, $second_url);
+    }
 }
 
 class DummyMiddleware

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -669,13 +669,8 @@ class UnitTest extends \Tests\TestCase
         $file = UploadedFile::fake()->image('avatar.jpg');
 
         $photo = Livewire::test(FileUploadComponent::class)
-        ->set('photo', $file)
-        ->viewData('photo');
-
-        // Due to Livewire object still being in memory, we need to
-        // reset the "shouldDisableBackButtonCache" property back to it's default
-        // which is false to ensure it's not applied to the below route
-        Livewire::enableBackButtonCache();
+            ->set('photo', $file)
+            ->viewData('photo');
 
         Carbon::setTestNow(Carbon::today()->setTime(10, 01, 00));
 


### PR DESCRIPTION
This is a reintroduction of my #5239 PR that was rejected for v2 because v3 was in development. The original discussion is in #5036 with a bigger real-world example.

The problem is that every time component state changes and the server re-renders the component, temporary URLs are currently changing and being re-generated, since they depend on the exact timestamp. This means, that if I have e.g. an input with `wire:model.live`, and a temporary preview URL for an uploaded photo, the photo gets re-downloaded every time I'm typing in the input field. This is obviously not a good thing in any way, so this PR makes the temporary URLs stable for one hour at a time.