### PR TITLE
Docs: Correct succeed callback argument from "effect" to "effects"

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -581,7 +581,7 @@ Livewire.hook('message.processed', (message, component) => {}) // [tl! remove]
 Livewire.hook('commit', ({ component, commit, respond, succeed, fail }) => { // [tl! add:14]
     // Equivalent of 'message.sent'
 
-    succeed(({ snapshot, effect }) => {
+    succeed(({ snapshot, effects }) => {
         // Equivalent of 'message.received'
 
         queueMicrotask(() => {


### PR DESCRIPTION
Fix documentation: The upgrading docs stated that the succeed callback receives an "effect" argument, which returns undefined. Updated it to correctly reference "effects".
