### PR TITLE
Name change reset function

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -517,7 +517,7 @@ class SearchPosts extends Component
 <div>
     <input wire:model.live="query">
 
-    <button wire:click="resetData">Reset Search</button> <!-- [tl! highlight] -->
+    <button wire:click="resetQuery">Reset Search</button> <!-- [tl! highlight] -->
 
     @foreach ($posts as $post)
         <!-- ... -->

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -497,7 +497,7 @@ class SearchPosts extends Component
     public $query = '';
 
     #[Js] // [tl! highlight:6]
-    public function resetData()
+    public function resetQuery()
     {
         return <<<'JS'
             $wire.query = '';

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -497,7 +497,7 @@ class SearchPosts extends Component
     public $query = '';
 
     #[Js] // [tl! highlight:6]
-    public function reset()
+    public function resetData()
     {
         return <<<'JS'
             $wire.query = '';
@@ -517,7 +517,7 @@ class SearchPosts extends Component
 <div>
     <input wire:model.live="query">
 
-    <button wire:click="reset">Reset Search</button> <!-- [tl! highlight] -->
+    <button wire:click="resetData">Reset Search</button> <!-- [tl! highlight] -->
 
     @foreach ($posts as $post)
         <!-- ... -->


### PR DESCRIPTION
In the documentation it is given as an example the addition of a reset() function, but if we take the example as is, we get an error because we are trying to redefine the function present in Component.

To avoid any confusion, I suggest renaming the function in the example to resetData which no longer poses any problems.
