### PR TITLE
Use `assertSetStrict` in tests

### DIFF
--- a/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeCastUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeCastUnitTest.php
@@ -338,19 +338,19 @@ class ModelAttributesCanBeCastUnitTest extends \Tests\TestCase
     public function can_cast_enum_attributes_from_model_casts_definition()
     {
         Livewire::test(ComponentForModelAttributeCasting::class)
-            ->assertSet('model.enum', null, true)
+            ->assertSetStrict('model.enum', null)
             ->assertSnapshotSet('model.enum', null)
 
             ->set('model.enum', TestingEnum::FOO->value)
             ->call('validateAttribute', 'model.enum')
             ->assertHasNoErrors('model.enum')
-            ->assertSet('model.enum', TestingEnum::FOO, true)
+            ->assertSetStrict('model.enum', TestingEnum::FOO)
             ->assertSnapshotSet('model.enum', TestingEnum::FOO->value, true)
 
             ->set('model.enum', '')
             ->call('validateAttribute', 'model.enum')
             ->assertHasNoErrors('model.enum')
-            ->assertSet('model.enum', null, true)
+            ->assertSetStrict('model.enum', null)
             ->assertSnapshotSet('model.enum', null, true);
     }
 }

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -282,7 +282,7 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             ->assertSet('name', 'is_array')
             ->set('name', 0)
             ->assertSet('name', null)
-            ->assertSet('name', 0, true)
+            ->assertSetStrict('name', 0)
             ->assertSet(
                 'name',
                 function ($propertyValue) {
@@ -292,7 +292,7 @@ class UnitTest extends \LegacyTests\Unit\TestCase
 
         $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
 
-        $component->assertSet('name', null, true);
+        $component->assertSetStrict('name', null);
     }
 
     /** @test */

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
@@ -24,13 +24,13 @@ class CarbonSynthUnitTest extends \Tests\TestCase
     public function public_nullable_carbon_properties_can_be_cast()
     {
         $testable = Livewire::test(ComponentWithNullablePublicCarbonCaster::class)
-            ->assertSet('date', null, true)
+            ->assertSetStrict('date', null)
             ->updateProperty('date', '2024-02-14')
             ->assertSet('date', Carbon::parse('2024-02-14'))
             ->updateProperty('date', '')
-            ->assertSet('date', null, true)
+            ->assertSetStrict('date', null)
             ->updateProperty('date', null)
-            ->assertSet('date', null, true);
+            ->assertSetStrict('date', null);
 
         $this->expectException(\Exception::class);
         $testable->updateProperty('date', 'Bad Date');
@@ -40,13 +40,13 @@ class CarbonSynthUnitTest extends \Tests\TestCase
     public function public_carbon_immutable_properties_can_be_cast()
     {
         $testable = Livewire::test(ComponentWithNullablePublicCarbonImmutableCaster::class)
-            ->assertSet('date', null, true)
+            ->assertSetStrict('date', null)
             ->updateProperty('date', '2024-02-14')
             ->assertSet('date', CarbonImmutable::parse('2024-02-14'))
             ->updateProperty('date', '')
-            ->assertSet('date', null, true)
+            ->assertSetStrict('date', null)
             ->updateProperty('date', null)
-            ->assertSet('date', null, true);
+            ->assertSetStrict('date', null);
 
         $this->expectException(\Exception::class);
         $testable->updateProperty('date', 'Bad Date');
@@ -56,13 +56,13 @@ class CarbonSynthUnitTest extends \Tests\TestCase
     public function public_datetime_properties_can_be_cast()
     {
         $testable = Livewire::test(ComponentWithNullablePublicDateTimeCaster::class)
-            ->assertSet('date', null, true)
+            ->assertSetStrict('date', null)
             ->updateProperty('date', '2024-02-14')
             ->assertSet('date', new \DateTime('2024-02-14'))
             ->updateProperty('date', '')
-            ->assertSet('date', null, true)
+            ->assertSetStrict('date', null)
             ->updateProperty('date', null)
-            ->assertSet('date', null, true);
+            ->assertSetStrict('date', null);
 
         $this->expectException(\Exception::class);
         $testable->updateProperty('date', 'Bad Date');
@@ -72,13 +72,13 @@ class CarbonSynthUnitTest extends \Tests\TestCase
     public function public_datetime_immutable_properties_can_be_cast()
     {
         $testable = Livewire::test(ComponentWithNullablePublicDateTimeImmutableCaster::class)
-            ->assertSet('date', null, true)
+            ->assertSetStrict('date', null)
             ->updateProperty('date', '2024-02-14')
             ->assertSet('date', new \DateTimeImmutable('2024-02-14'))
             ->updateProperty('date', '')
-            ->assertSet('date', null, true)
+            ->assertSetStrict('date', null)
             ->updateProperty('date', null)
-            ->assertSet('date', null, true);
+            ->assertSetStrict('date', null);
 
         $this->expectException(\Exception::class);
         $testable->updateProperty('date', 'Bad Date');

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -21,11 +21,11 @@ class EnumUnitTest extends \Tests\TestCase
     public function nullable_public_property_can_be_cast()
     {
         $testable = Livewire::test(ComponentWithNullablePublicEnumCaster::class)
-            ->assertSet('status', null, true)
+            ->assertSetStrict('status', null)
             ->updateProperty('status', 'Be excellent to each other')
             ->assertSet('status', TestingEnum::TEST)
             ->updateProperty('status', '')
-            ->assertSet('status', null, true);
+            ->assertSetStrict('status', null);
 
         $this->expectException(ValueError::class);
         $testable->updateProperty('status', 'Be excellent excellent to each other');

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/IntSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/IntSynthUnitTest.php
@@ -14,7 +14,7 @@ class IntSynthUnitTest extends \Tests\TestCase
     {
         Livewire::test(ComponentWithNullableInt::class)
             ->set('intField', null)
-            ->assertSet('intField', null, true); // Use strict mode
+            ->assertSetStrict('intField', null);
     }
 }
 


### PR DESCRIPTION
This PR replaces some obsolete `assertSet('property', $value, true)` with the new `assertSetStrict('property', $value)`.