### PR TITLE
Add `assertSnapshotSetStrict()` and `assertSnapshotNotSetStrict()`

### DIFF
--- a/src/Features/SupportTesting/MakesAssertions.php
+++ b/src/Features/SupportTesting/MakesAssertions.php
@@ -152,6 +152,20 @@ trait MakesAssertions
         return $this;
     }
 
+    function assertSnapshotSetStrict($name, $value)
+    {
+        $this->assertSnapshotSet($name, $value, true);
+
+        return $this;
+    }
+
+    function assertSnapshotNotSetStrict($name, $value)
+    {
+        $this->assertSnapshotNotSet($name, $value, true);
+
+        return $this;
+    }
+
     public function assertReturned($value)
     {
         $data = data_get($this->lastState->getEffects(), 'returns.0');

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -314,6 +314,28 @@ class UnitTest extends \LegacyTests\Unit\TestCase
         $component->assertNotSetStrict('name', '');
     }
 
+    function test_assert_snapshot_set_strict()
+    {
+        $component = Livewire::test(HasMountArguments::class, ['name' => 'foo'])
+            ->set('name', '')
+            ->assertSnapshotSetStrict('name', '');
+
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+
+        $component->assertSnapshotSetStrict('name', null);
+    }
+
+    function test_assert_snapshot_not_set_strict()
+    {
+        $component = Livewire::test(HasMountArguments::class, ['name' => 'foo'])
+            ->set('name', '')
+            ->assertSnapshotNotSetStrict('name', null);
+
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
+
+        $component->assertSnapshotNotSetStrict('name', '');
+    }
+
     function test_assert_count()
     {
         Livewire::test(HasMountArgumentsButDoesntPassThemToBladeView::class, ['name' => ['foo']])


### PR DESCRIPTION
Follow-up on https://github.com/livewire/livewire/pull/8457. Was working on strict types for `assertSnapshotSet`, but those methods were not available yet (and I don't prefer adding the `, true` parameter like `assertSnapshotSet('foo', 'bar', true)`.