### PR TITLE
Fix info on alpine page in the documentation

### DIFF
--- a/docs/alpine.md
+++ b/docs/alpine.md
@@ -45,7 +45,7 @@ Below is a simple Livewire component showing the details of a post model from th
 </div>
 ```
 
-By using Alpine, we can hide the content of the post until the user presses the "Show post content..." button. At that point, Alpine's `expanded` property will be set to `true` and the content will be shown on the page because `x-show="content"` is used to give Alpine control over the visibility of the post's content.
+By using Alpine, we can hide the content of the post until the user presses the "Show post content..." button. At that point, Alpine's `expanded` property will be set to `true` and the content will be shown on the page because `x-show="expanded"` is used to give Alpine control over the visibility of the post's content.
 
 This is an example of where Alpine shines: adding interactivity into your application without triggering Livewire server-roundtrips.
 


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
It is just a simple fix on the documentation. No need of discussion.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes, branch is called "fix-alpine-documentation".

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

4️⃣ Does it include tests? (Required)
No needed.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
It is just a simple fix on the alpine page of the documentation. Where's written x-show="content" was supposed to be x-show="expanded".
