### PR TITLE
Add `wire:stream` and Laravel Octane warning

### DIFF
--- a/docs/wire-stream.md
+++ b/docs/wire-stream.md
@@ -1,6 +1,9 @@
 
 Livewire allows you to stream content to a web page before a request is complete via the `wire:stream` API. This is an extremely useful feature for things like AI chat-bots which stream responses as they are generated.
 
+> [!warning] Not compatible with Laravel Octane
+> Livewire currently does not support using `wire:stream` with Laravel Octane.
+
 To demonstrate the most basic functionality of `wire:stream`, below is a simple CountDown component that when a button is pressed displays a count-down to the user from "3" to "0":
 
 ```php


### PR DESCRIPTION
Add a warning to `wire:stream` docs that Laravel Octane isn't currently supported.

<img width="807" alt="image" src="https://github.com/livewire/livewire/assets/882837/65ddbf7e-8488-4884-8562-c8bcc4c0bb94">
