### PR TITLE
Fix namespace collision with Post in UnitTest file

### DIFF
--- a/src/Features/SupportModels/BrowserTest.php
+++ b/src/Features/SupportModels/BrowserTest.php
@@ -23,12 +23,12 @@ class BrowserTest extends \Tests\BrowserTestCase
 
                 public function mount()
                 {
-                    $this->posts = Post::all();
+                    $this->posts = BrowserTestPost::all();
                 }
 
                 #[BaseOn('postDeleted')]
                 public function setPosts() {
-                    $this->posts = Post::all();
+                    $this->posts = BrowserTestPost::all();
                 }
 
                 public function render()
@@ -49,7 +49,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
                 public function delete($id)
                 {
-                    Post::find($id)->delete();
+                    BrowserTestPost::find($id)->delete();
                     $this->dispatch('postDeleted');
                 }
 
@@ -127,7 +127,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     }
 }
 
-class Post extends Model
+class BrowserTestPost extends Model
 {
     use Sushi;
 


### PR DESCRIPTION
There is a namespace collision with Post in the `SupportModels\UnitTest.php` and `SupportModels\BrowserTest.php` files. See https://github.com/livewire/livewire/pull/7468#issuecomment-1847127929 for more details.

This PR renames `Post` in the `BrowserTest.php` file.