### PR TITLE
Fix morph aware statements case sensitivity

### DIFF
--- a/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
+++ b/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
@@ -38,7 +38,7 @@ class SupportMorphAwareIfStatement extends ComponentHook
                     (?<![?=-])          # ... (Make sure we don\'t confuse ?>, ->, and =>, with HTML opening tag closings)
                     >                   # A ">" character that isn\'t preceded by a "<" character (meaning it\'s outside of a tag)
                 )
-            /mUx';
+            /mUxi';
 
             return $pattern;
         };

--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -347,6 +347,14 @@ class UnitTest extends \Tests\TestCase
                 </div>
                 HTML
             ],
+            25 => [
+                1,
+                <<<'HTML'
+                @IF(true)
+                    ...
+                @ENDIF
+                HTML
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR makes the insertion of morph markers case insensitive.

At the moment morph markers are only inserted if the blade directive is written in all lowercase but Laravels Blade directives are case insenstive. `@IF(true)` for example is valid, but Livewire does not insert the morph marker.
