### PR TITLE
Improvement: Support for Wireable casting on Model binding

### DIFF
--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -504,10 +504,10 @@ trait HandlesValidation
         }
 
         if ($value instanceof Model) {
-            return collect($value->toArray())
-                ->map(
-                    fn ($attribute) => $this->castDataForValidation($attribute)
-                )->toArray();
+            return array_map(
+                fn ($attribute) => $this->castDataForValidation($attribute),
+                $value->toArray()
+            );
         }
 
         if ($value instanceof Arrayable) {


### PR DESCRIPTION
Currently, if you want to work with a custom casting with model binding, you can't. Even if the value is being cast to a class that  has the  `Wireable` interface implemented.

This is because the `unwrapDataForValidation` function hasn't taken into consideration (neither on V2 nor V3) the properties of a model. Only casting the first depth of the values.

```php
protected function unwrapDataForValidation($data)
{
    return collect($data)->map(function ($value) {
        if ($value instanceof Wireable) return $value->toLivewire();
        else if ($value instanceof Arrayable) return $value->toArray();

        return $value;
    })->all();
}
```

## The problem

Having a custom class, with Wireable implemented, as it's described on docs:

```php
class CommaList implements Wireable
{
    // ...
    public static function fromLivewire($value): static
    {
        return new static($value);
    }

    public function toLivewire(): string
    {
        return $this->toString();
    }
}
```

And a casting for that class:

```php
class AsCommaList implements Castable
```

Being implemented on a Model:

```php
protected $casts = [
    'tags' => AsCommaList::class
];
```

Does throw a validation exception:

```php
public $rules = [
    'post.tags' => ['required', 'string', 'max:255'],
];
```

![image](https://github.com/livewire/livewire/assets/46875694/75628030-5179-4335-a37f-e618634ad76e)

This is because the Wireable function is never called.

![image](https://github.com/livewire/livewire/assets/46875694/bc79ee81-5577-4e9d-a7f9-b8dab64d7ee5)

## The solution

This PR extracts the casting to its own recursive function, to cast any attribute from a Model.

```php
protected function castDataForValidation($value)
{
    // @todo: this logic should be contained within "SupportWireables"...
    if ($value instanceof Wireable) {
        return $value->toLivewire();
    }

    if ($value instanceof Model) {
        return array_map(
            fn ($attribute) => $this->castDataForValidation($attribute),
            $value->toArray()
        );
    }

    if ($value instanceof Arrayable) {
        return $value->toArray();
    };

    return $value;
}

protected function unwrapDataForValidation($data)
{
    return collect($data)
        ->map(fn ($v) => $this->castDataForValidation($v))
        ->all();
}
```
The corrected result:

![image](https://github.com/livewire/livewire/assets/46875694/a80cb0b4-f0c8-4767-95a5-5170ae9aadb3)
