### PR TITLE
Create dedicated EventHandlerDoesNotExist exception

### DIFF
--- a/src/Exceptions/EventHandlerDoesNotExist.php
+++ b/src/Exceptions/EventHandlerDoesNotExist.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Livewire\Exceptions;
+
+class EventHandlerDoesNotExist extends \Exception
+{
+    public function __construct(public readonly string $eventName)
+    {
+        parent::__construct('Handler for event ' . $eventName . ' does not exist');
+    }
+}

--- a/src/Features/SupportEvents/SupportEvents.php
+++ b/src/Features/SupportEvents/SupportEvents.php
@@ -6,8 +6,8 @@ use function Livewire\wrap;
 use function Livewire\store;
 use function Livewire\invade;
 use Livewire\Features\SupportAttributes\AttributeLevel;
-use Livewire\Features\SupportAttributes\AttributeCollection;
 use Livewire\ComponentHook;
+use Livewire\Exceptions\EventHandlerDoesNotExist;
 use Livewire\Mechanisms\HandleComponents\BaseRenderless;
 
 class SupportEvents extends ComponentHook
@@ -20,7 +20,7 @@ class SupportEvents extends ComponentHook
             $names = static::getListenerEventNames($this->component);
 
             if (! in_array($name, $names)) {
-                throw new \Exception('Handler for event ' . $name . ' does not exist');
+                throw new EventHandlerDoesNotExist($name);
             }
 
             $method = static::getListenerMethodName($this->component, $name);


### PR DESCRIPTION
Based on @calebporzio's [comment on a recent PR](https://github.com/livewire/livewire/pull/7846#issuecomment-1917922330) I created a dedicated `EventHandlerDoesNotExist` exception.

@calebporzio I'm up for going through the code base and creating dedicated Exception types out of all `throw new \Exception` calls, I found 22 places in the code where a basic exception is currently thrown outside of tests - is that something you'd merge?