### PR TITLE
Fix passing null to parse_url() deprecation error

### DIFF
--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -146,7 +146,7 @@ class BaseUrl extends LivewireAttribute
 
     public function getFromRefererUrlQueryString($url, $key, $default = null)
     {
-        $parsedUrl = parse_url($url);
+        $parsedUrl = parse_url($url ?? '');
         $query = [];
 
         if (isset($parsedUrl['query'])) {


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes. Otherwise Sentry annoys me to deprecation warning

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

This is the branch

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

Tests are not relevant to this PR

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Sentry keep warn me about this deprecation error.

```bash
> parse_url(null);

   DEPRECATED  parse_url(): Passing null to parameter #1 ($url) of type string is deprecated in /Users/stinky/Herd/lendingpot-malaysia-personaleval()'d code.

= [
    "path" => "",
  ]

> parse_url('');  
= [
    "path" => "",
  ]


```
Thanks for contributing! 🙌
