### PR TITLE
Fix Testing - SubsequentRender response - effects payload does not work correctly

### DIFF
--- a/src/Features/SupportEvents/TestsEvents.php
+++ b/src/Features/SupportEvents/TestsEvents.php
@@ -65,7 +65,7 @@ trait TestsEvents
                 ksort($params);
 
                 return $item['name'] === $value
-                    && $commonParams === $params;
+                    && $commonParams == $params;
             });
 
             $encodedParams = json_encode($params);

--- a/src/Features/SupportTesting/SubsequentRender.php
+++ b/src/Features/SupportTesting/SubsequentRender.php
@@ -50,16 +50,11 @@ class SubsequentRender extends Render
             );
         }
 
-        $json = $response->json();
+        $componentResponsePayload = data_get($response, 'original.components.0');
 
-        // Set "original" to Blade view for assertions like "assertViewIs()"...
-        $response->original = $componentView;
+        $snapshot = json_decode(data_get($componentResponsePayload, 'snapshot'), true);
 
-        $componentResponsePayload = $json['components'][0];
-
-        $snapshot = json_decode($componentResponsePayload['snapshot'], true);
-
-        $effects = $componentResponsePayload['effects'];
+        $effects = data_get($componentResponsePayload, 'effects');
 
         // If no new HTML has been rendered, let's forward the last known HTML...
         $html = $effects['html'] ?? $this->lastState->getHtml(stripInitialData: true);

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanDispatchUnitTest.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanDispatchUnitTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Livewire\Features\SupportTesting\Tests;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class TestableLivewireCanDispatchUnitTest extends \Tests\TestCase
+{
+    /** @test */
+    function can_assert_dispatch()
+    {
+        Livewire::test(DispatchComponent::class)
+            ->call('sent')
+            ->assertDispatched('my-event', payload: [
+                'value_1' => 1,
+                'value_2' => 3.45,
+                'value_3' => 40.0,
+            ]);
+    }
+}
+
+class DispatchComponent extends Component
+{
+    function sent()
+    {
+        $this->dispatch('my-event', payload: [
+            'value_1' => 1,
+            'value_2' => 3.45,
+            'value_3' => 40.0,
+        ]);
+    }
+
+    function render()
+    {
+        return '<example>Hello!</example>';
+    }
+}

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanDispatchUnitTest.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanDispatchUnitTest.php
@@ -2,32 +2,72 @@
 
 namespace Livewire\Features\SupportTesting\Tests;
 
+use Illuminate\Support\Carbon;
 use Livewire\Component;
 use Livewire\Livewire;
 
 class TestableLivewireCanDispatchUnitTest extends \Tests\TestCase
 {
     /** @test */
-    function can_assert_dispatch()
+    function can_assert_dispatch_with_number_in_array_values()
     {
         Livewire::test(DispatchComponent::class)
-            ->call('sent')
+            ->call('sentNumbersInArrayValues')
             ->assertDispatched('my-event', payload: [
-                'value_1' => 1,
-                'value_2' => 3.45,
-                'value_3' => 40.0,
+                [
+                    'id' => 1,
+                    'value' => 10
+                ],
+                [
+                    'id' => 1,
+                    'value' => 34.5
+                ],
+                [
+                    'id' => 1,
+                    'value' => 40.0000
+                ],
+            ]);
+    }
+
+    /** @test */
+    function can_assert_dispatch_with_datetime_in_array_values()
+    {
+        $date = Carbon::create(2023, 12, 1, 10, 10, 59);
+
+        Carbon::setTestNow($date);
+
+        Livewire::test(DispatchComponent::class)
+            ->call('sentDateTimeInArrayValues')
+            ->assertDispatched('my-event', payload: [
+                'datetime' => $date
             ]);
     }
 }
 
 class DispatchComponent extends Component
 {
-    function sent()
+    function sentNumbersInArrayValues()
     {
         $this->dispatch('my-event', payload: [
-            'value_1' => 1,
-            'value_2' => 3.45,
-            'value_3' => 40.0,
+            [
+                'id' => 1,
+                'value' => 10
+            ],
+            [
+                'id' => 1,
+                'value' => 34.5
+            ],
+            [
+                'id' => 1,
+                'value' => 40.0000
+            ],
+        ]);
+    }
+
+    function sentDateTimeInArrayValues()
+    {
+        $this->dispatch('my-event', payload: [
+            'datetime' => Carbon::create(2023, 12, 1, 10, 10, 59)
         ]);
     }
 


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Master branch PR's will be closed)
Y
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
N
4️⃣ Does it include tests? (Required)
Y
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This PR improves the way test response is handled. Instead of getting the components via the json() method, it is captured by the "original" property.

This is because `json()` doesn't handle some returns well.
I also removed a line that would cause the test to error.

I submitted a failed test to secure PR

---

Here is a comparison:

### response->json()
```php
array:2 [ // ...livewire/src/Features/SupportTesting/SubsequentRender.php:53
  "components" => array:1 [
    0 => array:2 [
      "snapshot" => "{"data":[],"memo":{"id":"ffsGZ5S8JXeFduvL68gU","name":3207924939,"path":"livewire-unit-test-endpoint\/QmwXjJiNtLJl1ENjBWlK","method":"GET","children":[],"scripts":[],"assets":[],"errors":[],"locale":"en"},"checksum":"9c1601139aa55f54c79f1542e5d1c2261f48c9328a45bacce47f99459a9c4e4c"}"
      "effects" => array:3 [
        "returns" => array:1 [
          0 => null
        ]
        "html" => "<example wire:id="ffsGZ5S8JXeFduvL68gU">Hello!</example>"
        "dispatches" => array:1 [
          0 => array:2 [
            "name" => "my-event"
            "params" => array:1 [
              "payload" => array:3 [
                "value_1" => 1
                "value_2" => 3.45
                "value_3" => 40
              ]
            ]
          ]
        ]
      ]
    ]
  ]
  "assets" => []
]

```

### response->original
```php
array:2 [ // .../livewire/src/Features/SupportTesting/SubsequentRender.php:53
  "components" => array:1 [
    0 => array:2 [
      "snapshot" => "{"data":[],"memo":{"id":"VloKmI7aWbrsbkM2oOhP","name":3207924939,"path":"livewire-unit-test-endpoint\/8KHVffegHzr2yJZmg9Of","method":"GET","children":[],"scripts":[],"assets":[],"errors":[],"locale":"en"},"checksum":"537c46bb1394bf6327b2cd7cd8eefd800aed5da69d15c2a44a5b2be34f150b6a"}"
      "effects" => array:3 [
        "returns" => array:1 [
          0 => null
        ]
        "html" => "<example wire:id="VloKmI7aWbrsbkM2oOhP">Hello!</example>"
        "dispatches" => array:1 [
          0 => array:2 [
            "name" => "my-event"
            "params" => array:1 [
              "payload" => array:3 [
                "value_1" => 1
                "value_2" => 3.45
                "value_3" => 40.0
              ]
            ]
          ]
        ]
      ]
    ]
  ]
  "assets" => []
]
```

![image](https://github.com/livewire/livewire/assets/33601626/6f779d80-1525-449b-8078-2e78f9ba5af6)

Thanks for contributing! 🙌
