### PR TITLE
Flash data is being removed on initial render/dehydrate instead of subsequent renders

### DIFF
--- a/src/Features/SupportRedirects/SupportRedirects.php
+++ b/src/Features/SupportRedirects/SupportRedirects.php
@@ -21,8 +21,8 @@ class SupportRedirects extends ComponentHook
             if (! static::$atLeastOneComponentHasRedirected && app()->has('session.store')) {
                 foreach ($response['components'] as $component) {
                     $snapshot = json_decode($component['snapshot']);
-                    $id = $snapshot->memo->id;
-                    if (session()->has('_is_subsequent_request_for_'.$id)) {
+                    $id = $snapshot?->memo?->id;
+                    if (! $id || session()->has('_is_subsequent_request_for_'.$id)) {
                         session()->forget(session()->get('_flash.new'));
                         break;
                     } else {

--- a/src/Features/SupportRedirects/SupportRedirects.php
+++ b/src/Features/SupportRedirects/SupportRedirects.php
@@ -16,10 +16,19 @@ class SupportRedirects extends ComponentHook
     public static function provide()
     {
         // Wait until all components have been processed...
-        on('response', function () {
+        on('response', function ($response) {
             // If there was no redirect. Clear flash session data.
             if (! static::$atLeastOneComponentHasRedirected && app()->has('session.store')) {
-                session()->forget(session()->get('_flash.new'));
+                foreach ($response['components'] as $component) {
+                    $snapshot = json_decode($component['snapshot']);
+                    $id = $snapshot->memo->id;
+                    if (session()->has('_is_subsequent_request_for_'.$id)) {
+                        session()->forget(session()->get('_flash.new'));
+                        break;
+                    } else {
+                        session()->flash('_is_subsequent_request_for_'.$id, true);
+                    }
+                }
             }
         });
 

--- a/src/Features/SupportRedirects/UnitTest.php
+++ b/src/Features/SupportRedirects/UnitTest.php
@@ -186,6 +186,48 @@ class UnitTest extends \Tests\TestCase
         $this->assertNull($component->effects['html'] ?? null);
     }
 
+    /** @test */
+    public function flash_data_is_available_after_render()
+    {
+        session()->flash('foo', 'bar');
+        $this->assertEquals('bar', session()->get('foo'));
+
+        Livewire::test(RenderOnRedirectWithSkipRenderMethod::class)->call('$refresh');
+
+        $this->assertEquals('bar', session()->get('foo'));
+    }
+
+    /** @test */
+    public function flash_data_is_unavailable_after_subsequent_requests()
+    {
+        session()->flash('foo', 'bar');
+        $this->assertEquals('bar', session()->get('foo'));
+
+        $component = Livewire::test(RenderOnRedirectWithSkipRenderMethod::class);
+        $component->call('$refresh');
+
+        $this->assertEquals('bar', session()->get('foo'));
+
+        $component->call('$refresh');
+
+        $this->assertNull(session()->get('foo'));
+    }
+
+    /** @test */
+    public function flash_data_is_available_after_render_of_multiple_components()
+    {
+        session()->flash('foo', 'bar');
+        $this->assertEquals('bar', session()->get('foo'));
+
+        $component1 = Livewire::test(RenderOnRedirectWithSkipRenderMethod::class);
+        $component1->call('$refresh');
+
+        $component2 = Livewire::test(RenderOnRedirectWithSkipRenderMethod::class);
+        $component2->call('$refresh');
+
+        $this->assertEquals('bar', session()->get('foo'));
+    }
+
     protected function registerNamedRoute()
     {
         Route::get('foo', function () {

--- a/src/Features/SupportRedirects/UnitTest.php
+++ b/src/Features/SupportRedirects/UnitTest.php
@@ -339,10 +339,6 @@ HTML;
 
 class RenderOnRedirectWithSkipRenderMethod extends Component
 {
-    function mount() {
-
-    }
-
     function triggerRedirect()
     {
         $this->skipRender();

--- a/src/Features/SupportRedirects/UnitTest.php
+++ b/src/Features/SupportRedirects/UnitTest.php
@@ -192,7 +192,7 @@ class UnitTest extends \Tests\TestCase
         session()->flash('foo', 'bar');
         $this->assertEquals('bar', session()->get('foo'));
 
-        Livewire::test(RenderOnRedirectWithSkipRenderMethod::class)->call('$refresh');
+        Livewire::test(RenderOnRedirectWithSkipRenderMethod::class);
 
         $this->assertEquals('bar', session()->get('foo'));
     }
@@ -204,7 +204,6 @@ class UnitTest extends \Tests\TestCase
         $this->assertEquals('bar', session()->get('foo'));
 
         $component = Livewire::test(RenderOnRedirectWithSkipRenderMethod::class);
-        $component->call('$refresh');
 
         $this->assertEquals('bar', session()->get('foo'));
 
@@ -220,12 +219,14 @@ class UnitTest extends \Tests\TestCase
         $this->assertEquals('bar', session()->get('foo'));
 
         $component1 = Livewire::test(RenderOnRedirectWithSkipRenderMethod::class);
-        $component1->call('$refresh');
 
         $component2 = Livewire::test(RenderOnRedirectWithSkipRenderMethod::class);
-        $component2->call('$refresh');
 
         $this->assertEquals('bar', session()->get('foo'));
+
+        $component1->call('$refresh');
+
+        $this->assertNull(session()->get('foo'));
     }
 
     protected function registerNamedRoute()
@@ -338,6 +339,10 @@ HTML;
 
 class RenderOnRedirectWithSkipRenderMethod extends Component
 {
+    function mount() {
+
+    }
+
     function triggerRedirect()
     {
         $this->skipRender();

--- a/src/Mechanisms/HandleComponents/ComponentContext.php
+++ b/src/Mechanisms/HandleComponents/ComponentContext.php
@@ -15,6 +15,11 @@ class ComponentContext
         public $mounting = false,
     ) {}
 
+    public function isMounting()
+    {
+        return $this->mounting;
+    }
+
     public function addEffect($key, $value)
     {
         if (is_array($key)) {


### PR DESCRIPTION
We use flash data at the bottom of a page to display alerts/toasts, not in a component. V2 of Livewire wouldn't clear flash data on the initial dehydrate, but would wait until a subsequent dehydrate. V3 of Livewire clears flash data when the component renders. 

Here is a wirebox showcasing the issue: https://wirebox.app/b/x6r67

SupportsRedirects.php in v2 Livewire
```php
        Livewire::listen('component.dehydrate.subsequent', function ($component, $response) {
            // If there was no redirect. Clear flash session data.
            if (empty($component->redirectTo) && app()->has('session.store')) {
                session()->forget(session()->get('_flash.new'));

                return;
            }
        });
```

SupportsRedirects.php in v3 Livewire
```php
    public function dehydrate($context)
    {
        // Put the old redirector back into the container.
        app()->instance('redirect', array_pop(static::$redirectorCacheStack));

        $to = $this->storeGet('redirect');
        $usingNavigate = $this->storeGet('redirectUsingNavigate');

        if (is_subclass_of($to, Component::class)) {
            $to = url()->action($to);
        }

        if ($to && ! app(HandleRequests::class)->isLivewireRequest()) {
            abort(redirect($to));
        }

        if (! $to) {
            // If there was no redirect. Clear flash session data.
            if (app()->has('session.store')) {
                session()->forget(session()->get('_flash.new'));
            }

            return;
        }

        $context->addEffect('redirect', $to);
        $usingNavigate && $context->addEffect('redirectUsingNavigate', true);
    }
```

