### PR TITLE
Fix undefined error when payload does not contain assets

### DIFF
--- a/js/features/supportScriptsAndAssets.js
+++ b/js/features/supportScriptsAndAssets.js
@@ -6,6 +6,8 @@ let executedScripts = new WeakMap
 let executedAssets = new Set
 
 on('payload.intercept', async ({ assets }) => {
+    if(!assets) return
+    
     for (let [key, asset] of Object.entries(assets)) {
         await onlyIfAssetsHaventBeenLoadedAlreadyOnThisPage(key, async () => {
             await addAssetsToHeadTagOfPage(asset)


### PR DESCRIPTION
I noticed I was getting a `TypeError: Cannot convert undefined or null to object`, I'm not sure if `payload.intercept` should always contain the `asset` array, if it does, then this probably isn't the correct fix.