### PR TITLE
Bugfix/url attribute existence

### DIFF
--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -54,9 +54,11 @@ class BaseUrl extends LivewireAttribute
             $this->as = $this->getSubName();
         }
 
-        $initialValue = $this->getFromUrlQueryString($this->urlName(), 'noexist');
+        $nonExistentValue = uniqid('__no_exist__', true);
 
-        if ($initialValue === 'noexist') return;
+        $initialValue = $this->getFromUrlQueryString($this->urlName(), $nonExistentValue);
+
+        if ($initialValue === $nonExistentValue) return;
 
         $decoded = is_array($initialValue)
             ? json_decode(json_encode($initialValue), true)

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -73,4 +73,25 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertEquals('queryFromAttribute', $queryFromAttribute->getSubName());
     }
+
+    function test_noexist_query_parameter_is_allowed_value()
+    {
+        $component = Livewire::withQueryParams(['exists' => 'noexist'])
+            ->test(new class extends TestComponent {
+                #[BaseUrl]
+                public $exists;
+                #[BaseUrl]
+                public $noexists;
+            });
+
+        $attributes = $component->instance()->getAttributes();
+
+        $existsAttribute = $attributes->first(fn (BaseUrl $attribute) => $attribute->getName() === 'exists');
+        $noexistsAttribute = $attributes->first(fn (BaseUrl $attribute) => $attribute->getName() === 'noexists');
+
+        $this->assertEquals('noexist', $existsAttribute->getFromUrlQueryString($existsAttribute->urlName(), 'does not exist'));
+        $this->assertEquals('does not exist', $noexistsAttribute->getFromUrlQueryString($noexistsAttribute->urlName(), 'does not exist'));
+        $this->assertEquals('noexist', $component->instance()->exists);
+        $this->assertEquals('', $component->instance()->noexists);
+    }
 }


### PR DESCRIPTION
Just a little fix for somethign that was previously... undocumented behabiour.

If you had a `#[Url]` attribute and you _legitimately_ wanted to have a value of "noexist", the `BaseUrl` attribute would silently discard it:

`https://example.com/some-path?filter=noexist`
`dump($this->filter); // string ''`

This is a tiny fix which changes the "parameter doesn't exist in the URL" string to something random so that you should _probably_ never have a conflict. Or if you did, you would have to be incredibly, imensly lucky, and you should probably go invest your life savings in lottery tickets.