### PR TITLE
Fix Pest Scaffolding Behavior in `php artisan make:livewire` Command and Prioritize `--pest` Flag

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -41,7 +41,7 @@ class MakeCommand extends FileManipulationCommand implements PromptsForMissingIn
         $force = $this->option('force');
         $inline = $this->option('inline');
         $test = $this->option('test') || $this->option('pest');
-        $testType = $this->option('test') ? 'phpunit' : 'pest';
+        $testType = $this->option('pest') ? 'pest' : 'phpunit';
 
         $showWelcomeMessage = $this->isFirstTimeMakingAComponent();
 
@@ -108,7 +108,7 @@ class MakeCommand extends FileManipulationCommand implements PromptsForMissingIn
         return $viewPath;
     }
 
-    protected function createTest($force = false, $testType = 'phpunit')
+    protected function createTest($force = false, $testType)
     {
         $testPath = $this->parser->testPath();
 

--- a/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
@@ -39,7 +39,7 @@ class MakeCommandUnitTest extends \Tests\TestCase
     /** @test */
     public function component_pest_test_is_created_by_make_command_with_pest_option()
     {
-        Artisan::call('make:livewire', ['name' => 'foo', '--pest' => true]);
+        Artisan::call('make:livewire', ['name' => 'foo', '--test' => true, '--pest' => true]);
 
         $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
         $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));


### PR DESCRIPTION
Currently, when the `php artisan make:livewire` command is executed without any specific parameters, and you select the Pest option in the terminal, it generates the test using the PHPUnit scaffold. 

This PR addresses this behavior and ensures that Pest scaffolding is used as expected when Pest is chosen.

In addition, this PR enhances the command's behavior by giving precedence to the `--pest` flag over the `--test` flag. This means that even if both flags are provided, Pest scaffolding will be utilized, providing a more consistent and predictable experience.