### PR TITLE
Tweak forms.md

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -776,7 +776,7 @@ Often, you may build your dropdown options dynamically using Blade:
 ```blade
 <select wire:model="state">
     @foreach (\App\Models\State::all() as $state)
-        <option value="{{ $state->id }}">{{ $state->label }}</option>
+        <option value="{{ $state->id }}" wire:key="value="{{ $state->id }}">{{ $state->label }}</option>
     @endforeach
 </select>
 ```
@@ -788,7 +788,7 @@ If you don't have a specific option selected by default, you may want to show a 
     <option disabled>Select a state...</option>
 
     @foreach (\App\Models\State::all() as $state)
-        <option value="{{ $state->id }}">{{ $state->label }}</option>
+        <option value="{{ $state->id }}" wire:key="{{ $state->id }}">{{ $state->label }}</option>
     @endforeach
 </select>
 ```

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -776,7 +776,7 @@ Often, you may build your dropdown options dynamically using Blade:
 ```blade
 <select wire:model="state">
     @foreach (\App\Models\State::all() as $state)
-        <option value="{{ $state->id }}" wire:key="value="{{ $state->id }}">{{ $state->label }}</option>
+        <option value="{{ $state->id }}" wire:key="{{ $state->id }}">{{ $state->label }}</option>
     @endforeach
 </select>
 ```


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
#6882

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
https://github.com/austincarpenter/livewire/tree/add-wire-key-in-forms-docs

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
No, as docs-only change.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
#6882 

> With Livewire 2, when a dependent select's options were changed to no longer include the currently selected option (in terms of its value), it would default back to having selected a blank option.

> With Livewire 3, once the options are changed, the select will show the nth option available (where n is the selected option), despite its value being different.

Have since updated the discussion to recommend adding `wire:key`.

Thanks for contributing! 🙌
