### PR TITLE
Extract out Mechanism API

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -61,7 +61,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
     protected function registerMechanisms()
     {
         foreach ($this->getMechanisms() as $mechanism) {
-            app($mechanism)->register($this);
+            app($mechanism)->register();
         }
     }
 
@@ -74,7 +74,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
         }
 
         foreach ($this->getMechanisms() as $mechanism) {
-            app($mechanism)->boot($this);
+            app($mechanism)->boot();
         }
     }
 

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -51,7 +51,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
             \Livewire\Mechanisms\HandleRequests\HandleRequests::class,
             \Livewire\Mechanisms\FrontendAssets\FrontendAssets::class,
             \Livewire\Mechanisms\ExtendBlade\ExtendBlade::class,
-            \Livewire\Mechanisms\CompileLivewireTags::class,
+            \LiveWire\Mechanisms\CompileLivewireTags\CompileLivewireTags::class,
             \Livewire\Mechanisms\ComponentRegistry::class,
             \Livewire\Mechanisms\RenderComponent::class,
             \Livewire\Mechanisms\DataStore::class,

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -51,7 +51,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
             \Livewire\Mechanisms\HandleRequests\HandleRequests::class,
             \Livewire\Mechanisms\FrontendAssets\FrontendAssets::class,
             \Livewire\Mechanisms\ExtendBlade\ExtendBlade::class,
-            \LiveWire\Mechanisms\CompileLivewireTags\CompileLivewireTags::class,
+            \Livewire\Mechanisms\CompileLivewireTags\CompileLivewireTags::class,
             \Livewire\Mechanisms\ComponentRegistry::class,
             \Livewire\Mechanisms\RenderComponent::class,
             \Livewire\Mechanisms\DataStore::class,

--- a/src/Mechanisms/CompileLivewireTags/CompileLivewireTags.php
+++ b/src/Mechanisms/CompileLivewireTags/CompileLivewireTags.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Livewire\Mechanisms\CompileLivewireTags;
+
+use Livewire\Mechanisms\Mechanism;
+
+class CompileLivewireTags extends Mechanism
+{
+    public function boot()
+    {
+        app('blade.compiler')->precompiler(new LivewireTagPrecompiler);
+    }
+}

--- a/src/Mechanisms/CompileLivewireTags/LivewireTagPrecompiler.php
+++ b/src/Mechanisms/CompileLivewireTags/LivewireTagPrecompiler.php
@@ -1,24 +1,14 @@
 <?php
 
-namespace Livewire\Mechanisms;
+namespace Livewire\Mechanisms\CompileLivewireTags;
 
-use Livewire\Exceptions\ComponentAttributeMissingOnDynamicComponentException;
 use Illuminate\View\Compilers\ComponentTagCompiler;
 use Livewire\Drawer\Regexes;
+use Livewire\Exceptions\ComponentAttributeMissingOnDynamicComponentException;
 
-class CompileLivewireTags extends ComponentTagCompiler
+class LivewireTagPrecompiler extends ComponentTagCompiler
 {
-    public function register()
-    {
-        //
-    }
-
-    public function boot()
-    {
-        app('blade.compiler')->precompiler($this->compileLivewireSelfClosingTags(...));
-    }
-
-    protected function compileLivewireSelfClosingTags($value)
+    public function __invoke($value)
     {
         $pattern = '/'.Regexes::$livewireOpeningTagOrSelfClosingTag.'/x';
 

--- a/src/Mechanisms/CompileLivewireTags/UnitTest.php
+++ b/src/Mechanisms/CompileLivewireTags/UnitTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Livewire\Mechanisms;
+namespace Livewire\Mechanisms\CompileLivewireTags;
 
-use Livewire\Livewire;
 use Illuminate\Support\Facades\Blade;
+use Livewire\Livewire;
 
-class CompileLivewireTagsUnitTest extends \Tests\TestCase
+class UnitTest extends \Tests\TestCase
 {
     /** @test */
     public function can_compile_livewire_self_closing_tags()

--- a/src/Mechanisms/ComponentRegistry.php
+++ b/src/Mechanisms/ComponentRegistry.php
@@ -5,21 +5,11 @@ namespace Livewire\Mechanisms;
 use Livewire\Exceptions\ComponentNotFoundException;
 use Livewire\Component;
 
-class ComponentRegistry
+class ComponentRegistry extends Mechanism
 {
     protected $missingComponentResolvers = [];
     protected $nonAliasedClasses = [];
     protected $aliases = [];
-
-    function register()
-    {
-        app()->singleton($this::class);
-    }
-
-    function boot()
-    {
-        //
-    }
 
     function component($name, $class = null)
     {

--- a/src/Mechanisms/DataStore.php
+++ b/src/Mechanisms/DataStore.php
@@ -4,18 +4,8 @@ namespace Livewire\Mechanisms;
 
 use WeakMap;
 
-class DataStore
+class DataStore extends Mechanism
 {
-    function register()
-    {
-        app()->singleton($this::class);
-    }
-
-    function boot()
-    {
-        //
-    }
-
     protected $lookup;
 
     function __construct()

--- a/src/Mechanisms/ExtendBlade/ExtendBlade.php
+++ b/src/Mechanisms/ExtendBlade/ExtendBlade.php
@@ -3,10 +3,11 @@
 namespace Livewire\Mechanisms\ExtendBlade;
 
 use Illuminate\Support\Facades\Blade;
+use Livewire\Mechanisms\Mechanism;
 use function Livewire\invade;
 use function Livewire\on;
 
-class ExtendBlade
+class ExtendBlade extends Mechanism
 {
     protected $directives = [];
     protected $precompilers = [];
@@ -34,15 +35,8 @@ class ExtendBlade
         return ! empty(static::$livewireComponents);
     }
 
-    function register()
-    {
-        //
-    }
-
     function boot()
     {
-        app()->singleton($this::class, fn () => $this);
-
         Blade::directive('this', fn() => "window.Livewire.find('{{ \$_instance->getId() }}')");
 
         on('render', function ($target, $view) {

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -5,9 +5,10 @@ namespace Livewire\Mechanisms\FrontendAssets;
 use Livewire\Drawer\Utils;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Blade;
+use Livewire\Mechanisms\Mechanism;
 use function Livewire\on;
 
-class FrontendAssets
+class FrontendAssets extends Mechanism
 {
     public $hasRenderedScripts = false;
     public $hasRenderedStyles = false;
@@ -15,11 +16,6 @@ class FrontendAssets
     public $javaScriptRoute;
 
     public $scriptTagAttributes = [];
-
-    public function register()
-    {
-        app()->singleton($this::class);
-    }
 
     public function boot()
     {

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Mechanisms\HandleComponents;
 
+use Livewire\Mechanisms\Mechanism;
 use function Livewire\{ invade, store, trigger, wrap };
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Livewire\Exceptions\MethodNotFoundException;
@@ -9,7 +10,7 @@ use Livewire\Drawer\Utils;
 use Illuminate\Support\Facades\View;
 use ReflectionUnionType;
 
-class HandleComponents
+class HandleComponents extends Mechanism
 {
     protected $propertySynthesizers = [
         Synthesizers\CarbonSynth::class,
@@ -23,16 +24,6 @@ class HandleComponents
 
     public static $renderStack = [];
     public static $componentStack = [];
-
-    public function register()
-    {
-        app()->singleton($this::class);
-    }
-
-    public function boot()
-    {
-        //
-    }
 
     public function registerPropertySynthesizer($synth)
     {

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -5,16 +5,12 @@ namespace Livewire\Mechanisms\HandleRequests;
 use Illuminate\Support\Facades\Route;
 use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
 
+use Livewire\Mechanisms\Mechanism;
 use function Livewire\trigger;
 
-class HandleRequests
+class HandleRequests extends Mechanism
 {
     protected $updateRoute;
-
-    function register()
-    {
-        app()->singleton($this::class);
-    }
 
     function boot()
     {

--- a/src/Mechanisms/Mechanism.php
+++ b/src/Mechanisms/Mechanism.php
@@ -10,7 +10,7 @@ abstract class Mechanism
 {
     protected $singleton = true;
 
-    function register($provider)
+    function register()
     {
         if ($this->singleton) app()->instance(static::class, $this);
     }

--- a/src/Mechanisms/Mechanism.php
+++ b/src/Mechanisms/Mechanism.php
@@ -12,7 +12,7 @@ abstract class Mechanism
 
     function register($provider)
     {
-        if ($this->singleton) app()->singleton(static::class, fn() => $this);
+        if ($this->singleton) app()->instance(static::class, $this);
     }
 
     function boot()

--- a/src/Mechanisms/Mechanism.php
+++ b/src/Mechanisms/Mechanism.php
@@ -12,7 +12,7 @@ abstract class Mechanism
 
     function register($provider)
     {
-        if ($this->singleton) app()->singleton(static::class, $this);
+        if ($this->singleton) app()->singleton(static::class, fn() => $this);
     }
 
     function boot()

--- a/src/Mechanisms/Mechanism.php
+++ b/src/Mechanisms/Mechanism.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Livewire\Mechanisms;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Str;
+use Livewire\LivewireServiceProvider;
+
+abstract class Mechanism
+{
+    protected $singleton = true;
+
+    function register($provider)
+    {
+        if ($this->singleton) app()->singleton(static::class, $this);
+    }
+
+    function boot()
+    {
+        //
+    }
+}

--- a/src/Mechanisms/Mechanism.php
+++ b/src/Mechanisms/Mechanism.php
@@ -8,11 +8,9 @@ use Livewire\LivewireServiceProvider;
 
 abstract class Mechanism
 {
-    protected $singleton = true;
-
     function register()
     {
-        if ($this->singleton) app()->instance(static::class, $this);
+        app()->instance(static::class, $this);
     }
 
     function boot()

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -2,12 +2,13 @@
 
 namespace Livewire\Mechanisms\PersistentMiddleware;
 
+use Livewire\Mechanisms\Mechanism;
 use function Livewire\on;
 use Illuminate\Support\Str;
 use Livewire\Drawer\Utils;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
 
-class PersistentMiddleware
+class PersistentMiddleware extends Mechanism
 {
     protected static $persistentMiddleware = [
         \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
@@ -22,11 +23,6 @@ class PersistentMiddleware
 
     protected $path;
     protected $method;
-
-    function register()
-    {
-        app()->singleton($this::class, fn () => $this);
-    }
 
     function boot()
     {

--- a/src/Mechanisms/RenderComponent.php
+++ b/src/Mechanisms/RenderComponent.php
@@ -5,13 +5,8 @@ namespace Livewire\Mechanisms;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Str;
 
-class RenderComponent
+class RenderComponent extends Mechanism
 {
-    function register()
-    {
-        app()->singleton($this::class);
-    }
-
     function boot()
     {
         Blade::directive('livewire', [static::class, 'livewire']);


### PR DESCRIPTION
Currently, each mechanism handles registering itself as a singleton slightly differently. This PR just cleans that up by moving the shared code into a single `Mechanism` class and then deleting ~30 lines of duplicate code.

The only other change is to introduce a `LivewireTagPrecompiler` class, which should help isolate any future issues with changes to the upstream `ComponentTagCompiler` class in Laravel. This improves the mechanism API and, hopefully, minimizes future conflicts.