### PR TITLE
Fix various typos

### DIFF
--- a/docs/__outline.md
+++ b/docs/__outline.md
@@ -89,7 +89,7 @@ Fundamentals:
 	* Basic example
 	* Security concerns
 	* Firing events
-	* Listerns
+	* Listeners
 	* Passing parameters
 	* Scoping events
 		* parent / name / self

--- a/docs/alpine.md
+++ b/docs/alpine.md
@@ -230,7 +230,7 @@ You can easily refresh a Livewire component (trigger network roundtrip to re-ren
 
 ## Sharing state using `$wire.entangle`
 
-In most cases, `$wire` is all you need for interacting with Livewire state from Alpine. However, Livewire provides an additional `$wire.entangle()` utililty that can be used to keep values from Livewire in-sync with values in Alpine.
+In most cases, `$wire` is all you need for interacting with Livewire state from Alpine. However, Livewire provides an additional `$wire.entangle()` utility that can be used to keep values from Livewire in-sync with values in Alpine.
 
 To demonstrate, consider this dropdown example with its `showDropdown` property entangled between Livewire and Alpine using `$wire.entangle()`. By using entanglement, we are now able to control the state of the dropdown from both Alpine and Livewire:
 
@@ -281,10 +281,10 @@ By default, updating the state is deferred (changes on the client, but not immed
 ```
 
 > [!tip] You might not need `$wire.entangle`
-> In most cases, you can achieve what you want by using `$wire` to directly access Livewire properties from Alpine rather than entangling them. Entangling two properties rather than relying on one can cause predictibility and performance issues when using deeply nested objects that change frequently. For this reason, `$wire.entangle` has been de-emphasized in Livewire's documentation starting with version 3.
+> In most cases, you can achieve what you want by using `$wire` to directly access Livewire properties from Alpine rather than entangling them. Entangling two properties rather than relying on one can cause predictability and performance issues when using deeply nested objects that change frequently. For this reason, `$wire.entangle` has been de-emphasized in Livewire's documentation starting with version 3.
 
 > [!warning] Refrain from using the @@entangle directive
-> In Livewire version 2, it was recommended to use Blade's `@@entangle` directive. That is no longer the case in v3. `$wire.entangle()` is preffered as it is a more robust utility and avoids certain [issues when removing DOM elements](https://github.com/livewire/livewire/pull/6833#issuecomment-1902260844).
+> In Livewire version 2, it was recommended to use Blade's `@@entangle` directive. That is no longer the case in v3. `$wire.entangle()` is preferred as it is a more robust utility and avoids certain [issues when removing DOM elements](https://github.com/livewire/livewire/pull/6833#issuecomment-1902260844).
 
 ## Manually bundling Alpine in your JavaScript build
 

--- a/docs/bundling.md
+++ b/docs/bundling.md
@@ -1,6 +1,6 @@
 Every component update in Livewire triggers a network request. By default, when multiple components trigger updates at the same time, they are bundled into a single request.
 
-This results in fewer network connections to the server and can durastically reduce server load.
+This results in fewer network connections to the server and can drastically reduce server load.
 
 In addition to the performance gains, this also unlocks features internally that require collaboration between multiple components ([Reactive Properties](/docs/nesting#reactive-props), [Modelable Properties](/docs/nesting#binding-to-child-data-using-wiremodel), etc.)
 
@@ -10,7 +10,7 @@ However, there are times when disabling this bundling is desired for performance
 
 By using Livewire's `#[Isolate]` class attribute, you can mark a component as "isolated". This means that whenever that component makes a server roundtrip, it will attempt to isolate itself from other component requests.
 
-This is useful if the update is expensive and you'd rather execute this component's update in parallel with others. For example, if multiple components are using `wire:poll` or listening for an event on the page, you may want to isolate specific component's who's updates are expensive and would otherwise hold up the entire request.
+This is useful if the update is expensive and you'd rather execute this component's update in parallel with others. For example, if multiple components are using `wire:poll` or listening for an event on the page, you may want to isolate specific component whose updates are expensive and would otherwise hold up the entire request.
 
 ```php
 use Livewire\Attributes\Isolate;

--- a/docs/component-hooks.md
+++ b/docs/component-hooks.md
@@ -101,7 +101,7 @@ class AppServiceProvider extends ServiceProvider
 
 Now that you've seen the broad overview of Component Hooks, here's a more practical example of using them to provide useful functionality for your application.
 
-Let's say you wanted to support the ability return a CSV from any Livewire action, and it would automatically trigger a file download. For example, you could return a Csv from a method called `save` inside a `CreatePost` component:
+Let's say you wanted to support the ability to return a CSV from any Livewire action, and it would automatically trigger a file download. For example, you could return a Csv from a method called `save` inside a `CreatePost` component:
 
 ```php
 use Livewire\Component;

--- a/docs/components.md
+++ b/docs/components.md
@@ -726,7 +726,7 @@ The `$post` property will automatically be assigned to the model bound via the r
 
 ### Modifying the response
 
-In some scenarios you might want to modify the response and set a custom response header. You can hook into the response object by calling the `response()` method on the view and use a closure to modify the response object:
+In some scenarios, you might want to modify the response and set a custom response header. You can hook into the response object by calling the `response()` method on the view and use a closure to modify the response object:
 
 ```php
 <?php

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -4,7 +4,7 @@ Hi there and welcome to the Livewire contribution guide. In this guide, we are g
 To contribute, the easiest way is to ensure that the Livewire and Alpine repositories are set up on your local machine. This will allow you to make changes and run the test suite with ease.
 
 ### Forking and cloning the repositories
-To get started, the first step is to fork and clone the repositories. The easiest way to do this is by using the [Github CLI](https://cli.github.com/), but you can also perform these steps manually by clicking the "Fork" button on the Github [repository page](https://github.com/livewire/livewire).
+To get started, the first step is to fork and clone the repositories. The easiest way to do this is by using the [GitHub CLI](https://cli.github.com/), but you can also perform these steps manually by clicking the "Fork" button on the GitHub [repository page](https://github.com/livewire/livewire).
 
 ```shell
 # Fork and clone Livewire

--- a/docs/lazy.md
+++ b/docs/lazy.md
@@ -44,7 +44,7 @@ To enable lazy loading, you can pass the `lazy` parameter into the component:
 Now, instead of loading the component right away, Livewire will skip this component, loading the page without it. Then, when the component is visible in the viewport, Livewire will make a network request to fully load this component on the page.
 
 > [!info] Lazy requests are isolated by default
-> Unlike other network requests in Livewire, lazy loading updates are isolated from each other when sent to the server. This keeps lazy loading fast, by loading each component in parrallel when a page loads. [Read more on disabling this behavior here →](#disabling-request-isolation)
+> Unlike other network requests in Livewire, lazy loading updates are isolated from each other when sent to the server. This keeps lazy loading fast, by loading each component in parallel when a page loads. [Read more on disabling this behavior here →](#disabling-request-isolation)
 
 ## Rendering placeholder HTML
 
@@ -206,9 +206,9 @@ If you want to override lazy loading you can set the `lazy` parameter to `false`
 
 ### Disabling request isolation
 
-If there are multiple lazy-loaded components on the page, each component will make an independant network request, rather than each lazy update being bundled into a single request.
+If there are multiple lazy-loaded components on the page, each component will make an independent network request, rather than each lazy update being bundled into a single request.
 
-If you want to disabled this isolation behavior and instead bundle all updates together in a single network request you can do so with the `isolate: false` parameter:
+If you want to disable this isolation behavior and instead bundle all updates together in a single network request you can do so with the `isolate: false` parameter:
 
 ```php
 <?php

--- a/docs/redirecting.md
+++ b/docs/redirecting.md
@@ -120,7 +120,7 @@ class UpdatePost extends Component
 }
 ```
 
-Assuming the page being redirected to contains the following Blade snippet, the user will see a "Post successfully updated." message after updating the post:
+Assuming the page being redirected to contain the following Blade snippet, the user will see a "Post successfully updated." message after updating the post:
 
 ```blade
 @if (session('status'))

--- a/docs/rules/rules.md
+++ b/docs/rules/rules.md
@@ -10,12 +10,12 @@
 
 > Always include import statements 
 
-> Be consistant, but switch it up (tone, filler transition text, using colons)
+> Be consistent, but switch it up (tone, filler transition text, using colons)
 
-> Optimize for skimming (don't show "wrong" example first unless you have visual aid. People aint reading the words: this is wrong up-front)
+> Optimize for skimming (don't show "wrong" example first unless you have visual aid. People ain't reading the words: this is wrong up-front)
 
 
-[[Referencing file names in a sentance]]
+[[Referencing file names in a sentence]]
 [[Casing rules]]
 
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -145,7 +145,7 @@ use Livewire\Attributes\Validate;
 public $title;
 ```
 
-Now, when the validation fails for this property, the message will  be "Please provide a post title" instead of "The title field is required".
+Now, when the validation fails for this property, the message will be "Please provide a post title" instead of "The title field is required".
 
 If you wish to add different messages for different rules, you can simply provide multiple `#[Validate]` attributes:
 
@@ -497,7 +497,7 @@ class UpdatePost extends Form
 
 ## Manually controlling validation errors
 
-Livewire's validation utilities should handle most common validation scenarios; however, there are times when you may want full control over the validation messages in your component.
+Livewire's validation utilities should handle the most common validation scenarios; however, there are times when you may want full control over the validation messages in your component.
 
 Below are all the available methods for manipulating the validation errors in your Livewire component:
 

--- a/docs/wire-ignore.md
+++ b/docs/wire-ignore.md
@@ -21,7 +21,7 @@ Below is an example of wrapping an element used by a third-party library in `wir
 </form>
 ```
 
-You can also instruct Livewire to only ignore changes to attributes of the root element rather than observing changes to it's contents using `wire:ignore.self`.
+You can also instruct Livewire to only ignore changes to attributes of the root element rather than observing changes to its contents using `wire:ignore.self`.
 
 ```blade
 <div wire:ignore.self>

--- a/docs/wire-navigate.md
+++ b/docs/wire-navigate.md
@@ -13,7 +13,7 @@ Below is a simple example of adding `wire:navigate` to links in a nav bar:
 </nav>
 ```
 
-When any of these links are clicked, Livewire will intercept the click and instead of allowing the browser to perform a full page visit, Livewire will fetch the page in the background and swap it with the current page (resulting in much faster and smoother page navigation).
+When any of these links are clicked, Livewire will intercept the click and, instead of allowing the browser to perform a full page visit, Livewire will fetch the page in the background and swap it with the current page (resulting in much faster and smoother page navigation).
 
 ## Prefetching pages on hover
 

--- a/docs/wire-stream.md
+++ b/docs/wire-stream.md
@@ -126,7 +126,7 @@ class ChatBot extends Component
 ```
 
 Here's what's going on in the above example:
-* A user types into a text field labelled "Send a message" to ask the chat-bot a question.
+* A user types into a text field labeled "Send a message" to ask the chat-bot a question.
 * They press the [Enter] key.
 * A network request is sent to the server, sets the message to the `$question` property, and clears the `$prompt` property.
 * The response is sent back to the browser and the input is cleared. Because `$this->js('...')` was called, a new request is triggered to the server calling the `ask()` method.

--- a/docs/wire-transition.md
+++ b/docs/wire-transition.md
@@ -87,10 +87,10 @@ Modifier | Description
 --- | ---
 `.in` | Only transition the element "in"
 `.out` | Only transition the element "out"
-`.duration.[?]ms` | Customize the transtion duration in milliseconds
-`.duration.[?]s` | Customize the transtion duration in seconds
-`.delay.[?]ms` | Customize the transtion delay in milliseconds
-`.delay.[?]s` | Customize the transtion delay in seconds
+`.duration.[?]ms` | Customize the transition duration in milliseconds
+`.duration.[?]s` | Customize the transition duration in seconds
+`.delay.[?]ms` | Customize the transition delay in milliseconds
+`.delay.[?]s` | Customize the transition delay in seconds
 `.opacity` | Only apply the opacity transition
 `.scale` | Only apply the scale transition
 `.origin.[top\|bottom\|left\|right]` | Customize the scale "origin" used
@@ -99,7 +99,7 @@ Below is a list of various transition combinations that may help to better visua
 
 **Fade-only transition**
 
-By default Livewire both fades and scales the element when transitioning. You can disable scaling and only fade by adding the `.opacity` modifier. This is useful for things like transitioning a full-page overlay, where adding a scale doesn't make sense.
+By default, Livewire both fades and scales the element when transitioning. You can disable scaling and only fade by adding the `.opacity` modifier. This is useful for things like transitioning a full-page overlay, where adding a scale doesn't make sense.
 
 ```html
 <div wire:transition.opacity>


### PR DESCRIPTION
I found out various typos by reading the docs and fixed them.

I hope this fixes are welcome!
