### PR TITLE
fix: use published stubs

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/AttributeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/AttributeCommand.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Facades\File;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'livewire:attribute')]
@@ -36,7 +37,11 @@ class AttributeCommand extends GeneratorCommand
      */
     public function getStub()
     {
-        return __DIR__ . '/livewire.attribute.stub';
+        if (File::exists(base_path('stubs/livewire.attribute.stub'))) {
+            return base_path('stubs/livewire.attribute.stub');
+        }
+
+        return __DIR__ . DIRECTORY_SEPARATOR . 'livewire.attribute.stub';
     }
 
     /**

--- a/src/Features/SupportConsoleCommands/Commands/FormCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/FormCommand.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportConsoleCommands\Commands;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Facades\File;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'livewire:form')]
@@ -36,7 +37,11 @@ class FormCommand extends GeneratorCommand
      */
     public function getStub()
     {
-        return __DIR__ . '/livewire.form.stub';
+        if (File::exists(base_path('stubs/livewire.form.stub'))) {
+            return base_path('stubs/livewire.form.stub');
+        }
+
+        return __DIR__ . DIRECTORY_SEPARATOR . 'livewire.form.stub';
     }
 
     /**


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Could not find anything matching my issue/fix.
The PR about adding the possibility to publish theses stubs (https://github.com/livewire/livewire/pull/7816)

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
I forked the repo then created a branch from main

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
no

4️⃣ Does it include tests? (Required)
No

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
This PR fix the Form & Attribute command by adding the ability to use published stubs if it exists.

Thanks for contributing! 🙌
