### PR TITLE
Add Methods for Component Attribute Assertion in Testing

### DIFF
--- a/src/Features/SupportAttributes/TestsAttributes.php
+++ b/src/Features/SupportAttributes/TestsAttributes.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportAttributes;
 
 use Illuminate\Support\Collection;
+use Livewire\Attributes\Computed;
 use Livewire\Attributes\Lazy;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Session;
@@ -132,6 +133,7 @@ trait TestsAttributes
             Title::class => ['content'],
             Session::class => ['key'],
             Lazy::class => ['isolate'],
+            Computed::class => ['persist', 'cache', 'seconds', 'key', 'tags'],
         ];
 
         if (!isset($attributeComparisons[$attribute])) {

--- a/src/Features/SupportAttributes/TestsAttributes.php
+++ b/src/Features/SupportAttributes/TestsAttributes.php
@@ -143,8 +143,7 @@ trait TestsAttributes
         $fields = $attributeComparisons[$attribute];
 
         if (is_array($value)) {
-            $isAssociative = !array_is_list($value);
-            if (!$isAssociative) {
+            if (array_is_list($value)) {
                 $assigned = false;
                 foreach ($fields as $field) {
                     $actualValue = $this->getAttributeValue($item, $field);

--- a/src/Features/SupportAttributes/TestsAttributes.php
+++ b/src/Features/SupportAttributes/TestsAttributes.php
@@ -155,13 +155,13 @@ trait TestsAttributes
                     }
                 }
                 if (!$assigned) {
-                    PHPUnit::fail("Unable to assign flat array to any field of attribute {$attribute}.");
+                    return false;
                 }
             }
         } else if (count($fields) === 1) {
             $value = [$fields[0] => $value];
         } else {
-            PHPUnit::fail("Expected value for attribute {$attribute} must be an associative array with keys: " . implode(', ', $fields) . ".");
+            return false;
         }
 
         foreach ($value as $key => $expectedValue) {
@@ -179,7 +179,7 @@ trait TestsAttributes
                     return false;
                 }
             } else {
-                PHPUnit::fail("Attribute {$attribute} does not have a field named '{$key}'.");
+                return false;
             }
         }
 

--- a/src/Features/SupportAttributes/TestsAttributes.php
+++ b/src/Features/SupportAttributes/TestsAttributes.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Livewire\Features\SupportAttributes;
+
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Lazy;
+use Livewire\Attributes\On;
+use Livewire\Attributes\Session;
+use Livewire\Attributes\Title;
+use Livewire\Attributes\Validate;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+trait TestsAttributes
+{
+
+    public function assertComponentHasAttribute(string $attribute, string|array|null $value = null): self
+    {
+        $attributes = $this->getAttributes();
+
+        PHPUnit::assertTrue(
+            $attributes->contains(fn($item) => $item instanceof $attribute),
+            "Attribute {$attribute} does not exist on or within the component."
+        );
+
+        $this->checkValue(
+            $value,
+            $attributes->filter(fn($item) => $item instanceof $attribute),
+            $attribute
+        );
+
+        return $this;
+    }
+
+    public function assertClassHasAttribute(string $attribute, string|array|null $value = null): self
+    {
+        $attributes = $this->getAttributes();
+
+        $rootAttributes = $attributes->filter(fn($item) => $item->getLevel() === AttributeLevel::ROOT);
+
+        PHPUnit::assertTrue(
+            $rootAttributes->contains(fn($item) => $item instanceof $attribute),
+            "Attribute {$attribute} does not exist on the class root level of the component."
+        );
+
+        $this->checkValue($value, $rootAttributes, $attribute);
+
+        return $this;
+    }
+
+    public function assertMethodHasAttribute(string $methodName, string $attribute, string|array|null $value = null): self
+    {
+        $attributes = $this->getAttributes();
+
+        if (!method_exists($this->instance(), $methodName)) {
+            PHPUnit::fail("Method {$methodName} does not exist on the component.");
+        }
+
+        $methodAttributes = $attributes->filter(fn($item) => $item->getLevel() === AttributeLevel::METHOD && $item->getSubName() === $methodName
+        );
+
+        PHPUnit::assertTrue(
+            $methodAttributes->contains(fn($item) => $item instanceof $attribute),
+            "Attribute {$attribute} does not exist on or within the method."
+        );
+
+        $this->checkValue($value, $methodAttributes, $attribute);
+
+        return $this;
+    }
+
+    public function assertPropertyHasAttribute(string $propertyName, string $attribute, string|array|null $value = null): self
+    {
+        $attributes = $this->getAttributes();
+
+        if (!property_exists($this->instance(), $propertyName)) {
+            PHPUnit::fail("Property {$propertyName} does not exist on the component.");
+        }
+
+        $propertyAttributes = $attributes->filter(fn($item) => $item->getLevel() === AttributeLevel::PROPERTY && $item->getSubName() === $propertyName
+        );
+
+        PHPUnit::assertTrue(
+            $propertyAttributes->contains(fn($item) => $item instanceof $attribute),
+            "Attribute {$attribute} does not exist on or within the property."
+        );
+
+        $this->checkValue($value, $propertyAttributes, $attribute);
+
+        return $this;
+    }
+
+    private function getAttributes(): AttributeCollection
+    {
+        $attributes = $this->invade()->getAttributes();
+
+        if ($attributes->isEmpty()) {
+            PHPUnit::fail("No attributes exist on or within the component.");
+        }
+
+        return $attributes;
+    }
+
+    private function checkValue($value, $items, $attribute): void
+    {
+        if ($value !== null) {
+            $result = false;
+
+            if ($items instanceof Collection) {
+                foreach ($items as $item) {
+                    if ($this->attributeMatchesValue($value, $item, $attribute)) {
+                        $result = true;
+                        break;
+                    }
+                }
+            } else {
+                $result = $this->attributeMatchesValue($value, $items, $attribute);
+            }
+
+            PHPUnit::assertTrue($result, "Attribute {$attribute} does not contain the expected value.");
+        }
+    }
+
+    private function attributeMatchesValue($value, $item, $attribute): bool
+    {
+        if (!$item instanceof $attribute) {
+            return false;
+        }
+
+        $attributeComparisons = [
+            On::class => ['event'],
+            Validate::class => ['rule', 'as', 'message'],
+            Title::class => ['content'],
+            Session::class => ['key'],
+            Lazy::class => ['isolate'],
+        ];
+
+        if (!isset($attributeComparisons[$attribute])) {
+            PHPUnit::fail("Attribute {$attribute} is not supported for comparison.");
+        }
+
+        $fields = $attributeComparisons[$attribute];
+
+        if (is_array($value)) {
+            $isAssociative = !array_is_list($value);
+            if (!$isAssociative) {
+                $assigned = false;
+                foreach ($fields as $field) {
+                    $actualValue = $this->getAttributeValue($item, $field);
+                    if (is_array($actualValue)) {
+                        $value = [$field => $value];
+                        $assigned = true;
+                        break;
+                    }
+                }
+                if (!$assigned) {
+                    PHPUnit::fail("Unable to assign flat array to any field of attribute {$attribute}.");
+                }
+            }
+        } else if (count($fields) === 1) {
+            $value = [$fields[0] => $value];
+        } else {
+            PHPUnit::fail("Expected value for attribute {$attribute} must be an associative array with keys: " . implode(', ', $fields) . ".");
+        }
+
+        foreach ($value as $key => $expectedValue) {
+            if (in_array($key, $fields, true)) {
+                $actualValue = $this->getAttributeValue($item, $key);
+
+                if (is_array($expectedValue) && is_array($actualValue)) {
+                     sort($expectedValue);
+                     sort($actualValue);
+
+                    if ($expectedValue !== $actualValue) {
+                        return false;
+                    }
+                } else if ($actualValue !== $expectedValue) {
+                    return false;
+                }
+            } else {
+                PHPUnit::fail("Attribute {$attribute} does not have a field named '{$key}'.");
+            }
+        }
+
+        return true;
+    }
+
+    private function getAttributeValue($item, $key)
+    {
+        $methodName = 'get' . ucfirst($key);
+        if (method_exists($item, $methodName)) {
+            return $item->$methodName();
+        }
+
+        if (method_exists($item, $key)) {
+            return $item->$key();
+        }
+
+        if (property_exists($item, $key)) {
+            return $item->$key;
+        }
+
+        PHPUnit::fail("Unable to access field '{$key}' on attribute " . get_class($item) . ".");
+    }
+
+}

--- a/src/Features/SupportAttributes/UnitTest.php
+++ b/src/Features/SupportAttributes/UnitTest.php
@@ -80,7 +80,16 @@ class UnitTest extends \Tests\TestCase
         Livewire::test(NewComponent::class)
             ->assertMethodHasAttribute('jsMethod', Js::class)
             ->assertMethodHasAttribute('doubleFoo', On::class, 'fooEvent')
-            ->assertMethodHasAttribute('barMethod', On::class, ['barEvent', 'bazEvent']);
+            ->assertMethodHasAttribute('barMethod', On::class, ['barEvent', 'bazEvent'])
+            ->assertMethodHasAttribute('fooToThePowerOfTwo', Computed::class, [
+                'persist' => true,
+                'seconds' => 7200,
+            ])
+            ->assertMethodHasAttribute('anotherComputedProperty', Computed::class, [
+                'cache' => true,
+                'key' => 'homepage-posts',
+                'tags' => ['posts', 'homepage'],
+            ]);
     }
 
     public function test_component_has_property_level_attribute()
@@ -133,12 +142,26 @@ class NewComponent extends TestComponent {
     }
 
     #[On(['barEvent', 'bazEvent'])]
-    public function barMethod() {
+    public function barMethod(): string
+    {
         return 'bar';
     }
 
+    #[Computed(persist: true, seconds: 7200)]
+    public function fooToThePowerOfTwo(): int
+    {
+        return $this->foo ** 2;
+    }
+
+    #[Computed(cache: true, key: 'homepage-posts', tags: ['posts', 'homepage'])]
+    public function anotherComputedProperty(): string
+    {
+        return 'cached value';
+    }
+
     #[On('fooEvent')]
-    public function doubleFoo() {
+    public function doubleFoo(): int
+    {
         return $this->foo * 2;
     }
 }

--- a/src/Features/SupportAttributes/UnitTest.php
+++ b/src/Features/SupportAttributes/UnitTest.php
@@ -65,7 +65,8 @@ class UnitTest extends \Tests\TestCase
         Livewire::test(NewComponent::class)
                 ->assertComponentHasAttribute(Title::class, 'Class Level Attribute')
                 ->assertComponentHasAttribute(Validate::class, ['required', 'integer'])
-                ->assertComponentHasAttribute(On::class, 'fooEvent');
+                ->assertComponentHasAttribute(On::class, 'fooEvent')
+            ->assertComponentHasAttribute(Modelable::class);
     }
 
     public function test_component_has_class_level_attribute_with_value()
@@ -95,6 +96,9 @@ class UnitTest extends \Tests\TestCase
     public function test_component_has_property_level_attribute()
     {
         Livewire::test(NewComponent::class)
+            ->assertPropertyHasAttribute('fizz', Reactive::class)
+            ->assertPropertyHasAttribute('count2', Locked::class)
+            ->assertPropertyHasAttribute('count2', LifecycleHookAttribute::class)
             ->assertPropertyHasAttribute('bar', Session::class, ['key' => 'foo'])
             ->assertPropertyHasAttribute('foo', Validate::class, ['required', 'integer']);
     }
@@ -119,8 +123,16 @@ class UnitTest extends \Tests\TestCase
 #[Title('Class Level Attribute')]
 class NewComponent extends TestComponent {
 
+    #[Modelable]
     #[Validate(['required', 'integer'])]
     public ?int $foo = null;
+
+    #[Reactive]
+    public string $fizz = 'buzz';
+
+    #[Locked]
+    #[LifecycleHookAttribute]
+    public int $count2 = 0;
 
     #[Validate('required', as: 'date of birth')]
     #[Session(key: 'foo')]
@@ -164,29 +176,6 @@ class NewComponent extends TestComponent {
     {
         return $this->foo * 2;
     }
-}
-
-class HasAllAttributes extends TestComponent {
-
-    #[Validate('required')]
-    public $content = '';
-
-    #[Locked]
-    public $foo = 'bar';
-
-    #[Computed]
-    public function getFoo() {
-        return $this->foo;
-    }
-
-    #[Reactive]
-    public $bar = 'foo';
-
-    #[Modelable]
-    public $baz = 'baz';
-
-    #[LifecycleHookAttribute]
-    public $count2 = 0;
 }
 
 #[\Attribute]

--- a/src/Features/SupportAttributes/UnitTest.php
+++ b/src/Features/SupportAttributes/UnitTest.php
@@ -2,6 +2,17 @@
 
 namespace Livewire\Features\SupportAttributes;
 
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Isolate;
+use Livewire\Attributes\Js;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Modelable;
+use Livewire\Attributes\On;
+use Livewire\Attributes\Reactive;
+use Livewire\Attributes\Session;
+use Livewire\Attributes\Title;
+use Livewire\Attributes\Validate;
+use Livewire\Attributes\Lazy;
 use Livewire\Livewire;
 use Tests\TestComponent;
 
@@ -48,6 +59,111 @@ class UnitTest extends \Tests\TestCase
         })
             ->assertSetStrict('count', 0);
     }
+
+    public function test_component_has_attribute()
+    {
+        Livewire::test(NewComponent::class)
+                ->assertComponentHasAttribute(Title::class, 'Class Level Attribute')
+                ->assertComponentHasAttribute(Validate::class, ['required', 'integer'])
+                ->assertComponentHasAttribute(On::class, 'fooEvent');
+    }
+
+    public function test_component_has_class_level_attribute_with_value()
+    {
+        Livewire::test(NewComponent::class)
+            ->assertClassHasAttribute(Lazy::class, ['isolate' => false])
+            ->assertClassHasAttribute(Title::class, 'Class Level Attribute');
+    }
+
+    public function test_component_has_method_level_attribute()
+    {
+        Livewire::test(NewComponent::class)
+            ->assertMethodHasAttribute('jsMethod', Js::class)
+            ->assertMethodHasAttribute('doubleFoo', On::class, 'fooEvent')
+            ->assertMethodHasAttribute('barMethod', On::class, ['barEvent', 'bazEvent']);
+    }
+
+    public function test_component_has_property_level_attribute()
+    {
+        Livewire::test(NewComponent::class)
+            ->assertPropertyHasAttribute('bar', Session::class, ['key' => 'foo'])
+            ->assertPropertyHasAttribute('foo', Validate::class, ['required', 'integer']);
+    }
+
+    public function test_component_has_property_with_multiple_attributes()
+    {
+        Livewire::test(NewComponent::class)
+            ->assertPropertyHasAttribute('bar', Validate::class, [
+                'rule' => 'required',
+                'as' => 'date of birth',
+            ])
+            ->assertPropertyHasAttribute('baz', Validate::class, [
+                'rule' => 'required',
+                'message' => 'This is a custom message',
+            ])
+            ->assertPropertyHasAttribute('baz', Isolate::class);
+    }
+
+}
+
+#[Lazy(isolate: false)]
+#[Title('Class Level Attribute')]
+class NewComponent extends TestComponent {
+
+    #[Validate(['required', 'integer'])]
+    public ?int $foo = null;
+
+    #[Validate('required', as: 'date of birth')]
+    #[Session(key: 'foo')]
+    public string $bar = 'bar';
+
+    #[Validate('required', message: 'This is a custom message')]
+    #[Validate('integer', message: 'Why is this not an integer?')]
+    #[Isolate]
+    public $baz = 'baz';
+
+    #[Js]
+    public function jsMethod()
+    {
+        return <<<'JS'
+            $wire.on('fooEvent', () => {
+                console.log('fooEvent');
+            });
+        JS;
+    }
+
+    #[On(['barEvent', 'bazEvent'])]
+    public function barMethod() {
+        return 'bar';
+    }
+
+    #[On('fooEvent')]
+    public function doubleFoo() {
+        return $this->foo * 2;
+    }
+}
+
+class HasAllAttributes extends TestComponent {
+
+    #[Validate('required')]
+    public $content = '';
+
+    #[Locked]
+    public $foo = 'bar';
+
+    #[Computed]
+    public function getFoo() {
+        return $this->foo;
+    }
+
+    #[Reactive]
+    public $bar = 'foo';
+
+    #[Modelable]
+    public $baz = 'baz';
+
+    #[LifecycleHookAttribute]
+    public $count2 = 0;
 }
 
 #[\Attribute]

--- a/src/Features/SupportSession/BaseSession.php
+++ b/src/Features/SupportSession/BaseSession.php
@@ -42,7 +42,7 @@ class BaseSession extends LivewireAttribute
         Session::put($this->key(), $this->getValue());
     }
 
-    protected function key()
+    public function key()
     {
         if (! $this->key) {
             return (string) 'lw' . crc32($this->component->getName() . $this->getName());

--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportTesting;
 
+use Livewire\Features\SupportAttributes\TestsAttributes;
 use Livewire\Features\SupportFileDownloads\TestsFileDownloads;
 use Livewire\Features\SupportValidation\TestsValidation;
 use Livewire\Features\SupportRedirects\TestsRedirects;
@@ -17,6 +18,7 @@ class Testable
         TestsEvents,
         TestsRedirects,
         TestsValidation,
+        TestsAttributes,
         TestsFileDownloads;
 
     use Macroable { Macroable::__call as macroCall; }

--- a/src/Features/SupportValidation/BaseValidate.php
+++ b/src/Features/SupportValidation/BaseValidate.php
@@ -13,8 +13,8 @@ class BaseValidate extends LivewireAttribute
     function __construct(
         public $rule = null,
         protected $attribute = null,
-        protected $as = null,
-        protected $message = null,
+        public $as = null,
+        public $message = null,
         protected $onUpdate = true,
         protected bool $translate = true
     ) {}


### PR DESCRIPTION
This PR introduces the TestsAttributes trait, which provides a set of assertion methods to test the presence and values of attributes on Livewire components, including class-level, method-level, and property-level attributes.

It enhances the testing capabilities of Livewire by allowing developers to assert that specific attributes are present and have expected values, rather than traditionally having to use invade and loop through the values to assert the presence of the attributes. I believe it will really enhance component testing.

Methods that are being added by this PR:
- **Component Level (present anywhere in the component)**: assertComponentHasAttribute(string $attribute, string|array|null $value = null)
- **Class Level:** assertClassHasAttribute(string $attribute, string|array|null $value = null)
- **Method Level:** assertMethodHasAttribute(string $methodName, string $attribute, string|array|null $value = null)
- **Property Level:** assertPropertyHasAttribute(string $propertyName, string $attribute, string|array|null $value = null)

As the attributes can have a variety of strings, arrays & named properties placed within them, the logic in this PR is designed to handle all these edge cases in the new private method on the trait: attributeMatchesValue.

Note: the visibility on a couple of the Attribute properties have been changed to public in order to facilitate this to work.

Tests have been added to assert:
- Asserting attributes at different levels.
- Testing attributes with simple values, array values, and multiple fields.
- Handling multiple attributes of the same type on a single property or method.

The tests within the PR are the best example of how the code can be used, but I will place them here too:
```php
public function test_component_has_attribute()
{
    Livewire::test(NewComponent::class)
        ->assertComponentHasAttribute(Title::class, 'Class Level Attribute')
        ->assertComponentHasAttribute(Validate::class, ['required', 'integer'])
        ->assertComponentHasAttribute(On::class, 'fooEvent');
}

public function test_component_has_class_level_attribute_with_value()
{
    Livewire::test(NewComponent::class)
        ->assertClassHasAttribute(Lazy::class, ['isolate' => false])
        ->assertClassHasAttribute(Title::class, 'Class Level Attribute');
}

public function test_component_has_method_level_attribute()
{
    Livewire::test(NewComponent::class)
        ->assertMethodHasAttribute('jsMethod', Js::class)
        ->assertMethodHasAttribute('doubleFoo', On::class, 'fooEvent')
        ->assertMethodHasAttribute('barMethod', On::class, ['barEvent', 'bazEvent']);
}

public function test_component_has_property_level_attribute()
{
    Livewire::test(NewComponent::class)
        ->assertPropertyHasAttribute('bar', Session::class, ['key' => 'foo'])
        ->assertPropertyHasAttribute('foo', Validate::class, ['required', 'integer']);
}

public function test_component_has_property_with_multiple_attributes()
{
    Livewire::test(NewComponent::class)
        ->assertPropertyHasAttribute('bar', Validate::class, [
            'rule' => 'required',
            'as' => 'date of birth',
        ])
        ->assertPropertyHasAttribute('baz', Validate::class, [
            'rule' => 'required',
            'message' => 'This is a custom message',
        ])
        ->assertPropertyHasAttribute('baz', Isolate::class);
}
```

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Yes, often I write manual tests using invade to assert the presence of attributes on & in a component class. No I didn't create a discussion first.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
See above.