### PR TITLE
Fix nested component listeners not working with multi-word events

### DIFF
--- a/src/Features/SupportNestedComponentListeners/BrowserTest.php
+++ b/src/Features/SupportNestedComponentListeners/BrowserTest.php
@@ -88,5 +88,50 @@ class BrowserTest extends BrowserTestCase
         ->click('@button')
         ->waitForTextIn('@count', '5');
     }
+
+    /** @test */
+    function can_dispatch_multi_word_event_names()
+    {
+        Livewire::visit([
+            new class extends BaseComponent {
+                public $count = 0;
+
+                function increment() {
+                    $this->count++;
+                }
+
+                public function render() {
+                    return <<<'HTML'
+                        <div>
+                            <h1 dusk="count">{{ $count }}</h1>
+
+                            <livewire:child @fired-event="increment" />
+                        </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends BaseComponent {
+                public function fire() {
+                    $this->dispatch('fired-event');
+                }
+
+                public function render() {
+                    return <<<'HTML'
+                        <div>
+                            <button dusk="button" wire:click="fire">fire from child</button>
+                            <button dusk="button2" wire:click="$dispatch('fired-event')">fire from child (directly)</button>
+                        </div>
+                    HTML;
+                }
+            }
+        ])
+        ->assertSeeIn('@count', '0')
+        ->click('@button')
+        ->waitForTextIn('@count', '1')
+        ->click('@button')
+        ->waitForTextIn('@count', '2')
+        ->click('@button2')
+        ->waitForTextIn('@count', '3');
+    }
 }
 

--- a/src/Features/SupportNestedComponentListeners/SupportNestedComponentListeners.php
+++ b/src/Features/SupportNestedComponentListeners/SupportNestedComponentListeners.php
@@ -19,7 +19,9 @@ class SupportNestedComponentListeners extends ComponentHook
         // to the root element of the component...
         foreach ($params as $key => $value) {
             if (str($key)->startsWith('@')) {
-                $fullEvent = str($key)->after('@');
+                // any kebab-cased parameters passed in will have been converted to camelCase
+                // so we need to convert back to kebab to ensure events are valid in html
+                $fullEvent = str($key)->after('@')->kebab();
                 $attributeKey = 'x-on:'.$fullEvent;
                 $attributeValue = "\$wire.\$parent.".$value;
 


### PR DESCRIPTION
This PR fixes an issue with the nested component listeners, where multi-word events weren't working properly.

With the following event listener:
```blade
<livewire:child @my-event="$refresh" />
```

The `my-event` was being attached to the root element as `x-on:myevent`.
This PR changes it so it gets attached as `x-on:my-event`.

Hope this helps!