### PR TITLE
Add separate CannotUpdateLockedPropertyException

### DIFF
--- a/src/Features/SupportLockedProperties/BaseLocked.php
+++ b/src/Features/SupportLockedProperties/BaseLocked.php
@@ -9,6 +9,6 @@ class BaseLocked extends LivewireAttribute
 {
     public function update()
     {
-        throw new \Exception('Cannot update locked property: ['.$this->getName().']');
+        throw new CannotUpdateLockedPropertyException($this->getName());
     }
 }

--- a/src/Features/SupportLockedProperties/CannotUpdateLockedPropertyException.php
+++ b/src/Features/SupportLockedProperties/CannotUpdateLockedPropertyException.php
@@ -4,7 +4,7 @@ namespace Livewire\Features\SupportLockedProperties;
 
 class CannotUpdateLockedPropertyException extends \Exception
 {
-    public function __construct($property)
+    public function __construct(public $property)
     {
         parent::__construct(
             'Cannot update locked property: ['.$property.']'

--- a/src/Features/SupportLockedProperties/CannotUpdateLockedPropertyException.php
+++ b/src/Features/SupportLockedProperties/CannotUpdateLockedPropertyException.php
@@ -7,7 +7,7 @@ class CannotUpdateLockedPropertyException extends \Exception
     public function __construct(public $property)
     {
         parent::__construct(
-            'Cannot update locked property: ['.$property.']'
+            'Cannot update locked property: ['.$this->property.']'
         );
     }
 }

--- a/src/Features/SupportLockedProperties/CannotUpdateLockedPropertyException.php
+++ b/src/Features/SupportLockedProperties/CannotUpdateLockedPropertyException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Livewire\Features\SupportLockedProperties;
+
+class CannotUpdateLockedPropertyException extends \Exception
+{
+    public function __construct($property)
+    {
+        parent::__construct(
+            'Cannot update locked property: ['.$property.']'
+        );
+    }
+}

--- a/src/Features/SupportLockedProperties/UnitTest.php
+++ b/src/Features/SupportLockedProperties/UnitTest.php
@@ -32,6 +32,7 @@ class UnitTest extends \Tests\TestCase
     /** @test */
     function cant_deeply_update_locked_property()
     {
+        $this->expectExceptionObject(new CannotUpdateLockedPropertyException('foo'));
         $this->expectExceptionMessage(
             'Cannot update locked property: [foo]'
         );

--- a/src/Features/SupportLockedProperties/UnitTest.php
+++ b/src/Features/SupportLockedProperties/UnitTest.php
@@ -32,7 +32,7 @@ class UnitTest extends \Tests\TestCase
     /** @test */
     function cant_deeply_update_locked_property()
     {
-        $this->expectExceptionObject(new CannotUpdateLockedPropertyException('foo'));
+        $this->expectException(CannotUpdateLockedPropertyException::class);
         $this->expectExceptionMessage(
             'Cannot update locked property: [foo]'
         );
@@ -77,7 +77,7 @@ class UnitTest extends \Tests\TestCase
             ->assertOk();
     }
 }
-    
+
 class SomeForm extends Form {
     #[BaseLocked]
     public ?string $id = null;


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
No

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This PR creates a new Exception class used by the `#[Locked]` attribute. The functionality is unchanged, but this allows people to more easily scope to this exception. An example where this is useful is in writing regression tests, ensuring that properties thought locked stay locked. Rather than hoping that the general `\Exception` class is referring to the correct error or testing to the exception message which might be changed in future, being able to write `$this->expectException(CannotUpdateLockedPropertyException::class)` is much easier and more legible.