### PR TITLE
Skipping Locked Properties of `getPublicProperties`

### DIFF
--- a/src/Drawer/BaseUtils.php
+++ b/src/Drawer/BaseUtils.php
@@ -28,8 +28,9 @@ class BaseUtils
     static function getPublicProperties($target, $filter = null)
     {
         return collect((new \ReflectionObject($target))->getProperties())
-            ->filter(function ($property) {
-                return $property->isPublic() && ! $property->isStatic() && $property->isDefault();
+            ->filter(function ($property) use ($target) {
+                return $property->isPublic() && ! $property->isStatic() && $property->isDefault()
+                    && !static::hasAttribute($target, $property->getName(), \Livewire\Attributes\Locked::class);
             })
             ->filter($filter ?? fn () => true)
             ->mapWithKeys(function ($property) use ($target) {

--- a/src/Drawer/BaseUtils.php
+++ b/src/Drawer/BaseUtils.php
@@ -30,7 +30,7 @@ class BaseUtils
         return collect((new \ReflectionObject($target))->getProperties())
             ->filter(function ($property) use ($target) {
                 return $property->isPublic() && ! $property->isStatic() && $property->isDefault()
-                    && !static::hasAttribute($target, $property->getName(), \Livewire\Attributes\Locked::class);
+                    && ! static::hasAttribute($target, $property->getName(), \Livewire\Attributes\Locked::class);
             })
             ->filter($filter ?? fn () => true)
             ->mapWithKeys(function ($property) use ($target) {


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
I didn't create a discussion, but I think this is logical.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
There is no necessity.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

As we know, we can use the `#[Locked]` attribute to make edits to public properties impossible. Although this is extremely useful in many cases, I noticed that there is a bit of a loophole. As much as the developer understands that a certain property is "locked" just by looking at the use of the `#[Locked]` attribute, when using methods like `all` or `fill` we will be freely able to touch these properties and define their values internally, making examples like the code below result in the possibility of editing the values of locked properties:

```php
class UpdateForm extends Form
{
    public ?string $name = null;

    public ?string $email = null;

    public ?string $phone = null;

    #[Locked]
    public ?string $created = null;

    public function load(): void
    {
        $user = Auth::user();

        $this->fill([
            'name'    => $user->name,
            'email'   => $user->email,
            'phone'   => $user->phone,
            'created' => $user->created_at->format('d/m/Y'),
        ]);
    }
}
```

At this point, we can claim something like: "to avoid updating the locked property, just don't define it in the `fill` method array.". If you think that, you are correct.

However, if we look closely at another example we will see another problem without a solution as easy as the one mentioned above:

```php
public function save(): void
{
    $this->validate();

    user()->update([...$this->all()]);
}
```

As in Livewire 3 the use of the `all` method became extremely common, even mentioned several times in the documentation - [see example here](https://livewire.laravel.com/docs/forms#extracting-a-form-object), **BEFORE this PR** it will not escape properties that use this attribute, causing a property update to be executed.

**AFTER this PR**, methods such as `all` and `fill` (which uses `all`) will start to escape properties that use the `#[Locked]` attribute, thus avoiding undesirable internal edits.

### Final Thoughts

Although this may sound like breaking change, I don't see it that way, since the use of the `#[Locked]` property leads us to believe that this property should not be used for any updating purposes; including those that are persisting changes to databases, such as the example mentioned above.