### PR TITLE
Add dumpErrors to allow for easier test debug overview

### DIFF
--- a/src/Features/SupportValidation/TestsValidation.php
+++ b/src/Features/SupportValidation/TestsValidation.php
@@ -23,6 +23,12 @@ trait TestsValidation
         return new MessageBag;
     }
 
+    public function dumpErrors()
+    {
+        dump($this->errors());
+        return $this;
+    }
+
     function failedRules()
     {
         $validator = store($this->target)->get('testing.validator');


### PR DESCRIPTION
When testing the component we can chain on ->dumpHeaders() and ->dumpSession() in order to get the headers in console. When developing there are cases where it could be useful to dump the validation errors in the same way.

Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
No. I feel like it's a small and simple addition which will create value without affecting anything worth discussing. 

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
no. Just adding a tiny method for the validation test

4️⃣ Does it include tests? (Required)
Not really. It chains to the validation tests

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
