### PR TITLE
Add support for `#[On('updatedFoo')]`

### DIFF
--- a/src/Features/SupportEvents/UnitTest.php
+++ b/src/Features/SupportEvents/UnitTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportEvents;
 
 use Livewire\Component;
+use Livewire\Form;
 use Livewire\Livewire;
 
 class UnitTest extends \Tests\TestCase
@@ -128,6 +129,30 @@ class UnitTest extends \Tests\TestCase
             ->assertSet('counter', 1)
             ->dispatch('bar')
             ->assertSet('counter', 2);
+    }
+
+    public function test_it_can_listen_to_property_updates(): void
+    {
+        Livewire::test(ComponentWithUpdatedListener::class)
+            ->assertSetStrict('title', 'foo')
+            ->assertSetStrict('length', 3)
+            ->set('title', 'foo-bar')
+            ->assertDispatched('updatedTitle')
+            ->dispatch('updatedTitle')
+            ->assertSetStrict('title', 'foo-bar')
+            ->assertSetStrict('length', 7);
+    }
+
+    public function test_it_can_listen_to_property_updates_in_forms(): void
+    {
+        Livewire::test(ComponentWithFormAndUpdatedListener::class)
+            ->assertSetStrict('form.title', 'foo')
+            ->assertSetStrict('length', 3)
+            ->set('form.title', 'foo-bar')
+            ->assertDispatched('updatedFormTitle')
+            ->dispatch('updatedFormTitle')
+            ->assertSetStrict('form.title', 'foo-bar')
+            ->assertSetStrict('length', 7);
     }
 
     /** @test */
@@ -383,4 +408,37 @@ class ReceivesMultipleEventsUsingMultipleUserlandRefreshAttributes extends Compo
     public static $counter = 0;
 
     public function render() { static::$counter++; return '<div></div>'; }
+}
+
+class ComponentWithUpdatedListener extends Component
+{
+    public string $title = 'foo';
+    public int $length = 3;
+
+    #[BaseOn('updatedTitle')]
+    public function calculate(): void
+    {
+        $this->length = strlen($this->title);
+    }
+
+    public function render() { return '<div></div>'; }
+}
+
+class ComponentForm extends Form
+{
+    public string $title = 'foo';
+}
+
+class ComponentWithFormAndUpdatedListener extends Component
+{
+    public ComponentForm $form;
+    public int $length = 3;
+
+    #[BaseOn('updatedFormTitle')]
+    public function calculate(): void
+    {
+        $this->length = strlen($this->form->title);
+    }
+
+    public function render() { return '<div></div>'; }
 }

--- a/src/Features/SupportLifecycleHooks/SupportLifecycleHooks.php
+++ b/src/Features/SupportLifecycleHooks/SupportLifecycleHooks.php
@@ -76,8 +76,10 @@ class SupportLifecycleHooks extends ComponentHook
             $this->callTraitHook('updated', [$fullPath, $newValue]);
 
             $this->callHook($afterMethod, [$newValue, $keyAfterFirstDot]);
-
             $this->callHook($afterNestedMethod, [$newValue, $keyAfterLastDot]);
+
+            $this->callHook('dispatch', [$afterMethod]);
+            $this->callHook('dispatch', [$afterNestedMethod]);
         };
     }
 
@@ -99,7 +101,7 @@ class SupportLifecycleHooks extends ComponentHook
 
         $this->callTraitHook('call', ['methodName' => $methodName, 'params' => $params, 'returnEarly' => $returnEarly]);
     }
-    
+
     public function exception($e, $stopPropagation)
     {
         $this->callHook('exception', ['e' => $e, 'stopPropagation' => $stopPropagation]);


### PR DESCRIPTION
This PR adds support for using `#[On('updatedFoo')]`.
Previously no `updated*` events were fired, which prevented the usage of listeners.

Before:
```php
public function updatedDate()
{
    $this->calculate();
}

public function updatedFromCurrency()
{
    $this->calculate();
}

public function updatedFromAmount()
{
    $this->calculate();
}

public function calculate()
{
    //
}
```

After:
```php
#[On('updatedDate'), On('updatedFromCurrency'), On('updatedFromAmount')]
public function calculate()
{
    //
}
```