### PR TITLE
Fix file uploads while time travelling

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -23,6 +23,14 @@ class TemporaryUploadedFile extends UploadedFile
         $tmpFile = tmpfile();
 
         parent::__construct(stream_get_meta_data($tmpFile)['uri'], $this->path);
+
+        // While running tests, update the last modified timestamp to the current
+        // Carbon timestamp (which respects time traveling), because otherwise
+        // cleanupOldUploads() will mess up with the filesystem...
+        if (app()->runningUnitTests())
+        {
+            @touch($this->path(), now()->timestamp);
+        }
     }
 
     public function getPath(): string

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportFileUploads;
 
+use App\Livewire\UploadFile;
 use Carbon\Carbon;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Http;
@@ -783,6 +784,21 @@ class UnitTest extends \Tests\TestCase
         Livewire::test(FileReadContentComponent::class)
             ->set('file', $file)
             ->assertSet('content', $file->getContent());
+    }
+
+    public function test_validation_of_file_uploads_while_time_traveling()
+    {
+        Storage::fake('avatars');
+
+        $this->travelTo(now()->addMonth());
+
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->call('upload', 'uploaded-avatar.png');
+
+        Storage::disk('avatars')->assertExists('uploaded-avatar.png');
     }
 }
 


### PR DESCRIPTION
See https://github.com/livewire/livewire/discussions/8307

## Problem
File uploads are broken while time travelling with `Carbon::setTestNow()` or `$this->travelTo()`.

## Cause
While uploading files, old uploads are cleaned up, based on the file's last modification time.

https://github.com/livewire/livewire/blob/ed89372eb6eee3952bf7ccd1a6a082b29a709a4b/src/Features/SupportFileUploads/WithFileUploads.php#L114

While uploading during time travelling, the filesystem does not respect the 'fake' timestamp and uses the 'normal' timestamp for setting the file's last modification time. While passing Livewire's `cleanupOldUploads()` method, it looks like the file needs to be cleaned up and the file will be removed immediately.

## Solution 
After uploading a file while running tests, we can touch it and update the file's last modification time to the current timestamp (based on Carbon, so it respects time travelling).