### PR TITLE
Fix legacy model synth not allowing a property to be set to `null`

### DIFF
--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -62,7 +62,7 @@ class EloquentModelSynth extends Synth
 
     public function hydrate($data, $meta, $hydrateChild)
     {
-        if (is_null($data)) return null;
+        if ($data === '' || $data === null) return null;
         
         if (isset($meta['__child_from_parent'])) {
             $model = $meta['__child_from_parent'];

--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -62,6 +62,8 @@ class EloquentModelSynth extends Synth
 
     public function hydrate($data, $meta, $hydrateChild)
     {
+        if (is_null($data)) return null;
+        
         if (isset($meta['__child_from_parent'])) {
             $model = $meta['__child_from_parent'];
 

--- a/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeBoundDirectlyUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeBoundDirectlyUnitTest.php
@@ -88,6 +88,16 @@ class ModelAttributesCanBeBoundDirectlyUnitTest extends \Tests\TestCase
 
         $component->call('$refresh');
     }
+
+    /** @test */
+    public function an_eloquent_model_property_can_be_set_to_null()
+    {
+        $model = ModelForAttributeBinding::create(['id' => 1, 'title' => 'foo']);
+
+        Livewire::test(ComponentWithModelProperty::class, ['model' => $model])
+            ->set('model', null)
+            ->assertSuccessful();
+    }
 }
 
 class ModelForAttributeBinding extends Model


### PR DESCRIPTION
## Scenario
If you are storing an Eloquent model in a public property when using legacy model binding, sometimes you may need to set the property to `null` from the front end which triggers Livewire's update process.

## Problem
But at the moment when Livewire updates the property with `null`, the following error occurs.

<img width="1117" alt="image" src="https://github.com/livewire/livewire/assets/882837/5753ab6a-d875-4341-832d-d9ac78c98701">

The problem is that the hydrate method of the `SupportLegacyModels/EloquentModelSynth` is receiving the `null` as the `$data` prop, and when it tries to loop through the `$data` prop, it is throwing the error.

## Solution
So why this is happening?

Livewire runs `hydrate` method on a synth for a public property when it is restoring a snapshot, but it also calls `hydrate` method on a synth for a public property when it is updating a property.

https://github.com/livewire/livewire/blob/224c2f0e6a7685bb0fd18b7d1960586fda99f4ee/src/Mechanisms/HandleComponents/HandleComponents.php#L289-L300

This ensures that the synths are used when a property is updated to ensure it is still the correct type. For example if we had a `Carbon` date property, the front end will send a datestring as the update value, so we use the hydrate method on the `CarbonSynth` to convert that update value to a Carbon instance.

### Solution 1
Change the synth system to not run if the value is set to `null`.

**Pros**
- The synth's then don't all need to have a `null` or empty string check.

**Cons**
- It's possible that a synth may need to know about a `null` value, so this option moves the control out of the synths.

### Solution 2
Add a null check to the synth so it returns early if a `null` value is set.

**Pros**
- Really simple and doesn't change the underlying synth loading system.
- A lot of the other synths already have these `null` and empty string checks in the hydrate method, so this would make it consistent.

**Cons**
- This bug could be run into again in the future with other synths if they don't also implement a `null` check.
- Userland synths could also have the same issue

## Conclusion

I've gone with solution 2 in this PR and added a `null` check to the legacy model synth as it's consistent with all the other synths.

But it may be worth exploring a more permanent solution at some point (although that has a bunch of questions, like what to do with empty string values vs `null`, etc.).
