### PR TITLE
Pass the same parameter format in assertDispatch to avoid divergent comparisons

### DIFF
--- a/src/Features/SupportEvents/TestsEvents.php
+++ b/src/Features/SupportEvents/TestsEvents.php
@@ -48,7 +48,6 @@ trait TestsEvents
     protected function testDispatched($value, $params)
     {
         $assertionSuffix = '.';
-        $params = json_decode(json_encode($params), true);
 
         if (empty($params)) {
             $test = collect(data_get($this->effects, 'dispatches'))->contains('name', '=', $value);
@@ -59,6 +58,8 @@ trait TestsEvents
 
             $test = $event && $params[0]($event['name'], $event['params']);
         } else {
+            $params = json_decode(json_encode($params), true);
+
             $test = (bool) collect(data_get($this->effects, 'dispatches'))->first(function ($item) use ($value, $params) {
                 $commonParams = array_intersect_key($item['params'], $params);
 

--- a/src/Features/SupportEvents/TestsEvents.php
+++ b/src/Features/SupportEvents/TestsEvents.php
@@ -48,6 +48,7 @@ trait TestsEvents
     protected function testDispatched($value, $params)
     {
         $assertionSuffix = '.';
+        $params = json_decode(json_encode($params), true);
 
         if (empty($params)) {
             $test = collect(data_get($this->effects, 'dispatches'))->contains('name', '=', $value);

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanDispatchOriginalParamsUnitTest.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanDispatchOriginalParamsUnitTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Livewire\Features\SupportTesting\Tests;
+
+use Illuminate\Support\Carbon;
+use Livewire\Livewire;
+use Tests\TestComponent;
+
+class TestableLivewireCanDispatchOriginalParamsUnitTest extends \Tests\TestCase
+{
+    /** @test */
+    function can_assert_dispatch_with_number_in_array_values()
+    {
+        Livewire::test(new class extends TestComponent {
+            function sentNumbersInArrayValues()
+            {
+                $this->dispatch('my-event', payload: [ ['value' => 40.0] ]);
+            }
+
+            function dontSentNumbersInArrayValues()
+            {
+                // ...
+            }
+
+            function render() {
+                return <<<'HTML'
+                    <div></div>
+                HTML;
+            }
+        })
+            ->call('sentNumbersInArrayValues')
+            ->assertDispatched('my-event', payload: [ ['value' => 40.0] ])
+            ->call('dontSentNumbersInArrayValues')
+            ->assertNotDispatched('my-event', payload: [ ['value' => 40.0] ])
+        ;
+    }
+
+    /** @test */
+    function can_assert_dispatch_with_datetime_in_array_values()
+    {
+        $date = Carbon::create(2023, 12, 1, 10, 10, 58);
+
+        Carbon::setTestNow($date);
+
+        Livewire::test(new class extends TestComponent {
+            function sentDateTimeInArrayValues()
+            {
+                $this->dispatch('my-event', payload: [
+                    'datetime' => Carbon::create(2023, 12, 1, 10, 10, 58)
+                ]);
+            }
+
+            function dontSentDateTimeInArrayValues()
+            {
+                // ...
+            }
+
+            function render() {
+                return <<<'HTML'
+                    <div></div>
+                HTML;
+            }
+        })
+            ->call('sentDateTimeInArrayValues')
+            ->assertDispatched('my-event', payload: [
+                'datetime' => $date
+            ])
+            ->assertDispatched('my-event', payload: [
+                'datetime' => '2023-12-01T10:10:58.000000Z'
+            ])
+        ;
+    }
+}

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanDispatchOriginalParamsUnitTest.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanDispatchOriginalParamsUnitTest.php
@@ -38,7 +38,7 @@ class TestableLivewireCanDispatchOriginalParamsUnitTest extends \Tests\TestCase
     /** @test */
     function can_assert_dispatch_with_datetime_in_array_values()
     {
-        $date = Carbon::create(2023, 12, 1, 10, 10, 58);
+        $date = Carbon::create(2024, 01, 1, 11, 11, 58);
 
         Carbon::setTestNow($date);
 
@@ -46,7 +46,7 @@ class TestableLivewireCanDispatchOriginalParamsUnitTest extends \Tests\TestCase
             function sentDateTimeInArrayValues()
             {
                 $this->dispatch('my-event', payload: [
-                    'datetime' => Carbon::create(2023, 12, 1, 10, 10, 58)
+                    'datetime' => Carbon::create(2024, 01, 1, 11, 11, 58)
                 ]);
             }
 
@@ -66,7 +66,7 @@ class TestableLivewireCanDispatchOriginalParamsUnitTest extends \Tests\TestCase
                 'datetime' => $date
             ])
             ->assertDispatched('my-event', payload: [
-                'datetime' => '2023-12-01T10:10:58.000000Z'
+                'datetime' => '2024-01-01T11:11:58.000000Z'
             ])
         ;
     }


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
https://github.com/livewire/livewire/pull/7641

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Y
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
N
4️⃣ Does it include tests? (Required)
Y
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

When checking whether an event has been triggered, sometimes we have no way of knowing what format it is or what data will be lost due to the `$response->json()` method that converts the payload to javascript format.

This PR follows this same idea.

**Today it looks like this:**
* User dispatches an event with a carbon date format

```php
$this->dispatch('my-event', payload: [
      'datetime' => Carbon::create(2023, 12, 1, 10, 10, 58)
]);
```

* The test does not validate whether the "Carbon" date the user passed is the same as `2023-12-01T10:10:58.000000Z `compared in the test.

![image](https://github.com/livewire/livewire/assets/33601626/8361239b-498e-4679-9b64-0ba5a2593cf8)

---

**Ideal**:

* User dispatches an event with a carbon date format
* The test can check if a Carbon instance is the same as the one sent back by the response. (javascript). Then these two will pass:

```php
->assertDispatched('my-event', payload: [
      'datetime' => Carbon::create(2023, 12, 1, 10, 10, 58)
 ])
 ->assertDispatched('my-event', payload: [
      'datetime' => '2023-12-01T10:10:58.000000Z'
 ])
```



Thanks for contributing! 🙌
