### PR TITLE
Remove trailing full stop from command description

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
@@ -10,7 +10,7 @@ class S3CleanupCommand extends Command
 {
     protected $signature = 'livewire:configure-s3-upload-cleanup';
 
-    protected $description = 'Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs.';
+    protected $description = 'Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs';
 
     public function handle()
     {


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Very minor.

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
No...

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
Generally speaking the command descriptions in Laravel don't have a full stop at the end. In fact, all the Livewire commands don't have a full stop either apart from this one. So this just makes it all consistent.

```
 livewire
  livewire:attribute                    Create a new Livewire attribute class
  livewire:configure-s3-upload-cleanup  Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs.
  livewire:copy                         Copy a Livewire component
  livewire:delete                       Delete a Livewire component
  livewire:form                         Create a new Livewire form class
  livewire:layout                       Create a new app layout file
  livewire:make                         Create a new Livewire component
  livewire:move                         Move a Livewire component
  livewire:publish                      Publish Livewire configuration
  livewire:stubs                        Publish Livewire stubs
  livewire:upgrade                      Interactive upgrade helper to migrate from v2 to v3
```


Thanks for contributing! 🙌
