### PR TITLE
Add attributes warning to events page

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -34,6 +34,9 @@ $this->dispatch('post-created', title: $post->title);
 
 To listen for an event in a Livewire component, add the `#[On]` attribute above the method you want to be called when a given event is dispatched:
 
+> [!warning] Make sure you import attribute classes
+> Make sure you import any attribute classes. For example, the below `#[On()]` attributes requires the following import `use Livewire\Attributes\On;`.
+
 ```php
 use Livewire\Component;
 use Livewire\Attributes\On; // [tl! highlight]


### PR DESCRIPTION
There is a lot of confusion with the new PHP 8 attributes, especially with events, as applications that are missing the import statements just don't work. There is no warning or error thrown by PHP nor is it detected by IDEs as being invalid.

So I've added a basic warning to the first instance of an attribute on the events page. This could probably be added to a few of the other pages that use attributes too.

Here's a link from Hiighsky on discord with some details about attributes as to why it might not be throwing errors without the imports https://php.watch/articles/php-attributes#syntax-class-names