### PR TITLE
Update enum query parameter to set `null` for invalid values when nullable

### DIFF
--- a/src/Features/SupportAttributes/Attribute.php
+++ b/src/Features/SupportAttributes/Attribute.php
@@ -59,14 +59,20 @@ abstract class Attribute
         return data_get($this->component->all(), $this->levelName);
     }
 
-    function setValue($value)
+    function setValue($value, ?bool $nullable = false)
     {
         if ($this->level !== AttributeLevel::PROPERTY) {
             throw new \Exception('Can\'t set the value of a non-property attribute.');
         }
 
         if ($enum = $this->tryingToSetStringOrIntegerToEnum($value)) {
-            $value = $enum::from($value);
+            if($nullable) {
+                $value = $enum::tryFrom($value);
+            }
+
+            else {
+                $value = $enum::from($value);
+            }
         }
 
         data_set($this->component, $this->levelName, $value);

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -78,7 +78,7 @@ class BaseUrl extends LivewireAttribute
             $value = $decoded === null ? $initialValue : $decoded;
         }
 
-        $this->setValue($value);
+        $this->setValue($value, $this->nullable);
     }
 
     protected function recursivelyMergeArraysWithoutAppendingDuplicateValues(&$array1, &$array2)

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -483,6 +483,91 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_can_use_url_on_string_backed_enum_object_properties_with_initial_invalid_value_on_nullable()
+    {
+        Livewire::withQueryParams(['foo' => 'bar'])
+            ->visit([
+            new class extends Component
+            {
+                #[Url(nullable: true)]
+                public ?StringBackedEnumForUrlTesting $foo;
+
+                public function change()
+                {
+                    $this->foo = StringBackedEnumForUrlTesting::Second;
+                }
+
+                public function unsetFoo()
+                {
+                    $this->foo = null;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="change" dusk="button">Change</button>
+                        <h1 dusk="output">{{ $foo }}</h1>
+                        <button wire:click="unsetFoo" dusk="unsetButton">Unset foo</button>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->assertQueryStringHas('foo', '')
+            ->assertSee('foo', null)
+            ->waitForLivewire()->click('@button')
+            ->assertQueryStringHas('foo', 'second')
+            ->assertSeeIn('@output', 'second')
+            ->refresh()
+            ->assertQueryStringHas('foo', 'second')
+            ->assertSeeIn('@output', 'second')
+        ;
+    }
+
+
+    public function test_can_use_url_on_integer_backed_enum_object_properties_with_initial_invalid_value_on_nullable()
+    {
+        Livewire::withQueryParams(['foo' => 5])
+            ->visit([
+            new class extends Component
+            {
+                #[Url(nullable: true)]
+                public ?IntegerBackedEnumForUrlTesting $foo;
+
+                public function change()
+                {
+                    $this->foo = IntegerBackedEnumForUrlTesting::Second;
+                }
+
+                public function unsetFoo()
+                {
+                    $this->foo = null;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="change" dusk="button">Change</button>
+                        <h1 dusk="output">{{ $foo }}</h1>
+                        <button wire:click="unsetFoo" dusk="unsetButton">Unset foo</button>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->assertQueryStringHas('foo', '')
+            ->assertSee('foo', null)
+            ->waitForLivewire()->click('@button')
+            ->assertQueryStringHas('foo', '2')
+            ->assertSeeIn('@output', '2')
+            ->refresh()
+            ->assertQueryStringHas('foo', '2')
+            ->assertSeeIn('@output', '2')
+        ;
+    }
+
     public function test_it_does_not_break_string_typed_properties()
     {
         Livewire::withQueryParams(['foo' => 'bar'])


### PR DESCRIPTION
The default implementation when the URL query parameter type is enum it uses `$enum::from()` method this is a good catch when the attribute is not nullable, but when the attribute is nullable it should use `tryFrom()` instead of `from()` method.

So when the page loads with different enum value on a query paramtere it checks if the attribute is nullable or not, if its nullable it uses `tryFrom()` and if not `from()` method

Here is the problem I was getting
![image](https://github.com/user-attachments/assets/32661743-20bf-4c74-8ebf-2d5d25a35f54)
