### PR TITLE
Adding `assertSetModel()` / `assertNotSetModel()`

### DIFF
--- a/src/Features/SupportTesting/MakesAssertions.php
+++ b/src/Features/SupportTesting/MakesAssertions.php
@@ -105,6 +105,24 @@ trait MakesAssertions
         return $this;
     }
 
+    function assertSetModel($name, $value)
+    {
+        $actual = $this->get($name);
+
+        PHPUnit::assertTrue($value->is($actual));
+
+        return $this;
+    }
+
+    function assertNotSetModel($name, $value)
+    {
+        $actual = $this->get($name);
+
+        PHPUnit::assertFalse($value->is($actual));
+
+        return $this;
+    }
+
     function assertCount($name, $value)
     {
         PHPUnit::assertCount($value, $this->get($name));


### PR DESCRIPTION
This uses Laravel's `->is(...)` method on models to do a comparison that isn't as strict as PHPUnit's default `assertSame()` method.

This is helpful for when you've set a public property as a particular model and need to ensure that the model you've set is the one you've meant to set.

If this PR is accepted, I will update the docs to reflect the new assertion types.