### PR TITLE
[V3] Added missing import to docs

### DIFF
--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -187,6 +187,7 @@ Below is a complete example of testing the `UploadPhoto` component with Livewire
 
 namespace Tests\Feature\Livewire;
 
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use App\Livewire\UploadPhoto;
 use Livewire\Livewire;


### PR DESCRIPTION
The example code for [testing a file upload](https://livewire.laravel.com/docs/uploads#testing-file-uploads) is missing an import.