### PR TITLE
Bug Fix - QueryString- is Converted to Scientific Notation

### DIFF
--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -62,7 +62,7 @@ class BaseUrl extends LivewireAttribute
 
         $decoded = is_array($initialValue)
             ? json_decode(json_encode($initialValue), true)
-            : json_decode($initialValue, true);
+            : (json_validate($initialValue) ? $initialValue : json_decode($initialValue, true));
 
         // If only part of an array is present in the query string,
         // we want to merge instead of override the value...

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -60,9 +60,13 @@ class BaseUrl extends LivewireAttribute
 
         if ($initialValue === $nonExistentValue) return;
 
+        // If is an array, then json decode it
+        // If not an array json validate it to check for valid json
+        //   If valid json - json decode it
+        //   Else html_decode and urldecode it
         $decoded = is_array($initialValue)
             ? json_decode(json_encode($initialValue), true)
-            : (json_validate($initialValue) ? urldecode($initialValue) : json_decode($initialValue, true));
+            : (json_validate($initialValue) ? html_entity_decode(urldecode($initialValue)) : json_decode($initialValue, true));
 
         // If only part of an array is present in the query string,
         // we want to merge instead of override the value...

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -62,7 +62,7 @@ class BaseUrl extends LivewireAttribute
 
         $decoded = is_array($initialValue)
             ? json_decode(json_encode($initialValue), true)
-            : (json_validate($initialValue) ? $initialValue : json_decode($initialValue, true));
+            : (json_validate($initialValue) ? urldecode($initialValue) : json_decode($initialValue, true));
 
         // If only part of an array is present in the query string,
         // we want to merge instead of override the value...


### PR DESCRIPTION
QueryString is being incorrectly converted to Scientific Notation where it detects scientific notation syntax.  This can be impactful if you don't intend it as Scientific Notation

I've included an example component below.

If you set search to
13E7
Then refresh the page (so it uses the query string to populate)
It will convert to "130000000"

If you set search to 
12E33
Then refresh the page (so it uses the query string to populate)
It converts to "1.2E+34"

It's an interesting one in terms of when to/not to fix.

The simplest solution I found was to only decode valid json.  It does mean that any URL params that **are** scientific notation won't be converted, but I'd assume that fewer people need the automatic conversion vs don't need it.

```
use Livewire\Attributes\Url;

class TestComponent extends \Livewire\Component
{
    #[Url] 
    public string $search = '';

    public function mount()
    {

    }
    
    public function render()
    {
        return \Illuminate\Support\Facades\Blade::render(
            '<div><input type="text" wire:model.live="search" class="text-black" /></div>',
            deleteCachedView: true
        );
        
    }
}
```

The included fix appears to remediate the issue, as if the value is not an array, it validates that it is valid json before either returning the value, or a json_decoded value.

**However - I have not done sufficient testing to make myself confident of the fix!**

