### PR TITLE
Rely on providesTemporaryUrls for preview files

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -83,6 +83,10 @@ class TemporaryUploadedFile extends UploadedFile
 
     public function temporaryUrl()
     {
+        if (!$this->isPreviewable()) {
+            return null;
+        }
+
         $expiration = now()->addMinutes(30)->endOfHour();
 
         $temporaryUrlOptions = [];
@@ -99,7 +103,7 @@ class TemporaryUploadedFile extends UploadedFile
         );
     }
 
-    public function isPreviewable()
+    public function isPreviewable(): bool
     {
         $supportedPreviewTypes = config('livewire.temporary_file_upload.preview_mimes', [
             'png', 'gif', 'bmp', 'svg', 'wav', 'mp4',


### PR DESCRIPTION
The `providesTemporaryUrls` function tells whether the filesystem supports such urls. It's properly implemented in the S3 and GCS adapters. It also correctly recognizes customized temporary url functions added like described in the larave doc:

https://laravel.com/docs/10.x/filesystem#temporary-urls

By directly using providesTemporaryUrls, there's no need for a filesystem whitelist here.