### PR TITLE
Fix memory issue in `HandleRequests`

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -24,7 +24,7 @@ class HandleRequests extends Mechanism
     function getUpdateUri()
     {
         return (string) str(
-            route($this->updateRoute->getName(), [], false)
+            route($this->updateRoute, [], false)
         )->start('/');
     }
 
@@ -48,7 +48,7 @@ class HandleRequests extends Mechanism
             $route->name('livewire.update');
         }
 
-        $this->updateRoute = $route;
+        $this->updateRoute = $route->getName();
     }
 
     function isLivewireRequest()


### PR DESCRIPTION
Storing the full route object as a class property in `HandleRequests` leads to accumulating memory usage when running tests.
The `Route` object contains a reference to the `Router`. My assumption is that it isn't getting garbage collected properly which causes the memory leak.

Since only the route's name is used in `getUpdateUri`, a reference to the full route object seems unnecessary. My fix stores the route name only, which significantly reduces memory usage in testing suites.

Related discussions + PR's:
* https://github.com/livewire/livewire/discussions/7488
* https://github.com/livewire/livewire/pull/7181

### Steps to reproduce
To prove the memory leak, I created a new Laravel application with the following test:

```php
<?php
declare(strict_types=1);

final class MemoryLeakTest extends \Tests\TestCase
{
    public function test_leaks_memory_on_1000_iterations(): void
    {
        // Remove the existing application instance.
        $this->app->flush();
        $this->app = null;


        // Let's create a fully booted application instance 1,000 times.
        for($i = 1; $i <= 1000; ++$i) {
            $this->createApplication()->flush();

            // Each 50 times, report the MB used by the PHP process by dumping it.
            if ($i % 50 === 0) {
                dump('Using ' . ((int) (memory_get_usage(true) / (1024 * 1024))) . 'MB as ' . $i . ' iterations.');
            }
        }


        $this->app = $this->createApplication();
    }
}
```

The memory consumption at iteration 1000 was **50MB**.

After installing the latest Livewire version memory consumption goes up to **76MB**.
The leak gets worse with more routes (probably because the router has a larger memory footprint).

When I apply my patch, the memory usage is down to an acceptable amount (**58MB**).

### Comparison table

**Memory consumption after 1000 runs:**
| Clean install (6 routes) | Clean install (20 routes) | With Livewire (single route) | With Livewire (20 routes) | Patched (single route) | Patched (20 routes) |
|-------|-------|-------|-------|------|------|
| 50 MB | 54 MB | 76 MB | 102 MB | 58 MB | 62 MB |