### PR TITLE
Customize the file upload middleware

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -64,10 +64,11 @@ return [
     */
 
     'temporary_file_upload' => [
-        'disk' => null,        // Example: 'local', 's3'              | Default: 'default'
-        'rules' => null,       // Example: ['file', 'mimes:png,jpg']  | Default: ['required', 'file', 'max:12288'] (12MB)
-        'directory' => null,   // Example: 'tmp'                      | Default: 'livewire-tmp'
-        'middleware' => null,  // Example: 'throttle:5,1'             | Default: 'throttle:60,1'
+        'disk' => null,                // Example: 'local', 's3'              | Default: 'default'
+        'rules' => null,               // Example: ['file', 'mimes:png,jpg']  | Default: ['required', 'file', 'max:12288'] (12MB)
+        'directory' => null,           // Example: 'tmp'                      | Default: 'livewire-tmp'
+        'middleware' => null,          // Example: 'throttle:5,1'             | Default: 'throttle:60,1'
+        'default_middleware' => null,  // Example: 'web'                      | Default: 'web'
         'preview_mimes' => [   // Supported file types for temporary pre-signed file URLs...
             'png', 'gif', 'bmp', 'svg', 'wav', 'mp4',
             'mov', 'avi', 'wmv', 'mp3', 'm4a',

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -102,7 +102,7 @@ class FileUploadConfiguration
     public static function middleware()
     {
         $middleware = config('livewire.temporary_file_upload.middleware') ?: 'throttle:60,1';
-        $default = config('livewire.temporary_file_upload.default_middleware') ?: 'web';
+        $default = config('livewire.temporary_file_upload.default_middleware') ?? 'web';
 
         return array_merge((array) $default, (array) $middleware);
     }

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -101,7 +101,10 @@ class FileUploadConfiguration
 
     public static function middleware()
     {
-        return config('livewire.temporary_file_upload.middleware') ?: 'throttle:60,1';
+        $middleware = config('livewire.temporary_file_upload.middleware') ?: 'throttle:60,1';
+        $default = config('livewire.temporary_file_upload.default_middleware') ?: 'web';
+
+        return array_merge((array) $default, (array) $middleware);
     }
 
     public static function shouldCleanupOldUploads()

--- a/src/Features/SupportFileUploads/FileUploadController.php
+++ b/src/Features/SupportFileUploads/FileUploadController.php
@@ -10,10 +10,7 @@ class FileUploadController implements HasMiddleware
 {
     public static function middleware()
     {
-        return array_map(fn ($middleware) => new Middleware($middleware), array_merge(
-            ['web'],
-            (array) FileUploadConfiguration::middleware(),
-        ));
+        return array_map(fn ($middleware) => new Middleware($middleware), FileUploadConfiguration::middleware());
     }
 
     public function handle()

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -822,6 +822,17 @@ class UnitTest extends \Tests\TestCase
             FileUploadConfiguration::middleware()
         );
     }
+
+    public function test_the_file_upload_configuration_default_middleware_can_be_removed()
+    {
+        config()->set('livewire.temporary_file_upload.middleware', 'middleware');
+        config()->set('livewire.temporary_file_upload.default_middleware', []);
+
+        $this->assertEquals(
+            ['middleware'],
+            FileUploadConfiguration::middleware()
+        );
+    }
 }
 
 class DummyMiddleware

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -803,6 +803,25 @@ class UnitTest extends \Tests\TestCase
 
         Storage::disk('avatars')->assertMissing('malicious.php');
     }
+
+    public function test_the_file_upload_configuration_has_middleware()
+    {
+        $this->assertEquals(
+            ['web', 'throttle:60,1'],
+            FileUploadConfiguration::middleware()
+        );
+    }
+
+    public function test_the_file_upload_configuration_middleware_can_be_customized()
+    {
+        config()->set('livewire.temporary_file_upload.middleware', 'middleware');
+        config()->set('livewire.temporary_file_upload.default_middleware', 'default_middleware');
+
+        $this->assertEquals(
+            ['default_middleware', 'middleware'],
+            FileUploadConfiguration::middleware()
+        );
+    }
 }
 
 class DummyMiddleware


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

The project that I'm working on requires some middleware to run before the `web` group. Currently, that is not possible as the `web` group will always be prepended. Some projects may not have the `web` group at all. Having the ability to configure this would be preferable.

I have not created a discussion for this matter.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

Yes, I've included three test cases:
- The file upload configuration has default middleware, including the `web` group.
- The default and normal middleware can be configured.
- The default middleware can be removed entirely.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Currently, the `web` group middleware will always be prepended in the `FileUploadController`. It's not possible to customize that group. Middleware that has to be run before the `web` group can't be configured too. Some projects may not have the `web` group at all.

I've changed this logic by adding a new configuration key for this. The `default_middleware` can be used to change or remove the `web`  middleware. In case of the order, the `default_middleware` can be made empty, placing the `web` group in the `middleware` section.

The current defaults remain the same and this approach should not introduce any breaking changes.

Example configuration:

```php
'temporary_file_upload' => [
    'middleware' => [
        'custom',
        'web', // Optionally add "web" to the normal "middleware" section to control the order.
    ],
    'default_middleware' => [], // Will remove the default "web" group middleware.
],
```

This pull request is an alternative approach of my initial solution in #8930 . It should also cover the needs of #8905 as pointed out by @chillbram 