### PR TITLE
Fix deferred loading with alpine

### DIFF
--- a/src/Features/SupportDeferredLoading/BrowserTest.php
+++ b/src/Features/SupportDeferredLoading/BrowserTest.php
@@ -78,13 +78,11 @@ class BrowserTest extends BrowserTestCase
                     <div>
                         <button dusk="load" wire:click="loadUsers">Load Users</button>
                         <div x-data="{ users: @js($this->users) }">
-                            <template x-if="users.length > 0">
-                                <ul>
-                                    <template x-for="user in users" :key="user.id">
-                                        <li x-text="user.name"></li>
-                                    </template>
-                                </ul>
-                            </template>
+                            <ul>
+                                <template x-for="user in users" :key="user.id">
+                                    <li x-text="user.name"></li>
+                                </template>
+                            </ul>
                         </div>
                     </div>
                 BLADE;

--- a/src/Features/SupportDeferredLoading/BrowserTest.php
+++ b/src/Features/SupportDeferredLoading/BrowserTest.php
@@ -12,7 +12,7 @@ use Illuminate\Foundation\Auth\User as AuthUser;
 class BrowserTest extends BrowserTestCase
 {
     /** @test */
-    public function can_defer_loading_a_collection_of_models_in_blade()
+    public function can_defer_loading_of_a_collection_of_models_in_blade()
     {
         Livewire::visit(new class extends Component {
             public bool $load = false;
@@ -53,7 +53,7 @@ class BrowserTest extends BrowserTestCase
     }
 
     /** @test */
-    public function can_defer_loading_a_collection_of_models_into_alpine_state()
+    public function can_defer_loading_of_a_collection_of_models_into_alpine_state()
     {
         Livewire::visit(new class extends Component {
             public bool $load = false;

--- a/src/Features/SupportDeferredLoading/BrowserTest.php
+++ b/src/Features/SupportDeferredLoading/BrowserTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Livewire\Features\SupportDeferredLoading;
+
+use Sushi\Sushi;
+use Livewire\Livewire;
+use Livewire\Component;
+use Tests\BrowserTestCase;
+use Livewire\Attributes\Computed;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class BrowserTest extends BrowserTestCase
+{
+    /** @test */
+    public function can_defer_loading_a_collection_of_models_in_blade()
+    {
+        Livewire::visit(new class extends Component {
+            public bool $load = false;
+
+            public function loadUsers(): void
+            {
+                $this->load = true;
+                unset($this->users);
+            }
+
+            #[Computed]
+            public function users(): \Illuminate\Support\Collection
+            {
+                return $this->load
+                    ? User::query()->limit(2)->get()
+                    : collect();
+            }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <button dusk="load" wire:click="loadUsers">Load Users</button>
+                        <ul>
+                            @foreach ($this->users as $user)
+                                <li wire:key="{{ $user->id }}">{{ $user->name }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertDontSee('First User')
+            ->assertDontSee('Second User')
+            ->waitForLivewire()->click('@load')
+            ->assertSee('First User')
+            ->assertSee('Second User');
+    }
+
+    /** @test */
+    public function can_defer_loading_a_collection_of_models_into_alpine_state()
+    {
+        Livewire::visit(new class extends Component {
+            public bool $load = false;
+
+            public function loadUsers(): void
+            {
+                $this->load = true;
+                unset($this->users);
+            }
+
+            #[Computed]
+            public function users(): \Illuminate\Support\Collection
+            {
+                return $this->load
+                    ? User::query()->inRandomOrder()->limit(2)->get()
+                    : collect();
+            }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <button dusk="load" wire:click="loadUsers">Load Users</button>
+                        <div x-data="{ users: @js($this->users) }">
+                            <template x-if="users.length > 0">
+                                <ul>
+                                    <template x-for="user in users" :key="user.id">
+                                        <li x-text="user.name"></li>
+                                    </template>
+                                </ul>
+                            </template>
+                        </div>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertDontSee('First User')
+            ->assertDontSee('Second User')
+            ->waitForLivewire()->click('@load')
+            ->assertSee('First User')
+            ->assertSee('Second User');
+    }
+}
+
+class User extends AuthUser
+{
+    use Sushi;
+
+    protected $rows = [
+        [
+            'id' => 1,
+            'name' => 'First User',
+            'email' => 'first@laravel-livewire.com',
+            'password' => '',
+        ],
+        [
+            'id' => 2,
+            'name' => 'Second User',
+            'email' => 'second@laravel-livewire.com',
+            'password' => '',
+        ],
+    ];
+}


### PR DESCRIPTION
This relates to: https://github.com/livewire/livewire/discussions/7475

After upgrading an app from v2 to v3 there's a bug with [deferred loading logic](https://laravel-livewire.com/docs/2.x/defer-loading) that was previously working in v2.

Take the following component for example that previously worked:

```php
class DeferExample extends Component
{
    public bool $load = false;

    public function loadUsers(): void
    {
        $this->load = true;
    }

    public function render()
    {
        return view('livewire.defer-example', [
            'users' => $this->load
                ? User::query()->inRandomOrder()->limit(5)->get()
                : collect(),
        ]);
    }
}
```
```blade
<div>
    <button wire:click.prevent="loadUsers">Load</button>
    <div x-data="{ users: @js($users) }">
        <template x-for="user in users" :key="user.id">
            <div x-text="user.name"></div>
        </template>
    </div>
</div>

```
Now in v3 this is broken and outputs this error to the console:
```console
Alpine Expression Error: user is not defined

Expression: "user.name"
```
And this is the source code throwing the exception:
```js
(async function anonymous(__self,scope
) {
with (scope) { __self.result = user.name }; __self.finished = true; return __self.result;
})
```

As instructed by @joshhanley I've opened this PR with a failing test that replicates the above scenario in a browser test.

Main goal of this PR is to support deferred loading functionality which was possible in v2 and I think this is a genuine bug worth looking into because after initially upgrading to v3 I had similar alpine expression errors like this one happening almost everywhere. But after upgrading to the latest version (3.4.4) they all seem to be gone except for this one error which is still happening.

The two test cases added cover a pure blade implementation of deferred loading which works fine and passes as expected but the second test case added is for deferred loading of data into an alpine component which fails.