### PR TITLE
macro can be callable from view

### DIFF
--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -459,12 +459,16 @@ class HandleComponents extends Mechanism
             // @todo: put this in a better place:
             $methods[] = '__dispatch';
 
-            if (! in_array($method, $methods)) {
+            if (! in_array($method, $methods) && !$root::class::hasMacro($method)) {
                 throw new MethodNotFoundException($method);
             }
 
             if (config('app.debug')) $start = microtime(true);
-            $return = wrap($root)->{$method}(...$params);
+            if ($root::class::hasMacro($method)) {
+                $return = $root->macroCall($method, $params);
+            } else {
+                $return = wrap($root)->{$method}(...$params);
+            }
             if (config('app.debug')) trigger('profile', 'call'.$idx, $root->getId(), [$start, microtime(true)]);
 
             $returns[] = $finish($return);

--- a/src/Tests/ComponentIsMacroableUnitTest.php
+++ b/src/Tests/ComponentIsMacroableUnitTest.php
@@ -11,11 +11,13 @@ class ComponentIsMacroableUnitTest extends \Tests\TestCase
     public function it_resolves_the_mount_parameters()
     {
         Component::macro('macroedMethod', function ($first, $second) {
-            return [$first, $second];
+            $this->foo = [$first, $second];
         });
 
-        Livewire::test(ComponentWithMacroedMethodStub::class)
-            ->assertSet('foo', ['one', 'two']);
+        $test = Livewire::test(ComponentWithMacroedMethodStub::class)
+            ->assertSet('foo', ['one', 'two'])
+            ->call('macroedMethod', 'three', 'four')
+            ->assertSet('foo', ['three', 'four']);
     }
 }
 
@@ -25,7 +27,7 @@ class ComponentWithMacroedMethodStub extends Component
 
     public function mount()
     {
-        $this->foo = $this->macroedMethod('one', 'two');
+        $this->macroedMethod('one', 'two');
     }
 
     public function render()


### PR DESCRIPTION
Fixing a bug reproduced here: https://wirebox.app/b/4m82r

## Problem 
Since component macros are supported, one would expect that you can call the macro action/method from either the component methods or directly from the view (eg: with `wire:click="macroedMethod"`)
The latter usage throws an error and kinda defeat the purpose of using macros

<img width="728" alt="image" src="https://github.com/livewire/livewire/assets/4596409/f689b4ff-779a-41b3-81e2-5d7f71962810">

This MR fixes the issue by adding a conditional check on the callMethods to account for macros there.