### PR TITLE
Use #[Validate] instead of #[Rule]

### DIFF
--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -11,13 +11,13 @@ namespace App\Livewire;
 
 use Livewire\Component;
 use Livewire\WithFileUploads;
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 
 class UploadPhoto extends Component
 {
     use WithFileUploads;
 
-    #[Rule('image|max:1024')] // 1MB Max
+    #[Validate('image|max:1024')] // 1MB Max
     public $photo;
 
     public function save()
@@ -89,13 +89,13 @@ For example, below is a component with an array property named `$photos`. By add
 ```php
 use Livewire\Component;
 use Livewire\WithFileUploads;
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 
 class UploadPhotos extends Component
 {
     use WithFileUploads;
 
-    #[Rule(['photos.*' => 'image|max:1024'])]
+    #[Validate(['photos.*' => 'image|max:1024'])]
     public $photos = [];
 
     public function save()
@@ -140,13 +140,13 @@ Let's explore an example of a file upload with an image preview:
 ```php
 use Livewire\Component;
 use Livewire\WithFileUploads;
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 
 class UploadPhoto extends Component
 {
     use WithFileUploads;
 
-    #[Rule('image|max:1024')]
+    #[Validate('image|max:1024')]
     public $photo;
 
     // ...

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -53,23 +53,23 @@ On the frontend, you can use Laravel's existing Blade directives to show validat
 
 For more information, see [Laravel's documentation on rendering validation errors in Blade](https://laravel.com/docs/blade#validation-errors).
 
-## Rule attributes
+## Validate attributes
 
-If you prefer to co-locate your component's validation rules with the properties directly, you can use Livewire's `#[Rule]` attribute.
+If you prefer to co-locate your component's validation rules with the properties directly, you can use Livewire's `#[Validate]` attribute.
 
-By associating validation rules with properties using `#[Rule]`, Livewire will automatically run the properties validation rules before each update. However, you should still run `$this->validate()` before persisting data to a database so that properties that haven't been updated are also validated.
+By associating validation rules with properties using `#[Validate]`, Livewire will automatically run the properties validation rules before each update. However, you should still run `$this->validate()` before persisting data to a database so that properties that haven't been updated are also validated.
 
 ```php
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 use Livewire\Component;
 use App\Models\Post;
 
 class CreatePost extends Component
 {
-    #[Rule('required|min:3')] // [tl! highlight]
+    #[Validate('required|min:3')] // [tl! highlight]
 	public $title = '';
 
-    #[Rule('required|min:3')] // [tl! highlight]
+    #[Validate('required|min:3')] // [tl! highlight]
     public $content = '';
 
     public function save()
@@ -88,22 +88,24 @@ class CreatePost extends Component
 }
 ```
 
-> [!warning] Rule attributes have restrictions
-> PHP Attributes are restricted to certain syntaxes like plain strings and arrays. If you find yourself wanting to use run-time syntaxes like Laravel's rule objects (`Rule::exists(...)`) you should instead [define a `rules()` method](#defining-a-rules-method) in your component.
+> [!info] Validate attributes don't support Rule objects
+> PHP Attributes are restricted to certain syntaxes like plain strings and arrays. If you find yourself wanting to use run-time syntaxes like Laravel's Rule objects (`Rule::exists(...)`) you should instead [define a `rules()` method](#defining-a-rules-method) in your component.
+>
+> Learn more in the documentation on [using Laravel Rule objects with Livewire](#using-laravel-rule-objects).
 
-If you prefer more control over when the properties are validated, you can pass a `onUpdate: false` parameter to the `#[Rule]` attribute. This will disabled any automatic validation and instead assume you want to manually validate the properties using the `$this->validate()` method:
+If you prefer more control over when the properties are validated, you can pass a `onUpdate: false` parameter to the `#[Validate]` attribute. This will disabled any automatic validation and instead assume you want to manually validate the properties using the `$this->validate()` method:
 
 ```php
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 use Livewire\Component;
 use App\Models\Post;
 
 class CreatePost extends Component
 {
-    #[Rule('required|min:3', onUpdate: false)]
+    #[Validate('required|min:3', onUpdate: false)]
 	public $title = '';
 
-    #[Rule('required|min:3', onUpdate: false)]
+    #[Validate('required|min:3', onUpdate: false)]
     public $content = '';
 
     public function save()
@@ -124,9 +126,9 @@ class CreatePost extends Component
 If you wish to customize the attribute name injected into the validation message, you may do so using the `as: ` parameter:
 
 ```php
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 
-#[Rule('required', as: 'date of birth')]
+#[Validate('required', as: 'date of birth')]
 public $dob;
 ```
 
@@ -134,22 +136,22 @@ When validation fails in the above snippet, Laravel will use "date of birth" ins
 
 ### Custom validation message
 
-To bypass Laravel's validation message and replace it with your own, you can use the `message: ` parameter in the `#[Rule]` attribute:
+To bypass Laravel's validation message and replace it with your own, you can use the `message: ` parameter in the `#[Validate]` attribute:
 
 ```php
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 
-#[Rule('required', message: 'Please provide a post title')]
+#[Validate('required', message: 'Please provide a post title')]
 public $title;
 ```
 
 Now, when the validation fails for this property, the message will  be "Please provide a post title" instead of "The title field is required".
 
-If you wish to add different messages for different rules, you can simply provide multiple `#[Rule]` attributes:
+If you wish to add different messages for different rules, you can simply provide multiple `#[Validate]` attributes:
 
 ```php
-#[Rule('required', message: 'Please provide a post title')]
-#[Rule('min:3', message: 'This title is too short')]
+#[Validate('required', message: 'Please provide a post title')]
+#[Validate('min:3', message: 'This title is too short')]
 public $title;
 ```
 
@@ -157,21 +159,21 @@ public $title;
 
 By default, Livewire rule messages and attributes are localized using Laravel's translate helper: `trans()`.
 
-You can opt-out of locaization by passing the `translate: false` parameter to the Rule attribute:
+You can opt-out of locaization by passing the `translate: false` parameter to the `#[Validate]` attribute:
 
 ```php
-#[Rule('required', message: 'Please provide a post title', translate: false)]
+#[Validate('required', message: 'Please provide a post title', translate: false)]
 public $title;
 ```
 
 ### Custom key
 
-When applying validation rules directly to a property using the `#[Rule]` attribute, Livewire assumes the validation key should be the name of the property itself. However, there are times when you may want to customize the validation key.
+When applying validation rules directly to a property using the `#[Validate]` attribute, Livewire assumes the validation key should be the name of the property itself. However, there are times when you may want to customize the validation key.
 
-For example, you might want to provide separate validation rules for an array property and its children. In this case, instead of passing a validation rule as the first argument to the `#[Rule]` attribute, you can pass an array of key-value pairs instead:
+For example, you might want to provide separate validation rules for an array property and its children. In this case, instead of passing a validation rule as the first argument to the `#[Validate]` attribute, you can pass an array of key-value pairs instead:
 
 ```php
-#[Rule([
+#[Validate([
     'todos' => 'required',
     'todos.*' => [
         'required',
@@ -195,14 +197,15 @@ Below is the same `CreatePost` example, but now the properties and rules have be
 
 namespace App\Livewire\Forms;
 
+use Livewire\Attributes\Validate;
 use Livewire\Form;
 
 class PostForm extends Form
 {
-    #[Rule('required|min:3')]
+    #[Validate('required|min:3')]
 	public $title = '';
 
-    #[Rule('required|min:3')]
+    #[Validate('required|min:3')]
     public $content = '';
 }
 ```
@@ -251,7 +254,7 @@ Also, when referencing the property names in the template, you must prepend `for
 </form>
 ```
 
-When using form objects, `#[Rule]` attribute validation will be run every time a property is updated. However, if you disable this behavior by specifying `onUpdate: false` on the attribute, you can manually run a form object's validation using `$this->form->validate()`:
+When using form objects, `#[Validate]` attribute validation will be run every time a property is updated. However, if you disable this behavior by specifying `onUpdate: false` on the attribute, you can manually run a form object's validation using `$this->form->validate()`:
 
 ```php
 public function save()
@@ -270,7 +273,7 @@ Form objects are a useful abstraction for most larger datasets and a variety of 
 
 Real-time validation is the term used for when you validate a user's input as they fill out a form rather than waiting for the form submission.
 
-By using `#[Rule]` attributes directly on Livewire properties, any time a network request is sent to update a property's value on the server, the provided validation rules will be applied.
+By using `#[Validate]` attributes directly on Livewire properties, any time a network request is sent to update a property's value on the server, the provided validation rules will be applied.
 
 This means to provide a real-time validation experience for your users on a specific input, no extra backend work is required. The only thing that is required is using `wire:model.live` or `wire:model.blur` to instruct Livewire to trigger network requests as the fields are filled out.
 
@@ -283,6 +286,40 @@ In the below example, `wire:model.blur` has been added to the text input. Now, w
     <!-- -->
 </form>
 ```
+
+If you are using a `rules()` method to declare your validation rules for a property instead of the `#[Validate]` attribute, you can still include a #[Validate] attribute with no parameters to retain the real-time validating behavior:
+
+```php
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+use App\Models\Post;
+
+class CreatePost extends Component
+{
+    #[Validate] // [tl! highlight]
+	public $title = '';
+
+    public $content = '';
+
+    public function rules()
+    {
+        return [
+            'title' => 'required|min:5',
+            'content' => 'required|min:5',
+        ];
+    }
+
+    public function save()
+    {
+        $validated = $this->validate();
+
+		Post::create($validated);
+
+		return redirect()->to('/posts');
+    }
+```
+
+Now, in the above example, even though `#[Validate]` is empty, it will tell Livewire to run the fields validation provided by `rules()` everytime the property is updated.
 
 ## Customizing error messages
 
@@ -297,9 +334,9 @@ Sometimes the property you are validating has a name that isn't suited for displ
 Livewire allows you to specify an alternative name for a property using the `as: ` parameter:
 
 ```php
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 
-#[Rule('required', as: 'date of birth')]
+#[Validate('required', as: 'date of birth')]
 public $dob = '';
 ```
 
@@ -310,28 +347,28 @@ Now, if the `required` validation rule fails, the error message will state "The 
 If customizing the property name isn't enough, you can customize the entire validation message using the `message: ` parameter:
 
 ```php
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 
-#[Rule('required', message: 'Please fill out your date of birth.')]
+#[Validate('required', message: 'Please fill out your date of birth.')]
 public $dob = '';
 ```
 
-If you have multiple rules to customize the message for, it is recommended that you use entirely separate `#[Rule]` attributes for each, like so:
+If you have multiple rules to customize the message for, it is recommended that you use entirely separate `#[Validate]` attributes for each, like so:
 
 ```php
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 
-#[Rule('required', message: 'Please enter a title.')]
-#[Rule('min:5', message: 'Your title is too short.')]
+#[Validate('required', message: 'Please enter a title.')]
+#[Validate('min:5', message: 'Your title is too short.')]
 public $title = '';
 ```
 
-If you want to use the `#[Rule]` attribute's array syntax instead, you can specify custom attributes and messages like so:
+If you want to use the `#[Validate]` attribute's array syntax instead, you can specify custom attributes and messages like so:
 
 ```php
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 
-#[Rule([
+#[Validate([
     'titles' => 'required',
     'titles.*' => 'required|min:5',
 ], message: [
@@ -346,9 +383,9 @@ public $titles = [];
 
 ## Defining a `rules()` method
 
-As an alternative to Livewire's `#[Rule]` attributes, you can define a method in your component called `rules()` and return a list of fields and corresponding validation rules. This can be helpful if you are trying to use run-time syntaxes that aren't supported in PHP Attributes, for example, Laravel rule objects like `Rule::password()`.
+As an alternative to Livewire's `#[Validate]` attributes, you can define a method in your component called `rules()` and return a list of fields and corresponding validation rules. This can be helpful if you are trying to use run-time syntaxes that aren't supported in PHP Attributes, for example, Laravel rule objects like `Rule::password()`.
 
-These rules will then be applied when you run `$this->validate()` inside the component. You also can define the `messages()` and `attributes()` functions.
+These rules will then be applied when you run `$this->validate()` inside the component. You also can define the `messages()` and `validationAttributes()` functions.
 
 Here's an example:
 
@@ -370,7 +407,7 @@ class CreatePost extends Component
             'content' => 'required|min:3',
         ];
     }
-    
+
     public function messages() // [tl! highlight:6]
     {
         return [
@@ -378,7 +415,7 @@ class CreatePost extends Component
             'content.min' => 'The :attribute is too short.',
         ];
     }
-    
+
     public function validationAttributes() // [tl! highlight:6]
     {
         return [
@@ -403,7 +440,60 @@ class CreatePost extends Component
 ```
 
 > [!warning] The `rules()` method doesn't validate on data updates
-> When defining rules via the `rules()` method, Livewire will ONLY use these validation rules to validate properties when you run `$this->validate()`. This is different than standard `#[Rule]` attributes which are applied every time a field is updated via something like `wire:model`.
+> When defining rules via the `rules()` method, Livewire will ONLY use these validation rules to validate properties when you run `$this->validate()`. This is different than standard `#[Validate]` attributes which are applied every time a field is updated via something like `wire:model`. To apply these validation rules to a property every time it's updated, you can still use `#[Validate]` with no extra parameters.
+
+## Using Laravel Rule objects
+
+Laravel `Rule` objects are an extremely powerful way to add advanced validation behavior to your forms.
+
+Here is an example of using Rule objects in conjunction with Livewire's `rules()` method to achieve more sophisticated validation:
+
+```php
+<?php
+
+namespace App\Livewire;
+
+use Illuminate\Validation\Rule;
+use App\Models\Post;
+use Livewire\Form;
+
+class UpdatePost extends Form
+{
+    public ?Post $post;
+
+    public $title = '';
+
+    public $content = '';
+
+    public function rules()
+    {
+        return [
+            'title' => [
+                'required',
+                Rule::unique('posts')->ignore($this->post), // [tl! highlight]
+            ],
+            'content' => 'required|min:5',
+        ];
+    }
+
+    public function mount()
+    {
+        $this->title = $this->post->title;
+        $this->content = $this->post->content;
+    }
+
+    public function update()
+    {
+        $this->validate(); // [tl! highlight]
+
+        $this->post->update($this->all());
+
+        $this->reset();
+    }
+
+    // ...
+}
+```
 
 ## Manually controlling validation errors
 
@@ -427,16 +517,16 @@ Sometimes you may want to access the Validator instance that Livewire uses inter
 Below is an example of intercepting Livewire's internal validator to manually check a condition and add an additional validation message:
 
 ```php
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 use Livewire\Component;
 use App\Models\Post;
 
 class CreatePost extends Component
 {
-    #[Rule('required|min:3')]
+    #[Validate('required|min:3')]
 	public $title = '';
 
-    #[Rule('required|min:3')]
+    #[Validate('required|min:3')]
     public $content = '';
 
     public function boot()

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -645,3 +645,9 @@ public function cant_create_post_without_title_and_content()
 ```
 
 For more information on other testing utilities provided by Livewire, check out the [testing documentation](/docs/testing).
+
+## Deprecated `[#Rule]` attribute
+
+When Livewire v3 first launched, it used the term "Rule" instead of "Validate" for it's validation attributes (`#[Rule]`).
+
+Because of naming conflicts with Laravel rule objects, this has since been changed to `#[Validate]`. Both are supported in Livewire v3, however it is recommended that you change all occurances of `#[Rule]` with `#[Validate]` to stay current.

--- a/src/Attributes/Validate.php
+++ b/src/Attributes/Validate.php
@@ -3,10 +3,10 @@
 namespace Livewire\Attributes;
 
 use Attribute;
-use Livewire\Features\SupportValidation\BaseRule;
+use Livewire\Features\SupportValidation\BaseValidate;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_ALL)]
-class Validate extends BaseRule
+class Validate extends BaseValidate
 {
     //
 }

--- a/src/Attributes/Validate.php
+++ b/src/Attributes/Validate.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Attribute;
+use Livewire\Features\SupportValidation\BaseRule;
+
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_ALL)]
+class Validate extends BaseRule
+{
+    //
+}
+

--- a/src/Features/SupportConsoleCommands/Commands/livewire.form.stub
+++ b/src/Features/SupportConsoleCommands/Commands/livewire.form.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 use Livewire\Form;
 
 class DummyClass extends Form

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -3,7 +3,7 @@
 namespace Livewire\Features\SupportFormObjects;
 
 use Illuminate\Database\Eloquent\Model;
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 use Livewire\Component;
 use Livewire\Form;
 use Livewire\Livewire;
@@ -471,16 +471,16 @@ class PostFormValidateStub extends Form
 
 class PostFormRuleAttributeStub extends Form
 {
-    #[Rule('required')]
+    #[Validate('required')]
     public $title = '';
 
-    #[Rule('required')]
+    #[Validate('required')]
     public $content = '';
 }
 
 class PostFormRuleAttributeWithCustomNameStub extends Form
 {
-    #[Rule(
+    #[Validate(
         rule: [
             'required',
             'min:3',
@@ -493,10 +493,10 @@ class PostFormRuleAttributeWithCustomNameStub extends Form
 
 class PostFormDynamicValidationAttributesStub extends Form
 {
-    #[Rule('required')]
+    #[Validate('required')]
     public $title = '';
 
-    #[Rule('required')]
+    #[Validate('required')]
     public $content = '';
 
     public function validationAttributes() {
@@ -509,10 +509,10 @@ class PostFormDynamicValidationAttributesStub extends Form
 
 class PostFormDynamicMessagesStub extends Form
 {
-    #[Rule('required')]
+    #[Validate('required')]
     public $title = '';
 
-    #[Rule(['required', 'min:10'])]
+    #[Validate(['required', 'min:10'])]
     public $content = '';
 
     public function messages()
@@ -526,10 +526,10 @@ class PostFormDynamicMessagesStub extends Form
 
 class PostFormDynamicMessagesAndAttributesStub extends Form
 {
-    #[Rule('required')]
+    #[Validate('required')]
     public $title = '';
 
-    #[Rule('required')]
+    #[Validate('required')]
     public $content = '';
 
     public function validationAttributes() {

--- a/src/Features/SupportValidation/BaseRule.php
+++ b/src/Features/SupportValidation/BaseRule.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportValidation;
 
 use Attribute;
+use Illuminate\Auth\Events\Validated;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
 use function Livewire\wrap;
@@ -11,7 +12,7 @@ use function Livewire\wrap;
 class BaseRule extends LivewireAttribute
 {
     function __construct(
-        public $rule,
+        public $rule = null,
         protected $attribute = null,
         protected $as = null,
         protected $message = null,
@@ -23,9 +24,12 @@ class BaseRule extends LivewireAttribute
     {
         $rules = [];
 
-        // Support setting rules by key-value for this and other properties:
-        // For example, #[Rule(['foo' => 'required', 'foo.*' => 'required'])]
-        if (is_array($this->rule) && count($this->rule) > 0 && ! is_numeric(array_keys($this->rule)[0])) {
+        if (is_null($this->rule)) {
+            // Allow "Rule" to be used without a given validation rule. It's purpose is to instead
+            // trigger validation on property updates...
+        } elseif (is_array($this->rule) && count($this->rule) > 0 && ! is_numeric(array_keys($this->rule)[0])) {
+            // Support setting rules by key-value for this and other properties:
+            // For example, #[Rule(['foo' => 'required', 'foo.*' => 'required'])]
             $rules = $this->rule;
         } else {
             $rules[$this->getName()] = $this->rule;

--- a/src/Features/SupportValidation/BaseRule.php
+++ b/src/Features/SupportValidation/BaseRule.php
@@ -29,7 +29,7 @@ class BaseRule extends LivewireAttribute
             // trigger validation on property updates...
         } elseif (is_array($this->rule) && count($this->rule) > 0 && ! is_numeric(array_keys($this->rule)[0])) {
             // Support setting rules by key-value for this and other properties:
-            // For example, #[Rule(['foo' => 'required', 'foo.*' => 'required'])]
+            // For example, #[Validate(['foo' => 'required', 'foo.*' => 'required'])]
             $rules = $this->rule;
         } else {
             $rules[$this->getName()] = $this->rule;

--- a/src/Features/SupportValidation/BaseRule.php
+++ b/src/Features/SupportValidation/BaseRule.php
@@ -3,94 +3,9 @@
 namespace Livewire\Features\SupportValidation;
 
 use Attribute;
-use Illuminate\Auth\Events\Validated;
-use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
-
-use function Livewire\wrap;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_ALL)]
-class BaseRule extends LivewireAttribute
+class BaseRule extends BaseValidate
 {
-    function __construct(
-        public $rule = null,
-        protected $attribute = null,
-        protected $as = null,
-        protected $message = null,
-        protected $onUpdate = true,
-        protected bool $translate = true
-    ) {}
-
-    function boot()
-    {
-        $rules = [];
-
-        if (is_null($this->rule)) {
-            // Allow "Rule" to be used without a given validation rule. It's purpose is to instead
-            // trigger validation on property updates...
-        } elseif (is_array($this->rule) && count($this->rule) > 0 && ! is_numeric(array_keys($this->rule)[0])) {
-            // Support setting rules by key-value for this and other properties:
-            // For example, #[Validate(['foo' => 'required', 'foo.*' => 'required'])]
-            $rules = $this->rule;
-        } else {
-            $rules[$this->getName()] = $this->rule;
-        }
-
-        // @todo: make this more robust (account for FormObjects that
-        // aren't named "form")...
-        if (str($this->getName())->startsWith('form.')) {
-            $name = (string) str($this->getName())->after('form.');
-
-            $this->component->addValidationAttributesFromOutside([$this->getName() => $name]);
-        }
-
-        if ($this->attribute) {
-            if (is_array($this->attribute)) {
-                $this->component->addValidationAttributesFromOutside($this->attribute);
-            } else {
-                $this->component->addValidationAttributesFromOutside([$this->getName() => $this->attribute]);
-            }
-        }
-
-        if ($this->as) {
-            if (is_array($this->as)) {
-                $as = $this->translate
-                    ? array_map(fn ($i) => trans($i), $this->as)
-                    : $this->as;
-
-                $this->component->addValidationAttributesFromOutside($as);
-            } else {
-                $this->component->addValidationAttributesFromOutside([$this->getName() => $this->translate ? trans($this->as) : $this->as]);
-            }
-        }
-
-        if ($this->message) {
-            if (is_array($this->message)) {
-                $messages = $this->translate
-                    ? array_map(fn ($i) => trans($i), $this->message)
-                    : $this->message;
-
-                $this->component->addMessagesFromOutside($messages);
-            } else {
-                // If a single message was provided, apply it to the first given rule.
-                // There should have only been one rule provided in this case anyways...
-                $rule = head(array_values($rules));
-
-                // In the case of "min:5" or something, we only want "min"...
-                $rule = (string) str($rule)->before(':');
-
-                $this->component->addMessagesFromOutside([$this->getName().'.'.$rule => $this->translate ? trans($this->message) : $this->message]);
-            }
-        }
-
-        $this->component->addRulesFromOutside($rules);
-    }
-
-    function update($fullPath, $newValue)
-    {
-        if ($this->onUpdate === false) return;
-
-        return function () {
-            wrap($this->component)->validateOnly($this->getName());
-        };
-    }
+   // This class is kept here for backwards compatibility...
 }

--- a/src/Features/SupportValidation/BaseValidate.php
+++ b/src/Features/SupportValidation/BaseValidate.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Livewire\Features\SupportValidation;
+
+use Attribute;
+use Illuminate\Auth\Events\Validated;
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
+use function Livewire\wrap;
+
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_ALL)]
+class BaseValidate extends LivewireAttribute
+{
+    function __construct(
+        public $rule = null,
+        protected $attribute = null,
+        protected $as = null,
+        protected $message = null,
+        protected $onUpdate = true,
+        protected bool $translate = true
+    ) {}
+
+    function boot()
+    {
+        $rules = [];
+
+        if (is_null($this->rule)) {
+            // Allow "Rule" to be used without a given validation rule. It's purpose is to instead
+            // trigger validation on property updates...
+        } elseif (is_array($this->rule) && count($this->rule) > 0 && ! is_numeric(array_keys($this->rule)[0])) {
+            // Support setting rules by key-value for this and other properties:
+            // For example, #[Validate(['foo' => 'required', 'foo.*' => 'required'])]
+            $rules = $this->rule;
+        } else {
+            $rules[$this->getName()] = $this->rule;
+        }
+
+        // @todo: make this more robust (account for FormObjects that
+        // aren't named "form")...
+        if (str($this->getName())->startsWith('form.')) {
+            $name = (string) str($this->getName())->after('form.');
+
+            $this->component->addValidationAttributesFromOutside([$this->getName() => $name]);
+        }
+
+        if ($this->attribute) {
+            if (is_array($this->attribute)) {
+                $this->component->addValidationAttributesFromOutside($this->attribute);
+            } else {
+                $this->component->addValidationAttributesFromOutside([$this->getName() => $this->attribute]);
+            }
+        }
+
+        if ($this->as) {
+            if (is_array($this->as)) {
+                $as = $this->translate
+                    ? array_map(fn ($i) => trans($i), $this->as)
+                    : $this->as;
+
+                $this->component->addValidationAttributesFromOutside($as);
+            } else {
+                $this->component->addValidationAttributesFromOutside([$this->getName() => $this->translate ? trans($this->as) : $this->as]);
+            }
+        }
+
+        if ($this->message) {
+            if (is_array($this->message)) {
+                $messages = $this->translate
+                    ? array_map(fn ($i) => trans($i), $this->message)
+                    : $this->message;
+
+                $this->component->addMessagesFromOutside($messages);
+            } else {
+                // If a single message was provided, apply it to the first given rule.
+                // There should have only been one rule provided in this case anyways...
+                $rule = head(array_values($rules));
+
+                // In the case of "min:5" or something, we only want "min"...
+                $rule = (string) str($rule)->before(':');
+
+                $this->component->addMessagesFromOutside([$this->getName().'.'.$rule => $this->translate ? trans($this->message) : $this->message]);
+            }
+        }
+
+        $this->component->addRulesFromOutside($rules);
+    }
+
+    function update($fullPath, $newValue)
+    {
+        if ($this->onUpdate === false) return;
+
+        return function () {
+            wrap($this->component)->validateOnly($this->getName());
+        };
+    }
+}

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -8,6 +8,7 @@ use Livewire\Livewire;
 use Livewire\Exceptions\MissingRulesException;
 use Livewire\Component;
 use Livewire\Attributes\Validate;
+use Livewire\Attributes\Rule;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Lang;
@@ -43,13 +44,13 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    public function validate_alias_can_be_used()
+    public function deprecated_rule_alias_can_be_used()
     {
         Livewire::test(new class extends TestComponent {
-            #[Validate('required')]
+            #[Rule('required')]
             public $foo = '';
 
-            #[Validate('required')]
+            #[Rule('required')]
             public $bar = '';
 
             function clear() { $this->clearValidation(); }

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -20,10 +20,10 @@ class UnitTest extends \Tests\TestCase
     public function update_triggers_rule_attribute()
     {
         Livewire::test(new class extends TestComponent {
-            #[BaseRule('required')]
+            #[Validate('required')]
             public $foo = '';
 
-            #[BaseRule('required')]
+            #[Validate('required')]
             public $bar = '';
 
             function clear() { $this->clearValidation(); }
@@ -99,10 +99,10 @@ class UnitTest extends \Tests\TestCase
     public function realtime_validation_can_be_opted_out_of()
     {
         Livewire::test(new class extends TestComponent {
-            #[BaseRule('required|min:3', onUpdate: false)]
+            #[Validate('required|min:3', onUpdate: false)]
             public $foo = '';
 
-            #[BaseRule('required|min:3')]
+            #[Validate('required|min:3')]
             public $bar = '';
 
             function clear() { $this->clearValidation(); }
@@ -124,7 +124,7 @@ class UnitTest extends \Tests\TestCase
     public function rule_attribute_supports_custom_attribute()
     {
         Livewire::test(new class extends TestComponent {
-            #[BaseRule('required|min:3', attribute: 'The Foo')]
+            #[Validate('required|min:3', attribute: 'The Foo')]
             public $foo = '';
 
             function clear() { $this->clearValidation(); }
@@ -145,7 +145,7 @@ class UnitTest extends \Tests\TestCase
     public function rule_attribute_supports_custom_attribute_as_alias()
     {
         Livewire::test(new class extends TestComponent {
-            #[BaseRule('required|min:3', as: 'The Foo')]
+            #[Validate('required|min:3', as: 'The Foo')]
             public $foo = '';
 
             function clear() { $this->clearValidation(); }
@@ -168,7 +168,7 @@ class UnitTest extends \Tests\TestCase
         Lang::addLines(['translatable.foo' => 'Translated Foo'], App::currentLocale());
 
         Livewire::test(new class extends TestComponent {
-            #[BaseRule('required|min:3', as: 'translatable.foo')]
+            #[Validate('required|min:3', as: 'translatable.foo')]
             public $foo = '';
         })
             ->set('foo', 'te')
@@ -187,7 +187,7 @@ class UnitTest extends \Tests\TestCase
         Lang::addLines(['translatable.foo' => 'Translated Foo'], App::currentLocale());
 
         Livewire::test(new class extends TestComponent {
-            #[BaseRule('required|min:3', as: ['foo' => 'translatable.foo'])]
+            #[Validate('required|min:3', as: ['foo' => 'translatable.foo'])]
             public $foo = '';
         })
             ->set('foo', 'te')
@@ -206,7 +206,7 @@ class UnitTest extends \Tests\TestCase
         Lang::addLines(['translatable.foo' => 'Translated Foo'], App::currentLocale());
 
         Livewire::test(new class extends TestComponent {
-            #[BaseRule('required|min:3', as: 'translatable.foo', translate: false)]
+            #[Validate('required|min:3', as: 'translatable.foo', translate: false)]
             public $foo = '';
         })
             ->set('foo', 'te')
@@ -223,7 +223,7 @@ class UnitTest extends \Tests\TestCase
     public function rule_attribute_supports_custom_messages()
     {
         Livewire::test(new class extends TestComponent {
-            #[BaseRule('min:5', message: 'Your foo is too short.')]
+            #[Validate('min:5', message: 'Your foo is too short.')]
             public $foo = '';
 
             function clear() { $this->clearValidation(); }
@@ -244,8 +244,8 @@ class UnitTest extends \Tests\TestCase
     public function rule_attribute_supports_custom_messages_when_using_repeated_attributes()
     {
         Livewire::test(new class extends TestComponent {
-            #[BaseRule('required', message: 'Please provide a post title')]
-            #[BaseRule('min:3', message: 'This title is too short')]
+            #[Validate('required', message: 'Please provide a post title')]
+            #[Validate('min:3', message: 'This title is too short')]
             public $title = '';
         })
             ->set('title', '')
@@ -263,7 +263,7 @@ class UnitTest extends \Tests\TestCase
         Lang::addLines(['translatable.foo' => 'Your foo is too short.'], App::currentLocale());
 
         Livewire::test(new class extends TestComponent {
-            #[BaseRule('min:5', message: 'translatable.foo')]
+            #[Validate('min:5', message: 'translatable.foo')]
             public $foo = '';
         })
             ->set('foo', 'te')
@@ -282,7 +282,7 @@ class UnitTest extends \Tests\TestCase
         Lang::addLines(['translatable.foo' => 'Your foo is too short.'], App::currentLocale());
 
         Livewire::test(new class extends TestComponent {
-            #[BaseRule('min:5', message: ['min' => 'translatable.foo'])]
+            #[Validate('min:5', message: ['min' => 'translatable.foo'])]
             public $foo = '';
         })
             ->set('foo', 'te')
@@ -299,7 +299,7 @@ class UnitTest extends \Tests\TestCase
     public function rule_attributes_can_contain_rules_for_multiple_properties()
     {
         Livewire::test(new class extends TestComponent {
-            #[BaseRule(['foo' => 'required', 'bar' => 'required'])]
+            #[Validate(['foo' => 'required', 'bar' => 'required'])]
             public $foo = '';
 
             public $bar = '';
@@ -325,7 +325,7 @@ class UnitTest extends \Tests\TestCase
     public function rule_attributes_can_contain_multiple_rules()
     {
         Livewire::test(new class extends TestComponent {
-            #[BaseRule(['required', 'min:2', 'max:3'])]
+            #[Validate(['required', 'min:2', 'max:3'])]
             public $foo = '';
         })
             ->set('foo', '')
@@ -343,9 +343,9 @@ class UnitTest extends \Tests\TestCase
     public function rule_attributes_can_contain_multiple_rules_userland(): void
     {
         Livewire::test(new class extends TestComponent {
-            #[\Livewire\Attributes\Rule('required')]
-            #[\Livewire\Attributes\Rule('min:2')]
-            #[\Livewire\Attributes\Rule('max:3')]
+            #[\Livewire\Attributes\Validate('required')]
+            #[\Livewire\Attributes\Validate('min:2')]
+            #[\Livewire\Attributes\Validate('max:3')]
             public $foo = '';
         })
             ->set('foo', '')
@@ -363,14 +363,14 @@ class UnitTest extends \Tests\TestCase
     public function rule_attributes_can_be_repeated()
     {
         Livewire::test(new class extends TestComponent {
-            #[BaseRule('required')]
-            #[BaseRule('min:2')]
-            #[BaseRule('max:3')]
+            #[Validate('required')]
+            #[Validate('min:2')]
+            #[Validate('max:3')]
             public $foo = '';
 
             #[
-                BaseRule('sometimes'),
-                BaseRule('max:1')
+                Validate('sometimes'),
+                Validate('max:1')
             ]
             public $bar = '';
         })

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -2,16 +2,17 @@
 
 namespace Livewire\Features\SupportValidation;
 
+use Tests\TestComponent;
 use Livewire\Wireable;
 use Livewire\Livewire;
 use Livewire\Exceptions\MissingRulesException;
 use Livewire\Component;
+use Livewire\Attributes\Validate;
 use Illuminate\Support\ViewErrorBag;
-use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Collection;
-use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -39,6 +40,59 @@ class UnitTest extends \Tests\TestCase
             ->assertHasErrors([
                 'foo' => 'required',
             ]);
+    }
+
+    /** @test */
+    public function validate_alias_can_be_used()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Validate('required')]
+            public $foo = '';
+
+            #[Validate('required')]
+            public $bar = '';
+
+            function clear() { $this->clearValidation(); }
+
+            function save() { $this->validate(); }
+        })
+            ->set('bar', 'testing...')
+            ->assertHasNoErrors()
+            ->set('foo', '')
+            ->assertHasErrors(['foo' => 'required'])
+            ->call('clear')
+            ->assertHasNoErrors()
+            ->call('save')
+            ->assertHasErrors([
+                'foo' => 'required',
+            ]);
+    }
+
+    /** @test */
+    public function validate_can_be_used_without_a_rule()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Validate]
+            public $foo = '';
+
+            public $bar = '';
+
+            public function rules()
+            {
+                return [
+                    'foo' => 'required',
+                    'bar' => 'required',
+                ];
+            }
+
+            function clear() { $this->clearValidation(); }
+
+            function save() { $this->validate(); }
+        })
+            ->set('foo', 'testing...')
+            ->assertHasNoErrors()
+            ->set('foo', '')
+            ->assertHasErrors(['foo' => 'required']);
     }
 
     /** @test */

--- a/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
+++ b/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
@@ -3,7 +3,7 @@
 namespace Livewire\Features\SupportWireModelingNestedComponents;
 
 use Illuminate\Database\Eloquent\Model;
-use Livewire\Attributes\Rule;
+use Livewire\Attributes\Validate;
 use Livewire\Form;
 use Livewire\Livewire;
 use Sushi\Sushi;
@@ -279,7 +279,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
 class CreatePost extends Form
 {
-    #[Rule('required')]
+    #[Validate('required')]
     public $title;
 
     public function store()

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -89,7 +89,7 @@ class FrontendAssets
         $html = <<<HTML
         <!-- Livewire Styles -->
         <style {$nonce}>
-            [wire\:loading][wire\:loading], [wire\:loading\.delay][wire\:loading\.delay], [wire\:loading\.inline-block][wire\:loading\.inline-block], [wire\:loading\.inline][wire\:loading\.inline], [wire\:loading\.block][wire\:loading\.block], [wire\:loading\.flex].flex, [wire\:loading\.table][wire\:loading\.table], [wire\:loading\.grid][wire\:loading\.grid], [wire\:loading\.inline-flex][wire\:loading\.inline-flex] {
+            [wire\:loading][wire\:loading], [wire\:loading\.delay][wire\:loading\.delay], [wire\:loading\.inline-block][wire\:loading\.inline-block], [wire\:loading\.inline][wire\:loading\.inline], [wire\:loading\.block][wire\:loading\.block], [wire\:loading\.flex][wire\:loading\.flex], [wire\:loading\.table][wire\:loading\.table], [wire\:loading\.grid][wire\:loading\.grid], [wire\:loading\.inline-flex][wire\:loading\.inline-flex] {
                 display: none;
             }
 


### PR DESCRIPTION
There are two problems that led to this decision.

**Problem #1:**
The `#[Rule]` attribute class (`Livewire\Attributes\Rule`) conflicts with Laravel validation rule objects (`Illuminate\Validation\Rule`). This leads to people needing to alias one of them when importing which is confusing.

**Problem #2:**
#[Rule] attributes are restrictive for adding validation because they don't support run-time PHP code like Laravel rule objects.

Therefore, most times people are using `rules()` methods instead to declare their validation rules.

However, there are still times where it's nice to use the real-time validation capability of `#[Rule]` objects. You can use a bare `#[Rule]` attribute for this behavior (after a change in this PR), however, it reads oddly.

**Solution:**
Change `#[Rule]` to `#[Validate]` and make `#[Validate]` support not passing in rules and only using it to declare a field as real-time validating like so:

```php
#[Validate]
public $username = '';

public function rules()
{
    return ['username' => Rule::unique('users')->ignore($this->post)];
}
```

**Backwards compatibility:**
We will retain `#[Rule]` and `#[BaseRule]` in the codebase to prevent breaking apps until the next major release.

However, I updated all documentation to move to `#[Validate]` instead of `#[Rule]` and added notes about using Rule objects in Livewire to better educate people.

I also added a docs note about `#[Rule]` so that it still shows up in algolia search and SEO for people with old codebases or knowledge searching for documentation.

In the future we should probably re-work the docs a bit more to put less emphasis on `#[Validate]` in favor of using form objects and the `rules()` method.