### PR TITLE
Refactor: Combine Exception and Throwable Catch Blocks

### DIFF
--- a/legacy_tests/Browser/TestCase.php
+++ b/legacy_tests/Browser/TestCase.php
@@ -263,11 +263,7 @@ class TestCase extends BaseTestCase
         parent::browse(function (...$browsers) use ($callback) {
             try {
                 $callback(...$browsers);
-            } catch (Exception $e) {
-                if (DuskOptions::hasUI()) $this->breakIntoATinkerShell($browsers, $e);
-
-                throw $e;
-            } catch (Throwable $e) {
+            } catch (Exception|Throwable $e) {
                 if (DuskOptions::hasUI()) $this->breakIntoATinkerShell($browsers, $e);
 
                 throw $e;

--- a/src/Mechanisms/ExtendBlade/ExtendedCompilerEngine.php
+++ b/src/Mechanisms/ExtendBlade/ExtendedCompilerEngine.php
@@ -36,9 +36,7 @@ class ExtendedCompilerEngine extends \Illuminate\View\Engines\CompilerEngine {
                 extract($__data, EXTR_SKIP);
                 include $__path;
             }, $component, $component)();
-        } catch (\Exception $e) {
-            $this->handleViewException($e, $obLevel);
-        } catch (\Throwable $e) {
+        } catch (\Exception|\Throwable $e) {
             $this->handleViewException($e, $obLevel);
         }
 


### PR DESCRIPTION
Combined the catch blocks for `Exception` and `Throwable` into a single catch block.
Helps to reduce code duplication.