### PR TITLE
Add description for dispatching dynamic events

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -59,7 +59,23 @@ As you can see, additional data sent with the event will be provided to the acti
 
 Occasionally, you may want to dynamically generate event listener names at run-time using data from your component.
 
-For example, if you wanted to scope an event listener to a specific Eloquent model, you could append the model's ID to the event name like so:
+For example, if you wanted to scope an event listener to a specific Eloquent model, you could append the model's ID to the event name when dispatching like so:
+
+```php
+use Livewire\Component;
+
+class UpdatePost extends Component
+{
+    public function update()
+    {
+        // ...
+
+        $this->dispatch("post-updated.{$post->id}"); // [tl! highlight]
+    }
+}
+```
+
+And then listen for that specific model:
 
 ```php
 use Livewire\Component;


### PR DESCRIPTION
Just added a bit of extra documentation around dispatching the dynamic event since I found myself searching for it for a couple of minutes. Seemed nice to have it in the documentation close to the listener example.