### PR TITLE
Fetch post before authorization in Security docs example

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -73,11 +73,11 @@ Now, we can use the `$this->authorize()` method from the Livewire component to e
 ```php
 public function delete($id)
 {
+    $post = Post::find($id);
+
     // If the user doesn't own the post,
     // an AuthorizationException will be thrown...
     $this->authorize('delete', $post); // [tl! highlight]
-
-    $post = Post::find($id);
 
     $post->delete();
 }


### PR DESCRIPTION
Just a small fix to the security docs. In an authorization example, the `$post` variable was referenced in the authorization call but defined after.
