### PR TITLE
Fix missing semicolon inside `messages()` method in `validation.md`

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -376,7 +376,7 @@ class CreatePost extends Component
         return [
             'content.required' => 'The :attribute are missing.',
             'content.min' => 'The :attribute is too short.',
-        ]
+        ];
     }
     
     public function validationAttributes() // [tl! highlight:6]


### PR DESCRIPTION
Just adding the missing semicolon to the return array in the `messages()` method example, in case someone is copying and pasting like me. :sweat_smile:
