### PR TITLE
Child component is being triggered by any Parent change

### DIFF
--- a/src/Features/SupportReactiveProps/BrowserTest.php
+++ b/src/Features/SupportReactiveProps/BrowserTest.php
@@ -230,6 +230,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
                 public function incCount() { $this->count++; }
                 public function incReactive() { $this->reactive++; }
+                public function setReactive() { $this->reactive = $this->reactive; }
 
                 public function render() { return <<<'HTML'
                     <div>
@@ -238,6 +239,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
                         <button wire:click="incCount" dusk="parent.incCount">incCount</button>
                         <button wire:click="incReactive" dusk="parent.incReactive">incReactive</button>
+                        <button wire:click="setReactive" dusk="parent.setReactive">setReactive</button>
 
                         <livewire:child :$count :$reactive />
                     </div>
@@ -290,7 +292,17 @@ class BrowserTest extends \Tests\BrowserTestCase
 
         $random3 = $test->text('@child.random');
 
+        $test
+            ->waitForLivewire()->click('@parent.setReactive')
+            ->assertSeeIn('@parent.count', 1)
+            ->assertSeeIn('@parent.reactive', 1)
+            ->assertSeeIn('@child.count', 0)
+            ->assertSeeIn('@child.reactive', 1);
+
+        $random4 = $test->text('@child.random');
+
         $this->assertSame($random1, $random2);
         $this->assertNotSame($random2, $random3);
+        $this->assertSame($random3, $random4);
     }
 }


### PR DESCRIPTION
Looking at documentation about how Reactive works, it made me think it would be somehow more similar to how Vue works.

Currently, as soon as you have a Reative component, any updates to the parent component will trigger a render on the child component... while i would expect it only to trigger child renders when a reactive prop is changed.

Is that by design?

I think a lot of apps would benefit to avoid those unnecessary renders.