### PR TITLE
Converts `@test` to `test_` for PHPUNIT 12 support

### DIFF
--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -101,8 +101,7 @@ use Tests\TestCase;
 
 class UnitTest extends TestCase
 {
-    /** @test */
-    public function livewire_can_run_action(): void
+    public function test_livewire_can_run_action(): void
     {
        // ...
     }
@@ -116,8 +115,7 @@ use Tests\BrowserTestCase;
 
 class BrowserTest extends BrowserTestCase
 {
-    /** @test */
-    public function livewire_can_run_action()
+    public function test_livewire_can_run_action()
     {
         // ...
     }

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -80,8 +80,7 @@ Livewire also provides a `->assertFileDownloaded()` method to easily test that a
 ```php
 use App\Models\Invoice;
 
-/** @test */
-public function can_download_invoice()
+public function test_can_download_invoice()
 {
     $invoice = Invoice::factory();
 
@@ -96,8 +95,7 @@ You can also test to ensure a file was not downloaded using the `->assertNoFileD
 ```php
 use App\Models\Invoice;
 
-/** @test */
-public function does_not_download_invoice_if_unauthorised()
+public function test_does_not_download_invoice_if_unauthorised()
 {
     $invoice = Invoice::factory();
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -369,8 +369,7 @@ class CreatePostTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
-    public function it_dispatches_post_created_event()
+    public function test_it_dispatches_post_created_event()
     {
         Livewire::test(CreatePost::class)
             ->call('save')
@@ -398,8 +397,7 @@ class DashboardTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
-    public function it_updates_post_count_when_a_post_is_created()
+    public function test_it_updates_post_count_when_a_post_is_created()
     {
         Livewire::test(Dashboard::class)
             ->assertSee('Posts created: 0')

--- a/docs/lazy.md
+++ b/docs/lazy.md
@@ -268,8 +268,7 @@ use Tests\TestCase;
 
 class DashboardTest extends TestCase
 {
-    /** @test */
-    public function renders_successfully()
+    public function test_renders_successfully()
     {
         Livewire::withoutLazyLoading() // [tl! highlight]
             ->test(Dashboard::class)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,8 +22,7 @@ use Tests\TestCase;
 
 class CreatePostTest extends TestCase
 {
-    /** @test */
-    public function renders_successfully()
+    public function test_renders_successfully()
     {
         Livewire::test(CreatePost::class)
             ->assertStatus(200);
@@ -51,8 +50,7 @@ use Tests\TestCase;
 
 class CreatePostTest extends TestCase
 {
-    /** @test */
-    public function component_exists_on_the_page()
+    public function test_component_exists_on_the_page()
     {
         $this->get('/posts/create')
             ->assertSeeLivewire(CreatePost::class);
@@ -81,8 +79,7 @@ use Tests\TestCase;
 
 class ShowPostsTest extends TestCase
 {
-    /** @test */
-    public function displays_posts()
+    public function test_displays_posts()
     {
         Post::factory()->make(['title' => 'On bathing well']);
         Post::factory()->make(['title' => 'There\'s no time like bathtime']);
@@ -112,8 +109,7 @@ use Tests\TestCase;
 
 class ShowPostsTest extends TestCase
 {
-    /** @test */
-    public function displays_all_posts()
+    public function test_displays_all_posts()
     {
         Post::factory()->make(['title' => 'On bathing well']);
         Post::factory()->make(['title' => 'The bathtub is my sanctuary']);
@@ -155,8 +151,7 @@ use Tests\TestCase;
 
 class ShowPostsTest extends TestCase
 {
-    /** @test */
-    public function user_only_sees_their_own_posts()
+    public function test_user_only_sees_their_own_posts()
     {
         $user = User::factory()
             ->has(Post::factory()->count(3))
@@ -194,8 +189,7 @@ use Tests\TestCase;
 
 class CreatePostTest extends TestCase
 {
-    /** @test */
-    public function can_set_title()
+    public function test_can_set_title()
     {
         Livewire::test(CreatePost::class)
             ->set('title', 'Confessions of a serial soaker')
@@ -220,8 +214,7 @@ use Tests\TestCase;
 
 class UpdatePostTest extends TestCase
 {
-    /** @test */
-    public function title_field_is_populated()
+    public function test_title_field_is_populated()
     {
         $post = Post::factory()->make([
             'title' => 'Top ten bath bombs',
@@ -305,8 +298,7 @@ use Tests\TestCase;
 
 class SearchPostsTest extends TestCase
 {
-    /** @test */
-    public function can_search_posts_via_url_query_string()
+    public function test_can_search_posts_via_url_query_string()
     {
         Post::factory()->create(['title' => 'Testing the first water-proof hair dryer']);
         Post::factory()->create(['title' => 'Rubber duckies that actually float']);
@@ -360,8 +352,7 @@ use Tests\TestCase;
 
 class CartTest extends TestCase
 {
-    /** @test */
-    public function can_load_discount_token_from_a_cookie()
+    public function test_can_load_discount_token_from_a_cookie()
     {
         Livewire::withCookies(['discountToken' => 'CALEB2023'])
             ->test(Cart::class)
@@ -390,8 +381,7 @@ use Tests\TestCase;
 
 class CreatePostTest extends TestCase
 {
-    /** @test */
-    public function can_create_post()
+    public function test_can_create_post()
     {
         $this->assertEquals(0, Post::count());
 
@@ -428,8 +418,7 @@ use Tests\TestCase;
 
 class CreatePostTest extends TestCase
 {
-    /** @test */
-    public function title_field_is_required()
+    public function test_title_field_is_required()
     {
         Livewire::test(CreatePost::class)
             ->set('title', '')
@@ -468,8 +457,7 @@ use Tests\TestCase;
 
 class UpdatePostTest extends TestCase
 {
-    /** @test */
-    public function cant_update_another_users_post()
+    public function test_cant_update_another_users_post()
     {
         $user = User::factory()->create();
         $stranger = User::factory()->create();
@@ -513,8 +501,7 @@ use Tests\TestCase;
 
 class CreatePostTest extends TestCase
 {
-    /** @test */
-    public function redirected_to_all_posts_after_creating_a_post()
+    public function test_redirected_to_all_posts_after_creating_a_post()
     {
         Livewire::test(CreatePost::class)
             ->set('title', 'Using a loofah doesn\'t make you aloof...ugh')
@@ -546,8 +533,7 @@ use Tests\TestCase;
 
 class CreatePostTest extends TestCase
 {
-    /** @test */
-    public function creating_a_post_dispatches_event()
+    public function test_creating_a_post_dispatches_event()
     {
         Livewire::test(CreatePost::class)
             ->set('title', 'Top 100 bubble bath brands')
@@ -572,8 +558,7 @@ use Tests\TestCase;
 
 class PostCountBadgeTest extends TestCase
 {
-    /** @test */
-    public function post_count_is_updated_when_event_is_dispatched()
+    public function test_post_count_is_updated_when_event_is_dispatched()
     {
         $badge = Livewire::test(PostCountBadge::class)
             ->assertSee("0");
@@ -603,8 +588,7 @@ use Tests\TestCase;
 
 class ShowPostsTest extends TestCase
 {
-    /** @test */
-    public function notification_is_dispatched_when_deleting_a_post()
+    public function test_notification_is_dispatched_when_deleting_a_post()
     {
         Livewire::test(ShowPosts::class)
             ->call('delete', postId: 3)
@@ -628,8 +612,7 @@ use Tests\TestCase;
 
 class ShowPostsTest extends TestCase
 {
-    /** @test */
-    public function notification_is_dispatched_when_deleting_a_post()
+    public function test_notification_is_dispatched_when_deleting_a_post()
     {
         Livewire::test(ShowPosts::class)
             ->call('delete', postId: 3)

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -198,8 +198,7 @@ use Tests\TestCase;
 
 class UploadPhotoTest extends TestCase
 {
-    /** @test */
-    public function can_upload_photo()
+    public function test_can_upload_photo()
     {
         Storage::fake('avatars');
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -610,8 +610,7 @@ use Tests\TestCase;
 
 class CreatePostTest extends TestCase
 {
-    /** @test */
-    public function cant_create_post_without_title()
+    public function test_cant_create_post_without_title()
     {
         Livewire::test(CreatePost::class)
             ->set('content', 'Sample content...')
@@ -624,8 +623,7 @@ class CreatePostTest extends TestCase
 In addition to testing the presence of errors, `assertHasErrors` allows you to also narrow down the assertion to specific rules by passing the rules to assert against as the second argument to the method:
 
 ```php
-/** @test */
-public function cant_create_post_with_title_shorter_than_3_characters()
+public function test_cant_create_post_with_title_shorter_than_3_characters()
 {
     Livewire::test(CreatePost::class)
         ->set('title', 'Sa')
@@ -638,8 +636,7 @@ public function cant_create_post_with_title_shorter_than_3_characters()
 You can also assert the presence of validation errors for multiple properties at the same time:
 
 ```php
-/** @test */
-public function cant_create_post_without_title_and_content()
+public function test_cant_create_post_without_title_and_content()
 {
     Livewire::test(CreatePost::class)
         ->call('save')

--- a/scripts/stubs/FEATURE/Test.php.stub
+++ b/scripts/stubs/FEATURE/Test.php.stub
@@ -4,8 +4,7 @@ namespace Livewire\Features\[FEATURE];
 
 class Test extends \Tests\TestCase
 {
-    /** @test */
-    public function can_()
+    public function test_can_()
     {
         $this->assertTrue(true);
     }

--- a/src/Features/SupportComputed/BrowserTest.php
+++ b/src/Features/SupportComputed/BrowserTest.php
@@ -88,8 +88,7 @@ class BrowserTest extends BrowserTestCase
         ->assertSeeIn('@count', '1');
     }
 
-    /** @test */
-    public function computed_properties_cannot_be_set_on_front_end()
+    public function test_computed_properties_cannot_be_set_on_front_end()
     {
         Livewire::visit(new class extends Component {
             public $count = 0;

--- a/src/Features/SupportConsoleCommands/Commands/livewire.test.stub
+++ b/src/Features/SupportConsoleCommands/Commands/livewire.test.stub
@@ -10,8 +10,7 @@ use Tests\TestCase;
 
 class [testclass] extends TestCase
 {
-    /** @test */
-    public function renders_successfully()
+    public function test_renders_successfully()
     {
         Livewire::test([class]::class)
             ->assertStatus(200);

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -6,8 +6,7 @@ use Tests\TestCase;
 
 class UnitTest extends TestCase
 {
-    /** @test */
-    public function livewire_can_run_handle_request_without_components_on_payload(): void
+    public function test_livewire_can_run_handle_request_without_components_on_payload(): void
     {
         $handleRequestsInstance = new HandleRequests();
         $request = new Request();


### PR DESCRIPTION
**Problem**
When creating tests from the Livewire stubs, it adds the `@test` doc-comments to the method so PHPUNIT knows it's a test it should run. However, in PHPUNIT version 12 this is deprecated.

> Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

**Solution**
This PR converts all  `@test` doc-comments to  `test_` methods, which is compatible with PEST and PHPUNIT. It also changes docs and mentions of the `@test` doc-comments.

**Conversation**
I converted to `test_` methods since this has been the standard in the past, but we could use PHP attributes instead. But since PHP attributes are newer, it might break backward compatibility. My opinion is that adding `test_` to methods is a great compromise!