### PR TITLE
Update events.md

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -135,7 +135,9 @@ Additionally, you can dispatch events from within a component's `@script` like s
 ```html
 @script
 <script>
-    $wire.dispatch('post-created');
+    $nextTick(() => {
+        $wire.dispatch('post-created');
+    });
 </script>
 @endscript
 ```
@@ -153,7 +155,9 @@ You can pass any additional parameters to the event by passing an object as a se
 ```html
 @script
 <script>
-    $wire.dispatch('post-created', { refreshPosts: true });
+    $nextTick(() => {
+        $wire.dispatch('post-created', { refreshPosts: true });
+    });
 </script>
 @endscript
 ```


### PR DESCRIPTION
Based on discussion: https://github.com/livewire/livewire/discussions/8193 https://github.com/livewire/livewire/discussions/7795

Apparently dispatching event from `@script` immediately is not working if the code is not wrapped inside `$nextTick()`
