### PR TITLE
Fix typo in wire-model.md

### DIFF
--- a/docs/wire-model.md
+++ b/docs/wire-model.md
@@ -192,7 +192,7 @@ Below is an example of a select dropdown filled with a static list of states:
 
 ```blade
 <select wire:model="state">
-    <option value="AL">Alabama<option>
+    <option value="AL">Alabama</option>
     <option value="AK">Alaska</option>
     <option value="AZ">Arizona</option>
     ...


### PR DESCRIPTION
After looking at https://github.com/livewire/livewire/releases/tag/v3.2.0 release I noticed a closing tag was missing, this PR adds it.