### PR TITLE
Add missing new keyword in docs

### DIFF
--- a/docs/volt.md
+++ b/docs/volt.md
@@ -156,8 +156,7 @@ Sometimes, you may wish to interact with the view instance directly, for example
 use Illuminate\View\View;
 use Livewire\Volt\Component;
 
-class extends Component
-{
+new class extends Component {
     public function rendering(View $view): void
     {
         $view->title('Create Post');


### PR DESCRIPTION
In the Volt package section, in an example creating a class-based component there is a missed `new` keyword.