### PR TITLE
update ComponentParser.php

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/ComponentParser.php
+++ b/src/Features/SupportConsoleCommands/Commands/ComponentParser.php
@@ -218,8 +218,8 @@ class ComponentParser
 
     public static function generateTestPathFromNamespace($namespace)
     {
-        return str(base_path($namespace))
+        return base_path(str($namespace)
             ->replace('\\', '/', $namespace)
-            ->replaceFirst('T', 't');
+            ->replaceFirst('T', 't'));
     }
 }


### PR DESCRIPTION
Hi everyone, this is my first ever code-related pull request to a library I use!

fix the `generateTestPathFromNamespace` function to apply base_path only after applying modifications to the namespace

when given an argument like so `'Tests\Feature\Livewire'` the function in question replace `\` with `/` and replaces the first `T` with a `t` so that the argument becomes `tests/Features/Livewire`.

the catch is that this is applied after applying the base_path to the namespace.

which means that if, for instance, your project root is `BloodyTwitter` like mine, it will set the test path `Bloodytwitter/Tests/Features/Livewire` (note the lowercase t in twitter and the uppercase Tests)

my pull request simply applies the base_path after those string manipulations are done
