### PR TITLE
display:contents for persist wrapper

### DIFF
--- a/src/Features/SupportNavigate/SupportNavigate.php
+++ b/src/Features/SupportNavigate/SupportNavigate.php
@@ -11,7 +11,7 @@ class SupportNavigate extends ComponentHook
     static function provide()
     {
         Blade::directive('persist', function ($expression) {
-            return '<?php app("livewire")->forceAssetInjection(); ?><div x-persist="<?php echo e('.$expression.'); ?>">';
+            return '<?php app("livewire")->forceAssetInjection(); ?><div x-persist="<?php echo e('.$expression.'); ?>" style="display: contents">';
         });
 
         Blade::directive('endpersist', function ($expression) {

--- a/src/Features/SupportNavigate/SupportNavigate.php
+++ b/src/Features/SupportNavigate/SupportNavigate.php
@@ -11,7 +11,7 @@ class SupportNavigate extends ComponentHook
     static function provide()
     {
         Blade::directive('persist', function ($expression) {
-            return '<?php app("livewire")->forceAssetInjection(); ?><div x-persist="<?php echo e('.$expression.'); ?>" style="display: contents">';
+            return '<?php app("livewire")->forceAssetInjection(); ?><div x-persist="<?php echo e('.$expression.'); ?>">';
         });
 
         Blade::directive('endpersist', function ($expression) {

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -125,6 +125,10 @@ class FrontendAssets extends Mechanism
             [x-cloak] {
                 display: none !important;
             }
+
+            [x-persist] {
+                display: contents;
+            }
         </style>
         HTML;
 


### PR DESCRIPTION
The `persist` directive adds a wrapper `div` around the code you want to persist, and this could create different issues specially with styling, since you have a wrapper which you can't control.

For example if you want to persist a `sticky` audio player, you won't be able to put the `sticky` style inside your component and you will have to wrap the whole `@persist()` directive inside a `sticky` wrapper because `sticky` is only sticky inside its parent. So, if you put the style inside a component it will do nothing since the parent is only wrapping your player.

What `display: contents` does is it makes css ignore your parent in terms of styling even though you still have the same js functionality. This way you can style the contents as if the parent doesn't exist.

Another example is if you have `flex` or something else on the actual parent (not the parent injected by persist). The `flex` will be broken by the wrapper, and won't work for the contents of the persisted code. With `display: contents` it does.

Hopefully this is a small change with big benefits.