### PR TITLE
consider preview_mimes config when building preview url

### DIFF
--- a/src/Features/SupportFileUploads/FileNotPreviewableException.php
+++ b/src/Features/SupportFileUploads/FileNotPreviewableException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Livewire\Features\SupportFileUploads;
+
+use Livewire\Exceptions\BypassViewHandler;
+
+class FileNotPreviewableException extends \Exception
+{
+    use BypassViewHandler;
+
+    public function __construct(TemporaryUploadedFile $file)
+    {
+        parent::__construct(
+            "File with extension \"{$file->guessExtension()}\" is not previewable. See the livewire.temporary_file_upload.preview_mimes config."
+        );
+    }
+}

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -83,6 +83,10 @@ class TemporaryUploadedFile extends UploadedFile
 
     public function temporaryUrl()
     {
+        if (!$this->isPreviewable()) {
+            throw new FileNotPreviewableException($this);
+        }
+
         if ((FileUploadConfiguration::isUsingS3() or FileUploadConfiguration::isUsingGCS()) && ! app()->runningUnitTests()) {
             return $this->storage->temporaryUrl(
                 $this->path,
@@ -91,7 +95,7 @@ class TemporaryUploadedFile extends UploadedFile
             );
         }
 
-        if (method_exists($this->storage->getAdapter(), 'getTemporaryUrl') || ! $this->isPreviewable()) {
+        if (method_exists($this->storage->getAdapter(), 'getTemporaryUrl')) {
             // This will throw an error because it's not used with S3.
             return $this->storage->temporaryUrl($this->path, now()->addDay());
         }

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -505,6 +505,7 @@ class UnitTest extends \Tests\TestCase
             ->set('photo', $file)
             ->viewData('photo');
 
+        $this->expectException(FileNotPreviewableException::class);
         $photo->temporaryUrl();
 
         $this->assertFalse($photo->isPreviewable());


### PR DESCRIPTION
This commit considers temporary_file_upload.preview_mimes before building the preview url. Throwing an exception on non previewable files will allow to detect validation errors that otherwise will not be noted.

This is a bugfix. Otherwise the preview_mimes config is useless without enforcing it imho.