### PR TITLE
Fix TypeError / return null for deleted public legacy model

### DIFF
--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -70,6 +70,10 @@ class EloquentModelSynth extends Synth
             $model = $this->loadModel($meta);
         }
 
+        if($model === null) {
+            return null;
+        }
+
         if (isset($meta['relations'])) {
             foreach($meta['relations'] as $relationKey) {
                 if (! isset($data[$relationKey])) continue;

--- a/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
@@ -897,6 +897,20 @@ class PublicPropertyHydrationAndDehydrationUnitTest extends \Tests\TestCase
         Livewire::test(ModelsComponent::class, ['model' => $model])
             ->call('$refresh');
     }
+
+    /** @test */
+    public function it_returns_null_if_the_model_was_deleted() {
+        $this->expectNotToPerformAssertions();
+
+        $model = Author::create(['id' => 1, 'title' => 'foo', 'name' => 'bar', 'email' => 'baz']);
+
+        $component = Livewire::test(ModelsComponent::class, ['model' => $model])
+            ->call('$refresh');
+
+        $model->delete();
+
+        $component->call('$refresh');
+    }
 }
 
 class PostComponent extends Component


### PR DESCRIPTION
Discussion: https://github.com/livewire/livewire/discussions/7987

The failing testcase explains the problem quite well: if a public property legacy model is deleted and the component is refreshed a type error occurs:

`TypeError: Livewire\Features\SupportLegacyModels\EloquentModelSynth::setDataOnModel(): Argument #1 ($model) must be of type Illuminate\Database\Eloquent\Model, null given, called in .../src/Features/SupportLegacyModels/EloquentModelSynth.php on line 90`

My suggested fix in the second commit is to return it early as `null` if `loadModel` returned `null` beforehand to avoid the TypeError.


Thanks!