### PR TITLE
Fix: Alpine is not defined when using @livewireScriptConfig and show_progress_bar = false

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -178,7 +178,7 @@ class FrontendAssets
 
         $nonce = isset($options['nonce']) ? " nonce=\"{$options['nonce']}\"" : '';
 
-        $progressBar = config('livewire.navigate.show_progress_bar', true);
+        $progressBar = config('livewire.navigate.show_progress_bar', true) ? '' : 'data-no-progress-bar';
 
         $attributes = json_encode([
             'csrf' => app()->has('session.store') ? csrf_token() : '',


### PR DESCRIPTION
This fixes an issue where:

1) inject_assets is false (and livewireScriptConfig is used
and
2) navigate.show_progress_bar is false in config
```
    'navigate' => [
        'show_progress_bar' => false,
    ],
```

At present (last checked 3.0.10), this will result in an error:
_Uncaught ReferenceError: Alpine is not defined_

The fix uses the same logic as the standard js() method for injection, to ensure that a value is returned to 
```
$progressBar
```
Which is used in the generation of the script include for Livewire.

Without this fix, code output for 
```
@livewireScriptConfig 
```
is:
```
<script data-navigate-once="true">window.livewireScriptConfig = {"csrf":"zAK7ZGN5e3tqL1cNhjH3gwNC6J4DFASgaatoPD7P","uri":"\/livewire\/update","progressBar":false};</script>
```
With Fix:
```
<script data-navigate-once="true">window.livewireScriptConfig = {"csrf":"zAK7ZGN5e3tqL1cNhjH3gwNC6J4DFASgaatoPD7P","uri":"\/livewire\/update","progressBar":"data-no-progress-bar"};</script> 
```

The key difference being the "progressBar" parameter.

Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌


**Minimal testing has been performed however!**