### PR TITLE
Fix URL in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -11,4 +11,4 @@ contact_links:
     about: If you have a question or need help using the library
   - name: Documentation issue
     url: https://github.com/livewire/livewire/pulls
-    about: For documentation issues, open a pull request at the livewire/livewire repository
+    about: For documentation issues, please open a pull request

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,5 +10,5 @@ contact_links:
     url: https://github.com/livewire/livewire/discussions/new
     about: If you have a question or need help using the library
   - name: Documentation issue
-    url: https://github.com/livewire/docs
-    about: For documentation issues, open a pull request at the livewire/docs repository
+    url: https://github.com/livewire/livewire/pulls
+    about: For documentation issues, open a pull request at the livewire/livewire repository


### PR DESCRIPTION
The button for a 'Documentation issue' [here](https://github.com/livewire/livewire/issues/new/choose) was linking to `livewire/docs`.
See https://github.com/livewire/livewire/discussions/8290


