### PR TITLE
Pass `hashName` thru for testing

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -156,6 +156,15 @@ class TemporaryUploadedFile extends UploadedFile
         return $hash.$meta.$extension;
     }
 
+    public function hashName($path = null)
+    {
+        if (app()->runningUnitTests() && str($this->getfilename())->contains('-hash=')) {
+            return str($this->getFilename())->between('-hash=', '-')->value();
+        }
+
+        return parent::hashName($path);
+    }
+
     public function extractOriginalNameFromFilePath($path)
     {
         return base64_decode(head(explode('-', last(explode('-meta', str($path)->replace('_', '/'))))));

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -134,6 +134,20 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    public function storing_a_file_uses_uploaded_file_hashname()
+    {
+        Storage::fake('avatars');
+
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->call('uploadAndSetStoredFilename');
+
+        Storage::disk('avatars')->assertExists($file->hashName());
+    }
+
+    /** @test */
     public function can_get_a_file_original_name()
     {
         $file = UploadedFile::fake()->image('avatar.jpg');

--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -182,7 +182,7 @@ class Testable
     /** @todo Move me outta here and into the file upload folder somehow... */
     function upload($name, $files, $isMultiple = false)
     {
-        // This methhod simulates the calls Livewire's JavaScript
+        // This method simulates the calls Livewire's JavaScript
         // normally makes for file uploads.
         $this->call(
             '_startUpload',
@@ -209,10 +209,11 @@ class Testable
             return $this;
         }
 
-        // We are going to encode the file size in the filename so that when we create
-        // a new TemporaryUploadedFile instance we can fake a specific file size.
+        // We are going to encode the original file size and hashName in the filename
+        // so when we create a new TemporaryUploadedFile instance we can fake the
+        // same file size and hashName set for the original file upload.
         $newFileHashes = collect($files)->zip($fileHashes)->mapSpread(function ($file, $fileHash) {
-            return (string) str($fileHash)->replaceFirst('.', "-size={$file->getSize()}.");
+            return (string) str($fileHash)->replaceFirst('.', "-hash={$file->hashName()}-size={$file->getSize()}.");
         })->toArray();
 
         collect($fileHashes)->zip($newFileHashes)->mapSpread(function ($fileHash, $newFileHash) use ($storage) {


### PR DESCRIPTION
I was unable to test simply storing an uploaded file exactly as demonstrated in the [Laravel docs](https://laravel.com/docs/10.x/http-tests#testing-file-uploads).

This is because Livewire "reuploads" the uploaded file. This doesn't really matter in live mode, but in test mode it leads to unpredictable behavior as the uploaded file is not what you set in your test. More specifically, its `hashName` does not match. So methods like `store` end up using a different filename than expected.

More experienced Livewire developers may be aware of workarounds, but as a noob to Livewire this burnt my afternoon. So feel free to close this if I missed something. Otherwise…

This PR contains a proposed solution for ensuring Livewire preserves the `hashName` of the `UploadedFile::fake()`, thus leading to easier, more predictable testing which aligns with the examples outlined in the Livewire/Laravel docs. This solution  is similar to how the file size is preserved.