### PR TITLE
Fix facade actingAs return type docblock

### DIFF
--- a/src/Livewire.php
+++ b/src/Livewire.php
@@ -21,7 +21,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Livewire\LivewireManager withUrlParams($params)
  * @method static \Livewire\LivewireManager withQueryParams($params)
  * @method static \Livewire\Features\SupportTesting\Testable test($name, $params = [])
- * @method static \Livewire\Features\SupportTesting\Testable actingAs($user, $driver = null)
+ * @method static \Livewire\LivewireManager actingAs($user, $driver = null)
  * @method static bool isRunningServerless()
  * @method static void addPersistentMiddleware($middleware)
  * @method static void setPersistentMiddleware($middleware)


### PR DESCRIPTION
This PR fixes the return type of the `actingAs` method defined in the docblock of the `Livewire` Facade to match the signature in the `LivewireManager` [class](https://github.com/livewire/livewire/blob/main/src/LivewireManager.php#L206C14-L206C22).