### PR TITLE
Ensure model exists before dehydrating the key in legacy model binding

### DIFF
--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -25,7 +25,10 @@ class EloquentModelSynth extends Synth
 
         $meta = [];
 
-        $meta['key'] = $target->getKey();
+        if ($target->exists) {
+            $meta['key'] = $target->getKey();
+        }
+
         $meta['class'] = $alias;
 
         if ($target->getConnectionName() !== $class::make()->getConnectionName()) {

--- a/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
@@ -873,6 +873,19 @@ class PublicPropertyHydrationAndDehydrationUnitTest extends \Tests\TestCase
 
         $this->assertArrayNotHasKey('name', $results);
     }
+
+    /** @test */
+    public function it_ignores_the_key_if_the_model_does_not_exist()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $model = Author::make();
+
+        $model->id = 123;
+
+        Livewire::test(ModelsComponent::class, ['model' => $model])
+            ->call('$refresh');
+    }
 }
 
 class PostComponent extends Component


### PR DESCRIPTION
This PR fixes an issue with legacy model binding where models that didn't exist weren't able to be restored. In V2 Eloquent model binding would not send the key if the model didn't exist, so this PR makes sure V3 has the same process so we have parity with V2.

Hope this helps!