### PR TITLE
Real-time events using Mercure

### DIFF
--- a/js/features/index.js
+++ b/js/features/index.js
@@ -12,4 +12,5 @@ import './supportRedirects';
 import './supportNavigate';
 import './supportMorphDom';
 import './supportEntangle';
+import './supportMercure';
 import './supportEvents';

--- a/js/features/supportMercure.js
+++ b/js/features/supportMercure.js
@@ -1,0 +1,53 @@
+import { on } from '@/events'
+import { dispatchSelf } from './supportEvents'
+
+let mercureUrl = null
+
+function getMercureUrl() {
+    if (!mercureUrl && document.querySelector('[data-mercure-url]')) {
+        mercureUrl = document
+            .querySelector('[data-mercure-url]')
+            .getAttribute('data-mercure-url')
+    }
+    return mercureUrl
+}
+
+on('effects', (component, effects) => {
+    const listeners = effects.listeners || []
+
+    listeners.forEach((event) => {
+        if (event.startsWith('mercure')) {
+            const mercureUrl = getMercureUrl()
+            if (!mercureUrl) {
+                console.warn(
+                    "Warning: 'data-mercure-url' attribute not found. Ensure it is present in the HTML.",
+                )
+                return
+            }
+
+            if (typeof EventSource === 'undefined') {
+                console.warn(
+                    'Warning: EventSource API (for Mercure) not available. Check browser compatibility.',
+                )
+                return
+            }
+
+            const eventParts = event.split('mercure:')
+            const [s1, topic] = eventParts
+            const url = `${mercureUrl}?topic=${topic}`
+
+            const mercureEventSource = new EventSource(url, {
+                withCredentials: true,
+            })
+
+            mercureEventSource.onmessage = (e) => {
+                const data = JSON.parse(e.data)
+                dispatchSelf(component, event, [data])
+            }
+
+            mercureEventSource.onerror = (e) => {
+                // console.log(e)
+            }
+        }
+    })
+})

--- a/src/Features/SupportEvents/MercureBrowserTest.php
+++ b/src/Features/SupportEvents/MercureBrowserTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Livewire\Features\SupportEvents;
+
+use Illuminate\Support\Facades\Route;
+use Livewire\Attributes\On;
+use Livewire\Drawer\Utils;
+use Tests\BrowserTestCase;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class MercureBrowserTest extends BrowserTestCase
+{
+    /** @test */
+    public function can_listen_for_mercure_event_with_payload()
+    {
+        Route::get('/dusk/fake-eventsource', function () {
+            return Utils::pretendResponseIsFile(__DIR__.'/fake-eventsource.js');
+        });
+
+        Livewire::useScriptTagAttributes([
+            'data-mercure-url' => 'http://localhost:8888/.well-known/mercure',
+        ]);
+
+        Livewire::visit(new class extends Component {
+            public $orderId = 0;
+
+            #[On('mercure:orderShipped')]
+            function foo($event) {
+                $this->orderId = $event['order_id'];
+            }
+
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <span dusk="orderId">{{ $orderId }}</span>
+
+                    <script src="/dusk/fake-eventsource"></script>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@orderId', '0')
+        ->waitForLivewire(function ($b) {
+            $b->script("sources['http://localhost:8888/.well-known/mercure?topic=orderShipped'].emitMessage({'event': 'orderShipped', 'data': JSON.stringify({'order_id': '1234'})})");
+        })
+        ->assertSeeIn('@orderId', '1234');
+    }
+}

--- a/src/Features/SupportEvents/fake-eventsource.js
+++ b/src/Features/SupportEvents/fake-eventsource.js
@@ -1,0 +1,91 @@
+// Source: https://github.com/gcedo/eventsourcemock/blob/master/src/EventSource.js
+
+class EventEmitter{
+    constructor(){
+        this.callbacks = {}
+    }
+
+    on(event, cb){
+        if(!this.callbacks[event]) this.callbacks[event] = [];
+        this.callbacks[event].push(cb)
+    }
+
+    emit(event, data){
+        let cbs = this.callbacks[event]
+        if(cbs){
+            cbs.forEach(cb => cb(data))
+        }
+    }
+}
+
+const defaultOptions = {
+    withCredentials: false,
+}
+
+const sources = {}
+
+class EventSource {
+    static CONNECTING
+    static OPEN
+    static CLOSED
+
+    __emitter
+    onerror
+    onmessage
+    onopen
+    readyState
+    url
+    withCredentials
+    sources
+
+    constructor(url, configuration = defaultOptions) {
+        this.url = url
+        this.withCredentials = configuration.withCredentials
+        this.readyState = 0
+        this.__emitter = new EventEmitter()
+        sources[url] = this
+    }
+
+    addEventListener(eventName, listener) {
+        this.__emitter.addListener(eventName, listener)
+    }
+
+    removeEventListener(eventName, listener) {
+        this.__emitter.removeListener(eventName, listener)
+    }
+
+    close() {
+        this.readyState = 2
+    }
+
+    emit(eventName, messageEvent) {
+        this.__emitter.emit(eventName, messageEvent)
+    }
+
+    emitError(error) {
+        if (typeof this.onerror === 'function') {
+            this.onerror(error)
+        }
+    }
+
+    emitOpen() {
+        this.readyState = 1
+        if (typeof this.onopen === 'function') {
+            this.onopen()
+        }
+    }
+
+    emitMessage(message) {
+        if (typeof this.onmessage === 'function') {
+            this.onmessage(message)
+        }
+    }
+}
+
+EventSource.CONNECTING = 0
+EventSource.OPEN = 1
+EventSource.CLOSED = 2
+
+Object.defineProperty(window, 'EventSource', {
+    value: EventSource,
+})


### PR DESCRIPTION
This pull request adds support for [Mercure](https://mercure.rocks/) real-time events to Livewire. Mercure is a modern alternative to WebSockets that's a little simpler to setup in my opinion. It also ships included with [FrankenPHP](https://frankenphp.dev/) which has been getting some buzz recently.

The integration is fairly lightweight and closely follows the Echo implementation. Once Mercure's been configured as a Laravel Broadcast channel your Livewire component can listen for Mercure events by adding them to getListeners. Here's an example component that calls the `addMessage` method whenever it receives a `public.newMessage` event:

```php
<?php

namespace App\Livewire;

use Illuminate\Support\Carbon;
use Livewire\Component;

class Messages extends Component
{
    public array $messages = [];

    public function getListeners()
    {
        return [
            "mercure:public.newMessage" => 'addMessage',
        ];
    }

    public function addMessage(array $event)
    {
        array_push($this->messages, [
            'time' => Carbon::now()->format('g:i:sa'),
            'message' => $event['data']['payload'],
        ]);
    }

    public function render()
    {
        return view('livewire.messages');
    }
}
```

I also setup a demo repo showing how to configure Mercure as a broadcast channel. You can find the source code for the demo here: https://github.com/benbjurstrom/livewire-mercure-demo.

https://github.com/benbjurstrom/livewire-mercure-demo/assets/12499093/62f8372f-d79c-4e5a-ba46-aacb9792b428
