### PR TITLE
Swallow error during test

### DIFF
--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -11,7 +11,7 @@ class FileUploadConfiguration
     {
         if (app()->runningUnitTests()) {
             // We want to "fake" the first time in a test run, but not again because
-            // ::fake() whipes the storage directory every time its called.
+            // ::fake() wipes the storage directory every time its called.
             rescue(function () {
                 // If the storage disk is not found (meaning it's the first time),
                 // this will throw an error and trip the second callback.

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -9,20 +9,22 @@ class FileUploadConfiguration
 {
     public static function storage()
     {
+        $disk = static::disk();
+
         if (app()->runningUnitTests()) {
             // We want to "fake" the first time in a test run, but not again because
             // Storage::fake() wipes the storage directory every time its called.
             rescue(
                 // If the storage disk is not found (meaning it's the first time),
                 // this will throw an error and trip the second callback.
-                fn() => Storage::disk(static::disk()),
-                fn() => Storage::fake(static::disk()),
+                fn() => Storage::disk($disk),
+                fn() => Storage::fake($disk),
                 // swallows the error that is thrown on the frist try
                 report: false
             );
         }
 
-        return Storage::disk(static::disk());
+        return Storage::disk($disk);
     }
 
     public static function disk()

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -19,7 +19,7 @@ class FileUploadConfiguration
                 // this will throw an error and trip the second callback.
                 fn() => Storage::disk($disk),
                 fn() => Storage::fake($disk),
-                // swallows the error that is thrown on the frist try
+                // swallows the error that is thrown on the first try
                 report: false
             );
         }

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -18,7 +18,8 @@ class FileUploadConfiguration
                 return Storage::disk(static::disk());
             }, function () {
                 return Storage::fake(static::disk());
-            });
+            },
+            false);
         }
 
         return Storage::disk(static::disk());

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -11,15 +11,15 @@ class FileUploadConfiguration
     {
         if (app()->runningUnitTests()) {
             // We want to "fake" the first time in a test run, but not again because
-            // ::fake() wipes the storage directory every time its called.
-            rescue(function () {
+            // Storage::fake() wipes the storage directory every time its called.
+            rescue(
                 // If the storage disk is not found (meaning it's the first time),
                 // this will throw an error and trip the second callback.
-                return Storage::disk(static::disk());
-            }, function () {
-                return Storage::fake(static::disk());
-            },
-            false);
+                fn() => Storage::disk(static::disk()),
+                fn() => Storage::fake(static::disk()),
+                // swallows the error that is thrown on the frist try
+                report: false
+            );
         }
 
         return Storage::disk(static::disk());


### PR DESCRIPTION
When faking `tmp-for-tests` a error is thrown that is handled but also bubbles up and leads to "ugly" output

```bash
[2024-07-17 13:08:13] testing.ERROR: Disk [tmp-for-tests] does not have a configured driver. {"exception":"[object] (InvalidArgumentException(code: 0): Disk [tmp-for-tests] does not have a configured driver. at /home/adrian/code/bauservices/vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemManager.php:137)
[stacktrace]
...
```

This happens in a edgy-edge case when you have to call this in you test
```php
FileUploadConfiguration::storage();
TemporaryUploadedFile::createFromLivewire(...)
```

i've separated all refactoring steps into atomic commits:
* actual fix
* fixed a typo
* used arrow functions (available sind PHP 7.4)
* extracted disk to a variable (was called 3 times)