### PR TITLE
Add failing test for emoji aliases for url params

### DIFF
--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -1035,6 +1035,31 @@ class BrowserTest extends \Tests\BrowserTestCase
             ])
             ->assertScript('return window.location.search', '?foo[bar]=baz&bob%5Blob%5D=law');
     }
+
+    public function test_it_handles_emojis_as_aliases()
+    {
+        Livewire::visit([
+                new class () extends Component {
+                    #[BaseUrl(as: '⭐', except: false)]
+                    public bool $starred = false;
+
+                    public function render()
+                    {
+                        return <<<'HTML'
+                        <div>
+                            <input wire:model.live="starred" type="checkbox" dusk="star" />
+                        </div>
+                        HTML;
+                    }
+                },
+            ])
+            ->assertQueryStringMissing('⭐')
+            ->waitForLivewire()->click('@star')
+            ->assertQueryStringHas('⭐', 'true')
+            ->waitForLivewire()->click('@star')
+            ->assertQueryStringMissing('⭐')
+        ;
+    }
 }
 
 class FormObject extends \Livewire\Form


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
No, it's a bug I encountered when trying to use an emoji as an alias for a URL parameter.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes, it's called `emojis-as-aliases` and it's the target of this PR.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, it's a single (failing) test for the bug I encountered.

4️⃣ Does it include tests? (Required)
Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

When trying to use the `Url` attribute on a public property, using an emoji as the alias (`as:` param on the constructor), together with a default exception, it doesn't seem to work (the query string param doesn't go away when using the default state). I've only tested with a boolean triggered by a checkbox model. The same component works fine if there's no alias or the alias is a string so it's probably related to the url encoding of the emoji.
