### PR TITLE
Fix `@teleport` directive when view is cached

### DIFF
--- a/src/Features/SupportTeleporting/SupportTeleporting.php
+++ b/src/Features/SupportTeleporting/SupportTeleporting.php
@@ -2,17 +2,18 @@
 
 namespace Livewire\Features\SupportTeleporting;
 
+use Illuminate\Support\Facades\Blade;
 use Livewire\ComponentHook;
 
 class SupportTeleporting extends ComponentHook
 {
     static function provide()
     {
-        app('livewire')->directive('teleport', function ($expression) {
+        Blade::directive('teleport', function ($expression) {
             return '<template x-teleport="<?php echo e('.$expression.'); ?>">';
         });
 
-        app('livewire')->directive('endteleport', function () {
+        Blade::directive('endteleport', function () {
             return '</template>';
         });
     }


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
https://github.com/livewire/livewire/discussions/8130
2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
4️⃣ Does it include tests? (Required)
No
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

When we run php artisan view:cache, the `@teleport` directive is broken. I didn't understand the reason in depth, however, when we create a directive similar to `@this` using the Facade Blade, the same problem does not occur.

- I noticed how it is called to create the directive for `@teleport` differs from `@this`. For this reason, I left it the same as `@this` and it worked.

- I was unable to create a test that runs view:cache and generates the cache for a dusk test at run time

