### PR TITLE
Update modelable to support numeric array keys

### DIFF
--- a/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
+++ b/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
@@ -124,7 +124,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 {
                     return <<<'HTML'
                 <div>
-                    <span dusk='parent'>Parent: {{ $foo['bar'] }}</span>
+                    <span dusk='parent'>Parent: {{ $foo[0] }}</span>
                     <span x-text="$wire.foo[0]" dusk='parent.ephemeral'></span>
 
                     <livewire:child wire:model='foo.0' />

--- a/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
+++ b/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
@@ -64,6 +64,11 @@ class SupportWireModelingNestedComponents extends ComponentHook
             $outer = array_keys($bindings)[0];
             $inner = array_values($bindings)[0];
 
+            // Convert dot notation to array syntax as javascript doesn't support
+            // dot notation for integer indexes.
+            $outer = $this->convertDotNotationIntegerIndexesToArraySyntax($outer);
+            $inner = $this->convertDotNotationIntegerIndexesToArraySyntax($inner);
+
             // Attach the necessary Alpine directives so that the child and
             // parent's JS, ephemeral, values are bound.
             $replaceHtml(Utils::insertAttributesIntoHtmlRoot($html, [
@@ -81,5 +86,19 @@ class SupportWireModelingNestedComponents extends ComponentHook
 
         // Add the bindings metadata to the paylad for later reference...
         $context->addMemo('bindings', $bindings);
+    }
+
+    public function convertDotNotationIntegerIndexesToArraySyntax($value)
+    {
+        $parts = explode('.', $value);
+        $newValue = array_shift($parts);
+
+        for($i = 0; $i < count($parts); $i++) {
+            $newValue .= is_numeric($parts[$i])
+                ? '['.$parts[$i].']'
+                : '.'.$parts[$i];
+        }
+
+        return $newValue;
     }
 }


### PR DESCRIPTION
Currently, if you have a numeric array in a parent component and try to use modelable to bind it to a child component `<livewire:child wire:model="items.0.name" />`, it throws this error:

<img width="858" alt="image" src="https://github.com/livewire/livewire/assets/882837/7c3875f1-eae5-4e71-bea5-91cbc33fb121">

This is because javascript doesn't support using dot notation to access array indexes. So `items.0.name` won't work, and needs to be changed to `items[0].name`.

This PR fixes this by changing any key indexes to array notation just before we output `x-model` and `x-modelable` on the root element.

Hope this helps!