### PR TITLE
Add a session prefix for uniqueness

### DIFF
--- a/docs/session-properties.md
+++ b/docs/session-properties.md
@@ -66,3 +66,25 @@ class ShowPosts extends Component
 ```
 
 When Livewire stores and retrieves the value of the `$search` property, it will use the given key: "search".
+
+Additionally, if you want to generate the key dynamically from other properties in your component, you can do so using the following curly brace notation:
+
+```php
+<?php
+
+use Livewire\Attributes\Session;
+use Livewire\Component;
+use App\Models\Author;
+
+class ShowPosts extends Component
+{
+    public Author $author;
+
+    #[Session(key: 'search-{author.id}')] // [tl! highlight]
+    public $search;
+
+    // ...
+}
+```
+
+In the above example, if the `$author` model's id is "4", the session key will become: `search-4`

--- a/src/Features/SupportSession/BaseSession.php
+++ b/src/Features/SupportSession/BaseSession.php
@@ -48,9 +48,7 @@ class BaseSession extends LivewireAttribute
             return (string) 'lw' . crc32($this->component->getName() . $this->getName());
         }
 
-        $key = self::replaceDynamicPlaceholders($this->key, $this->component);
-
-        return $key;
+        return self::replaceDynamicPlaceholders($this->key, $this->component);
     }
 
     static function replaceDynamicPlaceholders($key, $component)

--- a/src/Features/SupportSession/BaseSession.php
+++ b/src/Features/SupportSession/BaseSession.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportSession;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Illuminate\Support\Facades\Session;
 use Attribute;
+use Livewire\Features\SupportSession\Contracts\SessionPrefix;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class BaseSession extends LivewireAttribute
@@ -44,6 +45,14 @@ class BaseSession extends LivewireAttribute
 
     protected function key()
     {
-        return $this->key ?: (string) 'lw' . crc32($this->component->getName() . $this->getName());
+        $prefix = '';
+
+        if ($this->component instanceof SessionPrefix) {
+            $prefix = $this->component->sessionPrefix();
+        }
+
+        return str($prefix)
+            ->append($this->key ?: (string) 'lw' . crc32($this->component->getName() . $this->getName()))
+            ->toString();
     }
 }

--- a/src/Features/SupportSession/Contracts/SessionPrefix.php
+++ b/src/Features/SupportSession/Contracts/SessionPrefix.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Livewire\Features\SupportSession\Contracts;
-
-interface SessionPrefix
-{
-    public function sessionPrefix(): string;
-}

--- a/src/Features/SupportSession/Contracts/SessionPrefix.php
+++ b/src/Features/SupportSession/Contracts/SessionPrefix.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Livewire\Features\SupportSession\Contracts;
+
+interface SessionPrefix
+{
+    public function sessionPrefix(): string;
+}

--- a/src/Features/SupportSession/UnitTest.php
+++ b/src/Features/SupportSession/UnitTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Livewire\Features\SupportSession;
+
+use Illuminate\Support\Facades\Session as FacadesSession;
+use Livewire\Attributes\Session;
+use Tests\TestCase;
+use Livewire\Livewire;
+use Tests\TestComponent;
+use Livewire\Features\SupportSession\Contracts\SessionPrefix;
+
+class UnitTest extends TestCase
+{
+    /** @test */
+    public function it_uses_the_session_key_method_if_contract_is_implemented()
+    {
+        Livewire::test(new class extends TestComponent implements SessionPrefix {
+            #[Session(key: 'baz')]
+            public $count = 0;
+
+            public function sessionPrefix(): string
+            {
+                return 'foo';
+            }
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $count }}</div>
+                HTML;
+            }
+        })
+            ->call('$refresh');
+
+        $this->assertTrue(FacadesSession::has('foobaz'));
+    }
+}

--- a/src/Features/SupportSession/UnitTest.php
+++ b/src/Features/SupportSession/UnitTest.php
@@ -7,30 +7,42 @@ use Livewire\Attributes\Session;
 use Tests\TestCase;
 use Livewire\Livewire;
 use Tests\TestComponent;
-use Livewire\Features\SupportSession\Contracts\SessionPrefix;
 
 class UnitTest extends TestCase
 {
     /** @test */
-    public function it_uses_the_session_key_method_if_contract_is_implemented()
+    public function it_creates_a_session_key()
     {
-        Livewire::test(new class extends TestComponent implements SessionPrefix {
-            #[Session(key: 'baz')]
+        $component = Livewire::test(new class extends TestComponent {
+            #[Session]
             public $count = 0;
-
-            public function sessionPrefix(): string
-            {
-                return 'foo';
-            }
 
             function render() {
                 return <<<'HTML'
                     <div>foo{{ $count }}</div>
                 HTML;
             }
-        })
-            ->call('$refresh');
+        });
 
-        $this->assertTrue(FacadesSession::has('foobaz'));
+        $this->assertTrue(FacadesSession::has('lw'.crc32($component->instance()->getName().'count')));
+    }
+
+    /** @test */
+    public function it_creates_a_dynamic_session_id()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $post = ['id' => 2];
+
+            #[Session(key: 'baz.{post.id}')]
+            public $count = 0;
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $count }}</div>
+                HTML;
+            }
+        });
+
+        $this->assertTrue(FacadesSession::has('baz.2'));
     }
 }


### PR DESCRIPTION
First of all: this PR is a proof of concept. I can imagine you prefer a different approach. Or perhaps do not want to address this at all, especially as this increases session counts. 

I found something while testing `#[Session]`. We have the following reusable component:

```php
class CustomerOrders extends Component
{
    #[Locked]
    public int $id;

    #[Session]
    public array $filters = [];
}
```

This component is used on the customer edit page to filter orders.

In this component we set `$id` to the customer id. But as this doesn't affect the session key, your filters will be the same for every customer. As the component is the same--it's just the `$id` that's different. It doesn't matter if you specify a key.

The end-result is:

1. You browse to customer 1 and use the filter. It gets stored in the session.
2. You go to customer 2 and the same session is used, which loads the same filters as customer 1.

So an end-user will have to reset those filters when they go the next page. They will not expect that.

My solution is a contract. It can be used as follows:

```php
class CustomerOrders extends Component implements SessionPrefix
{
    #[Locked]
    public int $id;

    #[Session]
    public array $filters = [];

    public function sessionPrefix()
    {
        return 'customer-orders-'.$this->id;
    }
}
```

This ensures we have a unique prefix per customer.