### PR TITLE
Adding temporarySafeUrl() and hasTemporaryUrl() for safe usage of temporaryUrl()

### DIFF
--- a/src/Features/SupportFileUploads/BrowserTest.php
+++ b/src/Features/SupportFileUploads/BrowserTest.php
@@ -61,4 +61,90 @@ class BrowserTest extends \Tests\BrowserTestCase
         })
         ;
     }
+
+    /** @test */
+    public function can_check_temporary_url_before_rendering()
+    {
+        Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photo;
+
+            function mount()
+            {
+                Storage::disk('tmp-for-tests')->deleteDirectory('photos');
+            }
+
+            function save()
+            {
+                $this->photo->storeAs('photos', 'photo.png');
+
+                // Break temporaryUrl
+                $this->photo = new TemporaryUploadedFile('', '');
+            }
+
+            function render() { return <<<'HTML'
+            <div>
+                <input type="file" wire:model="photo" dusk="upload">
+
+                <div wire:loading wire:target="photo">uploading...</div>
+
+                <button wire:click="$refresh">refresh</button>
+
+                <div>
+                    @if ($photo?->hasTemporaryUrl())
+                        <img src="{{ $photo->temporarySafeUrl() }}" dusk="preview">
+                    @else
+                        <p dusk="nopreview">Preview not available</p>
+                    @endif
+                </div>
+
+                <button wire:click="save" dusk="save">Save</button>
+            </div>
+            HTML; }
+        })
+            ->assertMissing('@preview')
+            ->attach('@upload', __DIR__ . '/browser_test_image.png')
+            ->pause(250)
+            ->assertVisible('@preview')
+            ->tap(function () {
+                Storage::disk('tmp-for-tests')->assertMissing('photos/photo.png');
+            })
+            ->waitForLivewire()
+            ->click('@save')
+            ->tap(function () {
+                Storage::disk('tmp-for-tests')->assertExists('photos/photo.png');
+            })
+            ->assertVisible('@nopreview')
+            ->assertMissing('@preview')
+        ;
+    }
+
+    /** @test */
+    public function can_safely_call_temporary_url()
+    {
+        Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photo;
+
+            function mount()
+            {
+                // Break temporaryUrl
+                $this->photo = new TemporaryUploadedFile('', '');
+            }
+
+            function render() { return <<<'HTML'
+            <div>
+                <p>Link: {{ $photo->temporarySafeUrl() ?? 'Not found' }}</p>
+            </div>
+            HTML; }
+        })
+            ->assertSee('Link: Not found');
+        ;
+    }
 }

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -7,6 +7,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Storage;
 use League\MimeTypeDetection\FinfoMimeTypeDetector;
+use Throwable;
 
 class TemporaryUploadedFile extends UploadedFile
 {
@@ -99,6 +100,20 @@ class TemporaryUploadedFile extends UploadedFile
         return URL::temporarySignedRoute(
             'livewire.preview-file', now()->addMinutes(30)->endOfHour(), ['filename' => $this->getFilename()]
         );
+    }
+
+    public function temporarySafeUrl()
+    {
+        try {
+            return $this->temporaryUrl();
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    public function hasTemporaryUrl()
+    {
+        return $this->temporarySafeUrl() !== null;
     }
 
     public function isPreviewable()

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -682,6 +682,74 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertEquals($first_url, $second_url);
     }
+
+    /** @test */
+    public function temporary_safe_url_returns_valid_temporary_url()
+    {
+        Storage::fake('avatars');
+
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->viewData('photo');
+
+        Carbon::setTestNow(Carbon::today()->setTime(10, 01, 00));
+
+        $expected_temporary_url = $photo->temporaryUrl();
+        $safe_temporary_url = $photo->temporarySafeUrl();
+
+        // Temporary safe url should always be equal to the temporary url when temporaryUrl does not throw exception
+        $this->assertEquals($expected_temporary_url, $safe_temporary_url);
+    }
+
+    /** @test */
+    public function temporary_safe_url_returns_null_instead_of_exception()
+    {
+        $temporary_upload_file = new TemporaryUploadedFile('', '');
+
+        // Temporary safe url should return null when driver is not supported
+        $this->assertEquals(null, $temporary_upload_file->temporarySafeUrl());
+
+        // Temporary url should throw an exception when driver is not supported
+        $this->expectException(\Exception::class);
+        $temporary_upload_file->temporaryUrl();
+    }
+
+    /** @test */
+    public function has_temporary_url_returns_true_when_exists()
+    {
+        Storage::fake('avatars');
+
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->viewData('photo');
+
+        Carbon::setTestNow(Carbon::today()->setTime(10, 01, 00));
+
+        $temporary_url = $photo->temporaryUrl();
+
+        // Temporary url is valid and returned correctly
+        $this->assertIsString($temporary_url);
+
+        // hasTemporaryUrl should return true since the temporary url exists
+        $this->assertTrue($photo->hasTemporaryUrl());
+    }
+
+    /** @test */
+    public function has_temporary_url_returns_false_when_does_not_exist()
+    {
+        $temporary_upload_file = new TemporaryUploadedFile('', '');
+
+        // Has temporary url should return false when driver is not supported
+        $this->assertFalse($temporary_upload_file->hasTemporaryUrl());
+
+        // Temporary url should throw an exception when driver is not supported
+        $this->expectException(\Exception::class);
+        $temporary_upload_file->temporaryUrl();
+    }
 }
 
 class DummyMiddleware


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
_Yes, there have been several discussion already:_

Explicit discussions: 

- https://github.com/livewire/livewire/discussions/5056

Other relevant discussions

- https://github.com/livewire/livewire/discussions/6578
- https://github.com/livewire/livewire/discussions/5618

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
_Yes_

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
_No, only the two new functions_

4️⃣ Does it include tests? (Required)
_Yes: Unit tests + Browser tests_

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌

### Problem and motivation

When using image uploads, livewire provides the ability of previewing the image. As stated in the documentation, this is the _"correct"_ way of doing it
```php
@if ($photo) 
        <img src="{{ $photo->temporaryUrl() }}">
 @endif
```

In the relevant discussions, you will find similar discussions on how other developers tried to avoid issues with temporaryUrl. However, this approach is **dangerous**

1. temporaryUrl() throws an exception. Since this function is mostly used in the front-end, it is very dangerous as it might throw an exception to the user.
2. Does not provide a way to catch the exception when in the front-end. One could either use a bunch of if-statements (ugly code) or add further if-statements in the backend to catch the error
3. The example on the documentation and in the relevant discussions is not safe. The example in the documentation can still fail if the `$photo` is a `TemporaryUploadFile` which does not support the temporaryUrl. 
4. In my case, the function threw an exception when the file was already uploaded. Although a bunch of if-statements can fix the issue, I believe **this PR will provide a cleaner way of handling such issues.**
5. This issue becomes worse when other image libraries are being used.

### Solution

The solution in this PR, **does not affect any pre-existing code**. It only adds two new functions. The PR consists of the following

1. temporarySafeUrl() function

- This catches the exception before thrown. If the temporaryUrl fails, the method will return null (additional configuration can be added to have a fallback string, but not included at this PR. If you agree, we can add it in another PR )

2. hasTemporaryUrl() function

- As already asked in a discussion (view above), some developers (including myself) would benefit from a hasTemporaryUrl function instead of adding a bunch of ugly if-statements to make sure that the dangerous code will not be executed. I kept it simple, to check only if temporarySafeUrl returns a valid string. 

### New possibilities after merging this PR

To begin with, the example in the documentation and anything similar, can be changed to the following:
```php
@if ($photo?->hasTemporaryUrl()) 
        <img src="{{ $photo->temporaryUrl() }}">
@endif
```

At the same time, one can use the following
```php
 <img src="{{ $photo?->temporarySafeUrl() }}">
```