### PR TITLE
Add failing test for `x-for` after back with `wire:navigate`

### DIFF
--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -195,6 +195,44 @@ class BrowserTest extends \Tests\BrowserTestCase
     }
 
     /** @test */
+    public function back_button_works_with_x_for()
+    {
+        $this->registerComponentTestRoutes([
+            '/second' => new class extends Component {
+                public function render(){ return <<<'HTML'
+                    <div>
+                        On second page
+                    </div>
+                HTML; }
+            },
+        ]);
+
+        $browser = Livewire::visit(new class extends Component {
+            public function render(){
+                return <<<'HTML'
+                    <div x-data="{ items: ['item 1', 'item 2', 'item 3'] }">
+                        <div dusk="target">
+                            <template x-for="item in items" :key="item">
+                                <div class='item' x-text="item"></div>
+                            </template>
+                        </div>
+
+                        <a href="/second" wire:navigate dusk="link">Go to second page</a>
+                    </div>
+                HTML;
+            }
+        })->assertSeeIn('@target', 'item 1')
+            ->tap(fn(Browser $browser) => $this->assertCount(3, $browser->elements('.item')))
+            ->click('@link')
+            ->waitForText('On second page')
+            ->back()
+            ->assertDontSee('On second page')
+            ->assertSeeIn('@target', 'item 1')
+            ->tap(fn(Browser $browser) => $this->assertCount(3, $browser->elements('.item')))
+        ;
+    }
+
+    /** @test */
     public function can_configure_progress_bar()
     {
         $this->browse(function ($browser) {


### PR DESCRIPTION
This PR adds a failing test for `x-for` after the back button is used with `wire:navigate`.

Given the following code:
```blade
<div x-data="{ items: ['item 1', 'item 2', 'item 3'] }">
    <template x-for="item in items" :key="item">
        <div class='item' x-text="item"></div>
    </template>

    <a href="/second" wire:navigate dusk="link">Go to second page</a>
</div>
```

After navigating to the second page and returning back by using the browsers "back" button. There are six `.item` divs in the DOM and there are three warnings and three errors in the console.

![Screenshot 2023-10-10 at 15 01 27](https://github.com/livewire/livewire/assets/25097194/e14facc6-d031-4c4a-a838-17fd5e57fd39)

