### PR TITLE
Fix: support empty root namespace

### DIFF
--- a/src/Mechanisms/ComponentRegistry.php
+++ b/src/Mechanisms/ComponentRegistry.php
@@ -170,6 +170,10 @@ class ComponentRegistry extends Mechanism
             ->map(fn ($segment) => (string) str($segment)->studly())
             ->join('\\');
 
+        if (empty($rootNamespace)) {
+            return $class;
+        }
+
         return '\\' . $rootNamespace . '\\' . $class;
     }
 


### PR DESCRIPTION
When config class_namespace is set to empty value livewire always add slashes, let's return only class