### PR TITLE
Fix array element in modelable component

### DIFF
--- a/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
+++ b/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
@@ -114,6 +114,60 @@ class BrowserTest extends \Tests\BrowserTestCase
     }
 
     /** @test */
+    public function can_bind_a_property_from_parent_indexed_array_to_property_from_child()
+    {
+        Livewire::visit([
+            new class extends \Livewire\Component {
+                public $foo = ['baz'];
+
+                public function render()
+                {
+                    return <<<'HTML'
+                <div>
+                    <span dusk='parent'>Parent: {{ $foo['0'] }}</span>
+                    <span x-text="$wire.foo[0]" dusk='parent.ephemeral'></span>
+
+                    <livewire:child wire:model='foo.0' />
+
+                    <button wire:click='$refresh' dusk='refresh'>refresh</button>
+                </div>
+                HTML;
+                }
+            },
+            'child' => new class extends \Livewire\Component {
+                #[BaseModelable]
+                public $bar;
+
+                public function render()
+                {
+                    return <<<'HTML'
+                <div>
+                    <span dusk='child'>Child: {{ $bar }}</span>
+                    <span x-text='$wire.bar' dusk='child.ephemeral'></span>
+                    <input type='text' wire:model='bar' dusk='child.input' />
+                </div>
+                HTML;
+                }
+            },
+        ])
+        ->assertDontSee('Property [$foo[0]] not found')
+        ->assertSeeIn('@parent', 'Parent: baz')
+        ->assertSeeIn('@child', 'Child: baz')
+        ->assertSeeIn('@parent.ephemeral', 'baz')
+        ->assertSeeIn('@child.ephemeral', 'baz')
+        ->type('@child.input', 'qux')
+        ->assertSeeIn('@parent', 'Parent: baz')
+        ->assertSeeIn('@child', 'Child: baz')
+        ->assertSeeIn('@parent.ephemeral', 'qux')
+        ->assertSeeIn('@child.ephemeral', 'qux')
+        ->waitForLivewire()->click('@refresh')
+        ->assertSeeIn('@parent', 'Parent: qux')
+        ->assertSeeIn('@child', 'Child: qux')
+        ->assertSeeIn('@parent.ephemeral', 'qux')
+        ->assertSeeIn('@child.ephemeral', 'qux');
+    }
+
+    /** @test */
     public function can_bind_a_property_from_parent_form_to_property_from_child()
     {
         Livewire::visit([

--- a/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
+++ b/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
@@ -124,7 +124,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 {
                     return <<<'HTML'
                 <div>
-                    <span dusk='parent'>Parent: {{ $foo['0'] }}</span>
+                    <span dusk='parent'>Parent: {{ $foo[0] }}</span>
                     <span x-text="$wire.foo[0]" dusk='parent.ephemeral'></span>
 
                     <livewire:child wire:model='foo.0' />

--- a/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
+++ b/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
@@ -64,6 +64,18 @@ class SupportWireModelingNestedComponents extends ComponentHook
             $outer = array_keys($bindings)[0];
             $inner = array_values($bindings)[0];
 
+            // We need to look through the dot notation parts of the outer
+            // variable name and check for any numerical values and replace
+            // them with [{num}].
+            $outer = trim(
+                array_reduce(
+                    explode(".", $outer),
+                    function($carry, $part) { return $carry.( ctype_digit($part) ?  "[$part]" : ".$part" ); },
+                    '',
+                ),
+                '.'
+            );
+
             // Attach the necessary Alpine directives so that the child and
             // parent's JS, ephemeral, values are bound.
             $replaceHtml(Utils::insertAttributesIntoHtmlRoot($html, [


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
This pull request resolves the issue #6955. It fixes the issue caused when trying to bind an element of an indexed array as the to a nested component's modelable property.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
I've added a small piece of code that checks the dot notation variable name for the parent variable. This code will check each part of the variable name and if it contains only digits then it will wrap it in [ ] so that the JS can find the variable correctly.

Thanks for contributing! 🙌
