### PR TITLE
Support integer backed enums in query string

### DIFF
--- a/src/Features/SupportAttributes/Attribute.php
+++ b/src/Features/SupportAttributes/Attribute.php
@@ -65,16 +65,16 @@ abstract class Attribute
             throw new \Exception('Can\'t set the value of a non-property attribute.');
         }
 
-        if ($enum = $this->tryingToSetStringToEnum($value)) {
+        if ($enum = $this->tryingToSetStringOrIntegerToEnum($value)) {
             $value = $enum::from($value);
         }
 
         data_set($this->component, $this->levelName, $value);
     }
 
-    protected function tryingToSetStringToEnum($subject)
+    protected function tryingToSetStringOrIntegerToEnum($subject)
     {
-        if (! is_string($subject)) return;
+        if (! is_string($subject) && ! is_int($subject)) return;
 
         $target = $this->subTarget ?? $this->component;
 

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -253,17 +253,89 @@ class BrowserTest extends \Tests\BrowserTestCase
     }
 
     /** @test */
+    public function can_use_url_on_string_backed_enum_object_properties()
+    {
+        Livewire::visit([
+            new class extends Component
+            {
+                #[BaseUrl]
+                public StringBackedEnumForUrlTesting $foo = StringBackedEnumForUrlTesting::First;
+
+                public function change()
+                {
+                    $this->foo = StringBackedEnumForUrlTesting::Second;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="change" dusk="button">Change</button>
+                        <h1 dusk="output">{{ $foo }}</h1>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->assertQueryStringMissing('foo')
+            ->assertSeeIn('@output', 'first')
+            ->waitForLivewire()->click('@button')
+            ->assertQueryStringHas('foo', 'second')
+            ->assertSeeIn('@output', 'second')
+            ->refresh()
+            ->assertQueryStringHas('foo', 'second')
+            ->assertSeeIn('@output', 'second')
+        ;
+    }
+
+    /** @test */
+    public function can_use_url_on_integer_backed_enum_object_properties()
+    {
+        Livewire::visit([
+            new class extends Component
+            {
+                #[BaseUrl]
+                public IntegerBackedEnumForUrlTesting $foo = IntegerBackedEnumForUrlTesting::First;
+
+                public function change()
+                {
+                    $this->foo = IntegerBackedEnumForUrlTesting::Second;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="change" dusk="button">Change</button>
+                        <h1 dusk="output">{{ $foo }}</h1>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->assertQueryStringMissing('foo')
+            ->assertSeeIn('@output', '1')
+            ->waitForLivewire()->click('@button')
+            ->assertQueryStringHas('foo', '2')
+            ->assertSeeIn('@output', '2')
+            ->refresh()
+            ->assertQueryStringHas('foo', '2')
+            ->assertSeeIn('@output', '2')
+        ;
+    }
+
+    /** @test */
     public function can_use_url_on_enum_object_properties()
     {
         Livewire::visit([
             new class extends Component
             {
                 #[BaseUrl]
-                public EnumForUrlTesting $foo = EnumForUrlTesting::First;
+                public StringBackedEnumForUrlTesting $foo = StringBackedEnumForUrlTesting::First;
 
                 public function change()
                 {
-                    $this->foo = EnumForUrlTesting::Second;
+                    $this->foo = StringBackedEnumForUrlTesting::Second;
                 }
 
                 public function render()
@@ -530,8 +602,14 @@ class FormObject extends \Livewire\Form
     public $bob = 'lob';
 }
 
-enum EnumForUrlTesting: string
+enum StringBackedEnumForUrlTesting: string
 {
     case First = 'first';
     case Second = 'second';
+}
+
+enum IntegerBackedEnumForUrlTesting: int
+{
+    case First = 1;
+    case Second = 2;
 }

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -325,42 +325,6 @@ class BrowserTest extends \Tests\BrowserTestCase
     }
 
     /** @test */
-    public function can_use_url_on_enum_object_properties()
-    {
-        Livewire::visit([
-            new class extends Component
-            {
-                #[BaseUrl]
-                public StringBackedEnumForUrlTesting $foo = StringBackedEnumForUrlTesting::First;
-
-                public function change()
-                {
-                    $this->foo = StringBackedEnumForUrlTesting::Second;
-                }
-
-                public function render()
-                {
-                    return <<<'HTML'
-                    <div>
-                        <button wire:click="change" dusk="button">Change</button>
-                        <h1 dusk="output">{{ $foo }}</h1>
-                    </div>
-                    HTML;
-                }
-            },
-        ])
-            ->assertQueryStringMissing('foo')
-            ->assertSeeIn('@output', 'first')
-            ->waitForLivewire()->click('@button')
-            ->assertQueryStringHas('foo', 'second')
-            ->assertSeeIn('@output', 'second')
-            ->refresh()
-            ->assertQueryStringHas('foo', 'second')
-            ->assertSeeIn('@output', 'second')
-        ;
-    }
-
-    /** @test */
     public function it_does_not_break_string_typed_properties()
     {
         Livewire::withQueryParams(['foo' => 'bar'])


### PR DESCRIPTION
Related to https://github.com/livewire/livewire/pull/7572

Query string is only supported for string backed enums.

There are also integer backed enums, that can also be useful.

With current implementation an integer cannot be set from url to populate an Enum property, because it's skipped here https://github.com/livewire/livewire/blob/main/src/Features/SupportAttributes/Attribute.php#L77

And it gives an error of trying to assign integer to an Enum-hinted attribute.

**Solution**
Both string and integer can be used to be converted into an enum.

Tests are added.