### PR TITLE
Add form flag to `MakeCommand`

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -11,7 +11,7 @@ use function Laravel\Prompts\select;
 
 class MakeCommand extends FileManipulationCommand implements PromptsForMissingInput
 {
-    protected $signature = 'livewire:make {name} {--force} {--inline} {--test} {--pest} {--stub= : If you have several stubs, stored in subfolders }';
+    protected $signature = 'livewire:make {name} {--force} {--inline} {--test} {--pest} {--form} {--stub= : If you have several stubs, stored in subfolders }';
 
     protected $description = 'Create a new Livewire component';
 
@@ -42,8 +42,16 @@ class MakeCommand extends FileManipulationCommand implements PromptsForMissingIn
         $inline = $this->option('inline');
         $test = $this->option('test') || $this->option('pest');
         $testType = $this->option('pest') ? 'pest' : 'phpunit';
+        $withForm = $this->option('form');
 
         $showWelcomeMessage = $this->isFirstTimeMakingAComponent();
+
+        if($withForm) {
+            $this->call('livewire:form', [
+                'name' => $this->parser->className() . 'Form',
+                '--force' => $force,
+            ]);
+        }
 
         $class = $this->createClass($force, $inline);
         $view = $this->createView($force, $inline);

--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -177,6 +177,16 @@ class MakeCommand extends FileManipulationCommand implements PromptsForMissingIn
                 $input->setOption('pest', true);
             }
         }
+
+        if(
+            confirm(
+                label: 'Do you want to create a form class?',
+                default: false
+            )
+        )
+        {
+            $input->setOption('form', true);
+        }
     }
 
     private function getReservedName()

--- a/src/Features/SupportConsoleCommands/Commands/MakeLivewireCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeLivewireCommand.php
@@ -4,5 +4,5 @@ namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 class MakeLivewireCommand extends MakeCommand
 {
-    protected $signature = 'make:livewire {name} {--force} {--inline} {--test} {--pest} {--stub=}';
+    protected $signature = 'make:livewire {name} {--force} {--inline} {--test} {--pest} {--form} {--stub=}';
 }


### PR DESCRIPTION
It's often a two-step process to create a component and a form, but with this small improvement it will be possible to generate the form along with the component

`php artisan livewire:make MyComponent --form`
