### PR TITLE
Add support for Validate message arrays

### DIFF
--- a/src/Features/SupportValidation/BaseValidate.php
+++ b/src/Features/SupportValidation/BaseValidate.php
@@ -63,9 +63,20 @@ class BaseValidate extends LivewireAttribute
 
         if ($this->message) {
             if (is_array($this->message)) {
+                if (count($rules) === 1) {
+                    $messages = [];
+                    foreach ($this->message as $key => $value) {
+                        if (! str_contains($key, '.')) {
+                            $messages[$name.'.'.$key] = $value;
+                        }
+                    }
+                } else {
+                    $messages = $this->message;
+                }
+
                 $messages = $this->translate
-                    ? array_map(fn ($i) => trans($i), $this->message)
-                    : $this->message;
+                    ? array_map(fn ($i) => trans($i), $messages)
+                    : $messages;
 
                 $target->addMessagesFromOutside($messages);
             } else {

--- a/src/Features/SupportValidation/BaseValidate.php
+++ b/src/Features/SupportValidation/BaseValidate.php
@@ -63,7 +63,9 @@ class BaseValidate extends LivewireAttribute
 
         if ($this->message) {
             if (is_array($this->message)) {
-                if (count($rules) === 1) {
+                if (count($rules) === 1 && isset($rules[$this->getSubName()])) {
+                    // if $this->rule was a string ('required|min:3') or numerically indexed array (['required', 'min:3']),
+                    // the $rules array is single rule. If it was an associative array, it is multiple rules
                     $messages = [];
                     foreach ($this->message as $key => $value) {
                         if (! str_contains($key, '.')) {

--- a/src/Features/SupportValidation/BaseValidate.php
+++ b/src/Features/SupportValidation/BaseValidate.php
@@ -67,9 +67,12 @@ class BaseValidate extends LivewireAttribute
                     // if $this->rule was a string ('required|min:3') or numerically indexed array (['required', 'min:3']),
                     // the $rules array is single rule. If it was an associative array, it is multiple rules
                     $messages = [];
+                    $prefix = $name.'.';
                     foreach ($this->message as $key => $value) {
-                        if (! str_contains($key, '.')) {
-                            $messages[$name.'.'.$key] = $value;
+                        if (! str_starts_with($key, $prefix)) {
+                            $messages[$prefix.$key] = $value;
+                        } else {
+                            $messages[$key] = $value;
                         }
                     }
                 } else {

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -239,7 +239,31 @@ class UnitTest extends \Tests\TestCase
 
                 $this->assertEquals('Your foo is too short.', $messages['foo'][0]);
             })
-            ;
+        ;
+    }
+
+    /** @test */
+    public function rule_attribute_supports_custom_messages_as_arrays()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Validate('min:5', message: ['min' => 'Your foo is too short.'])]
+            public $foo = '';
+
+            #[Validate('min:5', message: ['min' => 'Your bar is too short.'])]
+            public $bar = '123456';
+
+            function clear() { $this->clearValidation(); }
+
+            function save() { $this->validate(); }
+        })
+            ->set('foo', 'te')
+            ->assertHasErrors()
+            ->tap(function ($component) {
+                $messages = $component->errors()->getMessages();
+
+                $this->assertEquals('Your foo is too short.', $messages['foo'][0]);
+            })
+        ;
     }
 
     /** @test */

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -246,22 +246,58 @@ class UnitTest extends \Tests\TestCase
     public function rule_attribute_supports_custom_messages_as_arrays()
     {
         Livewire::test(new class extends TestComponent {
-            #[Validate('min:5', message: ['min' => 'Your foo is too short.'])]
+            #[Validate('min:5|max:8', message: ['min' => 'Your foo is too short.', 'max' => 'Your foo is too long.'])]
             public $foo = '';
 
-            #[Validate('min:5', message: ['min' => 'Your bar is too short.'])]
-            public $bar = '123456';
+            #[Validate('min:5|max:8', message: ['min' => 'Your bar is too short.', 'max' => 'Your bar is too long.'])]
+            public $bar = '';
+
+            #[Validate('min:5|max:8', message: ['min' => 'Your baz is too short.', 'max' => 'Your baz is too long.'])]
+            public $baz = '';
 
             function clear() { $this->clearValidation(); }
 
             function save() { $this->validate(); }
         })
-            ->set('foo', 'te')
+            ->set('foo', '12')
+            ->set('bar', '1234567890')
+            ->set('baz', '123456')
             ->assertHasErrors()
             ->tap(function ($component) {
                 $messages = $component->errors()->getMessages();
 
                 $this->assertEquals('Your foo is too short.', $messages['foo'][0]);
+                $this->assertEquals('Your bar is too long.', $messages['bar'][0]);
+            })
+        ;
+    }
+
+    /** @test */
+    public function rule_attribute_supports_custom_messages_as_arrays_when_rules_are_arrays()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Validate(['min:5', 'max:8'], message: ['min' => 'Your foo is too short.', 'max' => 'Your foo is too long.'])]
+            public $foo = '';
+
+            #[Validate(['min:5', 'max:8'], message: ['min' => 'Your bar is too short.', 'max' => 'Your bar is too long.'])]
+            public $bar = '';
+
+            #[Validate(['min:5', 'max:8'], message: ['min' => 'Your baz is too short.', 'max' => 'Your baz is too long.'])]
+            public $baz = '';
+
+            function clear() { $this->clearValidation(); }
+
+            function save() { $this->validate(); }
+        })
+            ->set('foo', '12')
+            ->set('bar', '1234567890')
+            ->set('baz', '123456')
+            ->assertHasErrors()
+            ->tap(function ($component) {
+                $messages = $component->errors()->getMessages();
+
+                $this->assertEquals('Your foo is too short.', $messages['foo'][0]);
+                $this->assertEquals('Your bar is too long.', $messages['bar'][0]);
             })
         ;
     }


### PR DESCRIPTION
Rather than doing this:
```php
#[Validate('required', as: 'Input A', message: 'Input A is required')]
#[Validate('max:6', as: 'Input A', message: 'Input A should be no more than 6 characters')]
#[Validate('min:2', as: 'Input A', message: 'Input A should be at least 2 characters')]
public $inputA;
```

It would be nice to do this:
```php
#[Validate('required|max:6|min:2', as: 'Input A', message: ['required' => 'Input A is required', 'min' => 'Input A should be at least 2 characters', 'max' => 'Input A should be no more than 6 characters'])]
public $inputA;
```
Currently, if you attempt to do this with multiple properties, each message gets applied to the global validation message since it isn't prefixed. This makes it look like a bug at first glance. Here is a wirebox showcasing the problem/feature: https://wirebox.app/b/4oppg

This PR would allow the messages to be passed as an array and have their property prefix added on.