### PR TITLE
Remove redundant alias of Rule

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -392,7 +392,7 @@ Here's an example:
 ```php
 use Livewire\Component;
 use App\Models\Post;
-use Illuminate\Validation\Rule as ValidationRule;
+use Illuminate\Validation\Rule;
 
 class CreatePost extends Component
 {
@@ -403,7 +403,7 @@ class CreatePost extends Component
     public function rules() // [tl! highlight:6]
     {
         return [
-            'title' => ValidationRule::exists('posts', 'title'),
+            'title' => Rule::exists('posts', 'title'),
             'content' => 'required|min:3',
         ];
     }


### PR DESCRIPTION
I noticed there was a redundant alias of the `Rule` class, which I'm guessing might've been a relic back from when the `Validate` attribute was called `Rule`.