### PR TITLE
Fix php deprecation warning in BaseUrl class

### DIFF
--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -62,7 +62,7 @@ class BaseUrl extends LivewireAttribute
 
         $decoded = is_array($initialValue)
             ? json_decode(json_encode($initialValue), true)
-            : json_decode($initialValue, true);
+            : json_decode($initialValue ?? '', true);
 
         // If only part of an array is present in the query string,
         // we want to merge instead of override the value...


### PR DESCRIPTION
When the BaseUrl-class json-decodes `null` then that causes a deprecation warning:
```
json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in /var/web/vd27736/releases/20240919140700/vendor/livewire/livewire/src/Features/SupportQueryString/BaseUrl.php on line 65
```

This PR fixes that by using an empty string if `$initialValue` is `null`. Json-decoding an empty string still results in `null`, so it does not change the behavior.