### PR TITLE
Made file-upload- and -preview-urls configurable

### DIFF
--- a/src/Features/SupportFileUploads/SupportFileUploads.php
+++ b/src/Features/SupportFileUploads/SupportFileUploads.php
@@ -31,10 +31,10 @@ class SupportFileUploads extends ComponentHook
             }
         });
 
-        Route::post('/livewire/upload-file', [FileUploadController::class, 'handle'])
+        Route::post(config('livewire.upload_file_uri','/livewire/upload-file' ), [FileUploadController::class, 'handle'])
             ->name('livewire.upload-file');
 
-        Route::get('/livewire/preview-file/{filename}', [FilePreviewController::class, 'handle'])
+        Route::get(config('livewire.preview_file_uri','/livewire/preview-file/{filename}' ), [FilePreviewController::class, 'handle'])
             ->name('livewire.preview-file');
     }
 }


### PR DESCRIPTION

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Configurable Upload URLs seem to be wanted/needed by others, see [https://github.com/livewire/livewire/pull/6803](https://github.com/livewire/livewire/pull/6803)

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
No

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

I have Laravel running under a subfolder and thus need to be able to customize my file upload and preview paths. So I just changed the hard-coded url paths to values fetched from config/livewire.php. I gave the formerly used fixed values as defaults, so if nothing is set in the config file, it will still work as expected.


