### PR TITLE
Docs: Typo Fixes

### DIFF
--- a/docs/how-livewire-works.md
+++ b/docs/how-livewire-works.md
@@ -142,7 +142,7 @@ function updateComponent(el, component, action) {
 ```php
 Route::post('/livewire/update', function () {
     $snapshot = request('snapshot');
-    $calls = requets('calls');
+    $calls = request('calls');
 
     $component = Livewire::fromSnapshot($snapshot);
 

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -398,7 +398,7 @@ let snapshot = {
     },
 
     // A securely encrypted hash of this snapshot. This way,
-    // if a malicous user tampers with the snapshot with
+    // if a malicious user tampers with the snapshot with
     // the goal of accessing un-owned resources on the server,
     // the checksum validation will fail and an error will
     // be thrown...

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -12,7 +12,7 @@ Here's a list of all the available component lifecycle hooks:
 | `rendering()`    | Called before `render()` is called                                              |
 | `rendered()`     | Called after `render()` is called                                               |
 | `dehydrate()`    | Called at the end of every component request                                    |
-| `exception($e, $stopProgation)` | Called when an exception is thrown                     |                    |
+| `exception($e, $stopPropagation)` | Called when an exception is thrown                     |                    |
 
 ## Mount
 

--- a/docs/wire-model.md
+++ b/docs/wire-model.md
@@ -250,7 +250,7 @@ Here's an example of two selects, one for states, one for cities. When the state
 </select>
 ```
 
-Again, the only thing non-standard here is the `wire:key` that has been added to the second select. This ensures that when the state changes, the "selectedCity" value will be reset propertly.
+Again, the only thing non-standard here is the `wire:key` that has been added to the second select. This ensures that when the state changes, the "selectedCity" value will be reset properly.
 
 ### Multi-select dropdowns
 

--- a/docs/wire-transition.md
+++ b/docs/wire-transition.md
@@ -38,7 +38,7 @@ Because `wire:transition` has been added to the `<div>` containing the post's co
 Currently, `wire:transition` is only supported on a single element inside a Blade conditional like `@if`. It will not work as expected when used in a list of sibling elements. For example, the following will NOT work properly:
 
 ```blade
-<!-- Warning: The following is code that will not work propertly -->
+<!-- Warning: The following is code that will not work properly -->
 <ul>
     @foreach ($post->comments as $comment)
         <li wire:transition wire:key="{{ $comment->id }}">{{ $comment->content }}</li>
@@ -50,7 +50,7 @@ If one of the above comment `<li>` elements were to get removed, you would expec
 
 ## Default transition style
 
-By default, Livewire applies both an opacity and a scale CSS transition to elements with `wire:transtion`. Here's a visual preview:
+By default, Livewire applies both an opacity and a scale CSS transition to elements with `wire:transition`. Here's a visual preview:
 
 <div x-data="{ show: false }" x-cloak class="border border-gray-700 rounded-xl p-6 w-full flex justify-between">
     <a href="#" x-on:click.prevent="show = ! show" class="py-2.5 outline-none">


### PR DESCRIPTION

This fixes a handful of typos, a couple that are examples that people are likely to copy/paste, and wonder why it doesn't work


Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
It's a documentation typo fix.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
N/A - it's documentation

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

There are approx 5 docs files with typo errors, some benign, some that are examples of how to do something, which may lead to frustration for newcomers.

Thanks for contributing! 🙌
