### PR TITLE
Indent security.md example

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -188,14 +188,14 @@ class ShowPost extends Component
         $this->postId = $postId;
     }
 
-public function delete()
-{
-    $post = Post::find($this->postId);
-
-    $this->authorize('delete', $post); // [tl! highlight]
-
-    $post->delete();
-}
+    public function delete()
+    {
+        $post = Post::find($this->postId);
+    
+        $this->authorize('delete', $post); // [tl! highlight]
+    
+        $post->delete();
+    }
 }
 ```
 


### PR DESCRIPTION
Add indentation to the `Authoring the property` example for consistency with the other examples.

![Authorizing the property](https://github.com/livewire/livewire/assets/949285/958d84ce-67ab-43a9-9708-2058d087b9ae)
