### PR TITLE
Added automated step of changing the namespace used in v2 for Livewire\TemporaryUploadedFile in the upgrade command

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/ReplaceTemporaryUploadedFileNamespace.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/ReplaceTemporaryUploadedFileNamespace.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Livewire\Features\SupportConsoleCommands\Commands\Upgrade;
+
+use Illuminate\Console\Command;
+
+class ReplaceTemporaryUploadedFileNamespace extends UpgradeStep
+{
+    public function handle(Command $console, \Closure $next)
+    {
+        $console->newLine(2);
+        $console->line("<fg=#FB70A9;bg=black;options=bold,reverse> Livewire Temporary uploaded file </>");
+        $console->newLine();
+        $console->line('In v2 you might have used the Livewire\TemporaryUploadedFile class.');
+        $console->line('For version 3, Livewire has the file on this new namespace Livewire\Features\SupportFileUploads\TemporaryUploadedFile');
+        $console->line('This step is fully automated.');
+        $console->confirm('Ready to continue?');
+
+        $this->interactiveReplacement(
+            console: $console,
+            title: 'Livewire\TemporaryUploadedFile is now Livewire\Features\SupportFileUploads\TemporaryUploadedFile.',
+            before: 'Livewire\TemporaryUploadedFile',
+            after: 'Livewire\Features\SupportFileUploads\TemporaryUploadedFile',
+            pattern: '/Livewire\\TemporaryUploadedFile/',
+            replacement: 'Livewire\\Features\\SupportFileUploads\\TemporaryUploadedFile',
+        );
+        if($console->confirm('Continue?', true))
+        {
+            return $next($console);
+        }
+    }
+}

--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/ReplaceTemporaryUploadedFileNamespace.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/ReplaceTemporaryUploadedFileNamespace.php
@@ -23,9 +23,9 @@ class ReplaceTemporaryUploadedFileNamespace extends UpgradeStep
             after: 'Livewire\Features\SupportFileUploads\TemporaryUploadedFile',
             pattern: '/Livewire\\TemporaryUploadedFile/',
             replacement: 'Livewire\\Features\\SupportFileUploads\\TemporaryUploadedFile',
+            directories: ['app', 'tests', 'resources/views']
         );
-        if($console->confirm('Continue?', true))
-        {
+        if ($console->confirm('Continue?', true)) {
             return $next($console);
         }
     }

--- a/src/Features/SupportConsoleCommands/Commands/Upgrade/ReplaceTemporaryUploadedFileNamespace.php
+++ b/src/Features/SupportConsoleCommands/Commands/Upgrade/ReplaceTemporaryUploadedFileNamespace.php
@@ -8,21 +8,13 @@ class ReplaceTemporaryUploadedFileNamespace extends UpgradeStep
 {
     public function handle(Command $console, \Closure $next)
     {
-        $console->newLine(2);
-        $console->line("<fg=#FB70A9;bg=black;options=bold,reverse> Livewire Temporary uploaded file </>");
-        $console->newLine();
-        $console->line('In v2 you might have used the Livewire\TemporaryUploadedFile class.');
-        $console->line('For version 3, Livewire has the file on this new namespace Livewire\Features\SupportFileUploads\TemporaryUploadedFile');
-        $console->line('This step is fully automated.');
-        $console->confirm('Ready to continue?');
-
         $this->interactiveReplacement(
             console: $console,
             title: 'Livewire\TemporaryUploadedFile is now Livewire\Features\SupportFileUploads\TemporaryUploadedFile.',
             before: 'Livewire\TemporaryUploadedFile',
             after: 'Livewire\Features\SupportFileUploads\TemporaryUploadedFile',
-            pattern: '/Livewire\\TemporaryUploadedFile/',
-            replacement: 'Livewire\\Features\\SupportFileUploads\\TemporaryUploadedFile',
+            pattern: '/Livewire\\\\TemporaryUploadedFile/',
+            replacement: "Livewire\\Features\\SupportFileUploads\\TemporaryUploadedFile",
             directories: ['app', 'tests', 'resources/views']
         );
         if ($console->confirm('Continue?', true)) {

--- a/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
@@ -20,7 +20,7 @@ use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RepublishNavigatio
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ThirdPartyUpgradeNotice;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeAlpineInstructions;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeConfigInstructions;
-use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ReplaceEmitWithDispatch;
+use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ReplaceTemporaryUploadedFileNamespace;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeIntroduction;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ChangeForgetComputedToUnset;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -53,9 +53,9 @@ class UpgradeCommand extends Command
             RepublishNavigation::class,
             ChangeTestAssertionMethods::class,
             ChangeForgetComputedToUnset::class,
+            ReplaceTemporaryUploadedFileNamespace::class,
 
             // Partially automated steps
-            ReplaceEmitWithDispatch::class,
 
             // Manual steps
             UpgradeConfigInstructions::class,

--- a/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
@@ -16,6 +16,7 @@ use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RemoveDeferModifie
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RemoveDeferModifierFromWireModelDirectives;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RemovePrefetchModifierFromWireClickDirective;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RemovePreventModifierFromWireSubmitDirective;
+use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ReplaceEmitWithDispatch;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RepublishNavigation;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ThirdPartyUpgradeNotice;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeAlpineInstructions;
@@ -56,6 +57,7 @@ class UpgradeCommand extends Command
             ReplaceTemporaryUploadedFileNamespace::class,
 
             // Partially automated steps
+            ReplaceEmitWithDispatch::class,
 
             // Manual steps
             UpgradeConfigInstructions::class,

--- a/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/UpgradeCommand.php
@@ -16,11 +16,11 @@ use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RemoveDeferModifie
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RemoveDeferModifierFromWireModelDirectives;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RemovePrefetchModifierFromWireClickDirective;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RemovePreventModifierFromWireSubmitDirective;
-use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ReplaceEmitWithDispatch;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\RepublishNavigation;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ThirdPartyUpgradeNotice;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeAlpineInstructions;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeConfigInstructions;
+use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ReplaceEmitWithDispatch;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ReplaceTemporaryUploadedFileNamespace;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\UpgradeIntroduction;
 use Livewire\Features\SupportConsoleCommands\Commands\Upgrade\ChangeForgetComputedToUnset;


### PR DESCRIPTION
The livewire upgrade command was a timesaver and this is going to be another addition to it.

I was working on a project which had livewire v2, and I was able to migrate and get all of it working by the upgrade command.

Once I migrated to v3 I found out that I was using the `Livewire\TemporaryUploadedFile` in some checks.

For example, 

```php

if($file instanceof Livewire\TemporaryUploadedFile){
  // return the preview url
}

```

I found out that this was broken and could be added to one of the automated to upgrades.

This PR contains the automated conversion of the namespace from `Livewire\TemporaryUploadedFile` to `Livewire\Features\SupportFileUploads\TemporaryUploadedFile`


Hope this would be useful for many as it would make one less step to move Livewire v3.




