### PR TITLE
Add global property lock

### DIFF
--- a/src/Attributes/Unlocked.php
+++ b/src/Attributes/Unlocked.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Livewire\Features\SupportLockedProperties\BaseUnlocked;
+
+#[\Attribute]
+class Unlocked extends BaseUnlocked
+{
+    //
+}

--- a/src/Features/SupportLockedProperties/BaseUnlocked.php
+++ b/src/Features/SupportLockedProperties/BaseUnlocked.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Livewire\Features\SupportLockedProperties;
+
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
+#[\Attribute]
+class BaseUnlocked extends LivewireAttribute
+{
+
+}

--- a/src/Features/SupportLockedProperties/SupportLockedProperties.php
+++ b/src/Features/SupportLockedProperties/SupportLockedProperties.php
@@ -14,7 +14,7 @@ class SupportLockedProperties extends ComponentHook
         if(self::$locked === false) {
             return;
         }
-
+        
         $componentIsUnlocked = $this->component
             ->getAttributes()
             ->whereInstanceOf(BaseUnlocked::class)

--- a/src/Features/SupportLockedProperties/SupportLockedProperties.php
+++ b/src/Features/SupportLockedProperties/SupportLockedProperties.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Livewire\Features\SupportLockedProperties;
+
+use Livewire\ComponentHook;
+use Livewire\Features\SupportAttributes\AttributeLevel;
+
+class SupportLockedProperties extends ComponentHook
+{
+    public static bool $locked = false;
+
+    function update($propertyName, $fullPath, $newValue)
+    {
+        if(self::$locked === false) {
+            return;
+        }
+
+        $componentIsUnlocked = $this->component
+            ->getAttributes()
+            ->whereInstanceOf(BaseUnlocked::class)
+            ->filter(fn(BaseUnlocked $attribute) => $attribute->getLevel() === AttributeLevel::ROOT)
+            ->isNotEmpty();
+
+        if($componentIsUnlocked) {
+            return;
+        }
+
+        $propertyIsUnlocked = $this->component
+            ->getAttributes()
+            ->whereInstanceOf(BaseUnlocked::class)
+            ->filter(fn(BaseUnlocked $attribute) => $attribute->getSubName() === $propertyName && $attribute->getLevel() === AttributeLevel::PROPERTY)
+            ->isNotEmpty();
+
+        throw_unless($propertyIsUnlocked, CannotUpdateLockedPropertyException::class, $propertyName);
+    }
+}

--- a/src/Features/SupportLockedProperties/UnitTest.php
+++ b/src/Features/SupportLockedProperties/UnitTest.php
@@ -9,6 +9,13 @@ use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
+    public function tearDown(): void
+    {
+        SupportLockedProperties::$locked = false;
+
+        parent::tearDown();
+    }
+
     function test_cant_update_locked_property()
     {
         $this->expectExceptionMessage(

--- a/src/Features/SupportLockedProperties/UnitTest.php
+++ b/src/Features/SupportLockedProperties/UnitTest.php
@@ -61,6 +61,46 @@ class UnitTest extends \Tests\TestCase
             ->assertSetStrict('form.foo', 'bar')
             ->assertOk();
     }
+
+    function test_cant_update_globally_locked_property()
+    {
+        $this->expectExceptionMessage(
+            'Cannot update locked property: [count]'
+        );
+
+        Livewire::lockProperties();
+
+        Livewire::test(new class extends TestComponent {
+            public $count = 1;
+
+            function increment() { $this->count++; }
+        })
+            ->assertSetStrict('count', 1)
+            ->set('count', 2);
+    }
+
+    function test_can_update_unlocked_property()
+    {
+        Livewire::lockProperties();
+
+        Livewire::test(new class extends TestComponent {
+            #[BaseUnlocked]
+            public $count = 1;
+        })
+            ->assertSetStrict('count', 1)
+            ->set('count', 2);
+    }
+
+    function test_can_update_unlocked_component()
+    {
+        Livewire::lockProperties();
+
+        Livewire::test(new #[BaseUnlocked] class extends TestComponent {
+            public $count = 1;
+        })
+            ->assertSetStrict('count', 1)
+            ->set('count', 2);
+    }
 }
 
 class SomeForm extends Form {

--- a/src/Livewire.php
+++ b/src/Livewire.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void listen($name, $callback)
  * @method static array update($snapshot, $diff, $calls)
  * @method static bool isLivewireRequest()
+ * @method static void lockProperties()
  * @method static void setUpdateRoute($callback)
  * @method static string getUpdateUri($callback)
  * @method static void setScriptRoute($callback)

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -2,6 +2,7 @@
 
 namespace Livewire;
 
+use Livewire\Features\SupportLockedProperties\SupportLockedProperties;
 use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
 use Livewire\Mechanisms\HandleComponents\HandleComponents;
@@ -114,6 +115,11 @@ class LivewireManager
     function componentHasBeenRendered()
     {
         return SupportAutoInjectedAssets::$hasRenderedAComponentThisRequest;
+    }
+
+    function lockProperties()
+    {
+        SupportLockedProperties::$locked = true;
     }
 
     function forceAssetInjection()

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Livewire;
 use Composer\InstalledVersions;
+use Hamcrest\FeatureMatcher;
 use Illuminate\Foundation\Console\AboutCommand;
 
 class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
@@ -90,6 +91,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
             Features\SupportComputed\SupportLegacyComputedPropertySyntax::class,
             Features\SupportNestingComponents\SupportNestingComponents::class,
             Features\SupportScriptsAndAssets\SupportScriptsAndAssets::class,
+            Features\SupportLockedProperties\SupportLockedProperties::class,
             Features\SupportBladeAttributes\SupportBladeAttributes::class,
             Features\SupportConsoleCommands\SupportConsoleCommands::class,
             Features\SupportPageComponents\SupportPageComponents::class,


### PR DESCRIPTION
This PR adds support for a global property lock. The idea is similar to the Laravel default where models are guarded from mass assignment. 

Especially newcomers to Livewire seem unaware that public properties can be modified using the client library and the security implications. 

**How it works**
To enable this feature, a user would add `Livewire::lockProperties();` to their `AppServiceProvider`. When enabled, a `CannotUpdateLockedPropertyException` exception will be thrown whenever a public property is attempted to be updated from the client side.

```php
class AppServiceProvider extends ServiceProvider
{
    /**
     * Register any application services.
     */
    public function register(): void
    {
        Livewire::lockProperties();
    }
}
```

A property can be unlocked on the property level:

```php
use Livewire\Attributes\Unlocked;

class Counter extends Component
{
    #[Unlocked]
    public $count = 0;
}
```

It is also possible to unlock all the properties for an entire component by adding the attribute to the root level:

```php
use Livewire\Attributes\Unlocked;

#[Unlocked]
class Counter extends Component
{
    public $count = 0;
}
```

Maybe this global lock could be enabled by default in Livewire 4 to provide the most secure setup by default. 

I'll add some docs if this PR is good to go 😄 
