### PR TITLE
Fix use statements in Url docs

### DIFF
--- a/docs/url.md
+++ b/docs/url.md
@@ -170,8 +170,8 @@ Because Livewire "replaces" the current history, pressing the "back" button in t
 To force Livewire to use `history.pushState` when updating the URL, you can provide the `history` parameter to the `#[Url]` attribute:
 
 ```php
+use Livewire\Attributes\Url;
 use Livewire\Component;
-use Livewire\With\Url;
 
 class ShowUsers extends Component
 {


### PR DESCRIPTION
I assume this was a copy-paste issue due to copying a `WithSomething` Trait name when writing the docs for the "Trait hooks" section. The namespace `Livewire\With` does not exist.

I also sorted the imports to match the other code samples.