### PR TITLE
Test Methods: Add Class Related Dusk Macros

### DIFF
--- a/src/Features/SupportTesting/DuskBrowserMacros.php
+++ b/src/Features/SupportTesting/DuskBrowserMacros.php
@@ -64,9 +64,92 @@ class DuskBrowserMacros
             PHPUnit::assertContains(
                 $className,
                 explode(' ', $this->attribute($selector, 'class')),
-                "Element [{$fullSelector}] missing class [{$className}]."
+                "Element [{$fullSelector}] is missing required class [{$className}]."
             );
 
+            return $this;
+        };
+    }
+
+    public function assertClassMissing()
+    {
+        return function ($selector, $className) {
+            /** @var \Laravel\Dusk\Browser $this */
+            $fullSelector = $this->resolver->format($selector);
+
+            PHPUnit::assertNotContains(
+                $className,
+                explode(' ', $this->attribute($selector, 'class')),
+                "Element [{$fullSelector}] has class that must be missing [{$className}]."
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertMissingClass()
+    {
+        // Map to existing method
+        return $this->assertClassMissing();
+    }
+
+    /**
+     * Ensures all classes in array are present
+     */
+    public function assertHasAllClasses()
+    {
+        return function ($selector, array $classNames) {
+            /** @var \Laravel\Dusk\Browser $this */
+            $fullSelector = $this->resolver->format($selector);
+
+            $invalidClasses = array_diff($classNames, explode(' ', $this->attribute($selector, 'class')));
+
+            PHPUnit::assertEmpty(
+                $invalidClasses,
+                "Element [{$fullSelector}] is missing required classes [".implode(" ", $invalidClasses)."]."
+            );
+            
+            return $this;
+        };
+
+    }
+
+    /**
+     * Ensures only classes in array are present
+     */
+    public function assertHasOnlyClasses()
+    {
+        return function ($selector, array $classNames) {
+            /** @var \Laravel\Dusk\Browser $this */
+            $fullSelector = $this->resolver->format($selector);
+
+            $invalidClasses = array_diff(explode(' ', $this->attribute($selector, 'class')), $classNames);
+
+            PHPUnit::assertEmpty(
+                $invalidClasses,
+                "Element [{$fullSelector}] has classes that must not be present [".implode(" ", $invalidClasses)."]."
+            );
+    
+            return $this;
+        };
+    }
+
+    /**
+     * Ensures all classes in array are missing
+     */
+    public function assertMissingAllClasses()
+    {
+        return function ($selector, array $classNames) {
+            /** @var \Laravel\Dusk\Browser $this */
+            $fullSelector = $this->resolver->format($selector);
+
+            $invalidClasses = array_intersect($classNames, explode(' ', $this->attribute($selector, 'class')));
+
+            PHPUnit::assertEmpty(
+                $invalidClasses,
+                "Element [{$fullSelector}] has classes that must be missing [".implode(" ", $invalidClasses)."]."
+            );
+            
             return $this;
         };
     }
@@ -128,22 +211,6 @@ class DuskBrowserMacros
             )[0];
 
             PHPUnit::assertEquals($invert ? false : true, $result);
-
-            return $this;
-        };
-    }
-
-    public function assertClassMissing()
-    {
-        return function ($selector, $className) {
-            /** @var \Laravel\Dusk\Browser $this */
-            $fullSelector = $this->resolver->format($selector);
-
-            PHPUnit::assertNotContains(
-                $className,
-                explode(' ', $this->attribute($selector, 'class')),
-                "Element [{$fullSelector}] has class [{$className}]."
-            );
 
             return $this;
         };


### PR DESCRIPTION
### Dusk Macros
This adds three new Dusk Macros for use in testing ,specifically in relation to HTML Classes.

This allows developers to pass an array of HTML Classes, and check for presence/absence in the resultant/rendered Component against a specified element.  This effectively extends the current  two existing methods:
assertHasClass/assertClassMissing

### The Problem
While you can presently use the assertHasClass/assertClassMissing, and write out multiple assertions in your Test it's not quite as intuitive if you're trying to check multiple classes are present/absent, or an element **only** has certain classes, as this involves having to add multiple assertions into your Test.

For example - checking that a table row has "text-black", "bg-white", and "text-xl" would result in three different assertions having to be written.
However - it won't detect that "text-blue" is also present in the element's class list, nor that it has a "hidden" class.

### Fix
To try and address this - in this PR are three new Macros, which allow for the use of an array of HTML classes, which should simplify checking for multiple HTML classes against an element found using the current HTML Selector approach.

#### assertMissingAllClasses
This is used to ensure that **all** classes in the $classNames array are missing from an element, i.e. you do not want any of the HTML classes to be present on an HTML Element.  It will fail if ANY of the HTML classes defined in the array **are** present.
For example - if passed "text-blue bg-black" it will not pass an element that has either of these present in it's classlist
```php
assertMissingAllClasses($selector, array $classNames) 
```

#### assertHasAllClasses
This is used to ensure that **all** classes in the $classNames array are present in an element.  It will fail if ANY of the HTML classes defined in the array **are not** present.
For example - if passed "text-blue bg-black" it will not pass an element that has neither of these present in it's classlist
```php
assertHasAllClasses($selector, array $classNames)
```

#### assertHasOnlyClasses
This is used to ensure that **only** classes in the $classNames array are present in an element, it differs from assertHasAllClasses in that any class in the element on the rendered component **must exist** in the array provided, but not all classes in the array are required to be present.
For example passing "text-blue bg-black" into it would permit an element with "text-blue bg-black", but not one that has "bg-white" in its classlist
```php
assertHasOnlyClasses($selector, array $classNames) 
```

In addition, one Alias
#### assertMissingClass()
This has been added but is just an alias for assertClassMissing, to try and get the naming convention consistent across all of these Macros
```php
assertMissingClass($selector, $className)
```

Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
It seems useful

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
This is a DuskMacros only

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
