### PR TITLE
Re-enable Laravel 11 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [10.*]
-        # exclude:
-        #   - php: 8.1
-        #     laravel: 11.*
+        laravel: [10.*, 11.*]
+        exclude:
+          - php: 8.1
+            laravel: 11.*
 
     name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
 


### PR DESCRIPTION
The Laravel 11 tests were disabled in 8e76c1a63f0093bbbb9c0d07a6f0f926a2d927d5, but since L11 seems quite stable right now, it's probably better to re-enable them.