### PR TITLE
Fix ReflectionException when getting property on stdClass object

### DIFF
--- a/src/Drawer/BaseUtils.php
+++ b/src/Drawer/BaseUtils.php
@@ -2,8 +2,6 @@
 
 namespace Livewire\Drawer;
 
-use ReflectionClass;
-
 class BaseUtils
 {
     static function isSyntheticTuple($payload) {
@@ -79,7 +77,7 @@ class BaseUtils
     }
 
     static function getProperty($target, $property) {
-        return (new ReflectionClass($target))->getProperty($property);
+        return (new \ReflectionObject($target))->getProperty($property);
     }
 
     static function propertyIsTyped($target, $property) {

--- a/src/Features/SupportStdClasses/BrowserTest.php
+++ b/src/Features/SupportStdClasses/BrowserTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Livewire\Features\SupportStdClasses;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    /** @test */
+    function can_use_wire_stdclass_property()
+    {
+        Livewire::visit(new class extends Component {
+            public $obj;
+
+            function mount()
+            {
+                $this->obj = (object)[];
+            }
+
+            function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <input type="text" dusk="input" wire:model.live="obj.property" />
+                        <span dusk="output">{{ $obj?->property ?? '' }}</span>
+                    </div>
+                HTML;
+            }
+        })
+            ->type('@input', 'foo')
+            ->pause(300)
+            ->append('@input', 'bar')
+            ->pause(300)
+            ->assertSeeIn('@output', 'foobar')
+        ;
+    }
+}

--- a/src/Features/SupportStdClasses/UnitTest.php
+++ b/src/Features/SupportStdClasses/UnitTest.php
@@ -6,12 +6,12 @@ use Livewire\Component;
 use Livewire\Livewire;
 use Tests\BrowserTestCase;
 
-class BrowserTest extends BrowserTestCase
+class UnitTest extends BrowserTestCase
 {
     /** @test */
     function can_use_wire_stdclass_property()
     {
-        Livewire::visit(new class extends Component {
+        Livewire::test(new class extends Component {
             public $obj;
 
             function mount()
@@ -29,11 +29,11 @@ class BrowserTest extends BrowserTestCase
                 HTML;
             }
         })
-            ->type('@input', 'foo')
-            ->pause(300)
-            ->append('@input', 'bar')
-            ->pause(300)
-            ->assertSeeIn('@output', 'foobar')
+            ->assertSet('obj.property', null)
+            ->set('obj.property', 'foo')
+            ->assertSet('obj.property', 'foo')
+            ->set('obj.property', 'bar')
+            ->assertSet('obj.property', 'bar')
         ;
     }
 }


### PR DESCRIPTION
Using a class property ($obj) of type stdClass in a livewire component and binding to the object property ($obj->property) results in a ReflectionException originating from the class BaseUtils and the method getProperty. This method calls ReflectionClass($target) with target being $obj. This PR uses ReflectionObject($target) instead.
```
class Test extends Component
{
    public $obj;

    public function mount()
    {
        $this->obj = (object)[];
    }

    public function render()
    {
        return <<<'HTML'
            <div>
                <input type="text" wire:model.live="obj.property">
                <span>{{ $obj?->property ?? '' }}</span>
            </div>
        HTML;
    }
}
```
