### PR TITLE
EnumSynth: Fix synthing empty string into null

### DIFF
--- a/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
@@ -27,7 +27,7 @@ class EnumSynth extends Synth {
     }
 
     function hydrate($value, $meta) {
-        if ($value === null) return null;
+        if ($value === null || $value === '') return null;
 
         $class = $meta['class'];
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -4,6 +4,7 @@ namespace Livewire\Mechanisms\HandleComponents\Synthesizers\Tests;
 
 use Livewire\Component;
 use Livewire\Livewire;
+use ValueError;
 
 class EnumUnitTest extends \Tests\TestCase
 {
@@ -14,6 +15,18 @@ class EnumUnitTest extends \Tests\TestCase
             ->call('storeTypeOf')
             ->assertSet('typeOf', TestingEnum::class)
             ->assertSet('enum', TestingEnum::from('Be excellent to each other'));
+    }
+
+    /** @test */
+    public function nullable_public_property_can_be_cast()
+    {
+        $testable = Livewire::test(ComponentWithNullablePublicEnumCaster::class)
+            ->assertSet('status', null, true)
+            ->updateProperty('status', 'Be excellent to each other')
+            ->assertSet('status', TestingEnum::TEST);
+
+        $this->expectException(ValueError::class);
+        $testable->updateProperty('status', 'Be excellent excellent to each other');
     }
 }
 
@@ -46,6 +59,16 @@ class ComponentWithPublicEnumCasters extends Component
     {
         $this->typeOf = get_class($this->enum);
     }
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}
+
+class ComponentWithNullablePublicEnumCaster extends Component
+{
+    public ?TestingEnum $status = null;
 
     public function render()
     {

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -23,7 +23,9 @@ class EnumUnitTest extends \Tests\TestCase
         $testable = Livewire::test(ComponentWithNullablePublicEnumCaster::class)
             ->assertSet('status', null, true)
             ->updateProperty('status', 'Be excellent to each other')
-            ->assertSet('status', TestingEnum::TEST);
+            ->assertSet('status', TestingEnum::TEST)
+            ->updateProperty('status', '')
+            ->assertSet('status', null, true);
 
         $this->expectException(ValueError::class);
         $testable->updateProperty('status', 'Be excellent excellent to each other');


### PR DESCRIPTION
This is a fix for the bug reported first in #7948.

Currently, I can set a public property of a component to have a nullable enum as type. It works well to assign an enum case to it, however, it doesn't work, trying to set that property to an empty value:

```php
class Foo extends Component {
  public ?StatusFilterEnum $status = null;
}
```

```html
<select wire:model="filter">
  <option value="">Show all</option> <!-- selecting this breaks -->
  <option value="active">Show only active users</option>
  ...
</select>
```

This PR fixes the logic in EnumSynth to be the same as in other synths (like IntSynth) to convert also empty strings into `null`.
