### PR TITLE
Add failing test for nested dynamic properties

### DIFF
--- a/src/Features/SupportLifecycleHooks/BrowserTest.php
+++ b/src/Features/SupportLifecycleHooks/BrowserTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Livewire\Features\SupportLifecycleHooks;
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    public function test_livewire_updated_hook_with_dynamic_properties()
+    {
+        Livewire::visit(new class extends Component {
+            public array $foo = ['bar' => []];
+            public string $resultUpdatedFooBarHook = '';
+            public string $resultUpdatedHook = '';
+
+            public function updated($propertyName): void
+            {
+                $this->resultUpdatedHook = 'YAY';
+            }
+
+            public function updatedFooBar(): void
+            {
+                $this->resultUpdatedFooBarHook = 'YAY';
+            }
+
+            #[Layout('layouts.app')]
+            function render()
+            {
+                return <<<'blade'
+                    <div>
+                        @for($i=0; $i<5; $i++)
+                            <label>
+                                <input type="checkbox" wire:model.live="foo.bar" value="{{ $i }}" dusk="{{ 'checkbox_'.$i }}">
+                                {{ $i }}
+                            </label>
+                        @endfor
+                        @if(! empty($this->resultUpdatedHook))
+                            <span dusk="resultUpdatedHook">{{ $this->resultUpdatedHook }}</span>
+                        @endif
+                        @if(! empty($this->resultUpdatedFooBarHook))
+                            <span dusk="resultUpdatedFooBarHook">{{ $this->resultUpdatedFooBarHook }}</span>
+                        @endif
+                    </div>
+                blade;
+            }
+        })
+            ->waitForLivewire()->click('@checkbox_2')
+            ->assertPresent('@resultUpdatedHook')
+            ->assertPresent('@resultUpdatedFooBarHook')
+        ;
+    }
+}


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Yes, you can find the discussion here: https://github.com/livewire/livewire/discussions/8318

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes, the branch is named `failing-test-updated-hook-dynamic-nested-array`

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, the changes are only related to the failing test.

4️⃣ Does it include tests? (Required)
It is a failing test :D

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
In Livewire 2 it was possible to use Lifecycle Hooks that are a part of the nested array. For example an array property like this:
```php
public array $foo = ['bar' => []];
```
If this is now a dynamic checkbox it won't work to use `updatedFooBar` as a Lifecycle Hook. This worked in v2. Now you have to use either
```php
  public function updated($propertyName): void
  {
    if(Str::startsWith($propertyName, 'foo.bar')) {
      // do something
    }
  }
```
or you have to use a very specific Lifecycle Hook like `updatedFooBar0` etc. This is very complicated for dynamic nested arrays. . I would like to implement a fix for it but I couldn't find the implementation of the nested Lifecycle Hooks in v2, sorry for that. I didn't know where do I add this test that's why I added a new BrowserTest file in the `Livewire\Features\SupportLifecycleHooks`. I hope that is okay.

Thanks for contributing! 🙌
No problem :-D
