### PR TITLE
Add Fallback Value to Utils::matchesCache()

### DIFF
--- a/src/Drawer/Utils.php
+++ b/src/Drawer/Utils.php
@@ -98,7 +98,7 @@ class Utils extends BaseUtils
 
     static function matchesCache($lastModified)
     {
-        $ifModifiedSince = app(Request::class)->header('if-modified-since');
+        $ifModifiedSince = app(Request::class)->header('if-modified-since') ?? now()->toString();
 
         return $ifModifiedSince !== null && @strtotime($ifModifiedSince) === $lastModified;
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Fixing a PHP Deprecation Warning for strtotime()

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yep! fix-php-strtotime-deprecation-warning

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Nope. Only a single line was changed.

4️⃣ Does it include tests? (Required)
No additional test was added.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
The following PHP Warning was occurring in PHP 8.3: `"strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated in /workspace/vendor/livewire/livewire/src/Drawer/Utils.php on line 103"`

To fix this, I changed line 101 of src/Drawer/Utils.php from:
`$ifModifiedSince = app(Request::class)->header('if-modified-since')`
to:
$ifModifiedSince = app(Request::class)->header('if-modified-since') ?? now()->toString();

This way, there will always be a value passed to `strtotime()` and because the value will differ from `$lastModified,` it will force the return to be false. This will also prevent a fatal PHP error in future versions of PHP.
