### PR TITLE
Add dependency injection to computed properties

### DIFF
--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -2,12 +2,12 @@
 
 namespace Livewire\Features\SupportComputed;
 
-use function Livewire\invade;
 use function Livewire\on;
 use function Livewire\off;
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
+use function Livewire\wrap;
 
 #[\Attribute]
 class BaseComputed extends Attribute
@@ -133,7 +133,7 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
-        return invade($this->component)->{parent::getName()}();
+        return wrap($this->component)->{parent::getName()}();
     }
 
     public function getName()

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -4,10 +4,10 @@ namespace Livewire\Features\SupportComputed;
 
 use function Livewire\on;
 use function Livewire\off;
+use function Livewire\wrap;
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
-use function Livewire\wrap;
 
 #[\Attribute]
 class BaseComputed extends Attribute

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -331,6 +331,13 @@ class UnitTest extends TestCase
     }
 
     /** @test */
+    public function injected_computed_property_attribute_is_accessible_within_blade_view()
+    {
+        Livewire::test(InjectedComputedPropertyWithAttributeStub::class)
+            ->assertSee('bar');
+    }
+
+    /** @test */
     public function computed_property_is_memoized_after_its_accessed()
     {
         Livewire::test(MemoizedComputedPropertyStub::class)
@@ -470,6 +477,24 @@ class NullIssetComputedPropertyStub extends Component{
         return <<<'HTML'
         <div>
             {{ var_dump(isset($this->foo)) }}
+        </div>
+        HTML;
+    }
+}
+
+class InjectedComputedPropertyWithAttributeStub extends Component
+{
+    #[Computed]
+    public function fooBar(FooDependency $foo)
+    {
+        return $foo->baz;
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            {{ var_dump($this->foo_bar) }}
         </div>
         HTML;
     }


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
https://github.com/livewire/livewire/discussions/6967

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Y
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
N
4️⃣ Does it include tests? (Required)
Y
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Fix the use of computed property with dependency injection when using Computed Attribute

```php
#[Computed]
public function fooBar(FooDependency $foo)
{
    return $foo->baz;
}
```
