### PR TITLE
Promote protected validation methods in docs

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -443,7 +443,7 @@ class PostForm extends Form
 
     public $content = '';
 
-    public function rules()
+    protected function rules()
     {
         return [
             'title' => [
@@ -490,7 +490,7 @@ class PostForm extends Form
 
     public $content = '';
 
-    public function rules()
+    protected function rules()
     {
         return [
             'title' => [

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -301,7 +301,7 @@ class CreatePost extends Component
 
     public $content = '';
 
-    public function rules()
+    protected function rules()
     {
         return [
             'title' => 'required|min:5',
@@ -400,7 +400,7 @@ class CreatePost extends Component
 
     public $content = '';
 
-    public function rules() // [tl! highlight:6]
+    protected function rules() // [tl! highlight:6]
     {
         return [
             'title' => Rule::exists('posts', 'title'),
@@ -408,7 +408,7 @@ class CreatePost extends Component
         ];
     }
 
-    public function messages() // [tl! highlight:6]
+    protected function messages() // [tl! highlight:6]
     {
         return [
             'content.required' => 'The :attribute are missing.',
@@ -416,7 +416,7 @@ class CreatePost extends Component
         ];
     }
 
-    public function validationAttributes() // [tl! highlight:6]
+    protected function validationAttributes() // [tl! highlight:6]
     {
         return [
             'content' => 'description',
@@ -468,7 +468,7 @@ class UpdatePost extends Form
 
     public $content = '';
 
-    public function rules()
+    protected function rules()
     {
         return [
             'title' => [


### PR DESCRIPTION
When the `rules()` method has public visibility, users can freely retrieve them. Simply typing `Livewire.first().call('rules')` in the console extracts the exact validation rules used by the component. This can leak valuable information and removes security through obscurity. I don't think this is expected behaviour as calling other public Livewire methods, like `mount()` or `reset()`, have been disabled.

That's why I propose promoting protected visibility for `rules()` (and related functions `messages()` and `validationAttributes()`). There is an alternative and that is to treat these methods differently from others and to prohibit calling these methods from the front-end similar to the previously mentioned lifecycle/internal methods. However, I do not know if the current behaviour is necessary for a valid use case somewhere.