### PR TITLE
Only migrate php files when migrating from the old to new namespace

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/ChangeDefaultNamespace.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/ChangeDefaultNamespace.php
@@ -10,8 +10,7 @@ class ChangeDefaultNamespace extends UpgradeStep
 {
     public function handle(UpgradeCommand $console, \Closure $next)
     {
-        if($this->hasOldNamespace())
-        {
+        if ($this->hasOldNamespace()) {
             $console->line("<fg=#FB70A9;bg=black;options=bold,reverse> The Livewire namespace has changed. </>");
             $console->newLine();
 
@@ -22,7 +21,7 @@ class ChangeDefaultNamespace extends UpgradeStep
                 'keep',
             ], 'migrate');
 
-            if($choice === 'keep') {
+            if ($choice === 'keep') {
                 $console->line('Keeping the old namespace...');
 
                 $this->publishConfigIfMissing($console);
@@ -38,9 +37,11 @@ class ChangeDefaultNamespace extends UpgradeStep
 
             $componentNames = [];
 
-            $results = collect($this->filesystem()->allFiles('app/Http/Livewire'))->map(function($file) {
-                return str($file)->after('app/Http/Livewire/')->before('.php')->__toString();
-            })->map(function($component) use (&$componentNames) {
+            $results = collect($this->filesystem()->allFiles('app/Http/Livewire'))
+                ->filter(fn($file) => str($file)->endsWith('.php'))
+                ->map(function ($file) {
+                    return str($file)->after('app/Http/Livewire/')->before('.php')->__toString();
+                })->map(function ($component) use (&$componentNames) {
 
                 // Track component names to update namespace references later on.
                 $componentNames[] = $component;
@@ -62,7 +63,7 @@ class ChangeDefaultNamespace extends UpgradeStep
                     return ['Skipped', $component, 'Already exists'];
                 }
 
-                if($this->filesystem()->directoryMissing(dirname($newParser->relativeClassPath()))) {
+                if ($this->filesystem()->directoryMissing(dirname($newParser->relativeClassPath()))) {
                     $this->filesystem()->createDirectory(dirname($newParser->relativeClassPath()));
                 }
 
@@ -72,7 +73,7 @@ class ChangeDefaultNamespace extends UpgradeStep
                 return ['Migrated', $component];
             });
 
-            foreach($componentNames as $name) {
+            foreach ($componentNames as $name) {
                 $name = str($name)->replace('/', '\\\\')->toString();
 
                 // Update any namespace references

--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/ChangeDefaultNamespace.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/ChangeDefaultNamespace.php
@@ -10,7 +10,8 @@ class ChangeDefaultNamespace extends UpgradeStep
 {
     public function handle(UpgradeCommand $console, \Closure $next)
     {
-        if ($this->hasOldNamespace()) {
+        if($this->hasOldNamespace())
+        {
             $console->line("<fg=#FB70A9;bg=black;options=bold,reverse> The Livewire namespace has changed. </>");
             $console->newLine();
 
@@ -21,7 +22,7 @@ class ChangeDefaultNamespace extends UpgradeStep
                 'keep',
             ], 'migrate');
 
-            if ($choice === 'keep') {
+            if($choice === 'keep') {
                 $console->line('Keeping the old namespace...');
 
                 $this->publishConfigIfMissing($console);
@@ -38,10 +39,12 @@ class ChangeDefaultNamespace extends UpgradeStep
             $componentNames = [];
 
             $results = collect($this->filesystem()->allFiles('app/Http/Livewire'))
-                ->filter(fn($file) => str($file)->endsWith('.php'))
-                ->map(function ($file) {
-                    return str($file)->after('app/Http/Livewire/')->before('.php')->__toString();
-                })->map(function ($component) use (&$componentNames) {
+                ->filter(function($file) {
+                    return str($file)->endsWith('.php');
+                })
+                ->map(function($file) {
+                return str($file)->after('app/Http/Livewire/')->before('.php')->__toString();
+            })->map(function($component) use (&$componentNames) {
 
                 // Track component names to update namespace references later on.
                 $componentNames[] = $component;
@@ -63,7 +66,7 @@ class ChangeDefaultNamespace extends UpgradeStep
                     return ['Skipped', $component, 'Already exists'];
                 }
 
-                if ($this->filesystem()->directoryMissing(dirname($newParser->relativeClassPath()))) {
+                if($this->filesystem()->directoryMissing(dirname($newParser->relativeClassPath()))) {
                     $this->filesystem()->createDirectory(dirname($newParser->relativeClassPath()));
                 }
 
@@ -73,7 +76,7 @@ class ChangeDefaultNamespace extends UpgradeStep
                 return ['Migrated', $component];
             });
 
-            foreach ($componentNames as $name) {
+            foreach($componentNames as $name) {
                 $name = str($name)->replace('/', '\\\\')->toString();
 
                 // Update any namespace references


### PR DESCRIPTION
#### fix upgrade issue while migrating old namespaces for a directory has none-php files such as .DSStore or any hidden files by filtering collected files collection to exclude files not ended with .php

```php
collect($this->filesystem()->allFiles('app/Http/Livewire'))
         + => =>       ->filter(fn($file) => str($file)->endsWith('.php'))
```
before map the collection

```php
   ErrorException

  file_get_contents(/Users/XUser/Sites/projectName/app/Http/Livewire/DSStore.php): Failed to open stream: No such file or directory

  at vendor/livewire/livewire/src/Features/SupportConsoleCommands/Commands/ComponentParserFromExistingComponent.php:18
     14▕     }
     15▕
     16▕     public function classContents($inline = false)
     17▕     {
  ➜  18▕         $originalFile = file_get_contents($this->existingParser->classPath());
     19▕
     20▕         $escapedClassNamespace = preg_replace('/\\\/', '\\\\\\', $this->existingParser->classNamespace());
     21▕
     22▕         return preg_replace_array(

      +2 vendor frames

  3   [internal]:0
      Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ChangeDefaultNamespace::Livewire\Features\SupportConsoleCommands\Commands\Upgrade\{closure}("Dashboard/.DS_Store")
      +21 vendor frames

  25  artisan:35
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```

hope you find this usefull

thanks