### PR TITLE
Fix routes with `scopeBindings()`

### DIFF
--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -110,7 +110,7 @@ class ImplicitRouteBinding
 
         $parent = $route->parentOfParameter($parameterName);
 
-        if ($parent instanceof UrlRoutable && array_key_exists($parameterName, $route->bindingFields())) {
+        if ($parent instanceof UrlRoutable && ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
             $model = $parent->resolveChildRouteBinding($parameterName, $parameterValue, $route->bindingFieldFor($parameterName));
         } else {
             if ($route->allowsTrashedBindings()) {


### PR DESCRIPTION
In a real-life example, I encounter some issues using `scopeBindings()` for routes.

## Issue
With a route and component like...
```php
Route::get('/route/{store:name}/{book:name}', Component::class)->scopeBindings();
```

```php
class ComponentWithScopeBindings extends Component
{
    public Store $store;
    public Book $book;
}
```
... the `$book` property does not contain the correct value, because the `$store` property is being ignored for scoping.

## Problem
We're only checking if the parameter is in the `bindingFields`, but we are ignoring the use of `scopeBindings()`.

https://github.com/livewire/livewire/blob/fdddb53726a101e655615b9c18c9ccc2c8016d35/src/Drawer/ImplicitRouteBinding.php#L113

Laravel also takes this into account:

https://github.com/laravel/framework/blob/21e6d31b39b007adefa36eb399329503f6afabde/src/Illuminate/Routing/ImplicitRouteBinding.php#L51

## Solution
We should also resolve the property via `resolveChildRouteBinding()` when it's enforced via `scopeBindings()`.