### PR TITLE
Add `assertHasError`

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -415,7 +415,7 @@ You can also pass parameters to actions by passing additional parameters into th
 
 ### Validation
 
-To test that a validation error has been thrown, you can use Livewire's `assertHasErrors()` method:
+To test that a validation error has been thrown, you can use Livewire's `assertHasError()` or `assertHasErrors()` methods:
 
 ```php
 <?php
@@ -434,7 +434,7 @@ class CreatePostTest extends TestCase
         Livewire::test(CreatePost::class)
             ->set('title', '')
             ->call('save')
-            ->assertHasErrors('title');
+            ->assertHasError('title');
     }
 }
 ```
@@ -442,7 +442,81 @@ class CreatePostTest extends TestCase
 If you want to test that a specific validation rule has failed, you can pass an array of rules:
 
 ```php
-$this->assertHasErrors(['title' => ['required']]);
+$this->assertHasError('title', 'required');
+```
+
+You can also assert that specific validation messages are present:
+
+```php
+$this->assertHasError('title', 'The title field is required.');
+```
+
+You can also pass a closure to make assertions of your own:
+
+```php
+$this->assertHasError('title', function ($rules, $messages) {
+    return in_array('required', $rules);
+
+    // Or...
+
+    return in_array('The title field is required.', $messages);
+});
+```
+
+If you wish to assert multiple validation errors at once, you can do so with the `assertHasErrors()` method:
+
+```php
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\CreatePost;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class CreatePostTest extends TestCase
+{
+    /** @test */
+    public function title_field_is_required()
+    {
+        Livewire::test(CreatePost::class)
+            ->set('title', '')
+            ->set('content', '')
+            ->call('save')
+            ->assertHasErrors(['title', 'content']);
+    }
+}
+```
+
+Similar to the singular `assertHasError()` method, `assertHasErrors()` supports asserting rules and messages:
+
+```php
+$this->assertHasErrors([
+    'title' => 'required',
+    'content' => 'The content field is required.'
+]);
+```
+
+You can also assert against multiple failed validation rules or messages at once:
+
+```php
+$this->assertHasErrors([
+    'title' => ['required', 'min:3'],
+]);
+```
+
+If you want full control over your validation assertions you can pass a callback and manually confirm validation scenarios:
+
+```php
+$this->assertHasErrors([
+    'title' => function ($rules, $messages) {
+        return in_array('required', $rules);
+
+        // Or...
+
+        return in_array('The title field is required.', $messages);
+    },
+]);
 ```
 
 ### Authorization
@@ -679,6 +753,10 @@ Livewire provides many more testing utilities. Below is a comprehensive list of 
 | `assertSeeHtmlInOrder([$firstString, $secondString])` | Assert that the provided HTML strings appear in order in the rendered output of the component                                                                                        |
 | `assertDispatched('post-created')`                    | Assert that the given event has been dispatched by the component                                                                                                                     |
 | `assertNotDispatched('post-created')`                 | Assert that the given event has not been dispatched by the component                                                                                                                 |
+| `assertHasError('title')`                            | Assert that validation has failed for the `title` property                                                                                                                           |
+| `assertHasError('title', 'required')`                | Assert that the provided validation rule failed for `title` property                                                                                                                           |
+| `assertHasError('title', 'The title field is required.')`                | Assert that the provided validation messsage exists for `title` property                                                                                                                           |
+| `assertHasErrors()`                                  | Assert that there are validation errors thrown property                                                                                                                           |
 | `assertHasErrors('title')`                            | Assert that validation has failed for the `title` property                                                                                                                           |
 | `assertHasErrors(['title' => ['required', 'min:6']])`   | Assert that the provided validation rules failed for the `title` property                                                                                                            |
 | `assertHasNoErrors('title')`                          | Assert that there are no validation errors for the `title` property                                                                                                                  |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -415,7 +415,7 @@ You can also pass parameters to actions by passing additional parameters into th
 
 ### Validation
 
-To test that a validation error has been thrown, you can use Livewire's `assertHasError()` or `assertHasErrors()` methods:
+To test that a validation error has been thrown, you can use Livewire's `assertHasErrors()` method:
 
 ```php
 <?php
@@ -434,7 +434,7 @@ class CreatePostTest extends TestCase
         Livewire::test(CreatePost::class)
             ->set('title', '')
             ->call('save')
-            ->assertHasError('title');
+            ->assertHasErrors('title');
     }
 }
 ```
@@ -442,81 +442,7 @@ class CreatePostTest extends TestCase
 If you want to test that a specific validation rule has failed, you can pass an array of rules:
 
 ```php
-$this->assertHasError('title', 'required');
-```
-
-You can also assert that specific validation messages are present:
-
-```php
-$this->assertHasError('title', 'The title field is required.');
-```
-
-You can also pass a closure to make assertions of your own:
-
-```php
-$this->assertHasError('title', function ($rules, $messages) {
-    return in_array('required', $rules);
-
-    // Or...
-
-    return in_array('The title field is required.', $messages);
-});
-```
-
-If you wish to assert multiple validation errors at once, you can do so with the `assertHasErrors()` method:
-
-```php
-<?php
-
-namespace Tests\Feature\Livewire;
-
-use App\Livewire\CreatePost;
-use Livewire\Livewire;
-use Tests\TestCase;
-
-class CreatePostTest extends TestCase
-{
-    /** @test */
-    public function title_field_is_required()
-    {
-        Livewire::test(CreatePost::class)
-            ->set('title', '')
-            ->set('content', '')
-            ->call('save')
-            ->assertHasErrors(['title', 'content']);
-    }
-}
-```
-
-Similar to the singular `assertHasError()` method, `assertHasErrors()` supports asserting rules and messages:
-
-```php
-$this->assertHasErrors([
-    'title' => 'required',
-    'content' => 'The content field is required.'
-]);
-```
-
-You can also assert against multiple failed validation rules or messages at once:
-
-```php
-$this->assertHasErrors([
-    'title' => ['required', 'min:3'],
-]);
-```
-
-If you want full control over your validation assertions you can pass a callback and manually confirm validation scenarios:
-
-```php
-$this->assertHasErrors([
-    'title' => function ($rules, $messages) {
-        return in_array('required', $rules);
-
-        // Or...
-
-        return in_array('The title field is required.', $messages);
-    },
-]);
+$this->assertHasErrors(['title' => ['required']]);
 ```
 
 ### Authorization
@@ -753,10 +679,6 @@ Livewire provides many more testing utilities. Below is a comprehensive list of 
 | `assertSeeHtmlInOrder([$firstString, $secondString])` | Assert that the provided HTML strings appear in order in the rendered output of the component                                                                                        |
 | `assertDispatched('post-created')`                    | Assert that the given event has been dispatched by the component                                                                                                                     |
 | `assertNotDispatched('post-created')`                 | Assert that the given event has not been dispatched by the component                                                                                                                 |
-| `assertHasError('title')`                            | Assert that validation has failed for the `title` property                                                                                                                           |
-| `assertHasError('title', 'required')`                | Assert that the provided validation rule failed for `title` property                                                                                                                           |
-| `assertHasError('title', 'The title field is required.')`                | Assert that the provided validation messsage exists for `title` property                                                                                                                           |
-| `assertHasErrors()`                                  | Assert that there are validation errors thrown property                                                                                                                           |
 | `assertHasErrors('title')`                            | Assert that validation has failed for the `title` property                                                                                                                           |
 | `assertHasErrors(['title' => ['required', 'min:6']])`   | Assert that the provided validation rules failed for the `title` property                                                                                                            |
 | `assertHasNoErrors('title')`                          | Assert that there are no validation errors for the `title` property                                                                                                                  |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -445,6 +445,12 @@ If you want to test that a specific validation rule has failed, you can pass an 
 $this->assertHasErrors(['title' => ['required']]);
 ```
 
+Or if you'd rather assert a validation message exists, you can do so as well:
+
+```php
+$this->assertHasErrors(['title' => ['The title field is required.']]);
+```
+
 ### Authorization
 
 Authorizing actions relying on untrusted input in your Livewire components is [essential](/docs/properties#authorizing-the-input). Livewire provides `assertUnauthorized()` and `assertForbidden()` methods to ensure that an authentication or authorization check has failed:

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -592,7 +592,7 @@ class CreatePost extends Component
 
 ## Testing validation
 
-Livewire provides useful testing utilities for validation scenarios, such as the `assertHasError()` method.
+Livewire provides useful testing utilities for validation scenarios, such as the `assertHasErrors()` method.
 
 Below is a basic test case that ensures validation errors are thrown if no input is set for the `title` property:
 
@@ -613,12 +613,12 @@ class CreatePostTest extends TestCase
         Livewire::test(CreatePost::class)
             ->set('content', 'Sample content...')
             ->call('save')
-            ->assertHasError('title');
+            ->assertHasErrors('title');
     }
 }
 ```
 
-In addition to testing the presence of errors, `assertHasError` allows you to also narrow down the assertion to specific rules by passing the rules to assert against as the second argument to the method:
+In addition to testing the presence of errors, `assertHasErrors` allows you to also narrow down the assertion to specific rules by passing the rules to assert against as the second argument to the method:
 
 ```php
 /** @test */
@@ -628,11 +628,11 @@ public function cant_create_post_with_title_shorter_than_3_characters()
         ->set('title', 'Sa')
         ->set('content', 'Sample content...')
         ->call('save')
-        ->assertHasError(['title' => ['min:3']]);
+        ->assertHasErrors(['title' => ['min:3']]);
 }
 ```
 
-You can also assert the presence of validation errors for multiple properties at the same time using `assertHasErrors()`:
+You can also assert the presence of validation errors for multiple properties at the same time:
 
 ```php
 /** @test */

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -592,7 +592,7 @@ class CreatePost extends Component
 
 ## Testing validation
 
-Livewire provides useful testing utilities for validation scenarios, such as the `assertHasErrors()` method.
+Livewire provides useful testing utilities for validation scenarios, such as the `assertHasError()` method.
 
 Below is a basic test case that ensures validation errors are thrown if no input is set for the `title` property:
 
@@ -613,12 +613,12 @@ class CreatePostTest extends TestCase
         Livewire::test(CreatePost::class)
             ->set('content', 'Sample content...')
             ->call('save')
-            ->assertHasErrors('title');
+            ->assertHasError('title');
     }
 }
 ```
 
-In addition to testing the presence of errors, `assertHasErrors` allows you to also narrow down the assertion to specific rules by passing the rules to assert against as the second argument to the method:
+In addition to testing the presence of errors, `assertHasError` allows you to also narrow down the assertion to specific rules by passing the rules to assert against as the second argument to the method:
 
 ```php
 /** @test */
@@ -628,11 +628,11 @@ public function cant_create_post_with_title_shorter_than_3_characters()
         ->set('title', 'Sa')
         ->set('content', 'Sample content...')
         ->call('save')
-        ->assertHasErrors(['title' => ['min:3']]);
+        ->assertHasError(['title' => ['min:3']]);
 }
 ```
 
-You can also assert the presence of validation errors for multiple properties at the same time:
+You can also assert the presence of validation errors for multiple properties at the same time using `assertHasErrors()`:
 
 ```php
 /** @test */

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -449,6 +449,14 @@ class UnitTest extends \LegacyTests\Unit\TestCase
     }
 
     /** @test */
+    function assert_has_error_and_message_with_manually_added_error()
+    {
+        Livewire::test(ValidatesDataWithSubmitStub::class)
+            ->call('manuallyAddError')
+            ->assertHasError('bob', 'lob');
+    }
+
+    /** @test */
     function assert_has_error_with_submit_validation()
     {
         Livewire::test(ValidatesDataWithSubmitStub::class)

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -440,66 +440,9 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             });
     }
 
-    /** @test */
-    function assert_has_error_with_manually_added_error()
-    {
-        Livewire::test(ValidatesDataWithSubmitStub::class)
-            ->call('manuallyAddError')
-            ->assertHasErrors('bob');
-    }
 
     /** @test */
-    function assert_has_error()
-    {
-        Livewire::test(ValidatesDataWithSubmitStub::class)
-            ->call('submit')
-            ->assertHasError();
-    }
-
-    /** @test */
-    function assert_has_error_for_specific_field()
-    {
-        Livewire::test(ValidatesDataWithSubmitStub::class)
-            ->call('submit')
-            ->assertHasError('foo');
-    }
-
-    /** @test */
-    function assert_has_error_with_provided_rule()
-    {
-        Livewire::test(ValidatesDataWithSubmitStub::class)
-            ->call('submit')
-            ->assertHasError('foo', 'required');
-    }
-
-    /** @test */
-    function assert_has_error_with_provided_message()
-    {
-        Livewire::test(ValidatesDataWithSubmitStub::class)
-            ->call('submit')
-            ->assertHasError('foo', 'The foo field is required.');
-    }
-
-    /** @test */
-    function assert_has_error_with_provided_callback()
-    {
-        Livewire::test(ValidatesDataWithSubmitStub::class)
-            ->call('submit')
-            ->assertHasError('foo', function ($rules, $messages) {
-                return in_array('required', $rules) && in_array('The foo field is required.', $messages);
-            });
-    }
-
-    /** @test */
-    function assert_has_error_and_message_with_manually_added_error()
-    {
-        Livewire::test(ValidatesDataWithSubmitStub::class)
-            ->call('manuallyAddError')
-            ->assertHasError('bob', 'lob');
-    }
-
-    /** @test */
-    function assert_has_errors_honors_the_same_api_as_the_singular_alternative()
+    function assert_has_errors()
     {
         Livewire::test(ValidatesDataWithSubmitStub::class)
             ->call('submit')
@@ -515,6 +458,14 @@ class UnitTest extends \LegacyTests\Unit\TestCase
                 return in_array('required', $rules) && in_array('The foo field is required.', $messages);
             }])
             ;
+    }
+
+    /** @test */
+    function assert_has_error_with_manually_added_error()
+    {
+        Livewire::test(ValidatesDataWithSubmitStub::class)
+            ->call('manuallyAddError')
+            ->assertHasErrors('bob');
     }
 
     /** @test */

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -449,6 +449,22 @@ class UnitTest extends \LegacyTests\Unit\TestCase
     }
 
     /** @test */
+    function assert_has_error()
+    {
+        Livewire::test(ValidatesDataWithSubmitStub::class)
+            ->call('submit')
+            ->assertHasError('foo');
+    }
+
+    /** @test */
+    function assert_has_error_with_provided_rule()
+    {
+        Livewire::test(ValidatesDataWithSubmitStub::class)
+            ->call('submit')
+            ->assertHasError('foo', 'required');
+    }
+
+    /** @test */
     function assert_has_error_and_message_with_manually_added_error()
     {
         Livewire::test(ValidatesDataWithSubmitStub::class)

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -453,6 +453,14 @@ class UnitTest extends \LegacyTests\Unit\TestCase
     {
         Livewire::test(ValidatesDataWithSubmitStub::class)
             ->call('submit')
+            ->assertHasError();
+    }
+
+    /** @test */
+    function assert_has_error_for_specific_field()
+    {
+        Livewire::test(ValidatesDataWithSubmitStub::class)
+            ->call('submit')
             ->assertHasError('foo');
     }
 
@@ -465,11 +473,48 @@ class UnitTest extends \LegacyTests\Unit\TestCase
     }
 
     /** @test */
+    function assert_has_error_with_provided_message()
+    {
+        Livewire::test(ValidatesDataWithSubmitStub::class)
+            ->call('submit')
+            ->assertHasError('foo', 'The foo field is required.');
+    }
+
+    /** @test */
+    function assert_has_error_with_provided_callback()
+    {
+        Livewire::test(ValidatesDataWithSubmitStub::class)
+            ->call('submit')
+            ->assertHasError('foo', function ($rules, $messages) {
+                return in_array('required', $rules) && in_array('The foo field is required.', $messages);
+            });
+    }
+
+    /** @test */
     function assert_has_error_and_message_with_manually_added_error()
     {
         Livewire::test(ValidatesDataWithSubmitStub::class)
             ->call('manuallyAddError')
             ->assertHasError('bob', 'lob');
+    }
+
+    /** @test */
+    function assert_has_errors_honors_the_same_api_as_the_singular_alternative()
+    {
+        Livewire::test(ValidatesDataWithSubmitStub::class)
+            ->call('submit')
+            ->assertHasErrors()
+            ->assertHasErrors('foo')
+            ->assertHasErrors(['foo'])
+            ->assertHasErrors(['foo' => 'required'])
+            ->assertHasErrors(['foo' => 'The foo field is required.'])
+            ->assertHasErrors(['foo' => 'required', 'bar' => 'required'])
+            ->assertHasErrors(['foo' => 'The foo field is required.', 'bar' => 'The bar field is required.'])
+            ->assertHasErrors(['foo' => ['The foo field is required.'], 'bar' => ['The bar field is required.']])
+            ->assertHasErrors(['foo' => function ($rules, $messages) {
+                return in_array('required', $rules) && in_array('The foo field is required.', $messages);
+            }])
+            ;
     }
 
     /** @test */

--- a/src/Features/SupportValidation/TestsValidation.php
+++ b/src/Features/SupportValidation/TestsValidation.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportValidation;
 
+use Closure;
 use function Livewire\store;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Support\Str;
@@ -28,6 +29,21 @@ trait TestsValidation
         $validator = store($this->target)->get('testing.validator');
 
         return $validator ? $validator->failed() : [];
+    }
+
+    public function assertHasError($key, $value = null)
+    {
+        $errors = $this->errors();
+
+        if (is_null($value)) {
+            PHPUnit::assertTrue($errors->has($key), "Component missing error: $key");
+        } elseif ($value instanceof Closure) {
+            PHPUnit::assertTrue($value($errors->get($key)));
+        } else {
+            PHPUnit::assertContains($value, $errors->get($key));
+        }
+
+        return $this;
     }
 
     public function assertHasErrors($keys = [])

--- a/src/Features/SupportValidation/TestsValidation.php
+++ b/src/Features/SupportValidation/TestsValidation.php
@@ -41,23 +41,23 @@ trait TestsValidation
 
         foreach ($keys as $key => $value) {
             if (is_int($key)) {
-                $this->assertHasError($value);
+                $this->makeErrorAssertion($value);
             } else {
-                $this->assertHasError($key, $value);
+                $this->makeErrorAssertion($key, $value);
             }
         }
 
         return $this;
     }
 
-    public  function assertHasError($key = null, $value = null) {
+    protected function makeErrorAssertion($key = null, $value = null) {
         $errors = $this->errors();
 
         $messages = $errors->get($key);
 
         $failed = $this->failedRules() ?: [];
         $failedRules = array_keys(Arr::get($failed, $key, []));
-        $failedRules = array_map(fn ($i) => Str::lower($i), $failedRules);
+        $failedRules = array_map(fn ($i) => Str::snake($i), $failedRules);
 
         PHPUnit::assertTrue($errors->isNotEmpty(), 'Component has no errors.');
 


### PR DESCRIPTION
I wanted to test the following line of code which adds a custom error message, but couldn't.

```php
$this->addError('repository', 'Please enter the repository in `vendor/package` format.');
```

With this PR, I can:

```php
Livewire::test(MyComponentClass::class)
    ->submit()
    ->assertHasError('repository', 'Please enter the repository in `vendor/package` format.');
```

This assertion mimics `assertSessionHas` in Laravel - you may assert the key exists, it matches a specific value, or even pass a closure for more advanced checks.

There may be opportunity to update the existing `assertHasErrors` method. But changing its signature potentially felt like a breaking change. Furthermore, I personally feel the parameter overloading gets nuts. I'd rather have single purpose, straightforward methods.