### PR TITLE
Fix `reset()` to ensure a property initially set to `null` can be reset

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -52,17 +52,15 @@ trait InteractsWithProperties
         $freshInstance = new static;
 
         foreach ($properties as $property) {
-            $defaultValue = data_get($freshInstance, $property);
-            $unset = '__unset__';
-            $unsetByDefault = !$defaultValue && $unset === data_get($freshInstance, $property, $unset);
+            $isInitialized = (new \ReflectionProperty($freshInstance, $property))->isInitialized($freshInstance);
 
-            // Handle resetting properties that are unset by default.
-            if ($unsetByDefault) {
+            // Handle resetting properties that are not initialized by default.
+            if (! $isInitialized) {
                 data_forget($this, $property);
                 continue;
             }
 
-            data_set($this, $property, $defaultValue);
+            data_set($this, $property, data_get($freshInstance, $property));
         }
     }
 

--- a/src/Concerns/Tests/ResetPropertiesUnitTest.php
+++ b/src/Concerns/Tests/ResetPropertiesUnitTest.php
@@ -82,6 +82,19 @@ class ResetPropertiesUnitTest extends \Tests\TestCase
 
         $this->assertFalse(isset($component->notSet));
     }
+
+    /** @test */
+    public function can_reset_null_properties()
+    {
+        $component = Livewire::test(ResetPropertiesComponent::class)
+            ->set('nullProp', 1)
+            ->assertSet('nullProp', 1)
+            // Reset only nullProp.
+            ->call('resetKeys', 'nullProp')
+            ->assertSet('nullProp', null);
+
+        $this->assertTrue(is_null($component->nullProp));
+    }
 }
 
 class ResetPropertiesComponent extends Component
@@ -93,6 +106,8 @@ class ResetPropertiesComponent extends Component
     public $mwa = 'hah';
 
     public int $notSet;
+
+    public ?int $nullProp = null;
 
     public function resetAll()
     {


### PR DESCRIPTION
Failing test for #6540

When the `reset()` method is called on a property with default `null` will destroy the property from the component.
`Livewire\Exceptions\PropertyNotFoundException : Property [$nullProp] not found on component:`

With Livewire V2 instead when the `reset()` method was called it would reset the property to null
