### PR TITLE
Fix `CarbonSynth` to use type matching

### DIFF
--- a/src/Mechanisms/HandleComponents/Synthesizers/CarbonSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CarbonSynth.php
@@ -27,6 +27,10 @@ class CarbonSynth extends Synth {
         return false;
     }
 
+    static function matchByType($type) {
+        return is_subclass_of($type, DateTimeInterface::class);
+    }
+
     function dehydrate($target) {
         return [
             $target->format(DateTimeInterface::ATOM),
@@ -34,7 +38,15 @@ class CarbonSynth extends Synth {
         ];
     }
 
+    static function hydrateFromType($type, $value) {
+        if ($value === '' || $value === null) return null;
+
+        return new $type($value);
+    }
+
     function hydrate($value, $meta) {
+        if ($value === '' || $value === null) return null;
+
         return new static::$types[$meta['type']]($value);
     }
 }

--- a/src/Mechanisms/HandleComponents/Synthesizers/Synth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Synth.php
@@ -44,7 +44,7 @@ abstract class Synth {
         }
 
         if ($method === 'hydrateFromType') {
-            throw new \Exception('You must define a "hydrate" method');
+            throw new \Exception('You must define a "hydrateFromType" method');
         }
 
         if ($method === 'get') {

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\Synthesizers\Tests;
+
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class CarbonSynthUnitTest extends \Tests\TestCase
+{
+    /** @test */
+    public function public_carbon_properties_can_be_cast()
+    {
+        $testable = Livewire::test(ComponentWithPublicCarbonCaster::class)
+            ->updateProperty('date', '2024-02-14')
+            ->assertSet('date', Carbon::parse('2024-02-14'));
+
+        $this->expectException(\Exception::class);
+        $testable->updateProperty('date', 'Bad Date');
+    }
+
+    /** @test */
+    public function public_carbon_properties_throws_exception_when_set_to_null_cast()
+    {
+        $this->expectException(\Exception::class);
+        $testable = Livewire::test(ComponentWithPublicCarbonCaster::class)
+            ->updateProperty('date', null);
+    }
+
+    /** @test */
+    public function public_nullable_carbon_properties_can_be_cast()
+    {
+        $testable = Livewire::test(ComponentWithNullablePublicCarbonCaster::class)
+            ->assertSet('date', null, true)
+            ->updateProperty('date', '2024-02-14')
+            ->assertSet('date', Carbon::parse('2024-02-14'))
+            ->updateProperty('date', '')
+            ->assertSet('date', null, true)
+            ->updateProperty('date', null)
+            ->assertSet('date', null, true);
+
+        $this->expectException(\Exception::class);
+        $testable->updateProperty('date', 'Bad Date');
+    }
+
+    /** @test */
+    public function public_carbon_immutable_properties_can_be_cast()
+    {
+        $testable = Livewire::test(ComponentWithNullablePublicCarbonImmutableCaster::class)
+            ->assertSet('date', null, true)
+            ->updateProperty('date', '2024-02-14')
+            ->assertSet('date', CarbonImmutable::parse('2024-02-14'))
+            ->updateProperty('date', '')
+            ->assertSet('date', null, true)
+            ->updateProperty('date', null)
+            ->assertSet('date', null, true);
+
+        $this->expectException(\Exception::class);
+        $testable->updateProperty('date', 'Bad Date');
+    }
+
+    /** @test */
+    public function public_datetime_properties_can_be_cast()
+    {
+        $testable = Livewire::test(ComponentWithNullablePublicDateTimeCaster::class)
+            ->assertSet('date', null, true)
+            ->updateProperty('date', '2024-02-14')
+            ->assertSet('date', new \DateTime('2024-02-14'))
+            ->updateProperty('date', '')
+            ->assertSet('date', null, true)
+            ->updateProperty('date', null)
+            ->assertSet('date', null, true);
+
+        $this->expectException(\Exception::class);
+        $testable->updateProperty('date', 'Bad Date');
+    }
+
+    /** @test */
+    public function public_datetime_immutable_properties_can_be_cast()
+    {
+        $testable = Livewire::test(ComponentWithNullablePublicDateTimeImmutableCaster::class)
+            ->assertSet('date', null, true)
+            ->updateProperty('date', '2024-02-14')
+            ->assertSet('date', new \DateTimeImmutable('2024-02-14'))
+            ->updateProperty('date', '')
+            ->assertSet('date', null, true)
+            ->updateProperty('date', null)
+            ->assertSet('date', null, true);
+
+        $this->expectException(\Exception::class);
+        $testable->updateProperty('date', 'Bad Date');
+    }
+}
+
+class ComponentWithPublicCarbonCaster extends Component
+{
+    public Carbon $date;
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}
+class ComponentWithNullablePublicCarbonCaster extends Component
+{
+    public ?Carbon $date = null;
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}
+
+class ComponentWithNullablePublicCarbonImmutableCaster extends Component
+{
+    public ?CarbonImmutable $date = null;
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}
+
+class ComponentWithNullablePublicDateTimeCaster extends Component
+{
+    public ?\DateTime $date = null;
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}
+class ComponentWithNullablePublicDateTimeImmutableCaster extends Component
+{
+    public ?\DateTimeImmutable $date = null;
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
@@ -21,14 +21,6 @@ class CarbonSynthUnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    public function public_carbon_properties_throws_exception_when_set_to_null_cast()
-    {
-        $this->expectException(\Exception::class);
-        $testable = Livewire::test(ComponentWithPublicCarbonCaster::class)
-            ->updateProperty('date', null);
-    }
-
-    /** @test */
     public function public_nullable_carbon_properties_can_be_cast()
     {
         $testable = Livewire::test(ComponentWithNullablePublicCarbonCaster::class)


### PR DESCRIPTION
The CarbonSynth does not seem to be working as expected. A string is trying to be assigned to the public property. I have created Test class CarbonSynthUnitTest to demonstrate the issue.
