### PR TITLE
Use anonymous class to prevent incrementing Mockery assertion count

### DIFF
--- a/src/Features/SupportFileUploads/SupportFileUploads.php
+++ b/src/Features/SupportFileUploads/SupportFileUploads.php
@@ -13,10 +13,9 @@ class SupportFileUploads extends ComponentHook
     {
         if (app()->runningUnitTests()) {
             // Don't actually generate S3 signedUrls during testing.
-            // Can't use ::partialMock because it's not available in older versions of Laravel.
-            $mock = \Mockery::mock(GenerateSignedUploadUrl::class);
-            $mock->makePartial()->shouldReceive('forS3')->andReturn([]);
-            GenerateSignedUploadUrlFacade::swap($mock);
+            GenerateSignedUploadUrlFacade::swap(new class extends GenerateSignedUploadUrl {
+                public function forS3($file, $visibility = '') { return [] }
+            });
         }
 
         app('livewire')->propertySynthesizer([


### PR DESCRIPTION
### Summary

This PR resolves an issue where Livewire uses **Mockery** to override a method, but it unintentionally increases the assertion count by `1` when [tearDownTheTestEnvironment](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php#L134
) is called in Laravel's test class.  

### Problem

When **Mockery** is used to mock a method, Laravel’s testing lifecycle triggers [tearDownTheTestEnvironment](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php#L134), which interacts with Mockery’s internal expectations. This behavior unintentionally increments the assertion count, leading to false positives or misreported test results.

### Solution
To avoid this, the PR replaces the Mockery usage with an anonymous class. This achieves the same method override functionality without interfering with Laravel's test assertion count.

#### Key Changes:

Use an anonymous class instead of Mockery for overriding the [forS3 ](https://github.com/livewire/livewire/blob/7bbf80d93db9b866776bf957ca6229364bca8d87/src/Features/SupportFileUploads/GenerateSignedUploadUrl.php#L18)method.
Avoids interacting with Mockery's expectation system.

### Before and After

#### Before:
Assertion count unexpectedly increases by 1 when tearDownTheTestEnvironment is called.

#### After:
Assertion count remains accurate and unchanged when the test ends.

### Tests
No new tests are needed since this change does not alter Livewire's functionality. It is a refactor to ensure better test assertion behavior.