### PR TITLE
Fix - navigation wire:navigate with progress bar animation

### DIFF
--- a/js/plugins/navigate/bar.js
+++ b/js/plugins/navigate/bar.js
@@ -5,7 +5,7 @@ NProgress.configure({
     minimum: 0.1,
     trickleSpeed: 200,
     showSpinner: false,
-    parent: 'html',
+    parent: 'body',
 })
 
 injectStyles()


### PR DESCRIPTION
After the recent changes on this PR #8204, there is a visual artefact during spa navigation. The native browser scrollbar it resets after each page change.

NProgress should use parent:"body" instead "html" tag. 

 
