### PR TITLE
Add Enum binding support

### DIFF
--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -95,18 +95,8 @@ class ImplicitRouteBinding
             return $parameterValue;
         }
 
-        if ($parameterValue instanceof BackedEnum) {
-            return $parameterValue;
-        }
-
-        if ((new ReflectionClass($parameterClassName))->isEnum()) {
-            $enum = $parameterClassName::tryFrom($parameterValue);
-
-            if (is_null($enum)) {
-                throw new BackedEnumCaseNotFoundException($parameterClassName, $parameterValue);
-            }
-
-            return $enum;
+        if($enumValue = $this->resolveEnumParameter($parameterValue, $parameterClassName)) {
+            return $enumValue;
         }
 
         $instance = $this->container->make($parameterClassName);
@@ -124,5 +114,24 @@ class ImplicitRouteBinding
         }
 
         return $model;
+    }
+
+    protected function resolveEnumParameter($parameterValue, $parameterClassName)
+    {
+        if ($parameterValue instanceof BackedEnum) {
+            return $parameterValue;
+        }
+
+        if ((new ReflectionClass($parameterClassName))->isEnum()) {
+            $enumValue = $parameterClassName::tryFrom($parameterValue);
+
+            if (is_null($enumValue)) {
+                throw new BackedEnumCaseNotFoundException($parameterClassName, $parameterValue);
+            }
+
+            return $enumValue;
+        }
+
+        return null;
     }
 }

--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -2,8 +2,8 @@
 
 namespace Livewire\Drawer;
 
-use BackedEnum;
 use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
+use BackedEnum;
 use ReflectionClass;
 use ReflectionMethod;
 use Livewire\Component;

--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -10,6 +10,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Livewire\Drawer\Utils;
+use UnitEnum;
 
 /**
  * This class mirrors the functionality of Laravel's Illuminate\Routing\ImplicitRouteBinding class.
@@ -90,6 +91,10 @@ class ImplicitRouteBinding
         $parameterValue = $route->parameter($parameterName);
 
         if ($parameterValue instanceof UrlRoutable) {
+            return $parameterValue;
+        }
+
+        if ($parameterValue instanceof UnitEnum) {
             return $parameterValue;
         }
 

--- a/src/ImplicitlyBoundMethod.php
+++ b/src/ImplicitlyBoundMethod.php
@@ -61,7 +61,6 @@ class ImplicitlyBoundMethod extends BoundMethod
     {
         $paramName = $parameter->getName();
 
-
         // check if we have a candidate for implicit binding
         if (is_null($className = static::getClassForImplicitBinding($parameter))) {
             return;
@@ -80,17 +79,11 @@ class ImplicitlyBoundMethod extends BoundMethod
     {
         $className = static::getParameterClassName($parameter);
 
-        if(is_null($className)){
-            return null;
-        }
+        if (is_null($className)) return null;
 
-        if(static::isEnum($parameter)){
-            return null;
-        }
+        if (static::isEnum($parameter)) return null;
 
-        if (!static::implementsInterface($parameter)) {
-            return $className;
-        }
+        if (! static::implementsInterface($parameter)) return $className;
 
         return null;
     }
@@ -99,24 +92,18 @@ class ImplicitlyBoundMethod extends BoundMethod
     {
         $className = static::getParameterClassName($parameter);
 
-        if(is_null($className)){
-            return null;
-        }
+        if (is_null($className)) return null;
 
-        if(static::isEnum($parameter)){
-            return $className;
-        }
+        if (static::isEnum($parameter)) return $className;
 
-        if (static::implementsInterface($parameter)) {
-            return $className;
-        }
+        if (static::implementsInterface($parameter)) return $className;
 
         return null;
     }
 
     protected static function getImplicitBinding($container, $className, $value)
     {
-        if((new ReflectionClass($className))->isEnum()){
+        if ((new ReflectionClass($className))->isEnum()) {
             return $className::from($value);
         }
 
@@ -133,13 +120,9 @@ class ImplicitlyBoundMethod extends BoundMethod
     {
         $type = $parameter->getType();
 
-        if(!$type){
-            return null;
-        }
+        if (! $type) return null;
 
-        if(! $type instanceof ReflectionNamedType){
-            return null;
-        }
+        if (! $type instanceof ReflectionNamedType) return null;
 
         return (! $type->isBuiltin()) ? $type->getName() : null;
     }

--- a/src/ImplicitlyBoundMethod.php
+++ b/src/ImplicitlyBoundMethod.php
@@ -78,12 +78,7 @@ class ImplicitlyBoundMethod extends BoundMethod
 
     protected static function getClassForDependencyInjection($parameter)
     {
-//        $className = static::getParameterClassName($parameter);
-
-        if (! is_null($className = static::getParameterClassName($parameter)) && ! static::implementsInterface($parameter)) {
-            return $className;
-        }
-
+        $className = static::getParameterClassName($parameter);
 
         if(is_null($className)){
             return null;
@@ -93,7 +88,7 @@ class ImplicitlyBoundMethod extends BoundMethod
             return null;
         }
 
-        if (static::implementsInterface($parameter)) {
+        if (!static::implementsInterface($parameter)) {
             return $className;
         }
 

--- a/src/Tests/ComponentMethodBindingsUnitTest.php
+++ b/src/Tests/ComponentMethodBindingsUnitTest.php
@@ -83,7 +83,7 @@ class ComponentMethodBindingsUnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    public function mount_method_receives_route_and_implicit_binding_and_dependency_injection()
+    public function mount_method_receives_route_and_implicit_model_binding_and_dependency_injection()
     {
         Livewire::test(ComponentWithMountInjections::class, [
             'foo',
@@ -113,7 +113,7 @@ class ComponentMethodBindingsUnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    public function action_receives_implicit_binding()
+    public function action_receives_implicit_model_binding()
     {
         $component = Livewire::test(ComponentWithBindings::class)
             ->assertSee('model-default');
@@ -126,7 +126,7 @@ class ComponentMethodBindingsUnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    public function action_receives_implicit_binding_independent_of_parameter_order()
+    public function action_receives_implicit_model_binding_independent_of_parameter_order()
     {
         $component = Livewire::test(ComponentWithBindings::class)
             ->assertSee('model-default');
@@ -139,7 +139,7 @@ class ComponentMethodBindingsUnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    public function action_implicit_binding_plays_well_with_dependency_injection()
+    public function action_implicit_model_binding_plays_well_with_dependency_injection()
     {
         $component = Livewire::test(ComponentWithBindings::class)
             ->assertSee('model-default');

--- a/src/Tests/ComponentMethodBindingsUnitTest.php
+++ b/src/Tests/ComponentMethodBindingsUnitTest.php
@@ -39,24 +39,24 @@ class ComponentMethodBindingsUnitTest extends \Tests\TestCase
     /** @test */
     public function mount_method_receives_implicit_model_binding()
     {
-//        Livewire::test(ComponentWithBindings::class, [
-//            'model' => 'new model',
-//        ])->assertSeeText('new model:param-default');
-//
-//        Livewire::test(ComponentWithBindings::class, [
-//            'model' => 'new model',
-//            'param' => 'foo',
-//        ])->assertSeeText('new model:foo');
+        Livewire::test(ComponentWithBindings::class, [
+            'model' => 'new model',
+        ])->assertSeeText('new model:param-default');
+
+        Livewire::test(ComponentWithBindings::class, [
+            'model' => 'new model',
+            'param' => 'foo',
+        ])->assertSeeText('new model:foo');
 
         Livewire::test(ComponentWithBindings::class, [
             'new model',
             'foo',
         ])->assertSeeText('new model:foo');
-//
-//        Livewire::test(ComponentWithBindings::class, [
-//            'foo',
-//            'model' => 'new model',
-//        ])->assertSeeText('new model:foo');
+
+        Livewire::test(ComponentWithBindings::class, [
+            'foo',
+            'model' => 'new model',
+        ])->assertSeeText('new model:foo');
     }
 
     /** @test */
@@ -118,26 +118,11 @@ class ComponentMethodBindingsUnitTest extends \Tests\TestCase
         $component = Livewire::test(ComponentWithBindings::class)
             ->assertSee('model-default');
 
-        dump('start');
-
         $component->runAction('actionWithModel', 'implicitly bound');
         $this->assertEquals('implicitly bound:param-default', $component->name);
 
-//        $component->runAction('actionWithModel', 'implicitly bound', 'foo');
-//        $this->assertEquals('implicitly bound:foo', $component->name);
-    }
-
-    /** @test */
-    public function action_receives_implicit_enum_binding()
-    {
-        $component = Livewire::test(ComponentWithEnumBindings::class, ['enum' => EnumToBeBound::FIRST])
-            ->assertSee('enum-first:param-default');
-
-        $component->runAction('actionWithEnum', 'enum-first');
-        $this->assertEquals('enum-first:param-default', $component->name);
-
-        $component->runAction('actionWithEnum', 'enum-first', 'foo');
-        $this->assertEquals('enum-first:foo', $component->name);
+        $component->runAction('actionWithModel', 'implicitly bound', 'foo');
+        $this->assertEquals('implicitly bound:foo', $component->name);
     }
 
     /** @test */
@@ -166,33 +151,44 @@ class ComponentMethodBindingsUnitTest extends \Tests\TestCase
         $this->assertEquals('implicitly bound:http://localhost/some-url/foo', $component->name);
     }
 
+    /** @test */
+    public function action_receives_implicit_enum_binding()
+    {
+        $component = Livewire::test(ComponentWithEnumBindings::class, ['enum' => EnumToBeBound::FIRST])
+            ->assertSee('enum-first:param-default');
 
+        $component->runAction('actionWithEnum', 'enum-first');
+        $this->assertEquals('enum-first:param-default', $component->name);
 
-//    /** @test */
-//    public function action_receives_implicit_binding_independent_of_parameter_order()
-//    {
-//        $component = Livewire::test(ComponentWithBindings::class)
-//            ->assertSee('model-default');
-//
-//        $component->runAction('actionWithModelAsSecond', 'bar', 'implicitly bound');
-//        $this->assertEquals('bar:implicitly bound:param-default', $component->name);
-//
-//        $component->runAction('actionWithModelAsSecond', 'bar', 'implicitly bound', 'foo');
-//        $this->assertEquals('bar:implicitly bound:foo', $component->name);
-//    }
-//
-//    /** @test */
-//    public function action_implicit_binding_plays_well_with_dependency_injection()
-//    {
-//        $component = Livewire::test(ComponentWithBindings::class)
-//            ->assertSee('model-default');
-//
-//        $component->runAction('actionWithModelAndDependency', 'implicitly bound');
-//        $this->assertEquals('implicitly bound:http://localhost/some-url/param-default', $component->name);
-//
-//        $component->runAction('actionWithModelAndDependency', 'implicitly bound', 'foo');
-//        $this->assertEquals('implicitly bound:http://localhost/some-url/foo', $component->name);
-//    }
+        $component->runAction('actionWithEnum', 'enum-first', 'foo');
+        $this->assertEquals('enum-first:foo', $component->name);
+    }
+
+    /** @test */
+    public function action_receives_implicit_enum_binding_independent_of_parameter_order()
+    {
+        $component = Livewire::test(ComponentWithEnumBindings::class, ['enum' => EnumToBeBound::FIRST])
+            ->assertSee('enum-first:param-default');
+
+        $component->runAction('actionWithEnumAsSecond', 'bar', 'enum-first');
+        $this->assertEquals('bar:enum-first:param-default', $component->name);
+
+        $component->runAction('actionWithEnumAsSecond', 'bar', 'enum-first', 'foo');
+        $this->assertEquals('bar:enum-first:foo', $component->name);
+    }
+
+    /** @test */
+    public function action_implicit_enum_binding_plays_well_with_dependency_injection()
+    {
+        $component = Livewire::test(ComponentWithEnumBindings::class, ['enum' => EnumToBeBound::FIRST])
+            ->assertSee('enum-first:param-default');
+
+        $component->runAction('actionWithEnumAndDependency', 'enum-first');
+        $this->assertEquals('enum-first:http://localhost/some-url/param-default', $component->name);
+
+        $component->runAction('actionWithEnumAndDependency', 'enum-first', 'foo');
+        $this->assertEquals('enum-first:http://localhost/some-url/foo', $component->name);
+    }
 }
 
 class ModelToBeBound extends Model

--- a/src/Tests/ComponentMethodBindingsUnitTest.php
+++ b/src/Tests/ComponentMethodBindingsUnitTest.php
@@ -256,14 +256,14 @@ class ComponentWithEnumBindings extends Component
         $this->name = collect([$enum->value, $param])->join(':');
     }
 
-    public function actionWithEnumAsSecond($foo, EnumToBeBound $Enum, $param = 'param-default')
+    public function actionWithEnumAsSecond($foo, EnumToBeBound $enum, $param = 'param-default')
     {
-        $this->name = collect([$foo, $Enum->value, $param])->join(':');
+        $this->name = collect([$foo, $enum->value, $param])->join(':');
     }
 
-    public function actionWithEnumAndDependency(UrlGenerator $generator, EnumToBeBound $Enum, $param = 'param-default')
+    public function actionWithEnumAndDependency(UrlGenerator $generator, EnumToBeBound $enum, $param = 'param-default')
     {
-        $this->name = collect([$Enum->value, $generator->to('/some-url/' . $param)])->join(':');
+        $this->name = collect([$enum->value, $generator->to('/some-url/' . $param)])->join(':');
     }
 
     public function render()


### PR DESCRIPTION
## Description
This pull request significantly enhances Livewire by adding support for binding Enums in both Full Page and regular Livewire components. It extends this functionality to include route binding and binding through component mounts and actions.

## Problem
Currently, while Laravel supports enum route binding, Livewire does not extend this support to its components, leading to a `BindingResolutionException` when an Enum is bound to a Livewire route or component. This limitation affects both Full Page and standard Livewire components.

## Code Examples

1. **Enum Declaration in `app/Enums/Color.php`:**
    ```PHP
    enum Color: string {
        case BLUE = 'blue';
        // ... other cases ...
    }
    ```

2. **Route Definition in `web.php`:**
    ```PHP
    Route::get('/create/{color}', ColorForm::class);
    ```

3. **Livewire Component in `Livewire/ColorForm`:**
```PHP
namespace App\Livewire;

use Livewire\Component;
use Enums\Color;

class ColorForm extends Component
{
   public Color $color;

   public function changeColor(Color $color) 
   {
      $this->color = $color;   
   }
}
```

## Proposed Solution
This PR introduces modifications to enable seamless Enum binding within Livewire components.

## Request for Feedback
I am keen to hear your thoughts on this implementation, particularly regarding any potential for simplification or further optimization.

Thank you very much!
