### PR TITLE
Fix bug in reset() when using nested dot notation or wildcard

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -57,7 +57,7 @@ trait InteractsWithProperties
             // Check if the property contains a dot which means it is actually on a nested object like a FormObject
             if (str($property)->contains('.')) {
                 $propertyName = $property->afterLast('.');
-                $objectName = $property->beforeLast('.');
+                $objectName = $property->before('.');
 
                 if (method_exists($this->{$objectName}, 'reset')) {
                     $this->{$objectName}->reset($propertyName);

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -66,6 +66,22 @@ class UnitTest extends \Tests\TestCase
             ->assertSetStrict('form.content', 'bar')
         ;
     }
+    function test_can_reset_form_object_handle_dot_notation_with_asterisk_wildcard()
+    {
+        Livewire::test(new class extends TestComponent {
+            public PostFormStubWithArrayDefaults $form;
+
+            public function resetForm()
+            {
+                $this->reset([
+                    'form.content.*',
+                ]);
+            }
+        })
+            ->assertSetStrict('form.content', [1 => true, 2 => false])
+            ->call('resetForm')
+        ;
+    }
 
     function test_set_form_object_with_typed_nullable_properties()
     {
@@ -289,7 +305,7 @@ class UnitTest extends \Tests\TestCase
             ->call('save')
         ;
     }
-    
+
     public function test_validation_errors_persist_across_validation_errors()
     {
         $component = Livewire::test(new class extends Component {
@@ -810,6 +826,16 @@ class PostFormStubWithDefaults extends Form
     public $title = 'foo';
 
     public $content = 'bar';
+}
+
+class PostFormStubWithArrayDefaults extends Form
+{
+    public $title = 'foo';
+
+    public $content = [
+        1 => true,
+        2 => false,
+    ];
 }
 
 class PostFormWithTypedProperties extends Form

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -78,7 +78,24 @@ class UnitTest extends \Tests\TestCase
                 ]);
             }
         })
-            ->assertSetStrict('form.content', [1 => true, 2 => false])
+            ->assertSetStrict('form.content', [1 => true, 2 => false, 'foo' => ['bar' => 'baz']])
+            ->call('resetForm')
+        ;
+    }
+
+    function test_can_reset_form_object_handle_nested_dot_notation()
+    {
+        Livewire::test(new class extends TestComponent {
+            public PostFormStubWithArrayDefaults $form;
+
+            public function resetForm()
+            {
+                $this->reset([
+                    'form.content.foo',
+                ]);
+            }
+        })
+            ->assertSetStrict('form.content', [1 => true, 2 => false, 'foo' => ['bar' => 'baz']])
             ->call('resetForm')
         ;
     }
@@ -835,6 +852,7 @@ class PostFormStubWithArrayDefaults extends Form
     public $content = [
         1 => true,
         2 => false,
+        'foo' => ['bar' => 'baz'],
     ];
 }
 


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Yes, you can find the discussion here https://github.com/livewire/livewire/discussions/8785 and related discussion here https://github.com/livewire/livewire/pull/8464
2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
4️⃣ Does it include tests? (Required)
Yes
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

After updating to Livewire v3.5 our code stopped working. I've traced it back to #8464 
After submitting a form we want to reset some input fields, where the recipients field are checkboxes.
```
 $this->reset([
    'title',
    'description',
    'recipients.*',
    'body',
);
```
It chokes on `'recipients.*',`  giving us  `method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given` This would work before updating v3.5

It would also throw an error when using nested dot notation like
```
 $this->reset(['title.bar.baz']);
```