### PR TITLE
Attribute validation rules precedence

### DIFF
--- a/src/Features/SupportValidation/BaseRule.php
+++ b/src/Features/SupportValidation/BaseRule.php
@@ -10,7 +10,6 @@ use function Livewire\wrap;
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_ALL)]
 class BaseRule extends LivewireAttribute
 {
-    // @todo: support custom messages...
     function __construct(
         public $rule,
         protected $attribute = null,
@@ -68,7 +67,14 @@ class BaseRule extends LivewireAttribute
 
                 $this->component->addMessagesFromOutside($messages);
             } else {
-                $this->component->addMessagesFromOutside([$this->getName() => $this->translate ? trans($this->message) : $this->message]);
+                // If a single message was provided, apply it to the first given rule.
+                // There should have only been one rule provided in this case anyways...
+                $rule = head(array_values($rules));
+
+                // In the case of "min:5" or something, we only want "min"...
+                $rule = (string) str($rule)->before(':');
+
+                $this->component->addMessagesFromOutside([$this->getName().'.'.$rule => $this->translate ? trans($this->message) : $this->message]);
             }
         }
 

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -28,7 +28,7 @@ trait HandlesValidation
 
     public function addMessagesFromOutside($messages)
     {
-        $this->messagesFromOutside = array_merge_recursive($this->messagesFromOutside, $messages);
+        $this->messagesFromOutside = array_merge($this->messagesFromOutside, $messages);
     }
 
     public function addValidationAttributesFromOutside($validationAttributes)

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -28,7 +28,7 @@ trait HandlesValidation
 
     public function addMessagesFromOutside($messages)
     {
-        $this->messagesFromOutside = array_merge($this->messagesFromOutside, $messages);
+        $this->messagesFromOutside = array_merge_recursive($this->messagesFromOutside, $messages);
     }
 
     public function addValidationAttributesFromOutside($validationAttributes)

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -187,6 +187,23 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    public function rule_attribute_supports_custom_messages_when_using_repeated_attributes()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[BaseRule('required', message: 'Please provide a post title')]
+            #[BaseRule('min:3', message: 'This title is too short')]
+            public $title = '';
+        })
+            ->set('title', '')
+            ->assertHasErrors(['title' => 'required'])
+            ->tap(function ($component) {
+                $messages = $component->errors()->getMessages();
+                $this->assertEquals('Please provide a post title', $messages['title'][0]);
+            })
+        ;
+    }
+
+    /** @test */
     public function rule_attribute_message_is_translatable()
     {
         Lang::addLines(['translatable.foo' => 'Your foo is too short.'], App::currentLocale());


### PR DESCRIPTION
Add failing test for https://github.com/livewire/livewire/discussions/6734.

When using repeated validation attributes, validation seems to be done in the wrong order:

```php
#[Rule('required', message: 'Please provide a post title')]
#[Rule('min:3', message: 'This title is too short')]
public $title;
```

This will return `This title is too short` while `required` should take precedence. 
If you swap the attribute order, it will return the correct error message:

```php
#[Rule('min:3', message: 'This title is too short')]
#[Rule('required', message: 'Please provide a post title')]
public $title;
```