### PR TITLE
[V2] Fix TemporaryUploadedFile::dimensions return type

### DIFF
--- a/src/TemporaryUploadedFile.php
+++ b/src/TemporaryUploadedFile.php
@@ -74,7 +74,7 @@ class TemporaryUploadedFile extends UploadedFile
         return $this->extractOriginalNameFromFilePath($this->path);
     }
 
-    public function dimensions(): ?array
+    public function dimensions()
     {
         stream_copy_to_stream($this->storage->readStream($this->path), $tmpFile = tmpfile());
 

--- a/tests/Unit/FileUploadsTest.php
+++ b/tests/Unit/FileUploadsTest.php
@@ -323,6 +323,22 @@ class FileUploadsTest extends TestCase
     }
 
     /** @test */
+    public function invalid_file_extension_can_validate_dimensions()
+    {
+        Storage::fake('avatars');
+
+        $file = UploadedFile::fake()
+            ->create('not-a-png-image.pdf', 512, 512);
+
+        Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->call('validateUploadWithDimensions')
+            ->assertHasErrors(['photo' => 'dimensions']);
+
+        Storage::disk('avatars')->assertMissing('uploaded-not-a-png-image.png');
+    }
+
+    /** @test */
     public function temporary_files_older_than_24_hours_are_cleaned_up_on_every_new_upload()
     {
         Storage::fake('avatars');


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
https://github.com/livewire/livewire/discussions/7873
2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
4️⃣ Does it include tests? (Required)
Yes
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This PR implements the same changes as https://github.com/livewire/livewire/pull/6479 but for v2 of Livewire.

Thanks for contributing! 🙌
