### PR TITLE
Add note recommending `@js` directive

### DIFF
--- a/docs/alpine.md
+++ b/docs/alpine.md
@@ -211,6 +211,15 @@ To fix this, we need to add quotations around the Blade expression like so:
 >
 ```
 
+Blade also has a `@js` directive that turns your PHP output into valid Javascript. It is better at handling different types, and special character issues, so it is recommended over the above method.
+
+```html
+<button
+    type="button"
+    x-on:click="$wire.deletePost(@js($post->uuid))"
+>
+```
+
 Now the above template will render properly and everything will work as expected:
 
 ```html


### PR DESCRIPTION
the `@js` directive is better at turning your PHP into JS than manual handling, so add a note for that.

I would even go so far as to say we should remove the example of manually concatenating single quotes, but I'll start with this.
