### PR TITLE
Fixed missing semicolon in forms.md

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -437,7 +437,7 @@ use Livewire\Form;
 
 class PostForm extends Form
 {
-    public ?Post $post
+    public ?Post $post;
 
     #[Validate] // [tl! highlight]
     public $title = '';


### PR DESCRIPTION
Fixes a simple typo in the documentation found by Discord user justus0432, posted in the Livewire Discord channel. 