### PR TITLE
Add locked documentation to security.md

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -169,6 +169,37 @@ class ShowPost extends Component
 
 This component is now secured because there is no way for a malicious user to change the `$post` property to a different Eloquent model.
 
+### Locking the property
+Another way to prevent properties from being set to unwanted values is to use [locked properties](https://livewire.laravel.com/docs/locked). Locking properties is done by applying the `#[Locked]` attribute. Now if users attempt to tamper with this value an error will be thrown.
+
+Note that properties with the Locked attribute can still be changed in the back-end, so care still needs to taken that untrusted user input is not passed to the property in your own Livewire functions.
+
+```php
+<?php
+
+use App\Models\Post;
+use Livewire\Component;
+use Livewire\Attributes\Locked;
+
+class ShowPost extends Component
+{
+    #[Locked] // [tl! highlight]
+    public $postId;
+
+    public function mount($postId)
+    {
+        $this->postId = $postId;
+    }
+
+    public function delete()
+    {
+        $post = Post::find($this->postId);
+
+        $post->delete();
+    }
+}
+```
+
 ### Authorizing the property
 
 If using a model property is undesired in your scenario, you can of course fall-back to manually authorizing the deletion of the post inside the `delete` action:


### PR DESCRIPTION
Added short `#[Locked]` explanation to the security docs, as one of the means to protect from tampering public properties. I have linked to the Locked docs and included a cautionary note with regards to changing the property through PHP code