### PR TITLE
Show which error caused s3 setup cleanup command to fail

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
@@ -58,6 +58,7 @@ class S3CleanupCommand extends Command
             ]);
         } catch (\Exception $e) {
             $this->error('Failed to configure S3 bucket ['.$bucket.'] to automatically cleanup files older than 24hrs!');
+            $this->error($e->getMessage());
 
             return;
         }

--- a/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
@@ -58,7 +58,7 @@ class S3CleanupCommand extends Command
             ]);
         } catch (\Exception $e) {
             $this->error('Failed to configure S3 bucket ['.$bucket.'] to automatically cleanup files older than 24hrs!');
-            $this->error($e->getMessage()); 
+            $this->error($e->getMessage());
 
             return;
         }

--- a/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
@@ -58,7 +58,7 @@ class S3CleanupCommand extends Command
             ]);
         } catch (\Exception $e) {
             $this->error('Failed to configure S3 bucket ['.$bucket.'] to automatically cleanup files older than 24hrs!');
-            $this->error($e->getMessage());
+            $this->error($e->getMessage()); 
 
             return;
         }


### PR DESCRIPTION
This adds the exception message to the output when setting up s3 cleanup fails.