### PR TITLE
Enable cookie testing on subsequent request

### DIFF
--- a/src/Features/SupportTesting/SubsequentRender.php
+++ b/src/Features/SupportTesting/SubsequentRender.php
@@ -9,14 +9,14 @@ class SubsequentRender extends Render
         protected ComponentState $lastState,
     ) {}
 
-    static function make($requestBroker, $lastState, $calls = [], $updates = [])
+    static function make($requestBroker, $lastState, $calls = [], $updates = [], $cookies = [])
     {
         $instance = new static($requestBroker, $lastState);
 
-        return $instance->makeSubsequentRequest($calls, $updates);
+        return $instance->makeSubsequentRequest($calls, $updates, $cookies);
     }
 
-    function makeSubsequentRequest($calls = [], $updates = []) {
+    function makeSubsequentRequest($calls = [], $updates = [], $cookies = []) {
         $uri = app('livewire')->getUpdateUri();
 
         $encodedSnapshot = json_encode($this->lastState->getSnapshot());
@@ -31,9 +31,9 @@ class SubsequentRender extends Render
             ],
         ];
 
-        [$response, $componentInstance, $componentView] = $this->extractComponentAndBladeView(function () use ($uri, $payload) {
-            return $this->requestBroker->temporarilyDisableExceptionHandlingAndMiddleware(function ($requestBroker) use ($uri, $payload) {
-                return $requestBroker->withHeaders(['X-Livewire' => true])->post($uri, $payload);
+        [$response, $componentInstance, $componentView] = $this->extractComponentAndBladeView(function () use ($uri, $payload, $cookies) {
+            return $this->requestBroker->temporarilyDisableExceptionHandlingAndMiddleware(function ($requestBroker) use ($uri, $payload, $cookies) {
+                return $requestBroker->addHeaders(['X-Livewire' => true])->call('POST', $uri, $payload, $cookies);
             });
         });
 

--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -2,11 +2,11 @@
 
 namespace Livewire\Features\SupportTesting;
 
-use Illuminate\Support\Traits\Macroable;
-use Livewire\Features\SupportEvents\TestsEvents;
-use Livewire\Features\SupportRedirects\TestsRedirects;
-use Livewire\Features\SupportValidation\TestsValidation;
 use Livewire\Features\SupportFileDownloads\TestsFileDownloads;
+use Livewire\Features\SupportValidation\TestsValidation;
+use Livewire\Features\SupportRedirects\TestsRedirects;
+use Livewire\Features\SupportEvents\TestsEvents;
+use Illuminate\Support\Traits\Macroable;
 
 /** @mixin \Illuminate\Testing\TestResponse */
 

--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -3,10 +3,10 @@
 namespace Livewire\Features\SupportTesting;
 
 use Illuminate\Support\Traits\Macroable;
-use Livewire\Features\SupportFileDownloads\TestsFileDownloads;
-use Livewire\Features\SupportValidation\TestsValidation;
-use Livewire\Features\SupportRedirects\TestsRedirects;
 use Livewire\Features\SupportEvents\TestsEvents;
+use Livewire\Features\SupportRedirects\TestsRedirects;
+use Livewire\Features\SupportValidation\TestsValidation;
+use Livewire\Features\SupportFileDownloads\TestsFileDownloads;
 
 /** @mixin \Illuminate\Testing\TestResponse */
 
@@ -177,6 +177,7 @@ class Testable
             $this->lastState,
             $calls,
             $updates,
+            app('request')->cookies->all()
         );
 
         $this->lastState = $newState;

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -3,14 +3,14 @@
 namespace Livewire\Features\SupportTesting;
 
 use Closure;
-use Illuminate\Contracts\Validation\ValidationRule;
-use PHPUnit\Framework\ExpectationFailedException;
-use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\Route;
-use Illuminate\Testing\TestResponse;
-use Illuminate\Testing\TestView;
-use Livewire\Component;
 use Livewire\Livewire;
+use Livewire\Component;
+use Illuminate\Testing\TestView;
+use Illuminate\Testing\TestResponse;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\ExpectationFailedException;
+use Illuminate\Contracts\Validation\ValidationRule;
 
 // TODO - Change this to \Tests\TestCase
 class UnitTest extends \LegacyTests\Unit\TestCase
@@ -615,6 +615,33 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             ->assertSet('colourHeader', 'blue')
             ->assertSet('nameHeader', 'Taylor')
             ;
+    }
+
+    /** @test */
+    public function can_set_cookies_and_use_it_for_testing_subsequent_request()
+    {
+        // Test both the `withCookies` and `withCookie` methods that Laravel normally provides
+        Livewire::withCookies(['colour' => 'blue'])
+        ->withCookie('name', 'Taylor')
+        ->test(new class extends Component
+        {
+            public $colourCookie = '';
+            public $nameCookie = '';
+
+            public function setTheCookies()
+            {
+                $this->colourCookie = request()->cookie('colour');
+                $this->nameCookie = request()->cookie('name');
+            }
+
+            public function render()
+            {
+                return '<div></div>';
+            }
+        })
+            ->call('setTheCookies')
+            ->assertSet('colourCookie', 'blue')
+            ->assertSet('nameCookie', 'Taylor');
     }
 }
 

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -2,15 +2,15 @@
 
 namespace Livewire\Features\SupportTesting;
 
-use Closure;
-use Livewire\Livewire;
-use Livewire\Component;
-use Illuminate\Testing\TestView;
-use Illuminate\Testing\TestResponse;
-use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Artisan;
-use PHPUnit\Framework\ExpectationFailedException;
 use Illuminate\Contracts\Validation\ValidationRule;
+use PHPUnit\Framework\ExpectationFailedException;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Testing\TestResponse;
+use Illuminate\Testing\TestView;
+use Livewire\Component;
+use Livewire\Livewire;
+use Closure;
 
 // TODO - Change this to \Tests\TestCase
 class UnitTest extends \LegacyTests\Unit\TestCase
@@ -621,24 +621,22 @@ class UnitTest extends \LegacyTests\Unit\TestCase
     public function can_set_cookies_and_use_it_for_testing_subsequent_request()
     {
         // Test both the `withCookies` and `withCookie` methods that Laravel normally provides
-        Livewire::withCookies(['colour' => 'blue'])
-        ->withCookie('name', 'Taylor')
-        ->test(new class extends Component
-        {
-            public $colourCookie = '';
-            public $nameCookie = '';
+        Livewire::withCookies(['colour' => 'blue'])->withCookie('name', 'Taylor')
+            ->test(new class extends Component {
+                public $colourCookie = '';
+                public $nameCookie = '';
 
-            public function setTheCookies()
-            {
-                $this->colourCookie = request()->cookie('colour');
-                $this->nameCookie = request()->cookie('name');
-            }
+                public function setTheCookies()
+                {
+                    $this->colourCookie = request()->cookie('colour');
+                    $this->nameCookie = request()->cookie('name');
+                }
 
-            public function render()
-            {
-                return '<div></div>';
-            }
-        })
+                public function render()
+                {
+                    return '<div></div>';
+                }
+            })
             ->call('setTheCookies')
             ->assertSet('colourCookie', 'blue')
             ->assertSet('nameCookie', 'Taylor');


### PR DESCRIPTION
This is a continuation from PR #6822. It was not completed because the cookie is not passed on the subsequent request.

The idea is to also able to read cookie on subsequent request, which is when calling the action method. When manually testing inside browser, the cookie works. But fail on Livewire unit test. This PR should fix the problem. Test is also included.
