### PR TITLE
[v3.x] - Urlencode the filename in the Response Content Disposition header

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -104,7 +104,7 @@ class TemporaryUploadedFile extends UploadedFile
             return $this->storage->temporaryUrl(
                 $this->path,
                 now()->addDay()->endOfHour(),
-                ['ResponseContentDisposition' => 'attachment; filename="' . $this->getClientOriginalName() . '"']
+                ['ResponseContentDisposition' => 'attachment; filename="' . urlencode($this->getClientOriginalName()) . '"']
             );
         }
 


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
This resolves a bug when passing a filename to S3 in the response-content-disposition header when the filename includes non ISO-8859-1 characters.

Discussion with repo to replicate the issue: https://github.com/livewire/livewire/discussions/8694

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

One single change.

4️⃣ Does it include tests? (Required)

No, as the ResponseContentDisposition header is only set during the temporaryUrl call and is bypassed during testing. So there is no way to write a test to validate this.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Discussion contains the full description and steps to replicate using a provided repo.
https://github.com/livewire/livewire/discussions/8694