### PR TITLE
Add @alpinejs/persist to npm link command in contribute guide

### DIFF
--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -53,7 +53,7 @@ cd alpine/packages/persist && npm link
 cd ../livewire
 
 # Link all packages
-npm link alpinejs @alpinejs/anchor @alpinejs/collapse @alpinejs/csp @alpinejs/docs @alpinejs/focus @alpinejs/history @alpinejs/intersect @alpinejs/mask @alpinejs/morph @alpinejs/navigate @alpinejs
+npm link alpinejs @alpinejs/anchor @alpinejs/collapse @alpinejs/csp @alpinejs/docs @alpinejs/focus @alpinejs/history @alpinejs/intersect @alpinejs/mask @alpinejs/morph @alpinejs/navigate @alpinejs/persist
 
 # Build Livewire
 npm run build


### PR DESCRIPTION
https://livewire.laravel.com/docs/contribution-guide#forking-and-cloning-the-repositories

In the part: # Link all packages
the npm link command didn't include @alpinejs/persist