### PR TITLE
Add test method for asserting partial match in redirect path

### DIFF
--- a/src/Features/SupportRedirects/TestsRedirects.php
+++ b/src/Features/SupportRedirects/TestsRedirects.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportRedirects;
 
+use Illuminate\Support\Str;
 use Livewire\Component;
 use PHPUnit\Framework\Assert as PHPUnit;
 
@@ -28,6 +29,31 @@ trait TestsRedirects
         if (! is_null($uri)) {
             PHPUnit::assertSame(url($uri), url($this->effects['redirect']));
         }
+
+        return $this;
+    }
+
+    public function assertRedirectContains($uri)
+    {
+        if (is_subclass_of($uri, Component::class)) {
+            $uri = url()->action($uri);
+        }
+
+        if (! app('livewire')->isLivewireRequest()) {
+            $this->lastState->getResponse()->assertRedirectContains($uri);
+
+            return $this;
+        }
+
+        PHPUnit::assertArrayHasKey(
+            'redirect',
+            $this->effects,
+            'Component did not perform a redirect.'
+        );
+
+        PHPUnit::assertTrue(
+            Str::contains($this->effects['redirect'], $uri), 'Redirect location ['.$this->effects['redirect'].'] does not contain ['.$uri.'].'
+        );
 
         return $this;
     }


### PR DESCRIPTION
Laravel has `assertRedirect` and `assertRedirectContains` for test requests.
Livewire currently only has `assertRedirect` so there is no way for asserting a partial match on redirect path.

This PR adds `assertRedirectContains` by mimicking how `assertRedirect` has already been implemented for Livewire, and using the Laravel code in `Illuminate\Testing\TestResponse::assertRedirectContains`.