### PR TITLE
Fix unsetting legacy computed properties

### DIFF
--- a/src/Features/SupportComputed/SupportLegacyComputedPropertySyntax.php
+++ b/src/Features/SupportComputed/SupportLegacyComputedPropertySyntax.php
@@ -18,6 +18,12 @@ class SupportLegacyComputedPropertySyntax extends ComponentHook
                 $returnValue(static::getComputedProperty($target, $property));
             }
         });
+
+        on('__unset', function ($target, $property) {
+            if (static::hasComputedProperty($target, $property)) {
+                store($target)->unset('computedProperties', $property);
+            }
+        });
     }
 
     public static function getComputedProperties($target)

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -387,6 +387,54 @@ class UnitTest extends TestCase
         Livewire::test(NullIssetComputedPropertyStub::class)
             ->assertSee('false');
     }
+
+    /** @test */
+    public function it_supports_legacy_computed_properties()
+    {
+        Livewire::test(new class extends TestComponent {
+            public function getFooProperty()
+            {
+                return 'bar';
+            }
+
+            public function render()
+            {
+                return '<div></div>';
+            }
+        })
+            ->assertSet('foo', 'bar');
+    }
+
+    /** @test */
+    public function it_supports_unsetting_legacy_computed_properties()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $changeFoo = false;
+
+            public function getFooProperty()
+            {
+                return $this->changeFoo ? 'baz' : 'bar';
+            }
+
+            public function save()
+            {
+                // Access foo to ensure it is memoized.
+                $this->foo;
+
+                $this->changeFoo = true;
+
+                unset($this->foo);
+            }
+
+            public function render()
+            {
+                return '<div></div>';
+            }
+        })
+            ->assertSet('foo', 'bar')
+            ->call('save')
+            ->assertSet('foo', 'baz');
+    }
 }
 
 class ComputedPropertyStub extends Component

--- a/src/Mechanisms/DataStore.php
+++ b/src/Mechanisms/DataStore.php
@@ -86,4 +86,27 @@ class DataStore extends Mechanism
             $this->lookup[$instance][$key][] = $value;
         }
     }
+
+    function unset($instance, $key, $iKey = null)
+    {
+        if (! isset($this->lookup[$instance])) {
+            return;
+        }
+
+        if ($iKey !== null) {
+            // Set a local variable to avoid the "indirect modification" error.
+            $keyValue = $this->lookup[$instance][$key];
+
+            unset($keyValue[$iKey]);
+
+            $this->lookup[$instance][$key] = $keyValue;
+        } else {
+            // Set a local variable to avoid the "indirect modification" error.
+            $instanceValue = $this->lookup[$instance];
+
+            unset($instanceValue[$key]);
+
+            $this->lookup[$instance] = $instanceValue;
+        }
+    }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -166,5 +166,10 @@ function store($instance = null)
         {
             return app(\Livewire\Mechanisms\DataStore::class)->has($this->instance, $key, $iKey);
         }
+
+        function unset($key, $iKey = null)
+        {
+            return app(\Livewire\Mechanisms\DataStore::class)->unset($this->instance, $key, $iKey);
+        }
     };
 }


### PR DESCRIPTION
I'm in the process of upgrading a large V2 app and have refactored all of the `$this->forgetComputed()` to `unset()`.

Except this app still has all legacy computed properties `getFooProperty()` and I have found that `unset()` does nothing for legacy computed properties.

This PR adds support for unsetting legacy computed properties.