### PR TITLE
Fix form property has two same error messages

### DIFF
--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -306,12 +306,8 @@ trait HandlesValidation
             throw $e;
         }
 
-        // If main validation passed, go through other sub-validation exceptions
-        // and throw the first one with the cumulative messages...
-        foreach ($formExceptions as $e) {
-            $e->validator->errors()->merge($cumulativeErrors);
-
-            throw $e;
+        if ($cumulativeErrors->isNotEmpty()) {
+            throw ValidationException::withMessages($cumulativeErrors->toArray());
         }
 
         // All validation has passed, we can return the data...


### PR DESCRIPTION
Use a form property in a Livewire Component, and call `$this->validate()` in the component, will see two same errors.

Example:
![image](https://github.com/livewire/livewire/assets/48778797/cb13fef6-b025-4196-abb8-bb24818b4ac6)
