### PR TITLE
Fix EloquentCollectionSynth with empty collection

### DIFF
--- a/src/Features/SupportModels/BrowserTest.php
+++ b/src/Features/SupportModels/BrowserTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportModels;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Component;
@@ -17,7 +18,8 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function parent_component_with_eloquent_collection_property_does_not_error_when_child_deletes_a_model_contained_within_it()
     {
         Livewire::visit([
-            new class extends Component {
+            new class extends Component
+            {
                 public $posts;
 
                 public function mount()
@@ -26,7 +28,8 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
 
                 #[BaseOn('postDeleted')]
-                public function setPosts() {
+                public function setPosts()
+                {
                     $this->posts = Post::all();
                 }
 
@@ -43,7 +46,8 @@ class BrowserTest extends \Tests\BrowserTestCase
                     HTML;
                 }
             },
-            'child' => new class extends Component {
+            'child' => new class extends Component
+            {
                 public $post;
 
                 public function delete($id)
@@ -68,8 +72,41 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertPresent('@post-1')
             ->assertSeeIn('@post-1', 'Post #1')
             ->waitForLivewire()->click('@delete-1')
-            ->assertNotPresent('@parent-post-1')
-            ;
+            ->assertNotPresent('@parent-post-1');
+    }
+
+    /** @test */
+    public function empty_eloquent_collection_property_is_dehydrated_without_errors()
+    {
+        Livewire::visit([
+            new class extends Component
+            {
+                public $posts;
+
+                public function mount()
+                {
+                    $this->posts = new Collection();
+                }
+
+                function refresh()
+                {
+                    // 
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <div dusk="refresh" wire:click="refresh">Foo</div>
+                    </div>
+                    HTML;
+                }
+            },
+
+        ])
+            ->waitForLivewireToLoad()
+            ->waitForLivewire()->click('@refresh')
+            ->assertSeeIn('@refresh', 'Foo');
     }
 }
 
@@ -79,7 +116,8 @@ class Post extends Model
 
     protected $guarded = [];
 
-    public function getRows() {
+    public function getRows()
+    {
         return [
             ['id' => 1, 'title' => 'Post #1'],
             ['id' => 2, 'title' => 'Post #2'],

--- a/src/Features/SupportModels/BrowserTest.php
+++ b/src/Features/SupportModels/BrowserTest.php
@@ -18,8 +18,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function parent_component_with_eloquent_collection_property_does_not_error_when_child_deletes_a_model_contained_within_it()
     {
         Livewire::visit([
-            new class extends Component
-            {
+            new class extends Component {
                 public $posts;
 
                 public function mount()
@@ -28,8 +27,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
 
                 #[BaseOn('postDeleted')]
-                public function setPosts()
-                {
+                public function setPosts() {
                     $this->posts = Post::all();
                 }
 
@@ -46,8 +44,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                     HTML;
                 }
             },
-            'child' => new class extends Component
-            {
+            'child' => new class extends Component {
                 public $post;
 
                 public function delete($id)
@@ -72,7 +69,8 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertPresent('@post-1')
             ->assertSeeIn('@post-1', 'Post #1')
             ->waitForLivewire()->click('@delete-1')
-            ->assertNotPresent('@parent-post-1');
+            ->assertNotPresent('@parent-post-1')
+            ;
     }
 
     /** @test */
@@ -97,7 +95,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 {
                     return <<<'HTML'
                     <div>
-                        <div dusk="refresh" wire:click="refresh">Foo</div>
+                        <button dusk="refresh" wire:click="refresh">Foo</button>
                     </div>
                     HTML;
                 }
@@ -116,8 +114,7 @@ class Post extends Model
 
     protected $guarded = [];
 
-    public function getRows()
-    {
+    public function getRows() {
         return [
             ['id' => 1, 'title' => 'Post #1'],
             ['id' => 2, 'title' => 'Post #2'],

--- a/src/Features/SupportModels/BrowserTest.php
+++ b/src/Features/SupportModels/BrowserTest.php
@@ -81,9 +81,14 @@ class BrowserTest extends \Tests\BrowserTestCase
             {
                 public $posts;
 
+                public Collection $typedPostsNotInitialized;
+
+                public Collection $typedPostsInitialized;
+
                 public function mount()
                 {
                     $this->posts = new Collection();
+                    $this->typedPostsInitialized = new Collection();
                 }
 
                 function refresh()
@@ -95,7 +100,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 {
                     return <<<'HTML'
                     <div>
-                        <button dusk="refresh" wire:click="refresh">Foo</button>
+                        <button dusk="refresh" wire:click="refresh">Placeholder</button>
                     </div>
                     HTML;
                 }
@@ -104,7 +109,7 @@ class BrowserTest extends \Tests\BrowserTestCase
         ])
             ->waitForLivewireToLoad()
             ->waitForLivewire()->click('@refresh')
-            ->assertSeeIn('@refresh', 'Foo');
+            ->assertSeeIn('@refresh', 'Placeholder');
     }
 }
 

--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -7,7 +7,8 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 
-class EloquentCollectionSynth extends Synth {
+class EloquentCollectionSynth extends Synth
+{
     use SerializesAndRestoresModelIdentifiers;
 
     public static $key = 'elcln';
@@ -29,7 +30,7 @@ class EloquentCollectionSynth extends Synth {
          *
          * If no alias is found, this just returns the class name
          */
-        $modelAlias = (new $modelClass)->getMorphClass();
+        $modelAlias = $modelClass ? (new $modelClass)->getMorphClass() : null;
 
         $meta = [];
 
@@ -54,7 +55,7 @@ class EloquentCollectionSynth extends Synth {
         // If no alias found, this returns `null`
         $modelAlias = Relation::getMorphedModel($modelClass);
 
-        if (! is_null($modelAlias)) {
+        if (!is_null($modelAlias)) {
             $modelClass = $modelAlias;
         }
 
@@ -72,15 +73,18 @@ class EloquentCollectionSynth extends Synth {
         return $collection;
     }
 
-    function get(&$target, $key) {
+    function get(&$target, $key)
+    {
         throw new \Exception('Can\'t access model properties directly');
     }
 
-    function set(&$target, $key, $value, $pathThusFar, $fullPath) {
+    function set(&$target, $key, $value, $pathThusFar, $fullPath)
+    {
         throw new \Exception('Can\'t set model properties directly');
     }
 
-    function call($target, $method, $params, $addEffect) {
+    function call($target, $method, $params, $addEffect)
+    {
         throw new \Exception('Can\'t call model methods directly');
     }
 }

--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -7,8 +7,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 
-class EloquentCollectionSynth extends Synth
-{
+class EloquentCollectionSynth extends Synth {
     use SerializesAndRestoresModelIdentifiers;
 
     public static $key = 'elcln';
@@ -55,7 +54,7 @@ class EloquentCollectionSynth extends Synth
         // If no alias found, this returns `null`
         $modelAlias = Relation::getMorphedModel($modelClass);
 
-        if (!is_null($modelAlias)) {
+        if (! is_null($modelAlias)) {
             $modelClass = $modelAlias;
         }
 
@@ -73,18 +72,15 @@ class EloquentCollectionSynth extends Synth
         return $collection;
     }
 
-    function get(&$target, $key)
-    {
+    function get(&$target, $key) {
         throw new \Exception('Can\'t access model properties directly');
     }
 
-    function set(&$target, $key, $value, $pathThusFar, $fullPath)
-    {
+    function set(&$target, $key, $value, $pathThusFar, $fullPath) {
         throw new \Exception('Can\'t set model properties directly');
     }
 
-    function call($target, $method, $params, $addEffect)
-    {
+    function call($target, $method, $params, $addEffect) {
         throw new \Exception('Can\'t call model methods directly');
     }
 }


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

This bug was introduced in #7003. 
A component with an empty eloquent collection public property can't be dehydrated  because `$target->getQueueableClass()` return null and then can't be instantiated.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

The MR prevent the error to be thrown.

Thanks for contributing! 🙌
