### PR TITLE
Re-add default parameter value to make command

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -108,7 +108,7 @@ class MakeCommand extends FileManipulationCommand implements PromptsForMissingIn
         return $viewPath;
     }
 
-    protected function createTest($force = false, $testType)
+    protected function createTest($force = false, $testType = 'phpunit')
     {
         $testPath = $this->parser->testPath();
 


### PR DESCRIPTION
There is a deprecation warning happening due to the removal of a default parameter value, see #7315.

This PR re-adds the default parameter that was removed in PR #7248. I have run the commands and checked, and everything is still running as expected.