### PR TITLE
Fix resetting forms properties via `$this->reset('form.title')`

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -59,6 +59,11 @@ trait InteractsWithProperties
                 $propertyName = $property->afterLast('.');
                 $objectName = $property->beforeLast('.');
 
+                if (method_exists($this->{$objectName}, 'reset')) {
+                    $this->{$objectName}->reset($propertyName);
+                    continue;
+                }
+
                 $object = data_get($freshInstance, $objectName, null);
 
                 if (is_object($object)) {

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -44,13 +44,37 @@ class UnitTest extends \Tests\TestCase
                 return '<div></div>';
             }
         })
-            ->assertSet('form.title', '')
-            ->assertSet('form.content', '')
+            ->assertSetStrict('form.title', '')
+            ->assertSetStrict('form.content', '')
             ->set('form.title', 'Some Title')
             ->set('form.content', 'Some content...')
             ->call('resetForm')
-            ->assertSet('form.title', '')
-            ->assertSet('form.content', '')
+            ->assertSetStrict('form.title', '')
+            ->assertSetStrict('form.content', '')
+        ;
+    }
+
+    function test_can_reset_form_object_property_to_defaults()
+    {
+        Livewire::test(new class extends Component {
+            public PostFormStubWithDefaults $form;
+
+            public function resetForm()
+            {
+                $this->reset('form.title', 'form.content');
+            }
+
+            public function render() {
+                return '<div></div>';
+            }
+        })
+            ->assertSetStrict('form.title', 'foo')
+            ->assertSetStrict('form.content', 'bar')
+            ->set('form.title', 'Some Title')
+            ->set('form.content', 'Some content...')
+            ->call('resetForm')
+            ->assertSetStrict('form.title', 'foo')
+            ->assertSetStrict('form.content', 'bar')
         ;
     }
 
@@ -745,6 +769,13 @@ class PostFormStub extends Form
     public $title = '';
 
     public $content = '';
+}
+
+class PostFormStubWithDefaults extends Form
+{
+    public $title = 'foo';
+
+    public $content = 'bar';
 }
 
 class PostFormWithRulesStub extends Form


### PR DESCRIPTION
Follow-up on https://github.com/livewire/livewire/pull/8457.
Resetting form properties via `$this->reset('form.title')` was broken. `$title` was always reset to `null`, and because of the loose comparison to `(string) ''`, it was passing. While resetting properties to the default value via `$freshInstance = new static;`, the form isn't initialized yet, so it'll always return `null` as "default" value. I got around by calling the reset method directly on the Form. I've also added a test to make sure that the properties are reset the the actual default values (instead of `null` or `(string) ''`).