### PR TITLE
Enhance Redirect Handling with Navigate Methods

### DIFF
--- a/src/Features/SupportRedirects/HandlesRedirects.php
+++ b/src/Features/SupportRedirects/HandlesRedirects.php
@@ -33,4 +33,26 @@ trait HandlesRedirects
     {
         $this->redirect(action($name, $parameters, $absolute), $navigate);
     }
+
+    public function navigateTo($name, $parameters = [], $absolute = true, $navigate = true)
+    {
+        $this->redirect(action($name, $parameters, $absolute), $navigate);
+    }
+
+    public function navigateRoute($name, $parameters = [], $absolute = true, $navigate = true)
+    {
+        $this->redirect(route($name, $parameters, $absolute), $navigate);
+    }
+
+    public function navigateIntended($default = '/', $navigate = true)
+    {
+        $url = session()->pull('url.intended', $default);
+    
+        $this->redirect($url, $navigate);
+    }
+
+    public function navigateAction($name, $parameters = [], $absolute = true, $navigate = true)
+    {
+        $this->redirect(action($name, $parameters, $absolute), $navigate);
+    }
 }


### PR DESCRIPTION
#### Overview
This pull request introduces a more robust approach to managing redirects within Livewire components by implementing dedicated `navigate` methods. These methods eliminate the need to explicitly pass the `navigate` parameter when performing common redirect operations, thereby simplifying the codebase and reducing the likelihood of errors.

#### Key Changes

- **New Navigate Methods**: 
  - `navigateTo`
  - `navigateRoute`
  - `navigateIntended`
  - `navigateAction`

These methods are now available to handle redirects where the `navigate` flag is always `true`. This allows for cleaner and more intuitive method calls.

#### Example Usage

Before:
```php
$this->redirect('url', navigate: true);
```

After:
```php
$this->navigateTo('url');
```

This change ensures that developers can use a more straightforward syntax without worrying about passing the `navigate` parameter manually.

#### Code Implementation

The new methods leverage the existing `redirect` method but default the `navigate` parameter to `true`, thereby ensuring consistent behaviour across the application.

```php
public function navigateTo($name, $parameters = [], $absolute = true)
{
    $this->redirect(action($name, $parameters, $absolute), true);
}

public function navigateRoute($name, $parameters = [], $absolute = true)
{
    $this->redirect(route($name, $parameters, $absolute), true);
}

public function navigateIntended($default = '/')
{
    $url = session()->pull('url.intended', $default);
    $this->redirect($url, true);
}

public function navigateAction($name, $parameters = [], $absolute = true)
{
    $this->redirect(action($name, $parameters, $absolute), true);
}
```

This PR aims to make redirect management more intuitive and reduce boilerplate code.