### PR TITLE
Revert "Add dependency injection to computed properties"

### DIFF
--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -2,9 +2,9 @@
 
 namespace Livewire\Features\SupportComputed;
 
+use function Livewire\invade;
 use function Livewire\on;
 use function Livewire\off;
-use function Livewire\wrap;
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
@@ -135,7 +135,7 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
-        return wrap($this->component)->{parent::getName()}();
+        return invade($this->component)->{parent::getName()}();
     }
 
     public function getName()

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -361,13 +361,6 @@ class UnitTest extends TestCase
     }
 
     /** @test */
-    public function injected_computed_property_attribute_is_accessible_within_blade_view()
-    {
-        Livewire::test(InjectedComputedPropertyWithAttributeStub::class)
-            ->assertSee('bar');
-    }
-
-    /** @test */
     public function computed_property_is_memoized_after_its_accessed()
     {
         Livewire::test(MemoizedComputedPropertyStub::class)
@@ -507,24 +500,6 @@ class NullIssetComputedPropertyStub extends Component{
         return <<<'HTML'
         <div>
             {{ var_dump(isset($this->foo)) }}
-        </div>
-        HTML;
-    }
-}
-
-class InjectedComputedPropertyWithAttributeStub extends Component
-{
-    #[Computed]
-    public function fooBar(FooDependency $foo)
-    {
-        return $foo->baz;
-    }
-
-    public function render()
-    {
-        return <<<'HTML'
-        <div>
-            {{ var_dump($this->foo_bar) }}
         </div>
         HTML;
     }


### PR DESCRIPTION
Reverts livewire/livewire#7690

This is being reverted because it breaks the ability to use a protected method as a computed property.

https://github.com/livewire/livewire/discussions/7823