### PR TITLE
Add support for DI on computed properties

### DIFF
--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -8,6 +8,7 @@ use function Livewire\off;
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
+use Laravel\SerializableClosure\Support\ReflectionClosure;
 
 #[\Attribute]
 class BaseComputed extends Attribute
@@ -20,6 +21,7 @@ class BaseComputed extends Attribute
         public $cache = false,
         public $key = null,
         public $tags = null,
+        public $inject = false,
     ) {}
 
     function boot()
@@ -135,6 +137,10 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
+        if ($this->inject) {
+            return app()->call([$this->component, parent::getName()]);
+        }
+
         return invade($this->component)->{parent::getName()}();
     }
 

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -9,6 +9,7 @@ use function Livewire\off;
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
+use Livewire\ImplicitlyBoundMethod;
 
 #[\Attribute]
 class BaseComputed extends Attribute
@@ -21,7 +22,6 @@ class BaseComputed extends Attribute
         public $cache = false,
         public $key = null,
         public $tags = null,
-        public $inject = false,
     ) {}
 
     function boot()
@@ -137,11 +137,7 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
-        if ($this->inject) {
-            return app()->call([$this->component, parent::getName()]);
-        }
-
-        return invade($this->component)->{parent::getName()}();
+        return ImplicitlyBoundMethod::call(app(), [$this->component, parent::getName()]);
     }
 
     public function getName()

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -436,7 +436,7 @@ class UnitTest extends TestCase
         App::bind(ComputedPropertyInjectedStub::class);
 
         Livewire::test(new class extends TestComponent {
-            #[Computed(inject: true)]
+            #[Computed()]
             function foo(ComputedPropertyInjectedStub $stub) {
                 return $stub->foo;
             }

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -441,19 +441,27 @@ class UnitTest extends TestCase
                 return $stub->foo;
             }
 
+            #[Computed()]
+            protected function baz(ComputedPropertyInjectedStub $stub) {
+                return $stub->baz;
+            }
+
             function render() {
                 return <<<'HTML'
                     <div>foo{{ $this->foo }}</div>
+                    <div>baz{{ $this->baz }}</div>
                 HTML;
             }
         })
-            ->assertSee('foobar');
+            ->assertSee('foobar')
+            ->assertSee('bazqux');
     }
 }
 
 class ComputedPropertyInjectedStub
 {
     public $foo = 'bar';
+    public $baz = 'qux';
 }
 
 class ComputedPropertyStub extends Component

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportComputed;
 
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
 use Tests\TestComponent;
 use Tests\TestCase;
@@ -429,6 +430,30 @@ class UnitTest extends TestCase
             ->dispatch('bar', 'baz')
             ->assertSetStrict('foo', 'baz');
     }
+
+    public function test_it_supports_injected_parameters()
+    {
+        App::bind(ComputedPropertyInjectedStub::class);
+
+        Livewire::test(new class extends TestComponent {
+            #[Computed(inject: true)]
+            function foo(ComputedPropertyInjectedStub $stub) {
+                return $stub->foo;
+            }
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $this->foo }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobar');
+    }
+}
+
+class ComputedPropertyInjectedStub
+{
+    public $foo = 'bar';
 }
 
 class ComputedPropertyStub extends Component


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes – discussion here: https://github.com/livewire/livewire/discussions/6967

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No,

4️⃣ Does it include tests? (Required)

Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Currently it's not possible to resolve parameters from the container on computed property methods. This is inconsistent with actions which _do_ support DI parameters.

This pull request adds backwards compatible support for this behaviour by-way of a new `inject` argument on the `Computed` attribute.

This will change how computed properties are invoked and call the method through Laravel's container instead.

Here's what you need to do at the minute:

```php
#[Computed]
function foo() {
	$dep = app(MyDep::class);

	return $dep->something();
}
```

And with this change:

```php
#[Computed(inject: true)]
function foo(MyDep $dep) {
	return $dep->something();
}
```
