### PR TITLE
Improve data_get property value from component hooks / attributes 

### DIFF
--- a/src/ComponentHook.php
+++ b/src/ComponentHook.php
@@ -78,7 +78,7 @@ abstract class ComponentHook
 
     function getProperty($name)
     {
-        return data_get($this->getProperties(), $name);
+        return data_get($this->component, $name);
     }
 
     function storeSet($key, $value)

--- a/src/Features/SupportAttributes/Attribute.php
+++ b/src/Features/SupportAttributes/Attribute.php
@@ -56,7 +56,7 @@ abstract class Attribute
             throw new \Exception('Can\'t set the value of a non-property attribute.');
         }
 
-        return data_get($this->component->all(), $this->levelName);
+        return data_get($this->component, $this->levelName);
     }
 
     function setValue($value)


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
N
2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Y
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
N
4️⃣ Does it include tests? (Required)
N
5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

When using attributes such as `Url`, `Session`, `Reactive`, and `Modelable`, hidden performance issues may arise, particularly when these attributes are applied in components within loops.

**The Problem**
Internally, when one of these attributes is used, the getValue function stores all properties and their corresponding values in memory for each invocation. This causes unnecessary memory consumption in PHP, as a data_get operation is ultimately performed to extract the required values. Consequently, this approach leads to redundant memory allocation, which can degrade the application's performance.

Thanks for contributing! 🙌
