### PR TITLE
Added refresh method to Testable

### DIFF
--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -165,6 +165,11 @@ class Testable
         return $this->update();
     }
 
+    function refresh()
+    {
+        return $this->update();
+    }
+
     function update($calls = [], $updates = [])
     {
         $newState = SubsequentRender::make(


### PR DESCRIPTION
In the docs, under the section **available testing utilities** of Testing, `refresh` method is documented
https://livewire.laravel.com/docs/testing#interacting-with-components

but its missing in `Livewire\Features\SupportTesting\Testable.php` 
this PR added the `refresh` method in `Testable` class as discussed here [#7842](https://github.com/livewire/livewire/discussions/7842)

the `refresh` method is essentially a call to `update` method similiar to `commit`
