### PR TITLE
Add Package Development page to docs

### DIFF
--- a/docs/__nav.md
+++ b/docs/__nav.md
@@ -49,6 +49,7 @@ Concepts:
     Nesting: { uri: /docs/understanding-nesting, file: /understanding-nesting.md }
 Advanced:
     Troubleshooting: { uri: /docs/troubleshooting, file: /troubleshooting.md }
+    Package Development: { uri: /docs/package-dev, file: /package-development.md }
     Security: { uri: /docs/security, file: /security.md }
     JavaScript: { uri: /docs/javascript, file: /javascript.md }
     Synthesizers: { uri: /docs/synthesizers, file: /synthesizers.md }

--- a/docs/package-development.md
+++ b/docs/package-development.md
@@ -1,11 +1,12 @@
 ## Registering Custom Components
 
-You may manually register components using the `Livewire::component` method. This can be useful if you want to provide Livewire components from a composer package. Typically this should be done in the `boot` method of a service provider.
+You may manually register components using the `Livewire::component` method. This can be useful if you want to provide Livewire components from a composer package. Typically, this should be done in a service provider's `register` method.
 
 ```php
-class YourPackageServiceProvider extends ServiceProvider {
-    public function boot() {
-        Livewire::component('some-component', SomeComponent::class);
+class YourPackageServiceProvider extends \Illuminate\Support\ServiceProvider
+{
+    public function register() {
+        Livewire::component('your-component', YourComponent::class);
     }
 }
 ```
@@ -14,6 +15,6 @@ Now, applications with your package installed can consume your component in thei
 
 ```blade
 <div>
-    @livewire('some-component')
+    <livewire:your-component />
 </div>
 ```

--- a/docs/package-development.md
+++ b/docs/package-development.md
@@ -1,6 +1,6 @@
 ## Registering Custom Components
 
-You may manually register components using the Livewire::component method. This can be useful if you want to provide Livewire components from a composer package. Typically this should be done in the boot method of a service provider.
+You may manually register components using the `Livewire::component` method. This can be useful if you want to provide Livewire components from a composer package. Typically this should be done in the `boot` method of a service provider.
 
 ```php
 class YourPackageServiceProvider extends ServiceProvider {

--- a/docs/package-development.md
+++ b/docs/package-development.md
@@ -1,0 +1,19 @@
+## Registering Custom Components
+
+You may manually register components using the Livewire::component method. This can be useful if you want to provide Livewire components from a composer package. Typically this should be done in the boot method of a service provider.
+
+```php
+class YourPackageServiceProvider extends ServiceProvider {
+    public function boot() {
+        Livewire::component('some-component', SomeComponent::class);
+    }
+}
+```
+
+Now, applications with your package installed can consume your component in their views like so:
+
+```blade
+<div>
+    @livewire('some-component')
+</div>
+```


### PR DESCRIPTION
After the discussion here https://github.com/livewire/livewire/discussions/8582

Just a copy paste from earlier documentation.

Not sure these changes are sufficient to update the documentation.