### PR TITLE
fix: file upload indicator

### DIFF
--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -77,6 +77,8 @@ function whenTargetsArePartOfRequest(component, targets, inverted, [ startLoadin
 
         startLoading()
 
+        if (payload.calls?.[0]?.method === '_startUpload') return
+
         respond(() => {
             endLoading()
         })


### PR DESCRIPTION
The file upload loading indicator was being disabled right after the sign url request gets responded.
So, i have added a check to not disable loading if the response call equals to _startUpload in whenTargetsArePartOfRequest FN

``
function whenTargetsArePartOfRequest(component, targets, inverted, [ startLoading, endLoading ]) {
    return on('commit', ({ component: iComponent, commit: payload, respond }) => {
        if (iComponent !== component) return

        if (targets.length > 0 && containsTargets(payload, targets) === inverted) return

        startLoading()

        if (payload.calls?.[0]?.method === '_startUpload') return      // this is the extra check

        respond(() => {
            endLoading()
        })
    })
}
``

It's a fix for this discussion https://github.com/livewire/livewire/discussions/6814