### PR TITLE
Add failing test for Alpine error when using array_unshift with a loop

### DIFF
--- a/src/Tests/AlpineMorphingBrowserTest.php
+++ b/src/Tests/AlpineMorphingBrowserTest.php
@@ -146,11 +146,6 @@ class AlpineMorphingBrowserTest extends \Tests\BrowserTestCase
                 array_unshift($this->values, count($this->values));
             }
 
-            public function push()
-            {
-                array_push($this->values, count($this->values));
-            }
-
             public function render(): string
             {
                 return <<<'BLADE'
@@ -165,8 +160,6 @@ class AlpineMorphingBrowserTest extends \Tests\BrowserTestCase
                         </div>
 
                         <button type="button" wire:click="unshift" dusk="unshift">Unshift</button>
-
-                        <button type="button" wire:click="push" dusk="push">Push</button>
                     </div>
                 BLADE;
             }


### PR DESCRIPTION
This PR adds a failing test for handling alpine components in a loop when using array_unshift or a similar operation.

When rendering a loop in Livewire, if a new item is unshifted, Alpine components (`x-data`) inside the loop will fail and throw errors.

The error only occurs after the second Livewire re-render. After the unshift operation, any other render will break alpine.

I suspect the problem to be related to the morph algorithm as unshifting in an HTML list causes the entire list to be recreated (new node).

However, the system functions correctly when using operations like push or when reordering the list. 

It's quite easy to reproduce this issue, making me wonder if I'm overlooking something or if there's an alternative solution.