### PR TITLE
Add support for non-backed enums in `EnumSynth`

### DIFF
--- a/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
@@ -6,22 +6,32 @@ class EnumSynth extends Synth {
     public static $key = 'enm';
 
     static function match($target) {
-        return is_object($target) && is_subclass_of($target, 'BackedEnum');
+        return is_object($target) && is_subclass_of($target, 'UnitEnum');
     }
 
     static function matchByType($type) {
-        return is_subclass_of($type, 'BackedEnum');
+        return is_subclass_of($type, 'UnitEnum');
     }
 
     static function hydrateFromType($type, $value) {
         if ($value === '') return null;
 
+        $backed = is_subclass_of($type, 'BackedEnum');
+
+        if(! $backed) {
+            return is_subclass_of($value, 'UnitEnum')
+                ? $value
+                : constant("$type::$value");
+        }
+
         return $type::from($value);
     }
 
     function dehydrate($target) {
+        $backed = is_subclass_of($target, 'BackedEnum');
+
         return [
-            $target->value,
+            $backed ? $target->value : $target->name,
             ['class' => get_class($target)]
         ];
     }
@@ -31,6 +41,8 @@ class EnumSynth extends Synth {
 
         $class = $meta['class'];
 
-        return $class::from($value);
+        $backed = is_subclass_of($class, 'BackedEnum');
+
+        return $backed ? $class::from($value) : constant("$class::$value");
     }
 }

--- a/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
@@ -19,9 +19,7 @@ class EnumSynth extends Synth {
         $backed = is_subclass_of($type, 'BackedEnum');
 
         if(! $backed) {
-            return is_subclass_of($value, 'UnitEnum')
-                ? $value
-                : constant("$type::$value");
+            return is_subclass_of($value, 'UnitEnum') ? $value : constant("$type::$value");
         }
 
         return $type::from($value);

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Mechanisms\HandleComponents\Synthesizers\Tests;
 
+use Error;
 use Livewire\Livewire;
 use Tests\TestComponent;
 use ValueError;
@@ -33,10 +34,12 @@ class EnumUnitTest extends \Tests\TestCase
     {
         $testable = Livewire::test(ComponentWithUnbackedEnum::class)
             ->updateProperty('baz', UnbackedEnum::BAR)
+            ->assertSetStrict('baz', UnbackedEnum::BAR)
+            ->updateProperty('baz', 'BAR')
             ->assertSetStrict('baz', UnbackedEnum::BAR);
 
-        $this->expectException(ValueError::class);
-        $testable->updateProperty('baz', 'BAR');
+        $this->expectException(Error::class);
+        $testable->updateProperty('baz', 'BAZ');
     }
 }
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -28,11 +28,27 @@ class EnumUnitTest extends \Tests\TestCase
         $this->expectException(ValueError::class);
         $testable->updateProperty('status', 'Be excellent excellent to each other');
     }
+
+    public function test_unbacked_enum_can_be_used_as_property()
+    {
+        $testable = Livewire::test(ComponentWithUnbackedEnum::class)
+            ->updateProperty('baz', UnbackedEnum::BAR)
+            ->assertSetStrict('baz', UnbackedEnum::BAR);
+
+        $this->expectException(ValueError::class);
+        $testable->updateProperty('baz', 'bar');
+    }
 }
 
 enum TestingEnum: string
 {
     case TEST = 'Be excellent to each other';
+}
+
+enum UnbackedEnum
+{
+    case FOO;
+    case BAR;
 }
 
 class ComponentWithPublicEnumCasters extends TestComponent
@@ -64,4 +80,8 @@ class ComponentWithPublicEnumCasters extends TestComponent
 class ComponentWithNullablePublicEnumCaster extends TestComponent
 {
     public ?TestingEnum $status = null;
+}
+
+class ComponentWithUnbackedEnum extends TestComponent {
+    public UnbackedEnum $baz;
 }

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -36,7 +36,7 @@ class EnumUnitTest extends \Tests\TestCase
             ->assertSetStrict('baz', UnbackedEnum::BAR);
 
         $this->expectException(ValueError::class);
-        $testable->updateProperty('baz', 'bar');
+        $testable->updateProperty('baz', 'BAR');
     }
 }
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? 
Yes (although only by me so far!)

Did you create a discussion about it first?
No, but on reflection it would have been useful...

4️⃣ Does it include tests? (Required)
Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

My goal here is to support Pure Enums (I've referred to them as Unbacked in this PR - happy to change this if desired) as valid Livewire properties. My usecase is for an Onboarding page. I have the following Enum:

```php
enum OnboardingStage: string
{
    case StageFoo = 'stage-foo';
    case StageBar = 'stage-bar';
    case StageBaz = 'stage-baz';
    case StageQux = 'stage-qux';
}
```

...and it is used as so:

```
@if($stage === OnboardingStage::StageFoo)
    <div>
        Basic Explanation of StageFoo, maybe with a livewire component or two
    </div>
@elseif($stage === OnboardingStage::StageFoo)
    <div>
        Different text and different components
    </div>
@endif

<button wire:click="nextStage">
    Next Stage
</button>
```

This enum is only backed (currently) for the purpose of working with Livewire: its string value has no real meaning. I fully appreciate this is a tiny inconvinience to developers (and is easily workable!).

I've achieved this by modifying the existing `EnumSynth`, although with hindsight maybe a separate synth would be cleaner? A lot of the added code is typechecking, which I'm not a huge fan of. Happy to take a second swing with a new Synth if desired (and if anyone has any name ideas they'd be appreciated).
