### PR TITLE
Add ability for the temporary_file_upload.middleware config to be an array

### DIFF
--- a/src/Features/SupportFileUploads/FileUploadController.php
+++ b/src/Features/SupportFileUploads/FileUploadController.php
@@ -8,8 +8,14 @@ class FileUploadController
 {
     public function getMiddleware()
     {
+        $middleware = FileUploadConfiguration::middleware();
+
+        if (is_array($middleware)) {
+            return collect($middleware)->map(fn ($middleware) => ['middleware' => $middleware, 'options' => []]);
+        }
+
         return [[
-            'middleware' => FileUploadConfiguration::middleware(),
+            'middleware' => $middleware,
             'options' => [],
         ]];
     }

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -424,6 +424,20 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    public function the_global_upload_route_middleware_is_configurable_with_an_array_of_middlware()
+    {
+        config()->set('livewire.temporary_file_upload.middleware', [DummyMiddleware::class]);
+
+        $url = GenerateSignedUploadUrl::forLocal();
+
+        try {
+            $this->withoutExceptionHandling()->post($url);
+        } catch (\Throwable $th) {
+            $this->assertEquals('Middleware was hit!', $th->getMessage());
+        }
+    }
+
+    /** @test */
     public function can_preview_a_temporary_file_with_a_temporary_signed_url()
     {
         Storage::fake('avatars');


### PR DESCRIPTION
When I attempted to customize the middleware used for upload file routes I ran into an issue when I set `temporary_file_upload.middleware` to an array. 

In `config/livewire.php`, when I set the config to:
```
  'temporary_file_upload' => [
      'middleware' => ['web', 'throttle:5,1', 'universal', InitializeTenancyBySubdomain::class],
  ],
```
An exception would be thrown.
```
   TypeError 

  Illegal offset type in isset or empty

  at vendor\laravel\framework\src\Illuminate\Routing\Router.php:1451
    1447▕
    1448▕         foreach ($middleware as $value) {
    1449▕             $key = \is_object($value) ? \spl_object_id($value) : $value;
    1450▕
  ➜ 1451▕             if (!isset($seen[$key])) {
    1452▕                 $seen[$key] = true;
    1453▕                 $result[] = $value;
    1454▕             }
    1455▕         }

  1   vendor\laravel\framework\src\Illuminate\Routing\Route.php:1030
      Illuminate\Routing\Router::uniqueMiddleware()
```

I resolved this issue by adding an `is_array()` check and properly handling an array of middleware.