### PR TITLE
Add browser test to handle `x-for` and `x-if` state inside `@teleport` when request happened

### DIFF
--- a/src/Features/SupportTeleporting/BrowserTest.php
+++ b/src/Features/SupportTeleporting/BrowserTest.php
@@ -89,4 +89,48 @@ class BrowserTest extends BrowserTestCase
             ->assertSeeIn('@first-check', '2')
             ->assertSeeIn('@second-check', '2');
     }
+
+    /** @test */
+    public function can_handle_xfor_and_xif_state_when_request_happened()
+    {
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <template x-teleport="body">
+                            <div x-data="{ open: false }" style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+                                <button type="button" wire:click="$refresh" @click="open = !open" dusk="button">
+                                    Refresh
+                                </button>
+
+                                <!-- tinkering `open` state... -->
+                                <div x-text="'open value: ' + open"></div>
+                                <div x-show="open">x-show open</div>
+
+                                <div>
+                                    <template x-if="open">
+                                        <div>x-if open</div>
+                                    </template>
+                                </div>
+
+                                <div>
+                                    <template x-for="item in 3" :key="item">
+                                        <span x-text="item"></span>
+                                    </template>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+                HTML;
+            }
+        })
+            ->waitForLivewire()->click('@button')
+            ->assertSee('x-if open')
+            ->assertDontSee('123123')
+            ->waitForLivewire()->click('@button')
+            ->assertDontSee('123123')
+            ->assertDontSee('x-if open');
+    }
 }


### PR DESCRIPTION
This PR is failing test to handle `x-for` and `x-if` state inside `@teleport` when request happened.

Scenario:

Do something that need to morph the livewire component (i.e. `wire:click="$refresh"`)

Problem:

- `Alpine Expression Error: item is not defined` in the first request
- Duplicate elements occurred error second request or more

This can be resolved with `wire:ignore` with div element as root template tag.

```blade
<div wire:ignore>
    <template x-if="open">
        <div>x-if open</div>
    </template>
</div>
```

```blade
<div wire:ignore>
    <template x-for="item in 3" :key="item">
        <span x-text="item"></span>
    </template>
</div>
```

If so, we need add this to documentation (i.e. use `@foreach` instead of `<template x-for>` inside `@teleport`).