### PR TITLE
Add warning about Laravel Mix

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -149,3 +149,6 @@ Alpine.plugin(Clipboard)
 
 Livewire.start()
 ```
+
+> [!warning] Not compatible with Laravel Mix
+> Laravel Mix will not work if you are manually bundling Livewire and AlpineJS. We recommend you switch to Vite if you need this ability.


### PR DESCRIPTION
it appears that Laravel Mix will not generate working code if you want to manually bundle Livewire and AlpineJS, so we'll add a note to warn users about this.

I banged my head for 2 days trying to figure this out, so hopefully this helps other people in the same boat.