### PR TITLE
`assertSnapshotSetStrict()` for zero-fractions

### DIFF
--- a/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeCastUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeCastUnitTest.php
@@ -99,7 +99,7 @@ class ModelAttributesCanBeCastUnitTest extends \Tests\TestCase
 
         Livewire::test(ComponentForModelAttributeCasting::class)
             ->assertSetStrict('model.real_number', 2.0)
-            ->assertSnapshotSet('model.real_number', 2.0)
+            ->assertSnapshotSetStrict('model.real_number', 2)
 
             ->set('model.real_number', 2.9999999999)
             ->call('validateAttribute', 'model.real_number')
@@ -118,7 +118,7 @@ class ModelAttributesCanBeCastUnitTest extends \Tests\TestCase
     {
         Livewire::test(ComponentForModelAttributeCasting::class)
             ->assertSetStrict('model.float_number', 3.0)
-            ->assertSnapshotSet('model.float_number', 3.0)
+            ->assertSnapshotSetStrict('model.float_number', 3)
 
             ->set('model.float_number', 3.9999999998)
             ->call('validateAttribute', 'model.float_number')
@@ -138,7 +138,7 @@ class ModelAttributesCanBeCastUnitTest extends \Tests\TestCase
 
         Livewire::test(ComponentForModelAttributeCasting::class)
             ->assertSetStrict('model.double_precision_number', 4.0)
-            ->assertSnapshotSet('model.double_precision_number', 4.0)
+            ->assertSnapshotSetStrict('model.double_precision_number', 4)
 
             ->set('model.double_precision_number', 4.9999999997)
             ->call('validateAttribute', 'model.double_precision_number')

--- a/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeCastUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeCastUnitTest.php
@@ -157,38 +157,38 @@ class ModelAttributesCanBeCastUnitTest extends \Tests\TestCase
     {
         Livewire::test(ComponentForModelAttributeCasting::class)
             ->assertSetStrict('model.decimal_with_one_digit', '5.0')
-            ->assertSnapshotSetStrict('model.decimal_with_one_digit', '5.0')
+            ->assertSnapshotSet('model.decimal_with_one_digit', 5.0)
 
             ->set('model.decimal_with_one_digit', 5.120983)
             ->call('validateAttribute', 'model.decimal_with_one_digit')
             ->assertHasNoErrors('model.decimal_with_one_digit')
             ->assertSetStrict('model.decimal_with_one_digit', '5.1')
-            ->assertSnapshotSetStrict('model.decimal_with_one_digit', '5.1')
+            ->assertSnapshotSet('model.decimal_with_one_digit', 5.1)
 
             ->set('model.decimal_with_one_digit', '5.55')
             ->call('validateAttribute', 'model.decimal_with_one_digit')
             ->assertHasNoErrors('model.decimal_with_one_digit')
             ->assertSetStrict('model.decimal_with_one_digit', '5.6')
-            ->assertSnapshotSetStrict('model.decimal_with_one_digit', '5.6');
+            ->assertSnapshotSet('model.decimal_with_one_digit', 5.6);
     }
 
     public function test_can_cast_decimal_attributes_with_two_digits_from_model_casts_definition()
     {
         Livewire::test(ComponentForModelAttributeCasting::class)
             ->assertSetStrict('model.decimal_with_two_digits', '6.00')
-            ->assertSnapshotSetStrict('model.decimal_with_two_digits', '6.00')
+            ->assertSnapshotSet('model.decimal_with_two_digits', 6.0)
 
             ->set('model.decimal_with_two_digits', 6.4567)
             ->call('validateAttribute', 'model.decimal_with_two_digits')
             ->assertHasNoErrors('model.decimal_with_two_digits')
             ->assertSetStrict('model.decimal_with_two_digits', '6.46')
-            ->assertSnapshotSetStrict('model.decimal_with_two_digits', '6.46')
+            ->assertSnapshotSet('model.decimal_with_two_digits', 6.46)
 
             ->set('model.decimal_with_two_digits', '6.212')
             ->call('validateAttribute', 'model.decimal_with_two_digits')
             ->assertHasNoErrors('model.decimal_with_two_digits')
             ->assertSetStrict('model.decimal_with_two_digits', '6.21')
-            ->assertSnapshotSetStrict('model.decimal_with_two_digits', '6.21');
+            ->assertSnapshotSet('model.decimal_with_two_digits', 6.21);
     }
 
     public function test_can_cast_string_attributes_from_model_casts_definition()

--- a/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeCastUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeCastUnitTest.php
@@ -157,38 +157,38 @@ class ModelAttributesCanBeCastUnitTest extends \Tests\TestCase
     {
         Livewire::test(ComponentForModelAttributeCasting::class)
             ->assertSetStrict('model.decimal_with_one_digit', '5.0')
-            ->assertSnapshotSet('model.decimal_with_one_digit', 5.0)
+            ->assertSnapshotSetStrict('model.decimal_with_one_digit', '5.0')
 
             ->set('model.decimal_with_one_digit', 5.120983)
             ->call('validateAttribute', 'model.decimal_with_one_digit')
             ->assertHasNoErrors('model.decimal_with_one_digit')
             ->assertSetStrict('model.decimal_with_one_digit', '5.1')
-            ->assertSnapshotSet('model.decimal_with_one_digit', 5.1)
+            ->assertSnapshotSetStrict('model.decimal_with_one_digit', '5.1')
 
             ->set('model.decimal_with_one_digit', '5.55')
             ->call('validateAttribute', 'model.decimal_with_one_digit')
             ->assertHasNoErrors('model.decimal_with_one_digit')
             ->assertSetStrict('model.decimal_with_one_digit', '5.6')
-            ->assertSnapshotSet('model.decimal_with_one_digit', 5.6);
+            ->assertSnapshotSetStrict('model.decimal_with_one_digit', '5.6');
     }
 
     public function test_can_cast_decimal_attributes_with_two_digits_from_model_casts_definition()
     {
         Livewire::test(ComponentForModelAttributeCasting::class)
             ->assertSetStrict('model.decimal_with_two_digits', '6.00')
-            ->assertSnapshotSet('model.decimal_with_two_digits', 6.0)
+            ->assertSnapshotSetStrict('model.decimal_with_two_digits', '6.00')
 
             ->set('model.decimal_with_two_digits', 6.4567)
             ->call('validateAttribute', 'model.decimal_with_two_digits')
             ->assertHasNoErrors('model.decimal_with_two_digits')
             ->assertSetStrict('model.decimal_with_two_digits', '6.46')
-            ->assertSnapshotSet('model.decimal_with_two_digits', 6.46)
+            ->assertSnapshotSetStrict('model.decimal_with_two_digits', '6.46')
 
             ->set('model.decimal_with_two_digits', '6.212')
             ->call('validateAttribute', 'model.decimal_with_two_digits')
             ->assertHasNoErrors('model.decimal_with_two_digits')
             ->assertSetStrict('model.decimal_with_two_digits', '6.21')
-            ->assertSnapshotSet('model.decimal_with_two_digits', 6.21);
+            ->assertSnapshotSetStrict('model.decimal_with_two_digits', '6.21');
     }
 
     public function test_can_cast_string_attributes_from_model_casts_definition()


### PR DESCRIPTION
Follow-up on https://github.com/livewire/livewire/pull/8467.
These tests were expecting floats for the casted attributes, but the snapshot actually returns an integer.
When a snapshot is generated, it will be encoded to JSON:

https://github.com/livewire/livewire/blob/05fbe4e5a0e8cf412b75249ef33affe54b9fc2a4/src/Drawer/Utils.php#L51

Encoding `['foo' => 1.0]` will result in `{"foo":1}`, because JSON treats it as a number and removes redundant decimals.

As alternative, we can use the `JSON_PRESERVE_ZERO_FRACTION` flag for `json_encode`.
Encoding `['foo' => 1.0]` will then result in `{"foo":1.0}`, but it doesn't seem very necessary to suddenly have a different snapshot.