### PR TITLE
Docs: correct component name in redirect method

### DIFF
--- a/docs/redirecting.md
+++ b/docs/redirecting.md
@@ -92,7 +92,7 @@ public function save()
 {
     // ...
 
-    $this->redirect(ShowPage::class);
+    $this->redirect(ShowPosts::class);
 }
 ```
 


### PR DESCRIPTION
The `redirect()` method uses the correct Livewire component name, changing `ShowPage::class` to `ShowPosts::class` for consistency with the defined route.