### PR TITLE
Fixes Livewire.dispatchTo

### DIFF
--- a/js/$wire.js
+++ b/js/$wire.js
@@ -155,7 +155,7 @@ wireProperty('$on', (component) => (...params) => listen(component, ...params))
 
 wireProperty('$dispatch', (component) => (...params) => dispatch(component, ...params))
 wireProperty('$dispatchSelf', (component) => (...params) => dispatchSelf(component, ...params))
-wireProperty('$dispatchTo', (component) => (...params) => dispatchTo(component, ...params))
+wireProperty('$dispatchTo', (component) => (...params) => dispatchTo(...params))
 
 wireProperty('$upload', (component) => (...params) => upload(component, ...params))
 wireProperty('$uploadMultiple', (component) => (...params) => uploadMultiple(component, ...params))

--- a/js/features/supportEvents.js
+++ b/js/features/supportEvents.js
@@ -64,7 +64,7 @@ export function dispatchSelf(component, name, params) {
     dispatchEvent(component.el, name, params, false)
 }
 
-export function dispatchTo(component, componentName, name, params) {
+export function dispatchTo(componentName, name, params) {
     let targets = componentsByName(componentName)
 
     targets.forEach(target => {


### PR DESCRIPTION
This pull request fixes #6222, so that now Livewire.dispatchTo and $wire.dispatchTo accept the same arguments.

According to [documentation](https://livewire.laravel.com/docs/javascript#interacting-with-events) you can do something:
```Livewire.dispatchTo('dashboard', 'post-created', { postId: 2 });```

... except that **you can't.**

Why? That's because currently Livewire.dispatchTo requires 4 arguments, the first being **component**, [which is not used in the code](https://github.com/livewire/livewire/blob/5ab209d65f5409fac781dda1d28f030706b1619f/js/features/supportEvents.js#L67).

So, your code has to be something like:
```Livewire.dispatchTo(null, 'dashboard', 'post-created', { postId: 2 });```
which is weird and counter-intutive.

But this works:

```$wire.dispatchTo('dashboard', 'post-created', { postId: 2 });```

So, this pull request makes that Livewire.dispatchTo and $wire.dispatchTo work the same.