### PR TITLE
Docs: Add documentation for volt modelable properties

### DIFF
--- a/docs/volt.md
+++ b/docs/volt.md
@@ -322,6 +322,16 @@ To achieve this using Volt, you may chain the `reactive` method on the state you
 state(['todos'])->reactive();
 ```
 
+### Modelable properties
+
+In cases where you don't want to make use of reactive properties, Livewire provides a [modelable feature](/docs/nesting#binding-to-child-data-using-wiremodel) where you may share state between parent component and child component using `wire:model` directly on a child component.
+
+To achieve this using Volt, simply chain the `modelable` method on the state you wish to be modelable:
+
+```php
+state(['form'])->modelable();
+```
+
 ### Computed properties
 
 Livewire also allows you to define [computed properties](/docs/computed-properties), which can be useful for lazily fetching information needed by your component. Computed property results are "memoized", or cached in memory, for an individual Livewire request lifecycle.


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
It's needed in volt documentation

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
No. It's a documentation

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Under Volt section, there is a documentation for reactive and locked properties but no documentation for modelable properties. This documentation provides the documentation on how to make a state property a modelable property from the volt functional api.

Thanks for contributing! 🙌
