### PR TITLE
Fix morph marker edge case with one-liner statements

### DIFF
--- a/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
+++ b/src/Features/SupportMorphAwareIfStatement/SupportMorphAwareIfStatement.php
@@ -135,6 +135,10 @@ class SupportMorphAwareIfStatement extends ComponentHook
 
     protected static function suffixClosingDirective($found, $template)
     {
+        // Opening directives can contain a space before the parens, but that causes issues with closing
+        // directives. So we will just remove the trailing space if it exists...
+        $found = rtrim($found);
+
         $foundEscaped = preg_quote($found, '/');
 
         $suffix = '<!--[if ENDBLOCK]><![endif]-->';

--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -426,6 +426,12 @@ class UnitTest extends \Tests\TestCase
                 <?php endif; ?><!--[if ENDBLOCK]><![endif]-->
                 HTML,
             ],
+            30 => [
+                1,
+                <<<'HTML'
+                <div> @if (preg_replace('/[^a-zA-Z]+/', '', $spinner))<span> {{ $someProperty }} </span> @endif Hello</div>
+                HTML
+            ]
         ];
     }
 

--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -429,7 +429,13 @@ class UnitTest extends \Tests\TestCase
             30 => [
                 1,
                 <<<'HTML'
-                <div> @if (preg_replace('/[^a-zA-Z]+/', '', $spinner))<span> {{ $someProperty }} </span> @endif Hello</div>
+                <div> @if (preg_replace('/[^a-zA-Z]+/', '', $spinner))<span> {{ $someProperty }} </span> @endif Else</div>
+                HTML
+            ],
+            31 => [
+                1,
+                <<<'HTML'
+                <div> @for ($i=0; $i<3; $i++)<span> {{ $someProperty }} </span> @endfor Else</div>
                 HTML
             ]
         ];


### PR DESCRIPTION
This is related to the fixes in https://github.com/livewire/livewire/pull/7984

Actively working on a fix for this and will update the PR as soon as I learn more.

Prior to those changes you could have extra text next to a nasty one-liner if statement, but now it throws an error in the console. 
```
// Broken
<button>@if ($this->total > 0)<span>{{ $this->total }}</span> @endif Filters</button>

// Works
<button>@if ($this->total > 0)<span>{{ $this->total }}</span> @endif 
Filters</button>
```

The key is that having extra words on the same line as the `@endif` breaks now, whereas it didn't before.
![image](https://github.com/livewire/livewire/assets/575421/ff2425f6-b421-4616-9c70-160a36eecbae)

~~WIP ✌️~~

**Edit: This now includes a fix.**

The way the directive matching regex is set up, a trailing space gets matched even for closing directives, such as `@endif `. Opening directives may or may not include the space `@if(...)` or `@if (...)`. With closing directives, we don't need to match the space, so although we tried to find a more elegant regular expression solution, the `rtrim` seemed to be the path of least resistance here. Thank you!