### PR TITLE
Fix `resetExcept()` to not reset all when all properties supplied

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -93,6 +93,10 @@ trait InteractsWithProperties
 
         $keysToReset = array_diff(array_keys($this->all()), $properties);
 
+        if($keysToReset === []) {
+            return;
+        }
+
         $this->reset($keysToReset);
     }
 

--- a/src/Concerns/Tests/ResetPropertiesUnitTest.php
+++ b/src/Concerns/Tests/ResetPropertiesUnitTest.php
@@ -67,7 +67,12 @@ class ResetPropertiesUnitTest extends \Tests\TestCase
             ->call('resetKeysExcept', ['foo', 'bob'])
             ->assertSetStrict('foo', 'baz')
             ->assertSetStrict('bob', 'law')
-            ->assertSetStrict('mwa', 'hah');
+            ->assertSetStrict('mwa', 'hah')
+            // Reset all except all
+            ->call('resetKeysExcept', ['foo', 'bob', 'mwa', 'notSet', 'nullProp', 'pullResult'])
+            ->assertSetStrict('foo', 'baz')
+            ->assertSetStrict('bob', 'law')
+            ->assertSetStrict('mwa', 'aha');
     }
 
     public function test_can_reset_unset_properties()

--- a/src/Concerns/Tests/ResetPropertiesUnitTest.php
+++ b/src/Concerns/Tests/ResetPropertiesUnitTest.php
@@ -72,7 +72,7 @@ class ResetPropertiesUnitTest extends \Tests\TestCase
             ->call('resetKeysExcept', ['foo', 'bob', 'mwa', 'notSet', 'nullProp', 'pullResult'])
             ->assertSetStrict('foo', 'baz')
             ->assertSetStrict('bob', 'law')
-            ->assertSetStrict('mwa', 'aha');
+            ->assertSetStrict('mwa', 'hah');
     }
 
     public function test_can_reset_unset_properties()

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -167,6 +167,10 @@ class Form implements Arrayable
 
         $keysToReset = array_diff(array_keys($this->all()), $properties);
 
+        if($keysToReset === []) {
+            return;
+        }
+
         $this->reset($keysToReset);
     }
 

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -826,7 +826,12 @@ class UnitTest extends \Tests\TestCase
         ->assertSet('form.bob', 'loc')
         ->call('formResetExcept', ['foo'])
         ->assertSet('form.foo', 'baz')
-        ->assertSet('form.bob', 'lob');
+        ->assertSet('form.bob', 'lob')
+        ->set('form.foo', 'bar2')
+        ->set('form.bob', 'lob2')
+        ->call('formResetExcept', ['foo', 'bob'])
+        ->assertSet('form.foo', 'bar2')
+        ->assertSet('form.bob', 'lob2');
     }
 }
 

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -810,7 +810,7 @@ class UnitTest extends \Tests\TestCase
 
     function test_can_pull_some_properties()
     {
-        $component = Livewire::test(new class extends TestComponent {
+        Livewire::test(new class extends TestComponent {
             public ResetPropertiesForm $form;
 
             function formResetExcept(...$args)
@@ -824,10 +824,9 @@ class UnitTest extends \Tests\TestCase
         ->assertSet('form.bob', 'lob')
         ->set('form.bob', 'loc')
         ->assertSet('form.bob', 'loc')
-        ->call('formResetExcept', ['foo']);
-
-        $this->assertEquals('baz', $component->form->foo);
-        $this->assertEquals('lob', $component->form->bob);
+        ->call('formResetExcept', ['foo'])
+        ->assertSet('form.foo', 'baz')
+        ->assertSet('form.bob', 'lob');
     }
 }
 


### PR DESCRIPTION
Fixes bug discussed in https://github.com/livewire/livewire/discussions/8096.

Reproducing test has been added. Fix is very similar to one described in the discussion, although I chose a slightly 'stricter typing' approach.

This fix had to be applied in two places - you may notice `Form` declares most (although not all) functions from `InteractsWithProperties`. Once this PR is merged, it'd be good to see if `Form` can make use of `InteractsWithProperties` to prevent some of this duplication.
