### PR TITLE
Fix: dispatch 'upload:removed' after deleted file in array property

### DIFF
--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -102,6 +102,23 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    public function cant_remove_a_file_from_an_array_of_files_property_with_mismatched_filename_provided()
+    {
+        $file1 = UploadedFile::fake()->image('avatar1.jpg');
+        $file2 = UploadedFile::fake()->image('avatar2.jpg');
+
+        $component = Livewire::test(FileUploadComponent::class)
+            ->set('photos', [$file1, $file2]);
+
+        $component->call('_removeUpload', 'photos', 'mismatched-filename.png')
+            ->assertNotDispatched('upload:removed', name: 'photos', tmpFilename: 'mismatched-filename.png');
+
+        $tmpFiles = $component->call('$refresh')->viewData('photos');
+
+        $this->assertCount(2, $tmpFiles);
+    }
+
+    /** @test */
     public function if_the_file_property_is_an_array_the_uploaded_file_will_append_to_the_array()
     {
         Storage::fake('avatars');

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -102,7 +102,7 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    public function cant_remove_a_file_from_an_array_of_files_property_with_mismatched_filename_provided()
+    public function cant_dispatch_the_remove_upload_event_if_the_file_is_not_found_in_the_array_of_files_property()
     {
         $file1 = UploadedFile::fake()->image('avatar1.jpg');
         $file2 = UploadedFile::fake()->image('avatar2.jpg');

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -76,11 +76,12 @@ trait WithFileUploads
         $uploads = $this->getPropertyValue($name);
 
         if (is_array($uploads) && isset($uploads[0]) && $uploads[0] instanceof TemporaryUploadedFile) {
-            $this->dispatch('upload:removed', name: $name, tmpFilename: $tmpFilename)->self();
-
-            app('livewire')->updateProperty($this, $name, array_values(array_filter($uploads, function ($upload) use ($tmpFilename) {
+            app('livewire')->updateProperty($this, $name, array_values(array_filter($uploads, function ($upload) use ($name, $tmpFilename) {
                 if ($upload->getFilename() === $tmpFilename) {
                     $upload->delete();
+
+                    $this->dispatch('upload:removed', name: $name, tmpFilename: $tmpFilename)->self();
+
                     return false;
                 }
 


### PR DESCRIPTION
When `$removeUpload` is executed, an event is only fired when the file has been found. The same should happen for multiple uploads

The ideal would be to fire the 'upload:removed' event only when at least one file is found