### PR TITLE
Add `shouldBoot` hook for conditional component features

### DIFF
--- a/src/ComponentHookRegistry.php
+++ b/src/ComponentHookRegistry.php
@@ -37,20 +37,18 @@ class ComponentHookRegistry
 
         foreach (static::$componentHooks as $hook) {
             on('mount', function ($component, $params, $key, $parent) use ($hook) {
-                $hook = static::initializeHook($hook, $component);
-                
-                // If hook hasn't been initialized, then don't continue.
-                if (!$hook) return;
+                if (! $hook = static::initializeHook($hook, $component)) {
+                    return;
+                }
 
                 $hook->callBoot();
                 $hook->callMount($params, $parent);
             });
 
             on('hydrate', function ($component, $memo) use ($hook) {
-                $hook = static::initializeHook($hook, $component);
-                
-                // If hook hasn't been initialized, then don't continue.
-                if (!$hook) return;
+                if (! $hook = static::initializeHook($hook, $component)) {
+                    return;
+                }
 
                 $hook->callBoot();
                 $hook->callHydrate($memo);
@@ -89,14 +87,14 @@ class ComponentHookRegistry
         if (! isset(static::$components[$target])) static::$components[$target] = [];
 
         $hook = new $hook;
-        
+
         $hook->setComponent($target);
 
-        // If no `shouldBoot` method has been implemented, then boot the hook anyway
-        if (method_exists($hook, 'shouldBoot') && ! $hook->shouldBoot()) {
+        // If no `skip` method has been implemented, then boot the hook anyway
+        if (method_exists($hook, 'skip') && $hook->skip()) {
             return;
         }
-        
+
         static::$components[$target][] = $hook;
 
         return $hook;

--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -28,9 +28,9 @@ class SupportPagination extends ComponentHook
 
     protected $restoreOverriddenPaginationViews;
 
-    function shouldBoot()
+    function skip()
     {
-        return in_array(WithPagination::class, class_uses_recursive($this->component));
+        return ! in_array(WithPagination::class, class_uses_recursive($this->component));
     }
 
     function boot()

--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -28,10 +28,13 @@ class SupportPagination extends ComponentHook
 
     protected $restoreOverriddenPaginationViews;
 
+    function shouldBoot()
+    {
+        return in_array(WithPagination::class, class_uses_recursive($this->component));
+    }
+
     function boot()
     {
-        if (! in_array(WithPagination::class, class_uses_recursive($this->component))) return;
-
         $this->setPageResolvers();
 
         $this->overrideDefaultPaginationViews();
@@ -39,8 +42,6 @@ class SupportPagination extends ComponentHook
 
     function destroy()
     {
-        if (! in_array(WithPagination::class, class_uses_recursive($this->component))) return;
-        
         ($this->restoreOverriddenPaginationViews)();
     }
 


### PR DESCRIPTION
This PR adds a `shouldBoot` hook for conditional component features, such as `SupportPagination`. See PR #6708 for details.

I've implemented it so that any existing features, that currently don't have a `shouldBoot` method, still boot anyway.

I looked at calling it like the other hooks using `proxyCallToHooks` and having a `callShouldBoot` method on the base `ComponentHook` class, but it looked like it wouldn't work due to needing the return value, so just called it manually if it existed.

Hope this helps!