### PR TITLE
feat: allow to store props in cookie

### DIFF
--- a/src/Attributes/Cookie.php
+++ b/src/Attributes/Cookie.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Attribute;
+use Livewire\Features\SupportCookie\BaseCookie;
+
+/**
+ * This class is designed to provide sensible defaults for cookie handling while
+ * ensuring security best practices. Developers can customize the behavior, but
+ * they should be cautious about potential risks when deviating from these defaults.
+ *
+ * **Important Notes:**
+ * - **Do not use cookies to store sensitive data** (e.g., passwords, personal information, or data subject to GDPR or other regulations).
+ * - Cookies are inherently less secure than server-side storage. Always consider alternative storage mechanisms for critical data.
+ *
+ * **Default Values and Security Considerations:**
+ * - `$secure`: Defaults to `true`, ensuring cookies are sent only over HTTPS connections. This helps prevent data interception on insecure networks.
+ * - `$httpOnly`: Defaults to `true`, making cookies inaccessible to JavaScript and mitigating the risk of XSS attacks.
+ * - `$sameSite`: Defaults to `'Lax'`, providing protection against CSRF attacks while maintaining usability in most cases.
+ * - `$minutes`: Defaults to 30 days (60 * 24 * 30). For shorter-lived sessions, reduce this value as needed.
+ *
+ * **Usage Recommendations:**
+ * - Always use HTTPS in your application to maximize the effectiveness of the `Secure` flag.
+ * - Avoid using this mechanism for storing sensitive or long-term authentication tokens.
+ * - If custom values are set for `$secure`, `$httpOnly`, or `$sameSite`, ensure they align with your application's security policies.
+ *
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Cookie extends BaseCookie
+{
+    //
+}

--- a/src/Features/SupportCookie/BaseCookie.php
+++ b/src/Features/SupportCookie/BaseCookie.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Livewire\Features\SupportCookie;
+
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Facades\Config;
+use Attribute;
+
+#[Attribute(\Attribute::TARGET_PROPERTY)]
+class BaseCookie extends LivewireAttribute
+{
+    /**
+     * BaseCookie allows Livewire properties to be automatically persisted in cookies.
+     * This is useful for storing user preferences, authentication tokens, or any stateful data.
+     *
+     * By default, this class respects Laravel's session configuration to ensure secure and consistent cookie handling.
+     *
+     * @param string|null $key       The unique name of the cookie. If null, Livewire will generate a default key.
+     * @param int         $minutes   Cookie expiration time in minutes (default: 30 days).
+     * @param string|null $path      The path where the cookie is available (default: "/").
+     * @param string|null $domain    The domain that the cookie is available to. Uses `config('session.domain')` by default.
+     * @param bool|null   $secure    Whether the cookie should only be sent over HTTPS. Defaults to `config('session.secure')`.
+     * @param bool        $httpOnly  If true, the cookie will be inaccessible to JavaScript (default: true).
+     * @param bool        $raw       If true, the cookie is sent without URL encoding (default: false).
+     * @param string|null $sameSite  Controls how cookies are sent with cross-site requests. Defaults to `config('session.same_site', 'lax')`.
+     */
+    public function __construct(
+        protected $key = null,
+        protected $minutes = 60 * 24 * 30, // 30 days
+        protected $path = '/',
+        protected $domain = null,
+        protected $secure = true, // Default to HTTPS only
+        protected $httpOnly = true, // Default to HttpOnly
+        protected $raw = false,
+        protected $sameSite = 'Lax', // Default to Lax for cross-site protection
+    ) {
+        $this->domain = $this->domain ?? Config::get('session.domain', null);
+        $this->secure = $this->secure ?? Config::get('session.secure', true);
+        $this->sameSite = $this->sameSite ?? Config::get('session.same_site', 'lax');
+    }
+
+    public function mount()
+    {
+        if (!$this->exists()) {
+            return;
+        }
+
+        $fromCookie = $this->read();
+
+        $this->setValue($fromCookie);
+    }
+
+    public function dehydrate()
+    {
+        $this->write();
+    }
+
+    protected function exists()
+    {
+        return Cookie::has($this->key());
+    }
+
+    protected function read()
+    {
+        return Cookie::get($this->key());
+    }
+
+    protected function write()
+    {
+        Cookie::queue(
+            name: $this->key(),
+            value: $this->getValue(),
+            minutes: $this->minutes,
+            path: $this->path,
+            domain: $this->domain,
+            secure: $this->secure,
+            httpOnly: $this->httpOnly,
+            raw: $this->raw,
+            sameSite: $this->sameSite,
+        );
+    }
+
+    protected function key()
+    {
+        if (! $this->key) {
+            return 'lw'.crc32($this->component->getName().$this->getName());
+        }
+
+        return self::replaceDynamicPlaceholders($this->key, $this->component);
+    }
+
+    public static function replaceDynamicPlaceholders($key, $component): string
+    {
+        return preg_replace_callback('/\{(.*)\}/U', function ($matches) use ($component) {
+            return data_get($component, $matches[1], function () use ($matches): void {
+                throw new \Exception('Unable to evaluate dynamic cookie key placeholder: '.$matches[0]);
+            });
+        }, $key);
+    }
+}

--- a/src/Features/SupportCookie/BrowserTest.php
+++ b/src/Features/SupportCookie/BrowserTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Livewire\Features\SupportCookie;
+
+use Livewire\Attributes\Cookie;
+use Tests\BrowserTestCase;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class BrowserTest extends BrowserTestCase
+{
+    public function test_can_persist_a_property_to_the_cookie()
+    {
+        Livewire::visit(new class extends Component {
+            #[Cookie]
+            public $count = 0;
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button dusk="button" wire:click="increment">+</button>
+                <span dusk="count">{{ $count }}</span>
+            </div>
+            HTML; }
+        })
+            ->assertSeeIn('@count', '0')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@count', '1')
+            ->refresh()
+            ->assertSeeIn('@count', '1')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@count', '2')
+            ;
+    }
+}

--- a/src/Features/SupportCookie/UnitTest.php
+++ b/src/Features/SupportCookie/UnitTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Livewire\Features\SupportCookie;
+
+use Illuminate\Support\Facades\Cookie as FacadesCookie;
+use Livewire\Attributes\Cookie;
+use Tests\TestCase;
+use Livewire\Livewire;
+use Tests\TestComponent;
+
+class UnitTest extends TestCase
+{
+    public function test_it_creates_a_cookie_key()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[Cookie]
+            public $count = 0;
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $count }}</div>
+                HTML;
+            }
+        });
+
+        $cookie = FacadesCookie::getQueuedCookies()[0];
+
+        $this->assertEquals('lw'.crc32($component->instance()->getName().'count'), $cookie->getName());
+    }
+
+    public function test_it_creates_a_dynamic_cookie_id()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $post = ['id' => 2];
+
+            #[Cookie(key: 'baz.{post.id}')]
+            public $count = 0;
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $count }}</div>
+                HTML;
+            }
+        });
+
+        $cookie = FacadesCookie::getQueuedCookies()[0];
+
+        $this->assertEquals('baz.2', $cookie->getName());
+    }
+}


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

I added this to my project, and I thought it might have a place in the Livewire repository.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Currently, it is possible to store information in the session using the PHP Session attribute, but I also need to store information in cookies to ensure it persists longer.

I believe that storing information in cookies could also be useful for other people using Livewire.

The usage is very simple. Just like the Session attribute, you only need to use the Cookie attribute.

```php
#[Cookie]
#[Cookie(key: 'my-key', minutes: 60 ...)]
```
