### PR TITLE
Allow computed snake case within blade view

### DIFF
--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -42,7 +42,7 @@ class BaseComputed extends Attribute
     protected function handleMagicGet($target, $property, $returnValue)
     {
         if ($target !== $this->component) return;
-        if ($property !== $this->getName()) return;
+        if ($this->generatePropertyName($property) !== $this->getName()) return;
 
         if ($this->persist) {
             $returnValue($this->handlePersistedGet());
@@ -135,4 +135,16 @@ class BaseComputed extends Attribute
     {
         return invade($this->component)->{$this->getName()}();
     }
+
+    public function getName()
+    {
+        return $this->generatePropertyName(parent::getName());
+    }
+
+    private function generatePropertyName($value)
+    {
+        return str($value)->camel()->toString();
+    }
+
+
 }

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -248,6 +248,30 @@ class UnitTest extends TestCase
     }
 
     /** @test */
+    function computed_property_is_accessible_using_snake_case()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $upperCasedFoo = 'FOO_BAR';
+
+            #[Computed]
+            public function fooBar()
+            {
+                return strtolower($this->upperCasedFoo);
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    {{ var_dump($this->foo_bar) }}
+                </div>
+                HTML;
+            }
+        })
+            ->assertSee('foo_bar');
+    }
+
+    /** @test */
     public function computed_property_is_accessable_within_blade_view()
     {
         Livewire::test(ComputedPropertyStub::class)


### PR DESCRIPTION
Review the contribution guide first at: https://laravel-livewire.com/docs/2.x/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
https://github.com/livewire/livewire/discussions/7352
https://github.com/livewire/livewire/discussions/7186

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

When it is necessary to utilize a computed property without the "Computed" attribute, we can access a method in the view using Snake Case, as demonstrated in version 2 of the software. However, in version 3, this behavior is not consistently maintained when the Computed Attribute is employed.

### It works currently

> component

```php
public function getFooBarProperty()
{
  return 'foo'
}
```

> blade

```blade
<div>
     {{ $this->foo_bar }} // foo
</div>
```

---

### Does not currently work

> component

```php
#[Computed]
public function fooBar()
{
  return 'foo'
}
```

> blade

```blade
//  Using a computed property with an attribute I got this error:
//  Property [$foo_bar] not found on the component:
<div>
     {{ $this->foo_bar }}
</div>
```

---

* This pull request enables us to employ Snake Case in the same manner as the conventional method when 
utilizing the investment attribute of the get.Property magic method.

* In addition, a corresponding test has been included for validation purposes.

Thanks for contributing! 🙌
