### PR TITLE
Fix flaky navigate test

### DIFF
--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -468,13 +468,18 @@ class BrowserTest extends \Tests\BrowserTestCase
                 ->assertNotInViewPort('@first-target')
                 ->scrollTo('@first-target')
                 ->assertInViewPort('@first-target')
+
                 ->click('@link.to.second')
                 ->waitForText('On second')
                 ->assertNotInViewPort('@second-target')
                 ->scrollTo('@second-target')
+
                 ->back()
+                ->waitForText('On first')
                 ->assertInViewPort('@first-target')
+
                 ->forward()
+                ->waitForText('On second')
                 ->assertInViewPort('@second-target')
             ;
         });


### PR DESCRIPTION
The `navigate_scrolls_to_top_and_back_preserves_scroll` seems to be failing randomly on most PRs. This PR fixes that.

I've run the test suite a few times to ensure it does actually fix the issue.

<img width="1182" alt="image" src="https://github.com/livewire/livewire/assets/882837/881323d1-040b-4189-b393-741b55b8b2f2">
