### PR TITLE
Allow tags for computed properties

### DIFF
--- a/docs/computed-properties.md
+++ b/docs/computed-properties.md
@@ -196,10 +196,31 @@ public function posts()
 }
 ```
 
+Instead of the `key` parameter, you can also use 'tags'.
+
+
+```php
+use Livewire\Attributes\Computed;
+use App\Models\Post;
+
+#[Computed(cache: true, tags: ['foo', 'bar'])]
+public function posts()
+{
+    return Post::all();
+}
+```
+
+
 Then somewhere else in your app, you may clear the cache for that property:
 
 ```php
 Cache::forget('homepage-posts');
+```
+
+or clear the entire tag:
+
+```php
+Cache::tags('foo')->flush();
 ```
 
 ## When to use computed properties?

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -19,6 +19,7 @@ class BaseComputed extends Attribute
         public $seconds = 3600, // 1 hour...
         public $cache = false,
         public $key = null,
+        public $tags = null,
     ) {}
 
     function boot()
@@ -84,18 +85,24 @@ class BaseComputed extends Attribute
     {
         $key = $this->generatePersistedKey();
 
-        return Cache::remember($key, $this->seconds, function () {
-            return $this->evaluateComputed();
-        });
+        $closure = fn () => $this->evaluateComputed();
+
+        return match(Cache::supportsTags() && !empty($this->tags)) {
+            true: Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
+            default: Cache::remember($key, $this->seconds, $closure)
+        }
     }
 
     protected function handleCachedGet()
     {
         $key = $this->generateCachedKey();
 
-        return Cache::remember($key, $this->seconds, function () {
-            return $this->evaluateComputed();
-        });
+        $closure = fn () => $this->evaluateComputed();
+
+        return match(Cache::supportsTags() && !empty($this->tags)) {
+            true: Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
+            default: Cache::remember($key, $this->seconds, $closure)
+        }
     }
 
     protected function handlePersistedUnset()

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -88,9 +88,9 @@ class BaseComputed extends Attribute
         $closure = fn () => $this->evaluateComputed();
 
         return match(Cache::supportsTags() && !empty($this->tags)) {
-            true: Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
-            default: Cache::remember($key, $this->seconds, $closure)
-        }
+            true => Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
+            default => Cache::remember($key, $this->seconds, $closure)
+        };
     }
 
     protected function handleCachedGet()
@@ -100,9 +100,9 @@ class BaseComputed extends Attribute
         $closure = fn () => $this->evaluateComputed();
 
         return match(Cache::supportsTags() && !empty($this->tags)) {
-            true: Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
-            default: Cache::remember($key, $this->seconds, $closure)
-        }
+            true => Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
+            default => Cache::remember($key, $this->seconds, $closure)
+        };
     }
 
     protected function handlePersistedUnset()

--- a/src/Features/SupportComputed/BrowserTest.php
+++ b/src/Features/SupportComputed/BrowserTest.php
@@ -6,7 +6,6 @@ use Livewire\Attributes\Computed;
 use Livewire\Component;
 use Livewire\Livewire;
 use Tests\BrowserTestCase;
-use Illuminate\Support\Facades\Cache;
 
 class BrowserTest extends BrowserTestCase
 {
@@ -18,17 +17,11 @@ class BrowserTest extends BrowserTestCase
 
             protected $thing = 'hey';
 
-            #[Computed(persist: true, tags: ['foo'])]
+            #[Computed(persist: true)]
             public function foo() {
                 $this->count++;
 
                 return 'bar';
-            }
-
-            function deleteCachedTags() {
-                if (Cache::supportsTags()) {
-                    Cache::tags(['foo'])->flush();
-                }
             }
 
             function unset()
@@ -44,7 +37,6 @@ class BrowserTest extends BrowserTestCase
                 <div>
                     <button wire:click="$refresh" dusk="refresh">refresh</button>
                     <button wire:click="unset" dusk="unset">unset</button>
-                    <button wire:click="deleteCachedTags" dusk="deleteCachedTags">deleteCachedTags</button>
 
                     <div dusk="count">{{ $count }}</div>
                 </div>
@@ -57,9 +49,7 @@ class BrowserTest extends BrowserTestCase
         ->waitForLivewire()->click('@unset')
         ->assertSeeIn('@count', '2')
         ->waitForLivewire()->click('@refresh')
-        ->assertSeeIn('@count', '2')
-        ->waitForLivewire()->click('@deleteCachedTags')
-        ->assertSeeIn('@count', Cache::supportsTags()?'3':'2');
+        ->assertSeeIn('@count', '2');
     }
 
     /** @test */
@@ -68,16 +58,9 @@ class BrowserTest extends BrowserTestCase
         Livewire::visit(new class extends Component {
             public $count = 0;
 
-            #[Computed(cache: true, tags: ['foo'])]
+            #[Computed(cache: true)]
             public function foo() {
                 return $this->count;
-            }
-
-            function deleteCachedTags() {
-                $this->count++;
-                if (Cache::supportsTags()) {
-                    Cache::tags(['foo'])->flush();
-                }
             }
 
             function increment()
@@ -94,7 +77,6 @@ class BrowserTest extends BrowserTestCase
                 <div>
                     <button wire:click="$refresh" dusk="refresh">refresh</button>
                     <button wire:click="increment" dusk="increment">unset</button>
-                    <button wire:click="deleteCachedTags" dusk="deleteCachedTags">deleteCachedTags</button>
 
                     <div dusk="count">{{ $this->foo }}</div>
                 </div>
@@ -105,8 +87,6 @@ class BrowserTest extends BrowserTestCase
         ->waitForLivewire()->click('@increment')
         ->assertSeeIn('@count', '1')
         ->refresh()
-        ->assertSeeIn('@count', '1')
-        ->waitForLivewire()->click('@deleteCachedTags')
-        ->assertSeeIn('@count', Cache::supportsTags()?'2':'1');
+        ->assertSeeIn('@count', '1');
     }
 }

--- a/src/Features/SupportComputed/BrowserTest.php
+++ b/src/Features/SupportComputed/BrowserTest.php
@@ -57,9 +57,9 @@ class BrowserTest extends BrowserTestCase
         ->waitForLivewire()->click('@unset')
         ->assertSeeIn('@count', '2')
         ->waitForLivewire()->click('@refresh')
-        ->assertSeeIn('@count', '2');
+        ->assertSeeIn('@count', '2')
         ->waitForLivewire()->click('@deleteCachedTags')
-        ->assertSeeIn('@count', Cache::supportsTags()?'3':'2')
+        ->assertSeeIn('@count', Cache::supportsTags()?'3':'2');
     }
 
     /** @test */


### PR DESCRIPTION
This PR introduces support for tags in computed and cached properties. Tags provide a way to manage and invalidate cached data associated with specific entities within your application.

If the current cache driver supports tags, you then can do something like.

```php
#[Computed(cache: true, tags: ['posts'])]
public function latestPosts(): Collection
{
	// Caching because this is global
	return Post::latest()->take(10)->get();
}

#[Computed(persist: true, tags: ['posts'])]
public function ownPosts(): Collection
{
	// Persisting because this is scoped to the current instance of the Livewire component
	return Auth::user()->posts()->latest()->take(10)->get();
}
```

When a Post-model is updated/deleted/restored then we clear the caching tag 'posts':
`Cache::tags('posts')->flush();`
After the next refresh, we get a fresh copy, instead of the outdated cached one.

Please see the modified UnitTest for detailed test cacse