### PR TITLE
Minor grammatical fix - docs/wire-model#dependent-select-dropdowns

### DIFF
--- a/docs/wire-model.md
+++ b/docs/wire-model.md
@@ -230,7 +230,7 @@ As you can see, there is no "placeholder" attribute for a select menu like there
 
 Sometimes you may want one select menu to be dependent on another. For example, a list of cities that changes based on which state is selected.
 
-For the most part, this works as you'd expect, however there is one important gotcha: You must add a `wire:key` to the changing select so that Livewire properly refreshes it's value when the options change.
+For the most part, this works as you'd expect, however there is one important gotcha: You must add a `wire:key` to the changing select so that Livewire properly refreshes its value when the options change.
 
 Here's an example of two selects, one for states, one for cities. When the state select changes, the options in the city select will change properly:
 


### PR DESCRIPTION
Very minor adjustment, correcting "it's" to "its"

Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
