### PR TITLE
Add `Livewire::resolveViewNameUsing` method to find view of components without render method

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -67,6 +67,16 @@ class LivewireManager
         return app(ComponentRegistry::class)->resolveMissingComponent($resolver);
     }
 
+    public function resolveViewNameUsing($resolver)
+    {
+        app(ComponentRegistry::class)->resolveMissingViewName($resolver);
+    }
+
+    public function resolveViewName($component)
+    {
+        return app(ComponentRegistry::class)->resolveViewName($component);
+    }
+
     function mount($name, $params = [], $key = null)
     {
         return app(HandleComponents::class)->mount($name, $params, $key);

--- a/src/Mechanisms/ComponentRegistry.php
+++ b/src/Mechanisms/ComponentRegistry.php
@@ -10,6 +10,7 @@ class ComponentRegistry extends Mechanism
     protected $missingComponentResolvers = [];
     protected $nonAliasedClasses = [];
     protected $aliases = [];
+    protected $missingViewNameResolver = null;
 
     function component($name, $class = null)
     {
@@ -79,6 +80,16 @@ class ComponentRegistry extends Mechanism
     function resolveMissingComponent($resolver)
     {
         $this->missingComponentResolvers[] = $resolver;
+    }
+
+    function resolveMissingViewName($resolver)
+    {
+        $this->missingViewNameResolver = $resolver;
+    }
+
+    function resolveViewName(Component $component) : ?string
+    {
+        return $this->missingViewNameResolver ? call_user_func($this->missingViewNameResolver, $component) : null;
     }
 
     protected function getNameAndClass($nameComponentOrClass)

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -205,6 +205,18 @@ class UnitTest extends \Tests\TestCase
             ])
         ;
     }
+
+    /** @test */
+    public function it_resolves_view_name_using_callback()
+    {
+        Livewire::resolveViewNameUsing(function ($component) {
+            $this->assertInstanceOf(BasicComponentWithoutRenderMethod::class, $component);
+
+            return 'null-view';
+        });
+
+        Livewire::test(BasicComponentWithoutRenderMethod::class)->assertViewIs('null-view');
+    }
 }
 
 class BasicComponent extends Component
@@ -247,4 +259,8 @@ class CountForm extends Form
 class SuitForm extends Form
 {
     public UnitSuit $selected;
+}
+
+class BasicComponentWithoutRenderMethod extends Component
+{
 }


### PR DESCRIPTION
When upgrading a project from Livewire v2 to v3, I got a lot of errors on components that did not define a render-method. After some digging, I found that in v3 the view filename is determined based on the component alias instead of the component class namespace (which was the case in v2). That meant I had to add a render-method to all those components to point livewire to the correct view.

This PR fixes that so you can define your logic on how Livewire should find a component's view name if no render-method is defined in the component. That way, it is unnecessary to always define a render-method if you don't want the view filenames to be based on the component alias.

```php
Livewire::resolveViewNameUsing(function ($component) {
	// If you do not have a render-method on your component then this method is 
	// executed so you can construct the view name however you want.
	return 'name-of-view';
});
```






_Alternative to https://github.com/livewire/livewire/pull/7686_