### PR TITLE
Update dependencies to match Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": "^8.1",
-    "symfony/http-kernel": "^5.0|^6.0",
+    "symfony/http-kernel": "^6.2",
     "illuminate/support": "^10.0",
     "illuminate/database": "^10.0",
     "illuminate/validation": "^10.0",
@@ -21,8 +21,8 @@
     "mockery/mockery": "^1.3.1",
     "phpunit/phpunit": "^9.0",
     "laravel/framework": "^10.0",
-    "orchestra/testbench": "^7.0|^8.0",
-    "orchestra/testbench-dusk": "^7.0|^8.0",
+    "orchestra/testbench": "^8.0",
+    "orchestra/testbench-dusk": "^8.0",
     "calebporzio/sushi": "^2.1",
     "laravel/prompts": "^0.1.6"
   },


### PR DESCRIPTION
* Support for `symfony/http-kernel` 5 ended with Laravel 8.
* Testbench 7 can only be used with Laravel 9.