### PR TITLE
Add layout method

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -76,7 +76,7 @@ abstract class Component
         store($this)->set('skipHydrate', true);
     }
 
-    function getLayout(){
+    function layout(){
         return null;
     }
 

--- a/src/Component.php
+++ b/src/Component.php
@@ -76,6 +76,10 @@ abstract class Component
         store($this)->set('skipHydrate', true);
     }
 
+    function getLayout(){
+        return null;
+    }
+
     function __isset($property)
     {
         try {

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -90,7 +90,7 @@ class SupportPageComponents extends ComponentHook
         // Only run this handler once for the parent-most component. Otherwise child components
         // will run this handler too and override the configured layout...
         $handler = once(function ($target, $view, $data) use (&$layoutConfig, &$slots) {
-            $layoutAttr = $target->getAttributes()->whereInstanceOf(BaseLayout::class)->first() ?? $target->getLayout();
+            $layoutAttr = $target->getAttributes()->whereInstanceOf(BaseLayout::class)->first() ?? $target->layout();
             $titleAttr = $target->getAttributes()->whereInstanceOf(BaseTitle::class)->first();
 
             if ($layoutAttr) {

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -90,7 +90,7 @@ class SupportPageComponents extends ComponentHook
         // Only run this handler once for the parent-most component. Otherwise child components
         // will run this handler too and override the configured layout...
         $handler = once(function ($target, $view, $data) use (&$layoutConfig, &$slots) {
-            $layoutAttr = $target->getAttributes()->whereInstanceOf(BaseLayout::class)->first();
+            $layoutAttr = $target->getAttributes()->whereInstanceOf(BaseLayout::class)->first() ?? $target->getLayout();
             $titleAttr = $target->getAttributes()->whereInstanceOf(BaseTitle::class)->first();
 
             if ($layoutAttr) {

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -174,6 +174,25 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    public function can_obtain_layout_from_get_layout_method()
+    {
+        Route::get('/configurable-layout', ComponentWithCustomLayout1::class);
+
+        $this->withoutExceptionHandling()->get('/configurable-layout')
+            ->assertSee('Custom Layout 1');
+    }
+
+    /** @test */
+    public function can_pass_attributes_to_a_component_with_get_layout_method()
+    {
+        Route::get('/configurable-layout', ComponentWithCustomLayout1::class);
+
+        $this
+            ->get('/configurable-layout')
+            ->assertSee('baz');
+    }
+
+    /** @test */
     public function can_extend_a_blade_layout()
     {
         $this->withoutExceptionHandling();
@@ -454,6 +473,9 @@ class UnitTest extends \Tests\TestCase
 
         $this->get('/route-with-params/123')->assertSeeText('123');
     }
+
+    /** @test */
+
 }
 
 class ComponentForRouteWithoutMountParametersTest extends Component
@@ -780,3 +802,22 @@ class ComponentWithStacks extends Component
         HTML;
     }
 }
+
+abstract class CustomComponentBaseWithGetLayoutMethod1 extends Component
+{
+    public function getLayout()
+    {
+        return new BaseLayout('layouts.app-layout-1', [
+            'customParam' => 'baz',
+        ]);
+    }
+}
+
+class ComponentWithCustomLayout1 extends CustomComponentBaseWithGetLayoutMethod1
+{
+    public function render()
+    {
+        return view('dummy-component');
+    }
+}
+

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -803,9 +803,9 @@ class ComponentWithStacks extends Component
     }
 }
 
-abstract class CustomComponentBaseWithGetLayoutMethod1 extends Component
+abstract class CustomComponentBaseWithlayoutMethod1 extends Component
 {
-    public function getLayout()
+    public function layout()
     {
         return new BaseLayout('layouts.app-layout-1', [
             'customParam' => 'baz',
@@ -813,7 +813,7 @@ abstract class CustomComponentBaseWithGetLayoutMethod1 extends Component
     }
 }
 
-class ComponentWithCustomLayout1 extends CustomComponentBaseWithGetLayoutMethod1
+class ComponentWithCustomLayout1 extends CustomComponentBaseWithlayoutMethod1
 {
     public function render()
     {

--- a/tests/views/dummy-component.blade.php
+++ b/tests/views/dummy-component.blade.php
@@ -1,0 +1,1 @@
+<p>Dummy Component</p>

--- a/tests/views/layouts/app-layout-1.blade.php
+++ b/tests/views/layouts/app-layout-1.blade.php
@@ -1,0 +1,2 @@
+Custom Layout 1
+{{ $slot }}{{ $customParam ?? '' }}


### PR DESCRIPTION
**About**

This pull request makes it possible to obtain the layout from a `layout()` method. This is especially useful when you have different views of the application: admin, financial, buyer... And so instead of defining `#[Layout()]`  in each component class, it becomes possible to define base classes that provide the same layout.

**Example**
```php
<?php
use Livewire\Component;

abstract class AdminComponentBase extends Component
{
    public function layout()
    {
        return new BaseLayout('layouts.admin-layout');
    }
}

class MonthlyBilling extends AdminComponentBase
{
    public function render()
    {
        return view('livewire.admin.monthly-billing');
    }
}


class ActivePayers extends AdminComponentBase
{
    public function render()
    {
        return view('livewire.admin.active-payers');
    }
}
```
This way, all the components in the admin context inherit from the AdminComponentBase class, avoiding code duplication.

Same here:

```php
<?php
use Livewire\Component;

abstract class BuyerComponentBase extends Component
{
    public function layout()
    {
        return new BaseLayout('layouts.buyer-layout');
    }
}

class ShopList extends BuyerComponentBase
{
    public function render()
    {
        return view('livewire.buyer.shop-list');
    }
}

class ShopCart extends BuyerComponentBase
{
    public function render()
    {
        return view('livewire.buyer.shop-cart');
    }
}
```