### PR TITLE
Only merge the web middleware for file uploads when it is absent

### DIFF
--- a/src/Features/SupportFileUploads/FileUploadController.php
+++ b/src/Features/SupportFileUploads/FileUploadController.php
@@ -10,10 +10,13 @@ class FileUploadController implements HasMiddleware
 {
     public static function middleware()
     {
-        return array_map(fn ($middleware) => new Middleware($middleware), array_merge(
-            ['web'],
-            (array) FileUploadConfiguration::middleware(),
-        ));
+        $middleware = (array) FileUploadConfiguration::middleware();
+
+        if (! in_array('web', $middleware)) {
+            $middleware = array_merge(['web'], $middleware);
+        }
+
+        return array_map(fn ($middleware) => new Middleware($middleware), $middleware);
     }
 
     public function handle()

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Http\UploadedFile;
 use Facades\Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl;
 use Illuminate\Http\Testing\FileFactory;
+use Illuminate\Support\Arr;
 use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
@@ -802,6 +803,24 @@ class UnitTest extends \Tests\TestCase
             ->assertHasErrors('photo');
 
         Storage::disk('avatars')->assertMissing('malicious.php');
+    }
+
+    public function test_the_file_upload_controller_middleware_prepends_the_web_group()
+    {
+        config()->set('livewire.temporary_file_upload.middleware', ['throttle:60,1']);
+
+        $middleware = Arr::pluck(FileUploadController::middleware(), 'middleware');
+
+        $this->assertEquals(['web', 'throttle:60,1'], $middleware);
+    }
+
+    public function test_the_file_upload_controller_middleware_only_adds_the_web_group_if_absent()
+    {
+        config()->set('livewire.temporary_file_upload.middleware', ['throttle:60,1', 'web']);
+
+        $middleware = Arr::pluck(FileUploadController::middleware(), 'middleware');
+
+        $this->assertEquals(['throttle:60,1', 'web'], $middleware);
     }
 }
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

The project that I'm working on requires some middleware to run before the `web` group. Currently, that is not possible as the `web` group will always be prepended.

I have not created a discussion for this matter.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

Yes, I've included two test cases:
- The `web` group will be prepended in the middleware.
- The `web` group will only be added if it is absent.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Currently, the `web` group middleware will always be prepended in the `FileUploadController`. It's not possible to change the order. Middleware that has to be run before the `web` group can't be configured.

I've changed this logic so it will only prepend the `web` group if it's absent. This way, the `web` middleware can be added in the list at the desired position.

```php
'temporary_file_upload' => [
    'middleware' => [
        'custom',
        'web',
    ],
],
```

Without this change, the `web` group would be run twice with the configuration above.