### PR TITLE
Fix Laravel 10.x dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psy/psysh": "^0.11.22|^0.12",
     "mockery/mockery": "^1.3.1",
     "phpunit/phpunit": "^10.4",
-    "laravel/framework": "^10.0|^11.0",
+    "laravel/framework": "^10.15.0|^11.0",
     "orchestra/testbench": "^8.21.0|^9.0",
     "orchestra/testbench-dusk": "^8.24|^9.1",
     "calebporzio/sushi": "^2.1",


### PR DESCRIPTION
Discussion #7786 talked about an issue when using Livewire 3 with Laravel 10: Livewire now depends on a new method introduced in Laravel `10.15.0` but still says it only needs `10.0`. So Livewire fails when using an older version. This fix corrects the dependency information to instruct composer to also upgrade Laravel to a newer version.