### PR TITLE
[3.x] Introduce a working `TemporaryUploadedFile::fake()` for users

### DIFF
--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -726,10 +726,8 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    public function user_can_create_a_functional_temporary_uploaded_file_for_testing_purpose()
+    public function hacky_user_can_create_a_functional_temporary_uploaded_file_for_testing_purpose()
     {
-
-
         // fake results come from \Illuminate\Http\UploadedFile
         $fileWithContent = TemporaryUploadedFile::fake()->createWithContent('example.txt', 'some content');
         $fileWithoutContent = TemporaryUploadedFile::fake()->create('example.mp3', 1024, 'audio/mpeg');
@@ -750,6 +748,24 @@ class UnitTest extends \Tests\TestCase
         $fileWithContent = TemporaryUploadedFile::createFromLivewire($fileWithContent->getFilename());
         $fileWithoutContent = TemporaryUploadedFile::createFromLivewire($fileWithoutContent->getFilename());
         $fileWithRealImage = TemporaryUploadedFile::createFromLivewire($fileWithRealImage->getFilename());
+
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $fileWithContent);
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $fileWithoutContent);
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $fileWithRealImage);
+
+        $this->assertEquals('some content', $fileWithContent->getContent());
+        $this->assertEquals('', $fileWithoutContent->getContent());
+        $this->assertTrue(!! imagecreatefromstring($fileWithRealImage->getContent()));
+
+        // add more assertions for name, extension, mimeType, path and so on
+    }
+
+    /** @test */
+    public function user_can_create_a_functional_temporary_uploaded_file_for_testing_purpose()
+    {
+        $fileWithContent = TemporaryUploadedFile::fake()->createWithContent('example.txt', 'some content');
+        $fileWithoutContent = TemporaryUploadedFile::fake()->create('example.mp3', 1024, 'audio/mpeg');
+        $fileWithRealImage = TemporaryUploadedFile::fake()->image('example.jpg', 20, 20);
 
         $this->assertInstanceOf(TemporaryUploadedFile::class, $fileWithContent);
         $this->assertInstanceOf(TemporaryUploadedFile::class, $fileWithoutContent);

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -728,6 +728,8 @@ class UnitTest extends \Tests\TestCase
     /** @test */
     public function hacky_user_can_create_a_functional_temporary_uploaded_file_for_testing_purpose()
     {
+        // this test should be removed once a better DX is implemented
+
         // fake results come from \Illuminate\Http\UploadedFile
         $fileWithContent = TemporaryUploadedFile::fake()->createWithContent('example.txt', 'some content');
         $fileWithoutContent = TemporaryUploadedFile::fake()->create('example.mp3', 1024, 'audio/mpeg');


### PR DESCRIPTION
Currently its "impossible" to test `TemporaryUploadedFile` without uploading a fiel through your component which makes testing a nightmare.

```php
// component
class UploadPhoto extends Component
{
    use WithFileUploads;
 
    public $photo;
 
    public function upload($name)
    {
        $this->photo->storeAs('/', $name, disk: 'avatars');
    }
}

// testing the component
class UploadPhotoTest extends TestCase
{
    /** @test */
    public function can_upload_photo()
    {
        Storage::fake('avatars');
 
        $file = UploadedFile::fake()->image('avatar.png');
 
        Livewire::test(UploadPhoto::class)
            ->set('photo', $file)
            ->call('upload', 'uploaded-avatar.png');
 
        Storage::disk('avatars')->assertExists('uploaded-avatar.png');
    }
}

//easy all works fine
```

```php
// component
class UploadPhoto extends Component
{
    use WithFileUploads;
 
    public $photo;
 
    public function upload($name)
    {
        resolve(SomeAction::class)->handle($this->photo, $name);
    }
}

// testing the component will still
class UploadPhotoTest extends TestCase
{
    /** @test */
    public function can_upload_photo()
    {
        Storage::fake('avatars');
 
        $file = UploadedFile::fake()->image('avatar.png');
 
        Livewire::test(UploadPhoto::class)
            ->set('photo', $file)
            ->call('upload', 'uploaded-avatar.png');
 
        Storage::disk('avatars')->assertExists('uploaded-avatar.png');
    }
}

// but now we are cooking
class SomeActionTest extends TestCase
{
    /** @test */
    public function can_handle_a_upload_photo()
    {
        Storage::fake('avatars');
 
        $file = UploadedFile::fake()->image('avatar.png');

        // will fail because $file is type-hinted as TemporaryUploadedFile
        // reason for type-hint is methods work different compared to UploadedFile
        resolve(SomeAction::class)->handle($file, 'uploaded-avatar.png');

         Storage::disk('avatars')->assertExists('uploaded-avatar.png');
    }
}
```

ideal situation for users would be to just call `TemporaryUploadedFile::fake()` and getting a functional `TemporaryUploadedFile` back as it would be "uploaded", without faking a disk and copy files around.

If you wish i could cook something.

cheers adrian