### PR TITLE
 Add support for "paginationSimpleView()" method in components 

### DIFF
--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -380,6 +380,7 @@ public function paginationView()
 {
     return 'custom-pagination-links-view';
 }
+
 public function paginationSimpleView()
 {
     return 'custom-simple-pagination-links-view';

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -359,7 +359,7 @@ Once the files have been published, you have complete control over them. When re
 If you wish to bypass Livewire's pagination views entirely, you can render your own in one of two ways:
 
 1. The `->links()` method in your Blade view
-2. The `paginationView()` method in your component
+2. The `paginationView()` or `paginationSimpleView()` method in your component
 
 ### Via `->links()`
 
@@ -371,14 +371,18 @@ The first approach is to simply pass your custom pagination Blade view name to t
 
 When rendering the pagination links, Livewire will now look for a view at `resources/views/custom-pagination-links.blade.php`.
 
-### Via `paginationView()`
+### Via `paginationView()` or `paginationSimpleView()`
 
-The second approach is to declare a `paginationView` method inside your component which returns the name of the view you would like to use:
+The second approach is to declare a `paginationView` or `paginationSimpleView` method inside your component which returns the name of the view you would like to use:
 
 ```php
 public function paginationView()
 {
     return 'custom-pagination-links-view';
+}
+public function paginationSimpleView()
+{
+    return 'custom-simple-pagination-links-view';
 }
 ```
 

--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -135,6 +135,10 @@ class SupportPagination extends ComponentHook
 
     protected function paginationSimpleView()
     {
+        if (method_exists($this->component, 'paginationSimpleView')) {
+            return $this->component->paginationSimpleView();
+        }
+
         return 'livewire::simple-' . (property_exists($this->component, 'paginationTheme') ? invade($this->component)->paginationTheme : config('livewire.pagination_theme', 'tailwind'));
     }
 

--- a/src/Features/SupportPagination/UnitTest.php
+++ b/src/Features/SupportPagination/UnitTest.php
@@ -83,6 +83,37 @@ class UnitTest extends \Tests\TestCase
         })->assertSee('Custom pagination theme');
     }
 
+    /** @test */
+    public function can_set_a_custom_simple_links_theme_in_component()
+    {
+        Livewire::test(new class extends Component {
+            use WithPagination;
+
+            function paginationSimpleView()
+            {
+                return 'custom-simple-pagination-theme';
+            }
+
+            #[Computed]
+            function posts()
+            {
+                return PaginatorPostTestModel::simplePaginate();
+            }
+
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @foreach ($this->posts as $post)
+                    @endforeach
+
+                    {{ $this->posts->links() }}
+                </div>
+                HTML;
+            }
+        })->assertSee('Custom simple pagination theme');
+    }
+
     public function test_calling_pagination_getPage_before_paginate_method_resolve_the_correct_page_number_in_first_visit_or_after_reload()
     {
         Livewire::withQueryParams(['page' => 5])->test(new class extends Component {

--- a/tests/views/custom-simple-pagination-theme.blade.php
+++ b/tests/views/custom-simple-pagination-theme.blade.php
@@ -1,0 +1,3 @@
+<div>
+    <span>Custom simple pagination theme</span>
+</div>


### PR DESCRIPTION
#1304

## Problem

If you switch to a paginator that uses simple or even the cursor offset based paginator. You lose the ability to configure the exact view used. Your only configuration option relies on the `paginationTheme` property which forces the `livewire` prefix, thus preventing the same override that exists on the `paginationView`.

## Cause

The function `paginationSimpleView` has no override, unlike the corresponding `paginationView` function: https://github.com/livewire/livewire/blob/main/src/Features/SupportPagination/SupportPagination.php#L127-L135


## Solution

Much like done in this [commit](https://github.com/livewire/livewire/commit/12130528b493cfe5260d989fc77f34ac30e746af), add override support for simple based paginators.