### PR TITLE
Additions related to the single-root requirement

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -561,6 +561,38 @@ public function render()
 }
 ```
 
+### Setting additional layout file slots
+
+If your [layout file](#layout-files) has any named slots in addition to `$slot`, you can set their content in your Blade view by defining `<x-slot>`s outside your root element. For example, if you want to be able to set the page language for each component individually, you can add a dynamic `$lang` slot into the opening HTML tag in your layout file:
+
+```blade
+<!-- resources/views/components/layouts/app.blade.php -->
+
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', $lang ?? app()->getLocale()) }}"> // [tl! highlight]
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+        <title>{{ $title ?? 'Page Title' }}</title>
+    </head>
+    <body>
+        {{ $slot }}
+    </body>
+</html>
+```
+
+Then, in your component view, define an `<x-slot>` element outside the root element:
+
+```blade
+<x-slot:lang>fr</x-slot> // This component is in French [!tl highlight]
+
+<div>
+    // French content goes here...
+</div>
+```
+
+
 ### Accessing route parameters
 
 When working with full-page components, you may need to access route parameters within your Livewire component.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -84,6 +84,10 @@ Open the `resources/views/livewire/counter.blade.php` file and replace its conte
 
 This code will display the value of the `$count` property and two buttons that increment and decrement the `$count` property, respectively.
 
+> [!warning] Livewire components MUST have a single root element
+> In order for Livewire to work, components must have just **one** single element as its root. If multiple root elements are detected, an exception is thrown. It is recommended to use a `<div>` element as in the example. HTML comments count as separate elements and should be put inside the root element.
+> When rendering [full-page components](/docs/components#full-page-components), named slots for the layout file may be put outside the root element. These are removed before the component is rendered.
+
 ## Register a route for the component
 
 Open the `routes/web.php` file in your Laravel application and add the following code:


### PR DESCRIPTION
This PR adds two sections related to the requirement that components must have a single root element:

- a warning on the _Quickstart_ page about the existence of the requirement (probably accidentally left out in the v3 docs, cf. #7187)
- a section on the _Components_ page (under _Full-page components_, after _Setting the page title_) to clarify that, despite the requirement, `<x-slot>`s for the containing layout file should go _outside_ the root element