### PR TITLE
Fix validating forms via `$this->validate()`

### DIFF
--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -81,6 +81,29 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
+    function can_validate_a_form_with_the_general_validate_function()
+    {
+        Livewire::test(new class extends Component {
+            public PostFormValidateStub $form;
+
+            function save()
+            {
+                $this->validate();
+            }
+
+            public function render() {
+                return '<div></div>';
+            }
+        })
+            ->call('save')
+            ->tap(function ($component) {
+                $this->assertCount(1, $component->errors()->get('form.title'));
+                $this->assertCount(1, $component->errors()->get('form.content'));
+            })
+        ;
+    }
+
+    /** @test */
     function can_validate_a_specific_rule_has_errors_in_a_form_object()
     {
         Livewire::test(new class extends Component {

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -309,7 +309,7 @@ trait HandlesValidation
         // If main validation passed, go through other sub-validation exceptions
         // and throw the first one with the cumulative messages...
         foreach ($formExceptions as $e) {
-            $e->validator->errors()->merge($cumulativeErrors);
+            $e->validator->errors()->merge($cumulativeErrors->unique());
 
             throw $e;
         }


### PR DESCRIPTION
When validating a component with forms via `$this->validate()` instead of directly calling `$this->form->validate()`, it duplicates the error messages. See #8051