### PR TITLE
pagination: add text option to data array to show/hide pagination text

### DIFF
--- a/src/Features/SupportPagination/views/tailwind.blade.php
+++ b/src/Features/SupportPagination/views/tailwind.blade.php
@@ -8,6 +8,10 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
        (\$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).scrollIntoView()
     JS
     : '';
+
+if (! isset($text)) {
+    $text = true;
+}
 @endphp
 
 <div>
@@ -39,18 +43,24 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                 </span>
             </div>
 
-            <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
-                <div>
-                    <p class="text-sm text-gray-700 leading-5">
-                        <span>{!! __('Showing') !!}</span>
-                        <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                        <span>{!! __('to') !!}</span>
-                        <span class="font-medium">{{ $paginator->lastItem() }}</span>
-                        <span>{!! __('of') !!}</span>
-                        <span class="font-medium">{{ $paginator->total() }}</span>
-                        <span>{!! __('results') !!}</span>
-                    </p>
-                </div>
+            <div @class([
+                'hidden sm:flex-1 sm:flex sm:items-center',
+                'sm:justify-between' => $text,
+                'sm:justify-center' => !$text,
+                ])>
+                @if ($text)
+                    <div>
+                        <p class="text-sm text-gray-700 leading-5">
+                            <span>{!! __('Showing') !!}</span>
+                            <span class="font-medium">{{ $paginator->firstItem() }}</span>
+                            <span>{!! __('to') !!}</span>
+                            <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                            <span>{!! __('of') !!}</span>
+                            <span class="font-medium">{{ $paginator->total() }}</span>
+                            <span>{!! __('results') !!}</span>
+                        </p>
+                    </div>
+                @endif
 
                 <div>
                     <span class="relative z-0 inline-flex rounded-md shadow-sm">


### PR DESCRIPTION
This pr adds the option for showing/hiding pagination text 

I've created a discussion about it #8008 

4️⃣ Does it include tests? (Required)
Sorry I couldn't do the test

https://github.com/AMoktar/livewire/blob/99ee51ad25462ada2c0f6e3eb99cdb519e076265/src/Features/SupportPagination/views/tailwind.blade.php#L12


```php
// ...

if (! isset($text)) {
    $text = true;
}

// ...

         <div @class([
                'hidden sm:flex-1 sm:flex sm:items-center',
                'sm:justify-between' => $text,
                'sm:justify-center' => !$text,
                ])>
                @if ($text)
                    <div>
                        <p class="text-sm text-gray-700 leading-5">
                            <span>{!! __('Showing') !!}</span>
                            <span class="font-medium">{{ $paginator->firstItem() }}</span>
``` 

I'm not sure this is the best solution, I hope that help anyway.

Thanks guys
