### PR TITLE
Support Laravel-style CSRF token definition

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -168,6 +168,11 @@ export function isSynthetic(subject) {
 export function getCsrfToken() {
     // Purposely not caching. Fetching it fresh every time ensures we're
     // not depending on a stale session's CSRF token...
+
+    if (document.querySelector('meta[name="csrf-token"]')) {
+        return document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+    }
+
     if (document.querySelector('[data-csrf]')) {
         return document.querySelector('[data-csrf]').getAttribute('data-csrf')
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Required to support Laravel's way of defining the CSRF token (https://github.com/laravel/jetstream/blob/2f170dada485713c64853872256f8e2f7405e674/stubs/livewire/resources/views/layouts/app.blade.php#L6). When regenerating sessions after login, one can dispatch a Livewire event and update the token using JS. This worked in v2, but in v3 I've had to add `data-csrf="{{ csrf_token() }}"`. Since Laravel Jetstream uses a `<meta>` tag instead, I've added support for it. I've kept the check for `[data-csrf]` too, but I'm not sure what standard it is and if you'd like to keep it?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yup.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Nope.

4️⃣ Does it include tests? (Required)

I believe there are no existing tests for this util?

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

See description at 1️⃣.
