### PR TITLE
feat: Add support for dispatching Jobs from dispatch method

### DIFF
--- a/src/Features/SupportEvents/HandlesEvents.php
+++ b/src/Features/SupportEvents/HandlesEvents.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportEvents;
 
 use function Livewire\store;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 trait HandlesEvents
 {
@@ -14,6 +15,10 @@ trait HandlesEvents
 
     public function dispatch($event, ...$params)
     {
+        if(method_exists($event, 'dispatch')) {
+            return $event->dispatch();
+        }
+
         $event = new Event($event, $params);
 
         store($this)->push('dispatched', $event);

--- a/src/Features/SupportEvents/HandlesEvents.php
+++ b/src/Features/SupportEvents/HandlesEvents.php
@@ -3,7 +3,6 @@
 namespace Livewire\Features\SupportEvents;
 
 use function Livewire\store;
-use Illuminate\Contracts\Queue\ShouldQueue;
 
 trait HandlesEvents
 {

--- a/src/Features/SupportEvents/UnitTest.php
+++ b/src/Features/SupportEvents/UnitTest.php
@@ -232,6 +232,7 @@ class UnitTest extends \Tests\TestCase
     public function test_dispatch_method_accepts_jobs()
     {
         Bus::fake();
+        
         $component = Livewire::test(new class extends TestComponent {
             public function dispatchFoo()
             {


### PR DESCRIPTION
**1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?**
This is something that I needed due to a conflict upgrading from Livewire v2.5 to Livewire v3. When upgrading, I had many components that used the `DispatchesJobs` trait. When Livewire v3 introduced the `dispatch` method, this created a conflict because `$this->dispatch` was being used to dispatch jobs and not events. A discussion thread has not been created yet.

**2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)**
Yes. The branch is called `support-dispatching-jobs-with-dispatch-method`

**3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.**
The PR introduces a potential change to the `dispatch` method and a unit test.

**4️⃣ Does it include tests? (Required)**
Yes. There is a single unit test added. More testing should be added before merging, but I'm assuming that this PR will receive feedback with a better implementation approach, and 

**5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.**
I don't necessarily think that the approach in this PR is the best way to handle this and this definitely needs more testing before being accepted. The issue I experienced was a conflict with upgrading v2 components that used the `DispatchesJobs` trait. While I understand that using this trait in Livewire may not be common practice, it added to the complexity of upgrading Livewire. Additionally, to me, the `dispatch` method in v3 can be confusing when Events, Jobs, and Browser events are all using the same method name. I understand that this is what was decided in this discussion thread and I do not think that this change should be reversed. However, one way that the intended simplicity could be maintained would be to support multiple object types in the `dispatch` method, which is what I'm intending to introduce in this PR. 

Thank you 🌱 