### PR TITLE
Update alpine.md

### DIFF
--- a/docs/alpine.md
+++ b/docs/alpine.md
@@ -1,5 +1,5 @@
 
-[AlpineJS](https://alpinejs.dev/) is a lightweight JavaScript library that makes it easy to add client-side interactivity to your web pages. It was originally built to compliment tools like Livewire where a more JavaScript-centric utility is helpful for sprinkling interactivity around your app.
+[AlpineJS](https://alpinejs.dev/) is a lightweight JavaScript library that makes it easy to add client-side interactivity to your web pages. It was originally built to complement tools like Livewire where a more JavaScript-centric utility is helpful for sprinkling interactivity around your app.
 
 Livewire ships with Alpine out of the box so there is no need to install it into your project separately.
 


### PR DESCRIPTION
Super small change: In this context, the correct spelling should be "complement" (with an "e", not an "i"). 

Compliment refers to saying something nice, while complement refers to something that completes or fits well with something else.

