### PR TITLE
Add failing test for `wire:loading.remove` not working with other `wire:` directives

### DIFF
--- a/src/Features/SupportWireLoading/BrowserTest.php
+++ b/src/Features/SupportWireLoading/BrowserTest.php
@@ -79,6 +79,37 @@ class BrowserTest extends \Tests\BrowserTestCase
     }
 
     /** @test */
+    public function wire_loading_remove_works_with_other_wire_directives()
+    {
+        Livewire::visit(new class extends Component
+        {
+            public function doSomething()
+            {
+                // Need to delay the update so that Dusk can catch the loading state change in the DOM.
+                usleep(500000);
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <button wire:click="doSomething" dusk="button">
+                            <span wire:loading.remove wire:foo>Do something</span>
+                            <span wire:loading>...</span>
+                        </button>
+                    </div>
+                HTML;
+            }
+        })
+        ->waitForText('Do something')
+        ->click('@button')
+        ->waitForText('...')
+        ->assertDontSee('Do something')
+        ->waitForText('Do something')
+        ->assertDontSee('...');
+    }
+
+    /** @test */
     function wire_loading_remove_works_with_renderless_methods()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
Not sure if this is a bug or if I m doing something wrong. I have no idea how I would go about fixing it, so have created a failing test for this scenario.

We are using Wire Elements Pro and we have a couple of buttons in a modal like this...

```html
<a wire:loading.remove wire:foo class="tw-inline-block tw-w-full tw-px-5 tw-py-3 tw-text-sm tw-font-semibold tw-text-center tw-text-red-500 tw-border tw-border-red-400 tw-rounded-lg sm:tw-w-auto" href="#">
    Cancel
</a>
```

The reason I noticed this is because we are using Wire Elements Pro and that allows you to do this `wire:modal="close, {force: true}"`.

When that directive is on a button, along with `wire:loading.remove`, the button does not get removed.

I have created a simple example that can be viewed that shows this in action here https://wirebox.app/b/x6dq1

Both blue buttons should hide after the red button is clicked, but only one of them does.

Thanks

