### PR TITLE
Add #[Cache] attribute

### DIFF
--- a/src/Attributes/Cache.php
+++ b/src/Attributes/Cache.php
@@ -3,10 +3,10 @@
 namespace Livewire\Attributes;
 
 use Attribute;
-use Livewire\Features\SupportSession\BaseSession;
+use Livewire\Features\SupportCache\BaseCache;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
-class Cache extends BaseSession
+class Cache extends BaseCache
 {
     //
 }

--- a/src/Attributes/Cache.php
+++ b/src/Attributes/Cache.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Attribute;
+use Livewire\Features\SupportSession\BaseSession;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Cache extends BaseSession
+{
+    //
+}

--- a/src/Features/SupportCache/BaseCache.php
+++ b/src/Features/SupportCache/BaseCache.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportSession;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Attribute;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Session;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class BaseCache extends LivewireAttribute
@@ -12,15 +13,16 @@ class BaseCache extends LivewireAttribute
     function __construct(
         protected $key = null,
         protected $ttl = null,
+        protected $private = false,
     ) {}
 
     public function mount($params)
     {
         if (! $this->exists()) return;
 
-        $fromSession = $this->read();
+        $fromCache = $this->read();
 
-        $this->setValue($fromSession);
+        $this->setValue($fromCache);
     }
 
     public function dehydrate($context)
@@ -45,6 +47,8 @@ class BaseCache extends LivewireAttribute
 
     protected function key()
     {
-        return $this->key ?: (string) 'lw' . crc32($this->component->getName() . $this->getName());
+        $key = $this->key ?: (string) 'lw' . crc32($this->component->getName() . $this->getName());
+
+        return $this->private ? Session::getId() . '-' . $key : $key;
     }
 }

--- a/src/Features/SupportCache/BaseCache.php
+++ b/src/Features/SupportCache/BaseCache.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Livewire\Features\SupportSession;
+namespace Livewire\Features\SupportCache;
 
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Attribute;

--- a/src/Features/SupportCache/BaseSession.php
+++ b/src/Features/SupportCache/BaseSession.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Livewire\Features\SupportSession;
+
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+use Attribute;
+use Illuminate\Support\Facades\Cache;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class BaseCache extends LivewireAttribute
+{
+    function __construct(
+        protected $key = null,
+        protected $ttl = null,
+    ) {}
+
+    public function mount($params)
+    {
+        if (! $this->exists()) return;
+
+        $fromSession = $this->read();
+
+        $this->setValue($fromSession);
+    }
+
+    public function dehydrate($context)
+    {
+        $this->write();
+    }
+
+    protected function exists()
+    {
+        return Cache::has($this->key());
+    }
+
+    protected function read()
+    {
+        return Cache::get($this->key());
+    }
+
+    protected function write()
+    {
+        Cache::put($this->key(), $this->getValue(), $this->ttl);
+    }
+
+    protected function key()
+    {
+        return $this->key ?: (string) 'lw' . crc32($this->component->getName() . $this->getName());
+    }
+}

--- a/src/Features/SupportCache/BrowserTest.php
+++ b/src/Features/SupportCache/BrowserTest.php
@@ -47,7 +47,6 @@ class BrowserTest extends BrowserTestCase
 
             public function increment()
             {
-                usleep(1001);
                 $this->count++;
             }
 
@@ -58,9 +57,13 @@ class BrowserTest extends BrowserTestCase
             </div>
             HTML; }
         })
+
             ->assertSeeIn('@count', '0')
             ->waitForLivewire()->click('@button')
-            ->assertDontSeeIn('@count', '0')
+            ->assertSeeIn('@count', '1')
+            ->pause(1000)
+            ->refresh()
+            ->assertSeeIn('@count', '0')
             ;
     }
 }

--- a/src/Features/SupportCache/BrowserTest.php
+++ b/src/Features/SupportCache/BrowserTest.php
@@ -37,4 +37,30 @@ class BrowserTest extends BrowserTestCase
             ->assertSeeIn('@count', '2')
             ;
     }
+
+    /** @test */
+    public function it_removes_cached_property_when_ttl_is_passed()
+    {
+        Livewire::visit(new class extends Component {
+            #[Cache(ttl: 1)]
+            public $count = 0;
+
+            public function increment()
+            {
+                usleep(1001);
+                $this->count++;
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button dusk="button" wire:click="increment">+</button>
+                <span dusk="count">{{ $count }}</span>
+            </div>
+            HTML; }
+        })
+            ->assertSeeIn('@count', '0')
+            ->waitForLivewire()->click('@button')
+            ->assertDontSeeIn('@count', '0')
+            ;
+    }
 }

--- a/src/Features/SupportCache/BrowserTest.php
+++ b/src/Features/SupportCache/BrowserTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Livewire\Features\SupportCache;
+
+use Livewire\Attributes\Cache;
+use Tests\BrowserTestCase;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class BrowserTest extends BrowserTestCase
+{
+    /** @test */
+    public function can_persist_a_property_to_the_cache()
+    {
+        Livewire::visit(new class extends Component {
+            #[Cache]
+            public $count = 0;
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button dusk="button" wire:click="increment">+</button>
+                <span dusk="count">{{ $count }}</span>
+            </div>
+            HTML; }
+        })
+            ->assertSeeIn('@count', '0')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@count', '1')
+            ->refresh()
+            ->assertSeeIn('@count', '1')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@count', '2')
+            ;
+    }
+}


### PR DESCRIPTION
I feel bad for opening this PR after reading the 'inbox zero' email. Sorry! 

This PR is nearly identical to #7748.

There are many use-cases for cached properties. Ours isn't the most persuasive one I think :)

`#[Session]` is awesome. It's such a smart idea. I really like it. But I'm not sure yet if it works for us in the current app I'm working on, as it comes with some performance bottlenecks. And we have some things planned where it makes sense to cache larger filters of several pages (and keep them active for some time too). So here's the `#[Cache]` attribute.

It comes with a `private`-option which allows you to cache properties just for a user. I think if you set `private` it should also set a default ttl, as you don't want cached items hanging around that will never be used again. This isn't implemented yet.

```php
use Livewire\Attributes\Cache;
use Livewire\Component;
use App\Models\Post;

class ShowPosts extends Component
{
    #[Cache(private: true, ttl: 360)]
    public $search;

    protected function posts()
    {
        return $this->search === ''
            ? Post::all();
            ? Post::where('title', 'like', '%'.$this->search.'%');
    }

    public function render()
    {
        return view('livewire.show-posts', [
            'posts' => $this->posts(),
        ]);
    }
}
```

<s>Sorry, tests are limited. I can't run Dusk tests on my local machine. I have followed the contribution guide but no luck for me.</s>

Turns out it's looking for a session table. I've changed the phpunit.xml.dist on my machine to circumvent that, obviously not committing this here :)