### PR TITLE
Added query string hook documentation

### DIFF
--- a/docs/url.md
+++ b/docs/url.md
@@ -158,3 +158,44 @@ class ShowUsers extends Component
 ```
 
 In the example above, when a user changes the search value from "bob" to "frank" and then clicks the browser's back button, the search value (and the URL) will be set back to "bob" instead of navigating to the previously visited page.
+
+## Using the queryString method
+
+The query string can also be defined as a method on the component. This can be useful if some properties have dynamic options.
+
+```php
+use Livewire\Component;
+
+class ShowUsers extends Component
+{
+    // ...
+
+    protected function queryString()
+    {
+        return [
+            'search' => [
+                'as' => 'q',
+            ],
+        ];
+    }
+}
+```
+
+## Trait hooks
+
+Livewire offers [hooks](/docs/lifecycle-hooks) for query strings as well.
+
+```php
+trait WithSorting
+{
+    // ...
+
+    protected function queryStringWithSorting()
+    {
+        return [
+            'sortBy' => ['as' => 'sort'],
+            'sortDirection' => ['as' => 'direction'],
+        ];
+    }
+}
+```


### PR DESCRIPTION
The new [Url](https://livewire.laravel.com/docs/url) attribute for query strings is very eloquent. It's very easy to make the property available via the query string. However, by using an attribute, some functionality is lost.

I've added some documentation about the usage of the query string like in the [previous](https://laravel-livewire.com/docs/2.x/traits) version of Livewire. Although it's the [legacy](https://github.com/livewire/livewire/blob/main/src/Features/SupportQueryString/SupportQueryString.php#L13) syntax, I think it still provides a valid use case: dynamic options.

By having a method available on the component or a trait, we will be able to dynamically assign the options. A few examples:

1. We can easily add a prefix to our properties when using a method. This prefix has to be defined once on the component and prevents overriding multiple `Url` attributes. This can be helpful when working with multiple instances of the same component.

```php
protected string $prefix = 'blog';

protected function queryString()
{
    return [
        'search' => [
            'as' => $this->prefix.'_search',
        ],
    ];
}
```

2. Disabling the query string. If we add a property to the component which determines to use the query string or not, we could return an empty array to not make use of it.  


```php
protected bool $useQueryString = false;

protected function queryString()
{
    if (! $this->useQueryString) {
        return [];
    }

    return [
        'search' => [
            'as' => 'q',
        ],
    ];
}
```

I'm very curious about your thoughts!