### PR TITLE
Use argument name that's specified in the interface

### DIFF
--- a/docs/properties.md
+++ b/docs/properties.md
@@ -286,10 +286,10 @@ class Customer implements Wireable
         ];
     }
 
-    public static function fromLivewire($data)
+    public static function fromLivewire($value)
     {
-        $name = $data['name'];
-        $age = $data['age'];
+        $name = $value['name'];
+        $age = $value['age'];
 
         return new static($name, $age);
     }


### PR DESCRIPTION
Hey! This PR proposes a possible typo fix for the docs.

I was just doing some reading on Wireables and I copied and pasted the code over from the docs directly into my DTO (that I'm updating to be wireable). These are the two methods I copied:

```php
public function toLivewire()
{
    return [
        'name' => $this->name,
        'age' => $this->age,
    ];
}
 
public static function fromLivewire($data)
{
    $name = $data['name'];
    $age = $data['age'];
 
    return new static($name, $age);
}
```

 PhpStorm started complaining that the parameter name for the `fromLivewire` method didn't match the parameter name specified in the interface. The docs show the param as being called `$data`, but the interface calls it `$value` like so:

```php
namespace Livewire;

interface Wireable
{
    public function toLivewire();

    public static function fromLivewire($value);
}
```

I'm not sure if you purposely set the parameter name to `$data` in the docs example to make it easier to understand. But I just thought I'd propose this small change just in case it was a small mistake that might have slipped through at some point 😄

Apologies if this isn't needed or if I've done anything wrong!