### PR TITLE
Fix "Cancel upload" tests failing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,10 +71,10 @@ jobs:
 
       - name: Run Cancel Upload test
         if: success() || failure()
-        run: vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload"
+        run: FORCE_RUN=1 vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload"
         env:
           RUNNING_IN_CI: true
-          FORCE_RUN: true
+          FORCE_RUN: 1
 
       - name: Run Legacy Browser tests
         if: success() || failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,13 @@ jobs:
         env:
           RUNNING_IN_CI: true
 
+      - name: Run Cancel Upload test
+        if: success() || failure()
+        run: vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload"
+        env:
+          RUNNING_IN_CI: true
+          FORCE_RUN: true
+
       - name: Run Legacy Browser tests
         if: success() || failure()
         run: vendor/bin/phpunit --testsuite LegacyBrowser

--- a/src/Features/SupportFileUploads/BrowserTest.php
+++ b/src/Features/SupportFileUploads/BrowserTest.php
@@ -64,6 +64,10 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_can_cancel_an_upload()
     {
+        if (getenv('FORCE_RUN') !== '1') {
+            $this->markTestSkipped('Skipped');
+        }
+
         Storage::persistentFake('tmp-for-tests');
 
         Livewire::visit(new class extends Component {
@@ -97,7 +101,7 @@ class BrowserTest extends \Tests\BrowserTestCase
         })
         ->assertMissing('@preview')
         ->attach('@upload', __DIR__ . '/browser_test_image_big.jpg')
-        ->pause(10)
+        ->pause(5)
         ->click('@cancel')
         ->assertSeeIn('@output', 'cancelled')
         ;


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
N
2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Y
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Y
4️⃣ Does it include tests? (Required)
Y
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

To fix the problem with the cancel upload test, it was necessary to leave it running alone.

So, in the first step, it is skipped, but in the second it is run normally

Thanks for contributing! 🙌
