### PR TITLE
fix: Stream cuts chunked JSON objects in half

### DIFF
--- a/dist/livewire.esm.js
+++ b/dist/livewire.esm.js
@@ -8344,18 +8344,18 @@ on("request", ({ respond }) => {
 });
 async function interceptStreamAndReturnFinalResponse(response, callback) {
   let reader = response.body.getReader();
-  let finalResponse = "";
+  let remainingResponse = "";
   while (true) {
     let { done, value: chunk } = await reader.read();
     let decoder = new TextDecoder();
     let output = decoder.decode(chunk);
-    let [streams, remaining] = extractStreamObjects(output);
+    let [streams, remaining] = extractStreamObjects(remainingResponse + output);
     streams.forEach((stream) => {
       callback(stream);
     });
-    finalResponse = finalResponse + remaining;
+    remainingResponse = remaining;
     if (done)
-      return finalResponse;
+      return remainingResponse;
   }
 }
 function extractStreamObjects(raw) {

--- a/dist/livewire.js
+++ b/dist/livewire.js
@@ -7503,18 +7503,18 @@ ${expression ? 'Expression: "' + expression + '"\n\n' : ""}`, el);
   });
   async function interceptStreamAndReturnFinalResponse(response, callback) {
     let reader = response.body.getReader();
-    let finalResponse = "";
+    let remainingResponse = "";
     while (true) {
       let { done, value: chunk } = await reader.read();
       let decoder = new TextDecoder();
       let output = decoder.decode(chunk);
-      let [streams, remaining] = extractStreamObjects(output);
+      let [streams, remaining] = extractStreamObjects(remainingResponse + output);
       streams.forEach((stream) => {
         callback(stream);
       });
-      finalResponse = finalResponse + remaining;
+      remainingResponse = remaining;
       if (done)
-        return finalResponse;
+        return remainingResponse;
     }
   }
   function extractStreamObjects(raw2) {

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,2 +1,2 @@
 
-{"/livewire.js":"5d3e67e0"}
+{"/livewire.js":"0dbf3a79"}

--- a/js/directives/wire-stream.js
+++ b/js/directives/wire-stream.js
@@ -46,7 +46,7 @@ on('request', ({ respond }) => {
 
 async function interceptStreamAndReturnFinalResponse(response, callback) {
     let reader = response.body.getReader()
-    let finalResponse = ''
+    let remainingResponse = ''
 
     while (true) {
         let { done, value: chunk } = await reader.read()
@@ -54,15 +54,15 @@ async function interceptStreamAndReturnFinalResponse(response, callback) {
         let decoder = new TextDecoder
         let output = decoder.decode(chunk)
 
-        let [ streams, remaining ] = extractStreamObjects(output)
+        let [ streams, remaining ] = extractStreamObjects(remainingResponse + output)
 
         streams.forEach(stream => {
             callback(stream)
         })
 
-        finalResponse = finalResponse + remaining
+        remainingResponse = remaining
 
-        if (done) return finalResponse
+        if (done) return remainingResponse
     }
 }
 


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

No

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

No streaming tests at all yet, I don't have the time to dedicate to creating those yet

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Sometimes, `reader.read()` returns an incomplete JSON object - half of it is stuck in the next chunk of the response. Incomplete JSON objects cannot be identified as stream chunks, and therefore do not get extracted, and end up in the `finalResponse`. When they remain in the `finalResponse`, they corrupt the JSON structure of the real final response when it gets parsed. These need to be removed from the final response at all costs otherwise the streamed request cannot complete.

This PR changes the logic, so instead of discarding incomplete JSON chunks as "finalResponse", it appends them onto the start of the next response. This allows Livewire to reattempt parsing them as a complete chunk, meaning that they don't end up in the final response when it is parsed.

Thanks for contributing! 🙌
