### PR TITLE
Script URL generation with UrlGenerator

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -150,7 +150,7 @@ class FrontendAssets extends Mechanism
     public static function js($options)
     {
         // Use the default endpoint...
-        $url = app(static::class)->javaScriptRoute->uri;
+        $url = app('url')->toRoute(app(static::class)->javaScriptRoute, [], false);
 
         // Use the configured one...
         $url = config('livewire.asset_url') ?: $url;


### PR DESCRIPTION
Provide Script URL generation using UrlGenerator.

I'm sure it's correct when link generation is performed in a system-wide way, because its functionality can be changed in the project.

For example, my current project is located in a subfolder and I am forced to use the following hack (AppServiceProvider):

```
$this->app['livewire']->setScriptRoute(fn (array $handle) => tap(
    $this->app['router']->getRoutes()->getByAction(join('@', $handle)),
    fn ($route) => $this->app['config']->set(
        'livewire.asset_url',
        $this->app['url']->toRoute($route, [], false)
    )
));
```