### PR TITLE
update custom asset url docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,10 +84,25 @@ Livewire::setUpdateRoute(function ($handle) {
 
 ## Customizing the asset URL
 
-By default, Livewire will serve its JavaScript assets from the following URL: `https://example.com/livewire/livewire.js`. Additionally, Livewire will reference this asset from a script tag like so:
+By default, Livewire will serve its JavaScript assets from the following URL: 
 
+- When `APP_DEBUG` is `True`,
+
+`https://example.com/livewire/livewire.js`. 
+
+- Otherwise,
+
+`https://example.com/livewire/livewire.min.js`. 
+
+Additionally, Livewire will reference this asset from a script tag like so:
+
+- When `APP_DEBUG` is `True`
 ```blade
 <script src="/livewire/livewire.js" ...
+```
+- Otherwise,
+```blade
+<script src="/livewire/livewire.min.js" ...
 ```
 
 If your application has global route prefixes due to localization or multi-tenancy, you can register your own endpoint that Livewire should use internally when fetching its JavaScript.
@@ -96,14 +111,21 @@ To use a custom JavaScript asset endpoint, you can register your own route insid
 
 ```php
 Livewire::setScriptRoute(function ($handle) {
-    return Route::get('/custom/livewire/livewire.js', $handle);
+    return config('app.debug')
+        ? Route::get('/custom/livewire/livewire.js', $handle)
+        : Route::get('/custom/livewire.min.js', $handle);
 });
 ```
 
 Now, Livewire will load its JavaScript like so:
 
+- When `APP_DEBUG` is `True`
 ```blade
 <script src="/custom/livewire/livewire.js" ...
+```
+- Otherwise,
+```blade
+<script src="/custom/livewire/livewire.min.js" ...
 ```
 
 ## Manually bundling Livewire and Alpine

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -113,7 +113,7 @@ To use a custom JavaScript asset endpoint, you can register your own route insid
 Livewire::setScriptRoute(function ($handle) {
     return config('app.debug')
         ? Route::get('/custom/livewire/livewire.js', $handle)
-        : Route::get('/custom/livewire.min.js', $handle);
+        : Route::get('/custom/livewire/livewire.min.js', $handle);
 });
 ```
 


### PR DESCRIPTION
Due to [#7928](https://github.com/livewire/livewire/pull/7928), the docs should reflect the changes and be clear. 

I was thinking of using 
> [!WARNING]
> You should use `livewire.min.js` when APP_DEBUG is disabled

But that would require changing the initial wording.