### PR TITLE
EloquentModelSynth: convert empty string to null for enum casted attributes

### DIFF
--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -106,6 +106,10 @@ class EloquentModelSynth extends Synth
             return $target->setRelation($key, $value);
         }
 
+        if (array_key_exists($key, $target->getCasts()) && enum_exists($target->getCasts()[$key]) && $value === '') {
+            $value = null;
+        }
+
         $target->$key = $value;
     }
 


### PR DESCRIPTION
This PR addresses an issue encountered in applications utilizing legacy model binding with model attributes cast to enums. 
It is somewhat related to #7955 where the same issue was fixed for enum properties without legacy model binding.

### Problem Encountered:

Selecting an empty option of a `<select>` tag that is bound to an eloquent model triggers the following ValueError:

```
ValueError  "" is not a valid backing value for enum "App\Enums\Status".
```

Other options derived from the enum work as expected.

### Code snippets to reproduce the issue

Enum

```php
enum TestingEnum: string
{
    case FOO = 'bar';
}
```

Model

```php
class TestModel extends Model
{
    protected $casts = [
        'enum_attribute' => TestingEnum::class,
    ];
}
```

Component

```php
class TestComponent extends Component
{
    public TestModel $model;

    public function rules(): array
    {
        return [
            'model.enum_attribute' => ['nullable', Rule::enum(TestingEnum::class)]
        ];
    }
}
```

View

```blade
<select wire:model="model.enum_attribute">
    <option value="">EmptyOption</option><!-- selecting this breaks -->
    @foreach(TestingEnum::cases() as $enum)
        <option value="{{ $enum->value }}">{{ $enum->value }}</option>
    @endforeach
</select>
```

### Solution
Convert the empty string to `null` before it is set to the model.
