### PR TITLE
fix computed attribute - snake case in method name

### DIFF
--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -133,7 +133,7 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
-        return invade($this->component)->{$this->getName()}();
+        return invade($this->component)->{parent::getName()}();
     }
 
     public function getName()

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -272,6 +272,51 @@ class UnitTest extends TestCase
     }
 
     /** @test */
+    function computed_property_is_accessible_when_using_snake_case_or_camel_case_in_the_method_name_in_the_class()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $upperCasedFoo = 'FOO_BAR';
+
+            #[Computed]
+            public function foo_bar_snake_case_in_component_class()
+            {
+                return strtolower($this->upperCasedFoo);
+            }
+
+            #[Computed]
+            public function fooBarCamelCaseInComponentClass()
+            {
+                return strtolower($this->upperCasedFoo);
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <!-- Snake Case in Component Class -->
+                        snake_case_in_component_class_{{ $this->foo_bar_snake_case_in_component_class }}
+
+                        <!-- Camel Case in Blade View -->
+                        camelCaseInBladeView_snake_case_method_{{ $this->fooBarCamelCaseInComponentClass }}
+
+                        <!-- Camel Case in Component Class -->
+                        camel_case_in_component_class_{{ $this->foo_bar_camel_case_in_component_class }}
+
+                        <!-- Camel Case in Blade View -->
+                        camelCaseInBladeView_camel_case_method_{{ $this->fooBarCamelCaseInComponentClass }}
+                    </div>
+                HTML;
+            }
+        })
+            ->assertSeeInOrder([
+                'snake_case_in_component_class_foo_bar',
+                'camelCaseInBladeView_snake_case_method_foo_bar',
+                'camel_case_in_component_class_foo_bar',
+                'camelCaseInBladeView_camel_case_method_foo_bar'
+            ]);
+    }
+
+    /** @test */
     public function computed_property_is_accessable_within_blade_view()
     {
         Livewire::test(ComputedPropertyStub::class)


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
N
2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Y
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
N
4️⃣ Does it include tests? (Required)
Y
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Fix: https://github.com/livewire/livewire/pull/7426#issuecomment-1873020792

The problem was generated when searching for the value of the method that was overwritten. Now, the value is taken based on the original name of the loaded method.

```php
#[Computed]
public function some_long_property_name_thats_easier_to_read_as_snake_case(): string
{
     return "Yeah!!!";
}
```

Thanks for contributing! 🙌
