### PR TITLE
Fix: Resolve JavaScript Asset Retrieval in Livewire

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -156,4 +156,15 @@ return [
     */
 
     'pagination_theme' => 'tailwind',
+
+    /*
+    |---------------------------------------------------------------------------
+    | Asset url
+    |---------------------------------------------------------------------------
+    |
+    | This route path is configured to return the primary JavaScript
+    | asset as a file, with the default set to '/dist/livewire.js'.
+    |
+    */
+    'asset_url' => '/livewire/livewire.js'
 ];

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -24,7 +24,7 @@ class FrontendAssets
     public function boot()
     {
         app($this::class)->setScriptRoute(function ($handle) {
-            return Route::get('/livewire/livewire.js', $handle);
+            return Route::get(config('livewire.asset_url'), $handle);
         });
 
         Blade::directive('livewireScripts', [static::class, 'livewireScripts']);


### PR DESCRIPTION
Resolved an issue in Livewire where the designated route path was not correctly returning the primary JavaScript asset as a file. This problem was particularly evident in local Windows environments using OpenServer (Apache, Nginx). The issue, often manifesting as a 404 error, occurred when routes ended with a dot (.). The fix implemented now allows modification without overriding and binding a new service provider.