### PR TITLE
Expose disk and real storage path of `TemporaryUploadedFile`

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -82,7 +82,6 @@ class TemporaryUploadedFile extends UploadedFile
     public function getPathname(): string
     {
         return $this->getRealPath();
-
     }
 
     public function getClientOriginalName(): string

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -30,6 +30,11 @@ class TemporaryUploadedFile extends UploadedFile
         return $this->storage->path(FileUploadConfiguration::directory());
     }
 
+    public function getDisk(): string
+    {
+        return $this->disk;
+    }
+
     public function isValid(): bool
     {
         return true;
@@ -67,6 +72,11 @@ class TemporaryUploadedFile extends UploadedFile
     public function getRealPath(): string
     {
         return $this->storage->path($this->path);
+    }
+
+    public function getStoragePath(): string
+    {
+        return $this->path;
     }
 
     public function getClientOriginalName(): string

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -175,6 +175,33 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    public function can_get_disk()
+    {
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->viewData('photo');
+
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $photo);
+        $this->assertEquals('tmp-for-tests', $photo->getDisk());
+    }
+
+    /** @test */
+    public function can_get_storage_path()
+    {
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->viewData('photo');
+
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $photo);
+        $this->assertStringStartsNotWith('livewire-tmp', $photo->getRealPath());
+        $this->assertStringStartsWith('livewire-tmp', $photo->getStoragePath());
+    }
+
+    /** @test */
     public function can_set_a_file_as_a_property_using_the_s3_driver_and_store_it()
     {
         config()->set('livewire.temporary_file_upload.disk', 's3');
@@ -822,4 +849,3 @@ class FileUploadInArrayComponent extends FileUploadComponent
         unset($this->obj['file_uploads'][$key]);
     }
 }
-


### PR DESCRIPTION
In all our projects at work, we use `spatie/laravel-medialibrary` to save the uploaded files. To save a file that already exists on a storage disk, I need the path of the file on the storage disk (and the name of the storage disk).

Currently, there is no way to get that path. For example, the `getRealPath()` method exists, but that is not the real storage path as the `$this->storage->path()` is used. When you try to move the storage file using the path you get from the `getRealPath()` method, you will see that it does not work. The returned path is prefixed based on the config of the disk. 

This PR fixes that by introducing a `getStoragePath()` method and a `getDisk()` method.