### PR TITLE
Fix image upload extension validation

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -168,7 +168,7 @@ class TemporaryUploadedFile extends UploadedFile
     {
         $hash = str()->random(30);
         $meta = str('-meta'.base64_encode($file->getClientOriginalName()).'-')->replace('/', '_');
-        $extension = '.'.$file->guessExtension();
+        $extension = '.'.$file->getClientOriginalExtension();
 
         return $hash.$meta.$extension;
     }

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -13,6 +13,7 @@ use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Http\UploadedFile;
 use Facades\Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl;
+use Illuminate\Http\Testing\FileFactory;
 use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
@@ -788,6 +789,20 @@ class UnitTest extends \Tests\TestCase
 
         Storage::disk('avatars')->assertExists('uploaded-avatar.png');
     }
+
+    public function test_extension_validation_cant_be_spoofed_by_manipulating_the_mime_type()
+    {
+        Storage::fake('avatars');
+
+        $file = (new \Illuminate\Http\Testing\FileFactory)->create('malicious.php', 0, 'image/png');
+
+        Livewire::test(FileExtensionValidatorComponent::class)
+            ->set('photo', $file)
+            ->call('save')
+            ->assertHasErrors('photo');
+
+        Storage::disk('avatars')->assertMissing('malicious.php');
+    }
 }
 
 class DummyMiddleware
@@ -905,6 +920,22 @@ class FileReadContentComponent extends FileUploadComponent
     public function updatedFile()
     {
         $this->content = $this->file->getContent();
+    }
+}
+
+class FileExtensionValidatorComponent extends FileUploadComponent
+{
+    use WithFileUploads;
+
+    public $photo;
+
+    public function save()
+    {
+        $this->validate([
+            'photo' => 'extensions:png',
+        ]);
+
+        $this->photo->storeAs('/', 'malicious.'.$this->photo->getClientOriginalExtension(), $disk = 'avatars');
     }
 }
 


### PR DESCRIPTION
Currently Livewire derives the extension of an uploaded file from it's MIME type.

This poses a problem for image validation, because, typically, image validation relies on two basic pillars:
1. Ensuring the mime type of the file is an image type
2. Ensuring the file extension is an image type

Currently Livewire creates an environment where you're only validating mime types and could potentially lead to a vulnerability if all of the following conditions were met:
1. You construct a stored filename based on `$file->getClientOriginalExtension()`
2. You are storing files directly on your server in a public storage disk
3. Your nginx configuration allows executing files with .php extensions that aren't index.php

To better explain, here's a potentially vulnerable Livewire component:

```php
class SomeComponent extends Component
{
    use WithFileUploads;

    #[Validate('extensions:png')]
    public $file;

    public function save()
    {
        $this->validate();

        $this->file->storeAs(
            path: 'images',
            name: $this->file->getClientOriginalName(),
            options: ['disk' => 'public'],
        );
    }
```

In this scenario, a user could upload a file called `malicious.php` with a `image/png` MIME type and execute it on your server (assuming your nginx configuration allows).

This PR fixes the vulnerability by no longer deriving the temporary file upload extension from the MIME type, but rather from the actual file extension uploaded instead.

This makes it so that `extensions:png` validation will work and catch non-PHP extension files.