### PR TITLE
Fix legacy model synth not allowing a property to be set to boolean

### DIFF
--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -62,8 +62,8 @@ class EloquentModelSynth extends Synth
 
     public function hydrate($data, $meta, $hydrateChild)
     {
-        if ($data === '' || $data === null) return null;
-        
+        if (! is_iterable($data)) return null;
+
         if (isset($meta['__child_from_parent'])) {
             $model = $meta['__child_from_parent'];
 

--- a/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeBoundDirectlyUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelAttributesCanBeBoundDirectlyUnitTest.php
@@ -94,6 +94,15 @@ class ModelAttributesCanBeBoundDirectlyUnitTest extends \Tests\TestCase
             ->set('model', null)
             ->assertSuccessful();
     }
+
+    public function test_an_eloquent_model_property_can_be_set_to_boolean()
+    {
+        $model = ModelForAttributeBinding::create(['id' => 1, 'title' => 'foo']);
+
+        Livewire::test(ComponentWithModelProperty::class, ['model' => $model])
+            ->set('model', false)
+            ->assertSuccessful();
+    }
 }
 
 class ModelForAttributeBinding extends Model


### PR DESCRIPTION
Improving the https://github.com/livewire/livewire/pull/8343 

### Scenario
If you are storing an Eloquent model in a public property when using legacy model binding, sometimes you may need to set the property to a boolean value from the front end which triggers Livewire's update process.

Problem
Currently, when Livewire updates the property with a boolean value, the following error occurs:


> foreach() argument must be of type array|object, bool given


The issue is that the hydrate method of the SupportLegacyModels/EloquentModelSynth is receiving the boolean value as the $data prop, and when it tries to loop through the $data prop, it is throwing the error.

### Solution
**Why This Is Happening**
Livewire runs the hydrate method on a synth for a public property when it is restoring a snapshot, but it also calls the hydrate method on a synth for a public property when it is updating a property.

**Here is the relevant code snippet:**

```
// livewire/src/Mechanisms/HandleComponents/HandleComponents.php

protected function updateProperties($component, $updates, $data, $context)
{
    $finishes = [];

    foreach ($updates as $path => $value) {
        $value = $this->hydrateForUpdate($data, $path, $value, $context);

        // We only want to run "updated" hooks after all properties have
        // been updated so that each individual hook has the ability
        // to overwrite the updated states of other properties...
        $finishes[] = $this->updateProperty($component, $path, $value, $context);
    }
}
```

**Solution 1**
Change the synth system to not run if the value is set to a boolean.

Pros:

The synths then don't all need to have a boolean or empty string check.
Cons:

It's possible that a synth may need to know about a boolean value, so this option moves the control out of the synths.

**Solution 2**
Update the condition to check if the data is iterable.

Pros:

Simple and doesn't change the underlying synth loading system.
Makes the check more flexible and applicable to other non-iterable types like boolean, null, and empty string.
Cons:

This bug could be run into again in the future with other synths if they don't also implement an iterable check.
Implementation
I've gone with solution 2 in this PR and updated the legacy model synth's hydrate method to check if the data is iterable.

Here is the updated code in EloquentModelSynth:

```
// Before
if ($data === '' || $data === null) return null;

// After
if (!is_iterable($data)) return null;
```

### Conclusion
This change ensures that the synths handle boolean values correctly, in addition to null and empty string values. It aligns with the overall design of the synths while making the hydrate method more robust and consistent with other synths.