### PR TITLE
Add #[Required] attribute

### DIFF
--- a/src/Attributes/Required.php
+++ b/src/Attributes/Required.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Attribute;
+use Livewire\Features\SupportRequiredProperties\BaseRequired;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Required extends BaseRequired
+{
+    //
+}

--- a/src/Features/SupportRequiredProperties/BaseRequired.php
+++ b/src/Features/SupportRequiredProperties/BaseRequired.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Livewire\Features\SupportRequiredProperties;
+
+use Attribute;
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class BaseRequired extends LivewireAttribute
+{
+    //
+}

--- a/src/Features/SupportRequiredProperties/RequiredPropertyNotProvidedException.php
+++ b/src/Features/SupportRequiredProperties/RequiredPropertyNotProvidedException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Livewire\Features\SupportRequiredProperties;
+
+use Illuminate\Support\Str;
+
+class RequiredPropertyNotProvidedException extends \Exception
+{
+    public function __construct($componentName, $missingProperties)
+    {
+        parent::__construct(sprintf(
+            'Missing required %s [%s] in component [%s]',
+            Str::plural('property', $missingProperties->count()),
+            $missingProperties->implode(', '),
+            $componentName,
+        ));
+    }
+}

--- a/src/Features/SupportRequiredProperties/SupportRequiredProperties.php
+++ b/src/Features/SupportRequiredProperties/SupportRequiredProperties.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Livewire\Features\SupportRequiredProperties;
+
+use Livewire\ComponentHook;
+
+class SupportRequiredProperties extends ComponentHook
+{
+    public function mount($params)
+    {
+        $requiredProperties = $this->component
+            ->getAttributes()
+            ->whereInstanceOf(BaseRequired::class)
+            ->map(fn ($property) => $property->getName());
+
+        $missingProperties = $requiredProperties->diff(array_keys($params));
+
+        throw_if(
+            $missingProperties->count(),
+            new RequiredPropertyNotProvidedException($this->component->getName(), $missingProperties),
+        );
+    }
+}

--- a/src/Features/SupportRequiredProperties/UnitTest.php
+++ b/src/Features/SupportRequiredProperties/UnitTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Features\SupportRequiredProperties;
+
+use Livewire\Attributes\Required;
+use Livewire\Livewire;
+use Tests\TestCase;
+use Tests\TestComponent;
+
+class UnitTest extends TestCase
+{
+    public function test_unprovided_required_property_triggers_exception()
+    {
+        $this->expectExceptionMessageMatches(
+            '/Missing required property \[foo] in component \[.*]/',
+        );
+
+        Livewire::test(new class extends TestComponent {
+            #[Required]
+            public string $foo;
+        });
+    }
+
+    public function test_multiple_unprovided_required_properties_triggers_exception()
+    {
+        $this->expectExceptionMessageMatches(
+            '/Missing required properties \[foo, bar] in component \[.*]/',
+        );
+
+        Livewire::test(new class extends TestComponent {
+            #[Required]
+            public string $foo;
+
+            #[Required]
+            public string $bar;
+        });
+    }
+
+    public function test_providing_required_properties_renders_component()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Required]
+            public string $foo;
+
+            #[Required]
+            public string $bar;
+        }, ['foo' => '1', 'bar' => '2'])
+            ->assertOk()
+            ->assertSetStrict('foo', '1')
+            ->assertSetStrict('bar', '2');
+    }
+
+    public function test_provided_required_properties_with_incorrect_types_are_still_applied()
+    {
+        $this->expectExceptionMessage(
+            'Cannot assign null to property Tests\TestComponent@anonymous::$foo of type string',
+        );
+
+        Livewire::test(new class extends TestComponent {
+            #[Required]
+            public string $foo;
+        }, ['foo' => null]);
+    }
+}

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -87,6 +87,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
             Features\SupportNestedComponentListeners\SupportNestedComponentListeners::class,
             Features\SupportMorphAwareIfStatement\SupportMorphAwareIfStatement::class,
             Features\SupportAutoInjectedAssets\SupportAutoInjectedAssets::class,
+            Features\SupportRequiredProperties\SupportRequiredProperties::class,
             Features\SupportComputed\SupportLegacyComputedPropertySyntax::class,
             Features\SupportNestingComponents\SupportNestingComponents::class,
             Features\SupportScriptsAndAssets\SupportScriptsAndAssets::class,


### PR DESCRIPTION
1️⃣ _Is this something that is wanted/needed? Did you create a discussion about it first?_

It's something I'd personally find useful, and imagine others would too. No discussion though.

2️⃣ _Did you create a branch for your fix/feature? (Main branch PR's will be closed)_

Yes: `required-attribute`

3️⃣ _Does it contain multiple, unrelated changes? Please separate the PRs out._

No, just this feature.

4️⃣ _Does it include tests? (Required)_

Yes

5️⃣ _Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful._

### Motivation

Due to the way attributes on Livewire components are set on the component's properties (i.e. not through a constructor), properties without default values can be left uninitialized if the corresponding attributes are missing from the component tag.

This can cause any number of different errors depending on how the property is used. Commonly something like:

* `Attempt to read property "foo" on null`
* `Typed property Foo::$bar must not be accessed before initialization`

These errors generally aren't too difficult to diagnose, but if another developer wrote the component, and particularly if the property is used in a less straightforward way (e.g. within an Alpine component), it can become much less obvious what is causing the error.

Also, there is no distinction between properties that need to be passed to the component, and properties that are simply set within the component itself (via actions etc.). So, again if another developer wrote the component, it's not always clear what needs to be passed via attributes unless it is documented.

### Solution

This PR adds a simple `#[Required]` attribute that can be added to properties that should be passed to the component. If any required attributes are missing, an error will be thrown on mount:

```
Missing required properties [foo, bar] in component [my-component]
```
