### PR TITLE
Child elements don't render after failed validation

### DIFF
--- a/src/Features/SupportNestingComponents/UnitTest.php
+++ b/src/Features/SupportNestingComponents/UnitTest.php
@@ -111,6 +111,23 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertContains($children, $component->snapshot['memo']);
     }
+
+    /** @test */
+    public function parent_renders_children_after_failed_validation()
+    {
+        app('livewire')->component('parent', ParentFormNestedStub::class);
+        app('livewire')->component('child', ChildComponentForNestingStub::class);
+        $component = app('livewire')->test('parent');
+
+        $this->assertStringContainsString('Foo', $component->html());
+
+        $component
+            ->set('name', 'f')
+            ->call('submit')
+            ->assertHasErrors();
+
+        $this->assertStringContainsString('Foo', $component->html());
+    }
 }
 
 class ParentComponentForNestingChildStub extends Component
@@ -209,5 +226,32 @@ class ParentComponentForSkipRenderStub extends Component
         return app('view')->make('show-child', [
             'child' => ['name' => 'foo'],
         ]);
+    }
+}
+
+class ParentFormNestedStub extends Component
+{
+    public $name;
+
+    public function rules()
+    {
+        return [
+            'name' => 'min:3',
+        ];
+    }
+
+    public function render()
+    {
+        return <<<'blade'
+            <form wire:submit="submit">
+                <input type="text" wire:model="name" />
+                <livewire:child name='Foo' />
+            </form>
+blade;
+    }
+
+    public function submit()
+    {
+        $this->validate();
     }
 }

--- a/src/Features/SupportNestingComponents/UnitTest.php
+++ b/src/Features/SupportNestingComponents/UnitTest.php
@@ -111,23 +111,6 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertContains($children, $component->snapshot['memo']);
     }
-
-    /** @test */
-    public function parent_renders_children_after_failed_validation()
-    {
-        app('livewire')->component('parent', ParentFormNestedStub::class);
-        app('livewire')->component('child', ChildComponentForNestingStub::class);
-        $component = app('livewire')->test('parent');
-
-        $this->assertStringContainsString('Foo', $component->html());
-
-        $component
-            ->set('name', 'f')
-            ->call('submit')
-            ->assertHasErrors();
-
-        $this->assertStringContainsString('Foo', $component->html());
-    }
 }
 
 class ParentComponentForNestingChildStub extends Component
@@ -226,32 +209,5 @@ class ParentComponentForSkipRenderStub extends Component
         return app('view')->make('show-child', [
             'child' => ['name' => 'foo'],
         ]);
-    }
-}
-
-class ParentFormNestedStub extends Component
-{
-    public $name;
-
-    public function rules()
-    {
-        return [
-            'name' => 'min:3',
-        ];
-    }
-
-    public function render()
-    {
-        return <<<'blade'
-            <form wire:submit="submit">
-                <input type="text" wire:model="name" />
-                <livewire:child name='Foo' />
-            </form>
-blade;
-    }
-
-    public function submit()
-    {
-        $this->validate();
     }
 }


### PR DESCRIPTION
After validating a component using `$this->validate()`, child components of that component are no longer rendered.

The browsers' developer tools indicate that the snapshot of the component is no longer available so the child elements container is empty. Below is a screenshot from the application where I encountered the issue.

![image](https://github.com/livewire/livewire/assets/3493941/600678b5-708f-4aba-9406-1502f2e270c6)

This PR adds a failing test for this issue as I'm unable to find the cause.