### PR TITLE
BaseUrl Attribute properties are not filled similarly when using queryString() methods

### DIFF
--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -39,7 +39,7 @@ class BaseUrl extends LivewireAttribute
         $reflectionClass = new ReflectionClass($this->getSubTarget() ?? $this->getComponent());
 
         // It's nullable if there's a nullable typehint like: public ?string $foo;
-        if ($reflectionClass->hasProperty($this->getSubName())) {
+        if ($this->getSubName() && $reflectionClass->hasProperty($this->getSubName())) {
             $property = $reflectionClass->getProperty($this->getSubName());
 
             return $property->getType()?->allowsNull() ?? false;

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -39,7 +39,7 @@ class BaseUrl extends LivewireAttribute
         $reflectionClass = new ReflectionClass($this->getSubTarget() ?? $this->getComponent());
 
         // It's nullable if there's a nullable typehint like: public ?string $foo;
-        if ($this->getSubName() && $reflectionClass->hasProperty($this->getSubName())) {
+        if ($reflectionClass->hasProperty($this->getSubName())) {
             $property = $reflectionClass->getProperty($this->getSubName());
 
             return $property->getType()?->allowsNull() ?? false;

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -5,6 +5,16 @@ namespace Livewire\Features\SupportQueryString;
 use Livewire\Livewire;
 use Livewire\Component;
 
+trait WithSorting
+{
+    protected function queryStringWithSorting()
+    {
+        return [
+            'queryFromTrait',
+        ];
+    }
+}
+
 class UnitTest extends \Tests\TestCase
 {
     /** @test */
@@ -22,5 +32,42 @@ class UnitTest extends \Tests\TestCase
         });
 
         $this->assertTrue(isset($component->effects['url']));
+    }
+
+    /** @test */
+    function it_correctly_fills_base_url_attribute_properties()
+    {
+        $component = Livewire::test(new class extends Component {
+            use WithSorting;
+
+            #[BaseUrl]
+            public $queryFromAttribute;
+
+            public function render()
+            {
+                return '<div></div>';
+            }
+
+            protected function queryString()
+            {
+                return [
+                    'queryFromMethod',
+                ];
+            }
+        });
+        /** @var \Illuminate\Support\Collection $attributes */
+        $attributes = $component->instance()->getAttributes();
+
+        /** @var BaseUrl $queryFromAttribute */
+        /** @var BaseUrl $queryFromMethod */
+        /** @var BaseUrl $queryFromTrait */
+
+        $queryFromAttribute = $attributes->first(fn (BaseUrl $attribute) => $attribute->getName() === 'queryFromAttribute');
+        $queryFromMethod = $attributes->first(fn (BaseUrl $attribute) => $attribute->getName() === 'queryFromMethod');
+        $queryFromTrait = $attributes->first(fn (BaseUrl $attribute) => $attribute->getName() === 'queryFromTrait');
+
+        $this->assertEquals('queryFromAttribute', $queryFromAttribute->getSubName());
+        $this->assertEquals('queryFromMethod', $queryFromMethod->getSubName());
+        $this->assertEquals('queryFromTrait', $queryFromTrait->getSubName());
     }
 }

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -35,14 +35,9 @@ class UnitTest extends \Tests\TestCase
     }
 
     /** @test */
-    function it_correctly_fills_base_url_attribute_properties()
+    function sub_name_is_null_in_attributes_from_query_string_component_method()
     {
         $component = Livewire::test(new class extends Component {
-            use WithSorting;
-
-            #[BaseUrl]
-            public $queryFromAttribute;
-
             public function render()
             {
                 return '<div></div>';
@@ -58,12 +53,47 @@ class UnitTest extends \Tests\TestCase
 
         $attributes = $component->instance()->getAttributes();
 
-        $queryFromAttribute = $attributes->first(fn (BaseUrl $attribute) => $attribute->getName() === 'queryFromAttribute');
         $queryFromMethod = $attributes->first(fn (BaseUrl $attribute) => $attribute->getName() === 'queryFromMethod');
+
+        $this->assertEquals(null, $queryFromMethod->getSubName());
+    }
+
+    /** @test */
+    function sub_name_is_null_in_attributes_from_query_string_trait_method()
+    {
+        $component = Livewire::test(new class extends Component {
+            use WithSorting;
+
+            public function render()
+            {
+                return '<div></div>';
+            }
+        });
+
+        $attributes = $component->instance()->getAttributes();
+
         $queryFromTrait = $attributes->first(fn (BaseUrl $attribute) => $attribute->getName() === 'queryFromTrait');
 
+        $this->assertEquals(null, $queryFromTrait->getSubName());
+    }
+
+    /** @test */
+    function sub_name_is_same_as_name_in_attributes_from_base_url_property_attribute()
+    {
+        $component = Livewire::test(new class extends Component {
+            #[BaseUrl]
+            public $queryFromAttribute;
+
+            public function render()
+            {
+                return '<div></div>';
+            }
+        });
+
+        $attributes = $component->instance()->getAttributes();
+
+        $queryFromAttribute = $attributes->first(fn (BaseUrl $attribute) => $attribute->getName() === 'queryFromAttribute');
+
         $this->assertEquals('queryFromAttribute', $queryFromAttribute->getSubName());
-        $this->assertEquals('queryFromMethod', $queryFromMethod->getSubName());
-        $this->assertEquals('queryFromTrait', $queryFromTrait->getSubName());
     }
 }

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -55,12 +55,8 @@ class UnitTest extends \Tests\TestCase
                 ];
             }
         });
-        /** @var \Illuminate\Support\Collection $attributes */
-        $attributes = $component->instance()->getAttributes();
 
-        /** @var BaseUrl $queryFromAttribute */
-        /** @var BaseUrl $queryFromMethod */
-        /** @var BaseUrl $queryFromTrait */
+        $attributes = $component->instance()->getAttributes();
 
         $queryFromAttribute = $attributes->first(fn (BaseUrl $attribute) => $attribute->getName() === 'queryFromAttribute');
         $queryFromMethod = $attributes->first(fn (BaseUrl $attribute) => $attribute->getName() === 'queryFromMethod');


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Yes, I have created a [discussion](https://github.com/livewire/livewire/discussions/8070). This is a fix for warnings that appear when using [query string trait hooks](https://livewire.laravel.com/docs/url#trait-hooks)

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
yes, fix-deprecated-null-param-on-BaseUrl

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Just the fact that $subName is `null` by default will eventually cause this warning to appear.

Nullable property: https://github.com/livewire/livewire/blob/main/src/Features/SupportAttributes/Attribute.php#L19C70-L19C85

The warning appears here: https://github.com/livewire/livewire/blob/main/src/Features/SupportQueryString/BaseUrl.php#L42

warning message: ReflectionClass::hasProperty(): Passing null to parameter 1 ($name) of type string is deprecated