### PR TITLE
Fix `Latest compiled component path not found` error

### DIFF
--- a/src/Mechanisms/ExtendBlade/DeterministicBladeKeys.php
+++ b/src/Mechanisms/ExtendBlade/DeterministicBladeKeys.php
@@ -32,8 +32,8 @@ class DeterministicBladeKeys
         return $this->countersByPath[$this->lastPath]++;
     }
 
-    public function interceptCompile(BladeCompiler $compiler)
+    public function setLastPath($path)
     {
-        $this->lastPath = $compiler->getPath();
+        $this->lastPath = $path;
     }
 }

--- a/src/Mechanisms/ExtendBlade/ExtendBlade.php
+++ b/src/Mechanisms/ExtendBlade/ExtendBlade.php
@@ -73,14 +73,9 @@ class ExtendBlade extends Mechanism
             app()->singleton(DeterministicBladeKeys::class);
         });
 
-        // We're using "precompiler" as a hook for the point in time when
-        // Laravel compiles a Blade view...
-        app('blade.compiler')->precompiler(function ($value) {
-            app(DeterministicBladeKeys::class)->interceptCompile(
-                app('blade.compiler'),
-            );
-
-            return $value;
+        // Get the last component path from the compiler everytime it is called
+        on('view:compile', function($component, $path) {
+            app(DeterministicBladeKeys::class)->setLastPath($path);
         });
     }
 

--- a/src/Mechanisms/ExtendBlade/ExtendedCompilerEngine.php
+++ b/src/Mechanisms/ExtendBlade/ExtendedCompilerEngine.php
@@ -7,7 +7,11 @@ use function Livewire\trigger;
 class ExtendedCompilerEngine extends \Illuminate\View\Engines\CompilerEngine {
     public function get($path, array $data = [])
     {
-        if (! ExtendBlade::isRenderingLivewireComponent()) return parent::get($path, $data);
+        if (! ExtendBlade::isRenderingLivewireComponent()) {
+            trigger('view:compile', null, $path);
+
+            return parent::get($path, $data);
+        }
 
         $currentComponent = ExtendBlade::currentRendering();
 


### PR DESCRIPTION
This PR attempts to fix the issues raised in discussion #7934 where in some app/environments Livewire is throwing a `Latest compiled component path not found` error.

This error is thrown by the recent load balancer changes made in PR #7751.

Basically what is happening is if there is an exception in a view (like an invalid property, missing package, anything at all), and the view has previously been compiled, then the precompiler won't run therefore the `lastPath` property in `DeterministicBladeKeys` won't be set. As such the exception `Latest compiled component path not found.` is being thrown.

We can fix this by changing to listen to Livewire's internal `view:compile` event and get the path from that.

This functions great when manually testing it in the browser.

But it was failing in unit testing. The reason is fails, is because in unit testing, the Livewire component is rendered inside of a `Blade::render()` string, so there is no parent Livewire component view path to cache.

So we can fix that by ensuring that the `view:compile` event is fired for every view compile. This is not ideal though as it runs for every blade view regardless of if it is a Livewire view or not.

Struggled writing tests for this due to complicated reproduction steps.

## Reproduction steps

1) Create a component with a nested component inside of it. Inside the nested component, add an incorrect property name

```php
class Parent extends Component
{
    public function render()
   {
       return <<<'HTML'
           <div>
               <livewire:child />
           </div>
       HTML;
   }
}

class Parent extends Component
{
    public function render()
   {
       return <<<'HTML'
           <div>
               {{ $propertyThatDoesNotExist }}
           </div>
       HTML;
   }
}
```

2) And map it to a route

```php
Route::get('/', Parent::class);
```

3) Then run `php artisan view:clear` and also clear out `laravel.log`.

4) Finally, load the parent component route in the browser.

If you look at `laravel.log` you will only see `Undefined variable` errors.

5) If you empty `laravel.log` again (but don't clear the view cache) and refresh the browser again.

Now there will be `Undefined variable` errors as well as `Latest compiled component path not found`.