### PR TITLE
Fix Issue where S3 Cleanup Command Overwrites Existing Rules

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
@@ -2,6 +2,8 @@
 
 namespace Livewire\Features\SupportConsoleCommands\Commands;
 
+use Aws\S3\S3Client;
+use function array_merge;
 use function Livewire\invade;
 use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
 use Illuminate\Console\Command;
@@ -33,21 +35,63 @@ class S3CleanupCommand extends Command
         // Flysystem V2+ doesn't allow direct access to bucket, so we need to invade instead.
         $bucket = invade($adapter)->bucket;
 
-        $client->putBucketLifecycleConfiguration([
-            'Bucket' => $bucket,
-            'LifecycleConfiguration' => [
-                'Rules' => [
-                    [
-                        'Prefix' => $prefix = FileUploadConfiguration::path(),
-                        'Expiration' => [
-                            'Days' => 1,
-                        ],
-                        'Status' => 'Enabled',
-                    ],
-                ],
+        $prefix = FileUploadConfiguration::path();
+
+        $rules[] = [
+            'Filter' => [
+                'Prefix' => $prefix,
             ],
-        ]);
+            'Expiration' => [
+                'Days' => 1,
+            ],
+            'Status' => 'Enabled',
+        ];
+
+        $rules = $this->mergeRulesWithExistingConfiguration($client, $bucket, $prefix, $rules);
+
+        try {
+            $client->putBucketLifecycleConfiguration([
+                'Bucket' => $bucket,
+                'LifecycleConfiguration' => [
+                    'Rules' => $rules
+                ],
+            ]);
+        } catch (\Exception $e) {
+            $this->error('Failed to configure S3 bucket ['.$bucket.'] to automatically cleanup files older than 24hrs!');
+
+            return;
+        }
 
         $this->info('Livewire temporary S3 upload directory ['.$prefix.'] set to automatically cleanup files older than 24hrs!');
+    }
+
+    private function checkIfLivewireConfigurationIsAlreadySet(array $existingConfigurationRules, string $bucket, S3Client $client, string $prefix) {
+        $existingConfigurationHasLivewire = collect($existingConfigurationRules)->contains('Filter.Prefix', $prefix);
+
+        if($existingConfigurationHasLivewire) {
+            $this->info('Livewire temporary S3 upload directory ['.$prefix.'] already set to automatically cleanup files older than 24hrs!');
+            $this->info('No changes made to S3 bucket ['.$bucket.'] configuration.');
+            exit;
+        }
+    }
+
+    private function mergeRulesWithExistingConfiguration(S3Client $client, string $bucket, string $prefix, array $rules): array
+    {
+        try {
+            $existingConfiguration = $client->getBucketLifecycleConfiguration([
+                'Bucket' => $bucket,
+            ]);
+        } catch (\Exception $e) {
+            // if no configuration exists, we'll just ignore the error and continue.
+            $existingConfiguration = null;
+        }
+
+        if ($existingConfiguration) {
+            $this->checkIfLivewireConfigurationIsAlreadySet($existingConfiguration['Rules'], $bucket, $client, $prefix);
+            $existingConfiguration = $existingConfiguration['Rules'];
+            $rules = array_merge($existingConfiguration, $rules);
+        }
+
+        return $rules;
     }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

I did not start a discuss, but it's a bugfix for an existing feature.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No, it's one single thing

4️⃣ Does it include tests? (Required)

I did not write any tests. 

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

I ran the `livewire:configure-s3-upload-cleanup` command today and when I did, I noticed that it overwrote my existing rules in my s3 bucket. I checked and the `putBucketLifecycleConfiguration` method from the S3 SDK overwrites the existing rules instead of appending the livewire rule to others. See: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html

Specifically: Creates a new lifecycle configuration for the bucket or replaces an existing lifecycle configuration. Keep in mind that **this will overwrite an existing lifecycle configuration, so if you want to retain any configuration details, they must be included in the new lifecycle configuration.**

This update first checks to see if there are any rules on the bucket. 

- If it finds a rule related to the livewire-tmp folder (or whatever was specified by the app in the config), then it returns and does nothing. 
- If it finds other rules, then those rules are appended to the new rule for the livewire-tmp folder before calling `putBuckerLifecycleConfiguration`
- If it does not find any other rules, the API throws an exception (which is a strange way for the AWS API to say there are no rules IMO), but we just catch that exception, ignore it, and proceed with adding the new rule as the only rule for the bucket.

I have tested this with all three scenarios listed above, and it all works.