### PR TITLE
[3.x] Fix conflicts with PHP's predefined classes

### DIFF
--- a/src/Mechanisms/ComponentRegistry.php
+++ b/src/Mechanisms/ComponentRegistry.php
@@ -87,7 +87,7 @@ class ComponentRegistry extends Mechanism
         $nameOrClass = is_object($nameComponentOrClass) ? $nameComponentOrClass::class : $nameComponentOrClass;
 
         // If a component class was passed in, use that...
-        if (class_exists($nameOrClass)) {
+        if (class_exists($nameOrClass) && is_subclass_of($nameOrClass, Component::class)) {
             $class = $nameOrClass;
         // Otherwise, assume it was a simple name...
         } else {

--- a/src/Tests/ComponentWontConflictWithPredefinedClasses.php
+++ b/src/Tests/ComponentWontConflictWithPredefinedClasses.php
@@ -27,7 +27,7 @@ class ComponentWontConflictWithPredefinedClasses extends \Tests\TestCase
     }
 
     /** @test */
-    public function wont_conflict_on_sequential_request()
+    public function wont_conflict_on_subsequent_requests()
     {
         $component = Livewire::test(Directory::class);
 

--- a/src/Tests/ComponentWontConflictWithPredefinedClasses.php
+++ b/src/Tests/ComponentWontConflictWithPredefinedClasses.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Livewire\Tests;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class ComponentWontConflictWithPredefinedClasses extends \Tests\TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // We need to set Livewire's class namespace to the current namespace, because
+        // Livewire's mechanism will only conflict with PHP's predefined classes
+        // when the relative path to the class matches exactly to any of
+        // the predefined classes (for example 'directory').
+        config()->set('livewire.class_namespace', 'Livewire\\Tests');
+    }
+
+    /** @test */
+    public function wont_conflict_on_initial_request()
+    {
+        $component = Livewire::test(Directory::class);
+
+        $component->assertSee('Count: 1');
+    }
+
+    /** @test */
+    public function wont_conflict_on_sequential_request()
+    {
+        $component = Livewire::test(Directory::class);
+
+        $component->call('increment');
+        $component->assertSee('Count: 2');
+    }
+}
+
+class Directory extends Component
+{
+    public int $count = 1;
+
+    public function increment()
+    {
+        $this->count++;
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+            <div>
+                Count: {{ $count }}
+            </div>
+        HTML;
+    }
+}


### PR DESCRIPTION
This PR fixes the problem described in discussion https://github.com/livewire/livewire/discussions/8248.

## Problem
When you have a component in Livewire's root class namespace that matches any of [PHP's predefined classes](https://www.php.net/manual/en/reserved.classes.php), subsequent requests won't work. 

So, an initial request for the component `App\Livewire\Directory` works, but subsequent requests won't. Those will trigger Livewire's `ComponentNotFoundException`: 

> Unable to find component: [directory]

Note: when the component is located as `App\Livewire\Foo\Directory`, also subsequent requests will work.

## Cause
For subsequent requests, Livewire will try to resolve the requested component's location.
Initially, it will check if a class exists for the requested component:

https://github.com/livewire/livewire/blob/4f86fc1d770ad76d008b4abba17d52cf2791fd7b/src/Mechanisms/ComponentRegistry.php#L90

For `App\Livewire\Directory` (which will be requested as `directory`), this will return true, because `class_exists('directory')` returns true as it matches PHP's predefined class. Note: that is also the explanation why locating `App\Livewire\Foo\Directory` works, because `class_exists('foo.directory')` won't conflict.

## Solution
We can extend the class existance-check with a check if the found class also extends Livewire's `Component` class. Obviously PHP's predefined class does not comply with that, while `App\Livewire\Directory` will.
