### PR TITLE
Fix documentation in installation page where `@livewireScripts` is rendered as an actual blade syntax

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ If you want more control over this behavior, you can manually include the assets
 By including these assets manually on a page, Livewire knows not to inject the assets automatically.
 
 > [!warning] AlpineJS is bundled with Livewire
-> Because Alpine is bundled with Livewire's JavaScript assets, you must include `@livewireScripts` on every page you wish to use Alpine. Even if you're not using Livewire on that page.
+> Because Alpine is bundled with Livewire's JavaScript assets, you must include ```@livewireScripts``` on every page you wish to use Alpine. Even if you're not using Livewire on that page.
 
 Though rarely required, you may disable Livewire's auto-injecting asset behavior by updating the `inject_assets` [configuration option](#publishing-config) in your application's `config/livewire.php` file:
 


### PR DESCRIPTION
In the installation page on [manually including frontend assets](https://livewire.laravel.com/docs/installation#manually-including-livewires-frontend-assets), the warning section shows this info:
![image](https://github.com/livewire/livewire/assets/46296739/a67a93e8-b3e4-4caa-ae93-d30e716330e4)

You see that it writes ".... you must include [] on ....". The "[]" is actually written as \`@livewireScripts\` on the raw markdown github file. Inspecting on the page using view-source shows that it's being rendered as this:
```html
<p>Because Alpine is bundled with Livewire's JavaScript assets, you must include <code><script src="[/livewire/livewire.js?id=f30e93ad](view-source:https://livewire.laravel.com/livewire/livewire.js?id=f30e93ad)"   data-csrf="wSkDtdYTtlkivU09z2ACweatYtBWcNA4X2goc5NI" data-uri="/livewire/update" data-navigate-once="true"></script></code> on every page you wish to use Alpine. Even if you're not using Livewire on that page.</p>
```

I'm changing it to be written with 3 backticks (\```@livewireScripts\```) instead of just one (\`@livewireScripts\`). But please note that I 100% don't know if this will fix the issue. The purpose of this pull request is mainly to bring up the issue to your attention.

This is also my first pull request ever, so I apologize if I'm doing it incorrectly.