### PR TITLE
Fixed undefined key with unset method of DataStore

### DIFF
--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -8,6 +8,7 @@ use Tests\TestCase;
 use Livewire\Livewire;
 use Livewire\Component;
 use Livewire\Attributes\Computed;
+use Livewire\Features\SupportEvents\BaseOn;
 
 class UnitTest extends TestCase
 {
@@ -420,6 +421,30 @@ class UnitTest extends TestCase
         })
             ->assertSet('foo', 'bar')
             ->call('save')
+            ->assertSet('foo', 'baz');
+    }
+
+    /** @test */
+    public function it_supports_unsetting_legacy_computed_properties_for_events()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $changeFoo = false;
+
+            public function getFooProperty()
+            {
+                return $this->changeFoo ? 'baz' : 'bar';
+            }
+
+            #[BaseOn('bar')]
+            public function onBar()
+            {
+                $this->changeFoo = true;
+
+                unset($this->foo);
+            }
+        })
+            ->assertSet('foo', 'bar')
+            ->dispatch('bar', 'baz')
             ->assertSet('foo', 'baz');
     }
 }

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -397,6 +397,11 @@ class UnitTest extends TestCase
             {
                 return 'bar';
             }
+
+            public function render()
+            {
+                return '<div></div>';
+            }
         })
             ->assertSet('foo', 'bar');
     }
@@ -414,9 +419,17 @@ class UnitTest extends TestCase
 
             public function save()
             {
+                // Access foo to ensure it is memoized.
+                $this->foo;
+
                 $this->changeFoo = true;
 
                 unset($this->foo);
+            }
+
+            public function render()
+            {
+                return '<div></div>';
             }
         })
             ->assertSet('foo', 'bar')

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -418,9 +418,6 @@ class UnitTest extends TestCase
 
             public function save()
             {
-                // Access foo to ensure it is memoized.
-                $this->foo;
-
                 $this->changeFoo = true;
 
                 unset($this->foo);

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -396,11 +396,6 @@ class UnitTest extends TestCase
             {
                 return 'bar';
             }
-
-            public function render()
-            {
-                return '<div></div>';
-            }
         })
             ->assertSet('foo', 'bar');
     }
@@ -421,11 +416,6 @@ class UnitTest extends TestCase
                 $this->changeFoo = true;
 
                 unset($this->foo);
-            }
-
-            public function render()
-            {
-                return '<div></div>';
             }
         })
             ->assertSet('foo', 'bar')

--- a/src/Mechanisms/DataStore.php
+++ b/src/Mechanisms/DataStore.php
@@ -93,6 +93,10 @@ class DataStore extends Mechanism
             return;
         }
 
+        if (! isset($this->lookup[$instance][$key])) {
+            return;
+        }
+
         if ($iKey !== null) {
             // Set a local variable to avoid the "indirect modification" error.
             $keyValue = $this->lookup[$instance][$key];


### PR DESCRIPTION
Ran into a new exception today after upgrading my app to the latest version.

The exception is `Undefined array key "computedProperties"` which I was able to trace back to #8048 and that there needed to be another `isset()` check on the `$key`.

The issue I was able to replicate that this fixes is with a legacy computed property (ex: `getUserProperty()`) which is using an event attribute `ex: [On('someEvent')]` and I guess it isn't in the data store for that kind of flow.

I updated the test added in #8048 and without the change I've made would fail, but continues to pass with the change, supporting both cases.