### PR TITLE
Fix eloquent models and collections

### DIFF
--- a/docs/properties.md
+++ b/docs/properties.md
@@ -195,6 +195,11 @@ Supported PHP types:
 | Carbon | `Carbon\Carbon` |
 | Stringable | `Illuminate\Support\Stringable` |
 
+> [!warning] Eloquent Collections and Models
+> When storing Eloquent Collections and Models in Livewire properties, additional query constraints like select(...) will not be re-applied on subsequent requests.
+>
+> See [Eloquent constraints aren't preserved between requests](#eloquent-constraints-arent-preserved-between-requests) for more details
+
 Here's a quick example of setting properties as these various types:
 
 ```php

--- a/src/Features/SupportModels/BrowserTest.php
+++ b/src/Features/SupportModels/BrowserTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Livewire\Features\SupportModels;
+
+use Illuminate\Database\Eloquent\Model;
+use Livewire\Component;
+use Livewire\Features\SupportEvents\BaseOn;
+use Livewire\Livewire;
+use Sushi\Sushi;
+
+class BrowserTest extends \Tests\BrowserTestCase
+{
+    /** @test */
+    public function parent_component_with_eloquent_collection_property_does_not_error_when_child_deletes_a_model_contained_within_it()
+    {
+        // Ensure sushi has all models each time
+        Post::firstOrCreate(['id' => 1, 'title' => 'Post #1']);
+        Post::firstOrCreate(['id' => 2, 'title' => 'Post #2']);
+        Post::firstOrCreate(['id' => 3, 'title' => 'Post #3']);
+
+        Livewire::visit([
+            new class extends Component {
+                public $posts;
+
+                public function mount()
+                {
+                    $this->posts = Post::all();
+                }
+
+                #[BaseOn('postDeleted')]
+                public function setPosts() {
+                    $this->posts = Post::all();
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        @foreach($posts as $post)
+                            <div wire:key="parent-post-{{ $post->id }}">
+                                <livewire:child wire:key="{{ $post->id }}" :post="$post" />
+                            </div>
+                        @endforeach
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public $post;
+
+                public function delete($id)
+                {
+                    Post::find($id)->delete();
+                    $this->dispatch('postDeleted');
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div dusk="post-{{ $post->id }}">
+                        {{ $post->title }}
+
+                        <button dusk="delete-{{ $post->id }}" wire:click="delete({{ $post->id }})">Delete</button>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->waitForLivewireToLoad()
+            ->assertPresent('@post-1')
+            ->assertSeeIn('@post-1', 'Post #1')
+            ->waitForLivewire()->click('@delete-1')
+            ->assertNotPresent('@parent-post-1')
+            ;
+    }
+}
+
+class Post extends Model
+{
+    use Sushi;
+
+    protected $guarded = [];
+
+    protected $rows = [
+        ['id' => 1, 'title' => 'Post #1'],
+        ['id' => 2, 'title' => 'Post #2'],
+        ['id' => 3, 'title' => 'Post #3'],
+    ];
+}

--- a/src/Features/SupportModels/BrowserTest.php
+++ b/src/Features/SupportModels/BrowserTest.php
@@ -14,9 +14,9 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function parent_component_with_eloquent_collection_property_does_not_error_when_child_deletes_a_model_contained_within_it()
     {
         // Ensure sushi has all models each time
-        Post::firstOrCreate(['id' => 1, 'title' => 'Post #1']);
-        Post::firstOrCreate(['id' => 2, 'title' => 'Post #2']);
-        Post::firstOrCreate(['id' => 3, 'title' => 'Post #3']);
+        Post::firstOrCreate(['id' => 1], ['title' => 'Post #1']);
+        Post::firstOrCreate(['id' => 2], ['title' => 'Post #2']);
+        Post::firstOrCreate(['id' => 3], ['title' => 'Post #3']);
 
         Livewire::visit([
             new class extends Component {

--- a/src/Features/SupportModels/BrowserTest.php
+++ b/src/Features/SupportModels/BrowserTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportModels;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Component;
 use Livewire\Features\SupportEvents\BaseOn;
 use Livewire\Livewire;
@@ -10,14 +11,11 @@ use Sushi\Sushi;
 
 class BrowserTest extends \Tests\BrowserTestCase
 {
+    use RefreshDatabase;
+
     /** @test */
     public function parent_component_with_eloquent_collection_property_does_not_error_when_child_deletes_a_model_contained_within_it()
     {
-        // Ensure sushi has all models each time
-        Post::firstOrCreate(['id' => 1], ['title' => 'Post #1']);
-        Post::firstOrCreate(['id' => 2], ['title' => 'Post #2']);
-        Post::firstOrCreate(['id' => 3], ['title' => 'Post #3']);
-
         Livewire::visit([
             new class extends Component {
                 public $posts;
@@ -81,9 +79,11 @@ class Post extends Model
 
     protected $guarded = [];
 
-    protected $rows = [
-        ['id' => 1, 'title' => 'Post #1'],
-        ['id' => 2, 'title' => 'Post #2'],
-        ['id' => 3, 'title' => 'Post #3'],
-    ];
+    public function getRows() {
+        return [
+            ['id' => 1, 'title' => 'Post #1'],
+            ['id' => 2, 'title' => 'Post #2'],
+            ['id' => 3, 'title' => 'Post #3'],
+        ];
+    }
 }

--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -64,6 +64,9 @@ class EloquentCollectionSynth extends Synth {
             return new $class();
         }
 
+        // We are using Laravel's method here for restoring the collection, which ensures
+        // that all models in the collection are restored in one query, preventing n+1
+        // issues and also only restores models that exist.
         $collection = (new $modelClass)->newQueryForRestoration($keys)->useWritePdo()->get();
 
         return $collection;

--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Livewire\Features\SupportModels;
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+
+class EloquentCollectionSynth extends Synth {
+    use SerializesAndRestoresModelIdentifiers;
+
+    public static $key = 'elcln';
+
+    static function match($target)
+    {
+        return $target instanceof EloquentCollection;
+    }
+
+    function dehydrate(EloquentCollection $target, $dehydrateChild)
+    {
+        $class = $target::class;
+        $modelClass = $target->getQueueableClass();
+
+        /**
+         * `getQueueableClass` above checks all models are the same and
+         * then returns the class. We then instantiate a model object
+         * so we can call `getMorphClass()` on it.
+         *
+         * If no alias is found, this just returns the class name
+         */
+        $modelAlias = (new $modelClass)->getMorphClass();
+
+        $meta = [];
+
+        $serializedCollection = (array) $this->getSerializedPropertyValue($target);
+
+        $meta['keys'] = $serializedCollection['id'];
+        $meta['class'] = $class;
+        $meta['modelClass'] = $modelAlias;
+
+        return [
+            null,
+            $meta
+        ];
+    }
+
+    function hydrate($data, $meta, $hydrateChild)
+    {
+        $class = $meta['class'];
+
+        $modelClass = $meta['modelClass'];
+
+        // If no alias found, this returns `null`
+        $modelAlias = Relation::getMorphedModel($modelClass);
+
+        if (! is_null($modelAlias)) {
+            $modelClass = $modelAlias;
+        }
+
+        $keys = $meta['keys'] ?? [];
+
+        if (count($keys) === 0) {
+            return new $class();
+        }
+
+        $collection = (new $modelClass)->newQueryForRestoration($keys)->useWritePdo()->get();
+
+        return $collection;
+    }
+
+    function get(&$target, $key) {
+        throw new \Exception('Can\'t access model properties directly');
+    }
+
+    function set(&$target, $key, $value, $pathThusFar, $fullPath) {
+        throw new \Exception('Can\'t set model properties directly');
+    }
+
+    function call($target, $method, $params, $addEffect) {
+        throw new \Exception('Can\'t call model methods directly');
+    }
+}

--- a/src/Features/SupportModels/ModelSynth.php
+++ b/src/Features/SupportModels/ModelSynth.php
@@ -24,14 +24,14 @@ class ModelSynth extends Synth {
             ? (array) $this->getSerializedPropertyValue($target)
             : null;
 
-        $data = ['class' => $alias];
+        $meta = ['class' => $alias];
 
-        if ($serializedModel) $data['key'] = $serializedModel['id'];
+        if ($serializedModel) $meta['key'] = $serializedModel['id'];
         
 
         return [
             null,
-            $data,
+            $meta,
         ];
     }
 

--- a/src/Features/SupportModels/ModelSynth.php
+++ b/src/Features/SupportModels/ModelSynth.php
@@ -26,6 +26,8 @@ class ModelSynth extends Synth {
 
         $meta = ['class' => $alias];
 
+        // If the model doesn't exist as it's an empty model or has been
+        // recently deleted, then we don't want to include any key.
         if ($serializedModel) $meta['key'] = $serializedModel['id'];
         
 
@@ -45,6 +47,7 @@ class ModelSynth extends Synth {
             $class = $aliasClass;
         }
 
+        // If no key is provided then an empty model is returned
         if (! array_key_exists('key', $meta)) {
             return new $class;
         }

--- a/src/Features/SupportModels/SupportModels.php
+++ b/src/Features/SupportModels/SupportModels.php
@@ -10,6 +10,7 @@ class SupportModels extends ComponentHook
     {
         app('livewire')->propertySynthesizer([
             ModelSynth::class,
+            EloquentCollectionSynth::class,
         ]);
     }
 }

--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -71,6 +71,29 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    public function unpersisted_models_can_be_assigned_but_no_data_is_persisted_between_requests()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public Post $post;
+
+            public function mount() {
+                $this->post = new Post();
+            }
+
+            public function render() { return <<<'HTML'
+                <div>{{ $post->title }}</div>
+            HTML; }
+        })
+        ->call('$refresh')
+        ->assertSet('post', new Post())
+        ;
+        
+        $data = $component->getData();
+
+        $this->assertNull($data['post']);
+    }
+
+    /** @test */
     public function model_properties_are_lazy_loaded()
     {
         $this->markTestSkipped(); // @todo: probably not going to go this route...

--- a/src/Features/SupportNestingComponents/BrowserTest.php
+++ b/src/Features/SupportNestingComponents/BrowserTest.php
@@ -2,12 +2,9 @@
 
 namespace Livewire\Features\SupportNestingComponents;
 
-use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
-use Livewire\Features\SupportEvents\BaseOn;
 use Livewire\Livewire;
-use Sushi\Sushi;
 
 class BrowserTest extends \Tests\BrowserTestCase
 {
@@ -184,70 +181,6 @@ class BrowserTest extends \Tests\BrowserTestCase
     }
 
     /** @test */
-    public function nested_components_do_not_error_when_child_deleted_with_state()
-    {
-        // Ensure sushi has all models each time
-        Post::firstOrCreate(['id' => 1, 'title' => 'Post #1']);
-        Post::firstOrCreate(['id' => 2, 'title' => 'Post #2']);
-        Post::firstOrCreate(['id' => 3, 'title' => 'Post #3']);
-
-        Livewire::visit([
-            new class extends Component {
-                public $posts;
-
-                public function mount()
-                {
-                    $this->posts = Post::all();
-                }
-
-                #[BaseOn('postDeleted')]
-                public function setPosts() {
-                    $this->posts = Post::all();
-                }
-
-                public function render()
-                {
-                    return <<<'HTML'
-                    <div>
-                        @foreach($posts as $post)
-                            <div wire:key="parent-post-{{ $post->id }}">
-                                <livewire:child wire:key="{{ $post->id }}" :post="$post" />
-                            </div>
-                        @endforeach
-                    </div>
-                    HTML;
-                }
-            },
-            'child' => new class extends Component {
-                public $post;
-
-                public function delete($id)
-                {
-                    Post::find($id)->delete();
-                    $this->dispatch('postDeleted');
-                }
-
-                public function render()
-                {
-                    return <<<'HTML'
-                    <div dusk="post-{{ $post->id }}">
-                        {{ $post->title }}
-
-                        <button dusk="delete-{{ $post->id }}" wire:click="delete({{ $post->id }})">Delete</button>
-                    </div>
-                    HTML;
-                }
-            },
-        ])
-            ->waitForLivewireToLoad()
-            ->assertPresent('@post-1')
-            ->assertSeeIn('@post-1', 'Post #1')
-            ->waitForLivewire()->click('@delete-1')
-            ->assertNotPresent('@parent-post-1')
-            ;
-    }
-
-    /** @test */
     public function lazy_nested_components_do_not_call_boot_method_twice()
     {
         Livewire::visit([
@@ -383,17 +316,4 @@ class NestedBootComponent extends Component
     {
         return '<div>Boot count: {{ $bootCount }}</div>';
     }
-}
-
-class Post extends Model
-{
-    use Sushi;
-
-    protected $guarded = [];
-
-    protected $rows = [
-        ['id' => 1, 'title' => 'Post #1'],
-        ['id' => 2, 'title' => 'Post #2'],
-        ['id' => 3, 'title' => 'Post #3'],
-    ];
 }


### PR DESCRIPTION
This PR fixes issues with Eloquent Models and Collections when are assigned to public properties and then are deleted, throwing 404s and causing n+1 problems. See #6120, #6297, #6302, #6457, #6511, #6792, #6964.

As per a discussion with Caleb, we have decided to:
- Allow empty models to be assigned (gets rid of `Can't set model as property if it hasn't been persisted yet` error)
- If a model has been assigned to a property and then it has been deleted, then we just assign an empty model of the same class to the property (this stops a 404 issue) - we decided this was better than setting to `null`
- Add an Eloquent Collection synth that ensures Eloquent Collections are correctly rehydrated using a `whereIn()` query (this also stops a different 404 issue and also ensures that restoring collections don't cause an n+1 problem) 

I've merged the test from PR #6858 into this PR, so will close that one and #6272.

Hope this helps!

Edit: I have also added a warning box to the properties page regarding custom queries and Eloquent Collection and Model properties, under where Eloquent Collections and Models are listed for the first time, and added a link to the section at the bottom of the page which explains in more detail.

**I wonder if we should also mention in that warning box that any data stored on the Model/Collection that hasn't been persisted won't be preserved between requests?**

<img width="876" alt="image" src="https://github.com/livewire/livewire/assets/882837/6f3b84b1-60bf-44da-938a-67cd1a2c23e6">
