### PR TITLE
Add assertions to test the contents of file downloads

### DIFF
--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -106,3 +106,35 @@ public function does_not_download_invoice_if_unauthorised()
         ->assertNoFileDownloaded();
 }
 ```
+
+You can test to ensure a downloaded file contains a string using the `->assertFileDownloadedContains()` method:
+
+```php
+use App\Models\Invoice;
+
+/** @test */
+public function download_invoice_contains_text()
+{
+    $invoice = Invoice::factory();
+
+    Livewire::test(ShowInvoice::class)
+        ->call('download')
+        ->assertFileDownloadedContains('text that should be there');
+}
+```
+
+You can also test to ensure a downloaded file does not contain a string using the `->assertFileDownloadedNotContains()` method:
+
+```php
+use App\Models\Invoice;
+
+/** @test */
+public function download_invoice_does_not_contain_text()
+{
+    $invoice = Invoice::factory();
+
+    Livewire::test(ShowInvoice::class)
+        ->call('download')
+        ->assertFileDownloadedNotContains('text that should be missing');
+}
+```

--- a/src/Features/SupportFileDownloads/TestsFileDownloads.php
+++ b/src/Features/SupportFileDownloads/TestsFileDownloads.php
@@ -46,4 +46,28 @@ trait TestsFileDownloads
 
         return $this;
     }
+
+    public function assertFileDownloadedContains($content)
+    {
+        $downloadedContent = data_get($this->effects, 'download.content');
+
+        PHPUnit::assertStringContainsString(
+            $content,
+            base64_decode($downloadedContent)
+        );
+
+        return $this;
+    }
+
+    public function assertFileDownloadedNotContains($content)
+    {
+        $downloadedContent = data_get($this->effects, 'download.content');
+
+        PHPUnit::assertStringNotContainsString(
+            $content,
+            base64_decode($downloadedContent)
+        );
+
+        return $this;
+    }
 }

--- a/src/Features/SupportFileDownloads/UnitTest.php
+++ b/src/Features/SupportFileDownloads/UnitTest.php
@@ -124,6 +124,22 @@ class UnitTest extends \Tests\TestCase
             ->call('download')
             ->assertNoFileDownloaded();
     }
+
+    /** @test */
+    public function can_check_a_downloaded_file_contains()
+    {
+        Livewire::test(FileDownloadComponent::class)
+            ->call('streamDownload', 'download.txt')
+            ->assertFileDownloadedContains('alpine');
+    }
+
+    /** @test */
+    public function can_check_a_downloaded_file_does_not_contain()
+    {
+        Livewire::test(FileDownloadComponent::class)
+            ->call('streamDownload', 'download.txt')
+            ->assertFileDownloadedNotContains('vuejs');
+    }
 }
 
 class FileDownloadComponent extends Component


### PR DESCRIPTION
This PR adds two methods to test thae contents of file downloads: `assertFileDownloadedContains()` and `assertFileDownloadedNotContains()`.

@joshhanley you high level reviewed this in #5192 but closed it down while V3 was being finalised. I've updated to be V3 compatible.

