### PR TITLE
Fix Test: Enhance Wait for Preview in Test

### DIFF
--- a/src/Features/SupportFileUploads/BrowserTest.php
+++ b/src/Features/SupportFileUploads/BrowserTest.php
@@ -49,7 +49,7 @@ class BrowserTest extends \Tests\BrowserTestCase
         })
         ->assertMissing('@preview')
         ->attach('@upload', __DIR__ . '/browser_test_image.png')
-        ->pause(250)
+        ->waitFor('@preview')
         ->assertVisible('@preview')
         ->tap(function () {
             Storage::disk('tmp-for-tests')->assertMissing('photos/photo.png');


### PR DESCRIPTION
This PR makes a small code change to improve waiting behavior during the test.

Change Test Browser file `src/Features/SupportFileUploads/BrowserTest.php`,
function  `test_can_upload_preview_and_save_a_file`

I replaced the line  `->wait(250)`, which ensures that the test waits until the element with the selector `@preview` is available before proceeding. This should enhance test reliability and ensure proper loading of the preview.
```diff
    ->assertMissing('@preview')
    ->attach('@upload', __DIR__ . '/browser_test_image.png')
-   ->wait(250)
+   ->waitFor('@preview')
    ->assertVisible('@preview')
```


Please review and approve if you agree! 😊👍



