### PR TITLE
EnumSynth tryFrom

### DIFF
--- a/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
@@ -16,7 +16,7 @@ class EnumSynth extends Synth {
     static function hydrateFromType($type, $value) {
         if ($value === '') return null;
 
-        return $type::from($value);
+        return $type::tryFrom($value);
     }
 
     function dehydrate($target) {
@@ -31,6 +31,6 @@ class EnumSynth extends Synth {
 
         $class = $meta['class'];
 
-        return $class::from($value);
+        return $class::tryFrom($value);
     }
 }


### PR DESCRIPTION
When hydrating within `EnumSynth` use `tryFrom()` instead of `from()`. The following describes a use case scenario using enums for select options. For example, the enum:

```php
<?php

namespace App\Enums;

enum Status: string
{
    case ENABLED = 'enabled';
    case DISABLED = 'disabled';
}
```

The Livewire form component:

```php
<?php

namespace App\Livewire\Forms;

use App\Enums\Status;
use Illuminate\Validation\Rule;
use Livewire\Form;

class AccountForm extends Form
{
    public ?Status $status = null;

    public function rules(): array
    {
        return [
            'status' => ['nullable', Rule::enum(Status::class)],
        ];
    }
}
```

The Blade template:

```blade
<select wire:model="form.status">
    <option>Show All</option>

    @foreach(\App\Enums\Status::cases() as $status)
        <option value="{{ $status->value }}">{{ $status->name }}</option>
    @endforeach
</select>
```

Selecting one of the enum options works as expected. When attempting to clear the input via the empty `<option>`, we'll see the following error:

```
ValueError  "" is not a valid backing value for enum "App\Enums\Status".
```

Another way to quickly show the issue is via `tinker`:

```
$ php artisan tinker
> \App\Enums\Status::from('')

   ValueError  "" is not a valid backing value for enum "App\Enums\Status".

> \App\Enums\Status::tryFrom('')
= null
```