### PR TITLE
Added quotation marks to Dispatching events from Blade template Documentation

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -319,7 +319,7 @@ class CreatePost extends Component
 You can dispatch events directly from your Blade templates using the `$dispatch` JavaScript function. This is useful when you want to trigger an event from a user interaction, such as a button click:
 
 ```blade
-<button wire:click="$dispatch('show-post-modal', { id: {{ $post->id }} })">
+<button wire:click="$dispatch('show-post-modal', '{ id: {{ $post->id }}' })">
     EditPost
 </button>
 ```

--- a/docs/events.md
+++ b/docs/events.md
@@ -319,7 +319,7 @@ class CreatePost extends Component
 You can dispatch events directly from your Blade templates using the `$dispatch` JavaScript function. This is useful when you want to trigger an event from a user interaction, such as a button click:
 
 ```blade
-<button wire:click="$dispatch('show-post-modal', '{ id: {{ $post->id }}' })">
+<button wire:click="$dispatch('show-post-modal', { id: '{{ $post->id }}' })">
     EditPost
 </button>
 ```

--- a/docs/events.md
+++ b/docs/events.md
@@ -329,7 +329,7 @@ In this example, when the button is clicked, the `show-post-modal` event will be
 If you want to dispatch an event directly to another component you can use the `$dispatchTo()` JavaScript function:
 
 ```blade
-<button wire:click="$dispatchTo('posts', 'show-post-modal', { id: {{ $post->id }} })">
+<button wire:click="$dispatchTo('posts', 'show-post-modal', { id: '{{ $post->id }}' })">
     EditPost
 </button>
 ```


### PR DESCRIPTION
Added Quotation marks so the dispatch works with Uuids

Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Its needed if you follow the current docs it won`t work with Uuids

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
No

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
No

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
I added Quotation marks in the Code Snippet of the Documentation for Dispatching events from Blade template. So the dispatch will work if you are using a uuid

Thanks for contributing! 🙌
