### PR TITLE
Fix morph marker edge cases

### DIFF
--- a/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
+++ b/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
@@ -142,7 +142,7 @@ class SupportMorphAwareIfStatement extends ComponentHook
 
         $foundWithSuffix = $found.$suffix;
 
-        $pattern = "/{$foundEscaped}(?!{$suffixEscaped})(?![^<]*(?<![?=-])>)/mUi";
+        $pattern = "/{$foundEscaped}(?!\w)(?!{$suffixEscaped})(?![^<]*(?<![?=-])>)/mUi";
 
         return preg_replace($pattern, $foundWithSuffix, $template);
     }

--- a/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
+++ b/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
@@ -125,7 +125,8 @@ class SupportMorphAwareIfStatement extends ComponentHook
 
         $prefixEscaped = preg_quote($prefix);
 
-        $foundWithPrefix = $prefix.$found;
+        // `preg_replace` replacement prop needs `$` and `\` to be escaped
+        $foundWithPrefix = addcslashes($prefix.$found, '$\\');
 
         $pattern = "/(?<!{$prefixEscaped}){$foundEscaped}(?![^<]*(?<![?=-])>)/mUi";
 
@@ -140,7 +141,8 @@ class SupportMorphAwareIfStatement extends ComponentHook
 
         $suffixEscaped = preg_quote($suffix);
 
-        $foundWithSuffix = $found.$suffix;
+        // `preg_replace` replacement prop needs `$` and `\` to be escaped
+        $foundWithSuffix = addcslashes($found.$suffix, '$\\');
 
         $pattern = "/{$foundEscaped}(?!\w)(?!{$suffixEscaped})(?![^<]*(?<![?=-])>)/mUi";
 

--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -388,6 +388,31 @@ class UnitTest extends \Tests\TestCase
                 </div>
                 HTML
             ],
+            27 => [
+                2,
+                <<<'HTML'
+                <div>
+                    @forelse([1, 2] as $post)
+                        @for($i=0; $i < 10; $i++)
+                            <span> {{ $i }} </span>
+                        @endfor
+                    @empty
+                        <span> {{ $someProperty }} </span>
+                    @endforelse
+                </div>
+                HTML,
+                <<<'HTML'
+                <div>
+                    <!--[if BLOCK]><![endif]--><?php $__empty_1 = true; $__currentLoopData = [1, 2]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $post): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?>
+                        <!--[if BLOCK]><![endif]--><?php for($i=0; $i < 10; $i++): ?>
+                            <span> <?php echo e($i); ?> </span>
+                        <?php endfor; ?><!--[if ENDBLOCK]><![endif]-->
+                    <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_1): ?>
+                        <span> <?php echo e($someProperty); ?> </span>
+                    <?php endif; ?><!--[if ENDBLOCK]><![endif]-->
+                </div>
+                HTML,
+            ],
         ];
     }
 

--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -388,7 +388,7 @@ class UnitTest extends \Tests\TestCase
                 </div>
                 HTML
             ],
-            27 => [
+            28 => [
                 2,
                 <<<'HTML'
                 <div>
@@ -411,6 +411,19 @@ class UnitTest extends \Tests\TestCase
                         <span> <?php echo e($someProperty); ?> </span>
                     <?php endif; ?><!--[if ENDBLOCK]><![endif]-->
                 </div>
+                HTML,
+            ],
+            29 => [
+                1,
+                <<<'HTML'
+                @if ($item > 2 && request()->is(str(url('/'))->replace('\\', '/')))
+                    foo
+                @endif
+                HTML,
+                <<<'HTML'
+                <!--[if BLOCK]><![endif]--><?php if($item > 2 && request()->is(str(url('/'))->replace('\\', '/'))): ?>
+                    foo
+                <?php endif; ?><!--[if ENDBLOCK]><![endif]-->
                 HTML,
             ],
         ];


### PR DESCRIPTION
There are a couple of edge cases that have come up with the new morph marker strategy, see discussion #7981.

One is the regex wasn't matching the closing tags correctly, as it was finding `@endfor` inside of an `@endforelse`. So I have made that regex more robust.

The other was if a conditional contains a `$` or `\`, then the `preg_replace` call was trying to use them as match indicators in the replacement string. So needed to ensure they had been correctly escaped.