### PR TITLE
Fix Livewire component key generation across load balanced servers

### DIFF
--- a/src/Mechanisms/ExtendBlade/DeterministicBladeKeys.php
+++ b/src/Mechanisms/ExtendBlade/DeterministicBladeKeys.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Livewire\Mechanisms\ExtendBlade;
+
+use Illuminate\View\Compilers\BladeCompiler;
+
+class DeterministicBladeKeys
+{
+    protected $countersByPath = [];
+
+    protected $lastPath;
+
+    public function generate()
+    {
+        if (! $this->lastPath) {
+            throw new \Exception('Latest compiled component path not found.');
+        }
+
+        $path = $this->lastPath;
+        $count = $this->counter();
+
+        // $key = "lw-[hash of Blade view path]-[current @livewire directive count]"
+        return 'lw-' . crc32($this->lastPath) . '-' . $count;
+    }
+
+    public function counter()
+    {
+        if (! isset($this->countersByPath[$this->lastPath])) {
+            $this->countersByPath[$this->lastPath] = 0;
+        }
+
+        return $this->countersByPath[$this->lastPath]++;
+    }
+
+    public function interceptCompile(BladeCompiler $compiler)
+    {
+        $this->lastPath = $compiler->getPath();
+    }
+}

--- a/src/Mechanisms/ExtendBlade/ExtendBlade.php
+++ b/src/Mechanisms/ExtendBlade/ExtendBlade.php
@@ -65,6 +65,23 @@ class ExtendBlade extends Mechanism
         app()->make('view.engine.resolver')->register('blade', function () {
             return new ExtendedCompilerEngine(app('blade.compiler'));
         });
+
+        app()->singleton(DeterministicBladeKeys::class);
+
+        // Reset this singleton between tests and Octane requests...
+        on('flush-state', function () {
+            app()->singleton(DeterministicBladeKeys::class);
+        });
+
+        // We're using "precompiler" as a hook for the point in time when
+        // Laravel compiles a Blade view...
+        app('blade.compiler')->precompiler(function ($value) {
+            app(DeterministicBladeKeys::class)->interceptCompile(
+                app('blade.compiler'),
+            );
+
+            return $value;
+        });
     }
 
     function livewireOnlyDirective($name, $handler)

--- a/src/Mechanisms/RenderComponent.php
+++ b/src/Mechanisms/RenderComponent.php
@@ -13,9 +13,7 @@ class RenderComponent extends Mechanism
 
     public static function livewire($expression)
     {
-        $key = app(\Livewire\Mechanisms\ExtendBlade\DeterministicBladeKeys::class)->generate();
-
-        $key = "'{$key}'";
+        $key = null;
 
         $pattern = "/,\s*?key\(([\s\S]*)\)/"; // everything between ",key(" and ")"
 
@@ -23,6 +21,11 @@ class RenderComponent extends Mechanism
             $key = trim($match[1]) ?: $key;
             return "";
         }, $expression);
+
+        if (! $key) {
+            $key = app(\Livewire\Mechanisms\ExtendBlade\DeterministicBladeKeys::class)->generate();
+            $key = "'{$key}'";
+        }
 
         return <<<EOT
 <?php

--- a/src/Mechanisms/RenderComponent.php
+++ b/src/Mechanisms/RenderComponent.php
@@ -3,7 +3,7 @@
 namespace Livewire\Mechanisms;
 
 use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\Str;
+use Livewire\Livewire;
 
 class RenderComponent extends Mechanism
 {
@@ -14,25 +14,16 @@ class RenderComponent extends Mechanism
 
     public static function livewire($expression)
     {
-        $key = "'" . Str::random(7) . "'";
+        $key = app(\Livewire\Mechanisms\ExtendBlade\DeterministicBladeKeys::class)->generate();
 
-        $pattern = "/,\s*?key\(([\s\S]*)\)/"; //everything between ",key(" and ")"
+        $key = "'{$key}'";
+
+        $pattern = "/,\s*?key\(([\s\S]*)\)/"; // everything between ",key(" and ")"
 
         $expression = preg_replace_callback($pattern, function ($match) use (&$key) {
             $key = trim($match[1]) ?: $key;
             return "";
         }, $expression);
-
-        // If we are inside a Livewire component, we know we're rendering a child.
-        // Therefore, we must create a more deterministic view cache key so that
-        // Livewire children are properly tracked across load balancers.
-        // if (LivewireManager::$currentCompilingViewPath !== null) {
-        //     // $key = '[hash of Blade view path]-[current @livewire directive count]'
-        //     $key = "'l" . crc32(LivewireManager::$currentCompilingViewPath) . "-" . LivewireManager::$currentCompilingChildCounter . "'";
-
-        //     // We'll increment count, so each cache key inside a compiled view is unique.
-        //     LivewireManager::$currentCompilingChildCounter++;
-        // }
 
         return <<<EOT
 <?php

--- a/src/Mechanisms/RenderComponent.php
+++ b/src/Mechanisms/RenderComponent.php
@@ -3,7 +3,6 @@
 namespace Livewire\Mechanisms;
 
 use Illuminate\Support\Facades\Blade;
-use Livewire\Livewire;
 
 class RenderComponent extends Mechanism
 {

--- a/src/Mechanisms/Tests/LoadBalancerCompatibilityUnitTest.php
+++ b/src/Mechanisms/Tests/LoadBalancerCompatibilityUnitTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Livewire\Mechanisms\Tests;
+
+use Livewire\Livewire;
+use Livewire\Component;
+
+class LoadBalancerCompatibilityUnitTest extends \Tests\TestCase
+{
+    /** @test */
+    public function component_keys_are_deterministic_across_load_balancers()
+    {
+        $component = Livewire::test([new class extends Component {
+            public function render()
+            {
+                return '<div> <livewire:child /> </div>';
+            }
+        },
+        'child' => new class extends Component {
+            public function render()
+            {
+                return '<div></div>';
+            }
+        }]);
+
+        $firstKey = array_keys($component->snapshot['memo']['children'])[0];
+
+        // Clear the view cache to simulate blade views being cached on two different servers...
+        \Illuminate\Support\Facades\Artisan::call('view:clear');
+
+        $component = Livewire::test([new class extends Component {
+            public function render()
+            {
+                return '<div> <livewire:child /> </div>';
+            }
+        },
+        'child' => new class extends Component {
+            public function render()
+            {
+                return '<div></div>';
+            }
+        }]);
+
+        $secondKey = array_keys($component->snapshot['memo']['children'])[0];
+
+        $this->assertEquals($firstKey, $secondKey);
+    }
+}


### PR DESCRIPTION
Because Livewire child component keys are random strings and are generated at Laravel compile-time, load-balanced environments experience bugs because the Livewire component keys are different across servers.

This PR makes Livewire component "key" generation deterministic across load balanced environments by using the current Blade view and an incrementing counter as the key instead of a random string.