### PR TITLE
allow to define a different middleware for file upload controller, th…

### DIFF
--- a/src/Features/SupportFileUploads/FileUploadController.php
+++ b/src/Features/SupportFileUploads/FileUploadController.php
@@ -8,10 +8,12 @@ use Illuminate\Support\Facades\Validator;
 
 class FileUploadController implements HasMiddleware
 {
+    public static array $middleware = ['web'];
+
     public static function middleware()
     {
         return array_map(fn ($middleware) => new Middleware($middleware), array_merge(
-            ['web'],
+            [static::$middleware],
             (array) FileUploadConfiguration::middleware(),
         ));
     }


### PR DESCRIPTION
Allow to define a different middleware for FileUploadController the same as you can do for FilePreviewController.  
In a multi-tenant setup I don't have the `web` middleware and at the moment I'm getting an error when I upload a file.
We should be able to overwrite `web` middleware to something else.

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
No. I checked the other PRs and how this can be fixed,

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
No

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
This is so file uploads work if we don't have `web` middleware defined, usually in a multi tenant setup.
By having the `$middleware` defined statically on the controller, we would be able to overwrite it in a service provider: 
```
FileUploadController::$middleware = ['tenant', ...];
```

Thanks!