### PR TITLE
Data store has() with non-existent array key

### DIFF
--- a/src/Mechanisms/DataStore.php
+++ b/src/Mechanisms/DataStore.php
@@ -42,7 +42,7 @@ class DataStore
         }
 
         if ($iKey !== null) {
-            return !! $this->lookup[$instance][$key][$iKey] ?? false;
+            return !! ($this->lookup[$instance][$key][$iKey] ?? false);
         }
 
         return true;


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Just a bug fix

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

There are no tests for the Data Store yet.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

When the `$iKey` key does not exist in the array, `Undefined array key` is thrown. I think this is because `!! $this->lookup[$instance][$key][$iKey]` is evaluated first, before `?? false`, so the null catch does not happen early enough.

Thanks for contributing! 🙌
