### PR TITLE
HandleRequests: use empty array as default value to avoid error in foreach

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -13,7 +13,7 @@ class HandleRequests extends Mechanism
 {
     protected $updateRoute;
 
-    public function boot()
+    function boot()
     {
         // Only set it if another provider hasn't already set it....
         if (! $this->updateRoute) {
@@ -25,14 +25,14 @@ class HandleRequests extends Mechanism
         $this->skipRequestPayloadTamperingMiddleware();
     }
 
-    public function getUpdateUri()
+    function getUpdateUri()
     {
         return (string) str(
             route($this->updateRoute->getName(), [], false)
         )->start('/');
     }
 
-    public function skipRequestPayloadTamperingMiddleware()
+    function skipRequestPayloadTamperingMiddleware()
     {
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::skipWhen(function () {
             return $this->isLivewireRequest();
@@ -43,7 +43,7 @@ class HandleRequests extends Mechanism
         });
     }
 
-    public function setUpdateRoute($callback)
+    function setUpdateRoute($callback)
     {
         $route = $callback([self::class, 'handleUpdate']);
 
@@ -55,12 +55,12 @@ class HandleRequests extends Mechanism
         $this->updateRoute = $route;
     }
 
-    public function isLivewireRequest()
+    function isLivewireRequest()
     {
         return request()->hasHeader('X-Livewire');
     }
 
-    public function isLivewireRoute()
+    function isLivewireRoute()
     {
         // @todo: Rename this back to `isLivewireRequest` once the need for it in tests has been fixed.
         $route = request()->route();
@@ -78,7 +78,7 @@ class HandleRequests extends Mechanism
         return $route->named('*livewire.update');
     }
 
-    public function handleUpdate()
+    function handleUpdate()
     {
         $requestPayload = request(key: 'components', default: []);
 

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -78,9 +78,8 @@ class HandleRequests extends Mechanism
 
     function handleUpdate()
     {
-        // $requestPayload = request(key: 'components', default: []);
-        $requestPayload = request(key: 'components', default: null);
-
+        $requestPayload = request(key: 'components', default: []);
+        
         $finish = trigger('request', $requestPayload);
 
         $requestPayload = $finish($requestPayload);

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -65,9 +65,7 @@ class HandleRequests extends Mechanism
         // @todo: Rename this back to `isLivewireRequest` once the need for it in tests has been fixed.
         $route = request()->route();
 
-        if (! $route) {
-            return false;
-        }
+        if (! $route) return false;
 
         /*
          * Check to see if route name ends with `livewire.update`, as if

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -78,7 +78,8 @@ class HandleRequests extends Mechanism
 
     function handleUpdate()
     {
-        $requestPayload = request(key: 'components', default: []);
+        // $requestPayload = request(key: 'components', default: []);
+        $requestPayload = request(key: 'components', default: null);
 
         $finish = trigger('request', $requestPayload);
 

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -6,13 +6,14 @@ use Illuminate\Support\Facades\Route;
 use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
 
 use Livewire\Mechanisms\Mechanism;
+
 use function Livewire\trigger;
 
 class HandleRequests extends Mechanism
 {
     protected $updateRoute;
 
-    function boot()
+    public function boot()
     {
         // Only set it if another provider hasn't already set it....
         if (! $this->updateRoute) {
@@ -24,14 +25,14 @@ class HandleRequests extends Mechanism
         $this->skipRequestPayloadTamperingMiddleware();
     }
 
-    function getUpdateUri()
+    public function getUpdateUri()
     {
         return (string) str(
             route($this->updateRoute->getName(), [], false)
         )->start('/');
     }
 
-    function skipRequestPayloadTamperingMiddleware()
+    public function skipRequestPayloadTamperingMiddleware()
     {
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::skipWhen(function () {
             return $this->isLivewireRequest();
@@ -42,7 +43,7 @@ class HandleRequests extends Mechanism
         });
     }
 
-    function setUpdateRoute($callback)
+    public function setUpdateRoute($callback)
     {
         $route = $callback([self::class, 'handleUpdate']);
 
@@ -54,17 +55,19 @@ class HandleRequests extends Mechanism
         $this->updateRoute = $route;
     }
 
-    function isLivewireRequest()
+    public function isLivewireRequest()
     {
         return request()->hasHeader('X-Livewire');
     }
 
-    function isLivewireRoute()
+    public function isLivewireRoute()
     {
         // @todo: Rename this back to `isLivewireRequest` once the need for it in tests has been fixed.
         $route = request()->route();
 
-        if (! $route) return false;
+        if (! $route) {
+            return false;
+        }
 
         /*
          * Check to see if route name ends with `livewire.update`, as if
@@ -75,9 +78,9 @@ class HandleRequests extends Mechanism
         return $route->named('*livewire.update');
     }
 
-    function handleUpdate()
+    public function handleUpdate()
     {
-        $requestPayload = request('components');
+        $requestPayload = request(key: 'components', default: []);
 
         $finish = trigger('request', $requestPayload);
 

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Http\Request;
+use Livewire\Mechanisms\HandleRequests\HandleRequests;
+use Tests\TestCase;
+
+class UnitTest extends TestCase
+{
+    /** @test */
+    public function livewire_can_run_handle_request_without_components_on_payload(): void
+    {
+        $handleRequestsInstance = new HandleRequests();
+        $request = new Request();
+
+        $result = $handleRequestsInstance->handleUpdate($request);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('components', $result);
+        $this->assertArrayHasKey('assets', $result);
+        $this->assertIsArray($result['components']);
+        $this->assertEmpty($result['components']);
+        $this->assertIsArray($result['assets']);
+        $this->assertEmpty($result['assets']);
+
+    }
+}


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
