### PR TITLE
fix: ReflectionClass::hasProperty(): Passing null parameter

### DIFF
--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -39,7 +39,7 @@ class BaseUrl extends LivewireAttribute
         $reflectionClass = new ReflectionClass($this->getSubTarget() ?? $this->getComponent());
 
         // It's nullable if there's a nullable typehint like: public ?string $foo;
-        if ($reflectionClass->hasProperty($this->getSubName())) {
+        if ($this->getSubName() && $reflectionClass->hasProperty($this->getSubName())) {
             $property = $reflectionClass->getProperty($this->getSubName());
 
             return $property->getType()?->allowsNull() ?? false;


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Yes, I have created a [discussion](https://github.com/livewire/livewire/discussions/8070).

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
yes, check-nullable-getter-in-base-url-attribute

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
I really don't know how to test that an warning is thrown. There is other PR #8099 that shows `$this->getSubName()` can be nullable.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Just the fact that $subName is null by default will eventually cause this warning to appear.

Nullable property: https://github.com/livewire/livewire/blob/main/src/Features/SupportAttributes/Attribute.php#L19C70-L19C85

The warning appears here: https://github.com/livewire/livewire/blob/main/src/Features/SupportQueryString/BaseUrl.php#L42

warning message: ReflectionClass::hasProperty(): Passing null to parameter 1 ($name) of type string is deprecated