### PR TITLE
A locked property prevents updates to similar named properties

### DIFF
--- a/src/Features/SupportLockedProperties/UnitTest.php
+++ b/src/Features/SupportLockedProperties/UnitTest.php
@@ -48,4 +48,21 @@ class UnitTest extends \Tests\TestCase
         ->assertSet('foo.count', 1)
         ->set('foo.count', 2);
     }
+
+    /** @test */
+    function can_update_locked_property_with_similar_name()
+    {
+        Livewire::test(new class extends Component {
+            #[BaseLocked]
+            public $count = 1;
+
+            public $count2 = 1;
+
+            public function render() {
+                return '<div></div>';
+            }
+        })
+        ->assertSet('count2', 1)
+        ->set('count2', 2);
+    }
 }


### PR DESCRIPTION
Failing test for: https://github.com/livewire/livewire/discussions/6917

```php
new class extends Component {
    #[BaseLocked]
    public $count = 1;

    public $count2 = 1;

    public function render() {
        return '<div></div>';
    }
}
```

When you try to set `$count2` it will fail and throw an exception:

```
Exception: Cannot update locked property: [count]
```

Might be a PHP bug?