### PR TITLE
Add support for adding cookies to tests

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -319,6 +319,57 @@ class SearchPostsTest extends TestCase
 }
 ```
 
+### Setting cookies
+
+If your Livewire component depends on cookies, you can use the `withCookie()` or `withCookies()` methods to set the cookies manually for your test.
+
+Below is a basic `Cart` component that loads a discount token from a cookie on mount:
+
+```php
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+use Livewire\With\Url;
+use App\Models\Post;
+
+class Cart extends Component
+{
+    public $discountToken;
+
+    public mount()
+    {
+        $this->discountToken = request()->cookie('discountToken');
+    }
+}
+```
+
+As you can see, the `$discountToken` property above gets its value from a cookie in the request.
+
+Below is an example of how you would simulate the scenario of loading this component on a page with cookies:
+
+```php
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\Cart;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class CartTest extends TestCase
+{
+    /** @test */
+    public function can_load_discount_token_from_a_cookie()
+    {
+        Livewire::withCookies(['discountToken' => 'CALEB2023'])
+            ->test(Cart::class)
+            ->assertSet('discountToken', 'CALEB2023');
+    }
+}
+```
+
 ## Calling actions
 
 Livewire actions are typically called from the frontend using something like `wire:click`.
@@ -587,6 +638,9 @@ Livewire provides many more testing utilities. Below is a comprehensive list of 
 | `Livewire::test(UpdatePost::class, ['post' => $post])`                      | Test the `UpdatePost` component with the `post` parameter (To be received through the `mount()` method) |
 | `Livewire::actingAs($user)`                      | Set the provided user as the session's authenticated user |
 | `Livewire::withQueryParams(['search' => '...'])`                      | Set the test's `search` URL query parameter to the provided value (ex. `?search=...`). Typically in the context of a property using Livewire's [`#[Url]` attribute](/docs/url) |
+| `Livewire::withCookie('color', 'blue')`                      | Set the test's `color` cookie to the provided value (`blue`). |
+| `Livewire::withCookies(['color' => 'blue', 'name' => 'Taylor])`                      | Set the test's `color` and `name` cookies to the provided values (`blue`, `Taylor`). |
+
 
 ### Interacting with components
 | Method                                                  | Description                                                                                                      |

--- a/src/Features/SupportTesting/InitialRender.php
+++ b/src/Features/SupportTesting/InitialRender.php
@@ -10,14 +10,14 @@ class InitialRender extends Render
         protected RequestBroker $requestBroker,
     ) {}
 
-    static function make($requestBroker, $name, $params = [], $fromQueryString = [])
+    static function make($requestBroker, $name, $params = [], $fromQueryString = [], $cookies = [])
     {
         $instance = new static($requestBroker);
 
-        return $instance->makeInitialRequest($name, $params, $fromQueryString);
+        return $instance->makeInitialRequest($name, $params, $fromQueryString, $cookies);
     }
 
-    function makeInitialRequest($name, $params, $fromQueryString = []) {
+    function makeInitialRequest($name, $params, $fromQueryString = [], $cookies = []) {
         $uri = '/livewire-unit-test-endpoint/'.str()->random(20);
 
         $this->registerRouteBeforeExistingRoutes($uri, function () use ($name, $params) {
@@ -27,9 +27,9 @@ class InitialRender extends Render
             ]);
         });
 
-        [$response, $componentInstance, $componentView] = $this->extractComponentAndBladeView(function () use ($uri, $fromQueryString) {
-            return $this->requestBroker->temporarilyDisableExceptionHandlingAndMiddleware(function ($requestBroker) use ($uri, $fromQueryString) {
-                return $requestBroker->call('GET', $uri, $fromQueryString);
+        [$response, $componentInstance, $componentView] = $this->extractComponentAndBladeView(function () use ($uri, $fromQueryString, $cookies) {
+            return $this->requestBroker->temporarilyDisableExceptionHandlingAndMiddleware(function ($requestBroker) use ($uri, $fromQueryString, $cookies) {
+                return $requestBroker->call('GET', $uri, $fromQueryString, $cookies);
             });
         });
 

--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -25,7 +25,7 @@ class Testable
         protected ComponentState $lastState,
     ) {}
 
-    static function create($name, $params = [], $fromQueryString = [])
+    static function create($name, $params = [], $fromQueryString = [], $cookies = [])
     {
         $name = static::normalizeAndRegisterComponentName($name);
 
@@ -36,6 +36,7 @@ class Testable
             $name,
             $params,
             $fromQueryString,
+            $cookies,
         );
 
         return new static($requestBroker, $initialState);

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -501,6 +501,30 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             ->assertReturned('bar')
             ->assertReturned(fn ($data) => $data === 'bar');
     }
+    /** @test */
+    public function can_set_cookies_for_use_with_testing()
+    {
+        // Test both the `withCookies` and `withCookie` methods that Laravel normally provides
+        Livewire::withCookies(['colour' => 'blue'])
+            ->withCookie('name', 'Taylor')
+            ->test(new class extends Component {
+                public $colourCookie = '';
+                public $nameCookie = '';
+                public function mount()
+                {
+                    $this->colourCookie = request()->cookie('colour');
+                    $this->nameCookie = request()->cookie('name');
+                }
+
+                public function render()
+                {
+                    return '<div></div>';
+                }
+            })
+            ->assertSet('colourCookie', 'blue')
+            ->assertSet('nameCookie', 'Taylor')
+            ;
+    }
 }
 
 class HasMountArguments extends Component

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -140,6 +140,8 @@ class LivewireManager
 
     protected $queryParamsForTesting = [];
 
+    protected $cookiesForTesting = [];
+
     function withUrlParams($params)
     {
         return $this->withQueryParams($params);
@@ -152,9 +154,23 @@ class LivewireManager
         return $this;
     }
 
+    function withCookie($name, $value)
+    {
+        $this->cookiesForTesting[$name] = $value;
+
+        return $this;
+    }
+
+    function withCookies($cookies)
+    {
+        $this->cookiesForTesting = array_merge($this->cookiesForTesting, $cookies);
+
+        return $this;
+    }
+
     function test($name, $params = [])
     {
-        return Testable::create($name, $params, $this->queryParamsForTesting);
+        return Testable::create($name, $params, $this->queryParamsForTesting, $this->cookiesForTesting);
     }
 
     function visit($name)


### PR DESCRIPTION
Laravel has `withCookie()` and `withCookies()` methods for injecting cookies to a request for testing purposes. But currently there is no way to use cookies with a Livewire test.

This PR adds Livewire support for `withCookie()` and `withCookies()` with the same API as Laravel https://laravel.com/docs/10.x/http-tests#cookies

They can be used like:

```php
Livewire::withCookie('name', 'Taylor')
    ->test(MyComponent::class);
```

```php
Livewire::withCookies(['colour' => 'blue, 'name' => 'Taylor'])
    ->test(MyComponent::class);
```

I have also added docs to `testing.md`.

Hope this helps!