### PR TITLE
Support attributes on component parent classes

### DIFF
--- a/src/Features/SupportAttributes/AttributeCollection.php
+++ b/src/Features/SupportAttributes/AttributeCollection.php
@@ -14,7 +14,7 @@ class AttributeCollection extends Collection
 
         $reflected = new ReflectionObject($subTarget ?? $component);
 
-        foreach ($reflected->getAttributes(Attribute::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+        foreach (static::getClassAttributesRecursively($reflected) as $attribute) {
             $instance->push(tap($attribute->newInstance(), function ($attribute) use ($component, $subTarget) {
                 $attribute->__boot($component, AttributeLevel::ROOT, null, null, $subTarget);
             }));
@@ -37,5 +37,19 @@ class AttributeCollection extends Collection
         }
 
         return $instance;
+    }
+
+    protected static function getClassAttributesRecursively($reflected) {
+        $attributes = [];
+
+        while ($reflected) {
+            foreach ($reflected->getAttributes(Attribute::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                $attributes[] = $attribute;
+            }
+
+            $reflected = $reflected->getParentClass();
+        }
+
+        return $attributes;
     }
 }

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -368,6 +368,18 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    public function can_configure_layout_using_layout_attribute_on_parent_class()
+    {
+        Route::get('/configurable-layout', ComponentForParentClassLayoutAttribute::class);
+
+        $this
+            ->withoutExceptionHandling()
+            ->get('/configurable-layout')
+            ->assertSee('bob')
+            ->assertSee('baz');
+    }
+
+    /** @test */
     public function can_configure_title_using_title_attribute()
     {
         Route::get('/configurable-layout', ComponentForTitleAttribute::class);
@@ -708,6 +720,11 @@ class ComponentForClassLayoutAttribute extends Component
     {
         return view('show-name');
     }
+}
+
+class ComponentForParentClassLayoutAttribute extends ComponentForClassLayoutAttribute
+{
+    //
 }
 
 class ComponentForTitleAttribute extends Component


### PR DESCRIPTION
This allows you to use things like `#[Layout]` on base component classes you might re-use in your app:

```php
class AdminPanel extends AdminComponent {}

// Parent component:

#[Layout('components.layouts.admin)]
class AdminComponent extends \Livewire\Component {}
```
