### PR TITLE
Fix crc32(): Passing null deprecation

### DIFF
--- a/src/Features/SupportScriptsAndAssets/SupportScriptsAndAssets.php
+++ b/src/Features/SupportScriptsAndAssets/SupportScriptsAndAssets.php
@@ -28,7 +28,7 @@ class SupportScriptsAndAssets extends ComponentHook
         // from using load-balancers and such.
         // Therefore, we create a key based on the currently compiling view path and
         // number of already compiled directives here...
-        $viewPath = crc32(app('blade.compiler')->getPath());
+        $viewPath = crc32(app('blade.compiler')->getPath() ?? '');
 
         if (! isset(static::$countersByViewPath[$viewPath])) static::$countersByViewPath[$viewPath] = 0;
 


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes. Sentry have been warning me about this every deploy

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Just 1 change

4️⃣ Does it include tests? (Required)

Tests are not relevant for this fix

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

On every envoyer deployment, my deploy script have this command as recommended in filament documentation

```bash
php artisan filament:cache-components
```

Then Sentry will give me an alert telling me this

```php
crc32(): Passing null to parameter #1 ($string) of type string is deprecated in /home/forge/my-website/releases/20240703092217/vendor/livewire/livewire/src/Features/SupportScriptsAndAssets/SupportScriptsAndAssets.php on line 31
```

My hope is this will silence it as it appears that `app('blade.compiler')->getPath()` return null when i try it in tinker. So maybe it always return null if called as part of a console command

Here is the tinker output to show crc32('') & crc32(null) are identical. But that crc32('') don't give me those deprecation warnings & Sentry alerts

```php
> crc32(null);

   DEPRECATED  crc32(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/MyUserName/Herd/my-laravel-projecteval()'d code.

= 0

> crc32('')
= 0


```

Thanks for contributing! 🙌
