### PR TITLE
Fix memory leak when adding persistent middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,9 @@
   "require": {
     "php": "^8.1",
     "symfony/http-kernel": "^6.2|^7.0",
-    "illuminate/support": "^10.0|^11.0",
     "illuminate/database": "^10.0|^11.0",
+    "illuminate/routing": "^10.0|^11.0",
+    "illuminate/support": "^10.0|^11.0",
     "illuminate/validation": "^10.0|^11.0",
     "league/mime-type-detection": "^1.9"
   },

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Mechanisms\PersistentMiddleware;
 
+use Illuminate\Routing\Router;
 use Livewire\Mechanisms\Mechanism;
 use function Livewire\on;
 use Illuminate\Support\Str;
@@ -51,12 +52,12 @@ class PersistentMiddleware extends Mechanism
 
     function addPersistentMiddleware($middleware)
     {
-        static::$persistentMiddleware = array_merge(static::$persistentMiddleware, (array) $middleware);
+        static::$persistentMiddleware = Router::uniqueMiddleware(array_merge(static::$persistentMiddleware, (array) $middleware));
     }
 
     function setPersistentMiddleware($middleware)
     {
-        static::$persistentMiddleware = (array) $middleware;
+        static::$persistentMiddleware = Router::uniqueMiddleware((array) $middleware);
     }
 
     function getPersistentMiddleware()

--- a/src/Mechanisms/PersistentMiddleware/UnitTest.php
+++ b/src/Mechanisms/PersistentMiddleware/UnitTest.php
@@ -15,6 +15,7 @@ class UnitTest extends \LegacyTests\Unit\TestCase
     /** @test */
     public function it_does_not_have_persistent_middleware_memory_leak_when_adding_middleware()
     {
+        $base = Livewire::getPersistentMiddleware();
         Livewire::addPersistentMiddleware('MyMiddleware');
 
         $config = $this->app['config'];
@@ -27,9 +28,15 @@ class UnitTest extends \LegacyTests\Unit\TestCase
 
         // It hangs around because it is a static variable, so we do expect
         // it to still exist here.
-        $this->assertCount(1, array_filter(Livewire::getPersistentMiddleware(), fn ($middleware) => $middleware === 'MyMiddleware'));
+        $this->assertSame([
+            ...$base,
+            'MyMiddleware',
+        ], Livewire::getPersistentMiddleware());
 
         Livewire::addPersistentMiddleware('MyMiddleware');
-        $this->assertCount(1, array_filter(Livewire::getPersistentMiddleware(), fn ($middleware) => $middleware === 'MyMiddleware'));
+        $this->assertSame([
+            ...$base,
+            'MyMiddleware',
+        ], Livewire::getPersistentMiddleware());
     }
 }

--- a/src/Mechanisms/PersistentMiddleware/UnitTest.php
+++ b/src/Mechanisms/PersistentMiddleware/UnitTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Livewire\Mechanisms\PersistentMiddleware;
+
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Stringable;
+use Livewire\Component;
+use Livewire\Form;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class UnitTest extends \LegacyTests\Unit\TestCase
+{
+    /** @test */
+    public function it_does_not_have_persistent_middleware_memory_leak_when_adding_middleware()
+    {
+        Livewire::addPersistentMiddleware('MyMiddleware');
+
+        $config = $this->app['config'];
+        $this->app->forgetInstances();
+        $this->app->forgetScopedInstances();
+        Facade::clearResolvedInstances();
+        // Need to rebind these for the testcase cleanup to work.
+        $this->app->instance('app', $this->app);
+        $this->app->instance('config', $config);
+
+        // It hangs around because it is a static variable, so we do expect
+        // it to still exist here.
+        $this->assertCount(1, array_filter(Livewire::getPersistentMiddleware(), fn ($middleware) => $middleware === 'MyMiddleware'));
+
+        Livewire::addPersistentMiddleware('MyMiddleware');
+        $this->assertCount(1, array_filter(Livewire::getPersistentMiddleware(), fn ($middleware) => $middleware === 'MyMiddleware'));
+    }
+}


### PR DESCRIPTION
## Why

There is currently a memory leak that occurs in testsuites due to the static nature of the `Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware::$persistentMiddleware` array.

```php
Livewire::addPersistentMiddleware('MyMiddleware');
Livewire::addPersistentMiddleware('MyMiddleware');
Livewire::addPersistentMiddleware('MyMiddleware');
Livewire::addPersistentMiddleware('MyMiddleware');
Livewire::addPersistentMiddleware('MyMiddleware');

Livewire::getPersistentMiddleware();

// [
//     '\Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class',
//     '\Laravel\Jetstream\Http\Middleware\AuthenticateSession::class',
//     '\Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class',
//     '\Illuminate\Routing\Middleware\SubstituteBindings::class',
//     '\App\Http\Middleware\RedirectIfAuthenticated::class',
//     '\Illuminate\Auth\Middleware\Authenticate::class',
//     '\Illuminate\Auth\Middleware\Authorize::class',
//     '\App\Http\Middleware\Authenticate::class',
//     'MyMiddleware',
//     'MyMiddleware',
//     'MyMiddleware',
//     'MyMiddleware',
//     'MyMiddleware',
// ];
```

This is problematic in a testsuite where static variables are not cleared between runs. If an app was to call `Livewire::addPersistentMiddleware('MyMiddleware')` once in their service provider, as documented, the on every test a new entry would be added to the array.

If a testsuite had 1,000 tests there would be 1,000 `'MyMiddleware'` entries in this array for the last test.

In `laravel/pulse` we add two persistent middleware in the service provider which means this imaginary testsuite would now have 2,000 `'MyMiddleware'` entries. It also means that all non-livewire applications that install Pulse can be impacted by this memory leak.

## The fix

Middleware are now ensured to be unique while being added to Livewires stack. We use Laravel's internal `Router::uniqueMiddleware` to ensure the order matches how Laravel would handle things in the router.

## Notes

There is still a potential weirdness for long lived environments, such as Octane, testsuites, etc., where middleware added dynamically outside of a service provider would not be forgotten for the next request. I'm not sure if this is really a concern as the documentation shows `Livewire::addPersistentMiddleware` being used in a service provider.

It was on my mind so I wanted to share it but I don't know that it needs to be resolved as I can't think of a way that it would be problematic in a real-world scenario.