### PR TITLE
Fix Laravel 11 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [10.*]
-        # exclude:
-        #   - php: 8.1
-        #     laravel: 11.*
+        laravel: [10.*, 11.*]
+        exclude:
+          - php: 8.1
+            laravel: 11.*
 
     name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [10.*, 11.*]
-        exclude:
-          - php: 8.1
-            laravel: 11.*
+        laravel: [10.*]
+        # exclude:
+        #   - php: 8.1
+        #     laravel: 11.*
 
     name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
 

--- a/legacy_tests/Browser/DuskCommand.php
+++ b/legacy_tests/Browser/DuskCommand.php
@@ -27,7 +27,7 @@ class DuskCommand extends Command
         $this->setName('dusk');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $file = (new ReflectionClass($this->testCase))->getFilename();
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,5 +21,6 @@
     </testsuites>
     <php>
         <env name="CACHE_STORE" value="file"/>
+        <env name="SESSION_DRIVER" value="file"/>
     </php>
 </phpunit>


### PR DESCRIPTION
This PR fixes the broken tests when running Laravel 11.

Currently, if someone clones the Livewire repo and runs `composer install` it installs Laravel 11 by default. But the problem was that tests were failing with a `no such table: sessions` error. See here https://github.com/livewire/livewire/discussions/7862#discussioncomment-8344473

I raised an issue on the testbench repo and was told the issue is due to Laravel 11 setting the session driver to `database` by default (from `file`) https://github.com/orchestral/testbench/issues/391

So I've set the session driver back to `file` in `phpunit.xml.dist` to ensure our tests run without needing to have the database configured for sessions.

I've also fixed a type hint warning (and tested it still works on Laravel 10) ~~and reenabled the Laravel 11 tests.~~

**Edit:** Had to disable Laravel 11 tests again as they are still failing in CI. But I can confirm that most tests are running locally (as opposed to them all failing due to the session error), so we should merge this anyway.

Hope this helps!