### PR TITLE
Cleanup render methods in internal tests

### DIFF
--- a/src/Concerns/Tests/ComponentCanReturnPublicPropertiesUnitTest.php
+++ b/src/Concerns/Tests/ComponentCanReturnPublicPropertiesUnitTest.php
@@ -3,7 +3,7 @@
 namespace Livewire\Concerns\Tests;
 
 use Livewire\Livewire;
-use Livewire\Component;
+use Tests\TestComponent;
 
 class ComponentCanReturnPublicPropertiesUnitTest extends \Tests\TestCase
 {
@@ -32,7 +32,7 @@ class ComponentCanReturnPublicPropertiesUnitTest extends \Tests\TestCase
     }
 }
 
-class ComponentWithProperties extends Component
+class ComponentWithProperties extends TestComponent
 {
     public $onlyProperties = [];
 
@@ -59,10 +59,5 @@ class ComponentWithProperties extends Component
     public function setAllProperties()
     {
         $this->allProperties = $this->all();
-    }
-
-    public function render()
-    {
-        return view('null-view');
     }
 }

--- a/src/Concerns/Tests/ResetPropertiesUnitTest.php
+++ b/src/Concerns/Tests/ResetPropertiesUnitTest.php
@@ -2,8 +2,8 @@
 
 namespace Livewire\Concerns\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class ResetPropertiesUnitTest extends \Tests\TestCase
 {
@@ -132,7 +132,7 @@ class ResetPropertiesUnitTest extends \Tests\TestCase
     }
 }
 
-class ResetPropertiesComponent extends Component
+class ResetPropertiesComponent extends TestComponent
 {
     public $foo = 'bar';
 
@@ -164,10 +164,5 @@ class ResetPropertiesComponent extends Component
     public function proxyPull(...$args)
     {
         $this->pullResult = $this->pull(...$args);
-    }
-
-    public function render()
-    {
-        return view('null-view');
     }
 }

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -378,11 +378,6 @@ class UnitTest extends TestCase
             {
                 return 'bar';
             }
-
-            public function render()
-            {
-                return '<div></div>';
-            }
         })
             ->assertSetStrict('foo', 'bar');
     }
@@ -405,11 +400,6 @@ class UnitTest extends TestCase
                 $this->changeFoo = true;
 
                 unset($this->foo);
-            }
-
-            public function render()
-            {
-                return '<div></div>';
             }
         })
             ->assertSetStrict('foo', 'bar')

--- a/src/Features/SupportDisablingBackButtonCache/UnitTest.php
+++ b/src/Features/SupportDisablingBackButtonCache/UnitTest.php
@@ -3,7 +3,7 @@
 namespace Livewire\Features\SupportDisablingBackButtonCache;
 
 use Illuminate\Support\Facades\Route;
-use Livewire\Component;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -32,16 +32,11 @@ class UnitTest extends \Tests\TestCase
     }
 }
 
-class DisableBrowserCache extends Component
+class DisableBrowserCache extends TestComponent
 {
     public function mount()
     {
         $this->disableBackButtonCache();
-    }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
     }
 }
 

--- a/src/Features/SupportEvents/UnitTest.php
+++ b/src/Features/SupportEvents/UnitTest.php
@@ -4,12 +4,13 @@ namespace Livewire\Features\SupportEvents;
 
 use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
     public function test_receive_event_with_attribute()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             public $foo = 'bar';
 
             #[BaseOn('bar')]
@@ -17,8 +18,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->foo = $param;
             }
-
-            public function render() { return '<div></div>'; }
         });
 
         $component->dispatch('bar', 'baz');
@@ -28,7 +27,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_listen_for_dynamic_event_name()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             public $post = ['id' => 2];
 
             public $foo = 'bar';
@@ -38,8 +37,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->foo = $param;
             }
-
-            public function render() { return '<div></div>'; }
         });
 
         $component->dispatch('bar.2', 'baz');
@@ -49,7 +46,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_listens_for_event_with_named_params()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             public $foo = 'bar';
 
             #[BaseOn('bar')]
@@ -57,8 +54,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->foo = $name . $game;
             }
-
-            public function render() { return '<div></div>'; }
         });
 
         $component->dispatch('bar', game: 'shmaz', name: 'baz');
@@ -68,13 +63,11 @@ class UnitTest extends \Tests\TestCase
 
     public function test_dispatches_event_with_named_params()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public function dispatchFoo()
             {
                 $this->dispatch('foo', name: 'bar', game: 'baz');
             }
-
-            public function render() { return '<div></div>'; }
         })
             ->call('dispatchFoo')
             ->assertDispatched('foo')
@@ -88,7 +81,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_it_can_register_multiple_listeners_via_attribute(): void
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public $counter = 0;
 
             #[BaseOn('foo'), BaseOn('bar')]
@@ -96,8 +89,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->counter++;
             }
-
-            public function render() { return '<div></div>'; }
         })
             ->dispatch('foo')
             ->assertSetStrict('counter', 1)
@@ -107,7 +98,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_it_can_register_multiple_listeners_via_attribute_userland(): void
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public $counter = 0;
 
             #[\Livewire\Attributes\On('foo'), \Livewire\Attributes\On('bar')]
@@ -115,8 +106,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->counter++;
             }
-
-            public function render() { return '<div></div>'; }
         })
             ->dispatch('foo')
             ->assertSetStrict('counter', 1)
@@ -235,7 +224,7 @@ class UnitTest extends \Tests\TestCase
     }
 }
 
-class ReceivesEvents extends Component
+class ReceivesEvents extends TestComponent
 {
     public $foo;
 
@@ -265,14 +254,9 @@ class ReceivesEvents extends Component
     {
         $this->dispatch('foo', 'test')->to(ItCanReceiveEventUsingClassname::class);
     }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class ReceivesEventsWithSingleValueListener extends Component
+class ReceivesEventsWithSingleValueListener extends TestComponent
 {
     public $foo;
 
@@ -282,14 +266,9 @@ class ReceivesEventsWithSingleValueListener extends Component
     {
         $this->foo = $value;
     }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class ReceivesEventsWithDynamicListeners extends Component
+class ReceivesEventsWithDynamicListeners extends TestComponent
 {
     public $listener;
     public $foo = '';
@@ -308,14 +287,9 @@ class ReceivesEventsWithDynamicListeners extends Component
     {
         $this->foo = $value;
     }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class ItCanReceiveEventUsingClassname extends Component
+class ItCanReceiveEventUsingClassname extends TestComponent
 {
     public $bar;
 
@@ -326,11 +300,6 @@ class ItCanReceiveEventUsingClassname extends Component
     public function onBar($value)
     {
         $this->bar = $value;
-    }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
     }
 }
 

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -15,6 +15,7 @@ use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Http\UploadedFile;
 use Facades\Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -799,14 +800,12 @@ class DummyMiddleware
     }
 }
 
-class NonFileUploadComponent extends Component
+class NonFileUploadComponent extends TestComponent
 {
     public $photo;
-
-    public function render() { return app('view')->make('null-view'); }
 }
 
-class FileUploadComponent extends Component
+class FileUploadComponent extends TestComponent
 {
     use WithFileUploads;
 
@@ -879,8 +878,6 @@ class FileUploadComponent extends Component
     {
         $this->_uploadErrored($name, null, false);
     }
-
-    public function render() { return app('view')->make('null-view'); }
 }
 
 class FileUploadInArrayComponent extends FileUploadComponent

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -9,17 +9,14 @@ use Livewire\Form;
 use Livewire\Livewire;
 use PHPUnit\Framework\Assert;
 use Sushi\Sushi;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
     function test_can_use_a_form_object()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormStub $form;
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertSetStrict('form.title', '')
         ->assertSetStrict('form.content', '')
@@ -32,16 +29,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_reset_form_object_property()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormStub $form;
 
             public function resetForm()
             {
                 $this->reset('form.title', 'form.content');
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
             ->assertSetStrict('form.title', '')
@@ -56,16 +49,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_reset_form_object_property_to_defaults()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormStubWithDefaults $form;
 
             public function resetForm()
             {
                 $this->reset('form.title', 'form.content');
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
             ->assertSetStrict('form.title', 'foo')
@@ -80,16 +69,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_form_object()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             function save()
             {
                 $this->form->validate();
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertSetStrict('form.title', '')
@@ -103,16 +88,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_form_with_the_general_validate_function()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             function save()
             {
                 $this->validate();
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
             ->call('save')
@@ -125,16 +106,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_specific_rule_has_errors_in_a_form_object()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             function save()
             {
                 $this->validate();
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertSetStrict('form.title', '')
@@ -146,16 +123,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_form_object_with_validate_only()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             function save()
             {
                 $this->form->validateOnly('title');
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertHasNoErrors()
@@ -167,16 +140,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_specific_rule_for_form_object_with_validate_only()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             function save()
             {
                 $this->form->validateOnly('title');
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
             ->assertHasNoErrors()
@@ -187,12 +156,8 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_specific_rule_has_errors_on_update_in_a_form_object()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateOnUpdateStub $form;
-
-            public function render() {
-                return '<div></div>';
-            }
         })
             ->assertHasNoErrors()
             ->set('form.title', 'foo')
@@ -202,16 +167,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_form_object_with_root_component_validate_only()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             function save()
             {
                 $this->validateOnly('form.title');
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertHasNoErrors()
@@ -223,16 +184,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_form_object_using_rule_attributes()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormRuleAttributeStub $form;
 
             function save()
             {
                 $this->form->validate();
-            }
-
-            function render() {
-                return '<div></div>';
             }
         })
         ->assertSetStrict('form.title', '')
@@ -250,16 +207,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_validate_a_form_object_using_rule_attribute_with_custom_name()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormRuleAttributeWithCustomNameStub $form;
 
             function save()
             {
                 $this->form->validate();
-            }
-
-            function render() {
-                return '<div></div>';
             }
         })
             ->assertSetStrict('form.name', '')
@@ -298,16 +251,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_reset_property()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormStub $form;
 
             function save()
             {
                 $this->form->reset('title');
-            }
-
-            function render() {
-                return '<div></div>';
             }
         })
         ->set('form.title', 'Some title...')
@@ -323,16 +272,12 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_reset_all_properties()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormStub $form;
 
             function save()
             {
                 $this->form->reset();
-            }
-
-            function render() {
-                return '<div></div>';
             }
         })
         ->set('form.title', 'Some title...')
@@ -348,7 +293,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_all_properties_are_available_in_rules_method()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormWithRulesStub $form;
 
             public function mount()
@@ -358,10 +303,6 @@ class UnitTest extends \Tests\TestCase
 
             function save() {
                 $this->form->validate();
-            }
-
-            function render() {
-                return '<div></div>';
             }
         })
         ->assertSetStrict('form.post', 42)
@@ -505,7 +446,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_can_fill_a_form_object_from_model()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostForFormObjectTesting $post;
             public PostFormStub $form;
 
@@ -518,11 +459,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->form->fill($this->post);
             }
-
-            public function render()
-            {
-                return '<div></div>';
-            }
         })
             ->assertSetStrict('form.title', '')
             ->assertSetStrict('form.content', '')
@@ -534,7 +470,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_can_fill_a_form_object_from_array()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormStub $form;
 
             public function fillForm()
@@ -543,11 +479,6 @@ class UnitTest extends \Tests\TestCase
                     'title' => 'Title from array',
                     'content' => 'Content from array',
                 ]);
-            }
-
-            public function render()
-            {
-                return '<div></div>';
             }
         })
             ->assertSetStrict('form.title', '')
@@ -560,7 +491,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_form_object_validation_runs_alongside_component_validation()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             #[Validate('required')]
@@ -569,10 +500,6 @@ class UnitTest extends \Tests\TestCase
             function save()
             {
                 $this->validate();
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertHasNoErrors()
@@ -585,7 +512,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_form_object_validation_wont_run_if_rules_are_passed_into_validate()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             public $username = '';
@@ -593,10 +520,6 @@ class UnitTest extends \Tests\TestCase
             function save()
             {
                 $this->validate(['username' => 'required']);
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertHasNoErrors()
@@ -609,7 +532,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_allows_form_object_without_rules_without_throwing_an_error()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormWithoutRules $form;
 
             public $username = '';
@@ -625,10 +548,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->validate();
             }
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertHasNoErrors()
         ->call('save')
@@ -638,7 +557,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_allows_form_object_without_rules_but_can_still_validate_it_with_its_own_rules()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormWithoutRules $form;
 
             public $username = '';
@@ -655,10 +574,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->validate();
             }
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertHasNoErrors()
         ->call('save')
@@ -669,7 +584,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_form_object_without_rules_can_still_be_validated_and_return_proper_data()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormWithoutRules $form;
 
             public $username = '';
@@ -690,10 +605,6 @@ class UnitTest extends \Tests\TestCase
                 \PHPUnit\Framework\Assert::assertEquals('bar', data_get($data, 'form.title'));
                 \PHPUnit\Framework\Assert::assertEquals('not-found', data_get($data, 'form.content', 'not-found'));
             }
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertHasNoErrors()
         ->set('username', 'foo')
@@ -705,7 +616,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_resetting_validation_errors_resets_form_objects_as_well()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateStub $form;
 
             #[Validate('required')]
@@ -720,10 +631,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->resetValidation();
             }
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertHasNoErrors()
         ->call('save')
@@ -737,7 +644,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_intercept_form_object_validator_instance()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public PostFormValidateWithInterceptStub $form;
 
             function save()
@@ -748,10 +655,6 @@ class UnitTest extends \Tests\TestCase
             function resetVal()
             {
                 $this->resetValidation();
-            }
-
-            public function render() {
-                return '<div></div>';
             }
         })
         ->assertHasNoErrors()

--- a/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeBoundDirectlyUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeBoundDirectlyUnitTest.php
@@ -9,6 +9,7 @@ use Livewire\Features\SupportLegacyModels\CannotBindToModelDataWithoutValidation
 use Livewire\Livewire;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
 
+use Tests\TestComponent;
 use function Livewire\invade;
 
 class ModelAttributesCanBeBoundDirectlyUnitTest extends \Tests\TestCase
@@ -101,7 +102,7 @@ class ModelForAttributeBinding extends Model
     protected $guarded = [];
 }
 
-class ComponentWithModelProperty extends Component
+class ComponentWithModelProperty extends TestComponent
 {
     public $model;
 
@@ -125,25 +126,15 @@ class ComponentWithModelProperty extends Component
     {
         $this->model->refresh();
     }
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class ComponentWithoutRulesArray extends Component
+class ComponentWithoutRulesArray extends TestComponent
 {
     public $model;
 
     public function mount(ModelForAttributeBinding $model)
     {
         $this->model = $model;
-    }
-
-    public function render()
-    {
-        return view('null-view');
     }
 }
 

--- a/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeCastUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeCastUnitTest.php
@@ -4,9 +4,9 @@ namespace Livewire\Features\SupportLegacyModels\Tests;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Validation\Rule;
-use Livewire\Component;
 use Livewire\Livewire;
 use Sushi\Sushi;
+use Tests\TestComponent;
 
 class ModelAttributesCanBeCastUnitTest extends \Tests\TestCase
 {
@@ -441,7 +441,7 @@ enum TestingEnum: string
     case FOO = 'bar';
 }
 
-class ComponentForModelAttributeCasting extends Component
+class ComponentForModelAttributeCasting extends TestComponent
 {
     public $model;
 
@@ -481,10 +481,5 @@ class ComponentForModelAttributeCasting extends Component
     public function validateAttribute(string $attribute)
     {
         $this->validateOnly($attribute);
-    }
-
-    public function render()
-    {
-        return view('null-view');
     }
 }

--- a/src/Features/SupportLegacyModels/Tests/ModelCollectionAttributesCanBeBoundDirectlyUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelCollectionAttributesCanBeBoundDirectlyUnitTest.php
@@ -10,6 +10,7 @@ use Livewire\Livewire;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
 use Sushi\Sushi;
 
+use Tests\TestComponent;
 use function Livewire\invade;
 
 class ModelCollectionAttributesCanBeBoundDirectlyUnitTest extends \Tests\TestCase
@@ -155,7 +156,7 @@ class ModelWithCustomCollectionForBinding extends Model
     }
 }
 
-class ComponentWithModelCollectionProperty extends Component
+class ComponentWithModelCollectionProperty extends TestComponent
 {
     public $models;
     public $modelsType;
@@ -194,10 +195,5 @@ class ComponentWithModelCollectionProperty extends Component
     public function refreshModels()
     {
         $this->models = $this->models->filter->exists->fresh();
-    }
-
-    public function render()
-    {
-        return view('null-view');
     }
 }

--- a/src/Features/SupportLegacyModels/Tests/ModelValidationUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelValidationUnitTest.php
@@ -2,9 +2,9 @@
 
 namespace Livewire\Features\SupportLegacyModels\Tests;
 
+use Tests\TestComponent;
 use function Livewire\invade;
 use Illuminate\Database\Eloquent\Model;
-use Livewire\Component;
 use Livewire\Livewire;
 use Sushi\Sushi;
 
@@ -48,7 +48,7 @@ class FooModelForUniquenessValidation extends Model
     ];
 }
 
-class ComponentWithRulesPropertyAndModelWithUniquenessValidation extends Component
+class ComponentWithRulesPropertyAndModelWithUniquenessValidation extends TestComponent
 {
     public $foo;
 
@@ -73,14 +73,9 @@ class ComponentWithRulesPropertyAndModelWithUniquenessValidation extends Compone
 
         $this->validate();
     }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class ComponentWithRulesPropertyAndModelUniquenessValidationWithIdExceptions extends Component
+class ComponentWithRulesPropertyAndModelUniquenessValidationWithIdExceptions extends TestComponent
 {
     public $foo;
 
@@ -105,10 +100,5 @@ class ComponentWithRulesPropertyAndModelUniquenessValidationWithIdExceptions ext
         invade($db)->connections = $connections;
 
         $this->validate();
-    }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
     }
 }

--- a/src/Features/SupportLegacyModels/Tests/ModelsCanBeFilledUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelsCanBeFilledUnitTest.php
@@ -3,8 +3,8 @@
 namespace Livewire\Features\SupportLegacyModels\Tests;
 
 use Livewire\Livewire;
-use Livewire\Component;
 use Illuminate\Database\Eloquent\Model;
+use Tests\TestComponent;
 
 class ModelsCanBeFilledUnitTest extends \Tests\TestCase
 {
@@ -49,17 +49,12 @@ class UserModel extends Model
     }
 }
 
-class ComponentWithFillableProperties extends Component
+class ComponentWithFillableProperties extends TestComponent
 {
     public $user;
 
     public function callFill($values)
     {
         $this->fill($values);
-    }
-
-    public function render()
-    {
-        return '<div></div>';
     }
 }

--- a/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
@@ -3,10 +3,10 @@
 namespace Livewire\Features\SupportLegacyModels\Tests;
 
 use Livewire\Livewire;
-use Livewire\Component;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Model;
+use Tests\TestComponent;
 
 class PublicPropertyHydrationAndDehydrationUnitTest extends \Tests\TestCase
 {
@@ -878,7 +878,7 @@ class PublicPropertyHydrationAndDehydrationUnitTest extends \Tests\TestCase
     }
 }
 
-class PostComponent extends Component
+class PostComponent extends TestComponent
 {
     public $post;
 
@@ -886,16 +886,9 @@ class PostComponent extends Component
     {
         $this->post = Post::first();
     }
-
-    public function render()
-    {
-        return <<<'HTML'
-        <div></div>
-        HTML;
-    }
 }
 
-class ModelsComponent extends Component
+class ModelsComponent extends TestComponent
 {
     public $model;
     public $models;
@@ -923,13 +916,6 @@ class ModelsComponent extends Component
         if (isset($rules)) {
             $this->_rules = $rules;
         }
-    }
-
-    public function render()
-    {
-        return <<<'HTML'
-        <div></div>
-        HTML;
     }
 }
 

--- a/src/Features/SupportLegacyModels/Tests/TestableLivewireCanAssertModelUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/TestableLivewireCanAssertModelUnitTest.php
@@ -4,8 +4,8 @@ namespace Livewire\Features\SupportLegacyModels\Tests;
 
 use Sushi\Sushi;
 use Livewire\Livewire;
-use Livewire\Component;
 use Illuminate\Database\Eloquent\Model;
+use Tests\TestComponent;
 
 class TestableLivewireCanAssertModelUnitTest extends \Tests\TestCase
 {
@@ -32,12 +32,7 @@ class ModelForPropertyTesting extends Model
     }
 }
 
-class PropertyTestingComponent extends Component
+class PropertyTestingComponent extends TestComponent
 {
     public $model;
-
-    public function render()
-    {
-        return '<div></div>';
-    }
 }

--- a/src/Features/SupportLifecycleHooks/UnitTest.php
+++ b/src/Features/SupportLifecycleHooks/UnitTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Stringable;
 use Livewire\Component;
 use Livewire\Livewire;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -254,7 +255,7 @@ class UnitTest extends \Tests\TestCase
     }
 }
 
-class ForProtectedLifecycleHooks extends Component
+class ForProtectedLifecycleHooks extends TestComponent
 {
     public function mount()
     {
@@ -299,11 +300,6 @@ class ForProtectedLifecycleHooks extends Component
     public function updatedFoo($value)
     {
         //
-    }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
     }
 }
 
@@ -437,7 +433,7 @@ class ComponentWithBootMethodDI extends Component
     }
 }
 
-class ComponentWithOptionalParameters extends Component
+class ComponentWithOptionalParameters extends TestComponent
 {
     public $foo;
     public $bar;
@@ -447,14 +443,9 @@ class ComponentWithOptionalParameters extends Component
         $this->foo = $foo;
         $this->bar = $bar;
     }
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class ComponentWithOnlyFooParameter extends Component
+class ComponentWithOnlyFooParameter extends TestComponent
 {
     public $foo;
 
@@ -462,25 +453,14 @@ class ComponentWithOnlyFooParameter extends Component
     {
         $this->foo = $foo;
     }
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class ComponentWithoutMount extends Component
+class ComponentWithoutMount extends TestComponent
 {
     public $foo = 0;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-
-class ForLifecycleHooks extends Component
+class ForLifecycleHooks extends TestComponent
 {
     public $foo;
 
@@ -624,11 +604,6 @@ class ForLifecycleHooks extends Component
     public function rendering()
     {
         $this->lifecycles['rendering']++;
-    }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
     }
 
     public function rendered()

--- a/src/Features/SupportLocales/UnitTest.php
+++ b/src/Features/SupportLocales/UnitTest.php
@@ -3,8 +3,8 @@
 namespace Livewire\Features\SupportLocales;
 
 use Illuminate\Support\Facades\App;
-use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -28,15 +28,10 @@ class UnitTest extends \Tests\TestCase
     }
 }
 
-class ComponentForLocalePersistanceHydrationMiddleware extends Component
+class ComponentForLocalePersistanceHydrationMiddleware extends TestComponent
 {
     public function mount()
     {
         App::setLocale('es');
-    }
-
-    public function render()
-    {
-        return view('null-view');
     }
 }

--- a/src/Features/SupportLockedProperties/UnitTest.php
+++ b/src/Features/SupportLockedProperties/UnitTest.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportLockedProperties;
 use Livewire\Livewire;
 use Livewire\Component as BaseComponent;
 use Livewire\Form;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -14,15 +15,11 @@ class UnitTest extends \Tests\TestCase
             'Cannot update locked property: [count]'
         );
 
-        Livewire::test(new class extends BaseComponent {
+        Livewire::test(new class extends TestComponent {
             #[BaseLocked]
             public $count = 1;
 
             function increment() { $this->count++; }
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertSetStrict('count', 1)
         ->set('count', 2);
@@ -35,15 +32,11 @@ class UnitTest extends \Tests\TestCase
             'Cannot update locked property: [foo]'
         );
 
-        Livewire::test(new class extends BaseComponent {
+        Livewire::test(new class extends TestComponent {
             #[BaseLocked]
             public $foo = ['count' => 1];
 
             function increment() { $this->foo['count']++; }
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertSetStrict('foo.count', 1)
         ->set('foo.count', 2);
@@ -51,15 +44,11 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_update_locked_property_with_similar_name()
     {
-        Livewire::test(new class extends BaseComponent {
+        Livewire::test(new class extends TestComponent {
             #[BaseLocked]
             public $count = 1;
 
             public $count2 = 1;
-
-            public function render() {
-                return '<div></div>';
-            }
         })
         ->assertSetStrict('count2', 1)
         ->set('count2', 2);

--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Livewire\Livewire;
 use Sushi\Sushi;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -95,7 +96,7 @@ class UnitTest extends \Tests\TestCase
         $this->markTestSkipped(); // @todo: probably not going to go this route...
         (new Article)::resolveConnection()->enableQueryLog();
 
-        Livewire::test(new class extends \Livewire\Component {
+        Livewire::test(new class extends TestComponent {
             #[Lazy]
             public Article $article;
 
@@ -107,10 +108,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->article->save();
             }
-
-            public function render() { return <<<'HTML'
-                <div></div>
-            HTML; }
         })
         ->call('$refresh')
         ->call('save');
@@ -200,19 +197,12 @@ class UnitTest extends \Tests\TestCase
         Relation::morphMap([], false);
         Relation::requireMorphMap();
 
-        $component = Livewire::test(new class extends \Livewire\Component {
+        $component = Livewire::test(new class extends TestComponent {
             public $article;
 
             public function mount()
             {
                 $this->article = Article::first();
-            }
-
-            public function render()
-            {
-                return <<<'HTML'
-                <div></div>
-                HTML;
             }
         });
 
@@ -227,20 +217,13 @@ class Lazy {
     //
 }
 
-class ArticleComponent extends \Livewire\Component
+class ArticleComponent extends TestComponent
 {
     public $article;
 
     public function mount()
     {
         $this->article = Article::first();
-    }
-
-    public function render()
-    {
-        return <<<'HTML'
-        <div></div>
-        HTML;
     }
 }
 

--- a/src/Features/SupportPagination/UnitTest.php
+++ b/src/Features/SupportPagination/UnitTest.php
@@ -8,6 +8,7 @@ use Livewire\Component;
 use Livewire\Livewire;
 use Livewire\WithPagination;
 use Sushi\Sushi;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -141,14 +142,9 @@ class UnitTest extends \Tests\TestCase
     }
 }
 
-class ComponentWithPaginationStub extends Component
+class ComponentWithPaginationStub extends TestComponent
 {
     use WithPagination;
-
-    public function render()
-    {
-        return '<div></div>';
-    }
 }
 
 class PaginatorPostTestModel extends Model

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -3,7 +3,7 @@
 namespace Livewire\Features\SupportQueryString;
 
 use Livewire\Livewire;
-use Livewire\Component;
+use Tests\TestComponent;
 
 trait WithSorting
 {
@@ -19,15 +19,11 @@ class UnitTest extends \Tests\TestCase
 {
     function test_can_track_properties_in_the_url()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             #[BaseUrl]
             public $count = 1;
 
             function increment() { $this->count++; }
-
-            public function render() {
-                return '<div></div>';
-            }
         });
 
         $this->assertTrue(isset($component->effects['url']));
@@ -35,12 +31,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_sub_name_is_null_in_attributes_from_query_string_component_method()
     {
-        $component = Livewire::test(new class extends Component {
-            public function render()
-            {
-                return '<div></div>';
-            }
-
+        $component = Livewire::test(new class extends TestComponent {
             protected function queryString()
             {
                 return [
@@ -58,13 +49,8 @@ class UnitTest extends \Tests\TestCase
 
     function test_sub_name_is_null_in_attributes_from_query_string_trait_method()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             use WithSorting;
-
-            public function render()
-            {
-                return '<div></div>';
-            }
         });
 
         $attributes = $component->instance()->getAttributes();
@@ -76,14 +62,9 @@ class UnitTest extends \Tests\TestCase
 
     function test_sub_name_is_same_as_name_in_attributes_from_base_url_property_attribute()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             #[BaseUrl]
             public $queryFromAttribute;
-
-            public function render()
-            {
-                return '<div></div>';
-            }
         });
 
         $attributes = $component->instance()->getAttributes();

--- a/src/Features/SupportRedirects/UnitTest.php
+++ b/src/Features/SupportRedirects/UnitTest.php
@@ -224,7 +224,7 @@ class UnitTest extends \Tests\TestCase
     }
 }
 
-class TriggersRedirectStub extends Component
+class TriggersRedirectStub extends TestComponent
 {
     public function triggerRedirect()
     {
@@ -282,23 +282,13 @@ class TriggersRedirectStub extends Component
     {
         return redirect()->away('foo');
     }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class TriggersRedirectOnMountStub extends Component
+class TriggersRedirectOnMountStub extends TestComponent
 {
     public function mount()
     {
         $this->redirect('/local');
-    }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
     }
 }
 

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanAssertNoRedirectUnitTest.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanAssertNoRedirectUnitTest.php
@@ -2,8 +2,8 @@
 
 namespace Livewire\Features\SupportTesting\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class TestableLivewireCanAssertNoRedirectUnitTest extends \Tests\TestCase
 {
@@ -33,15 +33,11 @@ class TestableLivewireCanAssertNoRedirectUnitTest extends \Tests\TestCase
     }
 }
 
-class PlainRenderingComponent extends Component
+class PlainRenderingComponent extends TestComponent
 {
-    function render()
-    {
-        return view('null-view');
-    }
 }
 
-class NoRedirectComponent extends Component
+class NoRedirectComponent extends TestComponent
 {
     function performRedirect()
     {
@@ -51,10 +47,5 @@ class NoRedirectComponent extends Component
     function performNoRedirect()
     {
         $this->dispatch('noRedirect');
-    }
-
-    function render()
-    {
-        return view('null-view');
     }
 }

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanAssertPropertiesUnitTest.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanAssertPropertiesUnitTest.php
@@ -2,8 +2,8 @@
 
 namespace Livewire\Features\SupportTesting\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class TestableLivewireCanAssertPropertiesUnitTest extends \Tests\TestCase
 {
@@ -38,7 +38,7 @@ class TestableLivewireCanAssertPropertiesUnitTest extends \Tests\TestCase
     }
 }
 
-class PropertyTestingComponent extends Component
+class PropertyTestingComponent extends TestComponent
 {
     public $foo = 'bar';
 
@@ -46,22 +46,12 @@ class PropertyTestingComponent extends Component
     {
         return 'lob';
     }
-
-    function render()
-    {
-        return '<div></div>';
-    }
 }
 
-class ComputedPropertyWithExceptionTestingComponent extends Component
+class ComputedPropertyWithExceptionTestingComponent extends TestComponent
 {
     function getThrowsExceptionProperty()
     {
         throw new \Exception('Test exception');
-    }
-
-    function render()
-    {
-        return '<div></div>';
     }
 }

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanAssertRedirectToRouteUnitTest.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanAssertRedirectToRouteUnitTest.php
@@ -2,9 +2,9 @@
 
 namespace Livewire\Features\SupportTesting\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
 use Illuminate\Support\Facades\Route;
+use Tests\TestComponent;
 
 class TestableLivewireCanAssertRedirectToRouteUnitTest extends \Tests\TestCase
 {
@@ -36,15 +36,10 @@ class TestableLivewireCanAssertRedirectToRouteUnitTest extends \Tests\TestCase
     }
 }
 
-class RedirectRouteComponent extends Component
+class RedirectRouteComponent extends TestComponent
 {
     function performRedirect()
     {
         $this->redirectRoute('foo');
-    }
-
-    function render()
-    {
-        return view('null-view');
     }
 }

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanAssertRedirectUnitTest.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanAssertRedirectUnitTest.php
@@ -2,8 +2,8 @@
 
 namespace Livewire\Features\SupportTesting\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class TestableLivewireCanAssertRedirectUnitTest extends \Tests\TestCase
 {
@@ -35,15 +35,10 @@ class TestableLivewireCanAssertRedirectUnitTest extends \Tests\TestCase
     }
 }
 
-class RedirectComponent extends Component
+class RedirectComponent extends TestComponent
 {
     function performRedirect()
     {
         $this->redirect('/some');
-    }
-
-    function render()
-    {
-        return view('null-view');
     }
 }

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanAssertViewIsUnitTest.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanAssertViewIsUnitTest.php
@@ -2,8 +2,8 @@
 
 namespace Livewire\Features\SupportTesting\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class TestableLivewireCanAssertViewIsUnitTest extends \Tests\TestCase
 {
@@ -14,7 +14,7 @@ class TestableLivewireCanAssertViewIsUnitTest extends \Tests\TestCase
     }
 }
 
-class ViewComponent extends Component
+class ViewComponent extends TestComponent
 {
     function render()
     {

--- a/src/Features/SupportTesting/Tests/TestableLivewireCanBeInvaded.php
+++ b/src/Features/SupportTesting/Tests/TestableLivewireCanBeInvaded.php
@@ -2,20 +2,16 @@
 
 namespace Livewire\Features\SupportTesting\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Tests\TestComponent;
 
 class TestableLivewireCanBeInvaded extends \Tests\TestCase
 {
     function test_can_invade_protected_properties()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             protected string $foo = 'bar';
-
-            function render() {
-                return '<div></div>';
-            }
         });
 
         PHPUnit::assertEquals('bar', $component->invade()->foo);
@@ -23,13 +19,9 @@ class TestableLivewireCanBeInvaded extends \Tests\TestCase
 
     function test_can_invade_protected_functions()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             protected function foo() : string {
                 return 'bar';
-            }
-
-            function render() {
-                return '<div></div>';
             }
         });
 
@@ -38,12 +30,8 @@ class TestableLivewireCanBeInvaded extends \Tests\TestCase
 
     function test_can_invade_private_properties()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             private string $foo = 'bar';
-
-            function render() {
-                return '<div></div>';
-            }
         });
 
         PHPUnit::assertEquals('bar', $component->invade()->foo);
@@ -51,13 +39,9 @@ class TestableLivewireCanBeInvaded extends \Tests\TestCase
 
     function test_can_invade_private_functions()
     {
-        $component = Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends TestComponent {
             private function foo() : string {
                 return 'bar';
-            }
-
-            function render() {
-                return '<div></div>';
             }
         });
 

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -11,6 +11,7 @@ use Illuminate\Testing\TestView;
 use Livewire\Component;
 use Livewire\Livewire;
 use Closure;
+use Tests\TestComponent;
 
 // TODO - Change this to \Tests\TestCase
 class UnitTest extends \LegacyTests\Unit\TestCase
@@ -565,18 +566,13 @@ class UnitTest extends \LegacyTests\Unit\TestCase
         // Test both the `withCookies` and `withCookie` methods that Laravel normally provides
         Livewire::withCookies(['colour' => 'blue'])
             ->withCookie('name', 'Taylor')
-            ->test(new class extends Component {
+            ->test(new class extends TestComponent {
                 public $colourCookie = '';
                 public $nameCookie = '';
                 public function mount()
                 {
                     $this->colourCookie = request()->cookie('colour');
                     $this->nameCookie = request()->cookie('name');
-                }
-
-                public function render()
-                {
-                    return '<div></div>';
                 }
             })
             ->assertSetStrict('colourCookie', 'blue')
@@ -587,18 +583,13 @@ class UnitTest extends \LegacyTests\Unit\TestCase
     public function test_can_set_headers_for_use_with_testing()
     {
         Livewire::withHeaders(['colour' => 'blue', 'name' => 'Taylor'])
-            ->test(new class extends Component {
+            ->test(new class extends TestComponent {
                 public $colourHeader = '';
                 public $nameHeader = '';
                 public function mount()
                 {
                     $this->colourHeader = request()->header('colour');
                     $this->nameHeader = request()->header('name');
-                }
-
-                public function render()
-                {
-                    return '<div></div>';
                 }
             })
             ->assertSetStrict('colourHeader', 'blue')
@@ -610,7 +601,7 @@ class UnitTest extends \LegacyTests\Unit\TestCase
     {
         // Test both the `withCookies` and `withCookie` methods that Laravel normally provides
         Livewire::withCookies(['colour' => 'blue'])->withCookie('name', 'Taylor')
-            ->test(new class extends Component {
+            ->test(new class extends TestComponent {
                 public $colourCookie = '';
                 public $nameCookie = '';
 
@@ -618,11 +609,6 @@ class UnitTest extends \LegacyTests\Unit\TestCase
                 {
                     $this->colourCookie = request()->cookie('colour');
                     $this->nameCookie = request()->cookie('name');
-                }
-
-                public function render()
-                {
-                    return '<div></div>';
                 }
             })
             ->call('setTheCookies')
@@ -654,15 +640,11 @@ class HasHtml extends Component
     }
 }
 
-class SomeComponentStub extends Component
+class SomeComponentStub extends TestComponent
 {
-    function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class HasMountArgumentsButDoesntPassThemToBladeView extends Component
+class HasMountArgumentsButDoesntPassThemToBladeView extends TestComponent
 {
     public $name;
 
@@ -670,14 +652,9 @@ class HasMountArgumentsButDoesntPassThemToBladeView extends Component
     {
         $this->name = $name;
     }
-
-    function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class DispatchesEventsComponentStub extends Component
+class DispatchesEventsComponentStub extends TestComponent
 {
     function dispatchFoo()
     {
@@ -703,11 +680,6 @@ class DispatchesEventsComponentStub extends Component
     {
         $this->dispatch('foo')->to(ComponentWhichReceivesEvent::class);
     }
-
-    function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
 class CustomValidationRule implements ValidationRule
@@ -720,7 +692,7 @@ class CustomValidationRule implements ValidationRule
     }
 }
 
-class ValidatesDataWithCustomRuleStub extends Component
+class ValidatesDataWithCustomRuleStub extends TestComponent
 {
     public bool $foo = false;
 
@@ -730,14 +702,9 @@ class ValidatesDataWithCustomRuleStub extends Component
             'foo' => new CustomValidationRule,
         ]);
     }
-
-    function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class ValidatesDataWithSubmitStub extends Component
+class ValidatesDataWithSubmitStub extends TestComponent
 {
     public $foo;
     public $bar;
@@ -754,14 +721,9 @@ class ValidatesDataWithSubmitStub extends Component
     {
         $this->addError('bob', 'lob');
     }
-
-    function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class ValidatesDataWithRealTimeStub extends Component
+class ValidatesDataWithRealTimeStub extends TestComponent
 {
     public $foo;
     public $bar;
@@ -773,14 +735,10 @@ class ValidatesDataWithRealTimeStub extends Component
             'bar' => 'required',
         ]);
     }
-
-    function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class ValidatesDataWithRulesHasParams extends Component{
+class ValidatesDataWithRulesHasParams extends TestComponent
+{
     public $foo, $bar;
 
     function submit()
@@ -789,39 +747,23 @@ class ValidatesDataWithRulesHasParams extends Component{
             'foo' => 'string|min:2',
         ]);
     }
-
-    function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
 class ComponentWhichReceivesEvent extends Component
 {
-
 }
 
-class ComponentWithMethodThatReturnsData extends Component
+class ComponentWithMethodThatReturnsData extends TestComponent
 {
     function foo()
     {
         return 'bar';
     }
-
-    function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class ComponentWithEnums extends Component
+class ComponentWithEnums extends TestComponent
 {
     public BackedFooBarEnum $backedFooBarEnum;
-
-    function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
 enum BackedFooBarEnum : string

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -884,7 +884,7 @@ class UnitTest extends \Tests\TestCase
     }
 }
 
-class ComponentWithRulesProperty extends Component
+class ComponentWithRulesProperty extends TestComponent
 {
     public $foo;
     public $bar = 'baz';
@@ -913,25 +913,15 @@ class ComponentWithRulesProperty extends Component
     {
         $this->validate();
     }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class ComponentWithoutRulesProperty extends Component
+class ComponentWithoutRulesProperty extends TestComponent
 {
     public $foo;
 
     public function save()
     {
         $this->validate();
-    }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
     }
 }
 
@@ -1236,7 +1226,7 @@ class WithValidationMethod extends Component
     }
 }
 
-class ValidatesOnlyTestComponent extends Component
+class ValidatesOnlyTestComponent extends TestComponent
 {
     public $image = '';
     public $image_alt = '';
@@ -1269,14 +1259,9 @@ class ValidatesOnlyTestComponent extends Component
     {
         $this->resetValidation();
     }
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class ValidatesComputedProperty extends Component
+class ValidatesComputedProperty extends TestComponent
 {
     public $helper;
 
@@ -1317,14 +1302,9 @@ class ValidatesComputedProperty extends Component
     {
         $this->resetValidation();
     }
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class ValidatesWireableProperty extends Component
+class ValidatesWireableProperty extends TestComponent
 {
     public CustomWireableValidationCollection $customCollection;
 
@@ -1342,11 +1322,6 @@ class ValidatesWireableProperty extends Component
     public function runValidation()
     {
         $this->validate();
-    }
-
-    public function render()
-    {
-        return view('null-view');
     }
 }
 

--- a/src/Mechanisms/ExtendBlade/UnitTest.php
+++ b/src/Mechanisms/ExtendBlade/UnitTest.php
@@ -12,6 +12,7 @@ use Livewire\Exceptions\BypassViewHandler;
 use Livewire\Livewire;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -245,41 +246,26 @@ class LivewireExceptionIsThrownInViewStub extends Component
     }
 }
 
-class Abort404IsThrownInComponentMountStub extends Component
+class Abort404IsThrownInComponentMountStub extends TestComponent
 {
     public function mount()
     {
         abort(404);
     }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class Abort500IsThrownInComponentMountStub extends Component
+class Abort500IsThrownInComponentMountStub extends TestComponent
 {
     public function mount()
     {
         abort(500);
     }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class AuthorizationExceptionIsThrownInComponentMountStub extends Component
+class AuthorizationExceptionIsThrownInComponentMountStub extends TestComponent
 {
     public function mount()
     {
         throw new AuthorizationException();
-    }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
     }
 }

--- a/src/Mechanisms/FrontendAssets/BrowserTest.php
+++ b/src/Mechanisms/FrontendAssets/BrowserTest.php
@@ -4,6 +4,7 @@ namespace Livewire\Mechanisms\FrontendAssets;
 
 use Illuminate\Support\Facades\Route;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class BrowserTest extends \Tests\BrowserTestCase
 {
@@ -15,10 +16,8 @@ class BrowserTest extends \Tests\BrowserTestCase
             });
         });
 
-        Livewire::visit(new class extends \Livewire\Component {
-            function render() { return '<div></div>'; }
-        })
-        ->assertDialogOpened('hi mom')
+        Livewire::visit(new class extends TestComponent {})
+            ->assertDialogOpened('hi mom')
         ;
     }
 }

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
@@ -4,8 +4,8 @@ namespace Livewire\Mechanisms\HandleComponents\Synthesizers\Tests;
 
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
-use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class CarbonSynthUnitTest extends \Tests\TestCase
 {
@@ -80,50 +80,26 @@ class CarbonSynthUnitTest extends \Tests\TestCase
     }
 }
 
-class ComponentWithPublicCarbonCaster extends Component
+class ComponentWithPublicCarbonCaster extends TestComponent
 {
     public Carbon $date;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
-class ComponentWithNullablePublicCarbonCaster extends Component
+
+class ComponentWithNullablePublicCarbonCaster extends TestComponent
 {
     public ?Carbon $date = null;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class ComponentWithNullablePublicCarbonImmutableCaster extends Component
+class ComponentWithNullablePublicCarbonImmutableCaster extends TestComponent
 {
     public ?CarbonImmutable $date = null;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class ComponentWithNullablePublicDateTimeCaster extends Component
+class ComponentWithNullablePublicDateTimeCaster extends TestComponent
 {
     public ?\DateTime $date = null;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
-class ComponentWithNullablePublicDateTimeImmutableCaster extends Component
+class ComponentWithNullablePublicDateTimeImmutableCaster extends TestComponent
 {
     public ?\DateTimeImmutable $date = null;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/DataBindingUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/DataBindingUnitTest.php
@@ -44,7 +44,7 @@ class DataBindingUnitTest extends \Tests\TestCase
     }
 }
 
-class DataBindingStub extends Component
+class DataBindingStub extends TestComponent
 {
     public $foo;
     public $bar;
@@ -69,10 +69,5 @@ class DataBindingStub extends Component
     public function removeArrayPropertyOne()
     {
         unset($this->arrayProperty[1]);
-    }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
     }
 }

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -2,8 +2,8 @@
 
 namespace Livewire\Mechanisms\HandleComponents\Synthesizers\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 use ValueError;
 
 class EnumUnitTest extends \Tests\TestCase
@@ -35,7 +35,7 @@ enum TestingEnum: string
     case TEST = 'Be excellent to each other';
 }
 
-class ComponentWithPublicEnumCasters extends Component
+class ComponentWithPublicEnumCasters extends TestComponent
 {
     public $typeOf;
     public $enum;
@@ -59,19 +59,9 @@ class ComponentWithPublicEnumCasters extends Component
     {
         $this->typeOf = get_class($this->enum);
     }
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class ComponentWithNullablePublicEnumCaster extends Component
+class ComponentWithNullablePublicEnumCaster extends TestComponent
 {
     public ?TestingEnum $status = null;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/FloatSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/FloatSynthUnitTest.php
@@ -2,9 +2,9 @@
 
 namespace Livewire\Mechanisms\HandleComponents\Synthesizers\Tests;
 
-use Livewire\Component;
 use Livewire\Form;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class FloatSynthUnitTest extends \Tests\TestCase
 {
@@ -83,44 +83,24 @@ class FloatSynthUnitTest extends \Tests\TestCase
     }
 }
 
-class ComponentWithNullableFloat extends Component
+class ComponentWithNullableFloat extends TestComponent
 {
     public ?float $floatField = null;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class ComponentWithFloat extends Component
+class ComponentWithFloat extends TestComponent
 {
     public float $floatField;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class ComponentWithFloatOrString extends Component
+class ComponentWithFloatOrString extends TestComponent
 {
     public float|string $floatOrStringField;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class FormComponentWithNullableFloat extends Component
+class FormComponentWithNullableFloat extends TestComponent
 {
     public FormWithNullableFloat $form;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
 class FormWithNullableFloat extends Form

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/IntSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/IntSynthUnitTest.php
@@ -2,8 +2,8 @@
 
 namespace Livewire\Mechanisms\HandleComponents\Synthesizers\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class IntSynthUnitTest extends \Tests\TestCase
 {
@@ -61,32 +61,17 @@ class IntSynthUnitTest extends \Tests\TestCase
     }
 }
 
-class ComponentWithNullableInt extends Component
+class ComponentWithNullableInt extends TestComponent
 {
     public ?int $intField = null;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class ComponentWithInt extends Component
+class ComponentWithInt extends TestComponent
 {
     public int $intField;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class ComponentWithIntOrString extends Component
+class ComponentWithIntOrString extends TestComponent
 {
     public int|string $intOrStringField;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Stringable;
 use Livewire\Component;
 use Livewire\Form;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -31,7 +32,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_synthesized_property_types_are_preserved_after_update()
     {
-        Livewire::test(new class extends Component {
+        Livewire::test(new class extends TestComponent {
             public $foo;
             public $isStringable;
             public function mount() { $this->foo = str('bar'); }
@@ -39,7 +40,6 @@ class UnitTest extends \Tests\TestCase
             {
                 $this->isStringable = $this->foo instanceof Stringable;
             }
-            public function render() { return '<div></div>'; }
         })
             ->assertSet('foo', 'bar')
             ->call('checkStringable')
@@ -200,25 +200,15 @@ class UnitTest extends \Tests\TestCase
     }
 }
 
-class BasicComponent extends Component
+class BasicComponent extends TestComponent
 {
     public $name;
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
-class ComponentWithStringPropertiesStub extends Component
+class ComponentWithStringPropertiesStub extends TestComponent
 {
     public $emptyString = '';
     public $oneSpace = ' ';
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
 enum UnitSuit: string

--- a/src/Mechanisms/Tests/LoadBalancerCompatibilityUnitTest.php
+++ b/src/Mechanisms/Tests/LoadBalancerCompatibilityUnitTest.php
@@ -4,6 +4,7 @@ namespace Livewire\Mechanisms\Tests;
 
 use Livewire\Livewire;
 use Livewire\Component;
+use Tests\TestComponent;
 
 class LoadBalancerCompatibilityUnitTest extends \Tests\TestCase
 {
@@ -15,12 +16,8 @@ class LoadBalancerCompatibilityUnitTest extends \Tests\TestCase
                 return '<div> <livewire:child /> </div>';
             }
         },
-        'child' => new class extends Component {
-            public function render()
-            {
-                return '<div></div>';
-            }
-        }]);
+        'child' => new class extends TestComponent {}
+        ]);
 
         $firstKey = array_keys($component->snapshot['memo']['children'])[0];
 
@@ -33,12 +30,8 @@ class LoadBalancerCompatibilityUnitTest extends \Tests\TestCase
                 return '<div> <livewire:child /> </div>';
             }
         },
-        'child' => new class extends Component {
-            public function render()
-            {
-                return '<div></div>';
-            }
-        }]);
+        'child' => new class extends TestComponent {}
+        ]);
 
         $secondKey = array_keys($component->snapshot['memo']['children'])[0];
 

--- a/src/Tests/ComponentDependencyInjectionUnitTest.php
+++ b/src/Tests/ComponentDependencyInjectionUnitTest.php
@@ -5,6 +5,7 @@ namespace Livewire\Tests;
 use Livewire\Component;
 use Livewire\Livewire;
 use Illuminate\Routing\UrlGenerator;
+use Tests\TestComponent;
 
 class ComponentDependencyInjectionUnitTest extends \Tests\TestCase
 {
@@ -124,7 +125,7 @@ class ComponentDependencyInjectionUnitTest extends \Tests\TestCase
     }
 }
 
-class ComponentWithDependencyInjection extends Component
+class ComponentWithDependencyInjection extends TestComponent
 {
     public $foo;
     public $bar;
@@ -173,11 +174,6 @@ class ComponentWithDependencyInjection extends Component
     {
         $this->foo = $foo;
     }
-
-    public function render()
-    {
-        return view('null-view');
-    }
 }
 
 class CustomComponent extends Component
@@ -198,7 +194,7 @@ class CustomService
     }
 }
 
-class ComponentWithUnionTypes extends Component
+class ComponentWithUnionTypes extends TestComponent
 {
     public $foo;
     public $bar;
@@ -213,10 +209,5 @@ class ComponentWithUnionTypes extends Component
     {
         $this->foo = $generator->to("/");
         $this->bar = $bar;
-    }
-
-    public function render()
-    {
-        return view("null-view");
     }
 }

--- a/src/Tests/ComponentIsMacroableUnitTest.php
+++ b/src/Tests/ComponentIsMacroableUnitTest.php
@@ -4,6 +4,7 @@ namespace Livewire\Tests;
 
 use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class ComponentIsMacroableUnitTest extends \Tests\TestCase
 {
@@ -18,17 +19,12 @@ class ComponentIsMacroableUnitTest extends \Tests\TestCase
     }
 }
 
-class ComponentWithMacroedMethodStub extends Component
+class ComponentWithMacroedMethodStub extends TestComponent
 {
     public $foo;
 
     public function mount()
     {
         $this->foo = $this->macroedMethod('one', 'two');
-    }
-
-    public function render()
-    {
-        return view('null-view');
     }
 }

--- a/src/Tests/ComponentUsesCustomNameUnitTest.php
+++ b/src/Tests/ComponentUsesCustomNameUnitTest.php
@@ -2,8 +2,8 @@
 
 namespace Livewire\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class ComponentUsesCustomNameUnitTest extends \Tests\TestCase
 {
@@ -24,24 +24,14 @@ class ComponentUsesCustomNameUnitTest extends \Tests\TestCase
     }
 }
 
-class UsesDefaultComponentName extends Component
+class UsesDefaultComponentName extends TestComponent
 {
     public $name = 'Hello World';
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class PreservesNameProperty extends Component
+class PreservesNameProperty extends TestComponent
 {
     public $name = 'Hello World';
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 
     public function getName()
     {

--- a/src/Tests/ComponentsAreSecureUnitTest.php
+++ b/src/Tests/ComponentsAreSecureUnitTest.php
@@ -6,7 +6,7 @@ use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
 use Livewire\Exceptions\PublicPropertyNotFoundException;
 use Livewire\Exceptions\NonPublicComponentMethodCall;
 use Livewire\Exceptions\MethodNotFoundException;
-use Livewire\Component;
+use Tests\TestComponent;
 
 class ComponentsAreSecureUnitTest extends \Tests\TestCase
 {
@@ -97,7 +97,7 @@ class ComponentsAreSecureUnitTest extends \Tests\TestCase
     }
 }
 
-class SecurityTargetStub extends Component
+class SecurityTargetStub extends TestComponent
 {
     public $publicProperty = 'foo';
     protected $protectedProperty = 'bar';
@@ -109,22 +109,12 @@ class SecurityTargetStub extends Component
     protected function protectedMethod()
     {
     }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class UnsafeComponentStub extends Component
+class UnsafeComponentStub extends TestComponent
 {
     public function someMethod()
     {
         throw new \Exception('Should not be able to acess me!');
-    }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
     }
 }

--- a/src/Tests/LifecycleHooksUnitTest.php
+++ b/src/Tests/LifecycleHooksUnitTest.php
@@ -2,10 +2,10 @@
 
 namespace Livewire\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
 use Illuminate\Support\Stringable;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Tests\TestComponent;
 
 class CustomException extends \Exception {};
 
@@ -77,7 +77,7 @@ class LifecycleHooksUnitTest extends \Tests\TestCase
     }
 }
 
-class ForMagicMethods extends Component
+class ForMagicMethods extends TestComponent
 {
     public $foo;
 
@@ -226,10 +226,5 @@ class ForMagicMethods extends Component
         PHPUnit::assertEquals($expected_value, data_get($this->bar, $key));
 
         $this->lifecycles['updatedBarBaz'] = true;
-    }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
     }
 }

--- a/src/Tests/PublicPropertiesAreInitializedUnitTest.php
+++ b/src/Tests/PublicPropertiesAreInitializedUnitTest.php
@@ -5,6 +5,7 @@ namespace Livewire\Tests;
 use Livewire\Component;
 use Livewire\Livewire;
 use Stringable;
+use Tests\TestComponent;
 
 class PublicPropertiesAreInitializedUnitTest extends \Tests\TestCase
 {
@@ -57,14 +58,9 @@ class PublicPropertiesAreInitializedUnitTest extends \Tests\TestCase
     }
 }
 
-class UninitializedPublicPropertyComponent extends Component
+class UninitializedPublicPropertyComponent extends TestComponent
 {
     public $message;
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
 class InitializedPublicPropertyComponent extends Component
@@ -78,34 +74,19 @@ class InitializedPublicPropertyComponent extends Component
     }
 }
 
-class UninitializedPublicTypedPropertyComponent extends Component
+class UninitializedPublicTypedPropertyComponent extends TestComponent
 {
     public string $message;
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class UninitializedPublicUnionTypedPropertyComponent extends Component
+class UninitializedPublicUnionTypedPropertyComponent extends TestComponent
 {
     public string | Stringable $message;
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
-class UninitializedPublicTypedPropertyAfterRefreshComponent extends Component
+class UninitializedPublicTypedPropertyAfterRefreshComponent extends TestComponent
 {
     public string $message;
-
-    public function render()
-    {
-        return app('view')->make('null-view');
-    }
 }
 
 class InitializedPublicTypedPropertyComponent extends Component

--- a/src/Tests/PublicPropertyHydrationHooksUnitTest.php
+++ b/src/Tests/PublicPropertyHydrationHooksUnitTest.php
@@ -4,7 +4,7 @@ namespace Livewire\Tests;
 
 use Illuminate\Support\Str;
 use Livewire\Livewire;
-use Livewire\Component;
+use Tests\TestComponent;
 
 class PublicPropertyHydrationHooksUnitTest extends \Tests\TestCase
 {
@@ -30,7 +30,7 @@ class PublicPropertyHydrationHooksUnitTest extends \Tests\TestCase
     }
 }
 
-class ComponentWithPublicPropertyCasters extends Component
+class ComponentWithPublicPropertyCasters extends TestComponent
 {
     public $date;
     public $dateWithFormat;
@@ -76,10 +76,5 @@ class ComponentWithPublicPropertyCasters extends Component
             'allCaps' => $this->allCaps,
             'stringable' => get_class($this->stringable),
         ];
-    }
-
-    public function render()
-    {
-        return view('null-view');
     }
 }

--- a/src/Tests/QueryParamsUnitTest.php
+++ b/src/Tests/QueryParamsUnitTest.php
@@ -2,8 +2,8 @@
 
 namespace Livewire\Tests;
 
-use Livewire\Component;
 use Livewire\Livewire;
+use Tests\TestComponent;
 
 class QueryParamsUnitTest extends \Tests\TestCase
 {
@@ -23,17 +23,12 @@ class QueryParamsUnitTest extends \Tests\TestCase
     }
 }
 
-class QueryParamsComponent extends Component
+class QueryParamsComponent extends TestComponent
 {
     public $name;
 
     public function mount()
     {
         $this->name = request('name');
-    }
-
-    public function render()
-    {
-        return app('view')->make('null-view');
     }
 }


### PR DESCRIPTION
In a lot of tests, a render method is passed with an empty div, because otherwise the components don't work. 
But, our default `TestComponent` already contains this empty render method.
This PR refactors the test components to this `TestComponent`, eliminating all empty render methods and making the tests a lot clearer and cleaner.

Note: both `<div></div>` as `view('null-view')` render an empty div.