### PR TITLE
Add `$this->pull()` component method

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -373,7 +373,51 @@ $this->reset('title');
 
 // Or multiple at once...
 
-$this->reset('title', 'content');
+$this->reset(['title', 'content']);
+```
+
+### Pulling form fields
+
+Alternatively, you can use the `pull()` method to both retrieve a form's properties and reset them in one operation.
+
+```php
+<?php
+
+namespace App\Livewire\Forms;
+
+use Livewire\Attributes\Validate;
+use App\Models\Post;
+use Livewire\Form;
+
+class PostForm extends Form
+{
+    #[Validate('required|min:5')]
+    public $title = '';
+
+    #[Validate('required|min:5')]
+    public $content = '';
+
+    // ...
+
+    public function store()
+    {
+        $this->validate();
+
+        Post::create(
+            $this->pull() // [tl! highlight]
+        );
+    }
+}
+```
+
+You can also pull specific properties by passing the property names into the `pull()` method:
+
+```php
+// Return a value before resetting...
+$this->pull('title');
+
+ // Return a key-value array of properties before resetting...
+$this->pull(['title', 'content']);
 ```
 
 ### Using Rule objects

--- a/docs/nesting.md
+++ b/docs/nesting.md
@@ -231,10 +231,8 @@ class TodoList extends Component
     public function add()
     {
         Todo::create([
-            'content' => $this->todo,
+            'content' => $this->pull('todo'),
         ]);
-
-        $this->reset('todo');
     }
 
     public function render()

--- a/docs/properties.md
+++ b/docs/properties.md
@@ -151,6 +151,43 @@ In the above example, after a user clicks "Add Todo", the input field holding th
 > [!warning] `reset()` won't work on values set in `mount()`
 > `reset()` will reset a property to its state before the `mount()` method was called. If you initialized the property in `mount()` to a different value, you will need to reset the property manually.
 
+## Pulling properties
+
+Alternatively, you can use the `pull()` method to both reset and retrieve the value in one operation.
+
+Here's the same example from above, but simplified with `pull()`:
+
+```php
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class ManageTodos extends Component
+{
+    public $todos = [];
+
+    public $todo = '';
+
+    public function addTodo()
+    {
+        $this->todos[] = $this->pull('todo'); // [tl! highlight]
+    }
+
+    // ...
+}
+```
+
+The above example is pulling a single value, but `pull()` can also be used to reset and retrieve (as a key-value pair) all or some properties:
+
+```php
+// The same as $this->all() and $this->reset();
+$this->pull();
+
+// The same as $this->only(...) and $this->reset(...);
+$this->pull(['title', 'content']);
+```
 
 ## Supported property types
 

--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -91,6 +91,23 @@ trait InteractsWithProperties
         $this->reset($keysToReset);
     }
 
+    public function pull($properties = null)
+    {
+        $wantsASingleValue = is_string($properties);
+
+        $properties = is_array($properties) ? $properties : func_get_args();
+
+        $beforeReset = match (true) {
+            empty($properties) => $this->all(),
+            $wantsASingleValue => $this->getPropertyValue($properties[0]),
+            default => $this->only($properties),
+        };
+
+        $this->reset($properties);
+
+        return $beforeReset;
+    }
+
     public function only($properties)
     {
         $results = [];

--- a/src/Concerns/Tests/ResetPropertiesUnitTest.php
+++ b/src/Concerns/Tests/ResetPropertiesUnitTest.php
@@ -95,6 +95,47 @@ class ResetPropertiesUnitTest extends \Tests\TestCase
 
         $this->assertTrue(is_null($component->nullProp));
     }
+
+    /** @test */
+    public function can_reset_and_return_property_with_pull_method()
+    {
+        $component = Livewire::test(ResetPropertiesComponent::class)
+            ->assertSet('foo', 'bar')
+            ->set('foo', 'baz')
+            ->assertSet('foo', 'baz')
+            ->assertSet('pullResult', null)
+            ->call('proxyPull', 'foo')
+            ->assertSet('foo', 'bar')
+            ->assertSet('pullResult', 'baz');
+    }
+
+    /** @test */
+    public function can_pull_all_properties()
+    {
+        $component = Livewire::test(ResetPropertiesComponent::class)
+            ->assertSet('foo', 'bar')
+            ->set('foo', 'baz')
+            ->assertSet('foo', 'baz')
+            ->assertSet('pullResult', null)
+            ->call('proxyPull');
+
+        $this->assertEquals('baz', $component->pullResult['foo']);
+        $this->assertEquals('lob', $component->pullResult['bob']);
+    }
+
+    /** @test */
+    public function can_pull_some_properties()
+    {
+        $component = Livewire::test(ResetPropertiesComponent::class)
+            ->assertSet('foo', 'bar')
+            ->set('foo', 'baz')
+            ->assertSet('foo', 'baz')
+            ->assertSet('pullResult', null)
+            ->call('proxyPull', ['foo']);
+
+        $this->assertEquals('baz', $component->pullResult['foo']);
+        $this->assertFalse(array_key_exists('bob', $component->pullResult));
+    }
 }
 
 class ResetPropertiesComponent extends Component
@@ -109,6 +150,8 @@ class ResetPropertiesComponent extends Component
 
     public ?int $nullProp = null;
 
+    public $pullResult = null;
+
     public function resetAll()
     {
         $this->reset();
@@ -122,6 +165,11 @@ class ResetPropertiesComponent extends Component
     public function resetKeysExcept($keys)
     {
         $this->resetExcept($keys);
+    }
+
+    public function proxyPull(...$args)
+    {
+        $this->pullResult = $this->pull(...$args);
     }
 
     public function render()


### PR DESCRIPTION
Often, when using `$this->reset()`, I have to "use" a value first, then reset it. It would be nice to have a method like `$this->pull()` that did both operations in one swoop like so:

```php
public $todos = [];

public $todo = '';

public function addTodo()
{
    $this->todos[] = $this->pull('todo');
}
```