### PR TITLE
[3.x] Adds `rendering` to Volt's documentation

### DIFF
--- a/docs/volt.md
+++ b/docs/volt.md
@@ -170,7 +170,6 @@ class extends Component
     // ...
 ```
 
-
 ## Rendering and mounting components
 
 Just like a typical Livewire component, Volt components may be rendered using Livewire's tag syntax or the `@livewire` Blade directive:

--- a/docs/volt.md
+++ b/docs/volt.md
@@ -146,6 +146,31 @@ new class extends Component {
 </div>
 ```
 
+### View Instance
+
+Sometimes, you may wish to interact with the view instance directly, for example, to set the view's title using a translated string. To achieve this, you may use the `rendering` method:
+
+```blade
+<?php
+
+use Illuminate\View\View;
+use Livewire\Volt\Component;
+
+class extends Component
+{
+    public function rendering(View $view): View
+    {
+        $view->title('Create Post');
+
+        // ...
+
+        return $view;
+    }
+
+    // ...
+```
+
+
 ## Rendering and mounting components
 
 Just like a typical Livewire component, Volt components may be rendered using Livewire's tag syntax or the `@livewire` Blade directive:

--- a/docs/volt.md
+++ b/docs/volt.md
@@ -119,7 +119,7 @@ class extends Component
     // ...
 ```
 
-#### Adding additional view data
+#### Providing additional view data
 
 When using class-based Volt components, the rendered view is the template present in the same file. If you need to pass additional data to the view each time it is rendered, you may use the `with` method. This data will be passed to the view in addition to the component's public properties:
 

--- a/docs/volt.md
+++ b/docs/volt.md
@@ -119,9 +119,9 @@ class extends Component
     // ...
 ```
 
-#### View Data
+#### Adding additional view data
 
-When using class-based Volt components, the rendered view is the template present in the same file. If you need to pass additional data to the view each time it is rendered, you may use the `with` method:
+When using class-based Volt components, the rendered view is the template present in the same file. If you need to pass additional data to the view each time it is rendered, you may use the `with` method. This data will be passed to the view in addition to the component's public properties:
 
 ```blade
 <?php
@@ -146,9 +146,9 @@ new class extends Component {
 </div>
 ```
 
-### View Instance
+#### Modifying the view instance
 
-Sometimes, you may wish to interact with the view instance directly, for example, to set the view's title using a translated string. To achieve this, you may use the `rendering` method:
+Sometimes, you may wish to interact with the view instance directly, for example, to set the view's title using a translated string. To achieve this, you may define a `rendering` method on your component:
 
 ```blade
 <?php


### PR DESCRIPTION
This pull request adds documentation about the `rendering` method while using the class API on Volt.