### PR TITLE
Fix Docs: Save Method by Removing Unused $post Variable

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -264,7 +264,7 @@ class CreatePost extends Component
 
     public function save() // [tl! highlight:8]
     {
-		$post = Post::create([
+		Post::create([
 			'title' => $this->title
 		]);
 


### PR DESCRIPTION
### Summary
This pull request refactors the `save` method in the `CreatePost` Livewire component by removing the unused `$post` variable. 

### Changes Made
- Removed the assignment of the `$post` variable in the `save` method, simplifying the code while maintaining functionality.
- Updated the method to call `Post::create()` directly without storing the instance, as it was not being used afterward.

### Benefits
- Improves code readability and clarity by eliminating unnecessary variables.
- Simplifies the `save` method, making it more straightforward and easier to maintain.
