### PR TITLE
Fix typed nullable properties in forms

### DIFF
--- a/src/Features/SupportFormObjects/FormObjectSynth.php
+++ b/src/Features/SupportFormObjects/FormObjectSynth.php
@@ -48,7 +48,7 @@ class FormObjectSynth extends Synth {
 
     function set(&$target, $key, $value)
     {
-        if ($value === null && Utils::propertyIsTyped($target, $key)) {
+        if ($value === null && Utils::propertyIsTyped($target, $key) && ! Utils::getProperty($target, $key)->getType()->allowsNull()) {
             unset($target->$key);
         } else {
             $target->$key = $value;

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -78,6 +78,39 @@ class UnitTest extends \Tests\TestCase
         ;
     }
 
+    function test_set_form_object_with_typed_nullable_properties()
+    {
+        Livewire::test(new class extends Component {
+            public PostFormWithTypedProperties $form;
+
+            public function render() {
+                return <<<'BLADE'
+                    <div>
+                        Title: "{{ $form->title }}"
+                        Content: "{{ $form->content }}"
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertSetStrict('form.title', null)
+            ->assertSetStrict('form.content', null)
+            ->assertSee('Title: ""', false)
+            ->assertSee('Content: ""', false)
+            ->set('form.title', 'Some Title')
+            ->set('form.content', 'Some content...')
+            ->assertSetStrict('form.title', 'Some Title')
+            ->assertSetStrict('form.content', 'Some content...')
+            ->assertSee('Title: "Some Title"', false)
+            ->assertSee('Content: "Some content..."', false)
+            ->set('form.title', null)
+            ->set('form.content', null)
+            ->assertSetStrict('form.title', null)
+            ->assertSetStrict('form.content', null)
+            ->assertSee('Title: ""', false)
+            ->assertSee('Content: ""', false);
+        ;
+    }
+
     function test_can_validate_a_form_object()
     {
         Livewire::test(new class extends Component {
@@ -776,6 +809,13 @@ class PostFormStubWithDefaults extends Form
     public $title = 'foo';
 
     public $content = 'bar';
+}
+
+class PostFormWithTypedProperties extends Form
+{
+    public ?string $title = null;
+
+    public ?string $content = null;
 }
 
 class PostFormWithRulesStub extends Form


### PR DESCRIPTION
See https://github.com/livewire/livewire/discussions/8473

## Problem
In forms, properties typed like `string|null` cannot be (re)set to `null`.
It will unset the whole property, causing problems while rendering the view.
 
> Typed property App\Livewire\Form::$foo must not be accessed before initialization

## Cause
While setting the properties, the property will be unset when the given value is `null` and the property is typed to anything.
So that also goes for types like `string|null`.

https://github.com/livewire/livewire/blob/72e900825c560f0e4e620185b26c5441a8914435/src/Features/SupportFormObjects/FormObjectSynth.php#L51-L52

## Solution
We should perform an additional check whether the property type allows a null value.
If so, we should just set the property as "normal".