### PR TITLE
Docs: Fix Potential Naming Conflict

### DIFF
--- a/docs/morph.md
+++ b/docs/morph.md
@@ -29,8 +29,8 @@ class Todos extends Component
 ```blade
 <div wire:submit="add">
     <ul>
-        @foreach ($todos as $todo)
-            <li>{{ $todo }}</li>
+        @foreach ($todos as $item)
+            <li>{{ $item }}</li>
         @endforeach
     </ul>
 


### PR DESCRIPTION
In the official Livewire documentation, there is an[ example provided](https://livewire.laravel.com/docs/morphing#how-morphing-works) that may lead to potential naming conflicts and confusion for developers. The example code is as follows:

```html
<div wire:submit="add">
    <ul>
        @foreach ($todos as $todo)
            <li>{{ $todo }}</li>
        @endforeach
    </ul>
 
    <input wire:model="todo">
</div>
```

**The issue arises when a Livewire property and a loop variable share the same name, as demonstrated in the example above. After the loop, if you attempt to live display the item that will be added, you'll notice the conflict**

To prevent such naming conflicts and to make the code more understandable, it is recommended that Livewire users differentiate the Livewire property's name from the loop variable's name, as shown in the corrected example:

```html
<div wire:submit="add">
    <ul>
        @foreach ($todos as $item)
            <li>{{ $item }}</li>
        @endforeach
    </ul>
 
    <input wire:model="todo">
</div>
```

This clarification would help Livewire users avoid ambiguity and ensure smoother development experiences.

