### PR TITLE
Fix Documentation Examples for the `assertViewHas` method

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -120,7 +120,7 @@ class ShowPostsTest extends TestCase
 
         Livewire::test(ShowPosts::class)
             ->assertViewHas('posts', function ($posts) {
-                $this->assertEquals(2, count($posts));
+                return count($posts) == 2;
             });
     }
 }
@@ -169,7 +169,7 @@ class ShowPostsTest extends TestCase
         Livewire::actingAs($user)
             ->test(ShowPosts::class)
             ->assertViewHas('posts', function ($posts) {
-                $this->assertEquals(3, count($posts));
+                return count($posts) == 3;
             });
     }
 }


### PR DESCRIPTION
This PR addresses an issue with the `assertViewHas` method in the documentation. The current examples demonstrate the use of expectations that leads to a `Failed asserting that null is true` error. The root cause is that the `assertViewHas` closure expects to return a boolean.

This PR updates the examples in the documentation to align with the usage outlined in the Laravel documentation [assetViewHas method](https://laravel.com/docs/10.x/http-tests#assert-view-has).


