### PR TITLE
Add `#[View(...)]` attribute

### DIFF
--- a/src/Attributes/View.php
+++ b/src/Attributes/View.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Attribute;
+use Livewire\Mechanisms\HandleComponents\BaseView;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class View extends BaseView
+{
+    //
+}

--- a/src/Mechanisms/HandleComponents/BaseView.php
+++ b/src/Mechanisms/HandleComponents/BaseView.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents;
+
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
+#[\Attribute]
+class BaseView extends LivewireAttribute
+{
+    function __construct(
+        public $name,
+        public $params = [],
+    ) {}
+}

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -262,9 +262,13 @@ class HandleComponents extends Mechanism
 
         $fileName = str($dotName)->replace('.', '/')->__toString();
 
-        $viewOrString = method_exists($component, 'render')
-            ? wrap($component)->render()
-            : View::file($viewPath . '/' . $fileName . '.blade.php');
+        if ($viewName = $component->getAttributes()->whereInstanceOf(BaseView::class)->first()?->name) {
+            $viewOrString = app('view')->make($viewName);
+        } else {
+            $viewOrString = method_exists($component, 'render')
+                ? wrap($component)->render()
+                : View::file($viewPath . '/' . $fileName . '.blade.php');
+        }
 
         $properties = Utils::getPublicPropertiesDefinedOnSubclass($component);
 

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -4,12 +4,25 @@ namespace Livewire\Mechanisms\HandleComponents;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Stringable;
+use Livewire\Attributes\View;
 use Livewire\Component;
 use Livewire\Form;
 use Livewire\Livewire;
 
 class UnitTest extends \Tests\TestCase
 {
+    /** @test */
+    public function it_renders_view_provided_via_view_attribute()
+    {
+        Livewire::test(BasicComponentWithViewAttribute::class)->assertViewIs('null-view');
+    }
+
+    /** @test */
+    public function it_renders_view_provided_via_userland_view_attribute()
+    {
+        Livewire::test(BasicComponentWithUserlandViewAttribute::class)->assertViewIs('null-view');
+    }
+
     /** @test */
     public function it_restores_laravel_middleware_after_livewire_test()
     {
@@ -153,6 +166,17 @@ class UnitTest extends \Tests\TestCase
         ->assertSet('form.selected', null)
         ;
     }
+}
+
+
+#[View('null-view')]
+class BasicComponentWithViewAttribute extends Component
+{
+}
+
+#[\Livewire\Attributes\View('null-view')]
+class BasicComponentWithUserlandViewAttribute extends Component
+{
 }
 
 class BasicComponent extends Component


### PR DESCRIPTION
When upgrading a project from Livewire v2 to v3, I got a lot of errors on components that did not define a render-method. After some digging I found that in v3 the view filename is determined based on the component alias instead of the component class namespace (which was the case in v2). That meant I had to add a render-method to all those components to point livewire to the correct view. 

```php
// Before

class SomeComponent extends Component
{
   public function render() : View
   {
      return view('foo');
   }
}
```

That is a lot of lines of codes for such a basic thing, so why not provide a php attribute to do this? That's a lot less lines of codes 😄 

```php
// After

#[View('foo')]
class SomeComponent extends Component
{
}
```