### PR TITLE
Adding Anchor as a core included plugins, minor wording tweaks

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -199,6 +199,7 @@ If you include Alpine into your application via a script tag like the following,
 
 Livewire 3 now ships with the following Alpine plugins out-of-the-box:
 
+* [Anchor](https://alpinejs.dev/plugins/anchor)
 * [Collapse](https://alpinejs.dev/plugins/collapse)
 * [Focus](https://alpinejs.dev/plugins/focus)
 * [Intersect](https://alpinejs.dev/plugins/intersect)
@@ -206,7 +207,9 @@ Livewire 3 now ships with the following Alpine plugins out-of-the-box:
 * [Morph](https://alpinejs.dev/plugins/morph)
 * [Persist](https://alpinejs.dev/plugins/persist)
 
-If you have already included any of these in your application via `<script>` tags like below, you can remove them along with Alpine's core:
+It is worth keeping an eye on changes to the [package.json](https://github.com/livewire/livewire/blob/main/package.json) file, as new Alpine plugins may be added!
+
+If you have previously included any of these in your application via `<script>` tags like below, you should remove them along with Alpine's core:
 
 ```html
 <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/intersect@3.x.x/dist/cdn.min.js"></script> <!-- [tl! remove:1] -->
@@ -229,7 +232,7 @@ You may continue to do so, as Livewire internally includes and registers Alpine'
 
 ### Including via JS bundle
 
-If you have included Alpine and any relevant plugins via NPM into your applications JavaScript bundle like so:
+If you have included Alpine or any of the popular core Alpine plugins mentioned above via NPM into your applications JavaScript bundle like so:
 
 ```js
 // Warning: this is a snippet of the Livewire 2 approach to including Alpine


### PR DESCRIPTION
Very minor tweaks to the "Upgrade Guide" for the docs.

Added in:
- Reference to the inclusion of the AlpineJS Anchor plugin by default.
- Suggested that people monitor the package.json file for any additional AlpineJS plugins that get added

Tweaked:
- Adjusted wording where it felt ambiguous for including Alpine Plugins (as the old wording didn't make it clear that it was only relating to the core AlpineJS plugins)
- Changed "can" to "should" with reference to where people have previously included core plugins (that are now included as core) via the cdn/http.  Mostly as this seems much more likely to cause conflicts than the other approaches would.

Plus some very minor wording tweaks where I felt it sensible to reference other item

Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
Not relevant - docs change only

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
