### PR TITLE
Support optional middleware.

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -30,16 +30,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Livewire Guard
+    | Livewire Route Middleware
     |--------------------------------------------------------------------------
     |
-    | Here you may specify the authentication guard Livewire will use while
-    | authenticating users. This value should correspond with one of your
-    | guards that is already present in your "auth" configuration file.
+    | Here you may specify which middleware Livewire will assign to the routes
+    | that it registers with the application. When necessary, you may modify
+    | these middleware; however, this default value is usually sufficient.
     |
     */
 
-    'guard' => 'web',
+    'middleware' => 'web',
 
     /*
     |---------------------------------------------------------------------------

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -29,6 +29,19 @@ return [
     'view_path' => resource_path('views/livewire'),
 
     /*
+    |--------------------------------------------------------------------------
+    | Livewire Guard
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the authentication guard Livewire will use while
+    | authenticating users. This value should correspond with one of your
+    | guards that is already present in your "auth" configuration file.
+    |
+    */
+
+    'guard' => 'web',
+
+    /*
     |---------------------------------------------------------------------------
     | Layout
     |---------------------------------------------------------------------------

--- a/src/Features/SupportFileUploads/SupportFileUploads.php
+++ b/src/Features/SupportFileUploads/SupportFileUploads.php
@@ -33,10 +33,10 @@ class SupportFileUploads extends ComponentHook
 
         Route::post('/livewire/upload-file', [FileUploadController::class, 'handle'])
             ->name('livewire.upload-file')
-            ->middleware('web');
+            ->middleware(config('livewire.guard'));
 
         Route::get('/livewire/preview-file/{filename}', [FilePreviewController::class, 'handle'])
             ->name('livewire.preview-file')
-            ->middleware('web');
+            ->middleware(config('livewire.guard'));
     }
 }

--- a/src/Features/SupportFileUploads/SupportFileUploads.php
+++ b/src/Features/SupportFileUploads/SupportFileUploads.php
@@ -33,10 +33,10 @@ class SupportFileUploads extends ComponentHook
 
         Route::post('/livewire/upload-file', [FileUploadController::class, 'handle'])
             ->name('livewire.upload-file')
-            ->middleware(config('livewire.middleware'));
+            ->middleware(config('livewire.middleware', 'web'));
 
         Route::get('/livewire/preview-file/{filename}', [FilePreviewController::class, 'handle'])
             ->name('livewire.preview-file')
-            ->middleware(config('livewire.middleware'));
+            ->middleware(config('livewire.middleware', 'web'));
     }
 }

--- a/src/Features/SupportFileUploads/SupportFileUploads.php
+++ b/src/Features/SupportFileUploads/SupportFileUploads.php
@@ -33,10 +33,10 @@ class SupportFileUploads extends ComponentHook
 
         Route::post('/livewire/upload-file', [FileUploadController::class, 'handle'])
             ->name('livewire.upload-file')
-            ->middleware(config('livewire.guard'));
+            ->middleware(config('livewire.middleware'));
 
         Route::get('/livewire/preview-file/{filename}', [FilePreviewController::class, 'handle'])
             ->name('livewire.preview-file')
-            ->middleware(config('livewire.guard'));
+            ->middleware(config('livewire.middleware'));
     }
 }

--- a/src/Features/SupportTesting/DuskTestable.php
+++ b/src/Features/SupportTesting/DuskTestable.php
@@ -20,7 +20,7 @@ class DuskTestable
             $class = urldecode($component);
 
             return app()->call(app('livewire')->new($class));
-        })->middleware(config('livewire.middleware'));
+        })->middleware(config('livewire.middleware', 'web'));
 
         on('browser.testCase.setUp', function ($testCase) {
             static::$currentTestCase = $testCase;

--- a/src/Features/SupportTesting/DuskTestable.php
+++ b/src/Features/SupportTesting/DuskTestable.php
@@ -20,7 +20,7 @@ class DuskTestable
             $class = urldecode($component);
 
             return app()->call(app('livewire')->new($class));
-        })->middleware(config('livewire.guard'));
+        })->middleware(config('livewire.middleware'));
 
         on('browser.testCase.setUp', function ($testCase) {
             static::$currentTestCase = $testCase;

--- a/src/Features/SupportTesting/DuskTestable.php
+++ b/src/Features/SupportTesting/DuskTestable.php
@@ -20,7 +20,7 @@ class DuskTestable
             $class = urldecode($component);
 
             return app()->call(app('livewire')->new($class));
-        })->middleware('web');
+        })->middleware(config('livewire.guard'));
 
         on('browser.testCase.setUp', function ($testCase) {
             static::$currentTestCase = $testCase;

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -18,7 +18,7 @@ class HandleRequests
     function boot()
     {
         app($this::class)->setUpdateRoute(function ($handle) {
-            return Route::post('/livewire/update', $handle)->middleware(config('livewire.guard', 'web'));
+            return Route::post('/livewire/update', $handle)->middleware(config('livewire.middleware', 'web'));
         });
 
         $this->skipRequestPayloadTamperingMiddleware();

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -18,7 +18,7 @@ class HandleRequests
     function boot()
     {
         app($this::class)->setUpdateRoute(function ($handle) {
-            return Route::post('/livewire/update', $handle)->middleware('web');
+            return Route::post('/livewire/update', $handle)->middleware(config('livewire.guard', 'web'));
         });
 
         $this->skipRequestPayloadTamperingMiddleware();


### PR DESCRIPTION
The middleware does not always have to be web, its name can be changed. A new middleware option has been added to the configuration options to use it optionally.

An exception will occur if you delete or rename the default 'web' middleware group for any reason. To prevent this, this pull request makes the middleware option optional in the configuration file.