### PR TITLE
Docs: Remove commit prop from commit.prepare hook

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -552,7 +552,7 @@ These hooks expose `commit` objects. You can learn more about their schema by re
 The `commit.prepare` hook will be triggered immediately before a request is sent to the server. This gives you a chance to add any last minute updates or actions to the outgoing request:
 
 ```js
-Livewire.hook('commit.prepare', ({ component, commit }) => {
+Livewire.hook('commit.prepare', ({ component }) => {
     // Runs before commit payloads are collected and sent to the server...
 })
 ```


### PR DESCRIPTION
I've been reviewing the documentation for a feature I’m working on and needed to retrieve details from the commit property using `Livewire.hook('request.commit', ({ component, commit }) => {...})`. However, I noticed that commit is always undefined. After checking the code, this behavior makes sense.

As a result, I've decided to update the documentation to reflect this, at least until the core team decides whether to reintroduce the commit property in the hook callback in the future and to update to docs accordingly.

For anyone still looking to access commit details, you can use `Livewire.hook('commit', ({ component, commit, respond, succeed, fail }) => {...})` as an alternative.