### PR TITLE
Docs: alternative to wire:transition for loops

### DIFF
--- a/docs/wire-transition.md
+++ b/docs/wire-transition.md
@@ -48,6 +48,16 @@ Currently, `wire:transition` is only supported on a single element inside a Blad
 
 If one of the above comment `<li>` elements were to get removed, you would expect Livewire to transition it out. However, because of hurdles with Livewire's underlying "morph" mechanism, this will not be the case. There is currently no way to transition dynamic lists in Livewire using `wire:transition`.
 
+As an alternative, you can use [AutoAnimate](https://auto-animate.formkit.com) library with this [Alpine.js wrapper](https://github.com/marcreichel/alpine-auto-animate). Here is a example code below:
+
+```blade
+<ul x-auto-animate>
+    @foreach ($post->comments as $comment)
+        <li wire:key="{{ $comment->id }}">{{ $comment->content }}</li>
+    @endforeach
+</ul>
+```
+
 ## Default transition style
 
 By default, Livewire applies both an opacity and a scale CSS transition to elements with `wire:transtion`. Here's a visual preview:


### PR DESCRIPTION
With #7257 I looked for an alternative and found that AutoAnimate works great for this limitation.

Since you [told me on Twitter](https://x.com/calebporzio/status/1749604669557457334?s=46&t=Y9VGtT5ZjYQU4aUVcHgn_Q) that you would be interested in a PR proposing an alternative, here it is!

I also wrote a full article [about it on my bog](https://srwiez.com/posts/how-to-have-transition-working-with-dynamic-list-on-livewire) this morning.
