### PR TITLE
Docs: explain how to generate class-based volt component

### DIFF
--- a/docs/volt.md
+++ b/docs/volt.md
@@ -52,6 +52,13 @@ By adding the `--test` directive when generating a component, a corresponding te
 php artisan make:volt counter --test --pest
 ```
 
+
+By adding the `--class` directive it will generate a class-based volt component.
+
+```bash
+php artisan make:volt counter --class
+```
+
 ## API style
 
 By utilizing Volt's functional API, we can define a Livewire component's logic through imported `Livewire\Volt` functions. Volt then transforms and compiles the functional code into a conventional Livewire class, enabling us to leverage the extensive capabilities of Livewire with reduced boilerplate.


### PR DESCRIPTION
Just a short note for those who prefer class-based components

```bash
php artisan make:volt counter --class
```