### PR TITLE
#[Computed] Computed property dependency injection #6967

### DIFF
--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -387,6 +387,13 @@ class UnitTest extends TestCase
         Livewire::test(NullIssetComputedPropertyStub::class)
             ->assertSee('false');
     }
+
+    /** @test */
+    public function injected_computed_property_attribute_is_accessible_within_blade_view()
+    {
+        Livewire::test(InjectedComputedPropertyWithAttributeStub::class)
+            ->assertSee('bar');
+    }
 }
 
 class ComputedPropertyStub extends Component
@@ -500,6 +507,24 @@ class NullIssetComputedPropertyStub extends Component{
         return <<<'HTML'
         <div>
             {{ var_dump(isset($this->foo)) }}
+        </div>
+        HTML;
+    }
+}
+
+class InjectedComputedPropertyWithAttributeStub extends Component
+{
+    #[Computed]
+    public function fooBar(FooDependency $foo)
+    {
+        return $foo->baz;
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            {{ var_dump($this->foo_bar) }}
         </div>
         HTML;
     }

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -394,6 +394,20 @@ class UnitTest extends TestCase
         Livewire::test(InjectedComputedPropertyWithAttributeStub::class)
             ->assertSee('bar');
     }
+
+    /** @test */
+    public function call_computed_dynamic_property_non_public_method()
+    {
+        Livewire::test(CallComputedDynamicPropertyNonPublicMethod::class)
+            ->assertSee('bar');
+    }
+
+    /** @test */
+    public function call_computed_property_attribute_non_public_method()
+    {
+        Livewire::test(CallComputedPropertyAttributeNonPublicMethod::class)
+            ->assertSee('bar');
+    }
 }
 
 class ComputedPropertyStub extends Component
@@ -525,6 +539,58 @@ class InjectedComputedPropertyWithAttributeStub extends Component
         return <<<'HTML'
         <div>
             {{ var_dump($this->foo_bar) }}
+        </div>
+        HTML;
+    }
+}
+
+class CallComputedDynamicPropertyNonPublicMethod extends Component
+{
+    public $upperCasedFoo = 'FOO_BAR';
+
+    protected function getProtectedFooBarProperty()
+    {
+        return strtolower($this->upperCasedFoo);
+    }
+
+    private function getPrivateFooBarProperty()
+    {
+        return strtolower($this->upperCasedFoo);
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            {{ var_dump($this->protected_foo_bar) }}
+            {{ var_dump($this->private_foo_bar) }}
+        </div>
+        HTML;
+    }
+}
+
+class CallComputedPropertyAttributeNonPublicMethod extends Component
+{
+    public $upperCasedFoo = 'FOO_BAR';
+
+    #[Computed]
+    protected function protectedFooBar()
+    {
+        return strtolower($this->upperCasedFoo);
+    }
+
+    #[Computed]
+    private function privateFooBar()
+    {
+        return strtolower($this->upperCasedFoo);
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            {{ var_dump($this->protected_foo_bar) }}
+            {{ var_dump($this->private_foo_bar) }}
         </div>
         HTML;
     }


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Y - https://github.com/livewire/livewire/discussions/6967
2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Y
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
N
4️⃣ Does it include tests? (Required)
Y
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Reverted in https://github.com/livewire/livewire/pull/7834

A failing test was added to check the possibility of the property computed using an attribute working the same as the dynamic computed property (v2)

2 tests were put in place so that when this is fixed, other things without tests won't break.
- Access computed property using `protected/private`

call_computed_property_attribute_non_public_method - ✅ pass `[#Compute]`
call_computed_dynamic_property_non_public_method - ❌ failed `getProperty()`
