### PR TITLE
Allow `update_uri` to be specified from config file

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -157,4 +157,18 @@ return [
     */
 
     'pagination_theme' => 'tailwind',
-];
+
+
+    /*
+   |---------------------------------------------------------------------------
+   | Update URI
+   |---------------------------------------------------------------------------
+   |
+   | This configuration option is used to specify a custom URL for Livewire
+   | to use when sending update requests.
+   |
+   */
+   'update_uri' =>null,
+
+
+ ];

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -26,9 +26,9 @@ class HandleRequests extends Mechanism
 
     function getUpdateUri()
     {
-        $urlFromConfig = config('livewire.update_uri');
-        if ($urlFromConfig) {
-            return $urlFromConfig;
+        $uriFromConfig = config('livewire.update_uri');
+        if ($uriFromConfig) {
+            return (string) $uriFromConfig;
         }
 
         return (string) str(

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -26,6 +26,11 @@ class HandleRequests extends Mechanism
 
     function getUpdateUri()
     {
+        $urlFromConfig = config('livewire.update_uri');
+        if ($urlFromConfig) {
+            return $urlFromConfig;
+        }
+
         return (string) str(
             route($this->updateRoute->getName(), [], false)
         )->start('/');


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes i needed to override this method `getUpdateUri` in [this file](https://github.com/microweber/microweber/blob/6da4049151554272a048a7a21263e916b1a8244f/src/MicroweberPackages/Livewire/LivewireServiceProvider.php#L125-L127)  by doing not so good thing to extend the main class here, so a config option will solve this issue  

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes 

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

No, but it works for me manually testing

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

I would like to have the full URL with FQDN of the update route as here in the injected JS

![image](https://github.com/livewire/livewire/assets/5698247/9ea5e1c1-7f24-4530-9b6c-30552cd7a2bf)


 
Currently the function adds a slash at the start so its impossible to add FQDN via `app($this::class)->setUpdateRoute` because of [this line](https://github.com/livewire/livewire/blob/main/src/Mechanisms/HandleRequests/HandleRequests.php#L31)

![image](https://github.com/livewire/livewire/assets/5698247/c5611cc5-f46e-4dfa-936e-ff2a08a841b3)

 