### PR TITLE
Add example for overriding methods using the functional API

### DIFF
--- a/docs/volt.md
+++ b/docs/volt.md
@@ -691,6 +691,61 @@ use App\Concerns\WithSorting;
 uses([Sorting::class, WithSorting::class]);
 ```
 
+### Overriding methods
+
+You may override methods added through traits by creating an action with the same name as the method:
+
+```php
+use \Illuminate\Support\Facades\Log;
+
+trait WithLogging
+{
+    public function log(string $message): void
+    {
+        Log::info($message);
+    }
+}
+```
+
+```php
+use function Livewire\Volt\{uses};
+
+use App\Concerns\WithLogging;
+
+uses([WithLogging::class]);
+
+$log = function (string $message): void {
+    Log::info("Logging differently: $message");
+};
+```
+
+This works for protected methods as well:
+
+```php
+use \Illuminate\Support\Facades\Log;
+
+trait WithLogging
+{
+    protected function log(string $message): void
+    {
+        Log::info($message);
+    }
+}
+```
+
+```php
+use function Livewire\Volt\{uses, protect};
+
+use App\Concerns\WithLogging;
+
+uses([WithLogging::class]);
+
+$log = protect(function (string $message): void {
+    Log::info("Logging differently: $message");
+});
+```
+
+
 ## Anonymous components
 
 Sometimes, you may want to convert a small portion of a page into a Volt component without extracting it into a separate file. For example, imagine a Laravel route that returns the following view:


### PR DESCRIPTION
I wasn't able to find this in the documentation for the functional API. 

Using an anonymous class it's pretty straightforward to override a method from a trait, but using the functional API it's not immediately obvious.

This PR adds a subsection in the documentation about how to override methods using the functional API for public methods and for protected methods using the `protect` function.