### PR TITLE
fix: Missing driver of tmp-for-tests in testing

### DIFF
--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -27,7 +27,14 @@ class FileUploadConfiguration
     public static function disk()
     {
         if (app()->runningUnitTests()) {
-            return 'tmp-for-tests';
+            $disk = 'tmp-for-tests';
+
+            config()->set('filesystems.disks.'.$disk, [
+                'driver' => 'local',
+                'root' => storage_path('app')
+            ]);
+
+            return $disk;
         }
 
         return config('livewire.temporary_file_upload.disk') ?: config('filesystems.default');


### PR DESCRIPTION
There is an error when you use `Storage::fake('s3')` in testing. 

```text
[2023-12-20 15:23:01] testing.ERROR: Disk [tmp-for-tests] does not have a configured driver. {"userId":1,"exception":"[object] (InvalidArgumentException(code: 0): Disk [tmp-for-tests] does not have a configured driver.
```

I think the problem is that the value of disk is fixed to `tmp-for-tests` in order to avoid people actually uploading files to S3, but the `driver` and `root` of `tmp-for-tests` are not set.

I found someone else with the same problem in [#3105](https://github.com/livewire/livewire/discussions/3105#discussioncomment-5759768). 
