### PR TITLE
Fixed dispatch the `saved` event

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -100,7 +100,7 @@ Instead of passing `$refresh`, you can pass any method you normally would to som
 <livewire:edit-post @saved="close">
 ```
 
-If the child dispatched parameters along with the request, for example `$this->dispatch('close', postId: 1)`, you can forward those values to the parent method using the following syntax:
+If the child dispatched parameters along with the request, for example `$this->dispatch('saved', postId: 1)`, you can forward those values to the parent method using the following syntax:
 
 ```blade
 <livewire:edit-post @saved="close($event.detail.postId)">


### PR DESCRIPTION
In this example we fire a save event.

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first? 
No. No.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed) 
Yes, the branch is named `fix-dispatch-the-saved-event`.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, the changes are only related to my fix.

4️⃣ Does it include tests? (Required)
No.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
The child component dispatches a `saved` event instead of the parent's `close` method what should be called to the event.

Thanks for contributing! 🙌
