### PR TITLE
Add option to modify full page component response

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -634,3 +634,27 @@ class ShowPost extends Component
 ```
 
 The `$post` property will automatically be assigned to the model bound via the route's `{post}` parameter.
+
+### Modifying the response
+
+In some scenarios you might want to modify the response and set a custom response header. You can hook into the response object by calling the `response()` method on the view and use a closure to modify the response object:
+
+```php
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+use Illuminate\Http\Response;
+
+class ShowPost extends Component
+{
+    public function render()
+    {
+        return view('livewire.show-post')
+            ->response(function(Response $response) {
+                $response->header('x-livewire-is-the-way', true);
+            });
+    }
+}
+```

--- a/src/Features/SupportPageComponents/HandlesPageComponents.php
+++ b/src/Features/SupportPageComponents/HandlesPageComponents.php
@@ -21,6 +21,12 @@ trait HandlesPageComponents
 
         $layoutConfig->normalizeViewNameAndParamsForBladeComponents();
 
-        return SupportPageComponents::renderContentsIntoLayout($html, $layoutConfig);
+        $response = response(SupportPageComponents::renderContentsIntoLayout($html, $layoutConfig));
+
+        if (is_callable($layoutConfig->response)) {
+            call_user_func($layoutConfig->response, $response);
+        }
+
+        return $response;
     }
 }

--- a/src/Features/SupportPageComponents/HandlesPageComponents.php
+++ b/src/Features/SupportPageComponents/HandlesPageComponents.php
@@ -17,7 +17,7 @@ trait HandlesPageComponents
             $html = app('livewire')->mount($this::class, $params);
         });
 
-        $layoutConfig = $layoutConfig ?: new LayoutConfig;
+        $layoutConfig = $layoutConfig ?: new PageComponentConfig;
 
         $layoutConfig->normalizeViewNameAndParamsForBladeComponents();
 

--- a/src/Features/SupportPageComponents/LayoutConfig.php
+++ b/src/Features/SupportPageComponents/LayoutConfig.php
@@ -9,6 +9,7 @@ class LayoutConfig
 {
     public $slots = [];
     public $viewContext = null;
+    public $response;
 
     function __construct(
         public $type = 'component',

--- a/src/Features/SupportPageComponents/PageComponentConfig.php
+++ b/src/Features/SupportPageComponents/PageComponentConfig.php
@@ -5,7 +5,7 @@ namespace Livewire\Features\SupportPageComponents;
 use Illuminate\View\AnonymousComponent;
 use Livewire\Mechanisms\HandleComponents\ViewContext;
 
-class LayoutConfig
+class PageComponentConfig
 {
     public $slots = [];
     public $viewContext = null;

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -20,7 +20,7 @@ class SupportPageComponents extends ComponentHook
     static function registerLayoutViewMacros()
     {
         View::macro('layoutData', function ($data = []) {
-            if (! isset($this->layoutConfig)) $this->layoutConfig = new LayoutConfig;
+            if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->mergeParams($data);
 
@@ -28,7 +28,7 @@ class SupportPageComponents extends ComponentHook
         });
 
         View::macro('section', function ($section) {
-            if (! isset($this->layoutConfig)) $this->layoutConfig = new LayoutConfig;
+            if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->slotOrSection = $section;
 
@@ -36,7 +36,7 @@ class SupportPageComponents extends ComponentHook
         });
 
         View::macro('title', function ($title) {
-            if (! isset($this->layoutConfig)) $this->layoutConfig = new LayoutConfig;
+            if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->mergeParams(['title' => $title]);
 
@@ -44,7 +44,7 @@ class SupportPageComponents extends ComponentHook
         });
 
         View::macro('slot', function ($slot) {
-            if (! isset($this->layoutConfig)) $this->layoutConfig = new LayoutConfig;
+            if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->slotOrSection = $slot;
 
@@ -52,7 +52,7 @@ class SupportPageComponents extends ComponentHook
         });
 
         View::macro('extends', function ($view, $params = []) {
-            if (! isset($this->layoutConfig)) $this->layoutConfig = new LayoutConfig;
+            if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->type = 'extends';
             $this->layoutConfig->slotOrSection = 'content';
@@ -63,7 +63,7 @@ class SupportPageComponents extends ComponentHook
         });
 
         View::macro('layout', function ($view, $params = []) {
-            if (! isset($this->layoutConfig)) $this->layoutConfig = new LayoutConfig;
+            if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->type = 'component';
             $this->layoutConfig->slotOrSection = 'slot';
@@ -74,7 +74,7 @@ class SupportPageComponents extends ComponentHook
         });
 
         View::macro('response', function (callable $callback) {
-            if (! isset($this->layoutConfig)) $this->layoutConfig = new LayoutConfig;
+            if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->response = $callback;
 
@@ -101,7 +101,7 @@ class SupportPageComponents extends ComponentHook
                 $view->title($titleAttr->content);
             }
 
-            $layoutConfig = $view->layoutConfig ?? new LayoutConfig;
+            $layoutConfig = $view->layoutConfig ?? new PageComponentConfig;
 
             return function ($html, $replace, $viewContext) use ($view, $layoutConfig) {
                 // Gather up any slots and sections declared in the component template and store them

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -72,6 +72,14 @@ class SupportPageComponents extends ComponentHook
 
             return $this;
         });
+
+        View::macro('response', function (callable $callback) {
+            if (! isset($this->layoutConfig)) $this->layoutConfig = new LayoutConfig;
+
+            $this->layoutConfig->response = $callback;
+
+            return $this;
+        });
     }
 
     static function interceptTheRenderOfTheComponentAndRetreiveTheLayoutConfiguration($callback)

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportPageComponents;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
 use Livewire\Component;
 use Livewire\Livewire;
@@ -394,6 +395,16 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    public function can_modify_response()
+    {
+        Route::get('/configurable-layout', ComponentWithCustomResponseHeaders::class);
+
+        $this
+            ->get('/configurable-layout')
+            ->assertHeader('x-livewire', 'awesome');
+    }
+
+    /** @test */
     public function can_configure_title_in_render_method_and_layout_using_layout_attribute()
     {
         Route::get('/configurable-layout', ComponentWithClassBasedComponentTitleAndLayoutAttribute::class);
@@ -535,7 +546,6 @@ class ComponentForConfigurableLayoutTestWithCustomAttributes extends Component
     }
 }
 
-
 class ComponentWithExtendsLayout extends Component
 {
     public function render()
@@ -647,6 +657,14 @@ class ComponentWithCustomParamsAndLayout extends Component
         return view('null-view')->layout('layouts.data-test')->layoutData([
             'title' => 'livewire',
         ]);
+    }
+}
+
+class ComponentWithCustomResponseHeaders extends Component
+{
+    public function render()
+    {
+        return view('null-view')->response(fn(Response $response) => $response->header('x-livewire', 'awesome'));
     }
 }
 


### PR DESCRIPTION
In Laravel you can modify response headers by using the `response` helper:

```php
return response()
            ->view('hello', $data, 200)
            ->header('Content-Type', $type);
```

This will not work when you use a full-page component as Livewire expects a view to be returned and not a response object.
This PR adds the option to hook into the response when rendering full-page components.

```php
class Dashboard extends Component
{
    public function render()
    {
        return view('livewire.dashboard')->response(function(Response $response) {
            $response->header('x-hello-world', true);
        });
    }
}
```

The class name `LayoutConfig` feels a bit off now because a response is not really related to the layout. Maybe rename `LayoutConfig` to `PageComponentConfig`?