### PR TITLE
Create PHPStan extension for computed properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "orchestra/testbench": "^8.0",
     "orchestra/testbench-dusk": "^8.0",
     "calebporzio/sushi": "^2.1",
-    "laravel/prompts": "^0.1.6"
+    "laravel/prompts": "^0.1.6",
+    "phpstan/phpstan": "^1.10"
   },
   "autoload": {
     "files": [
@@ -49,6 +50,11 @@
       "aliases": {
         "Livewire": "Livewire\\Livewire"
       }
+    },
+    "phpstan": {
+      "includes": [
+        "extension.neon"
+      ]
     }
   },
   "minimum-stability": "dev",

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,4 @@
+services:
+    -
+        class: Livewire\PHPStan\Properties\ComputedPropertyExtension
+        tags: [phpstan.broker.propertiesClassReflectionExtension]

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,5 +19,8 @@
         <testsuite name="LegacyBrowser">
             <directory suffix="Test.php">./legacy_tests/Browser</directory>
         </testsuite>
+        <testsuite name="PHPStan">
+            <directory>tests/PHPStan</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/src/PHPStan/Properties/ComputedProperty.php
+++ b/src/PHPStan/Properties/ComputedProperty.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Livewire\PHPStan\Properties;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\Type;
+
+final class ComputedProperty implements PropertyReflection
+{
+    public function __construct(
+        private ClassReflection $declaringClass,
+        private ExtendedMethodReflection $methodReflection,
+        private Type $readableType,
+    ) {
+    }
+
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->declaringClass;
+    }
+
+    public function isStatic(): bool
+    {
+        return false;
+    }
+
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    public function isPublic(): bool
+    {
+        return true;
+    }
+
+    public function getDocComment(): ?string
+    {
+        return $this->methodReflection->getDocComment();
+    }
+
+    public function getReadableType(): Type
+    {
+        return $this->readableType;
+    }
+
+    public function getWritableType(): Type
+    {
+        return new NeverType();
+    }
+
+    public function canChangeTypeAfterAssignment(): bool
+    {
+        return false;
+    }
+
+    public function isReadable(): bool
+    {
+        return true;
+    }
+
+    public function isWritable(): bool
+    {
+        return false;
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return $this->methodReflection->isDeprecated();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return $this->methodReflection->getDeprecatedDescription();
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+}

--- a/src/PHPStan/Properties/ComputedPropertyExtension.php
+++ b/src/PHPStan/Properties/ComputedPropertyExtension.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Livewire\PHPStan\Properties;
+
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+use Livewire\PHPStan\Properties\ComputedProperty;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\PropertiesClassReflectionExtension;
+use PHPStan\Reflection\PropertyReflection;
+
+final class ComputedPropertyExtension implements PropertiesClassReflectionExtension
+{
+    public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
+    {
+        if (! $classReflection->isSubclassOf(Component::class)) {
+            return false;
+        }
+
+        if ($classReflection->isAbstract()) {
+            return false;
+        }
+
+        if (! $classReflection->hasNativeMethod($propertyName)) {
+            return false;
+        }
+
+        $methodReflection = $classReflection
+            ->getNativeReflection()
+            ->getMethod($propertyName);
+
+        if (! $methodReflection->isPublic()) {
+            return false;
+        }
+
+        return ! empty($methodReflection->getAttributes(Computed::class));
+    }
+
+    public function getProperty(
+        ClassReflection $classReflection,
+        string $propertyName,
+    ): PropertyReflection {
+        $methodReflection = $classReflection->getNativeMethod($propertyName);
+
+        $returnType = ParametersAcceptorSelector::selectSingle(
+            $methodReflection->getVariants(),
+        )->getReturnType();
+
+        return new ComputedProperty(
+            declaringClass: $classReflection,
+            methodReflection: $methodReflection,
+            readableType: $returnType,
+        );
+    }
+}

--- a/tests/PHPStan/Reflection/ComputedPropertyExtensionTest.php
+++ b/tests/PHPStan/Reflection/ComputedPropertyExtensionTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPStan\Reflection;
+
+use Livewire\PHPStan\Properties\ComputedPropertyExtension;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\Type\VerbosityLevel;
+use Tests\PHPStan\stubs\TestComponentWithComputedProperties;
+
+final class ComputedPropertyExtensionTest extends PHPStanTestCase
+{
+    private ClassReflection $classReflection;
+    private ComputedPropertyExtension $reflectionExtension;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->classReflection = $this->createReflectionProvider()
+            ->getClass(TestComponentWithComputedProperties::class);
+
+        $this->reflectionExtension = new ComputedPropertyExtension();
+    }
+
+    /** @test */
+    public function itMustHaveComputedAttribute(): void
+    {
+        $this->assertFalse($this->reflectionExtension->hasProperty(
+            $this->classReflection,
+            'notAComputedProperty',
+        ));
+    }
+
+    /** @test */
+    public function itMustBePublicMethod(): void
+    {
+        $this->assertFalse($this->reflectionExtension->hasProperty(
+            $this->classReflection,
+            'privateMethod',
+        ));
+
+        $this->assertFalse($this->reflectionExtension->hasProperty(
+            $this->classReflection,
+            'protectedMethod',
+        ));
+
+        $this->assertTrue($this->reflectionExtension->hasProperty(
+            $this->classReflection,
+            'property',
+        ));
+    }
+
+    /** @test */
+    public function itReturnsDocComment(): void
+    {
+        $property = $this->reflectionExtension->getProperty(
+            $this->classReflection,
+            'propertyWithComments',
+        );
+
+        $this->assertSame(
+            $property->getDocComment(),
+            '/** This is a comment. */',
+        );
+    }
+
+    /** @test */
+    public function itRespectsDeprecatedDoc(): void
+    {
+        $property = $this->reflectionExtension->getProperty(
+            $this->classReflection,
+            'property',
+        );
+        $deprecatedProperty = $this->reflectionExtension->getProperty(
+            $this->classReflection,
+            'deprecatedProperty',
+        );
+
+        $this->assertTrue($property->isDeprecated()->no());
+        $this->assertTrue($deprecatedProperty->isDeprecated()->yes());
+    }
+
+    /** @test */
+    public function itReturnsDeprecatedDescription(): void
+    {
+        $property = $this->reflectionExtension->getProperty(
+            $this->classReflection,
+            'property',
+        );
+        $deprecatedProperty = $this->reflectionExtension->getProperty(
+            $this->classReflection,
+            'deprecatedPropertyWithDescription',
+        );
+
+        $this->assertNull($property->getDeprecatedDescription());
+        $this->assertSame(
+            $deprecatedProperty->getDeprecatedDescription(),
+            'Has a description.'
+        );
+    }
+
+    /** @test */
+    public function itReturnsType(): void
+    {
+        $property = $this->reflectionExtension->getProperty(
+            $this->classReflection,
+            'property',
+        );
+
+        $this->assertSame(
+            $property->getReadableType()->describe(VerbosityLevel::typeOnly()),
+            'bool',
+        );
+    }
+
+    /** @test */
+    public function itReturnsGenericType(): void
+    {
+        $property = $this->reflectionExtension->getProperty(
+            $this->classReflection,
+            'propertyWithGenerics',
+        );
+
+        $this->assertSame(
+            $property->getReadableType()->describe(VerbosityLevel::typeOnly()),
+            'array<int, string>',
+        );
+    }
+}

--- a/tests/PHPStan/stubs/TestComponentWithComputedProperties.php
+++ b/tests/PHPStan/stubs/TestComponentWithComputedProperties.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPStan\stubs;
+
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+final class TestComponentWithComputedProperties extends Component
+{
+    public function notAComputedProperty(): bool
+    {
+        return true;
+    }
+
+    #[Computed]
+    private function privateMethod(): bool
+    {
+        return true;
+    }
+
+    #[Computed]
+    protected function protectedMethod(): bool
+    {
+        return true;
+    }
+
+    #[Computed]
+    public function property(): bool
+    {
+        return true;
+    }
+
+    /** This is a comment. */
+    #[Computed]
+    public function propertyWithComments(): bool
+    {
+        return true;
+    }
+
+    /** @deprecated */
+    #[Computed]
+    public function deprecatedProperty(): bool
+    {
+        return true;
+    }
+
+    /** @deprecated Has a description. */
+    #[Computed]
+    public function deprecatedPropertyWithDescription(): bool
+    {
+        return true;
+    }
+
+    /** @return array<int,string> */
+    #[Computed]
+    public function propertyWithGenerics(): array
+    {
+        return ['foo', 'bar'];
+    }
+}


### PR DESCRIPTION
Hello!

This PR creates a [PHPStan](https://phpstan.org/) extension for Livewire---it currently only supports computed properties but other functionality can be added as necessary. The extension supports [auto-installation](https://phpstan.org/user-guide/extension-library#installing-extensions) but can be manually included as well, depending on the user's configuration.

Some might question if this should be a separate package, however, including the PHPStan extension for a library's special functionality provides a much better developer experience. For example, consider the Carbon library which provides a [PHPStan extension for their macros](https://github.com/briannesbitt/Carbon/blob/master/extension.neon) out-of-the-box without having to install a separate phpstan package.

Thanks!