### PR TITLE
Fix error validation message for input upload files

### DIFF
--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -63,8 +63,8 @@ trait WithFileUploads
         }
 
         $errorsInJson = $isMultiple
-            ? str_ireplace('files', $name, $errorsInJson)
-            : str_ireplace('files.0', $name, $errorsInJson);
+            ? str_ireplace('files.0', $name, $errorsInJson)
+            : str_ireplace('files', $name, $errorsInJson);
 
         $errors = json_decode($errorsInJson, true)['errors'];
 


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
It is a minor bug and I figured out there was no need to make a discussion about it.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes, I forked `main`.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, only two lines of code.

4️⃣ Does it include tests? (Required)
Nope.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
The error message given after validating a file input was wrong. It would say `The fields.0 field...` instead of using the `$attribute` name.

Thanks for contributing! 🙌
