### PR TITLE
document method from underlying assertions class

### DIFF
--- a/src/Features/SupportTesting/MakesAssertions.php
+++ b/src/Features/SupportTesting/MakesAssertions.php
@@ -6,6 +6,9 @@ use Illuminate\Testing\Constraints\SeeInOrder;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Support\Arr;
 
+/**
+ * @method self assertSeeInOrder(array $values, bool $escape) $this
+ */
 trait MakesAssertions
 {
     function assertSee($values, $escape = true, $stripInitialData = true)


### PR DESCRIPTION
This simply documents the magic `__call()` method call to [this test method](https://github.com/laravel/framework/blob/1d0f002172d1570389e72fb474d16a6996fc943d/src/Illuminate/Testing/TestResponse.php#L573-L580) in the Laravel framework.

This tells my IDE what the return type is so I can continue chaining on other test methods.