### PR TITLE
Update GenerateSignedUploadUrl.php

### DIFF
--- a/src/Features/SupportFileUploads/GenerateSignedUploadUrl.php
+++ b/src/Features/SupportFileUploads/GenerateSignedUploadUrl.php
@@ -25,6 +25,12 @@ class GenerateSignedUploadUrl
         // Flysystem V2+ doesn't allow direct access to client, so we need to invade instead.
         $client = invade($adapter)->client;
 
+        // handle nested adapters like path prefix
+        while (!$client) {
+            $adapter = invade($adapter)->adapter;
+            $client = invade($adapter)->client;
+        }
+
         // Flysystem V2+ doesn't allow direct access to bucket, so we need to invade instead.
         $bucket = invade($adapter)->bucket;
 


### PR DESCRIPTION
TL;DR: You probably want to fix this issue in a better way, so this PR is merely a suggestion and to highlight what the issue is. I don't consider this a complete PR/fix (no tests to prove it's currently broken, for instance).

I am setting up a new app, and I want to upload files to S3. I want to reuse a space, so I figure I can use Laravel's s3 -> prefix config to store the files in an isolated "folder". Unfortunately, after installing the AWS adapter and the Path Prefix adapter, I run into an issue.

<img width="1298" alt="Screenshot 2024-03-24 at 08 40 47" src="https://github.com/livewire/livewire/assets/200609/95460842-8c9d-491f-8a3d-fabe8faf6ba7">

This is happening because Flysystem nests adapters, but this doesn't seem to be supported/handled by Livewire (and doesn't fail gracefully). A potential fix is to recursively search for the base adapter. I am not sure what other side-effects this approach has, though. I assume there are more complicated setups that might nest in a different order? Who knows.