### PR TITLE
Fix morph forward slash issue

### DIFF
--- a/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
+++ b/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
@@ -119,7 +119,7 @@ class SupportMorphAwareIfStatement extends ComponentHook
 
     protected static function prefixOpeningDirective($found, $template)
     {
-        $foundEscaped = preg_quote($found);
+        $foundEscaped = preg_quote($found, '/');
 
         $prefix = '<!--[if BLOCK]><![endif]-->';
 
@@ -134,7 +134,7 @@ class SupportMorphAwareIfStatement extends ComponentHook
 
     protected static function suffixClosingDirective($found, $template)
     {
-        $foundEscaped = preg_quote($found);
+        $foundEscaped = preg_quote($found, '/');
 
         $suffix = '<!--[if ENDBLOCK]><![endif]-->';
 

--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -378,6 +378,16 @@ class UnitTest extends \Tests\TestCase
                 </div>
                 HTML
             ],
+            27 => [
+                1,
+                <<<'HTML'
+                <div>
+                    @if (preg_replace('/[^a-zA-Z]+/', '', $spinner))
+                        <span> {{ $someProperty }} </span>
+                    @endif
+                </div>
+                HTML
+            ],
         ];
     }
 


### PR DESCRIPTION
There is an issue with morph markers if a `@if()` condition contains a forward slash as `preg_quote` won't escape forward slashes by default. This PR fixes it by ensuring forward slashes are also escaped.

<img width="1055" alt="image" src="https://github.com/livewire/livewire/assets/882837/557cd99f-4e91-4fac-b44a-6593de604606">
