### PR TITLE
Added validation call to form object docs

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -169,6 +169,8 @@ class CreatePost extends Component
 
     public function save()
     {
+        $this->validate();
+
         Post::create(
             $this->form->all()
         );


### PR DESCRIPTION
Added 1 line to the **Forms** page of the v3 docs.

In the **Extracting a form object** section I believe the call to validation `$this->validate();` is missing from the first code snippet.
Without that line, I experienced a situation where the form objects validation rules were not being run.

This PR adds that 1 line.