### PR TITLE
Added failing unittest for deprecation

### DIFF
--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -23,4 +23,30 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertTrue(isset($component->effects['url']));
     }
+
+    /** @test */
+    function does_not_fail_with_deprecation()
+    {
+        $this->withoutDeprecationHandling();
+        $component = Livewire::test(new class extends Component
+        {
+            public $foo = '';
+
+            protected function queryString()
+            {
+                return [
+                    'foo',
+                ];
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                        <div>
+                            <h1 dusk="output">{{ $foo }}</h1>
+                        </div>
+                        HTML;
+            }
+        });
+    }
 }


### PR DESCRIPTION
Added a unittest which fails with a deprecation.
Requested for this bug report: https://github.com/livewire/livewire/discussions/8057