### PR TITLE
Implements 2 new helper methods in the LivewireManager to set the urls for upload-file and preview-file routes.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,15 +54,19 @@ If you'd rather force Livewire to inject it's assets on a single page or multipl
 \Livewire\Livewire::forceAssetInjection();
 ```
 
-## Configuring Livewire's update endpoint
+## Configuring Livewire's messaging endpoints
 
 Every update in a Livewire component sends a network request to the server at the following endpoint: `https://example.com/livewire/update`
+The file upload and preview functionalities rely on two additionnal endpoints which are `https://example.com/livewire/upload-file` and `https://example.com/livewire/preview-file` by default.
 
-This can be a problem for some applications that use localization or multi-tenancy.
+This can be a problem for some applications that use localization or multi-tenancy or which have to apply constraint on their URL scheme for some reason.
 
-In those cases, you can register your own endpoint however you like, and as long as you do it inside `Livewire::setUpdateRoute()`,  Livewire will know to use this endpoint for all component updates:
+In those cases, you can register your own endpoints however you like, and as long as you do it using the provided methodes, Livewire will know to use these endpoints for all component updates, file uploads and previews:
 
+For example, for the update endpoint:
 ```php
+use Livewire\Livewire;
+
 Livewire::setUpdateRoute(function ($handle) {
 	return Route::post('/custom/livewire/update', $handle);
 });
@@ -73,11 +77,36 @@ Now, instead of using `/livewire/update`, Livewire will send component updates t
 Because Livewire allows you to register your own update route, you can declare any additional middleware you want Livewire to use directly inside `setUpdateRoute()`:
 
 ```php
+use Livewire\Livewire;
+
 Livewire::setUpdateRoute(function ($handle) {
 	return Route::post('/custom/livewire/update', $handle)
         ->middleware([...]); // [tl! highlight]
 });
 ```
+
+> [!tip] for the `update` endpoint, the Route you declare must be a `post` Route.
+
+And you can do the same for the other endpoints with:
+```php
+use Livewire\Livewire;
+
+Livewire::setUploadFileRoute(function ($handle) {
+	return Route::post('/custom/livewire/upload-file', $handle);
+});
+```
+
+> [!tip] for the `upload-file` endpoint, the Route you declare must be a `post` Route.
+
+```php
+use Livewire\Livewire;
+
+Livewire::setPreviewFileRoute(function ($handle) {
+	return Route::get('/custom/livewire/preview-file', $handle);
+});
+```
+
+> [!tip] for the `preview-file` endpoint, the Route you declare must be a `get` Route.
 
 ## Customizing the asset URL
 
@@ -102,6 +131,8 @@ Now, Livewire will load its JavaScript like so:
 ```blade
 <script src="/custom/livewire/livewire.js" ...
 ```
+
+> [!tip] Be sure to use a `get` Route when you customize the asset URL.
 
 ## Manually bundling Livewire and Alpine
 

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -12,6 +12,8 @@ use Livewire\Mechanisms\ComponentRegistry;
 use Livewire\Features\SupportTesting\Testable;
 use Livewire\Features\SupportTesting\DuskTestable;
 use Livewire\Features\SupportAutoInjectedAssets\SupportAutoInjectedAssets;
+use Livewire\Features\SupportFileUploads\FileUploadController;
+use Livewire\Features\SupportFileUploads\FilePreviewController;
 
 class LivewireManager
 {
@@ -123,6 +125,18 @@ class LivewireManager
         return app(HandleRequests::class)->setUpdateRoute($callback);
     }
 
+    function setUploadFileRoute($callback)
+    {
+        $route = $callback([FileUploadController::class, 'handle']);
+        $route->name('livewire.upload-file');
+    }
+
+    function setPreviewFileRoute($callback)
+    {
+        $route = $callback([FilePreviewController::class, 'handle']);
+        $route->name('livewire.preview-file');
+    }
+
     function getUpdateUri()
     {
         return app(HandleRequests::class)->getUpdateUri();
@@ -164,9 +178,9 @@ class LivewireManager
 
     function actingAs(\Illuminate\Contracts\Auth\Authenticatable $user, $driver = null)
     {
-         Testable::actingAs($user, $driver);
+        Testable::actingAs($user, $driver);
 
-         return $this;
+        return $this;
     }
 
     function isRunningServerless()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes: I started discussion #6771. However, I received no answer but since I am confident that there are use cases for these 2 additional helpers, I am submitting this simple PR.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No. Only one change.

4️⃣ Does it include tests? (Required)

No: but the other helpers (setUpdateRoute and setScriptRoute) do not have their own tests neither.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

The 2 new helpers allow the developer to do:

```php
Livewire::setUploadFileRoute(function ($handle) {
    return Route::post('/livewire/a/random/route/to/upload-file', $handle)
        ->middleware('web');
});

Livewire::setPreviewFileRoute(function ($handle) {
    // Here, the provided url should contain a {filename} parameter for model binding to work.
    return Route::get('/livewire/z/random/route/to/preview-file/{filename}', $handle)
        ->middleware('web');
});
```

This is a complement to the setUpdateRoute and setScriptRoute methods which already allow the developper to adjust the routing of livewire requests. I reproduced the style used in seUpdateRoute and setScriptRoute which makes the new helpers consistent and allow the developer to fully customize the route definition, adding whatever middleware he wants in particular.

These new methods register the new route into the Router and name them as livewire.upload-file and livewire.preview-file. The URL generation used in the SupportFileUpload and SupportFilePreview features actually rely on the fact that the generated URL depends on the last declared route (when multiple routes have the same name). However, Laravel is missing a feature to remove a Route from the Router (which would be a safe addition to these 2 helpers).

Despite that, I hope you will find this PR suitable for merging.
