### PR TITLE
Support laravel/prompts v0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "league/mime-type-detection": "^1.9",
     "symfony/console": "^6.0|^7.0",
     "symfony/http-kernel": "^6.2|^7.0",
-    "laravel/prompts": "^0.1.24|^0.2"
+    "laravel/prompts": "^0.1.24|^0.2|^0.3"
   },
   "require-dev": {
     "psy/psysh": "^0.11.22|^0.12",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "league/mime-type-detection": "^1.9",
     "symfony/console": "^6.0|^7.0",
     "symfony/http-kernel": "^6.2|^7.0",
-    "laravel/prompts": "^0.1.24"
+    "laravel/prompts": "^0.1.24|^0.2"
   },
   "require-dev": {
     "psy/psysh": "^0.11.22|^0.12",


### PR DESCRIPTION
Laravel v11.24.0 added support laravel/prompts v0.2 (https://github.com/laravel/framework/pull/52849). This PR ensures Livewire also supports that version, as currently you can not install the latest version of livewire when you are using the latest version of Laravel (unless you downgrade the version of laravel/prompts installed by laravel)