### PR TITLE
Docs: Validation Typo Fix

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -538,7 +538,7 @@ public function cant_create_post_with_title_shorter_than_3_characters()
         ->set('title', 'Sa')
         ->set('content', 'Sample content...')
         ->call('save')
-        ->assertHasErrors(['title', ['min:3']]);
+        ->assertHasErrors(['title' => ['min:3']]);
 }
 ```
 


### PR DESCRIPTION
I was trying the updates while reading the docs for Livewire3 validation and encountered a server error while attempting the validation test assertion. at the line: `->assertHasErrors(['title', ['min:3']]);`

# Before
```php
/** @test */
public function cant_create_post_with_title_shorter_than_3_characters()
{
    Livewire::test(CreatePost::class)
        ->set('title', 'Sa')
        ->set('content', 'Sample content...')
        ->call('save')
        ->assertHasErrors(['title', ['min:3']]);
}
```
While trying this, I faced the following error: `ErrorException: Array to string conversion`.

# After
```php
/** @test */
public function cant_create_post_with_title_shorter_than_3_characters()
{
    Livewire::test(CreatePost::class)
        ->set('title', 'Sa')
        ->set('content', 'Sample content...')
        ->call('save')
        ->assertHasErrors(['title' => ['min:3']]);
}
```
After assigning the validation rule to the perspective property, it has been updated to:
`->assertHasErrors(['title' => ['min:3']]);` and it worked as expected.


