### PR TITLE
Do not prepend slash for script asset url with a protocol

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -146,7 +146,7 @@ class FrontendAssets extends Mechanism
 
         $url = rtrim($url, '/');
 
-        $url = (string) str($url)->start('/');
+        $url = (string) str($url)->when(! str($url)->isUrl(), fn($url) => $url->start('/'));
 
         // Add the build manifest hash to it...
         $manifest = json_decode(file_get_contents(__DIR__.'/../../../dist/manifest.json'), true);

--- a/src/Mechanisms/FrontendAssets/UnitTest.php
+++ b/src/Mechanisms/FrontendAssets/UnitTest.php
@@ -50,4 +50,17 @@ class UnitTest extends \Tests\TestCase
         $this->assertFalse($assets->hasRenderedScripts);
         $this->assertFalse($assets->hasRenderedStyles);
     }
+
+    /** @test */
+    public function js_does_not_prepend_slash_for_url()
+    {
+        $url = 'https://example.com/livewire/livewire.js';
+        $this->assertStringStartsWith('<script src="'.$url, FrontendAssets::js(['url' => $url]));
+    }
+
+    public function js_prepends_slash_for_non_url()
+    {
+        $url = 'livewire/livewire.js';
+        $this->assertStringStartsWith('<script src="/'.$url, FrontendAssets::js(['url' => $url]));
+    }
 }


### PR DESCRIPTION
The static method `js` in the `FrontendAssets` class prepends a slash on $url string. This presents a problem when a user wants to serve their js asset on a server different than what the app resides on. e.g someone wanting to host their livewire.js file on an asset cdn.

This PR uses the laravel `Str` class to determine if the $url string is a valid url.

When $url is not a url, we then prepend the slash.

This PR address submitted bug #7747 

***
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
