### PR TITLE
`assertSetStrict()` for decimal casted attributes

### DIFF
--- a/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeCastUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeCastUnitTest.php
@@ -156,38 +156,38 @@ class ModelAttributesCanBeCastUnitTest extends \Tests\TestCase
     public function test_can_cast_decimal_attributes_with_one_digit_from_model_casts_definition()
     {
         Livewire::test(ComponentForModelAttributeCasting::class)
-            ->assertSet('model.decimal_with_one_digit', 5.0)
+            ->assertSetStrict('model.decimal_with_one_digit', '5.0')
             ->assertSnapshotSet('model.decimal_with_one_digit', 5.0)
 
             ->set('model.decimal_with_one_digit', 5.120983)
             ->call('validateAttribute', 'model.decimal_with_one_digit')
             ->assertHasNoErrors('model.decimal_with_one_digit')
-            ->assertSet('model.decimal_with_one_digit', 5.1)
+            ->assertSetStrict('model.decimal_with_one_digit', '5.1')
             ->assertSnapshotSet('model.decimal_with_one_digit', 5.1)
 
             ->set('model.decimal_with_one_digit', '5.55')
             ->call('validateAttribute', 'model.decimal_with_one_digit')
             ->assertHasNoErrors('model.decimal_with_one_digit')
-            ->assertSet('model.decimal_with_one_digit', 5.6)
+            ->assertSetStrict('model.decimal_with_one_digit', '5.6')
             ->assertSnapshotSet('model.decimal_with_one_digit', 5.6);
     }
 
     public function test_can_cast_decimal_attributes_with_two_digits_from_model_casts_definition()
     {
         Livewire::test(ComponentForModelAttributeCasting::class)
-            ->assertSet('model.decimal_with_two_digits', 6.0)
+            ->assertSetStrict('model.decimal_with_two_digits', '6.00')
             ->assertSnapshotSet('model.decimal_with_two_digits', 6.0)
 
             ->set('model.decimal_with_two_digits', 6.4567)
             ->call('validateAttribute', 'model.decimal_with_two_digits')
             ->assertHasNoErrors('model.decimal_with_two_digits')
-            ->assertSet('model.decimal_with_two_digits', 6.46)
+            ->assertSetStrict('model.decimal_with_two_digits', '6.46')
             ->assertSnapshotSet('model.decimal_with_two_digits', 6.46)
 
             ->set('model.decimal_with_two_digits', '6.212')
             ->call('validateAttribute', 'model.decimal_with_two_digits')
             ->assertHasNoErrors('model.decimal_with_two_digits')
-            ->assertSet('model.decimal_with_two_digits', 6.21)
+            ->assertSetStrict('model.decimal_with_two_digits', '6.21')
             ->assertSnapshotSet('model.decimal_with_two_digits', 6.21);
     }
 


### PR DESCRIPTION
Follow-up on https://github.com/livewire/livewire/pull/8457.
These tests were expecting floats for the casted decimals, [but Laravel returns the decimal as a string](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L1429-L1436).