### PR TITLE
Fix bug when the first item in a collection is a new model

### DIFF
--- a/src/Features/SupportLegacyModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentCollectionSynth.php
@@ -26,7 +26,7 @@ class EloquentCollectionSynth extends Synth
         $meta['class'] = $class;
         $meta['modelClass'] = $modelClass;
 
-        if ($modelClass && $connection = $this->getConnection($target) !== $modelClass::make()->getConnectionName()) {
+        if ($modelClass && ($connection = $this->getConnection($target)) !== $modelClass::make()->getConnectionName()) {
             $meta['connection'] = $connection;
         }
 

--- a/src/Features/SupportLegacyModels/Tests/ModelCollectionAttributesCanBeBoundDirectlyUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelCollectionAttributesCanBeBoundDirectlyUnitTest.php
@@ -35,6 +35,8 @@ class ModelCollectionAttributesCanBeBoundDirectlyUnitTest extends \Tests\TestCas
     public function tearDown(): void
     {
         ModelForBinding::truncate();
+
+        parent::tearDown();
     }
 
     /** @test */


### PR DESCRIPTION
This fixes a bug related to legacy binding of properties to Eloquent collections with models.

When adding a new model (not yet persisted) to a property which is an _empty_ Eloquent DB Collection, this error is observed:

```
InvalidArgumentException: Database connection [1] not configured.
```

Since the new model has a database connection of `null`, and it does not match the model's default connection name, we hit this line of code:

https://github.com/livewire/livewire/blob/main/src/Features/SupportLegacyModels/EloquentCollectionSynth.php#L29

The value of `$connection` is accidentally set to `true` rather than a string of the real connection due to missing parentheses.

```diff
-        if ($modelClass && $connection = $this->getConnection($target) !== $modelClass::make()->getConnectionName()) {
+        if ($modelClass && ($connection = $this->getConnection($target)) !== $modelClass::make()->getConnectionName()) {
```

The reason this was not caught before was because we use Sushi in the unit test, and Sushi always returns the model class for the connection name regardless of whether it's a "new" model.

I've updated the model in this test file to use testbench as the DB connection. Maybe there's a more elegant way to do it while keeping Sushi — let me know!