### PR TITLE
Allow download of preview files directly from storage

### DIFF
--- a/src/Drawer/Utils.php
+++ b/src/Drawer/Utils.php
@@ -2,8 +2,10 @@
 
 namespace Livewire\Drawer;
 
+use Illuminate\Http\Request;
 use Livewire\Exceptions\RootTagMissingFromViewException;
 
+use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
 use function Livewire\invade;
 
 class Utils extends BaseUtils
@@ -49,36 +51,54 @@ class Utils extends BaseUtils
         return htmlspecialchars(json_encode($subject), ENT_QUOTES|ENT_SUBSTITUTE);
     }
 
-    static function pretendResponseIsFile($file, $mimeType = 'application/javascript')
+    static function pretendResponseIsFile($file, $contentType = 'application/javascript; charset=utf-8')
+    {
+        $lastModified = filemtime($file);
+
+        return static::cachedFileResponse($file, $contentType, $lastModified,
+            fn ($headers) => response()->file($file, $headers));
+    }
+
+    static function pretendPreviewResponseIsPreviewFile($filename)
+    {
+        $file = FileUploadConfiguration::path($filename);
+        $storage = FileUploadConfiguration::storage();
+        $mimeType = FileUploadConfiguration::mimeType($filename);
+        $lastModified = FileUploadConfiguration::lastModified($file);
+
+        return self::cachedFileResponse($filename, $mimeType, $lastModified,
+            fn ($headers) => $storage->download($file, $filename, $headers));
+    }
+
+    static private function cachedFileResponse($filename, $contentType, $lastModified, $downloadCallback)
     {
         $expires = strtotime('+1 year');
-        $lastModified = filemtime($file);
         $cacheControl = 'public, max-age=31536000';
 
         if (static::matchesCache($lastModified)) {
-            return response()->make('', 304, [
+            return response('', 304, [
                 'Expires' => static::httpDate($expires),
                 'Cache-Control' => $cacheControl,
             ]);
         }
 
         $headers = [
-            'Content-Type' => "$mimeType; charset=utf-8",
+            'Content-Type' => $contentType,
             'Expires' => static::httpDate($expires),
             'Cache-Control' => $cacheControl,
             'Last-Modified' => static::httpDate($lastModified),
         ];
 
-        if (str($file)->endsWith('.br')) {
+        if (str($filename)->endsWith('.br')) {
             $headers['Content-Encoding'] = 'br';
         }
 
-        return response()->file($file, $headers);
+        return $downloadCallback($headers);
     }
 
     static function matchesCache($lastModified)
     {
-        $ifModifiedSince = $_SERVER['HTTP_IF_MODIFIED_SINCE'] ?? '';
+        $ifModifiedSince = app(Request::class)->header('if-modified-since');
 
         return @strtotime($ifModifiedSince) === $lastModified;
     }

--- a/src/Features/SupportFileUploads/FilePreviewController.php
+++ b/src/Features/SupportFileUploads/FilePreviewController.php
@@ -19,9 +19,6 @@ class FilePreviewController implements HasMiddleware
     {
         abort_unless(request()->hasValidSignature(), 401);
 
-        return Utils::pretendResponseIsFile(
-            FileUploadConfiguration::storage()->path(FileUploadConfiguration::path($filename)),
-            FileUploadConfiguration::mimeType($filename)
-        );
+        return Utils::pretendPreviewResponseIsPreviewFile($filename);
     }
 }

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -91,6 +91,11 @@ class FileUploadConfiguration
         return $mimeType === 'image/svg' ? 'image/svg+xml' : $mimeType;
     }
 
+    public static function lastModified($filename)
+    {
+        return static::storage()->lastModified($filename);
+    }
+
     public static function middleware()
     {
         return config('livewire.temporary_file_upload.middleware') ?: 'throttle:60,1';

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -3,6 +3,8 @@
 namespace Livewire\Features\SupportFileUploads;
 
 use Carbon\Carbon;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Http;
 use Livewire\WithFileUploads;
 use Livewire\Livewire;
 use Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButtonCache;
@@ -456,6 +458,64 @@ class UnitTest extends \Tests\TestCase
     public function can_preview_a_temporary_file_with_a_temporary_signed_url()
     {
         Storage::fake('avatars');
+
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->viewData('photo');
+
+        // Due to Livewire object still being in memory, we need to
+        // reset the "shouldDisableBackButtonCache" property back to its default
+        // which is false to ensure it's not applied to the below route
+        \Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+
+        ob_start();
+        $this->get($photo->temporaryUrl())->sendContent();
+        $rawFileContents = ob_get_clean();
+
+        $this->assertEquals($file->get(), $rawFileContents);
+
+        $this->assertTrue($photo->isPreviewable());
+    }
+
+    /** @test */
+    public function file_is_not_sent_on_cache_hit()
+    {
+        Storage::fake('avatars');
+
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->viewData('photo');
+
+        ob_start();
+        $response = $this->get($photo->temporaryUrl());
+        $response->sendContent();
+        $rawFileContents = ob_get_clean();
+        $this->assertEquals($file->get(), $rawFileContents);
+
+        ob_start();
+        $cachedResponse = $this->get($photo->temporaryUrl(), [
+            'If-Modified-Since' => $response->headers->get('last-modified'),
+        ]);
+        $cachedResponse->sendContent();
+        $this->assertEquals(304, $cachedResponse->getStatusCode());
+        $cachedFileContents = ob_get_clean();
+
+        $this->assertEquals('', $cachedFileContents);
+    }
+
+    /** @test */
+    public function can_preview_a_temporary_file_on_a_remote_storage()
+    {
+        $disk = Storage::fake('tmp-for-tests');
+
+        // A remote storage will always return the short path when calling $disk->path(). To simulate a remote
+        // storage, the fake storage will be recreated with an empty prefix option in order to get the short path even
+        // if it's a local filesystem.
+        Storage::set('tmp-for-tests', new FilesystemAdapter($disk->getDriver(), $disk->getAdapter(), ['prefix' => '']));
 
         $file = UploadedFile::fake()->image('avatar.jpg');
 


### PR DESCRIPTION
This commit introduces support for non-local storages again. This time
the cache hit path is fixed and tested which caused #7794 before.

Also the cachedFileResponse function has been changed to de-duplicate
the matchesCache check and to not return charset applied to the
Content-Type.

To support sending the header in the test, the If-Modified-Since
header is now fetched from the Laravel Request object, rather than from
$_SERVER.

Sorry for the mess that the other PR has caused.