### PR TITLE
Add support to invade `Testable`

### DIFF
--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -236,6 +236,11 @@ class Testable
         return $this->lastState->getComponent();
     }
 
+    function invade()
+    {
+        return \Livewire\invade($this->lastState->getComponent());
+    }
+
     function dump()
     {
         dump($this->lastState->getHtml());

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanBeInvaded.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanBeInvaded.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Livewire\Features\SupportTesting\Tests;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class TestableLivewireCanBeInvaded extends \Tests\TestCase
+{
+    /** @test */
+    function can_invade_protected_properties()
+    {
+        $component = Livewire::test(new class extends Component {
+            protected string $foo = 'bar';
+
+            function render() {
+                return '<div></div>';
+            }
+        });
+
+        PHPUnit::assertEquals('bar', $component->invade()->foo);
+    }
+
+    /** @test */
+    function can_invade_protected_functions()
+    {
+        $component = Livewire::test(new class extends Component {
+            protected function foo() : string {
+                return 'bar';
+            }
+
+            function render() {
+                return '<div></div>';
+            }
+        });
+
+        PHPUnit::assertEquals('bar', $component->invade()->foo());
+    }
+
+    /** @test */
+    function can_invade_private_properties()
+    {
+        $component = Livewire::test(new class extends Component {
+            private string $foo = 'bar';
+
+            function render() {
+                return '<div></div>';
+            }
+        });
+
+        PHPUnit::assertEquals('bar', $component->invade()->foo);
+    }
+
+    /** @test */
+    function can_invade_private_functions()
+    {
+        $component = Livewire::test(new class extends Component {
+            private function foo() : string {
+                return 'bar';
+            }
+
+            function render() {
+                return '<div></div>';
+            }
+        });
+
+        PHPUnit::assertEquals('bar', $component->invade()->foo());
+    }
+}


### PR DESCRIPTION
Every now and then I involve private and protected functions and properties in my tests.
It can be challenging to access those while testing, although `invade()` is the ideal solution.

This PR adds support for accessing protected and private functions and properties while testing via `->invade()`.

```php
$component = Livewire::test(new class extends Component {
    protected string $foo = 'bar';
});

$component->invade()->foo; // bar
```

I have this by default in my projects via a `Mixin`, but it may be useful to others as well.