### PR TITLE
Add failing test for select options not updating like they did in V2

### DIFF
--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -35,4 +35,96 @@ class BrowserTest extends BrowserTestCase
             ->assertDontSee('Unsaved changes...')
         ;
     }
+
+    /** @test */
+    public function can_display_correct_option_in_a_select_input_when_options_have_changed()
+    {
+        Livewire::visit(new class extends Component {
+            public $country = 'US';
+            public $state = 'TX';
+
+            public $countries = [
+                'US' => [
+                    'code' => 'US',
+                    'name' => 'United States',
+                    'states' => [
+                        'CA' => 'California',
+                        'TX' => 'Texas',
+                        'NY' => 'New York',
+                    ],
+                ],
+                'AU' => [
+                    'code' => 'AU',
+                    'name' => 'Australia',
+                    'states' => [
+                        'QLD' => 'Queensland',
+                        'SA' => 'South Australia',
+                        'NSW' => 'New South Wales',
+                    ],
+                ],
+            ];
+
+            public function getStateOptionsProperty()
+            {
+                if ($this->country === null|| $this->country == '') {
+                    return null;
+                }
+
+                return $this->countries[$this->country]['states'];
+            }
+
+            public function change()
+            {
+                $this->country = 'AU';
+                $this->state = 'NSW';
+            }
+
+            public function render()
+            {
+                return <<< 'HTML'
+                    <div>
+                        <div>
+                            Country: <span dusk="country">{{ $country }}</span>
+                        </div>
+
+                        <select wire:model.live="country" dusk="countrySelect">
+                            <option value="null" disabled>Select a country</option>
+                            @foreach ($this->countries as $countryOption)
+                                <option value="{{ $countryOption['code'] }}">{{ $countryOption['name'] }}</option>
+                            @endforeach
+                        </select>
+
+                        <div>
+                            State: <span dusk="state">{{ $state }}</span>
+                        </div>
+
+                        <div>
+                            @if ($this->stateOptions === null)
+                                <input type="text" name="state" wire:model.live="state" />
+                            @else
+                                <select wire:model.live="state" dusk="stateSelect">
+                                    <option value="null" disabled>Select a state</option>
+                                    @foreach ($this->stateOptions as $abbreviation => $name)
+                                        <option value="{{ $abbreviation }}">{{ $name }}</option>
+                                    @endforeach
+                                </select>
+                            @endif
+                        </div>
+
+                        <button type="button" wire:click="change" dusk="change">Change</button>
+                    </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@country', 'US')
+            ->assertSeeIn('@state', 'TX')
+            ->assertSelected('@countrySelect', 'US')
+            ->assertSelected('@stateSelect', 'TX')
+            ->waitForLivewire()->click('@change')
+            ->assertSeeIn('@country', 'AU')
+            ->assertSeeIn('@state', 'NSW')
+            ->assertSelected('@countrySelect', 'AU')
+            ->assertSelected('@stateSelect', 'NSW')
+            ;
+    }
 }


### PR DESCRIPTION
Currently, if the options inside a select input change between requests, if the value that the select input is set to isn't on the page, the selected option gets reset and nothing is displayed.

In V2, Livewire would morph the options first then it would deal with the databinding updates.

But in V3, this operation runs the opposite way, as Alpine's `forceModelUpdate()` is triggered inside an effect which updates the selected value, and then morph is being run.

So we need to find a way to change the order of operations in V3 to ensure the DOM is changed first, then we try and update the select input's selectedIndex, as trying to set the selected index before the option exists results in a no-op and the selectedIndex get's reset to -1.

Morph is an effect and effects run after Livewire merges the new snapshot.

## Debugging

Code sections to note:
Alpine:
`packages/alpinejs/src/directives/x-model.js:108`
`packages/alpinejs/src/utils/bind.js:122`

Livewire:
`js/commit.js:132`
`js/morph.js:29`

We can see in this screenshot that in V3 the `forceModelUpdate` happens before `morph-updating`, causing the issue.
<img width="549" alt="Pasted image 20231202162040" src="https://github.com/livewire/livewire/assets/882837/f00e7dd9-d845-41f4-9844-c931150e4c07">

This screenshot demonstrates what happens if we set a selected option to an option that doesn't exist (get's set to `-1`)
<img width="205" alt="Pasted image 20231202162012" src="https://github.com/livewire/livewire/assets/882837/a1cfea60-2adc-449e-be1e-e9b49989f2a0">

## V2 Code Path

Code:
`js/component/index.js:287`
`js/component/index.js:358`
`js/dom/dom.js:153`
`js/dom/dom.js:191` - updateSelect (same as Alpine `bind.js:122`)

<img width="751" alt="Pasted image 20231202162646" src="https://github.com/livewire/livewire/assets/882837/73a60fda-ac1b-458e-808c-83431dce4aee">

<img width="1114" alt="Pasted image 20231202162706" src="https://github.com/livewire/livewire/assets/882837/c811d067-6ba4-4d06-bc27-1aabe43727f8">

<img width="870" alt="Pasted image 20231202162722" src="https://github.com/livewire/livewire/assets/882837/51f6b6af-bf7d-465c-bca5-7ed6b6a8b16a">


