### PR TITLE
[Docs] Fix typo in `javascript.md`

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -587,7 +587,7 @@ Livewire.hook('commit', ({ component, commit, respond, succeed, fail }) => {
 If you would like to instead hook into the entire HTTP request going and returning from the server, you can do so using the `request` hook:
 
 ```js
-Livewire.hook('request', ({ uri, options, payload, respond, succeed, fail }) => {
+Livewire.hook('request', ({ url, options, payload, respond, succeed, fail }) => {
     // Runs after commit payloads are compiled, but before a network request is sent...
 
     respond(({ status, response }) => {


### PR DESCRIPTION
It's `url` instead of `uri`:

https://github.com/livewire/livewire/blob/ce1ce71b39a3492b98f7d2f2a4583f1b163fe6ae/js/request/index.js#L72-L79