### PR TITLE
Add fix for Volt `htmlspecialchars` error when there is an error in the view

### DIFF
--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -40,7 +40,7 @@ class ImplicitRouteBinding
         }
 
         // Cache the current route action (this callback actually), just to be safe.
-        $cache = $route->getAction('uses');
+        $cache = $route->getAction();
 
         // We'll set the route action to be the "mount" method from the chosen
         // Livewire component, to get the proper implicit bindings.
@@ -54,10 +54,10 @@ class ImplicitRouteBinding
             $parameters = $route->resolveMethodDependencies($route->parameters(), new ReflectionMethod($component, 'mount'));
 
             // Restore the original route action...
-            $route->uses($cache);
+            $route->setAction($cache);
         } catch(\Exception $e) {
             // Restore the original route action before an exception is thrown...
-            $route->uses($cache);
+            $route->setAction($cache);
 
             throw $e;
         }


### PR DESCRIPTION
At the moment if there is an error inside the view of a Volt component, the following error is displayed:

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/413821dd-da2a-474a-bd90-04c615967096" />

But what should be displayed is the actual error:

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/0201a62e-2370-4431-af93-b836b36e9c0c" />

This PR fixes it.

Fixes livewire/volt#117

So what was the problem?

The root of the problem was how the route `uses` was being restored in Livewire after we attempt to resolve the mount parameters.

Basically what is happening is when we call `$route->uses($cache)`, the route will actually re-process the handler for the route, but we don't want that to happen, we actually just want to restore the route action as it was before.

The nitty gritty:

When a route is a closure (like a Volt route), it will NOT have an `$action['controller']` key as there is no controller. So when the error handler calls `$route->getActionName();` the route either returns the controller name, or if it doesn't have one it returns the word `Closure`.

But if we call `$route->uses($cache)` it re-processes the handler and for some reason it actually sets the controller to be the Closure for the volt route. Which in turn means when the error handler calls `$route->getActionName();`, the route returns the whole Closure instead of just a name (like the controller name or the word 'Closure').

So when the error renderer tries to render, it is then passing the closure into `{{ $actionName }}`, which is triggering the error `htmlspecialchars: must be of type string, Closure given`.

To fix this, we need to cleanly cache the route action, and restore it exactly as it was without any processing. So the change to `->getAction()` gets the routes full `action` details (instead of a particular key) and caches it, then calling `->setAction($cache)` restores it exactly as it was.