### PR TITLE
Fix deterministic Blade key generation

### DIFF
--- a/src/Mechanisms/ExtendBlade/ExtendBlade.php
+++ b/src/Mechanisms/ExtendBlade/ExtendBlade.php
@@ -76,9 +76,7 @@ class ExtendBlade extends Mechanism
         // We're using "precompiler" as a hook for the point in time when
         // Laravel compiles a Blade view...
         app('blade.compiler')->precompiler(function ($value) {
-            app(DeterministicBladeKeys::class)->interceptCompile(
-                app('blade.compiler'),
-            );
+            app(DeterministicBladeKeys::class)->hookIntoCompile(app('blade.compiler'), $value);
 
             return $value;
         });

--- a/src/Mechanisms/Tests/LoadBalancerCompatibilityUnitTest.php
+++ b/src/Mechanisms/Tests/LoadBalancerCompatibilityUnitTest.php
@@ -45,4 +45,26 @@ class LoadBalancerCompatibilityUnitTest extends \Tests\TestCase
 
         $this->assertEquals($firstKey, $secondKey);
     }
+
+    /** @test */
+    public function deterministic_keys_can_still_be_generated_from_blade_strings_not_files()
+    {
+        $contentsA = app('blade.compiler')->compileString(<<<'HTML'
+        <div>
+            <livewire:the-child />
+        </div>
+        HTML);
+
+        // Reset any internal key counters...
+        app('livewire')->flushState();
+
+        $contentsB = app('blade.compiler')->compileString(<<<'HTML'
+        <div>
+            <livewire:the-child />
+        </div>
+        HTML);
+
+        $this->assertStringContainsString('lw-540987236-0', $contentsA);
+        $this->assertStringContainsString('lw-540987236-0', $contentsB);
+    }
 }


### PR DESCRIPTION

## The scenario

The following error is popping up in odd places in users Livewire environments:

```
Latest compiled component path not found.
```

It seems to be triggered in the background and is showing up in bug trackers and logs less than on pages directly.

Particularly when Blade views throw runtime errors.

## The problem

To really understand what's going on, it's helpful to understand how Livewire generates keys for components. So let's get caught up and then we can resume:

### A brief history of generating keys in Livewire

#### The scenario

Given, every Livewire component rendered on a page needs a key associated with it so that Livewire can properly track it inside a Blade view across network requests.

At first, we naively used `str()->random()` to generate random keys at compile-time for Livewire components if no key was provided, for example, the following blade:

```blade
@livewire('foo')
```

Would compile to something like:

```
app('livewire')->mount('foo', params: [], key: 'jksaac24df')
```

Because of Blade compiler code like the following:

```php
Blade::directive('livewire', function ($expression) {
    [ $name, $key ] = $this->processExpression($expression);

    if (! $key) {
        $key = str()->random();
    }

    return <<<HTML
    <?php
        echo app('livewire')->mount('$name', key: '$key');
    ?>
    HTML;
});
```

#### The problem

This worked fine for normal environments, however, in load balanced environments this was a problem because multiple servers would each have their own set of compiled Blade views with different keys generated inside them.

This means that a Livewire component might make requests to multiple different servers during its lifecycle and encounter issues because it's "key" from one server, won't match the key from the next and things break down.

To illustrate, you might end up with the following differing keys:

```
// Server #1:
app('livewire')->mount('foo', params: [], key: 'jksaac24df')

// Server #2:
app('livewire')->mount('foo', params: [], key: 'luxdiy6ky1')
```

#### The solution

The solution to this problem is to generate keys in a more deterministic (not-random) way so that keys across multiple load-balanced servers will match up.

The approach we chose was to generate a key from the following logic:

```
$key = 'lw-' . $currentBladeFile . $componentCounter;

// $currentBladeFile is the file name of the current Blade file (or a hash of it).

// $componentCounter is a running count of all the Livewire components on the page. This way each `@livewire` occurance on a page won't have a matching key.
```

Because this algorithm uses deterministic inputs (the Blade file name and an incrementing count), we can, in theory, generate deterministic keys across load-balanced servers.

Consider the following updated Blade compiler code for `@livewire` directives:

```php
// The @livewire directive compiler code:
Blade::directive('livewire', function ($expression) {
    [ $name, $key ] = $this->processExpression($expression);

    if (! $key) {
        $key = DeterministicKeyGenerator::generate();
    }

    return <<<HTML
    <?php
        echo app('livewire')->mount('$name', key: '$key');
    ?>
    HTML;
});

// The class for generating deterministic keys:
class DeterministicKeyGenerator
{
    public $currentBladeFile;

    public $componentCounter;

    public function setCurrentBladeFile($file)
    {
        $this->componentCounter = 0;

        $this->currentBladeFile = $file;
    }
    
    public function generate()
    {
        if (! $this->currentBladeFile) {
            throw new \Exception('Latest compiled component path not found.');
        }
        
        $this->componentCounter++;

        return 'lw-' . $this->currentBladeFile . $componentCounter;
    }
}

// The code that hooks into Blade compilation to give the
// key generator the context it needs at compile-time:
app('blade.compiler')->precompiler(function ($value) {
    app(DeterministicBladeKeys::class)->setCurrentBladeFile(
        app('blade.compiler')->getPath(),
    );

    return $value;
});
```

As you can see, the simple `@livewire` directive compilation code has expanded into an extra class to generate deterministic keys, as well as some "hook" code to make sure the key generator has the context it needs.

### Back to the problem at hand

Ok, so now that you're caught up on key generation in Livewire, here's the problem we're currently facing.

As you just learned, Livewire needs to know the current Blade file being compiled so that it can generate deterministic keys.

If, for any reason the `$currentBladeFile` isn't set, then the generator class won't be able to generate keys and will throw the above error: `Latest compiled component path not found.`

One scenario we can point to is when `Blade::compileString($contents)` is run directly instead of `Blade::compile($path)`.

As you might have noticed in the previously shown generator code, Livewire gets the current Blade view being rendered with this line of code:

```php
app('blade.compiler')->getPath();
```

Unsurprisingly, `->getPath()` can only return an actual path when one has been provided to the compiler. 

When `->compileString(...)` is called directly, `->getPath()` returns `null`.

Therefore, anytime a `@livewire` directive is encountered while compiling Blade directly from a string, the `Latest compiled component path not found.` will trigger.

This problem has specifically surfaced when errors are thrown inside Blade views because Spatie's Ignition package uses `->compileString()` directly to show more friendly error messages: https://github.com/spatie/laravel-ignition/blob/5f4eba2ac5831af0645158d4ae4eb492ae0898d4/src/Views/BladeSourceMapCompiler.php#L33

## The solution

Instead of solely relying on `->getPath()` to generate a deterministic key of a chunk of Blade, we can make the system more sophisticated by providing a fallback of a hash of the contents of the "string" being compiled.

Here's some pseudo code of the fix:

```php
app('blade.compiler')->precompiler(function ($value) {
    // $value is the contents currently being compiled...
    
    app(DeterministicBladeKeys::class)->setCurrentBladeFile(
        app('blade.compiler')->getPath() ?: $value,
    );

    return $value;
});
```

This makes it so that Livewire components can still be assigned keys deterministically, even when being used outside standard Blade views.

