### PR TITLE
Add assertRedirectToRoute test function

### DIFF
--- a/src/Features/SupportRedirects/TestsRedirects.php
+++ b/src/Features/SupportRedirects/TestsRedirects.php
@@ -32,6 +32,11 @@ trait TestsRedirects
         return $this;
     }
 
+    public function assertRedirectToRoute(string $routeName)
+    {
+        return $this->assertRedirect(route($routeName));
+    }
+
     public function assertNoRedirect()
     {
         PHPUnit::assertTrue(! isset($this->effects['redirect']));

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanAssertRedirectToRouteUnitTest.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanAssertRedirectToRouteUnitTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Livewire\Features\SupportTesting\Tests;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use Illuminate\Support\Facades\Route;
+
+class TestableLivewireCanAssertRedirectToRouteUnitTest extends \Tests\TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Route::get('foo', function () {
+            return true;
+        })->name('foo');
+    }
+
+    /** @test */
+    function can_assert_a_redirect_to_a_route()
+    {
+        $component = Livewire::test(RedirectComponent::class);
+
+        $component->call('performRedirect');
+
+        $component->assertRedirectToRoute('foo');
+    }
+
+    /** @test */
+    function can_detect_failed_redirect()
+    {
+        $component = Livewire::test(RedirectComponent::class);
+
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+
+        $component->assertRedirectToRoute('foo');
+    }
+}
+
+class RedirectComponent extends Component
+{
+    function performRedirect()
+    {
+        $this->redirectRoute('foo');
+    }
+
+    function render()
+    {
+        return view('null-view');
+    }
+}


### PR DESCRIPTION
This PR adds a test stub `assertRedirectToRoute` so named route redirects (`redirectRoute`) can be tested via PHPUnit.


