### PR TITLE
Fix: A locked property prevents updates to properties that start with the same string

### DIFF
--- a/src/Features/SupportAttributes/SupportAttributes.php
+++ b/src/Features/SupportAttributes/SupportAttributes.php
@@ -51,7 +51,7 @@ class SupportAttributes extends ComponentHook
             ->whereInstanceOf(LivewireAttribute::class)
             ->filter(fn ($attr) => $attr->getLevel() === AttributeLevel::PROPERTY)
             // Call "update" on the root property attribute even if it's a deep update...
-            ->filter(fn ($attr) => str($fullPath)->startsWith($attr->getName()))
+            ->filter(fn ($attr) => str($fullPath)->is($attr->getName()))
             ->map(function ($attribute) use ($fullPath, $newValue) {
                 if (method_exists($attribute, 'update')) {
                     return $attribute->update($fullPath, $newValue);

--- a/src/Features/SupportAttributes/SupportAttributes.php
+++ b/src/Features/SupportAttributes/SupportAttributes.php
@@ -51,7 +51,7 @@ class SupportAttributes extends ComponentHook
             ->whereInstanceOf(LivewireAttribute::class)
             ->filter(fn ($attr) => $attr->getLevel() === AttributeLevel::PROPERTY)
             // Call "update" on the root property attribute even if it's a deep update...
-            ->filter(fn ($attr) => str($fullPath)->is($attr->getName()))
+            ->filter(fn ($attr) => ((str($fullPath)->startsWith($attr->getName() . ".")) || str($fullPath)->is($attr->getName())))
             ->map(function ($attribute) use ($fullPath, $newValue) {
                 if (method_exists($attribute, 'update')) {
                     return $attribute->update($fullPath, $newValue);

--- a/src/Features/SupportAttributes/SupportAttributes.php
+++ b/src/Features/SupportAttributes/SupportAttributes.php
@@ -51,7 +51,12 @@ class SupportAttributes extends ComponentHook
             ->whereInstanceOf(LivewireAttribute::class)
             ->filter(fn ($attr) => $attr->getLevel() === AttributeLevel::PROPERTY)
             // Call "update" on the root property attribute even if it's a deep update...
-            ->filter(fn ($attr) => ((str($fullPath)->startsWith($attr->getName() . ".")) || str($fullPath)->is($attr->getName())))
+            ->filter(function ($attr) use ($fullPath) {
+                $attributeRoot = (string) str($attr->getName())->before('.');
+                $updatePathRoot = (string) str($fullPath)->before('.');
+
+                return $attributeRoot === $updatePathRoot;
+            })
             ->map(function ($attribute) use ($fullPath, $newValue) {
                 if (method_exists($attribute, 'update')) {
                     return $attribute->update($fullPath, $newValue);

--- a/src/Features/SupportLockedProperties/UnitTest.php
+++ b/src/Features/SupportLockedProperties/UnitTest.php
@@ -48,4 +48,21 @@ class UnitTest extends \Tests\TestCase
         ->assertSet('foo.count', 1)
         ->set('foo.count', 2);
     }
+
+    /** @test */
+    function can_update_locked_property_with_similar_name()
+    {
+        Livewire::test(new class extends Component {
+            #[BaseLocked]
+            public $count = 1;
+
+            public $count2 = 1;
+
+            public function render() {
+                return '<div></div>';
+            }
+        })
+        ->assertSet('count2', 1)
+        ->set('count2', 2);
+    }
 }


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)
Failing tests are available in PR from another contributor:
[https://github.com/livewire/livewire/pull/6925](https://github.com/livewire/livewire/pull/6925)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌

---

This fix relates to the failing test available here:
[https://github.com/livewire/livewire/pull/6925](https://github.com/livewire/livewire/pull/6925)

Which relates to the discussion available here:
[https://github.com/livewire/livewire/discussions/6917](https://github.com/livewire/livewire/discussions/6917)

---

Presently, the behaviour of Attribute matching, matches based on "startsWith", however - this will match to other variables available on the component.

Example of issue:
```
#[Locked]
public $query = 'abcd';

public $query123 = 'abcdefg';
```
In this scenario, both $query123 and $query will be locked.  Any error returned will relate only to $query.

The present work-around for this, is to ensure entirely distinct names for each variable on a component, e.g.

```
#[Locked]
public $query = 'abcd';

public $notQuery = 'abcdefg';
```
This results in the expected behaviour of $query being locked, and $notQuery not being locked in the frontend.

The PR seeks to address this by using an "is" approach rather than startsWith to match against variables.

**Minimal testing has been performed!**