### PR TITLE
[V2] Fix fingerprint errors when testing

### DIFF
--- a/src/Testing/TestableLivewire.php
+++ b/src/Testing/TestableLivewire.php
@@ -83,7 +83,7 @@ class TestableLivewire
 
         $this->lastResponse = $this->pretendWereMountingAComponentOnAPage($name, $params, $queryParams);
 
-        if (! $this->lastResponse->exception) {
+        if (! $this->lastResponse->exception && !empty($this->rawMountedResponse)) {
             $this->updateComponent([
                 'fingerprint' => $this->rawMountedResponse->fingerprint,
                 'serverMemo' => $this->rawMountedResponse->memo,
@@ -203,6 +203,9 @@ class TestableLivewire
 
     public function id()
     {
+        if (!array_key_exists('fingerprint', $this->payload)) {
+            return null;
+        }
         return $this->payload['fingerprint']['id'];
     }
 


### PR DESCRIPTION

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

We use an call to $this->authorize() in every boot method to control access to our livewire resources. This has the unfortunate side effect of breaking testing wherever the call fails, due to how to TestableLivewire handles the fingerprint.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

See attached

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

One change only

4️⃣ Does it include tests? (Required)

Not currently. Please advise what is required beyond existing TestableLivewire tests

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

TestableLivewire makes a mock request to a dummy page with the component mounted on it. This call ignores Exceptions, which should mean that it bypasses access tests in the boot hook, however it still tracks those Exceptions and doesn't set the Fingerprint if one is found. This prevents us from making subsequent calls to the component (e.g via call() or set()), which should throw an AuthorizationException(), but since the fingerprint is missing it fails on an internal error.

This PR fixes the issue with the fingerprint.

Thanks for contributing! 🙌
