### PR TITLE
added 'AllowDynamicProperties' to Component to silence log warning about dynamic property depreciation

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Traits\Macroable;
 use BadMethodCallException;
 use Livewire\Features\SupportFormObjects\HandlesFormObjects;
 
+#[\AllowDynamicProperties]
 abstract class Component
 {
     use Macroable { __call as macroCall; }


### PR DESCRIPTION
Review the [Livewire Contribution Guide](https://livewire.laravel.com/docs/contribution-guide) before proceeding.

---

1️⃣ **Is this something that is wanted/needed? Was there a prior discussion?**

Yes, @joshhanley previously requested this in a [discussion](https://github.com/livewire/livewire/discussions/6464).

---

2️⃣ **Did you create a branch for your fix/feature? (PRs on main will be closed)**

Yes, the branch is `feat/deprecated-dynamic-fix`.

---

3️⃣ **Does it contain multiple, unrelated changes?**

No, this PR solely adds the `AllowDynamicProperties` attribute to the `Component` class to silence deprecation notices, specifically those triggered by dynamic properties, like in Livewire Pagination:

```
[logs] ┌ 14:04:13 WARNING ────────────────────────────────────────────────────────────┐
[logs] │ Creation of dynamic property App\Livewire\Something\Show::$relation is deprecated... │
```

---

4️⃣ **Does it include tests? (Required)**

This change doesn't include tests due to its limited scope and the difficulty in quantifying its impact. Testing for the absence of deprecation warnings would involve generating logs both with and without the attribute, which is complex in Pest. Given that the attribute only silences these warnings without modifying behavior, I'm open to feedback on whether a test is still necessary.

I have tested this in one of my Laravel applications and it has worked as intended, silencing the error without affecting the functionality. 

---

5️⃣ **Thorough description (with code snippets) of the improvement and its usefulness:**

I added the `AllowDynamicProperties` attribute to the `Component` class in `src/Component.php` to eliminate deprecation warnings in the logs. Livewire Pagination relies on dynamic properties, and this change prevents log pollution without altering functionality. Given that rewriting to avoid dynamic properties would be more involved, this attribute provides a straightforward fix.

```php
#[\AllowDynamicProperties]
abstract class Component 
{
  // ...
}
```
