### PR TITLE
Replace set method before call method save

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -611,8 +611,8 @@ class CreatePostTest extends TestCase
     public function cant_create_post_without_title()
     {
         Livewire::test(CreatePost::class)
-            ->call('save')
             ->set('content', 'Sample content...')
+            ->call('save')
             ->assertHasErrors('title');
     }
 }


### PR DESCRIPTION
I imagine that it might be an error because the "call" method is being invoked before the content is set. In this case, the "assertHasErrors" method will pass smoothly, but I don't think it's didactic in the current form.