### PR TITLE
Revert "added 'AllowDynamicProperties' to Component to silence log warning about dynamic property depreciation"

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -17,7 +17,6 @@ use Illuminate\Support\Traits\Macroable;
 use BadMethodCallException;
 use Livewire\Features\SupportFormObjects\HandlesFormObjects;
 
-#[\AllowDynamicProperties]
 abstract class Component
 {
     use Macroable { __call as macroCall; }


### PR DESCRIPTION
Reverts livewire/livewire#8982