### PR TITLE
Fix rendering styles and script multiple times

### DIFF
--- a/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
+++ b/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
@@ -48,7 +48,7 @@ class SupportAutoInjectedAssets extends ComponentHook
                 $assetsBody .= FrontendAssets::scripts()."\n";
             }
 
-            if ($assetsHead === '' && $assetsBody === '') return;
+            if (trim($assetsHead) === '' && trim($assetsBody) === '') return;
 
             $html = $handled->response->getContent();
 
@@ -64,7 +64,6 @@ class SupportAutoInjectedAssets extends ComponentHook
     {
         if (! static::$forceAssetInjection && config('livewire.inject_assets', true) === false) return false;
         if ((! static::$hasRenderedAComponentThisRequest) && (! static::$forceAssetInjection)) return false;
-        if (app(FrontendAssets::class)->hasRenderedScripts) return false;
 
         return true;
     }

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -109,6 +109,8 @@ class FrontendAssets extends Mechanism
      */
     public static function styles($options = [])
     {
+        if (app(static::class)->hasRenderedStyles) return '';
+
         app(static::class)->hasRenderedStyles = true;
 
         $nonce = isset($options['nonce']) ? "nonce=\"{$options['nonce']}\" data-livewire-style" : '';
@@ -162,6 +164,8 @@ class FrontendAssets extends Mechanism
      */
     public static function scripts($options = [])
     {
+        if (app(static::class)->hasRenderedScripts) return '';
+
         app(static::class)->hasRenderedScripts = true;
 
         $debug = config('app.debug');

--- a/src/Mechanisms/FrontendAssets/UnitTest.php
+++ b/src/Mechanisms/FrontendAssets/UnitTest.php
@@ -35,13 +35,21 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertFalse($assets->hasRenderedStyles);
 
-        $this->assertStringStartsWith('<!-- Livewire Styles -->', $assets->styles());
+        $styles = $assets->styles();
 
-        $this->assertStringNotContainsString('data-livewire-style', $assets->styles());
-
-        $this->assertStringContainsString('nonce="test" data-livewire-style', $assets->styles(['nonce' => 'test']));
+        $this->assertStringStartsWith('<!-- Livewire Styles -->', $styles);
+        $this->assertStringNotContainsString('data-livewire-style', $styles);
 
         $this->assertTrue($assets->hasRenderedStyles);
+
+        $this->assertEmpty($assets->styles());
+    }
+
+    public function test_styles_with_nonce()
+    {
+        $assets = app(FrontendAssets::class);
+
+        $this->assertStringContainsString('nonce="test" data-livewire-style', $assets->styles(['nonce' => 'test']));
     }
 
     public function test_scripts()
@@ -54,6 +62,8 @@ class UnitTest extends \Tests\TestCase
         $this->assertStringContainsString('<script src="', $scripts);
 
         $this->assertTrue($assets->hasRenderedScripts);
+
+        $this->assertEmpty($assets->scripts());
     }
 
     public function test_use_normal_scripts_url_if_app_debug_is_true()


### PR DESCRIPTION
I am using Livewire, Flux UI and Wire Elements in my project and even though I think I did everything right and configured the right options (`inject_assets` as `false`) and made sure I had a single `@livewireStyles` and `@fluxStyles` I got rendered the inline CSS twice.

Looking at the code I noticed there is a flag to indicate the styles were already rendered, same for the scripts but only the scripts flag was used... and to top it of that script flag also applied to the CSS. This puzzled me so I tried to come up with a solution to use the flags as I think they were intended and stops rendering the styles multiple times for me, while everything else still works as expected. Maybe I missed something but this seems like a good start.

In addition, there is a check to see if there is any styles/scripts to be rendered before doing so after the request was handled but this almost always has a stray newline character resulting in the string not being empty. Added a `trim` to fix that.