### PR TITLE
Update `dump` and `dd` testing helpers to support writing the dumped HTML to disk

### DIFF
--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -241,15 +241,23 @@ class Testable
         return $this->lastState->getComponent();
     }
 
-    function dump()
+    function dump(?string $toFile = null)
     {
         dump($this->lastState->getHtml());
+
+        if ($toFile) {
+            $this->writeDumpedFile($toFile);
+        }
 
         return $this;
     }
 
-    function dd()
+    function dd(?string $toFile = null)
     {
+        if ($toFile) {
+            $this->writeDumpedFile($toFile);
+        }
+
         dd($this->lastState->getHtml());
     }
 
@@ -278,5 +286,12 @@ class Testable
         $this->lastState->getResponse()->{$method}(...$params);
 
         return $this;
+    }
+
+    protected function writeDumpedFile(string $toFile): void
+    {
+        $filename = str_ends_with($toFile, '.html') ? $toFile : $toFile . '.html';
+
+        file_put_contents(base_path($filename), $this->lastState->getHtml());
     }
 }


### PR DESCRIPTION
## Abstract

Updates the Livewire testing helpers to support writing the HTML to disk using an optional parameter. This makes it easier to debug things as you can open them up in a browser.

### Example

The following would save the dumped state to `example.html` in the base path.

```php
<?php

use App\Livewire\MyComponent;
use function Pest\Livewire\livewire;

test('Livewire component', function () {
    livewire(MyComponent::class)
        ->dd('example');
});
```

### Tests

I could not find any tests for these helpers, so I didn't include any. If you still want me to add tests, let me know.
