### PR TITLE
Prevent multiple 100% progress events by flooring the result

### DIFF
--- a/js/features/supportFileUploads.js
+++ b/js/features/supportFileUploads.js
@@ -178,7 +178,7 @@ class UploadManager {
 
         request.upload.addEventListener('progress', e => {
             e.detail = {}
-            e.detail.progress = Math.round((e.loaded * 100) / e.total)
+            e.detail.progress = Math.floor((e.loaded * 100) / e.total)
 
             this.uploadBag.first(name).progressCallback(e)
         })


### PR DESCRIPTION
Prevent multiple 100% progress events by flooring the result instead of rounding down
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
I had a quick look through the open discussions on file upload issues and could not find one matching my issue/fix.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
I forked the repository and created a new branch on my fork. The PR should merge from this fork-branch to main I believe.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Just a single issue with a single fix.

4️⃣ Does it include tests? (Required)
It does not.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

**Context**
I have been working on a large fileupload in Filamentphp, that works with livewire and Filepond. This upload creates 50mb chunks that are uploaded using livewire's $wire.upload function as well as the backend _startUpload, _finishUpload functions.  These fileChunks are being uploaded using the same fileName and property, `uploads.UUID.fileChunk`, 'filename.zip'. Once the FileUpload hits 100% the next chunk starts uploaded by calling $wire.upload().

**Issue**
While working on this, at times chunks were being uploaded multiple times. On a local machine this rarely happens, on the testing environment (which is a lot slower) this happend all the time. The upload didn't fail or error, so why were they being repeated?

It took a while to figure out, but the answer is.... the progress event with a 100% completion is being send out multiple times. Due to rounding errors on large file uploads, progress of 99,5% and up are rounded to 100% progress. Multiple 100% progress event trigger multiple start of new chunks, which get queued in the $wire.uploadsBag, and continuously repeated afterwards.

**Fix**
Hopefully rounding down instead of up on progress percentages saves other developers a wild goosechase and search into why 100% progress event are sometimes fired multiple times.



