### PR TITLE
Save latest Alpine (v3.13.5) in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,15 +7,15 @@
             "name": "laravel-livewire",
             "license": "MIT",
             "dependencies": {
-                "@alpinejs/anchor": "^3.13.3",
-                "@alpinejs/collapse": "^3.10.5",
-                "@alpinejs/focus": "^3.10.5",
-                "@alpinejs/intersect": "^3.10.5",
-                "@alpinejs/mask": "^3.10.5",
-                "@alpinejs/morph": "^3.10.5",
-                "@alpinejs/persist": "^3.10.5",
+                "@alpinejs/anchor": "^3.13.5",
+                "@alpinejs/collapse": "^3.13.5",
+                "@alpinejs/focus": "^3.13.5",
+                "@alpinejs/intersect": "^3.13.5",
+                "@alpinejs/mask": "^3.13.5",
+                "@alpinejs/morph": "^3.13.5",
+                "@alpinejs/persist": "^3.13.5",
                 "@vue/reactivity": "^3.2.45",
-                "alpinejs": "^3.10.5",
+                "alpinejs": "^3.13.5",
                 "nprogress": "^0.2.0"
             },
             "devDependencies": {
@@ -24,43 +24,43 @@
             }
         },
         "node_modules/@alpinejs/anchor": {
-            "version": "3.13.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.13.3.tgz",
-            "integrity": "sha512-Th2ddbS64GYQ6iVkaiKxdkqi1CJ7nq8Ar+/ysWWzZk+spe41ACtlRPRpi2503wrHHovIKnTTfJ2ZLc8nu5rw6Q=="
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.13.5.tgz",
+            "integrity": "sha512-SfCW3DvuO3dDZ0jyck/4TiGNAhGAml1htPpYDq7SolA11YQGYjhHCK7Tsi4kgOJAyseE7oV91AI+DCj9xMcPDw=="
         },
         "node_modules/@alpinejs/collapse": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.13.1.tgz",
-            "integrity": "sha512-EFJmrz7JVY0QC85Y/sD0A3Jo7B8WeI/XmLZbF2nkGUzv042qm13io1thor/Pr5ARgPuev3tJdH0yfemDdfpDJg=="
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.13.5.tgz",
+            "integrity": "sha512-LHtSF/T3Zrhr0WOeVm4ebdXNH6ftqoZMbmkBTU1n/j8r0joV3oLUsPCyn5qOU8+27d2P/N2a057etOm0MH60oQ=="
         },
         "node_modules/@alpinejs/focus": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.13.1.tgz",
-            "integrity": "sha512-wVM5fyM864q+U5YEyPGEwY7lOGJGei10hFjivWaB1TxE5eN9bWFaFK6UJ+7FOYOglwUT90NBdmntZi7RNS1KGQ==",
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.13.5.tgz",
+            "integrity": "sha512-ViZ1W9M3/leZKNdsMyTZvGCu2DPMyUSbRwrbGNOnCkzHMHOIP6zdGpzPkD+1HyhQ2SuG7wRgf7YlrPnlE6tMqA==",
             "dependencies": {
                 "focus-trap": "^6.9.4",
                 "tabbable": "^5.3.3"
             }
         },
         "node_modules/@alpinejs/intersect": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.13.1.tgz",
-            "integrity": "sha512-4M6X0tPCNB+ibXL9vyVgUvY2ZYMrBRly1L9N5iMN6p72Capm94e/sLwD76c9QKxUhr52rsoyUopjbGNqVJVrDw=="
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.13.5.tgz",
+            "integrity": "sha512-wBveYNRuZoFFirRq4GmUx1JgD5/7S9b10l8Ps5wQJX/deiRXTY8f1Op0zVTkmIoHLpXyouSsOZz9/U/lPU3NZw=="
         },
         "node_modules/@alpinejs/mask": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.13.1.tgz",
-            "integrity": "sha512-AFJO4v4z0PPLw7FAJGCsNATBsYFBry41dFwTSBQabUaqwXFaHeD/uALhNpjv4QXHBHo8Q4j4dpcJulOlO89Cvg=="
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.13.5.tgz",
+            "integrity": "sha512-cYUvqZFjm66TSrjjOcKzRTfdtLZdLm+kXLKG+riECWttIwhwrG8wUsngpPn7UTzIATulRNAT+i/OdzXy1wDerQ=="
         },
         "node_modules/@alpinejs/morph": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.13.1.tgz",
-            "integrity": "sha512-7QsJiWBIPhDOVsdXWj5pckwE5GHIQscnvfGcq0MlG10K6MFAe2xBdDqywlGn6JY9kCdnhV8JzzzSDxM02EzhzQ=="
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.13.5.tgz",
+            "integrity": "sha512-nuyONu4Fmms2udx7z6H0fC25i6S70Z7iREsrWHIu/67iBCum9nusF3cZKWQ3mWOovQYiKpEuuvDT0GoLLVlp7A=="
         },
         "node_modules/@alpinejs/persist": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.13.1.tgz",
-            "integrity": "sha512-sj+IO+Lk0S3irYuZp544I1f07aW8P5UQC5U1HPciyeUFDtz4+C7y/+u8ntzccv2lqHIVAL/K9bCi2DX7zUoKeg=="
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.13.5.tgz",
+            "integrity": "sha512-nmULi5Kp/v5/h4FtGpqyzzMPlulc2fmQ+Olhk0NwTcBKSCZDg6OtXgS998rnHpcWO0jsjCmvXn/Pul2av7D8lA=="
         },
         "node_modules/@vue/reactivity": {
             "version": "3.2.45",
@@ -76,9 +76,9 @@
             "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg=="
         },
         "node_modules/alpinejs": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.13.1.tgz",
-            "integrity": "sha512-/LZ7mumW02V7AV5xTTftJFHS0I3KOXLl7tHm4xpxXAV+HJ/zjTT0n8MU7RZ6UoGPhmO/i+KEhQojaH/0RsH5tg==",
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.13.5.tgz",
+            "integrity": "sha512-1d2XeNGN+Zn7j4mUAKXtAgdc4/rLeadyTMWeJGXF5DzwawPBxwTiBhFFm6w/Ei8eJxUZeyNWWSD9zknfdz1kEw==",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
             }
@@ -490,43 +490,43 @@
     },
     "dependencies": {
         "@alpinejs/anchor": {
-            "version": "3.13.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.13.3.tgz",
-            "integrity": "sha512-Th2ddbS64GYQ6iVkaiKxdkqi1CJ7nq8Ar+/ysWWzZk+spe41ACtlRPRpi2503wrHHovIKnTTfJ2ZLc8nu5rw6Q=="
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.13.5.tgz",
+            "integrity": "sha512-SfCW3DvuO3dDZ0jyck/4TiGNAhGAml1htPpYDq7SolA11YQGYjhHCK7Tsi4kgOJAyseE7oV91AI+DCj9xMcPDw=="
         },
         "@alpinejs/collapse": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.13.1.tgz",
-            "integrity": "sha512-EFJmrz7JVY0QC85Y/sD0A3Jo7B8WeI/XmLZbF2nkGUzv042qm13io1thor/Pr5ARgPuev3tJdH0yfemDdfpDJg=="
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.13.5.tgz",
+            "integrity": "sha512-LHtSF/T3Zrhr0WOeVm4ebdXNH6ftqoZMbmkBTU1n/j8r0joV3oLUsPCyn5qOU8+27d2P/N2a057etOm0MH60oQ=="
         },
         "@alpinejs/focus": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.13.1.tgz",
-            "integrity": "sha512-wVM5fyM864q+U5YEyPGEwY7lOGJGei10hFjivWaB1TxE5eN9bWFaFK6UJ+7FOYOglwUT90NBdmntZi7RNS1KGQ==",
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.13.5.tgz",
+            "integrity": "sha512-ViZ1W9M3/leZKNdsMyTZvGCu2DPMyUSbRwrbGNOnCkzHMHOIP6zdGpzPkD+1HyhQ2SuG7wRgf7YlrPnlE6tMqA==",
             "requires": {
                 "focus-trap": "^6.9.4",
                 "tabbable": "^5.3.3"
             }
         },
         "@alpinejs/intersect": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.13.1.tgz",
-            "integrity": "sha512-4M6X0tPCNB+ibXL9vyVgUvY2ZYMrBRly1L9N5iMN6p72Capm94e/sLwD76c9QKxUhr52rsoyUopjbGNqVJVrDw=="
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.13.5.tgz",
+            "integrity": "sha512-wBveYNRuZoFFirRq4GmUx1JgD5/7S9b10l8Ps5wQJX/deiRXTY8f1Op0zVTkmIoHLpXyouSsOZz9/U/lPU3NZw=="
         },
         "@alpinejs/mask": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.13.1.tgz",
-            "integrity": "sha512-AFJO4v4z0PPLw7FAJGCsNATBsYFBry41dFwTSBQabUaqwXFaHeD/uALhNpjv4QXHBHo8Q4j4dpcJulOlO89Cvg=="
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.13.5.tgz",
+            "integrity": "sha512-cYUvqZFjm66TSrjjOcKzRTfdtLZdLm+kXLKG+riECWttIwhwrG8wUsngpPn7UTzIATulRNAT+i/OdzXy1wDerQ=="
         },
         "@alpinejs/morph": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.13.1.tgz",
-            "integrity": "sha512-7QsJiWBIPhDOVsdXWj5pckwE5GHIQscnvfGcq0MlG10K6MFAe2xBdDqywlGn6JY9kCdnhV8JzzzSDxM02EzhzQ=="
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.13.5.tgz",
+            "integrity": "sha512-nuyONu4Fmms2udx7z6H0fC25i6S70Z7iREsrWHIu/67iBCum9nusF3cZKWQ3mWOovQYiKpEuuvDT0GoLLVlp7A=="
         },
         "@alpinejs/persist": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.13.1.tgz",
-            "integrity": "sha512-sj+IO+Lk0S3irYuZp544I1f07aW8P5UQC5U1HPciyeUFDtz4+C7y/+u8ntzccv2lqHIVAL/K9bCi2DX7zUoKeg=="
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.13.5.tgz",
+            "integrity": "sha512-nmULi5Kp/v5/h4FtGpqyzzMPlulc2fmQ+Olhk0NwTcBKSCZDg6OtXgS998rnHpcWO0jsjCmvXn/Pul2av7D8lA=="
         },
         "@vue/reactivity": {
             "version": "3.2.45",
@@ -542,9 +542,9 @@
             "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg=="
         },
         "alpinejs": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.13.1.tgz",
-            "integrity": "sha512-/LZ7mumW02V7AV5xTTftJFHS0I3KOXLl7tHm4xpxXAV+HJ/zjTT0n8MU7RZ6UoGPhmO/i+KEhQojaH/0RsH5tg==",
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.13.5.tgz",
+            "integrity": "sha512-1d2XeNGN+Zn7j4mUAKXtAgdc4/rLeadyTMWeJGXF5DzwawPBxwTiBhFFm6w/Ei8eJxUZeyNWWSD9zknfdz1kEw==",
             "requires": {
                 "@vue/reactivity": "~3.1.1"
             },

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
         "esbuild": "^0.14.49"
     },
     "dependencies": {
-        "@alpinejs/anchor": "^3.13.3",
-        "@alpinejs/collapse": "^3.10.5",
-        "@alpinejs/focus": "^3.10.5",
-        "@alpinejs/intersect": "^3.10.5",
-        "@alpinejs/mask": "^3.10.5",
-        "@alpinejs/morph": "^3.10.5",
-        "@alpinejs/persist": "^3.10.5",
+        "@alpinejs/anchor": "^3.13.5",
+        "@alpinejs/collapse": "^3.13.5",
+        "@alpinejs/focus": "^3.13.5",
+        "@alpinejs/intersect": "^3.13.5",
+        "@alpinejs/mask": "^3.13.5",
+        "@alpinejs/morph": "^3.13.5",
+        "@alpinejs/persist": "^3.13.5",
         "@vue/reactivity": "^3.2.45",
-        "alpinejs": "^3.10.5",
+        "alpinejs": "^3.13.5",
         "nprogress": "^0.2.0"
     }
 }


### PR DESCRIPTION
The `package-lock.json` file now contains an incompatible set of packages.

* `@alpinejs/anchor` is locked to 3.13.3
* `alpinejs` is locked to 3.13.1
* `@alpinejs/anchor` uses `Alpine.interceptClone`
* `Alpine.interceptClone` was added in `alpinejs` 3.13.3

This results in `Uncaught TypeError: Alpine3.interceptClone is not a function` when running Dusk