### PR TITLE
Update GitHub actions/checkout to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Update actions/checkout to v4
https://github.com/actions/checkout/releases/tag/v4.0.0
