### PR TITLE
Fix empty body after visiting 404 page in laravel octane

### DIFF
--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -46,14 +46,24 @@ class ImplicitRouteBinding
         // Livewire component, to get the proper implicit bindings.
         $route->uses(get_class($component).'@mount');
 
-        // This is normally handled in the "SubstituteBindings" middleware, but
-        // because that middleware has already ran, we need to run them again.
-        $this->container['router']->substituteImplicitBindings($route);
+        try
+        {
+            // This is normally handled in the "SubstituteBindings" middleware, but
+            // because that middleware has already ran, we need to run them again.
+            $this->container['router']->substituteImplicitBindings($route);
 
-        $parameters = $route->resolveMethodDependencies($route->parameters(), new ReflectionMethod($component, 'mount'));
+            $parameters = $route->resolveMethodDependencies($route->parameters(), new ReflectionMethod($component, 'mount'));
 
-        // Restore the original route action.
-        $route->uses($cache);
+            // Restore the original route action.
+            $route->uses($cache);
+        }
+        catch(\Exception $e)
+        {
+            // Restore the original route action before throws exception.
+            $route->uses($cache);
+
+            throw $e;
+        }
 
         return new Collection($parameters);
     }

--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -46,20 +46,17 @@ class ImplicitRouteBinding
         // Livewire component, to get the proper implicit bindings.
         $route->uses(get_class($component).'@mount');
 
-        try
-        {
+        try {
             // This is normally handled in the "SubstituteBindings" middleware, but
             // because that middleware has already ran, we need to run them again.
             $this->container['router']->substituteImplicitBindings($route);
 
             $parameters = $route->resolveMethodDependencies($route->parameters(), new ReflectionMethod($component, 'mount'));
 
-            // Restore the original route action.
+            // Restore the original route action...
             $route->uses($cache);
-        }
-        catch(\Exception $e)
-        {
-            // Restore the original route action before throws exception.
+        } catch(\Exception $e) {
+            // Restore the original route action before an exception is thrown...
             $route->uses($cache);
 
             throw $e;


### PR DESCRIPTION
See #8078 for details.

Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
yes

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
no

4️⃣ Does it include tests? (Required)
yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
Currently Livewire doesn't restore route cache properly when we get 404 in implicit route bindngs, this causes the problem as titled. This aims to fix it.

Thanks for contributing! 🙌
