### PR TITLE
Change assertRedirectToRoute to match Laravel Signature

### DIFF
--- a/src/Features/SupportRedirects/TestsRedirects.php
+++ b/src/Features/SupportRedirects/TestsRedirects.php
@@ -32,9 +32,11 @@ trait TestsRedirects
         return $this;
     }
 
-    public function assertRedirectToRoute(string $routeName)
+    public function assertRedirectToRoute($name, $parameters = [])
     {
-        return $this->assertRedirect(route($routeName));
+        $uri = route($name, $parameters);
+
+        return $this->assertRedirect($uri);
     }
 
     public function assertNoRedirect()

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanAssertRedirectToRouteUnitTest.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanAssertRedirectToRouteUnitTest.php
@@ -20,7 +20,7 @@ class TestableLivewireCanAssertRedirectToRouteUnitTest extends \Tests\TestCase
     /** @test */
     function can_assert_a_redirect_to_a_route()
     {
-        $component = Livewire::test(RedirectComponent::class);
+        $component = Livewire::test(RedirectRouteComponent::class);
 
         $component->call('performRedirect');
 
@@ -30,7 +30,7 @@ class TestableLivewireCanAssertRedirectToRouteUnitTest extends \Tests\TestCase
     /** @test */
     function can_detect_failed_redirect()
     {
-        $component = Livewire::test(RedirectComponent::class);
+        $component = Livewire::test(RedirectRouteComponent::class);
 
         $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
 
@@ -38,7 +38,7 @@ class TestableLivewireCanAssertRedirectToRouteUnitTest extends \Tests\TestCase
     }
 }
 
-class RedirectComponent extends Component
+class RedirectRouteComponent extends Component
 {
     function performRedirect()
     {


### PR DESCRIPTION
Previous PR might got merged a bit too soon, changed the `assertRedirectToRoute` function to match Laravels signature as per [nuernbergerA](https://github.com/nuernbergerA)'s comment https://github.com/livewire/livewire/pull/8016#issuecomment-1962945557 

Also changed the Redirect component name to RedirectRoute to fix failing tests.