### PR TITLE
Give computed properties precedence over standard properties in the view

### DIFF
--- a/src/Features/SupportComputed/BrowserTest.php
+++ b/src/Features/SupportComputed/BrowserTest.php
@@ -89,4 +89,28 @@ class BrowserTest extends BrowserTestCase
         ->refresh()
         ->assertSeeIn('@count', '1');
     }
+
+    /** @test */
+    public function can_priorize_gets_computed_property_instead_of_property_with_same_name(): void
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            #[Computed]
+            public function count()
+            {
+                return 1;
+            }
+
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <p dusk="count">{{ $this->count }}</p>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@count', '1');
+    }
 }


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
N
2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Y
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
N
4️⃣ Does it include tests? (Required)
Y
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

When we have two properties with the same name in the same component, but one of them is computed, and we are accessing the property using `$this` through Blade, Livewire is not prioritizing the computed property over the common property, when in my opinion it should prioritize the computed property due to the fact of using `$this` to access the property like mentioned in the docs: https://livewire.laravel.com/docs/computed-properties
