### PR TITLE
Fix bug with legacy model binding where uninitialised attributes couldn't be bound to

### DIFF
--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -153,10 +153,10 @@ class EloquentModelSynth extends Synth
     {
         $filteredAttributes = [];
 
-        foreach($rules as $rule) {
-            // If the rule is an array, it's for a relationship, so we can skip it.
+        foreach($rules as $key => $rule) {
+            // If the rule is an array, take the key instead
             if (is_array($rule)) {
-                continue;
+                $rule = $key;
             }
 
             // If someone has created an empty model, the attribute may not exist

--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -126,8 +126,8 @@ class EloquentModelSynth extends Synth
     protected function getDataFromModel(Model $model, $rules)
     {
         return [
-            ...$this->filterData($this->getAttributes($model), $rules),
-            ...$this->filterData($model->getRelations(), $rules),
+            ...$this->filterAttributes($this->getAttributes($model), $rules),
+            ...$this->filterRelations($model->getRelations(), $rules),
         ];
     }
 
@@ -149,7 +149,25 @@ class EloquentModelSynth extends Synth
         return $attributes;
     }
 
-    protected function filterData($data, $rules)
+    protected function filterAttributes($data, $rules)
+    {
+        $filteredAttributes = [];
+
+        foreach($rules as $rule) {
+            // If the rule is an array, it's for a relationship, so we can skip it.
+            if (is_array($rule)) {
+                continue;
+            }
+
+            // If someone has created an empty model, the attribute may not exist
+            // yet, so use data_get so it will still be sent to the front end.
+            $filteredAttributes[$rule] = data_get($data, $rule);
+        }
+
+        return $filteredAttributes;
+    }
+
+    protected function filterRelations($data, $rules)
     {
         return array_filter($data, function ($key) use ($rules) {
             return array_key_exists($key, $rules) || in_array($key, $rules);

--- a/src/Features/SupportLegacyModels/Tests/DataBindingModelsBrowserTest.php
+++ b/src/Features/SupportLegacyModels/Tests/DataBindingModelsBrowserTest.php
@@ -80,7 +80,7 @@ class DataBindingComponent extends BaseComponent
 {
     public $author;
 
-    public ?DataBindingPost $post;
+    public ?DataBindingPost $thepost;
 
     protected $rules = [
         'author.name' => '',
@@ -88,14 +88,14 @@ class DataBindingComponent extends BaseComponent
         'author.posts.*.title' => '',
         'author.posts.*.comments.*.comment' => '',
         'author.posts.*.comments.*.author.name' => '',
-        'post.title' => '',
+        'thepost.title' => '',
     ];
 
     public function mount()
     {
         $this->author = DataBindingAuthor::with(['posts', 'posts.comments', 'posts.comments.author'])->first();
 
-        $this->post = new DataBindingPost();
+        $this->thepost = new DataBindingPost();
     }
 
     public function save()
@@ -150,10 +150,10 @@ class DataBindingComponent extends BaseComponent
 
     <button wire:click="save" type="button" dusk="save">Save</button>
 
-    <div x-data="{ title: @entangle('post.title').live }">
+    <div x-data="{ title: @entangle('thepost.title').live }">
         Post Title
         <input dusk='post.title' x-model='title' />
-        <span dusk='output.post.title'>{{ $post->title }}</span>
+        <span dusk='output.post.title'>{{ $thepost->title }}</span>
     </div>
 </div>
 HTML;

--- a/src/Features/SupportLegacyModels/Tests/DataBindingModelsBrowserTest.php
+++ b/src/Features/SupportLegacyModels/Tests/DataBindingModelsBrowserTest.php
@@ -64,11 +64,23 @@ class DataBindingModelsBrowserTest extends TestCase
         $author->posts[0]->comments[1]->author->name = 'John';
         $author->push();
     }
+
+    /** @test */
+    public function it_enables_changing_model_attributes_that_have_not_been_initialized()
+    {
+        $this->browse(function (Browser $browser) {
+            $this->visitLivewireComponent($browser, DataBindingComponent::class)
+                ->waitForLivewire()->type('@post.title', 'Livewire is awesome')
+                ->assertSeeIn('@output.post.title', 'Livewire is awesome');
+        });
+    }
 }
 
 class DataBindingComponent extends BaseComponent
 {
     public $author;
+
+    public ?DataBindingPost $post;
 
     protected $rules = [
         'author.name' => '',
@@ -76,11 +88,14 @@ class DataBindingComponent extends BaseComponent
         'author.posts.*.title' => '',
         'author.posts.*.comments.*.comment' => '',
         'author.posts.*.comments.*.author.name' => '',
+        'post.title' => '',
     ];
 
     public function mount()
     {
         $this->author = DataBindingAuthor::with(['posts', 'posts.comments', 'posts.comments.author'])->first();
+
+        $this->post = new DataBindingPost();
     }
 
     public function save()
@@ -134,6 +149,12 @@ class DataBindingComponent extends BaseComponent
     </div>
 
     <button wire:click="save" type="button" dusk="save">Save</button>
+
+    <div>
+        Post Title
+        <input dusk='post.title' wire:model.live='post.title' />
+        <span dusk='output.post.title'>{{ $post->title }}</span>
+    </div>
 </div>
 HTML;
     }

--- a/src/Features/SupportLegacyModels/Tests/DataBindingModelsBrowserTest.php
+++ b/src/Features/SupportLegacyModels/Tests/DataBindingModelsBrowserTest.php
@@ -66,7 +66,7 @@ class DataBindingModelsBrowserTest extends TestCase
     }
 
     /** @test */
-    public function it_enables_changing_model_attributes_that_have_not_been_initialized()
+    public function it_enables_changing_model_attributes_that_have_not_been_initialized_using_entangle()
     {
         $this->browse(function (Browser $browser) {
             $this->visitLivewireComponent($browser, DataBindingComponent::class)
@@ -150,9 +150,9 @@ class DataBindingComponent extends BaseComponent
 
     <button wire:click="save" type="button" dusk="save">Save</button>
 
-    <div>
+    <div x-data="{ title: @entangle('post.title').live }">
         Post Title
-        <input dusk='post.title' wire:model.live='post.title' />
+        <input dusk='post.title' x-model='title' />
         <span dusk='output.post.title'>{{ $post->title }}</span>
     </div>
 </div>

--- a/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
@@ -778,7 +778,7 @@ class PublicPropertyHydrationAndDehydrationUnitTest extends \Tests\TestCase
         Comment::create(['id' => 3, 'comment' => 'Comment 3', 'post_id' => 2, 'author_id' => 1]);
         Comment::create(['id' => 4, 'comment' => 'Comment 4', 'post_id' => 2, 'author_id' => 2]);
 
-        $models = Author::with(['posts'])->get();
+        $models = Author::with(['posts', 'posts.comments'])->get();
 
         $rules = [
             'models.*.title' => '',
@@ -816,10 +816,10 @@ class PublicPropertyHydrationAndDehydrationUnitTest extends \Tests\TestCase
         $this->assertEquals($expected[0]['title'], $results[0][0]['title']);
         $this->assertEquals($expected[0]['email'], $results[0][0]['email']);
         $this->assertEquals($expected[0]['posts'][0]['title'], $results[0][0]['posts'][0][0][0]['title']);
-        $this->assertArrayNotHasKey('comments', $results[0][0]['posts'][0][0][0]);
+        $this->assertArrayHasKey('comments', $results[0][0]['posts'][0][0][0]);
 
         $this->assertEquals($expected[0]['posts'][1]['title'], $results[0][0]['posts'][0][1][0]['title']);
-        $this->assertArrayNotHasKey('comments', $results[0][0]['posts'][0][1][0]);
+        $this->assertArrayHasKey('comments', $results[0][0]['posts'][0][1][0]);
 
         $this->assertEquals($expected[1]['title'], $results[1][0]['title']);
         $this->assertEquals($expected[1]['email'], $results[1][0]['email']);
@@ -850,7 +850,7 @@ class PublicPropertyHydrationAndDehydrationUnitTest extends \Tests\TestCase
 
         $this->assertEquals($expected['title'], $results['title']);
         $this->assertEquals($expected['email'], $results['email']);
-        $this->assertArrayNotHasKey('foo', $results);
+        $this->assertEquals($expected['foo'], $results['foo']);
     }
 
     /** @test */
@@ -871,7 +871,7 @@ class PublicPropertyHydrationAndDehydrationUnitTest extends \Tests\TestCase
 
         $results = $component->snapshot['data']['model'][0];
 
-        $this->assertArrayNotHasKey('name', $results);
+        $this->assertEquals($expected['name'], $results['name']);
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds a failing test for a bug where you can't bind to model attributes that haven't been initialized yet.

Feel free to refactor the test if you want!