### PR TITLE
Failing test for add and select `option` in `select`

### DIFF
--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -35,4 +35,43 @@ class BrowserTest extends BrowserTestCase
             ->assertDontSee('Unsaved changes...')
         ;
     }
+
+    /** @test */
+    function can_add_option_and_select()
+    {
+        Livewire::visit(new class extends Component {
+            public int $customer = 2;
+
+            public array $customers = [
+                ['id' => 1, 'name' => 'Foo'],
+                ['id' => 2, 'name' => 'Bar'],
+                ['id' => 3, 'name' => 'FooBar'],
+            ];
+
+            public function addAndSelect()
+            {
+                $this->customers[] = ['id' => 4, 'name' => 'BarFoo'];
+                $this->customer = 4;
+            }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <select dusk="customer" wire:model.live="customer">
+                            @foreach ($this->customers as $customer)
+                                <option value="{{ $customer['id'] }}" wire:key="{{ $customer['id'] }}">{{ $customer['name'] }}</option>
+                            @endforeach
+                        </select>
+                        <button dusk="addAndSelect" wire:click="addAndSelect">Button</button>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertSelected('@customer', '2')
+            ->waitForLivewire()->click('@addAndSelect')
+            ->assertSelectHasOption('@customer', '4')
+            ->assertSelected('@customer', '4')
+        ;
+    }
 }


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
#6505

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
`add-option-and-select`

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
✅ 

4️⃣ Does it include tests? (Required)
✅

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
A combination of adding items to `$customers` and setting `$customer` will cause a failure in updating the front-end variable (the `<select>` will be set to the first item instead of the newly added item).

It works without adding the item to `$customers` and setting `$customer` to `3` though.

Thanks for contributing! 🙌
