### PR TITLE
Add failing test for prefix config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,9 @@
     "orchestra/testbench": "8.20.0|^9.0",
     "orchestra/testbench-dusk": "8.20.0|^9.0",
     "calebporzio/sushi": "^2.1",
-    "laravel/prompts": "^0.1.6"
+    "laravel/prompts": "^0.1.6",
+    "league/flysystem-aws-s3-v3": "^3.0",
+    "league/flysystem-path-prefixing": "^3.3"
   },
   "autoload": {
     "files": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,5 +22,14 @@
     <php>
         <env name="CACHE_STORE" value="file"/>
         <env name="SESSION_DRIVER" value="file"/>
+
+        <env name="S3_ENDPOINT" value=""/>
+        <env name="S3_KEY" value=""/>
+        <env name="S3_SECRET" value=""/>
+        <env name="S3_REGION" value=""/>
+        <env name="S3_BUCKET" value=""/>
+        <env name="S3_VISIBILITY" value=""/>
+        <env name="S3_PREFIX" value="/prefix/"/>
+
     </php>
 </phpunit>

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -7,11 +7,11 @@ use League\Flysystem\WhitespacePathNormalizer;
 
 class FileUploadConfiguration
 {
-    public static function storage()
+    public static function storage($useRealDiskInTests = false)
     {
-        if (app()->runningUnitTests()) {
+        if (!$useRealDiskInTests && app()->runningUnitTests()) {
             // We want to "fake" the first time in a test run, but not again because
-            // ::fake() whipes the storage directory every time its called.
+            // ::fake() wipes the storage directory every time its called.
             rescue(function () {
                 // If the storage disk is not found (meaning it's the first time),
                 // this will throw an error and trip the second callback.
@@ -21,12 +21,12 @@ class FileUploadConfiguration
             });
         }
 
-        return Storage::disk(static::disk());
+        return Storage::disk(static::disk($useRealDiskInTests));
     }
 
-    public static function disk()
+    public static function disk($useRealDiskInTests = false)
     {
-        if (app()->runningUnitTests()) {
+        if (!$useRealDiskInTests && app()->runningUnitTests()) {
             return 'tmp-for-tests';
         }
 

--- a/src/Features/SupportFileUploads/GenerateSignedUploadUrl.php
+++ b/src/Features/SupportFileUploads/GenerateSignedUploadUrl.php
@@ -15,9 +15,9 @@ class GenerateSignedUploadUrl
         );
     }
 
-    public function forS3($file, $visibility = 'private')
+    public function forS3($file, $visibility = 'private', $useRealDiskInTests = false)
     {
-        $driver = FileUploadConfiguration::storage()->getDriver();
+        $driver = FileUploadConfiguration::storage(useRealDiskInTests: $useRealDiskInTests)->getDriver();
 
         // Flysystem V2+ doesn't allow direct access to adapter, so we need to invade instead.
         $adapter = invade($driver)->adapter;

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -784,6 +784,33 @@ class UnitTest extends \Tests\TestCase
             ->set('file', $file)
             ->assertSet('content', $file->getContent());
     }
+
+    /** @test */
+    public function prefix_config_is_supported()
+    {
+        if (empty(env('S3_KEY'))) {
+            $this->markTestSkipped('S3_* env vars not set for prefix test');
+        }
+
+        config()->set('filesystems.default', 's3');
+        config()->set('filesystems.disks.s3', [
+            'driver' => 's3',
+            'key' => env('S3_KEY'),
+            'secret' => env('S3_SECRET'),
+            'endpoint' => env('S3_ENDPOINT'),
+            'region' => env('S3_REGION'),
+            'bucket' => env('S3_BUCKET'),
+            'visibility' => env('S3_VISIBILITY'),
+            'prefix' => env('S3_PREFIX'),
+        ]);
+
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        $service = new \Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl;
+        $result = $service->forS3($file, useRealDiskInTests: true);
+
+        $this->assertIsArray($result);
+    }
 }
 
 class DummyMiddleware


### PR DESCRIPTION
Unfortunately, the testing setup doesn't appear to cover `GenerateSignedUploadUrl::forS3` and it seems impossible to test this (aside from the conditions that force a mock storage disk) without using S3 credentials. Please reach out to me and I can provide you with a set of credentials (to use locally), to reproduce this failing test result for yourself.

cgpitt@gmail.com + twitter.com/assertchris

Edit:
The error is happening because https://github.com/livewire/livewire/blob/83392ce47c0d53ca4383ebba7480486b44272594/src/Features/SupportFileUploads/GenerateSignedUploadUrl.php#L26 assumes `client` is defined, but when using prefix config; the adapter is nested. So, instead of `adapter->client` we need to reach for `adapter->adapter->client`. Unclear what other scenarios make this nesting deeper, so a hack I have used to get around this error is to recursively walk the adapter tree until I do find `client`.