### PR TITLE
Handle null in dataGet helper to prevent TypeError

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -84,9 +84,7 @@ export function dataGet(object, key) {
     if (key === '') return object
 
     return key.split('.').reduce((carry, i) => {
-        if (carry === undefined) return undefined
-
-        return carry[i]
+        return carry?.[i]
     }, object)
 }
 


### PR DESCRIPTION
Hello, 
I have found myself using `$wire.$get('someObject.nested.property')` and when setting `someObject` to `null` I had a javascript error because the helper only handle `undefined`.
<img width="641" alt="image" src="https://github.com/user-attachments/assets/5f421490-1606-4710-a94d-84a4c03e7d58">

Also I could have worked around this issue if there was a $set API counterpart for deleting nested properties such as `$wire.$delete` (will set to undefined) but since it is not available, it would help me here.

I know I am not providing any repro nor tests but hopefully this is a very simple and not controversial change that does not require spending much time on it 🤞 

Thanks