### PR TITLE
Add fix for standard model synth morph map exception

### DIFF
--- a/src/Features/SupportModels/ModelSynth.php
+++ b/src/Features/SupportModels/ModelSynth.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportModels;
 
+use Illuminate\Database\ClassMorphViolationException;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
@@ -17,8 +18,15 @@ class ModelSynth extends Synth {
     }
 
     function dehydrate($target) {
-        // If no alias is found, this just returns the class name
-        $alias = $target->getMorphClass();
+        $class = $target::class;
+        
+        try {
+            // If no alias is found, this just returns the class name
+            $alias = $target->getMorphClass();
+        } catch (ClassMorphViolationException $e) {
+            // If the model is not using morph classes, this exception is thrown
+            $alias = $class;
+        }
 
         $serializedModel = $target->exists
             ? (array) $this->getSerializedPropertyValue($target)

--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -202,6 +202,34 @@ class UnitTest extends \Tests\TestCase
         ->assertSee('Second-0')
         ->assertSee('First-1');
     }
+
+    /** @test */
+    public function it_does_not_trigger_ClassMorphViolationException_when_morh_map_is_enforced()
+    {
+        // reset morph
+        Relation::morphMap([], false);
+        Relation::requireMorphMap();
+
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public $post;
+
+            public function mount()
+            {
+                $this->post = Article::first();
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div></div>
+                HTML;
+            }
+        });
+
+        $this->assertEquals(Article::class, $component->snapshot['data']['post'][1]['class']);
+
+        Relation::requireMorphMap(false);
+    }
 }
 
 #[\Attribute]


### PR DESCRIPTION
This PR is an extension of PR #7810 by @Naoray to ensure that the morph map exception is also handled for the standard model synth.