### PR TITLE
Insert new `wire:stream` content into the DOM

### DIFF
--- a/js/directives/wire-stream.js
+++ b/js/directives/wire-stream.js
@@ -11,7 +11,7 @@ directive('stream', ({el, directive, cleanup }) => {
         if (modifiers.includes('replace') || replace) {
             el.innerHTML = content
         } else {
-            el.insertAdjacentHTML("beforeend", content)
+            el.insertAdjacentHTML('beforeend', content)
         }
     })
 

--- a/js/directives/wire-stream.js
+++ b/js/directives/wire-stream.js
@@ -11,7 +11,7 @@ directive('stream', ({el, directive, cleanup }) => {
         if (modifiers.includes('replace') || replace) {
             el.innerHTML = content
         } else {
-            el.innerHTML = el.innerHTML + content
+            el.insertAdjacentHTML("beforeend", content)
         }
     })
 


### PR DESCRIPTION
This PR is a one-line tweak that prevents the DOM element containing `wire:stream`ed content from being re-rendered with each partial.

This code causes a full re-render.
```html
el.innerHTML = el.innerHTML + content
```

Whereas this doesn't, preserving existing HTML.
```
el.insertAdjacentHTML("beforeend", content)
```

One use case for `wire:stream` as demonstrated in the docs is a chat bot.

I've applied a CSS transition to elements added to the DOM when streaming. This code change allows transitions to finish, as previously they were being destructed with DOM updates.

Before 👎:

https://github.com/user-attachments/assets/90597587-d5b2-4a55-8775-8933355480af

After 👍:

https://github.com/user-attachments/assets/015cb9bf-5d7a-411f-943a-670d35f17fde