### PR TITLE
Update upgrading.md to include additional new config key

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -53,6 +53,8 @@ The following configuration keys have been introduced in version 3:
 'inject_morph_markers' => true,
 
 'navigate' => false,
+
+'pagination_theme' => 'tailwind',
 ```
 
 You can reference [Livewire's new configuration file on GitHub](https://github.com/livewire/livewire/blob/master/config/livewire.php) for additional option descriptions and copy-pastable code.


### PR DESCRIPTION
The upgrade process mentions 4 of the 5 keys added to the livewire.php configuration file, I've added the final key to reduce any confusion for those updating.

The `pagination_theme` key was missing from the list of new keys.