### PR TITLE
Update teleport.md

### DIFF
--- a/docs/teleport.md
+++ b/docs/teleport.md
@@ -44,3 +44,23 @@ Now, when the above Livewire template is rendered on the page, the _contents_ po
 
 > [!warning] You must teleport outside the component
 > Livewire only supports teleporting HTML outside your components. For example, teleporting a modal to the `<body>` tag is fine, but teleporting it to another element within your component will not work.
+
+> [!warning] When updating a component that contains `@teleport`, it must be wrapped in a `<div wire:ignore> ... </div>` or your component will not update:
+
+```blade
+<main>
+    <!-- ... -->
+
+    <div wire:ignore>
+        @teleport('breadcrumbs')
+            <ol>
+                <li>link 1</li>
+                <li>link 2</li>
+                <li>etc...</li>
+            </ol>
+        @endteleport
+    </div>
+
+    <!-- rest of component that gets updated dynamically -->
+</main>
+```


### PR DESCRIPTION
I noticed that in order to have a component that is reactive and have a `@teleport()` directive on the page it must be wrapped in a `wire:ignore`. If this is a bug, I am happy to open an issue but I didn't want others to be stuck on this like I was.

Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
