### PR TITLE
Add asset publishing

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -150,6 +150,9 @@ Alpine.plugin(Clipboard)
 Livewire.start()
 ```
 
+> [!tip] Rebuild your assets after composer update
+> Make sure that if you are manually bundling Livewire and Alpine, that you rebuild your assets whenever you run `composer update`.
+
 > [!warning] Not compatible with Laravel Mix
 > Laravel Mix will not work if you are manually bundling Livewire and AlpineJS. We recommend you switch to Vite if you need this ability.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -152,3 +152,28 @@ Livewire.start()
 
 > [!warning] Not compatible with Laravel Mix
 > Laravel Mix will not work if you are manually bundling Livewire and AlpineJS. We recommend you switch to Vite if you need this ability.
+
+## Publishing Livewire's frontend assets
+
+> [!warning] Publishing assets isn't necessary
+> Publishing Livewire's assets isn't necessary for Livewire to run. Only do this if you have a specific need for it.
+
+If you prefer the JavaScript assets to be served by your web server not through Laravel, use the `livewire:publish` command:
+
+```bash
+php artisan livewire:publish --assets
+```
+
+To keep the assets up-to-date and avoid issues in future updates, we highly recommend adding the command to the `post-update-cmd` scripts in your composer.json file:
+
+```json
+{
+    "scripts": {
+        "post-update-cmd": [
+            // Other scripts
+            "@php artisan vendor:publish --tag=livewire:assets --ansi --force"
+        ]
+    }
+}
+```
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -154,7 +154,7 @@ Livewire.start()
 > Make sure that if you are manually bundling Livewire and Alpine, that you rebuild your assets whenever you run `composer update`.
 
 > [!warning] Not compatible with Laravel Mix
-> Laravel Mix will not work if you are manually bundling Livewire and AlpineJS. We recommend you switch to Vite if you need this ability.
+> Laravel Mix will not work if you are manually bundling Livewire and AlpineJS. Instead, we recommend that you [switch to Vite](https://laravel.com/docs/vite).
 
 ## Publishing Livewire's frontend assets
 
@@ -167,7 +167,7 @@ If you prefer the JavaScript assets to be served by your web server not through 
 php artisan livewire:publish --assets
 ```
 
-To keep the assets up-to-date and avoid issues in future updates, we highly recommend adding the command to the `post-update-cmd` scripts in your composer.json file:
+To keep assets up-to-date and avoid issues in future updates, we strongly recommend that you add the following command to your composer.json file:
 
 ```json
 {

--- a/src/Features/SupportConsoleCommands/Commands/PublishCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/PublishCommand.php
@@ -22,7 +22,6 @@ class PublishCommand extends Command
         } elseif ($this->option('pagination')) {
             $this->publishPagination();
         } else {
-            $this->publishAssets();
             $this->publishConfig();
             $this->publishPagination();
         }

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -193,7 +193,7 @@ class FrontendAssets extends Mechanism
                 $assetWarning = <<<HTML
                 <script {$nonce}>
                     console.warn('Livewire: The published Livewire assets are out of date\\n See: https://livewire.laravel.com/docs/installation#publishing-livewires-frontend-assets')
-                </script>
+                </script>\n
                 HTML;
             }
         }
@@ -207,8 +207,7 @@ class FrontendAssets extends Mechanism
         );
 
         return <<<HTML
-        {$assetWarning}
-        <script src="{$url}" {$nonce} {$progressBar} data-csrf="{$token}" data-update-uri="{$updateUri}" {$extraAttributes}></script>
+        {$assetWarning}<script src="{$url}" {$nonce} {$progressBar} data-csrf="{$token}" data-update-uri="{$updateUri}" {$extraAttributes}></script>
         HTML;
     }
 

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -33,7 +33,7 @@ class FrontendAssets extends Mechanism
 
         app('livewire')->provide(function() {
             $this->publishes(
-                    [
+                [
                     __DIR__.'/../../../dist' => public_path('vendor/livewire'),
                 ],
                 'livewire:assets',
@@ -175,7 +175,7 @@ class FrontendAssets extends Mechanism
         $assetWarning = null;
 
         $nonce = isset($options['nonce']) ? "nonce=\"{$options['nonce']}\"" : '';
-        
+
         // Use static assets if they have been published
         if (file_exists(public_path('vendor/livewire/manifest.json'))) {
             $publishedManifest = json_decode(file_get_contents(public_path('vendor/livewire/manifest.json')), true);

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -176,7 +176,7 @@ class FrontendAssets extends Mechanism
 
         $nonce = isset($options['nonce']) ? "nonce=\"{$options['nonce']}\"" : '';
 
-        // Use static assets if they have been published
+        // Use static assets if they have been published...
         if (file_exists(public_path('vendor/livewire/manifest.json'))) {
             $publishedManifest = json_decode(file_get_contents(public_path('vendor/livewire/manifest.json')), true);
             $versionedFileName = $publishedManifest['/livewire.js'];


### PR DESCRIPTION
This PR adds the option to publish assets.

One issue I had when writing this, was with the way it worked in V2, the asset URL didn't have `livewire.js` suffixed, but in V3 the `$url` does have `livewire.js` suffixed.

So in my implementation, I couldn't make use of the existing `$url` variable, so I created another one called `$assetUrl` that checks to see if there is the legacy config option and if not, just uses the public directory path.

One thing to note though is the legacy config option `livewire.asset_url` won't work if upgraded directly from V2 (if not publishing assets or if you are) due the suffix problem mentioned above. So it would need to be changed to include the suffix, if someone is making use of it. I'm happy to update how this works if it's not ideal (see `FrontendAssets` lines 152-156 and line 188).

I've added docs for publish assets too, with a warning that it is not needed, as people in V2 would publish thinking it was required, and frequently has assets out of date.

<img width="801" alt="image" src="https://github.com/livewire/livewire/assets/882837/63539fb3-98a9-4868-ad8d-9e7324be67ee">


I also added a tip to the manual bundling docs to rebuild after a composer update. I'm not a fan of the double up with the warning below it though. I think the Mix/Vite warning should be moved further up the "manually bundling section".

<img width="780" alt="image" src="https://github.com/livewire/livewire/assets/882837/5cc82abc-888f-4b40-8334-4dab1b70edb2">
