### PR TITLE
Fix exception hook code example in docs

### DIFF
--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -321,8 +321,8 @@ class ShowPost extends Component
     }
 
     public function exception($e, $stopPropagation) {
-        if($e instanceof NotFoundException) {
-            $this->notify('Post is not found')
+        if ($e instanceof NotFoundException) {
+            $this->notify('Post is not found');
             $stopPropagation();
         }
     }


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Yes, I wanted to set up an exception hook and tried to copy/paste the code example from the docs, but realized that the syntax was invalid. I did not create a discussion about it because it is a simple docs change and necessary.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes, my feature branch is named `fix-exception-code-example`.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, it is a simple 2-line change to a documentation file.

4️⃣ Does it include tests? (Required)
No, it only contains documentation changes, so no tests are possible.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
This PR consists of a small change to the exception hook code sample in the documentation. The existing documentation page is located at https://livewire.laravel.com/docs/lifecycle-hooks#exception. This PR consists of two changes:

1. Adds a semi-colon to a line so that the syntax is correct and the code can be copy/pasted by people experimenting and learning Livewire.
2. Adds a space in the if statement to improve readability and conform to popular code style guidelines.