### PR TITLE
Add `#[Persistent]` attribute for middleware

### DIFF
--- a/src/Attributes/Persistent.php
+++ b/src/Attributes/Persistent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Livewire\Mechanisms\PersistentMiddleware\BasePersistent;
+
+#[\Attribute]
+class Persistent extends BasePersistent
+{
+	//
+}

--- a/src/Mechanisms/PersistentMiddleware/BasePersistent.php
+++ b/src/Mechanisms/PersistentMiddleware/BasePersistent.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Livewire\Mechanisms\PersistentMiddleware;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class BasePersistent
+{
+	//
+}

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -166,10 +166,12 @@ class PersistentMiddleware extends Mechanism
         return $middleware
             ->filter(function ($value, $key) use ($persistentMiddleware) {
 				foreach ($persistentMiddleware as $iValue) {
+					// Some middlewares can be closures.
 					if (! is_string($value)) {
 						continue;
 					}
 					
+					// Ensure any middleware arguments aren't included in the comparison
 					if (Str::before($value, ':') == $iValue) {
 						return true;
 					}

--- a/src/Mechanisms/PersistentMiddleware/UnitTest.php
+++ b/src/Mechanisms/PersistentMiddleware/UnitTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Mechanisms\PersistentMiddleware;
 
 use Illuminate\Support\Facades\Facade;
+use Livewire\Attributes\Persistent;
 use Livewire\Livewire;
 
 class UnitTest extends \LegacyTests\Unit\TestCase
@@ -33,4 +34,56 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             'MyMiddleware',
         ], Livewire::getPersistentMiddleware());
     }
+	
+    public function test_it_can_filter_middleware_by_persistent_middleware_attribute()
+    {
+        $base = Livewire::getPersistentMiddleware();
+		
+        Livewire::addPersistentMiddleware([
+			PersistentMiddlewareViaMethod::class,
+			PersistentMiddlewareViaMethodAndAttribute::class,
+        ]);
+		
+		$filteredPersistentMiddleware = \Livewire\invade(app(PersistentMiddleware::class))->filterMiddlewareByPersistentMiddleware([
+			NonPersistentMiddleware::class,
+			PersistentMiddlewareViaMethod::class,
+			PersistentMiddlewareViaAttribute::class,
+			PersistentMiddlewareViaParentClassAttribute::class,
+			PersistentMiddlewareViaMethodAndAttribute::class,
+		]);
+		
+		$this->assertSame([
+			PersistentMiddlewareViaMethod::class,
+			PersistentMiddlewareViaAttribute::class,
+			PersistentMiddlewareViaParentClassAttribute::class,
+			PersistentMiddlewareViaMethodAndAttribute::class
+		], $filteredPersistentMiddleware);
+    }
+}
+
+class NonPersistentMiddleware
+{
+	//
+}
+
+class PersistentMiddlewareViaMethod
+{
+	//
+}
+
+#[Persistent]
+class PersistentMiddlewareViaAttribute
+{
+	//
+}
+
+class PersistentMiddlewareViaParentClassAttribute extends PersistentMiddlewareViaAttribute
+{
+	//
+}
+
+#[Persistent]
+class PersistentMiddlewareViaMethodAndAttribute
+{
+	//
 }

--- a/src/Mechanisms/PersistentMiddleware/UnitTest.php
+++ b/src/Mechanisms/PersistentMiddleware/UnitTest.php
@@ -5,6 +5,7 @@ namespace Livewire\Mechanisms\PersistentMiddleware;
 use Illuminate\Support\Facades\Facade;
 use Livewire\Attributes\Persistent;
 use Livewire\Livewire;
+use function Livewire\invade;
 
 class UnitTest extends \LegacyTests\Unit\TestCase
 {
@@ -44,7 +45,7 @@ class UnitTest extends \LegacyTests\Unit\TestCase
 			PersistentMiddlewareViaMethodAndAttribute::class,
         ]);
 		
-		$filteredPersistentMiddleware = \Livewire\invade(app(PersistentMiddleware::class))->filterMiddlewareByPersistentMiddleware([
+		$filteredPersistentMiddleware = invade(app(PersistentMiddleware::class))->filterMiddlewareByPersistentMiddleware([
 			NonPersistentMiddleware::class,
 			PersistentMiddlewareViaMethod::class,
 			PersistentMiddlewareViaAttribute::class,


### PR DESCRIPTION
Hello, thank you very much for all the great work you did and are doing on Livewire!

Quite often it happens that you add a new middleware to your routes, but don't immediately realize that it also needs to be marked as persistent. In my opinion, it is not super-convenient to create the middleware and _then_ look up a (big) service provider or something and _then_ add the middleware in `Livewire::addPersistentMiddleware()`.

This PR proposes a very easy solution to allow marking a middleware as `#[Persistent]` with a simple attribute, meaning that developers can just easily mark a middleware as persistent when creating them, without needing to open up a whole other file. It was actually pretty easy to do just inside the `filterMiddlewareByPersistentMiddleware()`, so I think this would be a great DX-improvement and would result in less middleware being "forgotten" to be marked as persistent. 

I also added tests for the method. Thanks!