### PR TITLE
fix: Livewire published script load on Laravel Vapor

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -227,7 +227,11 @@ class FrontendAssets extends Mechanism
 
         $versionedFileName = "{$fileName}?id={$versionedFileName}";
 
-        $assertUrl = config('livewire.asset_url') ?? url("vendor/livewire{$versionedFileName}");
+        $assertUrl = config('livewire.asset_url')
+            ?? (app('livewire')->isRunningServerless()
+                ? rtrim(config('app.asset_url'), '/')."/vendor/livewire$versionedFileName"
+                : url("vendor/livewire{$versionedFileName}")
+            );
 
         $url = $assertUrl;
 


### PR DESCRIPTION
This PR allows Livewire Scripts to be loaded when running on Laravel Vapor or Serverless environment. 

The Functionally seems to have been lost as of Version 3 of Livewire see https://github.com/livewire/livewire/pull/1693

This will allow livewire to run seemlessly on a Vapor environment when assets are published.

## Changes:

In `FrontendAssets` method `usePublishedAssetsIfAvailable` determine if we are in a serverless environment and if so use `config('app.asset_url')` to render the Url for the livewire.js script.