### PR TITLE
Fix `class "string" not found` bug

### DIFF
--- a/src/Features/SupportAttributes/Attribute.php
+++ b/src/Features/SupportAttributes/Attribute.php
@@ -86,7 +86,12 @@ abstract class Attribute
 
         // If the type is available, display its name
         if ($type instanceof \ReflectionNamedType) {
-            return $type->getName();
+            $name = $type->getName();
+            
+            // If the type is a BackedEnum then return it's name
+            if (is_subclass_of($name, \BackedEnum::class)) {
+                return $name;
+            }
         }
 
         return false;

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -145,6 +145,30 @@ class BrowserTest extends \Tests\BrowserTestCase
     }
 
     /** @test */
+    public function it_does_not_break_string_typed_properties()
+    {
+        Livewire::withQueryParams(['foo' => 'bar'])
+            ->visit([
+                new class extends Component
+                {
+                    #[BaseUrl]
+                    public string $foo = '';
+
+                    public function render()
+                    {
+                        return <<<'HTML'
+                        <div>
+                            <h1 dusk="output">{{ $foo }}</h1>
+                        </div>
+                        HTML;
+                    }
+                }
+            ])
+            ->assertSeeIn('@output', 'bar')
+        ;
+    }
+
+    /** @test */
     public function can_use_url_on_lazy_component()
     {
         Livewire::visit([


### PR DESCRIPTION
This PR fixes an issue #7574 introduced in v3.3.1 where it was trying to hydrate all strings from the query string as backed enums.

<img width="1436" alt="image" src="https://github.com/livewire/livewire/assets/882837/d0821a80-08c6-4fb7-b6bd-63cf425bddfc">
