### PR TITLE
Fix typo

### DIFF
--- a/docs/wire-stream.md
+++ b/docs/wire-stream.md
@@ -86,7 +86,7 @@ class ChatBot extends Component
 
     function ask()
     {
-        $this->answer = ChatBot::ask($this->question, function ($partial) {
+        $this->answer = OpenAI::ask($this->question, function ($partial) {
             $this->stream(to: 'answer', content: $partial); // [tl! highlight]
         });
     }


### PR DESCRIPTION
The current code *might* loop because the external OpenAI API is called ChatBot and the Livewire class is also called that.

The external API "ask" function is called statically, so I am not sure if it would loop or simply throw an exception.

With this change, there is no confusion.

And OpenAI is referenced in this page so using a class with this name will simply further detail that it's an external system.
