### PR TITLE
session flash data is missing when using redirect with nested component and Modelable

### DIFF
--- a/docs/session-properties.md
+++ b/docs/session-properties.md
@@ -67,7 +67,7 @@ class ShowPosts extends Component
 
 When Livewire stores and retrieves the value of the `$search` property, it will use the given key: "search".
 
-Additionally, if you want to generate they key dynamically from other properties in your component, you can do so using the following curly bracket notation:
+Additionally, if you want to generate the key dynamically from other properties in your component, you can do so using the following curly bracket notation:
 
 ```php
 <?php

--- a/docs/session-properties.md
+++ b/docs/session-properties.md
@@ -66,3 +66,26 @@ class ShowPosts extends Component
 ```
 
 When Livewire stores and retrieves the value of the `$search` property, it will use the given key: "search".
+
+Additionally, if you want to generate they key dynamically from other properties in your component, you can do so using the following curly bracket notation:
+
+```php
+<?php
+
+use Livewire\Attributes\Session;
+use Livewire\Component;
+use App\Models\Author;
+
+class ShowPosts extends Component
+{
+    public Author $author;
+
+    #[Session(key: 'search-{author.id}')] // [tl! highlight]
+    public $search;
+
+    // ...
+}
+```
+
+In the above example, if the `$author` model's id is "4", the session key will become: `search-4`
+

--- a/docs/session-properties.md
+++ b/docs/session-properties.md
@@ -67,7 +67,7 @@ class ShowPosts extends Component
 
 When Livewire stores and retrieves the value of the `$search` property, it will use the given key: "search".
 
-Additionally, if you want to generate the key dynamically from other properties in your component, you can do so using the following curly bracket notation:
+Additionally, if you want to generate the key dynamically from other properties in your component, you can do so using the following curly brace notation:
 
 ```php
 <?php

--- a/docs/session-properties.md
+++ b/docs/session-properties.md
@@ -66,26 +66,3 @@ class ShowPosts extends Component
 ```
 
 When Livewire stores and retrieves the value of the `$search` property, it will use the given key: "search".
-
-Additionally, if you want to generate the key dynamically from other properties in your component, you can do so using the following curly brace notation:
-
-```php
-<?php
-
-use Livewire\Attributes\Session;
-use Livewire\Component;
-use App\Models\Author;
-
-class ShowPosts extends Component
-{
-    public Author $author;
-
-    #[Session(key: 'search-{author.id}')] // [tl! highlight]
-    public $search;
-
-    // ...
-}
-```
-
-In the above example, if the `$author` model's id is "4", the session key will become: `search-4`
-

--- a/src/Features/SupportRedirects/BrowserTest.php
+++ b/src/Features/SupportRedirects/BrowserTest.php
@@ -2,6 +2,8 @@
 
 namespace Livewire\Features\SupportRedirects;
 
+use Illuminate\Support\Facades\Route;
+use Livewire\Attributes\Modelable;
 use Tests\BrowserTestCase;
 use Livewire\Livewire;
 use Livewire\Component;
@@ -28,4 +30,63 @@ class BrowserTest extends BrowserTestCase
         ->assertUrlIs('https://livewire.laravel.com/')
         ;
     }
+
+    /** @test */
+    public function session_flash_persist_when_redirecting_with_child_component_that_has_property_modelable()
+    {
+        config()->set('session.driver', 'file');
+
+        Route::get('/redirect', RedirectComponent::class)->middleware('web');
+
+        Livewire::visit([
+            new class extends Component {
+                public $foo = 0;
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <h1> Form : </h1>
+                    <form wire:submit="save">
+                        <livewire:child wire:model="foo" />
+                        <button type="submit" dusk="submit-form">save</button>
+                    </form>
+                </div>
+                HTML; }
+
+                public function save()
+                {
+                    session()->flash('alertMessage', 'session flash data persist');
+                    $this->redirect('/redirect');
+                }
+            },
+            'child' => new class extends Component {
+                #[Modelable]
+                public $bar;
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <label>Child</label>
+                    <input type="text" wire:model="bar" />
+                </div>
+                HTML; }
+            }
+        ])
+        ->waitForLivewireToLoad()
+        ->click('@submit-form')
+        ->waitForNavigate()
+        ->waitForLivewireToLoad()
+        ->assertSeeIn('@session-message', 'session flash data persist');
+    }
+}
+
+class RedirectComponent extends Component {
+    public function render() { return <<<'HTML'
+        <div>
+            <h1>redirected page</h1>
+            <div dusk="session-message">
+                @session('alertMessage')
+                    {{ $value }}
+                @endsession
+            </div>
+        </div>
+    HTML; }
 }

--- a/src/Features/SupportRedirects/SupportRedirects.php
+++ b/src/Features/SupportRedirects/SupportRedirects.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportRedirects;
 
+use Livewire\Attributes\Modelable;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
 use Livewire\ComponentHook;
 use Livewire\Component;
@@ -43,6 +44,13 @@ class SupportRedirects extends ComponentHook
         }
 
         if (! $to) {
+            // Skip if coming from modelable attribute
+            $attributes = $this->component->getAttributes();
+            foreach ($attributes as $attribute) {
+                if ($attribute instanceof Modelable) {
+                    return;
+                }
+            }
             // If there was no redirect. Clear flash session data.
             if (app()->has('session.store')) {
                 session()->forget(session()->get('_flash.new'));

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -96,7 +96,7 @@ class HandleRequests extends Mechanism
             'assets' => SupportScriptsAndAssets::getAssets(),
         ];
 
-        $finish = trigger('profile.response', $response);
+        $finish = trigger('response', $response);
 
         return $finish($response);
     }


### PR DESCRIPTION
This PR is an attempt to fix: https://github.com/livewire/livewire/discussions/7797

this will skip session forget if child component has attribute modelable and $to is null