### PR TITLE
Fix error in sample code div → form

### DIFF
--- a/docs/morph.md
+++ b/docs/morph.md
@@ -27,7 +27,7 @@ class Todos extends Component
 ```
 
 ```blade
-<div wire:submit="add">
+<form wire:submit="add">
     <ul>
         @foreach ($todos as $item)
             <li>{{ $item }}</li>
@@ -35,7 +35,7 @@ class Todos extends Component
     </ul>
 
     <input wire:model="todo">
-</div>
+</form>
 ```
 
 The initial render of this component will output the following HTML:


### PR DESCRIPTION
A titled, there is a minor error in the docs where a `div` was used that should be a `form`.