### PR TITLE
Fix strtotime(): Passing null to parameter #1 ($datetime) of type deprecation

### DIFF
--- a/src/Drawer/Utils.php
+++ b/src/Drawer/Utils.php
@@ -100,7 +100,7 @@ class Utils extends BaseUtils
     {
         $ifModifiedSince = app(Request::class)->header('if-modified-since');
 
-        return ($ifModifiedSince !== null) && @strtotime($ifModifiedSince) === $lastModified;
+        return $ifModifiedSince !== null && @strtotime($ifModifiedSince) === $lastModified;
     }
 
     static function httpDate($timestamp)

--- a/src/Drawer/Utils.php
+++ b/src/Drawer/Utils.php
@@ -100,7 +100,7 @@ class Utils extends BaseUtils
     {
         $ifModifiedSince = app(Request::class)->header('if-modified-since');
 
-        return @strtotime($ifModifiedSince) === $lastModified;
+        return ($ifModifiedSince !== null) && @strtotime($ifModifiedSince) === $lastModified;
     }
 
     static function httpDate($timestamp)


### PR DESCRIPTION
From time to time, **Sentry** gives me this warning:

> strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated in /home/forge/my-site-domain.com/vendor/livewire/livewire/src/Drawer/Utils.php on line 103

here is the piece of code that give me that issue

```php
static function matchesCache($lastModified)
    {
        $ifModifiedSince = app(Request::class)->header('if-modified-since');

        return @strtotime($ifModifiedSince) === $lastModified; // This is line 103
    }
```

I went to google the 'if-modified-since' header and according to this article

https://medium.com/@sarahisdevs/the-art-of-web-caching-last-modified-if-modified-since-demystified-716107742a96

It says:

> The If-Modified-Since Request Header may not be present, especially on the first call from a new client.

So my changes check for if $ifModifiedSince is not null 1st, before passing to strtotime