### PR TITLE
Add `withoutLazyLoading()` testing helper

### DIFF
--- a/docs/lazy.md
+++ b/docs/lazy.md
@@ -250,3 +250,33 @@ If you want to set a default placeholder view for all your components you can do
 ```
 
 Now, when a component is lazy-loaded and no `placeholder()` is defined, Livewire will use the configured Blade view (`livewire.placeholder` in this case.)
+
+## Disabling lazy loading for tests
+
+When unit testing a lazy component, or a page with nested lazy components, you may want to disable the "lazy" behavior so that you can assert the final rendered behavior. Otherwise, those components would be rendered as their placeholders during your tests.
+
+You can easily disable lazy loading using the `Livewire::withoutLazyLoading()` testing helper like so:
+
+```php
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\Dashboard;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class DashboardTest extends TestCase
+{
+    /** @test */
+    public function renders_successfully()
+    {
+        Livewire::withoutLazyLoading() // [tl! highlight]
+            ->test(Dashboard::class)
+            ->assertSee(...);
+    }
+}
+```
+
+Now, when the dashboard component is rendered for this test, it will skip rendering the `placeholder()` and instead render the full component as if lazy loading wasn't applied at all.
+

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -654,6 +654,7 @@ Livewire provides many more testing utilities. Below is a comprehensive list of 
 | `Livewire::withCookie('color', 'blue')`                      | Set the test's `color` cookie to the provided value (`blue`). |
 | `Livewire::withCookies(['color' => 'blue', 'name' => 'Taylor])`                      | Set the test's `color` and `name` cookies to the provided values (`blue`, `Taylor`). |
 | `Livewire::withHeaders(['X-COLOR' => 'blue', 'X-NAME' => 'Taylor])`                      | Set the test's `X-COLOR` and `X-NAME` headers to the provided values (`blue`, `Taylor`). |
+| `Livewire::withoutLazyLoading()`                      | Disable lazy loading in this and all child components under test. |
 
 
 ### Interacting with components

--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -4,7 +4,7 @@ namespace Livewire\Features\SupportLazyLoading;
 
 use Livewire\Features\SupportLifecycleHooks\SupportLifecycleHooks;
 use Livewire\Mechanisms\HandleComponents\ViewContext;
-use function Livewire\{ store, trigger, wrap };
+use function Livewire\{ on, store, trigger, wrap };
 use Illuminate\Routing\Route;
 use Livewire\ComponentHook;
 use Livewire\Drawer\Utils;
@@ -12,9 +12,20 @@ use Livewire\Component;
 
 class SupportLazyLoading extends ComponentHook
 {
+    static $disableWhileTesting = false;
+
+    static function disableWhileTesting()
+    {
+        static::$disableWhileTesting = true;
+    }
+
     static function provide()
     {
         static::registerRouteMacro();
+
+        on('flush-state', function () {
+            static::$disableWhileTesting = false;
+        });
     }
 
     static function registerRouteMacro()
@@ -35,6 +46,8 @@ class SupportLazyLoading extends ComponentHook
         $reflectionClass = new \ReflectionClass($this->component);
         $lazyAttribute = $reflectionClass->getAttributes(\Livewire\Attributes\Lazy::class)[0] ?? null;
 
+        // If Livewire::withoutLazyLoading()...
+        if (static::$disableWhileTesting) return;
         // If `:lazy="false"` disable lazy loading...
         if ($hasLazyParam && ! $lazyProperty) return;
         // If no lazy loading is included at all...

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -26,6 +26,37 @@ class UnitTest extends \Tests\TestCase
         $this->get('/two')->assertSee('This is a custom layout');
         $this->get('/three')->assertSee('This is a custom layout');
     }
+
+    /** @test */
+    public function can_disable_lazy_loading_during_unit_tests()
+    {
+        Livewire::component('lazy-component', BasicLazyComponent::class);
+
+        Livewire::withoutLazyLoading()->test(new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <livewire:lazy-component />
+                    </div>
+                HTML;
+            }
+        })
+        ->assertDontSee('Loading...')
+        ->assertSee('Hello world!');
+    }
+}
+
+#[Lazy]
+class BasicLazyComponent extends Component {
+    public function placeholder() {
+        return '<div>Loading...</div>';
+    }
+
+    public function render()
+    {
+        return '<div>Hello world!</div>';
+    }
 }
 
 #[Layout('components.layouts.custom'), Lazy]

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -12,6 +12,7 @@ use Livewire\Mechanisms\ComponentRegistry;
 use Livewire\Features\SupportTesting\Testable;
 use Livewire\Features\SupportTesting\DuskTestable;
 use Livewire\Features\SupportAutoInjectedAssets\SupportAutoInjectedAssets;
+use Livewire\Features\SupportLazyLoading\SupportLazyLoading;
 
 class LivewireManager
 {
@@ -179,6 +180,13 @@ class LivewireManager
         return $this;
     }
 
+    function withoutLazyLoading()
+    {
+        SupportLazyLoading::disableWhileTesting();
+
+        return $this;
+    }
+
     function test($name, $params = [])
     {
         return Testable::create(
@@ -186,7 +194,7 @@ class LivewireManager
             $params,
             $this->queryParamsForTesting,
             $this->cookiesForTesting,
-            $this->headersForTesting
+            $this->headersForTesting,
         );
     }
 


### PR DESCRIPTION
When unit testing a lazy component, or a page with nested lazy components, you may want to disable the "lazy" behavior so that you can assert the final rendered behavior. Otherwise, those components would be rendered as their placeholders during your tests.

This PR adds a `Livewire::withoutLazyLoading()` helper that can be used like so:

```php
/** @test */
public function renders_successfully()
{
    Livewire::withoutLazyLoading()
        ->test(Dashboard::class)
        ->assertSee(...);
}
```

Now, when the dashboard component is rendered for this test, it will skip rendering the `placeholder()` and instead render the full component as if lazy loading wasn't applied at all.