### PR TITLE
Removed unnecessary call to $property->setAccessible(true);

### DIFF
--- a/scripts/laravel.php
+++ b/scripts/laravel.php
@@ -148,8 +148,6 @@ function invade($obj)
         {
             $property = $this->reflected->getProperty($name);
 
-            $property->setAccessible(true);
-
             return $property->getValue($this->obj);
         }
 
@@ -157,16 +155,12 @@ function invade($obj)
         {
             $property = $this->reflected->getProperty($name);
 
-            $property->setAccessible(true);
-
             $property->setValue($this->obj, $value);
         }
 
         public function __call($name, $params)
         {
             $method = $this->reflected->getMethod($name);
-
-            $method->setAccessible(true);
 
             return $method->invoke($this->obj, ...$params);
         }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -54,8 +54,6 @@ function invade($obj)
         {
             $method = $this->reflected->getMethod($name);
 
-            $method->setAccessible(true);
-
             return $method->invoke($this->obj, ...$params);
         }
     };


### PR DESCRIPTION
Livewire 3  requires a minimum PHP version of 8.1, the call to setAccessible(true) is no longer needed, as properties are accessible by default from PHP 8.1 onwards

see https://www.php.net/manual/en/reflectionproperty.setaccessible.php