### PR TITLE
Added check to see if a route has already been registered

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -14,9 +14,11 @@ class HandleRequests extends Mechanism
 
     function boot()
     {
-        app($this::class)->setUpdateRoute(function ($handle) {
-            return Route::post('/livewire/update', $handle)->middleware('web');
-        });
+        if (!$this-updateRoute) {
+            app($this::class)->setUpdateRoute(function ($handle) {
+                return Route::post('/livewire/update', $handle)->middleware('web');
+            });
+        }
 
         $this->skipRequestPayloadTamperingMiddleware();
     }

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -14,7 +14,7 @@ class HandleRequests extends Mechanism
 
     function boot()
     {
-        if (!$this-updateRoute) {
+        if (!$this->updateRoute) {
             app($this::class)->setUpdateRoute(function ($handle) {
                 return Route::post('/livewire/update', $handle)->middleware('web');
             });

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -14,7 +14,8 @@ class HandleRequests extends Mechanism
 
     function boot()
     {
-        if (!$this->updateRoute) {
+        // Only set it if another provider hasn't already set it....
+        if (! $this->updateRoute) {
             app($this::class)->setUpdateRoute(function ($handle) {
                 return Route::post('/livewire/update', $handle)->middleware('web');
             });


### PR DESCRIPTION
A simple if around the core setUpdateRoute to check if one has already been defined.

This allows a user to call Livewire::setUpdateRoute() within the RouteServiceProvider register method without causing any problems.

I've also raised this as discussion https://github.com/livewire/livewire/discussions/7962

Thanks!