### PR TITLE
Test cleanups

### DIFF
--- a/legacy_tests/Browser/Dirty/Test.php
+++ b/legacy_tests/Browser/Dirty/Test.php
@@ -18,7 +18,7 @@ class Test extends BrowserTestCase
 
             public function render()
             {
-                return <<<HTML
+                return <<<'HTML'
                     <div>
                         <input wire:model.lazy="foo" wire:dirty.class="foo-dirty" dusk="foo">
                         <input wire:model.lazy="bar" wire:dirty.class.remove="bar-dirty" class="bar-dirty" dusk="bar">

--- a/legacy_tests/Browser/SupportStringables/Test.php
+++ b/legacy_tests/Browser/SupportStringables/Test.php
@@ -3,6 +3,7 @@
 namespace LegacyTests\Browser\SupportStringables;
 
 use Illuminate\Support\Str;
+use Livewire\Component;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -10,7 +11,7 @@ class Test extends TestCase
 {
     public function test_stringable_support()
     {
-        Livewire::test(new class extends \Livewire\Component {
+        Livewire::test(new class extends Component {
             public $string;
 
             public function mount()

--- a/src/Features/SupportAutoInjectedAssets/UnitTest.php
+++ b/src/Features/SupportAutoInjectedAssets/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportAutoInjectedAssets;
 
+use Livewire\Component;
 use Livewire\Livewire;
 use Tests\TestComponent;
 use Tests\TestCase;
@@ -26,7 +27,7 @@ class UnitTest extends TestCase
                 <body>
                 </body>
             </html>
-        HTML, <<<HTML
+        HTML, <<<'HTML'
             <!doctype html>
             <html>
                 <head>
@@ -48,7 +49,7 @@ class UnitTest extends TestCase
             <html>
                 <yolo />
             </html>
-        HTML, <<<HTML
+        HTML, <<<'HTML'
             <html>$livewireStyles
                 <yolo />
             $livewireScripts</html>
@@ -74,7 +75,7 @@ class UnitTest extends TestCase
                 </body
                 >
             </html>
-        HTML, <<<HTML
+        HTML, <<<'HTML'
             <!doctype html>
             <html
                 lang="en"
@@ -111,7 +112,7 @@ class UnitTest extends TestCase
                 </bOdY
                 >
             </HTML>
-        HTML, <<<HTML
+        HTML, <<<'HTML'
             <!doctype html>
             <HTML
                 lang="en"
@@ -210,7 +211,7 @@ class UnitTest extends TestCase
 
     public function test_response_maintains_original_view_after_asset_injection(): void
     {
-        Livewire::component('foo', new class extends \Livewire\Component {
+        Livewire::component('foo', new class extends Component {
             public function render() {
                 return '<div>Foo!</div>';
             }

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -378,11 +378,6 @@ class UnitTest extends TestCase
             {
                 return 'bar';
             }
-
-            public function render()
-            {
-                return '<div></div>';
-            }
         })
             ->assertSet('foo', 'bar');
     }
@@ -405,11 +400,6 @@ class UnitTest extends TestCase
                 $this->changeFoo = true;
 
                 unset($this->foo);
-            }
-
-            public function render()
-            {
-                return '<div></div>';
             }
         })
             ->assertSet('foo', 'bar')

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -16,14 +16,14 @@ class BrowserTest extends BrowserTestCase
 
             public function render()
             {
-                return <<<'BLADE'
+                return <<<'HTML'
                     <div>
                         <input dusk="checkbox" type="checkbox" wire:model="prop" value="true"  />
 
                         <div wire:dirty>Unsaved changes...</div>
                         <div wire:dirty.remove>The data is in-sync...</div>
                     </div>
-                BLADE;
+                HTML;
             }
         })
             ->assertSee('The data is in-sync...')
@@ -50,7 +50,7 @@ class BrowserTest extends BrowserTestCase
 
             public function render()
             {
-                return <<<'BLADE'
+                return <<<'HTML'
                     <div>
                         <select wire:model.live="foo" dusk="fooSelect">
                             <option value=""></option>
@@ -66,7 +66,7 @@ class BrowserTest extends BrowserTestCase
                             <option value="three">Three</option>
                         </select>
                     </div>
-                BLADE;
+                HTML;
             }
         })
             ->select('@barSelect', 'one')

--- a/src/Features/SupportEntangle/BrowserTest.php
+++ b/src/Features/SupportEntangle/BrowserTest.php
@@ -17,13 +17,13 @@ class BrowserTest extends BrowserTestCase
 
             public function render()
             {
-                return <<<'BLADE'
+                return <<<'HTML'
                     <div>
                         <div x-data="{ value: $persist(@entangle('input')) }">
                             <input dusk="input" x-model="value" />
                         </div>
                     </div>
-                BLADE;
+                HTML;
             }
         })
             ->type('@input', 'Hello World')

--- a/src/Features/SupportEvents/UnitTest.php
+++ b/src/Features/SupportEvents/UnitTest.php
@@ -4,12 +4,13 @@ namespace Livewire\Features\SupportEvents;
 
 use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
     public function test_receive_event_with_attribute()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             public $foo = 'bar';
 
             #[BaseOn('bar')]
@@ -17,8 +18,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->foo = $param;
             }
-
-            public function render() { return '<div></div>'; }
         });
 
         $component->dispatch('bar', 'baz');
@@ -28,7 +27,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_listen_for_dynamic_event_name()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             public $post = ['id' => 2];
 
             public $foo = 'bar';
@@ -38,8 +37,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->foo = $param;
             }
-
-            public function render() { return '<div></div>'; }
         });
 
         $component->dispatch('bar.2', 'baz');
@@ -49,7 +46,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_listens_for_event_with_named_params()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             public $foo = 'bar';
 
             #[BaseOn('bar')]
@@ -57,8 +54,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->foo = $name . $game;
             }
-
-            public function render() { return '<div></div>'; }
         });
 
         $component->dispatch('bar', game: 'shmaz', name: 'baz');
@@ -68,13 +63,11 @@ class UnitTest extends \Tests\TestCase
 
     public function test_dispatches_event_with_named_params()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public function dispatchFoo()
             {
                 $this->dispatch('foo', name: 'bar', game: 'baz');
             }
-
-            public function render() { return '<div></div>'; }
         })
             ->call('dispatchFoo')
             ->assertDispatched('foo')
@@ -88,7 +81,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_it_can_register_multiple_listeners_via_attribute(): void
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public $counter = 0;
 
             #[BaseOn('foo'), BaseOn('bar')]
@@ -96,8 +89,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->counter++;
             }
-
-            public function render() { return '<div></div>'; }
         })
             ->dispatch('foo')
             ->assertSet('counter', 1)
@@ -107,7 +98,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_it_can_register_multiple_listeners_via_attribute_userland(): void
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public $counter = 0;
 
             #[\Livewire\Attributes\On('foo'), \Livewire\Attributes\On('bar')]
@@ -115,8 +106,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->counter++;
             }
-
-            public function render() { return '<div></div>'; }
         })
             ->dispatch('foo')
             ->assertSet('counter', 1)

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -9,17 +9,14 @@ use Livewire\Form;
 use Livewire\Livewire;
 use PHPUnit\Framework\Assert;
 use Sushi\Sushi;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
     function test_can_use_a_form_object()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormStub $form;
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertSet('form.title', '')
         ->assertSet('form.content', '')
@@ -32,16 +29,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_reset_form_object_property()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormStub $form;
 
             public function resetForm()
             {
                 $this->reset('form.title', 'form.content');
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
             ->assertSet('form.title', '')
@@ -56,16 +49,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_form_object()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             function save()
             {
                 $this->form->validate();
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertSet('form.title', '')
@@ -79,16 +68,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_form_with_the_general_validate_function()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             function save()
             {
                 $this->validate();
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
             ->call('save')
@@ -101,16 +86,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_specific_rule_has_errors_in_a_form_object()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             function save()
             {
                 $this->validate();
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertSet('form.title', '')
@@ -122,16 +103,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_form_object_with_validate_only()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             function save()
             {
                 $this->form->validateOnly('title');
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertHasNoErrors()
@@ -143,16 +120,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_specific_rule_for_form_object_with_validate_only()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             function save()
             {
                 $this->form->validateOnly('title');
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
             ->assertHasNoErrors()
@@ -163,12 +136,8 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_specific_rule_has_errors_on_update_in_a_form_object()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateOnUpdateStub $form;
-
-            public function render() {
-                return '<div></div>';
-            }
         })
             ->assertHasNoErrors()
             ->set('form.title', 'foo')
@@ -178,16 +147,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_form_object_with_root_component_validate_only()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             function save()
             {
                 $this->validateOnly('form.title');
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertHasNoErrors()
@@ -199,16 +164,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_form_object_using_rule_attributes()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormRuleAttributeStub $form;
 
             function save()
             {
                 $this->form->validate();
-            }
-
-            function render() {
-                return '<div></div>';
             }
         })
         ->assertSet('form.title', '')
@@ -226,16 +187,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_form_object_using_rule_attribute_with_custom_name()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormRuleAttributeWithCustomNameStub $form;
 
             function save()
             {
                 $this->form->validate();
-            }
-
-            function render() {
-                return '<div></div>';
             }
         })
             ->assertSet('form.name', '')
@@ -274,16 +231,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_reset_property()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormStub $form;
 
             function save()
             {
                 $this->form->reset('title');
-            }
-
-            function render() {
-                return '<div></div>';
             }
         })
         ->set('form.title', 'Some title...')
@@ -299,16 +252,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_reset_all_properties()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormStub $form;
 
             function save()
             {
                 $this->form->reset();
-            }
-
-            function render() {
-                return '<div></div>';
             }
         })
         ->set('form.title', 'Some title...')
@@ -324,7 +273,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_all_properties_are_available_in_rules_method()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormWithRulesStub $form;
 
             public function mount()
@@ -334,10 +283,6 @@ class UnitTest extends \Tests\TestCase
 
             function save() {
                 $this->form->validate();
-            }
-
-            function render() {
-                return '<div></div>';
             }
         })
         ->assertSet('form.post', 42)
@@ -481,7 +426,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_can_fill_a_form_object_from_model()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostForFormObjectTesting $post;
             public PostFormStub $form;
 
@@ -494,11 +439,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->form->fill($this->post);
             }
-
-            public function render()
-            {
-                return '<div></div>';
-            }
         })
             ->assertSet('form.title', '')
             ->assertSet('form.content', '')
@@ -510,7 +450,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_can_fill_a_form_object_from_array()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormStub $form;
 
             public function fillForm()
@@ -519,11 +459,6 @@ class UnitTest extends \Tests\TestCase
                     'title' => 'Title from array',
                     'content' => 'Content from array',
                 ]);
-            }
-
-            public function render()
-            {
-                return '<div></div>';
             }
         })
             ->assertSet('form.title', '')
@@ -536,7 +471,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_form_object_validation_runs_alongside_component_validation()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             #[Validate('required')]
@@ -545,10 +480,6 @@ class UnitTest extends \Tests\TestCase
             function save()
             {
                 $this->validate();
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertHasNoErrors()
@@ -561,7 +492,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_form_object_validation_wont_run_if_rules_are_passed_into_validate()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             public $username = '';
@@ -569,10 +500,6 @@ class UnitTest extends \Tests\TestCase
             function save()
             {
                 $this->validate(['username' => 'required']);
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertHasNoErrors()
@@ -585,7 +512,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_allows_form_object_without_rules_without_throwing_an_error()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormWithoutRules $form;
 
             public $username = '';
@@ -601,10 +528,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->validate();
             }
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertHasNoErrors()
         ->call('save')
@@ -614,7 +537,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_allows_form_object_without_rules_but_can_still_validate_it_with_its_own_rules()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormWithoutRules $form;
 
             public $username = '';
@@ -631,10 +554,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->validate();
             }
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertHasNoErrors()
         ->call('save')
@@ -645,7 +564,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_form_object_without_rules_can_still_be_validated_and_return_proper_data()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormWithoutRules $form;
 
             public $username = '';
@@ -666,10 +585,6 @@ class UnitTest extends \Tests\TestCase
                 \PHPUnit\Framework\Assert::assertEquals('bar', data_get($data, 'form.title'));
                 \PHPUnit\Framework\Assert::assertEquals('not-found', data_get($data, 'form.content', 'not-found'));
             }
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertHasNoErrors()
         ->set('username', 'foo')
@@ -681,7 +596,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_resetting_validation_errors_resets_form_objects_as_well()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             #[Validate('required')]
@@ -696,10 +611,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->resetValidation();
             }
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertHasNoErrors()
         ->call('save')
@@ -713,7 +624,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_intercept_form_object_validator_instance()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateWithInterceptStub $form;
 
             function save()
@@ -724,10 +635,6 @@ class UnitTest extends \Tests\TestCase
             function resetVal()
             {
                 $this->resetValidation();
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertHasNoErrors()

--- a/src/Features/SupportIsolating/BrowserTest.php
+++ b/src/Features/SupportIsolating/BrowserTest.php
@@ -13,7 +13,7 @@ class BrowserTest extends BrowserTestCase
     public function test_components_can_be_marked_as_isolated()
     {
         Livewire::visit([new class extends Component {
-            public function render() { return <<<HTML
+            public function render() { return <<<'HTML'
             <div>
                 <livewire:child num="1" />
                 <livewire:child num="2" />
@@ -66,7 +66,7 @@ class BrowserTest extends BrowserTestCase
     public function test_lazy_requests_are_isolated_by_default()
     {
         Livewire::visit([new class extends Component {
-            public function render() { return <<<HTML
+            public function render() { return <<<'HTML'
             <div>
                 <livewire:child num="1" />
                 <livewire:child num="2" />
@@ -104,7 +104,7 @@ class BrowserTest extends BrowserTestCase
     public function test_lazy_requests_are_isolated_by_default_but_bundled_on_next_request_when_polling()
     {
         Livewire::visit([new class extends Component {
-            public function render() { return <<<HTML
+            public function render() { return <<<'HTML'
             <div>
                 <livewire:child num="1" />
                 <livewire:child num="2" />
@@ -155,7 +155,7 @@ class BrowserTest extends BrowserTestCase
     public function test_lazy_requests_can_be_bundled_with_attribute_parameter()
     {
         Livewire::visit([new class extends Component {
-            public function render() { return <<<HTML
+            public function render() { return <<<'HTML'
             <div>
                 <livewire:child num="1" />
                 <livewire:child num="2" />

--- a/src/Features/SupportJsEvaluation/BrowserTest.php
+++ b/src/Features/SupportJsEvaluation/BrowserTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportJsEvaluation;
 
+use Livewire\Component;
 use Livewire\Livewire;
 
 class BrowserTest extends \Tests\BrowserTestCase
@@ -9,7 +10,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_can_toggle_a_purely_js_property_with_a_purely_js_function()
     {
         Livewire::visit(
-            new class extends \Livewire\Component {
+            new class extends Component {
                 public $show = false;
 
                 #[BaseJs]
@@ -44,7 +45,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_can_evaluate_js_code_after_an_action_is_performed()
     {
         Livewire::visit(
-            new class extends \Livewire\Component {
+            new class extends Component {
                 public $show = false;
 
                 function toggle()

--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -13,7 +13,7 @@ class BrowserTest extends BrowserTestCase
     public function test_can_lazy_load_a_component()
     {
         Livewire::visit([new class extends Component {
-            public function render() { return <<<HTML
+            public function render() { return <<<'HTML'
             <div>
                 <livewire:child lazy />
             </div>
@@ -24,7 +24,7 @@ class BrowserTest extends BrowserTestCase
             }
 
             public function render() {
-                return <<<HTML
+                return <<<'HTML'
                 <div id="child">
                     Child!
                 </div>
@@ -42,7 +42,7 @@ class BrowserTest extends BrowserTestCase
         Livewire::visit([new class extends Component {
             public function render()
             {
-                return <<<HTML
+                return <<<'HTML'
             <div>
                 <div style="height: 200vh"></div>
                 <livewire:child lazy="on-load" />
@@ -57,7 +57,7 @@ class BrowserTest extends BrowserTestCase
 
             public function render()
             {
-                return <<<HTML
+                return <<<'HTML'
                 <div id="child">
                     Child!
                 </div>
@@ -74,7 +74,7 @@ class BrowserTest extends BrowserTestCase
         Livewire::visit([new class extends Component {
             public function render()
             {
-                return <<<HTML
+                return <<<'HTML'
             <div>
                 <div style="height: 200vh"></div>
                 <livewire:child lazy />
@@ -89,7 +89,7 @@ class BrowserTest extends BrowserTestCase
 
             public function render()
             {
-                return <<<HTML
+                return <<<'HTML'
                 <div id="child">
                     Child!
                 </div>
@@ -108,13 +108,13 @@ class BrowserTest extends BrowserTestCase
                 sleep(1);
             }
 
-            public function placeholder() { return <<<HTML
+            public function placeholder() { return <<<'HTML'
                 <div id="loading">
                     Loading...
                 </div>
                 HTML; }
 
-            public function render() { return <<<HTML
+            public function render() { return <<<'HTML'
                 <div id="page">
                     Hello World
                 </div>
@@ -151,19 +151,19 @@ class BrowserTest extends BrowserTestCase
     public function test_can_lazy_load_a_component_with_a_placeholder()
     {
         Livewire::visit([new class extends Component {
-            public function render() { return <<<HTML
+            public function render() { return <<<'HTML'
             <div>
                 <livewire:child lazy />
             </div>
             HTML; }
         }, 'child' => new class extends Component {
             public function mount() { sleep(1); }
-            public function placeholder() { return <<<HTML
+            public function placeholder() { return <<<'HTML'
                 <div id="loading">
                     Loading...
                 </div>
                 HTML; }
-            public function render() { return <<<HTML
+            public function render() { return <<<'HTML'
             <div id="child">
                 Child!
             </div>
@@ -259,7 +259,7 @@ class BrowserTest extends BrowserTestCase
     public function test_can_access_component_parameters_in_placeholder_view()
     {
         Livewire::visit([new class extends Component {
-            public function render() { return <<<HTML
+            public function render() { return <<<'HTML'
             <div>
                 <livewire:child my-parameter="A Parameter Value" lazy />
             </div>
@@ -272,7 +272,7 @@ class BrowserTest extends BrowserTestCase
                 return view('placeholder', $params);
             }
             public function render() {
-                return <<<HTML
+                return <<<'HTML'
                 <div id="child">
                     Child!
                 </div>
@@ -294,13 +294,13 @@ class Page extends Component {
         sleep(1);
     }
 
-    public function placeholder() { return <<<HTML
+    public function placeholder() { return <<<'HTML'
             <div id="loading">
                 Loading...
             </div>
             HTML; }
 
-    public function render() { return <<<HTML
+    public function render() { return <<<'HTML'
             <div id="page">
                 Hello World
             </div>

--- a/src/Features/SupportLegacyModels/Tests/ModelsCanBeFilledUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelsCanBeFilledUnitTest.php
@@ -3,8 +3,8 @@
 namespace Livewire\Features\SupportLegacyModels\Tests;
 
 use Livewire\Livewire;
-use Livewire\Component;
 use Illuminate\Database\Eloquent\Model;
+use Tests\TestComponent;
 
 class ModelsCanBeFilledUnitTest extends \Tests\TestCase
 {
@@ -49,17 +49,12 @@ class UserModel extends Model
     }
 }
 
-class ComponentWithFillableProperties extends Component
+class ComponentWithFillableProperties extends TestComponent
 {
     public $user;
 
     public function callFill($values)
     {
         $this->fill($values);
-    }
-
-    public function render()
-    {
-        return '<div></div>';
     }
 }

--- a/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
@@ -3,10 +3,10 @@
 namespace Livewire\Features\SupportLegacyModels\Tests;
 
 use Livewire\Livewire;
-use Livewire\Component;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Model;
+use Tests\TestComponent;
 
 class PublicPropertyHydrationAndDehydrationUnitTest extends \Tests\TestCase
 {
@@ -878,7 +878,7 @@ class PublicPropertyHydrationAndDehydrationUnitTest extends \Tests\TestCase
     }
 }
 
-class PostComponent extends Component
+class PostComponent extends TestComponent
 {
     public $post;
 
@@ -886,16 +886,9 @@ class PostComponent extends Component
     {
         $this->post = Post::first();
     }
-
-    public function render()
-    {
-        return <<<'HTML'
-        <div></div>
-        HTML;
-    }
 }
 
-class ModelsComponent extends Component
+class ModelsComponent extends TestComponent
 {
     public $model;
     public $models;
@@ -923,13 +916,6 @@ class ModelsComponent extends Component
         if (isset($rules)) {
             $this->_rules = $rules;
         }
-    }
-
-    public function render()
-    {
-        return <<<'HTML'
-        <div></div>
-        HTML;
     }
 }
 

--- a/src/Features/SupportLegacyModels/Tests/TestableLivewireCanAssertModelUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/TestableLivewireCanAssertModelUnitTest.php
@@ -4,8 +4,8 @@ namespace Livewire\Features\SupportLegacyModels\Tests;
 
 use Sushi\Sushi;
 use Livewire\Livewire;
-use Livewire\Component;
 use Illuminate\Database\Eloquent\Model;
+use Tests\TestComponent;
 
 class TestableLivewireCanAssertModelUnitTest extends \Tests\TestCase
 {
@@ -32,12 +32,7 @@ class ModelForPropertyTesting extends Model
     }
 }
 
-class PropertyTestingComponent extends Component
+class PropertyTestingComponent extends TestComponent
 {
     public $model;
-
-    public function render()
-    {
-        return '<div></div>';
-    }
 }

--- a/src/Features/SupportLockedProperties/UnitTest.php
+++ b/src/Features/SupportLockedProperties/UnitTest.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportLockedProperties;
 use Livewire\Livewire;
 use Livewire\Component as BaseComponent;
 use Livewire\Form;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -14,15 +15,11 @@ class UnitTest extends \Tests\TestCase
             'Cannot update locked property: [count]'
         );
 
-        Livewire::test(new class extends BaseComponent {
+        Livewire::test(new class extends TestComponent {
             #[BaseLocked]
             public $count = 1;
 
             function increment() { $this->count++; }
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertSet('count', 1)
         ->set('count', 2);
@@ -35,15 +32,11 @@ class UnitTest extends \Tests\TestCase
             'Cannot update locked property: [foo]'
         );
 
-        Livewire::test(new class extends BaseComponent {
+        Livewire::test(new class extends TestComponent {
             #[BaseLocked]
             public $foo = ['count' => 1];
 
             function increment() { $this->foo['count']++; }
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertSet('foo.count', 1)
         ->set('foo.count', 2);
@@ -51,15 +44,11 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_update_locked_property_with_similar_name()
     {
-        Livewire::test(new class extends BaseComponent {
+        Livewire::test(new class extends TestComponent {
             #[BaseLocked]
             public $count = 1;
 
             public $count2 = 1;
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertSet('count2', 1)
         ->set('count2', 2);

--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -5,8 +5,10 @@ namespace Livewire\Features\SupportModels;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Livewire\Component;
 use Livewire\Livewire;
 use Sushi\Sushi;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -14,7 +16,7 @@ class UnitTest extends \Tests\TestCase
     {
         (new Article)::resolveConnection()->enableQueryLog();
 
-        Livewire::test(new class extends \Livewire\Component {
+        Livewire::test(new class extends Component {
             public Article $article;
 
             public function mount() {
@@ -36,7 +38,7 @@ class UnitTest extends \Tests\TestCase
     {
         $this->expectExceptionMessage("Can't set model properties directly");
 
-        Livewire::test(new class extends \Livewire\Component {
+        Livewire::test(new class extends Component {
             public Article $article;
 
             public function mount() {
@@ -53,7 +55,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_cant_view_model_data_in_javascript()
     {
-        $data = Livewire::test(new class extends \Livewire\Component {
+        $data = Livewire::test(new class extends Component {
             public Article $article;
 
             public function mount() {
@@ -70,7 +72,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_unpersisted_models_can_be_assigned_but_no_data_is_persisted_between_requests()
     {
-        $component = Livewire::test(new class extends \Livewire\Component {
+        $component = Livewire::test(new class extends Component {
             public Article $article;
 
             public function mount() {
@@ -95,7 +97,7 @@ class UnitTest extends \Tests\TestCase
         $this->markTestSkipped(); // @todo: probably not going to go this route...
         (new Article)::resolveConnection()->enableQueryLog();
 
-        Livewire::test(new class extends \Livewire\Component {
+        Livewire::test(new class extends TestComponent {
             #[Lazy]
             public Article $article;
 
@@ -107,10 +109,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->article->save();
             }
-
-            public function render() { return <<<'HTML'
-                <div></div>
-            HTML; }
         })
         ->call('$refresh')
         ->call('save');
@@ -145,7 +143,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_collections_with_duplicate_models_are_available_when_hydrating()
     {
-        Livewire::test(new class extends \Livewire\Component {
+        Livewire::test(new class extends Component {
             public Collection $articles;
 
             public function mount() {
@@ -172,7 +170,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_collections_retain_their_order_on_hydration()
     {
-        Livewire::test(new class extends \Livewire\Component {
+        Livewire::test(new class extends Component {
             public Collection $articles;
 
             public function mount() {
@@ -200,19 +198,12 @@ class UnitTest extends \Tests\TestCase
         Relation::morphMap([], false);
         Relation::requireMorphMap();
 
-        $component = Livewire::test(new class extends \Livewire\Component {
+        $component = Livewire::test(new class extends TestComponent {
             public $article;
 
             public function mount()
             {
                 $this->article = Article::first();
-            }
-
-            public function render()
-            {
-                return <<<'HTML'
-                <div></div>
-                HTML;
             }
         });
 
@@ -227,20 +218,13 @@ class Lazy {
     //
 }
 
-class ArticleComponent extends \Livewire\Component
+class ArticleComponent extends TestComponent
 {
     public $article;
 
     public function mount()
     {
         $this->article = Article::first();
-    }
-
-    public function render()
-    {
-        return <<<'HTML'
-        <div></div>
-        HTML;
     }
 }
 

--- a/src/Features/SupportMorphAwareIfStatement/UnitTest.php
+++ b/src/Features/SupportMorphAwareIfStatement/UnitTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportMorphAwareIfStatement;
 
 use Illuminate\Support\Facades\Blade;
+use Livewire\Component;
 use Livewire\Livewire;
 use Livewire\Mechanisms\ExtendBlade\ExtendBlade;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -11,7 +12,7 @@ class UnitTest extends \Tests\TestCase
 {
     public function test_conditional_markers_are_only_added_to_if_statements_wrapping_elements()
     {
-        Livewire::component('foo', new class extends \Livewire\Component
+        Livewire::component('foo', new class extends Component
         {
             public function render()
             {

--- a/src/Features/SupportPagination/UnitTest.php
+++ b/src/Features/SupportPagination/UnitTest.php
@@ -8,6 +8,7 @@ use Livewire\Component;
 use Livewire\Livewire;
 use Livewire\WithPagination;
 use Sushi\Sushi;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -141,14 +142,9 @@ class UnitTest extends \Tests\TestCase
     }
 }
 
-class ComponentWithPaginationStub extends Component
+class ComponentWithPaginationStub extends TestComponent
 {
     use WithPagination;
-
-    public function render()
-    {
-        return '<div></div>';
-    }
 }
 
 class PaginatorPostTestModel extends Model

--- a/src/Features/SupportPolling/BrowserTest.php
+++ b/src/Features/SupportPolling/BrowserTest.php
@@ -11,7 +11,7 @@ class BrowserTest extends BrowserTestCase
     public function test_polling_requests_are_batched_by_default()
     {
         Livewire::visit([new class extends Component {
-            public function render() { return <<<HTML
+            public function render() { return <<<'HTML'
             <div>
                 <livewire:child num="1" />
                 <livewire:child num="2" />

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportQueryString;
 
+use Livewire\Form;
 use Livewire\Livewire;
 use Livewire\Component;
 use Livewire\Attributes\Url;
@@ -12,7 +13,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_it_does_not_add_null_values_to_the_query_string_array()
     {
         Livewire::visit([
-            new class extends \Livewire\Component {
+            new class extends Component {
                 #[Url]
                 public array $tableFilters = [
                     'filter_1' => [
@@ -380,7 +381,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_can_unset_the_array_key_when_using_dot_notation_without_except()
     {
         Livewire::visit([
-            new class extends \Livewire\Component {
+            new class extends Component {
                 public array $tableFilters = [];
 
                 protected function queryString() {
@@ -419,7 +420,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_can_unset_the_array_key_when_with_except()
     {
         Livewire::visit([
-            new class extends \Livewire\Component {
+            new class extends Component {
                 public array $tableFilters = [];
 
                 protected function queryString() {
@@ -463,7 +464,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_can_unset_the_array_key_when_without_except()
     {
         Livewire::visit([
-            new class extends \Livewire\Component {
+            new class extends Component {
                 public array $tableFilters = [];
 
                 protected function queryString() {
@@ -506,7 +507,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_can_unset_the_array_key_when_using_dot_notation_with_except()
     {
         Livewire::visit([
-            new class extends \Livewire\Component {
+            new class extends Component {
                 public array $tableFilters = [];
 
                 protected function queryString() {
@@ -825,7 +826,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
 }
 
-class FormObject extends \Livewire\Form
+class FormObject extends Form
 {
     #[\Livewire\Attributes\Url]
     public $foo = 'bar';

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -3,7 +3,7 @@
 namespace Livewire\Features\SupportQueryString;
 
 use Livewire\Livewire;
-use Livewire\Component;
+use Tests\TestComponent;
 
 trait WithSorting
 {
@@ -19,15 +19,11 @@ class UnitTest extends \Tests\TestCase
 {
     function test_can_track_properties_in_the_url()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             #[BaseUrl]
             public $count = 1;
 
             function increment() { $this->count++; }
-
-            public function render() {
-                return '<div></div>';
-            }
         });
 
         $this->assertTrue(isset($component->effects['url']));
@@ -35,12 +31,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_sub_name_is_null_in_attributes_from_query_string_component_method()
     {
-        $component = Livewire::test(new class extends Component {
-            public function render()
-            {
-                return '<div></div>';
-            }
-
+        $component = Livewire::test(new class extends TestComponent {
             protected function queryString()
             {
                 return [
@@ -58,13 +49,8 @@ class UnitTest extends \Tests\TestCase
 
     function test_sub_name_is_null_in_attributes_from_query_string_trait_method()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             use WithSorting;
-
-            public function render()
-            {
-                return '<div></div>';
-            }
         });
 
         $attributes = $component->instance()->getAttributes();
@@ -76,14 +62,9 @@ class UnitTest extends \Tests\TestCase
 
     function test_sub_name_is_same_as_name_in_attributes_from_base_url_property_attribute()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             #[BaseUrl]
             public $queryFromAttribute;
-
-            public function render()
-            {
-                return '<div></div>';
-            }
         });
 
         $attributes = $component->instance()->getAttributes();

--- a/src/Features/SupportRedirects/BrowserTest.php
+++ b/src/Features/SupportRedirects/BrowserTest.php
@@ -19,7 +19,7 @@ class BrowserTest extends BrowserTestCase
                 $this->redirect('https://livewire.laravel.com');
             }
 
-            public function render() { return <<<HTML
+            public function render() { return <<<'HTML'
             <div>
                 <button type="button" dusk="button" wire:click="redirectToWebsite">Redirect to Livewire</button>
             </div>

--- a/src/Features/SupportScriptsAndAssets/BrowserTest.php
+++ b/src/Features/SupportScriptsAndAssets/BrowserTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportScriptsAndAssets;
 
+use Livewire\Component;
 use Livewire\Livewire;
 use Livewire\Drawer\Utils;
 use Illuminate\Support\Facades\Route;
@@ -10,7 +11,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 {
     public function test_can_evaluate_a_script_inside_a_component()
     {
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public $message = 'original';
 
             public function render() { return <<<'HTML'
@@ -35,7 +36,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_can_register_an_alpine_component_inside_a_script_tag()
     {
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public $message = 'original';
 
             public function render() { return <<<'HTML'
@@ -60,7 +61,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_multiple_scripts_can_be_evaluated()
     {
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public function render() { return <<<'HTML'
             <div>
                 <h1 dusk="foo"></h1>
@@ -87,7 +88,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_scripts_can_be_added_conditionally()
     {
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public $show = false;
 
             public function render() { return <<<'HTML'
@@ -123,7 +124,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             return Utils::pretendResponseIsFile(__DIR__.'/test.js');
         });
 
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public function render() { return <<<'HTML'
             <div>
                 <h1 dusk="foo" wire:ignore></h1>
@@ -140,7 +141,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_remote_assets_can_be_loaded()
     {
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public function render() { return <<<'HTML'
             <div>
                 <input type="text" data-picker>
@@ -167,7 +168,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_remote_assets_can_be_loaded_lazily()
     {
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public $load = false;
 
             public function render() { return <<<'HTML'
@@ -201,7 +202,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_remote_assets_can_be_loaded_from_a_deferred_nested_component()
     {
-        Livewire::visit([new class extends \Livewire\Component {
+        Livewire::visit([new class extends Component {
             public $load = false;
 
             public function render() { return <<<'HTML'
@@ -216,7 +217,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             </div>
             HTML; }
         },
-        'child' => new class extends \Livewire\Component {
+        'child' => new class extends Component {
             public function render() { return <<<'HTML'
             <div>
                 <input type="text" data-picker>
@@ -243,7 +244,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_remote_inline_scripts_can_be_loaded_from_a_deferred_nested_component()
     {
-        Livewire::visit([new class extends \Livewire\Component {
+        Livewire::visit([new class extends Component {
             public $load = false;
 
             public function render() { return <<<'HTML'
@@ -258,7 +259,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             </div>
             HTML; }
         },
-        'child' => new class extends \Livewire\Component {
+        'child' => new class extends Component {
             public function render() { return <<<'HTML'
             <div>
                 <input type="text" data-picker>
@@ -290,7 +291,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_can_listen_for_initial_dispatches_inside_script()
     {
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public function render() {
                 $this->dispatch('test')->self();
 
@@ -315,7 +316,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_functions_loaded_in_scripts_are_not_auto_evaluated()
     {
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public function render() { return <<<'HTML'
             <div>
                 <div dusk="output"></div>

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanAssertPropertiesUnitTest.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanAssertPropertiesUnitTest.php
@@ -2,8 +2,8 @@
 
 namespace Livewire\Features\SupportTesting\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class TestableLivewireCanAssertPropertiesUnitTest extends \Tests\TestCase
 {
@@ -38,7 +38,7 @@ class TestableLivewireCanAssertPropertiesUnitTest extends \Tests\TestCase
     }
 }
 
-class PropertyTestingComponent extends Component
+class PropertyTestingComponent extends TestComponent
 {
     public $foo = 'bar';
 
@@ -46,22 +46,12 @@ class PropertyTestingComponent extends Component
     {
         return 'lob';
     }
-
-    function render()
-    {
-        return '<div></div>';
-    }
 }
 
-class ComputedPropertyWithExceptionTestingComponent extends Component
+class ComputedPropertyWithExceptionTestingComponent extends TestComponent
 {
     function getThrowsExceptionProperty()
     {
         throw new \Exception('Test exception');
-    }
-
-    function render()
-    {
-        return '<div></div>';
     }
 }

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanBeInvaded.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanBeInvaded.php
@@ -2,20 +2,16 @@
 
 namespace Livewire\Features\SupportTesting\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Tests\TestComponent;
 
 class TestableLivewireCanBeInvaded extends \Tests\TestCase
 {
     function test_can_invade_protected_properties()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             protected string $foo = 'bar';
-
-            function render() {
-                return '<div></div>';
-            }
         });
 
         PHPUnit::assertEquals('bar', $component->invade()->foo);
@@ -23,13 +19,9 @@ class TestableLivewireCanBeInvaded extends \Tests\TestCase
 
     function test_can_invade_protected_functions()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             protected function foo() : string {
                 return 'bar';
-            }
-
-            function render() {
-                return '<div></div>';
             }
         });
 
@@ -38,12 +30,8 @@ class TestableLivewireCanBeInvaded extends \Tests\TestCase
 
     function test_can_invade_private_properties()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             private string $foo = 'bar';
-
-            function render() {
-                return '<div></div>';
-            }
         });
 
         PHPUnit::assertEquals('bar', $component->invade()->foo);
@@ -51,13 +39,9 @@ class TestableLivewireCanBeInvaded extends \Tests\TestCase
 
     function test_can_invade_private_functions()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             private function foo() : string {
                 return 'bar';
-            }
-
-            function render() {
-                return '<div></div>';
             }
         });
 

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -11,6 +11,7 @@ use Illuminate\Testing\TestView;
 use Livewire\Component;
 use Livewire\Livewire;
 use Closure;
+use Tests\TestComponent;
 
 // TODO - Change this to \Tests\TestCase
 class UnitTest extends \LegacyTests\Unit\TestCase
@@ -543,18 +544,13 @@ class UnitTest extends \LegacyTests\Unit\TestCase
         // Test both the `withCookies` and `withCookie` methods that Laravel normally provides
         Livewire::withCookies(['colour' => 'blue'])
             ->withCookie('name', 'Taylor')
-            ->test(new class extends Component {
+            ->test(new class extends TestComponent {
                 public $colourCookie = '';
                 public $nameCookie = '';
                 public function mount()
                 {
                     $this->colourCookie = request()->cookie('colour');
                     $this->nameCookie = request()->cookie('name');
-                }
-
-                public function render()
-                {
-                    return '<div></div>';
                 }
             })
             ->assertSet('colourCookie', 'blue')
@@ -565,18 +561,13 @@ class UnitTest extends \LegacyTests\Unit\TestCase
     public function test_can_set_headers_for_use_with_testing()
     {
         Livewire::withHeaders(['colour' => 'blue', 'name' => 'Taylor'])
-            ->test(new class extends Component {
+            ->test(new class extends TestComponent {
                 public $colourHeader = '';
                 public $nameHeader = '';
                 public function mount()
                 {
                     $this->colourHeader = request()->header('colour');
                     $this->nameHeader = request()->header('name');
-                }
-
-                public function render()
-                {
-                    return '<div></div>';
                 }
             })
             ->assertSet('colourHeader', 'blue')
@@ -588,7 +579,7 @@ class UnitTest extends \LegacyTests\Unit\TestCase
     {
         // Test both the `withCookies` and `withCookie` methods that Laravel normally provides
         Livewire::withCookies(['colour' => 'blue'])->withCookie('name', 'Taylor')
-            ->test(new class extends Component {
+            ->test(new class extends TestComponent {
                 public $colourCookie = '';
                 public $nameCookie = '';
 
@@ -596,11 +587,6 @@ class UnitTest extends \LegacyTests\Unit\TestCase
                 {
                     $this->colourCookie = request()->cookie('colour');
                     $this->nameCookie = request()->cookie('name');
-                }
-
-                public function render()
-                {
-                    return '<div></div>';
                 }
             })
             ->call('setTheCookies')

--- a/src/Features/SupportTransitions/BrowserTest.php
+++ b/src/Features/SupportTransitions/BrowserTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportTransitions;
 
+use Livewire\Component;
 use Livewire\Livewire;
 
 class BrowserTest extends \Tests\BrowserTestCase
@@ -12,7 +13,7 @@ class BrowserTest extends \Tests\BrowserTestCase
         $isBlock = 'getComputedStyle(document.querySelector(\'[dusk="target"]\')).display === "block"';
 
         Livewire::visit(
-            new class extends \Livewire\Component {
+            new class extends Component {
                 public $show = false;
 
                 function toggle()
@@ -51,7 +52,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_elements_the_contain_transition_are_displayed_on_page_load()
     {
         Livewire::visit(
-            new class extends \Livewire\Component {
+            new class extends Component {
                 public $messages = [
                     'message 1',
                     'message 2',

--- a/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
+++ b/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
@@ -4,6 +4,7 @@ namespace Livewire\Features\SupportWireModelingNestedComponents;
 
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Validate;
+use Livewire\Component;
 use Livewire\Form;
 use Livewire\Livewire;
 use Sushi\Sushi;
@@ -14,7 +15,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_can_bind_a_property_from_parent_to_property_from_child()
     {
         Livewire::visit([
-            new class extends \Livewire\Component {
+            new class extends Component {
                 public $foo = 0;
 
                 public function render() { return <<<'HTML'
@@ -28,7 +29,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 </div>
                 HTML; }
             },
-            'child' => new class extends \Livewire\Component {
+            'child' => new class extends Component {
                 #[BaseModelable]
                 public $bar;
 
@@ -61,7 +62,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_can_bind_a_live_property_from_parent_to_property_from_child()
     {
         Livewire::visit([
-            new class extends \Livewire\Component {
+            new class extends Component {
                 public $foo = 0;
 
                 public function render() { return <<<'HTML'
@@ -75,7 +76,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 </div>
                 HTML; }
             },
-            'child' => new class extends \Livewire\Component {
+            'child' => new class extends Component {
                 #[BaseModelable]
                 public $bar;
 
@@ -103,7 +104,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_can_bind_a_property_from_parent_array_to_property_from_child()
     {
         Livewire::visit([
-            new class extends \Livewire\Component {
+            new class extends Component {
                 public $foo = ['bar' => 'baz'];
 
                 public function render()
@@ -120,7 +121,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 HTML;
                 }
             },
-            'child' => new class extends \Livewire\Component {
+            'child' => new class extends Component {
                 #[BaseModelable]
                 public $bar;
 
@@ -156,7 +157,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_can_bind_a_property_from_parent_array_using_a_numeric_index_to_property_from_child()
     {
         Livewire::visit([
-            new class extends \Livewire\Component {
+            new class extends Component {
                 public $foo = ['baz'];
 
                 public function render()
@@ -173,7 +174,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 HTML;
                 }
             },
-            'child' => new class extends \Livewire\Component {
+            'child' => new class extends Component {
                 #[BaseModelable]
                 public $bar;
 
@@ -209,7 +210,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_can_bind_a_property_from_parent_form_to_property_from_child()
     {
         Livewire::visit([
-            new class extends \Livewire\Component {
+            new class extends Component {
                 public CreatePost $form;
 
                 public function submit()
@@ -232,7 +233,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 HTML;
                 }
             },
-            'child' => new class extends \Livewire\Component {
+            'child' => new class extends Component {
                 #[BaseModelable]
                 public $bar;
 

--- a/src/Features/SupportWireables/BrowserTest.php
+++ b/src/Features/SupportWireables/BrowserTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportWireables;
 
+use Livewire\Component;
 use Livewire\Livewire;
 use Livewire\Wireable;
 use RuntimeException;
@@ -10,7 +11,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 {
     public function test_it_can_update_a_custom_wireable_object()
     {
-        Livewire::visit(new class () extends \Livewire\Component {
+        Livewire::visit(new class () extends Component {
             public Person $person;
 
             public function mount(): void
@@ -35,7 +36,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_it_can_update_a_custom_wireable_via_inputs()
     {
-        Livewire::visit(new class () extends \Livewire\Component {
+        Livewire::visit(new class () extends Component {
             public Person $person;
 
             public function mount(): void

--- a/src/Mechanisms/CompileLivewireTags/UnitTest.php
+++ b/src/Mechanisms/CompileLivewireTags/UnitTest.php
@@ -3,13 +3,14 @@
 namespace Livewire\Mechanisms\CompileLivewireTags;
 
 use Illuminate\Support\Facades\Blade;
+use Livewire\Component;
 use Livewire\Livewire;
 
 class UnitTest extends \Tests\TestCase
 {
     public function test_can_compile_livewire_self_closing_tags()
     {
-        Livewire::component('foo', new class extends \Livewire\Component {
+        Livewire::component('foo', new class extends Component {
             public function render() {
                 return '<div>noop</div>';
             }

--- a/src/Mechanisms/FrontendAssets/BrowserTest.php
+++ b/src/Mechanisms/FrontendAssets/BrowserTest.php
@@ -4,6 +4,7 @@ namespace Livewire\Mechanisms\FrontendAssets;
 
 use Illuminate\Support\Facades\Route;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class BrowserTest extends \Tests\BrowserTestCase
 {
@@ -15,9 +16,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             });
         });
 
-        Livewire::visit(new class extends \Livewire\Component {
-            function render() { return '<div></div>'; }
-        })
+        Livewire::visit(new class extends TestComponent {})
         ->assertDialogOpened('hi mom')
         ;
     }

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -99,7 +99,7 @@ class FrontendAssets extends Mechanism
 
         // Note: the attribute selectors are "doubled" so that they don't get overriden when Tailwind's CDN loads a script tag
         // BELOW the one Livewire injects...
-        $html = <<<HTML
+        $html = <<<'HTML'
         <!-- Livewire Styles -->
         <style {$nonce}>
             [wire\:loading][wire\:loading], [wire\:loading\.delay][wire\:loading\.delay], [wire\:loading\.inline-block][wire\:loading\.inline-block], [wire\:loading\.inline][wire\:loading\.inline], [wire\:loading\.block][wire\:loading\.block], [wire\:loading\.flex][wire\:loading\.flex], [wire\:loading\.table][wire\:loading\.table], [wire\:loading\.grid][wire\:loading\.grid], [wire\:loading\.inline-flex][wire\:loading\.inline-flex] {
@@ -186,7 +186,7 @@ class FrontendAssets extends Mechanism
             app(static::class)->scriptTagAttributes,
         );
 
-        return <<<HTML
+        return <<<'HTML'
         {$assetWarning}<script src="{$url}" {$nonce} {$progressBar} data-csrf="{$token}" data-update-uri="{$updateUri}" {$extraAttributes}></script>
         HTML;
     }
@@ -206,7 +206,7 @@ class FrontendAssets extends Mechanism
             'nonce' => isset($options['nonce']) ? $options['nonce'] : '',
         ]);
 
-        return <<<HTML
+        return <<<'HTML'
         <script{$nonce} data-navigate-once="true">window.livewireScriptConfig = {$attributes};</script>
         HTML;
     }
@@ -232,7 +232,7 @@ class FrontendAssets extends Mechanism
         $url = $assertUrl;
 
         if ($manifest !== $publishedManifest) {
-            $assetWarning = <<<HTML
+            $assetWarning = <<<'HTML'
             <script {$nonce}>
                 console.warn('Livewire: The published Livewire assets are out of date\\n See: https://livewire.laravel.com/docs/installation#publishing-livewires-frontend-assets')
             </script>\n

--- a/src/Mechanisms/HandleComponents/BrowserTest.php
+++ b/src/Mechanisms/HandleComponents/BrowserTest.php
@@ -11,7 +11,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 {
     public function test_corrupt_component_payload_exception_is_no_longer_thrown_from_data_incompatible_with_javascript()
     {
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public $subsequentRequest = false;
 
             public $negativeZero = -0;
@@ -70,7 +70,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_it_converts_empty_strings_to_null_for_integer_properties()
     {
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public ?int $number = 5;
 
             public function render()
@@ -91,7 +91,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_it_uses_the_synthesizers_for_multiple_types_property_updates()
     {
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public string|int $localValue = 15;
 
             public function render()
@@ -116,7 +116,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_it_uses_the_synthesizers_for_enum_property_updates_when_initial_state_is_null()
     {
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public Suit $selected;
 
             #[Computed]

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Stringable;
 use Livewire\Component;
 use Livewire\Form;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -31,7 +32,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_synthesized_property_types_are_preserved_after_update()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public $foo;
             public $isStringable;
             public function mount() { $this->foo = str('bar'); }
@@ -39,7 +40,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->isStringable = $this->foo instanceof Stringable;
             }
-            public function render() { return '<div></div>'; }
         })
             ->assertSet('foo', 'bar')
             ->call('checkStringable')
@@ -95,7 +95,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_it_uses_the_synthesizers_for_enum_property_updates_when_initial_state_is_null()
     {
-        Livewire::test(new class extends \Livewire\Component {
+        Livewire::test(new class extends Component {
             public ?UnitSuit $selected;
 
             #[\Livewire\Attributes\Computed]
@@ -129,7 +129,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_it_uses_the_synthesizers_for_enum_property_updates_when_initial_state_is_null_inside_form_object()
     {
-        Livewire::test(new class extends \Livewire\Component {
+        Livewire::test(new class extends Component {
             public SuitForm $form;
 
             public function render()
@@ -151,7 +151,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_it_bypasses_synthesizer_hydration_when_deleting()
     {
-        Livewire::test(new class extends \Livewire\Component {
+        Livewire::test(new class extends Component {
             public $suits;
             public $dates;
             public $objects;

--- a/src/Mechanisms/HandleRequests/BrowserTest.php
+++ b/src/Mechanisms/HandleRequests/BrowserTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Mechanisms\HandleRequests;
 
 use Illuminate\Support\Facades\Route;
+use Livewire\Component;
 use Livewire\Livewire;
 
 class BrowserTest extends \Tests\BrowserTestCase
@@ -23,7 +24,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             });
         });
 
-        Livewire::visit(new class extends \Livewire\Component {
+        Livewire::visit(new class extends Component {
             public $count = 1;
             function inc() { $this->count++; }
             function render() { return <<<'HTML'

--- a/src/Mechanisms/Tests/DirectlyAssignComponentParametersAsPropertiesUnitTest.php
+++ b/src/Mechanisms/Tests/DirectlyAssignComponentParametersAsPropertiesUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Mechanisms\Tests;
 
+use Livewire\Component;
 use Livewire\Livewire;
 
 class DirectlyAssignComponentParametersAsPropertiesUnitTest extends \Tests\TestCase
@@ -23,7 +24,7 @@ class DirectlyAssignComponentParametersAsPropertiesUnitTest extends \Tests\TestC
     }
 }
 
-class ComponentWithDirectlyAssignedProperties extends \Livewire\Component
+class ComponentWithDirectlyAssignedProperties extends Component
 {
     public $foo;
     public $baz;
@@ -36,7 +37,7 @@ class ComponentWithDirectlyAssignedProperties extends \Livewire\Component
     }
 }
 
-class ComponentWithDirectlyAssignedPropertiesAndMountMethod extends \Livewire\Component
+class ComponentWithDirectlyAssignedPropertiesAndMountMethod extends Component
 {
     public $foo;
     public $baz;

--- a/src/Mechanisms/Tests/LoadBalancerCompatibilityUnitTest.php
+++ b/src/Mechanisms/Tests/LoadBalancerCompatibilityUnitTest.php
@@ -4,6 +4,7 @@ namespace Livewire\Mechanisms\Tests;
 
 use Livewire\Livewire;
 use Livewire\Component;
+use Tests\TestComponent;
 
 class LoadBalancerCompatibilityUnitTest extends \Tests\TestCase
 {
@@ -15,12 +16,7 @@ class LoadBalancerCompatibilityUnitTest extends \Tests\TestCase
                 return '<div> <livewire:child /> </div>';
             }
         },
-        'child' => new class extends Component {
-            public function render()
-            {
-                return '<div></div>';
-            }
-        }]);
+        'child' => new class extends TestComponent {}]);
 
         $firstKey = array_keys($component->snapshot['memo']['children'])[0];
 
@@ -33,12 +29,7 @@ class LoadBalancerCompatibilityUnitTest extends \Tests\TestCase
                 return '<div> <livewire:child /> </div>';
             }
         },
-        'child' => new class extends Component {
-            public function render()
-            {
-                return '<div></div>';
-            }
-        }]);
+        'child' => new class extends TestComponent {}]);
 
         $secondKey = array_keys($component->snapshot['memo']['children'])[0];
 


### PR DESCRIPTION
Some test cleanups:
- Unified all `<<<HTML` to `<<<'HTML'`
- Use `Tests\TestComponent` for components with `<div></div>` as rendered output, so the test actually focuses on the necessary
- Some leftover imports