### PR TITLE
Command enhancement for livewire:make using Laravel Prompts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "laravel/framework": "^10.0",
     "orchestra/testbench": "^7.0|^8.0",
     "orchestra/testbench-dusk": "^7.0|^8.0",
-    "calebporzio/sushi": "^2.1"
+    "calebporzio/sushi": "^2.1",
+    "laravel/prompts": "^0.1.6"
   },
   "autoload": {
     "files": [

--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -154,7 +154,7 @@ class MakeCommand extends FileManipulationCommand implements PromptsForMissingIn
 
         if(
             $testSuite = select(
-                label: 'Do you want to create an test?',
+                label: 'Do you want to create a test file?',
                 options: [
                     false => 'No',
                     'phpunit' => 'PHPUnit',

--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -2,9 +2,14 @@
 
 namespace Livewire\Features\SupportConsoleCommands\Commands;
 
+use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
 
-class MakeCommand extends FileManipulationCommand
+class MakeCommand extends FileManipulationCommand implements PromptsForMissingInput
 {
     protected $signature = 'livewire:make {name} {--force} {--inline} {--test} {--pest} {--stub= : If you have several stubs, stored in subfolders }';
 
@@ -129,6 +134,41 @@ class MakeCommand extends FileManipulationCommand
     public function isReservedClassName($name)
     {
         return array_search(strtolower($name), $this->getReservedName()) !== false;
+    }
+
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->didReceiveOptions($input)) {
+            return;
+        }
+
+        if(
+            confirm(
+                label: 'Do you want to make this an inline component?',
+                default: false
+            )
+        )
+        {
+            $input->setOption('inline', true);
+        }
+
+        if(
+            $testSuite = select(
+                label: 'Do you want to create an test?',
+                options: [
+                    false => 'No',
+                    'phpunit' => 'PHPUnit',
+                    'pest' => 'Pest',
+                ],
+            )
+        )
+        {
+            $input->setOption('test', true);
+
+            if($testSuite === 'pest') {
+                $input->setOption('pest', true);
+            }
+        }
     }
 
     private function getReservedName()


### PR DESCRIPTION
The first step towards implementing Laravel Prompts. If you run `php artisan livewire:make` without any arguments it will prompt for the various options.

<img width="535" alt="image" src="https://github.com/livewire/livewire/assets/1133950/5906284b-9228-4232-b851-20822c4f06d9">
