### PR TITLE
FilePreviewController middleware from configuration

### DIFF
--- a/src/Features/SupportFileUploads/FilePreviewController.php
+++ b/src/Features/SupportFileUploads/FilePreviewController.php
@@ -8,11 +8,12 @@ use Livewire\Drawer\Utils;
 
 class FilePreviewController implements HasMiddleware
 {
-    public static array $middleware = ['web'];
-
     public static function middleware()
     {
-        return array_map(fn ($middleware) => new Middleware($middleware), static::$middleware);
+        return array_map(fn ($middleware) => new Middleware($middleware), array_merge(
+            ['web'],
+            (array) FileUploadConfiguration::middleware(),
+        ));
     }
 
     public function handle($filename)


### PR DESCRIPTION
On a multi tenant such as [archtechx/tenancy](https://github.com/archtechx/tenancy) in the views the [temporaryUrl()](https://github.com/livewire/livewire/blob/f1cd35802dd8ca47e8f187c67ce5cb74ce1a07ec/src/Features/SupportFileUploads/TemporaryUploadedFile.php#L89) method fails to correctly return the path to the tenant where the temporary file is on the livewire-tmp folder.

It is therefore necessary to pass to [FilePreviewController](https://github.com/livewire/livewire/blob/main/src/Features/SupportFileUploads/FilePreviewController.php) the middleware set in the Livewire configuration file (temporary_file_upload.middleware) as is already done on [FileUploadController](https://github.com/livewire/livewire/blob/main/src/Features/SupportFileUploads/FileUploadController.php)

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first? Related to multi-tenancy support

2️⃣ Did you create a branch for your fix/feature? Yes

3️⃣ Does it contain multiple, unrelated changes? No

4️⃣ Does it include tests? No

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌