### PR TITLE
Fix: Preserve error keys when merging validation errors from multiple forms

### DIFF
--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -238,6 +238,38 @@ class UnitTest extends \Tests\TestCase
         ;
     }
 
+    function test_multiple_forms_show_all_errors()
+    {
+        Livewire::test(new class extends TestComponent {
+            public PostFormValidateStub $form1;
+            public PostFormValidateStub $form2;
+
+            function save()
+            {
+                $this->validate();
+            }
+
+            function render()
+            {
+                return '<div>{{ $errors }}</div>';
+            }
+        })
+        ->assertHasNoErrors()
+        ->call('save')
+        ->assertHasErrors('form1.title')
+        ->assertHasErrors('form1.content')
+        ->assertHasErrors('form2.title')
+        ->assertHasErrors('form2.content')
+        ->assertSee('The title field is required')
+        ->assertSee('The content field is required')
+        ->set('form1.title', 'Valid Title 1')
+        ->set('form1.content', 'Valid Content 1')
+        ->set('form2.title', 'Valid Title 2')
+        ->set('form2.content', 'Valid Content 2')
+        ->call('save')
+        ->assertHasNoErrors();
+    }
+
     function test_can_validate_a_form_object_using_rule_attribute_with_custom_name()
     {
         Livewire::test(new class extends TestComponent {
@@ -257,6 +289,7 @@ class UnitTest extends \Tests\TestCase
             ->call('save')
         ;
     }
+    
     public function test_validation_errors_persist_across_validation_errors()
     {
         $component = Livewire::test(new class extends Component {

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -12,6 +12,7 @@ use Illuminate\Validation\ValidationException;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\ViewErrorBag;
 use Livewire\Form;
 
@@ -309,7 +310,9 @@ trait HandlesValidation
         // If main validation passed, go through other sub-validation exceptions
         // and throw the first one with the cumulative messages...
         foreach ($formExceptions as $e) {
-            $e->validator->errors()->merge($cumulativeErrors->unique());
+            $exceptionErrorKeys = $e->validator->errors()->keys();
+            $remainingErrors = Arr::except($cumulativeErrors->messages(), $exceptionErrorKeys);
+            $e->validator->errors()->merge($remainingErrors);
 
             throw $e;
         }


### PR DESCRIPTION
Hi there! 👋

I'm excited to contribute to this project. I've found and fixed a small but important bug related to handling validation errors in multiple forms.

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
No.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes, the branch is named fix/preserve-error-keys-multiple-forms

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, the changes are only related to my feature.

4️⃣ Does it include tests? (Required)
Yes (added one test)

**What I discovered:**
- When multiple forms throw validation errors, the current error merging process isn't working as intended.
- The unique() function called on the error bag was removing the keys, making it impossible to map errors back to their inputs.

**What I did to fix it:**
1. Modified the code to check which errors come from the current form.
2. Now it only merges the remaining errors from other forms.
3. This solves the issue of errors appearing twice in the exception without removing the crucial keys.
4. Added a new unit test to ensure this behavior stays consistent.

I hope this helps improve the project! Let me know if you'd like me to explain anything further or make any changes.

Thanks for considering my contribution! 😊