### PR TITLE
fix start variable

### DIFF
--- a/docs/wire-stream.md
+++ b/docs/wire-stream.md
@@ -30,11 +30,11 @@ class CountDown extends Component
 
     public function render()
     {
-        return <<<HTML
+        return <<<'HTML'
         <div>
             <button wire:click="begin">Start count-down</button>
 
-            <h1>Count: <span wire:stream="count">{{ $this->start }}</span></h1> <!-- [tl! highlight] -->
+            <h1>Count: <span wire:stream="count">{{ $start }}</span></h1> <!-- [tl! highlight] -->
         </div>
         HTML;
     }

--- a/docs/wire-stream.md
+++ b/docs/wire-stream.md
@@ -34,7 +34,7 @@ class CountDown extends Component
         <div>
             <button wire:click="begin">Start count-down</button>
 
-            <h1>Count: <span wire:stream="count">{{ $start }}</span></h1> <!-- [tl! highlight] -->
+            <h1>Count: <span wire:stream="count">{{ $this->start }}</span></h1> <!-- [tl! highlight] -->
         </div>
         HTML;
     }


### PR DESCRIPTION
Fix the example of steaming the countdown. 

The example explained in the documentation has an error in the html template. Since, the template has been defined inside the component.

# Before
```php
public function render()
    {
        return <<<HTML
        <div>
            <button wire:click="begin">Start count-down</button>

            <h1>Count: <span wire:stream="count">{{ $start }}</span></h1>
        </div>
        HTML;
    }
```

#### This code is throwing the error: `Undefined variable $start`. Which is indicating to this line: `<h1>Count: <span wire:stream="count">{{ $start }}</span></h1>`.

# After
```php
public function render()
    {
        return <<<HTML
        <div>
            <button wire:click="begin">Start count-down</button>

            <h1>Count: <span wire:stream="count">{{ $this->start }}</span></h1>
        </div>
        HTML;
    }
```
#### This code is being fixed by using "$this" variable. Since, the template is defined inside the component's class: `<h1>Count: <span wire:stream="count">{{ $this->start }}</span></h1>`.