### PR TITLE
Add assertPropertyHasAttribute test helper

### DIFF
--- a/src/Features/SupportTesting/MakesAssertions.php
+++ b/src/Features/SupportTesting/MakesAssertions.php
@@ -2,9 +2,10 @@
 
 namespace Livewire\Features\SupportTesting;
 
-use Illuminate\Testing\Constraints\SeeInOrder;
-use PHPUnit\Framework\Assert as PHPUnit;
+use ReflectionClass;
 use Illuminate\Support\Arr;
+use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Testing\Constraints\SeeInOrder;
 
 trait MakesAssertions
 {
@@ -147,6 +148,18 @@ trait MakesAssertions
         } else {
             PHPUnit::assertEquals($value, $data);
         }
+
+        return $this;
+    }
+
+    public function assertPropertyHasAttribute($property, $attribute, ...$arguments)
+    {
+        $reflect = (new ReflectionClass($this->instance()))->getProperty($property);
+
+        $attributes = collect($reflect->getAttributes($attribute))
+            ->mapWithKeys(fn ($data, $key) => [$key => ['name' => $data->getName(), 'arguments' => $data->getArguments()]]);
+
+        PHPUnit::assertNotEmpty($attributes->where('name', $attribute)->where('arguments', $arguments));
 
         return $this;
     }

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -3,14 +3,16 @@
 namespace Livewire\Features\SupportTesting;
 
 use Closure;
-use Illuminate\Contracts\Validation\ValidationRule;
-use PHPUnit\Framework\ExpectationFailedException;
-use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\Route;
-use Illuminate\Testing\TestResponse;
-use Illuminate\Testing\TestView;
-use Livewire\Component;
 use Livewire\Livewire;
+use Livewire\Component;
+use Tests\TestComponent;
+use Illuminate\Testing\TestView;
+use Livewire\Attributes\Session;
+use Illuminate\Testing\TestResponse;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\ExpectationFailedException;
+use Illuminate\Contracts\Validation\ValidationRule;
 
 // TODO - Change this to \Tests\TestCase
 class UnitTest extends \LegacyTests\Unit\TestCase
@@ -591,6 +593,38 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             ->assertSet('colourHeader', 'blue')
             ->assertSet('nameHeader', 'Taylor')
             ;
+    }
+
+    /** @test */
+    public function tests_if_an_attribute_exists()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Session]
+            public $count = 0;
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $count }}</div>
+                HTML;
+            }
+        })
+            ->assertPropertyHasAttribute('count', Session::class);
+    }
+
+    /** @test */
+    public function tests_if_an_attribute_values_match()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Session(key: 'foo')]
+            public $count = 0;
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $count }}</div>
+                HTML;
+            }
+        })
+            ->assertPropertyHasAttribute('count', Session::class, key: 'foo');
     }
 }
 


### PR DESCRIPTION
I would like to test if an attribute is assigned to a property. This may fit better in Christoph's [missing assertions package](https://github.com/christophrumpel/missing-livewire-assertions) but I leave that up you guys.

```php
class Filter extends Component
{
    #[Session(key: 'foo')]
    public array $filters = [];
}

Livewire::test(Filter::class)
    ->assertPropertyHasAttribute('filters', Session::class, key: 'foo');
```

I thought about supporting methods as well, but I think some of them are already covered by other tests (e.g. events). And it's also why I explicitly called it `assertPropertyHasAttribute`--to leave room for testing method attributes, and to have a similar naming convention: [`assertClassHasAttribute`](https://docs.phpunit.de/en/9.6/assertions.html#assertclasshasattribute).