### PR TITLE
Add request hook

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -77,32 +77,34 @@ class HandleRequests extends Mechanism
 
     function handleUpdate()
     {
-        $components = request('components');
+        $requestPayload = request('components');
 
-        trigger('request', $components);
+        $finish = trigger('request', $requestPayload);
 
-        $responses = [];
+        $requestPayload = $finish($requestPayload);
 
-        foreach ($components as $component) {
-            $snapshot = json_decode($component['snapshot'], associative: true);
-            $updates = $component['updates'];
-            $calls = $component['calls'];
+        $componentResponses = [];
+
+        foreach ($requestPayload as $componentPayload) {
+            $snapshot = json_decode($componentPayload['snapshot'], associative: true);
+            $updates = $componentPayload['updates'];
+            $calls = $componentPayload['calls'];
 
             [ $snapshot, $effects ] = app('livewire')->update($snapshot, $updates, $calls);
 
-            $responses[] = [
+            $componentResponses[] = [
                 'snapshot' => json_encode($snapshot),
                 'effects' => $effects,
             ];
         }
 
-        $response = [
-            'components' => $responses,
+        $responsePayload = [
+            'components' => $componentResponses,
             'assets' => SupportScriptsAndAssets::getAssets(),
         ];
 
-        $finish = trigger('response', $response);
+        $finish = trigger('response', $responsePayload);
 
-        return $finish($response);
+        return $finish($responsePayload);
     }
 }

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -79,7 +79,7 @@ class HandleRequests extends Mechanism
     {
         $components = request('components');
 
-        trigger('request', request());
+        trigger('request', $components);
 
         $responses = [];
 

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -79,6 +79,8 @@ class HandleRequests extends Mechanism
     {
         $components = request('components');
 
+        trigger('request', request());
+
         $responses = [];
 
         foreach ($components as $component) {


### PR DESCRIPTION
For Verbs Livewire, we need to be able to hook into the request before Livewire starts processing so we can set up the event queues and the response after Livewire has finished processing to finalise the event queues.

Currently, there is no hook for `request`, but there is one for `response`, so this PR adds a `request` hook in.

https://github.com/livewire/livewire/blob/1b1e0f02f2d23aaa8a5d7c8c977078aa3963206d/src/Mechanisms/HandleRequests/HandleRequests.php#L102