### PR TITLE
Pagination - Fixed three dot dark style

### DIFF
--- a/src/Features/SupportPagination/views/tailwind.blade.php
+++ b/src/Features/SupportPagination/views/tailwind.blade.php
@@ -78,7 +78,7 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                             {{-- "Three Dots" Separator --}}
                             @if (is_string($element))
                                 <span aria-disabled="true">
-                                    <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600 dark:bg-gray-800 dark:border-gray-600">{{ $element }}</span>
+                                    <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 cursor-default leading-5 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300">{{ $element }}</span>
                                 </span>
                             @endif
 


### PR DESCRIPTION
Removed duplicate tailwind dark model classes on the three-dot element and added the missing text colour