### PR TITLE
Update actions.md

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -468,7 +468,7 @@ public function getPostCount()
 Using `$wire`, the action may be invoked and its returned value resolved:
 
 ```blade
-<span x-text="await $wire.getPostCount()"></span>
+<span x-init="$el.innerHTML = await $wire.getPostCount()"></span>
 ```
 
 In this example, if the `getPostCount()` method returns "10", the `<span>` tag will also contain "10".


### PR DESCRIPTION
Based on discussion https://github.com/livewire/livewire/discussions/8119, Receiving return values with `$wire` object in `x-text` directly will make infinite request because `x-text` will re-evaluate again and again.

Maybe this is the better example using `$wire` object to assign element text (?)