### PR TITLE
[3.x] Make commands lazy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,13 @@
   ],
   "require": {
     "php": "^8.1",
-    "symfony/http-kernel": "^6.2|^7.0",
     "illuminate/database": "^10.0|^11.0",
     "illuminate/routing": "^10.0|^11.0",
     "illuminate/support": "^10.0|^11.0",
     "illuminate/validation": "^10.0|^11.0",
-    "league/mime-type-detection": "^1.9"
+    "league/mime-type-detection": "^1.9",
+    "symfony/console": "^6.0|^7.0",
+    "symfony/http-kernel": "^6.2|^7.0"
   },
   "require-dev": {
     "psy/psysh": "^0.11.22|^0.12",

--- a/src/Features/SupportConsoleCommands/Commands/AttributeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/AttributeCommand.php
@@ -3,7 +3,9 @@
 namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'livewire:attribute')]
 class AttributeCommand extends GeneratorCommand
 {
     /**

--- a/src/Features/SupportConsoleCommands/Commands/CopyCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/CopyCommand.php
@@ -3,7 +3,9 @@
 namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'livewire:copy')]
 class CopyCommand extends FileManipulationCommand
 {
     protected $signature = 'livewire:copy {name} {new-name} {--inline} {--force} {--test}';

--- a/src/Features/SupportConsoleCommands/Commands/DeleteCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/DeleteCommand.php
@@ -3,7 +3,9 @@
 namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'livewire:delete')]
 class DeleteCommand extends FileManipulationCommand
 {
     protected $signature = 'livewire:delete {name} {--inline} {--force} {--test}';

--- a/src/Features/SupportConsoleCommands/Commands/FormCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/FormCommand.php
@@ -3,7 +3,9 @@
 namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'livewire:form')]
 class FormCommand extends GeneratorCommand
 {
     /**

--- a/src/Features/SupportConsoleCommands/Commands/LayoutCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/LayoutCommand.php
@@ -4,7 +4,9 @@ namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'livewire:layout')]
 class LayoutCommand extends FileManipulationCommand
 {
     protected $signature = 'livewire:layout {--force} {--stub= : If you have several stubs, stored in subfolders }';

--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -4,11 +4,13 @@ namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\select;
 
+#[AsCommand(name: 'livewire:make')]
 class MakeCommand extends FileManipulationCommand implements PromptsForMissingInput
 {
     protected $signature = 'livewire:make {name} {--force} {--inline} {--test} {--pest} {--stub= : If you have several stubs, stored in subfolders }';

--- a/src/Features/SupportConsoleCommands/Commands/MoveCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MoveCommand.php
@@ -3,7 +3,9 @@
 namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'livewire:move')]
 class MoveCommand extends FileManipulationCommand
 {
     protected $signature = 'livewire:move {name} {new-name} {--force} {--inline}';

--- a/src/Features/SupportConsoleCommands/Commands/PublishCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/PublishCommand.php
@@ -3,7 +3,9 @@
 namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'livewire:publish')]
 class PublishCommand extends Command
 {
     protected $signature = 'livewire:publish

--- a/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
@@ -5,7 +5,9 @@ namespace Livewire\Features\SupportConsoleCommands\Commands;
 use function Livewire\invade;
 use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'livewire:configure-s3-upload-cleanup')]
 class S3CleanupCommand extends Command
 {
     protected $signature = 'livewire:configure-s3-upload-cleanup';

--- a/src/Features/SupportConsoleCommands/Commands/StubsCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/StubsCommand.php
@@ -4,7 +4,9 @@ namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'livewire:stubs')]
 class StubsCommand extends Command
 {
     protected $signature = 'livewire:stubs';

--- a/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
@@ -23,7 +23,9 @@ use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeConfigInstr
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ReplaceEmitWithDispatch;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeIntroduction;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ChangeForgetComputedToUnset;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'livewire:upgrade')]
 class UpgradeCommand extends Command
 {
     protected $signature = 'livewire:upgrade {--run-only=}';


### PR DESCRIPTION
This PR makes the Livewire commands "lazy", i.e., they do not need to be instantiated when running _other_ commands.

Currently, when you have Livewire installed in a Laravel project, if you were to run `php artisan make:model` all of the Livewire commands are instantiated. This is just how Symfony console commands work.

The `AsCommand` attribute was introduced to allow commands to be "lazy", i.e., they do not need to be instantiated when running _other_ commands.

Doing some work across the Laravel ecosystem to standardise this and thought I would drop by here and do the same.

See: https://github.com/laravel/framework/pull/50617