### PR TITLE
Check if model exists

### DIFF
--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -72,6 +72,10 @@ class EloquentModelSynth extends Synth
             $model = $this->loadModel($meta);
         }
 
+        if (! $model instanceof Model) {
+            return null;
+        }
+
         if (isset($meta['relations'])) {
             foreach($meta['relations'] as $relationKey) {
                 if (! isset($data[$relationKey])) continue;


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

```php
Livewire\Features\SupportLegacyModels\EloquentModelSynth::setDataOnModel(): Argument #1 ($model) must be of type Illuminate\Database\Eloquent\Model, null given, called in /app/vendor/livewire/livewire/src/Features/SupportLegacyModels/EloquentModelSynth.php on line 91
```

I didn't create a discussion first, because it's a bugfix. The Model instance can be empty/null, see `protected function loadModel($meta): ?Model`.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

No, because the current test should work.

I could add if it required. This seems to be caused by removing a model out of an array, and try to load it later.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This would fix using an array or collection, removing the record/model out of the database/table, refresh table.

Thanks for contributing! 🙌
