### PR TITLE
Add parent modifier to wire:loading.

### DIFF
--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -8,6 +8,10 @@ directive('loading', ({ el, directive, component, cleanup }) => {
 
     let [delay, abortDelay] = applyDelay(directive)
 
+    if (component.modifiers.includes('parent')) {
+        component = component.parent;
+    }
+
     let cleanupA = whenTargetsArePartOfRequest(component, targets, inverted, [
         () => delay(() => toggleBooleanStateDirective(el, directive, true)),
         () => abortDelay(() => toggleBooleanStateDirective(el, directive, false)),


### PR DESCRIPTION
This functionality is related to a discussion opened and available here - luckily I found a solution for it by myself.

The feature is available on the `wire-loading-parent` branch.

It contains one change on one file in one commit on the `wire-loading.js` directive.

The tests are not included.

Please refer to the discussion for description of the need for the feature.
https://github.com/livewire/livewire/discussions/9093

What the condition does is to check if the parent component is "loading", everything else stays the same.
It only works for the immediate parent.
