### PR TITLE
Add note to upgrade guide explaining livewire:discover is redundant in v3

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -125,6 +125,10 @@ You can either move all of your components to the new location or add the follow
 'class_namespace' => 'App\\Http\\Livewire',
 ```
 
+### Discovery
+
+With Livewire 3, there is no manifest present, and there is therefore nothing to “discover” in relation to Livewire Components, and you can safely remove any livewire:discover references from your build scripts without issue.
+
 ## Page component layout view
 
 When rendering Livewire components as full pages using a syntax like the following:


### PR DESCRIPTION
A short & sweet explanation that livewire:discover is now redundant, and can be removed from build scripts etc.

Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
