### PR TITLE
Isolated Components Test: Wait For Text

### DIFF
--- a/src/Features/SupportIsolating/BrowserTest.php
+++ b/src/Features/SupportIsolating/BrowserTest.php
@@ -54,9 +54,9 @@ class BrowserTest extends BrowserTestCase
         })
         ->waitForLivewire()->click('@trigger')
         ->tap(function ($b) {
-            $time1 = (float) $b->text('@time-1');
-            $time2 = (float) $b->text('@time-2');
-            $time3 = (float) $b->text('@time-3');
+            $time1 = (float) $b->waitFor('@time-1')->text('@time-1');
+            $time2 = (float) $b->waitFor('@time-2')->text('@time-2');
+            $time3 = (float) $b->waitFor('@time-3')->text('@time-3');
 
             $this->assertNotEquals($time1, $time2);
             $this->assertNotEquals($time2, $time3);


### PR DESCRIPTION
When running the test suite locally, I came across an odd failure:

```
$ php ./vendor/bin/phpunit src/Features/SupportIsolating/BrowserTest.php --filter=components_can_be_marked_as_isolated
PHPUnit 10.5.9 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.23
Configuration: /Users/jm/Dev/PHP/livewire/phpunit.xml.dist

F                                                                   1 / 1 (100%)

Time: 00:01.468, Memory: 34.50 MB

There was 1 failure:

1) Livewire\Features\SupportIsolating\BrowserTest::components_can_be_marked_as_isolated
Failed asserting that 1706202519.4668 is not equal to 1706202519.4668.

/Users/jm/Dev/PHP/livewire/src/Features/SupportIsolating/BrowserTest.php:66
/Users/jm/Dev/PHP/livewire/vendor/laravel/dusk/src/Browser.php:688
/Users/jm/Dev/PHP/livewire/src/Features/SupportIsolating/BrowserTest.php:67

FAILURES!
Tests: 1, Assertions: 4, Failures: 1.
```

When stepping through the test source code, everything was working as expected. This made me wonder if the problem is related to timing. When the test waits for `@time-#` it passes as expected.