### PR TITLE
Fix Laravel 11 tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "phpunit/phpunit": "^10.4",
     "laravel/framework": "^10.0|^11.0",
     "orchestra/testbench": "^8.21.0|^9.0",
-    "orchestra/testbench-dusk": "^8.21.0|^9.0",
+    "orchestra/testbench-dusk": "^8.24|^9.1",
     "calebporzio/sushi": "^2.1",
     "laravel/prompts": "^0.1.6"
   },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "phpunit/phpunit": "^10.4",
     "laravel/framework": "^10.0|^11.0",
     "orchestra/testbench": "8.20.0|^9.0",
-    "orchestra/testbench-dusk": "8.20.0|^9.0",
+    "orchestra/testbench-dusk": "^8.21.0|^9.0",
     "calebporzio/sushi": "^2.1",
     "laravel/prompts": "^0.1.6"
   },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "mockery/mockery": "^1.3.1",
     "phpunit/phpunit": "^10.4",
     "laravel/framework": "^10.0|^11.0",
-    "orchestra/testbench": "8.20.0|^9.0",
+    "orchestra/testbench": "^8.21.0|^9.0",
     "orchestra/testbench-dusk": "^8.21.0|^9.0",
     "calebporzio/sushi": "^2.1",
     "laravel/prompts": "^0.1.6"

--- a/legacy_tests/Browser/SupportsSafari.php
+++ b/legacy_tests/Browser/SupportsSafari.php
@@ -2,58 +2,18 @@
 
 namespace LegacyTests\Browser;
 
-use Override;
-
 // Thanks to https://github.com/appstract/laravel-dusk-safari for most of this source.
 trait SupportsSafari
 {
     protected static $safariProcess;
 
-    /**
-     * This is an override and customisation of orchestra/testbench-dusk/src/TestCase.php
-     * 
-     * @return void 
-     */
-    #[Override]
-    public static function setUpBeforeClass(): void
+    protected static function defineChromeDriver(): void
     {
-        static::setUpBeforeClassForInteractsWithWebDriverOptions();
-
-        if (! isset($_ENV['DUSK_DRIVER_URL'])) {
-            if (static::$useSafari) {
-                static::startSafariDriver();
-            } else {
-                static::startChromeDriver(['port' => 9515]);
-            }
+        if (static::$useSafari) {
+            static::startSafariDriver();
+        } else {
+            static::startChromeDriver(['port' => 9515]);
         }
-
-        /**
-         * As we don't want to call `parent::setUpBeforeClass();` which would call the
-         * method we are overriding. The method requires us to call it's parent but
-         * we can't do that. So we have had to create a copy of the method below
-         * and call it here instead.
-         */
-        static::parentOfParentSetUpBeforeClass();
-        static::startServing();
-    }
-
-    /**
-     * This is purely a copy of the core method from orchestra/testbench-core/src/TestCase.php
-     * As we can't call a parent of a parent, this seems to be the only way around it.
-     * 
-     * @return void 
-     */
-    public static function parentOfParentSetUpBeforeClass()
-    {
-        static::setUpBeforeClassUsingPHPUnit();
-
-        /** @phpstan-ignore-next-line */
-        if (static::usesTestingConcern(Pest\WithPest::class)) {
-            static::setUpBeforeClassUsingPest(); // @phpstan-ignore-line
-        }
-
-        static::setUpBeforeClassUsingTestCase();
-        static::setUpBeforeClassUsingWorkbench();
     }
 
     public function onlyRunOnChrome()

--- a/legacy_tests/Browser/SupportsSafari.php
+++ b/legacy_tests/Browser/SupportsSafari.php
@@ -2,19 +2,58 @@
 
 namespace LegacyTests\Browser;
 
+use Override;
+
 // Thanks to https://github.com/appstract/laravel-dusk-safari for most of this source.
 trait SupportsSafari
 {
     protected static $safariProcess;
 
-    /** @beforeClass */
-    public static function prepare()
+    /**
+     * This is an override and customisation of orchestra/testbench-dusk/src/TestCase.php
+     * 
+     * @return void 
+     */
+    #[Override]
+    public static function setUpBeforeClass(): void
     {
-        if (static::$useSafari) {
-            static::startSafariDriver();
-        } else {
-            static::startChromeDriver(['port' => 9515]);
+        static::setUpBeforeClassForInteractsWithWebDriverOptions();
+
+        if (! isset($_ENV['DUSK_DRIVER_URL'])) {
+            if (static::$useSafari) {
+                static::startSafariDriver();
+            } else {
+                static::startChromeDriver(['port' => 9515]);
+            }
         }
+
+        /**
+         * As we don't want to call `parent::setUpBeforeClass();` which would call the
+         * method we are overriding. The method requires us to call it's parent but
+         * we can't do that. So we have had to create a copy of the method below
+         * and call it here instead.
+         */
+        static::parentOfParentSetUpBeforeClass();
+        static::startServing();
+    }
+
+    /**
+     * This is purely a copy of the core method from orchestra/testbench-core/src/TestCase.php
+     * As we can't call a parent of a parent, this seems to be the only way around it.
+     * 
+     * @return void 
+     */
+    public static function parentOfParentSetUpBeforeClass()
+    {
+        static::setUpBeforeClassUsingPHPUnit();
+
+        /** @phpstan-ignore-next-line */
+        if (static::usesTestingConcern(Pest\WithPest::class)) {
+            static::setUpBeforeClassUsingPest(); // @phpstan-ignore-line
+        }
+
+        static::setUpBeforeClassUsingTestCase();
+        static::setUpBeforeClassUsingWorkbench();
     }
 
     public function onlyRunOnChrome()

--- a/src/Features/SupportTesting/DuskBrowserMacros.php
+++ b/src/Features/SupportTesting/DuskBrowserMacros.php
@@ -167,14 +167,18 @@ class DuskBrowserMacros
 
             $this->script([
                 "window.duskIsWaitingForLivewireRequest{$id} = true",
-                "window.Livewire.hook('request', ({ respond }) => {
+                "window.Livewire.hook('request', ({ respond, succeed, fail }) => {
                     window.duskIsWaitingForLivewireRequest{$id} = true
 
-                    respond(() => {
+                    let handle = () => {
                         queueMicrotask(() => {
+                            console.log('test')
                             delete window.duskIsWaitingForLivewireRequest{$id}
                         })
-                    })
+                    }
+
+                    succeed(handle)
+                    fail(handle)
                 })",
             ]);
 
@@ -213,14 +217,17 @@ class DuskBrowserMacros
 
             $this->script([
                 "window.duskIsWaitingForLivewireRequest{$id} = true",
-                "window.Livewire.hook('request', ({ respond }) => {
+                "window.Livewire.hook('request', ({ respond, succeed, fail }) => {
                     window.duskIsWaitingForLivewireRequest{$id} = true
 
-                    respond(() => {
+                    let handle = () => {
                         queueMicrotask(() => {
                             delete window.duskIsWaitingForLivewireRequest{$id}
                         })
-                    })
+                    }
+
+                    succeed(handle)
+                    fail(handle)
                 })",
             ]);
 


### PR DESCRIPTION
This PR fixes issues with the Laravel 11 tests not running correctly.

## Scenario
Previously, we ran into issues with our Dusk tests failing after v8.20.0 of `orchestra/testbench-dusk`, so we had locked `orchestra/testbench` and `orchestra/testbench-dusk` to version v8.20.0. See this commit where we did that https://github.com/livewire/livewire/commit/06e7bebeb4835fa923e646e963bce9957fea99b3

For Laravel 11 tests to run, it is required that `testbench` and `testbench-dusk` v9.0 or above is installed for compatibility reasons.

But it turns out that it means our tests for Laravel 11 started failing due to the same bug causing us to lock the v8 version.

## Problem
Upon investigation, I found that it was this commit https://github.com/orchestral/testbench-dusk/commit/c3e7fc1d98529dded7d3bb55e748541242b14a90 in `orchestra/testbench-dusk` that was released in v8.21.0 that caused our Dusk tests to have problems.

When I dug into the changes in the commit, I found that the `prepare()` method had been removed in favour of starting the chrome driver in `setUpBeforeClass()`.

But we were still doing it the old way and made use of starting the chrome driver in `prepare()` in `legacy_tests/Browser/SupportsSafari.php`

https://github.com/livewire/livewire/blob/4f3a726fc0c4510dc36865062619cd8d69d3347d/legacy_tests/Browser/SupportsSafari.php#L10-L18

## Solution
So I had to rework how that is all currently structured to remove our implementation of the `prepare()` method.

To do this though, I had to manually override the `setUpBeforeClass()` method from `testbench-dusk`, so we can make our specific changes. See below for the original:

https://github.com/orchestral/testbench-dusk/blob/576e2493ee60c073e154dd4d8fb1cde90dcb684e/src/TestCase.php#L288-L298

One issue I ran into is that the `setUpBeforeClass()` from `testbench-dusk` calls `parent::setUpBeforeClass()` which is inside the `testbench-core` package.

But PHP doesn't allow us to call the parent of a parent, so I had to make a copy of `setUpBeforeClass()` from the parent `testbench-core` to ensure everything runs correctly. See below for the one from `testbench-core`:

https://github.com/orchestral/testbench-core/blob/3b94cc71f00b9de01597aec5ae962ade106dc5e8/src/TestCase.php#L132-L143

These changes have allowed everything to run again as expected, but I think this should probably all be reviewed at some point. Maybe @crynobone might have some ideas for how we can clean it all up and hopefully make it less brittle to changes in the future.

I have also removed the v8.20.0 version lock from `testbench` and `testbench-dusk` and instead set their minimum versions to be v8.21.0 which is after these changes.

## Edit - New solution
Changed to using the new `defineChromeDriver()` in `testbench-dusk`. See comments below.

Also I forgot to mention the other changes to our `DuskBrowserMacros`, which fixed some tests before finding the issue raised above. To me it actually makes more sense for `waitForLivewire()` to wait until the request and all of processing is complete.

Hopefully that should remove some flakiness in future.

So have left those changes. But they can probably be successfully reverted if you don't want them.