### PR TITLE
Add support for using `@assets` outside of a Livewire component

### DIFF
--- a/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
+++ b/src/Features/SupportAutoInjectedAssets/SupportAutoInjectedAssets.php
@@ -29,6 +29,10 @@ class SupportAutoInjectedAssets extends ComponentHook
             $assetsHead = '';
             $assetsBody = '';
 
+            // If `@assets` has been used outside of a Livewire component then we need
+            // to process those assets to be injected alongside the other assets...
+            SupportScriptsAndAssets::processNonLivewireAssets();
+
             $assets = array_values(SupportScriptsAndAssets::getAssets());
 
             // If there are additional head assets, inject those...

--- a/src/Features/SupportScriptsAndAssets/SupportScriptsAndAssets.php
+++ b/src/Features/SupportScriptsAndAssets/SupportScriptsAndAssets.php
@@ -16,9 +16,30 @@ class SupportScriptsAndAssets extends ComponentHook
 
     public static $renderedAssets = [];
 
+    public static $nonLivewireAssets = [];
+
     public static function getAssets()
     {
         return static::$renderedAssets;
+    }
+
+    public static function processNonLivewireAssets()
+    {
+        // If any assets have been added outside of a Livewire component, then they will not be 
+        // processed like the other assets as there is no dehydrate being called. So instead 
+        // we process them manually that way they are included with the other assets when
+        // they are injected...
+        $alreadyRunAssetKeys = [];
+
+        foreach (static::$nonLivewireAssets as $key => $assets) {
+             if (! in_array($key, $alreadyRunAssetKeys)) {
+
+                // These will get injected into the HTML if it's an initial page load...
+                static::$renderedAssets[$key] = $assets;
+
+                $alreadyRunAssetKeys[] = $key;
+            }
+        }
     }
 
     public static function getUniqueBladeCompileTimeKey()
@@ -45,6 +66,7 @@ class SupportScriptsAndAssets extends ComponentHook
             static::$alreadyRunAssetKeys = [];
             static::$countersByViewPath = [];
             static::$renderedAssets = [];
+            static::$nonLivewireAssets = [];
         });
 
         Blade::directive('script', function () {
@@ -90,7 +112,13 @@ class SupportScriptsAndAssets extends ComponentHook
                         // Skip it...
                     } else {
                         \Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets::\$alreadyRunAssetKeys[] = \$__assetKey;
-                        \Livewire\store(\$this)->push('assets', \$__output, \$__assetKey);
+
+                        // Check if we're in a Livewire component or not and store the asset accordingly...
+                        if (isset(\$this)) {
+                            \Livewire\store(\$this)->push('assets', \$__output, \$__assetKey);
+                        } else {
+                            \Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets::\$nonLivewireAssets[\$__assetKey] = \$__output;
+                        }
                     }
                 ?>
             PHP;

--- a/src/Features/SupportScriptsAndAssets/non-livewire-asset.js
+++ b/src/Features/SupportScriptsAndAssets/non-livewire-asset.js
@@ -1,0 +1,2 @@
+
+document.querySelector('[dusk="foo"]').textContent = 'non livewire evaluated'


### PR DESCRIPTION
# The scenario

Currently if a Blade component makes use of the `@assets` directive and that component is used outside of a Livewire component, then a `Using $this when not in object context` error is thrown.

<img width="1198" alt="image" src="https://github.com/user-attachments/assets/b4c6df22-e80b-4f02-8847-5333159aa639" />

# The problem

The problem is that the assets directive makes a call to the store and passes `$this` (the Livewire component) in as a reference.

```php
\Livewire\store(\$this)->push('assets', \$__output, \$__assetKey);
```

But when `@assets` is used outside of a Livewire component then `$this` doesn't exist, hence the error is being thrown.

# The solution

To fix this, I have added support to the assets directive for keeping track of assets that have been called outside of a Livewire component, and injecting them into the layout alongside any Livewire component assets.

I did review whether we should do the same with the `@scripts` tag, but those scripts are evaluated on the front end by Livewire. Because of that, it didn't make much sense to change it at the moment as it would require a re-think on how all of those scripts are processed.

Fixes livewire/flux#802