### PR TITLE
Fix requested Content-Disposition header

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -87,7 +87,7 @@ class TemporaryUploadedFile extends UploadedFile
             return $this->storage->temporaryUrl(
                 $this->path,
                 now()->addDay()->endOfHour(),
-                ['ResponseContentDisposition' => 'filename="' . $this->getClientOriginalName() . '"']
+                ['ResponseContentDisposition' => 'attachment; filename="' . $this->getClientOriginalName() . '"']
             );
         }
 


### PR DESCRIPTION
This brings the `Content-Disposition` header we request from S3 into compliance with [RFC2616](https://datatracker.ietf.org/doc/html/rfc2616#section-19.5.1). This fixes an issue with S3 compatible services like Backblaze which are more strict with the values they accept for the `ResponseContentDisposition` field.

Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#syntax