### PR TITLE
Failing Test: Morph Marker when If contains calculation

### DIFF
--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -47,6 +47,23 @@ class UnitTest extends \Tests\TestCase
     }
 
     #[Test]
+    public function handles_if_statements_with_calculation_inside()
+    {
+        Livewire::component('foo', new class extends \Livewire\Component {
+            public $someProperty = 1.5;
+
+            public function render() {
+                return '<div> @if ($someProperty > 0) <span> {{ $someProperty }} </span> @endif </div>';
+            }
+        });
+
+        $output = Blade::render('<livewire:foo />');
+
+        $this->assertOccurrences(1, '<!--[if BLOCK]><![endif]-->', $output);
+        $this->assertOccurrences(1, '<!--[if ENDBLOCK]><![endif]-->', $output);
+    }
+
+    #[Test]
     #[DataProvider('templatesProvider')]
     function foo($occurrences, $template, $expectedCompiled = null)
     {


### PR DESCRIPTION
This bug is related to [Discussion 7819](https://github.com/livewire/livewire/discussions/7819) &  [Discussion 6663](https://github.com/livewire/livewire/discussions/6663).

Recently I run into a bug caused by Injecting Morph Markers, which causes the following error in the console.

<img width="427" alt="Screenshot 2024-02-14 at 6 16 45 PM" src="https://github.com/livewire/livewire/assets/4334696/206ee29c-e53d-4eea-a72a-0cb951c5618c">

This is the basic setup to replicate the issue:

```php
class Todo extends Component
{
    public $someProperty = 1.5;
    
    public function render() 
    {
        return '<div> @if ($someProperty > 0) <span> {{ $someProperty }} </span> @endif </div>';
    }
}
```

Instead of wrapping the `span`element with `<!--[if BLOCK]><![endif]-->` & `<!--[if ENDBLOCK]><![endif]-->`, it only renders the ENDBLOCK.
```html
<div>
    <span> 1.5 </span>
    <!--[if ENDBLOCK]><![endif]-->
</div>
```