### PR TITLE
Fix asset publishing

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,26 @@ php artisan livewire:publish --config
 
 This will create a new `livewire.php` file in your Laravel application's `config` directory.
 
+## Publishing the frontend assets
+
+If you prefer the JavaScript assets to be served by your web server not through Laravel, use the `livewire:publish` command:
+
+```shell
+php artisan livewire:publish --assets
+```
+
+To keep the assets up-to-date and avoid issues in future updates, we **highly recommend** adding the command to the `post-update-cmd` scripts in your `composer.json` file:
+
+```json
+{
+    "scripts": {
+        "post-update-cmd": [
+            "@php artisan livewire:publish --assets"
+        ]
+    }
+}
+```
+
 ## Manually including Livewire's frontend assets
 
 By default, Livewire injects the JavaScript and CSS assets it needs into each page that includes a Livewire component.

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -10,6 +10,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $this->registerLivewireSingleton();
         $this->registerConfig();
+        $this->registerAssets();
         $this->bootEventBus();
         $this->registerMechanisms();
     }
@@ -36,6 +37,13 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->publishes([$config => base_path('config/livewire.php')], ['livewire', 'livewire:config']);
 
         $this->mergeConfigFrom($config, 'livewire');
+    }
+
+    protected function registerAssets()
+    {
+        $assets = __DIR__.'/../dist';
+
+        $this->publishes([$assets => public_path('vendor/livewire')], ['livewire', 'livewire:assets']);
     }
 
     protected function bootEventBus()


### PR DESCRIPTION
This was discussed over in https://github.com/livewire/livewire/discussions/6328 and according to @joshhanley's [comment](https://github.com/livewire/livewire/discussions/6328#discussioncomment-7063624) it seems that breaking the `livewire:publish --assets` command was an oversight in v3 and PRs are welcome to fix it.

It looks to me like the fix is to add the relevant `publishes()` call in `LivewireServiceProvider.php` to go along with the similar call for setting up publishing of the config file. So, that's what I've done here.

I also added a relevant section to documentation in `installation.md` where this command had been documented for v1 and v2.