### PR TITLE
Added tests for Modelable on deeply nested arrays

### DIFF
--- a/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
+++ b/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
@@ -155,6 +155,60 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertSeeIn('@parent.ephemeral', 'qux')
         ->assertSeeIn('@child.ephemeral', 'qux');
     }
+    
+    /** @test */
+    public function can_bind_a_live_property_from_parent_array_to_property_from_child()
+    {
+        Livewire::visit([
+            new class extends \Livewire\Component {
+                public $foo = ['bar' => 'baz'];
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                <div>
+                    <span dusk='parent'>Parent: {{ $foo['bar'] }}</span>
+                    <span x-text="$wire.foo['bar']" dusk='parent.ephemeral'></span>
+
+                    <livewire:child wire:model.live='foo.bar' />
+
+                    <button wire:click='$refresh' dusk='refresh'>refresh</button>
+                </div>
+                HTML;
+                }
+            },
+            'child' => new class extends \Livewire\Component {
+                #[BaseModelable]
+                public $bar;
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                <div>
+                    <span dusk='child'>Child: {{ $bar }}</span>
+                    <span x-text='$wire.bar' dusk='child.ephemeral'></span>
+                    <input type='text' wire:model='bar' dusk='child.input' />
+                </div>
+                HTML;
+                }
+            },
+        ])
+            ->assertDontSee('Property [$foo.bar] not found')
+            ->assertSeeIn('@parent', 'Parent: baz')
+            ->assertSeeIn('@child', 'Child: baz')
+            ->assertSeeIn('@parent.ephemeral', 'baz')
+            ->assertSeeIn('@child.ephemeral', 'baz')
+            ->type('@child.input', 'qux')
+            ->assertSeeIn('@parent', 'Parent: baz')
+            ->assertSeeIn('@child', 'Child: baz')
+            ->assertSeeIn('@parent.ephemeral', 'qux')
+            ->assertSeeIn('@child.ephemeral', 'qux')
+            ->waitForLivewire()->click('@refresh')
+            ->assertSeeIn('@parent', 'Parent: qux')
+            ->assertSeeIn('@child', 'Child: qux')
+            ->assertSeeIn('@parent.ephemeral', 'qux')
+            ->assertSeeIn('@child.ephemeral', 'qux');
+    }
 
     /** @test */
     public function can_bind_a_property_from_parent_array_using_a_numeric_index_to_property_from_child()
@@ -209,7 +263,177 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertSeeIn('@parent.ephemeral', 'qux')
         ->assertSeeIn('@child.ephemeral', 'qux');
     }
+    
+    /** @test */
+    public function can_bind_a_live_property_from_parent_array_using_a_numeric_index_to_property_from_child()
+    {
+        Livewire::visit([
+            new class extends \Livewire\Component {
+                public $foo = ['baz'];
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                <div>
+                    <span dusk='parent'>Parent: {{ $foo[0] }}</span>
+                    <span x-text="$wire.foo[0]" dusk='parent.ephemeral'></span>
 
+                    <livewire:child wire:model.live='foo.0' />
+
+                    <button wire:click='$refresh' dusk='refresh'>refresh</button>
+                </div>
+                HTML;
+                }
+            },
+            'child' => new class extends \Livewire\Component {
+                #[BaseModelable]
+                public $bar;
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                <div>
+                    <span dusk='child'>Child: {{ $bar }}</span>
+                    <span x-text='$wire.bar' dusk='child.ephemeral'></span>
+                    <input type='text' wire:model='bar' dusk='child.input' />
+                </div>
+                HTML;
+                }
+            },
+        ])
+            ->assertDontSee('Property [$foo.0] not found')
+            ->assertSeeIn('@parent', 'Parent: baz')
+            ->assertSeeIn('@child', 'Child: baz')
+            ->assertSeeIn('@parent.ephemeral', 'baz')
+            ->assertSeeIn('@child.ephemeral', 'baz')
+            ->type('@child.input', 'qux')
+            ->assertSeeIn('@parent', 'Parent: baz')
+            ->assertSeeIn('@child', 'Child: baz')
+            ->assertSeeIn('@parent.ephemeral', 'qux')
+            ->assertSeeIn('@child.ephemeral', 'qux')
+            ->waitForLivewire()->click('@refresh')
+            ->assertSeeIn('@parent', 'Parent: qux')
+            ->assertSeeIn('@child', 'Child: qux')
+            ->assertSeeIn('@parent.ephemeral', 'qux')
+            ->assertSeeIn('@child.ephemeral', 'qux');
+    }
+    
+    /** @test */
+    public function can_bind_a_property_from_parent_array_with_nested_array_to_property_from_child()
+    {
+        Livewire::visit([
+            new class extends \Livewire\Component {
+                public $foo = [
+                    'bar' => [
+                        [ 'baz' => 'baz' ]
+                    ],
+                ];
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                <div>
+                    <span dusk='parent'>Parent: {{ $foo['bar'][0]['baz'] }}</span>
+                    <span x-text="$wire.foo['bar'][0]['baz']" dusk='parent.ephemeral'></span>
+
+                    <livewire:child wire:model='foo.bar' />
+
+                    <button wire:click='$refresh' dusk='refresh'>refresh</button>
+                </div>
+                HTML;
+                }
+            },
+            'child' => new class extends \Livewire\Component {
+                #[BaseModelable]
+                public $bar;
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                <div>
+                    <span dusk='child'>Child: {{ $bar[0]['baz'] }}</span>
+                    <span x-text="$wire.bar[0]['baz']" dusk='child.ephemeral'></span>
+                    <input type='text' wire:model='bar.0.baz' dusk='child.input' />
+                </div>
+                HTML;
+                }
+            },
+        ])
+            ->assertDontSee('Property [$foo.bar.0.baz] not found')
+            ->assertSeeIn('@parent', 'Parent: baz')
+            ->assertSeeIn('@child', 'Child: baz')
+            ->assertSeeIn('@parent.ephemeral', 'baz')
+            ->assertSeeIn('@child.ephemeral', 'baz')
+            ->type('@child.input', 'qux')
+            ->assertSeeIn('@parent', 'Parent: baz')
+            ->assertSeeIn('@child', 'Child: baz')
+            ->assertSeeIn('@parent.ephemeral', 'qux')
+            ->assertSeeIn('@child.ephemeral', 'qux')
+            ->waitForLivewire()->click('@refresh')
+            ->assertSeeIn('@parent', 'Parent: qux')
+            ->assertSeeIn('@child', 'Child: qux')
+            ->assertSeeIn('@parent.ephemeral', 'qux')
+            ->assertSeeIn('@child.ephemeral', 'qux');
+    }
+    
+    /** @test */
+    public function can_bind_a_live_property_from_parent_array_with_nested_array_to_property_from_child()
+    {
+        Livewire::visit([
+            new class extends \Livewire\Component {
+                public $foo = [
+                    'bar' => [
+                        [ 'baz' => 'baz' ]
+                    ],
+                ];
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                <div>
+                    <span dusk='parent'>Parent: {{ $foo['bar'][0]['baz'] }}</span>
+                    <span x-text="$wire.foo['bar'][0]['baz']" dusk='parent.ephemeral'></span>
+
+                    <livewire:child wire:model.live='foo.bar' />
+
+                    <button wire:click='$refresh' dusk='refresh'>refresh</button>
+                </div>
+                HTML;
+                }
+            },
+            'child' => new class extends \Livewire\Component {
+                #[BaseModelable]
+                public $bar;
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                <div>
+                    <span dusk='child'>Child: {{ $bar[0]['baz'] }}</span>
+                    <span x-text="$wire.bar[0]['baz']" dusk='child.ephemeral'></span>
+                    <input type='text' wire:model='bar.0.baz' dusk='child.input' />
+                </div>
+                HTML;
+                }
+            },
+        ])
+            ->assertDontSee('Property [$foo.bar.0.baz] not found')
+            ->assertSeeIn('@parent', 'Parent: baz')
+            ->assertSeeIn('@child', 'Child: baz')
+            ->assertSeeIn('@parent.ephemeral', 'baz')
+            ->assertSeeIn('@child.ephemeral', 'baz')
+            ->type('@child.input', 'qux')
+            ->assertSeeIn('@parent', 'Parent: baz')
+            ->assertSeeIn('@child', 'Child: baz')
+            ->assertSeeIn('@parent.ephemeral', 'qux')
+            ->assertSeeIn('@child.ephemeral', 'qux')
+            ->waitForLivewire()->click('@refresh')
+            ->assertSeeIn('@parent', 'Parent: qux')
+            ->assertSeeIn('@child', 'Child: qux')
+            ->assertSeeIn('@parent.ephemeral', 'qux')
+            ->assertSeeIn('@child.ephemeral', 'qux');
+    }
+    
     /** @test */
     public function can_bind_a_property_from_parent_form_to_property_from_child()
     {
@@ -273,6 +497,195 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertSeeNothingIn('@child.ephemeral', '')
         ;
     }
+    
+    /** @test */
+    public function can_bind_a_live_property_from_parent_form_to_property_from_child()
+    {
+        Livewire::visit([
+            new class extends \Livewire\Component {
+                public CreatePost $form;
+                
+                public function submit()
+                {
+                    $this->form->store();
+                }
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                <div>
+                    <span dusk='parent'>Parent: {{ $form->title }}</span>
+                    <span x-text='$wire.form.title' dusk='parent.ephemeral'></span>
+
+                    <livewire:child wire:model.live='form.title' />
+
+                    <button wire:click='$refresh' dusk='refresh'>refresh</button>
+                    <button wire:click='submit' dusk='submit'>submit</button>
+                </div>
+                HTML;
+                }
+            },
+            'child' => new class extends \Livewire\Component {
+                #[BaseModelable]
+                public $bar;
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                        <div>
+                            <span dusk='child'>Child: {{ $bar }}</span>
+                            <span x-text='$wire.bar' dusk='child.ephemeral'></span>
+                            <input type='text' wire:model='bar' dusk='child.input' />
+                        </div>
+                    HTML;
+                }
+            },
+        ])
+            ->assertDontSee('Property [$form.title] not found')
+            ->assertSeeIn('@parent', 'Parent:')
+            ->assertSeeIn('@child', 'Child:')
+            ->assertSeeNothingIn('@parent.ephemeral')
+            ->assertSeeNothingIn('@child.ephemeral')
+            ->type('@child.input', 'foo')
+            ->assertSeeIn('@parent', 'Parent:')
+            ->assertSeeIn('@child', 'Child:')
+            ->assertSeeIn('@parent.ephemeral', 'foo')
+            ->assertSeeIn('@child.ephemeral', 'foo')
+            ->waitForLivewire()->click('@refresh')
+            ->assertSeeIn('@parent', 'Parent: foo')
+            ->assertSeeIn('@child', 'Child: foo')
+            ->assertSeeIn('@parent.ephemeral', 'foo')
+            ->assertSeeIn('@child.ephemeral', 'foo')
+            ->waitForLivewire()->click('@submit')
+            ->assertSeeNothingIn('@parent.ephemeral', '')
+            ->assertSeeNothingIn('@child.ephemeral', '');
+    }
+    
+    /** @test */
+    public function can_bind_a_property_from_parent_form_with_nested_array_to_property_from_child()
+    {
+        $test = Livewire::visit([
+            new class extends \Livewire\Component {
+                public CreatePostUsingNestedArray $form;
+                
+                public function submit()
+                {
+                    $this->form->store();
+                }
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                <div>
+                    <span dusk='parent'>Parent: {{ $form->entries['bar'][0]['baz'] }}</span>
+                    <span x-text="$wire.form.entries['bar'][0]['baz']" dusk='parent.ephemeral'></span>
+
+                    <livewire:child wire:model='form.entries' />
+
+                    <button wire:click='$refresh' dusk='refresh'>refresh</button>
+                    <button wire:click='submit' dusk='submit'>submit</button>
+                </div>
+                HTML;
+                }
+            },
+            'child' => new class extends \Livewire\Component {
+                #[BaseModelable]
+                public $entry;
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                        <div>
+                            <span dusk='child'>Child: {{ $entry['bar'][0]['baz'] }}</span>
+                            <span x-text="$wire.entry['bar'][0]['baz']" dusk='child.ephemeral'></span>
+                            <input type='text' wire:model='entry.bar.0.baz' dusk='child.input' />
+                        </div>
+                    HTML;
+                }
+            },
+        ])
+            ->assertDontSee('Property [$form.entries.bar.0.baz] not found')
+            ->assertSeeIn('@parent', 'Parent:')
+            ->assertSeeIn('@child', 'Child:')
+            ->assertSeeNothingIn('@parent.ephemeral')
+            ->assertSeeNothingIn('@child.ephemeral')
+            ->type('@child.input', 'foo')
+            ->assertSeeIn('@parent', 'Parent:')
+            ->assertSeeIn('@child', 'Child:')
+            ->assertSeeIn('@parent.ephemeral', 'foo')
+            ->assertSeeIn('@child.ephemeral', 'foo')
+            ->waitForLivewire()->click('@refresh')
+            ->assertSeeIn('@parent', 'Parent: foo')
+            ->assertSeeIn('@child', 'Child: foo')
+            ->assertSeeIn('@parent.ephemeral', 'foo')
+            ->assertSeeIn('@child.ephemeral', 'foo')
+            ->waitForLivewire()->click('@submit')
+            ->assertSeeNothingIn('@parent.ephemeral', '')
+            ->assertSeeNothingIn('@child.ephemeral', '');
+    }
+    
+    /** @test */
+    public function can_bind_a_live_property_from_parent_form_with_nested_array_to_property_from_child()
+    {
+        $test = Livewire::visit([
+            new class extends \Livewire\Component {
+                public CreatePostUsingNestedArray $form;
+                
+                public function submit()
+                {
+                    $this->form->store();
+                }
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                <div>
+                    <span dusk='parent'>Parent: {{ $form->entries['bar'][0]['baz'] }}</span>
+                    <span x-text="$wire.form.entries['bar'][0]['baz']" dusk='parent.ephemeral'></span>
+
+                    <livewire:child wire:model.live='form.entries' />
+
+                    <button wire:click='$refresh' dusk='refresh'>refresh</button>
+                    <button wire:click='submit' dusk='submit'>submit</button>
+                </div>
+                HTML;
+                }
+            },
+            'child' => new class extends \Livewire\Component {
+                #[BaseModelable]
+                public $entry;
+                
+                public function render()
+                {
+                    return <<<'HTML'
+                        <div>
+                            <span dusk='child'>Child: {{ $entry['bar'][0]['baz'] }}</span>
+                            <span x-text="$wire.entry['bar'][0]['baz']" dusk='child.ephemeral'></span>
+                            <input type='text' wire:model='entry.bar.0.baz' dusk='child.input' />
+                        </div>
+                    HTML;
+                }
+            },
+        ])
+            ->assertDontSee('Property [$form.entries.bar.0.baz] not found')
+            ->assertSeeIn('@parent', 'Parent:')
+            ->assertSeeIn('@child', 'Child:')
+            ->assertSeeNothingIn('@parent.ephemeral')
+            ->assertSeeNothingIn('@child.ephemeral')
+            ->type('@child.input', 'foo')
+            ->assertSeeIn('@parent', 'Parent:')
+            ->assertSeeIn('@child', 'Child:')
+            ->assertSeeIn('@parent.ephemeral', 'foo')
+            ->assertSeeIn('@child.ephemeral', 'foo')
+            ->waitForLivewire()->click('@refresh')
+            ->assertSeeIn('@parent', 'Parent: foo')
+            ->assertSeeIn('@child', 'Child: foo')
+            ->assertSeeIn('@parent.ephemeral', 'foo')
+            ->assertSeeIn('@child.ephemeral', 'foo')
+            ->waitForLivewire()->click('@submit')
+            ->assertSeeNothingIn('@parent.ephemeral', '')
+            ->assertSeeNothingIn('@child.ephemeral', '');
+    }
 }
 
 
@@ -286,6 +699,25 @@ class CreatePost extends Form
     {
         Post::create($this->all());
 
+        $this->reset();
+    }
+}
+
+class CreatePostUsingNestedArray extends Form
+{
+    #[Rule('required')]
+    public $entries = [
+        'bar' => [
+            [ 'baz' => null ]
+        ]
+    ];
+    
+    public function store()
+    {
+        Post::create([
+            'title' => $this->entries['bar'][0]['baz']
+        ]);
+        
         $this->reset();
     }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Ensuring that Modelable works correctly on extreme/exotic data structures is strongly needed.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes, it's named `add-tests-for-modelable`.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

4️⃣ Does it include tests? (Required)
Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
Recently I created a PR (#7134) which has been closed since Caleb solved this issue (and others) in #7173, but in my PR I tested more exotic uses of the Modelable which could come handy in future implementations of this feature.

I can consider this my first contribution here, so I hope my work with these tests is good enough to be merged or at least improved to respect all the standards required to be part of this codebase!

> Thanks you all for the amazing work!
