### PR TITLE
Allow download of preview files directly from storage

### DIFF
--- a/src/Drawer/Utils.php
+++ b/src/Drawer/Utils.php
@@ -4,6 +4,7 @@ namespace Livewire\Drawer;
 
 use Livewire\Exceptions\RootTagMissingFromViewException;
 
+use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
 use function Livewire\invade;
 
 class Utils extends BaseUtils
@@ -51,8 +52,25 @@ class Utils extends BaseUtils
 
     static function pretendResponseIsFile($file, $mimeType = 'application/javascript')
     {
-        $expires = strtotime('+1 year');
         $lastModified = filemtime($file);
+        $headers = static::pretendedResponseIsFileHeaders($file, $mimeType, $lastModified);
+        return response()->file($file, $headers);
+    }
+
+    static function pretendPreviewResponseIsPreviewFile($filename)
+    {
+        $file = FileUploadConfiguration::path($filename);
+        $storage = FileUploadConfiguration::storage();
+        $mimeType = FileUploadConfiguration::mimeType($filename);
+        $lastModified = FileUploadConfiguration::lastModified($file);
+
+        $headers = self::pretendedResponseIsFileHeaders($filename, $mimeType, $lastModified);
+        return $storage->download($file, $filename, $headers);
+    }
+
+    static private function pretendedResponseIsFileHeaders($filename, $mimeType, $lastModified)
+    {
+        $expires = strtotime('+1 year');
         $cacheControl = 'public, max-age=31536000';
 
         if (static::matchesCache($lastModified)) {
@@ -69,11 +87,11 @@ class Utils extends BaseUtils
             'Last-Modified' => static::httpDate($lastModified),
         ];
 
-        if (str($file)->endsWith('.br')) {
+        if (str($filename)->endsWith('.br')) {
             $headers['Content-Encoding'] = 'br';
         }
 
-        return response()->file($file, $headers);
+        return $headers;
     }
 
     static function matchesCache($lastModified)

--- a/src/Features/SupportFileUploads/FilePreviewController.php
+++ b/src/Features/SupportFileUploads/FilePreviewController.php
@@ -10,10 +10,7 @@ class FilePreviewController
     {
         abort_unless(request()->hasValidSignature(), 401);
 
-        return Utils::pretendResponseIsFile(
-            FileUploadConfiguration::storage()->path(FileUploadConfiguration::path($filename)),
-            FileUploadConfiguration::mimeType($filename)
-        );
+        return Utils::pretendPreviewResponseIsPreviewFile($filename);
     }
 }
 

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -91,6 +91,11 @@ class FileUploadConfiguration
         return $mimeType === 'image/svg' ? 'image/svg+xml' : $mimeType;
     }
 
+    public static function lastModified($filename)
+    {
+        return static::storage()->lastModified($filename);
+    }
+
     public static function middleware()
     {
         return config('livewire.temporary_file_upload.middleware') ?: 'throttle:60,1';

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportFileUploads;
 
 use Carbon\Carbon;
+use Illuminate\Filesystem\FilesystemAdapter;
 use Livewire\WithFileUploads;
 use Livewire\Livewire;
 use Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButtonCache;
@@ -442,6 +443,36 @@ class UnitTest extends \Tests\TestCase
     public function can_preview_a_temporary_file_with_a_temporary_signed_url()
     {
         Storage::fake('avatars');
+
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->viewData('photo');
+
+        // Due to Livewire object still being in memory, we need to
+        // reset the "shouldDisableBackButtonCache" property back to it's default
+        // which is false to ensure it's not applied to the below route
+        \Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+
+        ob_start();
+        $this->get($photo->temporaryUrl())->sendContent();
+        $rawFileContents = ob_get_clean();
+
+        $this->assertEquals($file->get(), $rawFileContents);
+
+        $this->assertTrue($photo->isPreviewable());
+    }
+
+    /** @test */
+    public function can_preview_a_temporary_file_on_a_remote_storage()
+    {
+        $disk = Storage::fake('tmp-for-tests');
+
+        // A remote storage will always return the short path when calling $disk->path(). To simulate a remote
+        // storage, the fake storage will be recreated with an empty prefix option in order to get the short path even
+        // if it's a local filesystem.
+        Storage::set('tmp-for-tests', new FilesystemAdapter($disk->getDriver(), $disk->getAdapter(), ['prefix' => '']));
 
         $file = UploadedFile::fake()->image('avatar.jpg');
 


### PR DESCRIPTION
Currently preview file download relies on the file being stored on a local disk.

This commit introduces a new function that fetches the file and metadata directly from storage to enable non-local filesystems.
