### PR TITLE
Update test stub to use test_ prefix

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/livewire.test.stub
+++ b/src/Features/SupportConsoleCommands/Commands/livewire.test.stub
@@ -10,8 +10,7 @@ use Tests\TestCase;
 
 class [testclass] extends TestCase
 {
-    /** @test */
-    public function renders_successfully()
+    public function test_renders_successfully()
     {
         Livewire::test([class]::class)
             ->assertStatus(200);


### PR DESCRIPTION
This simply updates the test stub used by the `livewire:make` command. It replaces the docblock syntax `/** @test */` with the `test_` method name prefix.

* Laravel's test stubs use this prefix so this makes it more consistent, and
* [Livewire itself made the move towards this prefix](https://github.com/livewire/livewire/pull/8365).


