### PR TITLE
Correction getUpdateUri method parameter prompt

### DIFF
--- a/src/Livewire.php
+++ b/src/Livewire.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static array update($snapshot, $diff, $calls)
  * @method static bool isLivewireRequest()
  * @method static void setUpdateRoute($callback)
- * @method static string getUpdateUri($callback)
+ * @method static string getUpdateUri()
  * @method static void setScriptRoute($callback)
  * @method static void useScriptTagAttributes($attributes)
  * @method static \Livewire\LivewireManager withUrlParams($params)


### PR DESCRIPTION
When using this method, the editor will have an error message underlined, although this will not cause the program to report an error, the visual sense is not good.

![image](https://github.com/user-attachments/assets/a98306f8-83e0-4c7e-9eec-7c39873a36aa)
