### PR TITLE
Fix typo in validation docs

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -355,7 +355,7 @@ Here's an example:
 ```php
 use Livewire\Component;
 use App\Models\Post;
-use Illuminate\Validaion\Rule as ValidationRule;
+use Illuminate\Validation\Rule as ValidationRule;
 
 class CreatePost extends Component
 {


### PR DESCRIPTION
This PR resolves a typo in the validation documentation.