### PR TITLE
Add PHPDoc types to Testable

### DIFF
--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -26,6 +26,15 @@ class Testable
         protected ComponentState $lastState,
     ) {}
 
+    /**
+     * @param string $name
+     * @param array $params
+     * @param array $fromQueryString
+     * @param array $cookies
+     * @param array $headers
+     *
+     * @return static
+     */
     static function create($name, $params = [], $fromQueryString = [], $cookies = [], $headers = [])
     {
         $name = static::normalizeAndRegisterComponentName($name);
@@ -44,6 +53,11 @@ class Testable
         return new static($requestBroker, $initialState);
     }
 
+    /**
+     * @param string|array<string>|object $name
+     *
+     * @return string
+     */
     static function normalizeAndRegisterComponentName($name)
     {
         if (is_array($otherComponents = $name)) {
@@ -69,6 +83,11 @@ class Testable
         return $name;
     }
 
+    /**
+     * @param ?string $driver
+     *
+     * @return void
+     */
     static function actingAs(\Illuminate\Contracts\Auth\Authenticatable $user, $driver = null)
     {
         if (isset($user->wasRecentlyCreated) && $user->wasRecentlyCreated) {
@@ -84,21 +103,39 @@ class Testable
         return $this->lastState->getComponent()->getId();
     }
 
+    /**
+     * @param string $key
+     */
     function get($key)
     {
         return data_get($this->lastState->getComponent(), $key);
     }
 
+    /**
+     * @param bool $stripInitialData
+     *
+     * @return string
+     */
     function html($stripInitialData = false)
     {
         return $this->lastState->getHtml($stripInitialData);
     }
 
+    /**
+     * @param string $name
+     *
+     * @return $this
+     */
     function updateProperty($name, $value = null)
     {
         return $this->set($name, $value);
     }
 
+    /**
+     * @param array $values
+     *
+     * @return $this
+     */
     function fill($values)
     {
         foreach ($values as $name => $value) {
@@ -108,11 +145,21 @@ class Testable
         return $this;
     }
 
+    /**
+     * @param string $name
+     *
+     * @return $this
+     */
     function toggle($name)
     {
         return $this->set($name, ! $this->get($name));
     }
 
+    /**
+     * @param string|array<string mixed> $name
+     *
+     * @return $this
+     */
     function set($name, $value = null)
     {
         if (is_array($name)) {
@@ -126,6 +173,11 @@ class Testable
         return $this;
     }
 
+    /**
+     * @param string $name
+     *
+     * @return $this
+     */
     function setProperty($name, $value)
     {
         if ($value instanceof \Illuminate\Http\UploadedFile) {
@@ -139,11 +191,21 @@ class Testable
         return $this->update(updates: [$name => $value]);
     }
 
+    /**
+     * @param string $method
+     *
+     * @return $this
+     */
     function runAction($method, ...$params)
     {
         return $this->call($method, ...$params);
     }
 
+    /**
+     * @param string $method
+     *
+     * @return $this
+     */
     function call($method, ...$params)
     {
         if ($method === '$refresh') {
@@ -163,16 +225,28 @@ class Testable
         ]);
     }
 
+    /**
+     * @return $this
+     */
     function commit()
     {
         return $this->update();
     }
 
+    /**
+     * @return $this
+     */
     function refresh()
     {
         return $this->update();
     }
 
+    /**
+     * @param array $calls
+     * @param array $updates
+     *
+     * @return $this
+     */
     function update($calls = [], $updates = [])
     {
         $newState = SubsequentRender::make(
@@ -188,7 +262,15 @@ class Testable
         return $this;
     }
 
-    /** @todo Move me outta here and into the file upload folder somehow... */
+    /**
+     * @todo Move me outta here and into the file upload folder somehow...
+     *
+     * @param string $name
+     * @param array $files
+     * @param bool $isMultiple
+     *
+     * @return $this
+     */
     function upload($name, $files, $isMultiple = false)
     {
         // This method simulates the calls Livewire's JavaScript
@@ -239,6 +321,9 @@ class Testable
         return $this;
     }
 
+    /**
+     * @param string $key
+     */
     function viewData($key)
     {
         return $this->lastState->getView()->getData()[$key];
@@ -259,6 +344,9 @@ class Testable
         return \Livewire\invade($this->lastState->getComponent());
     }
 
+    /**
+     * @return $this
+     */
     function dump()
     {
         dump($this->lastState->getHtml());
@@ -266,11 +354,17 @@ class Testable
         return $this;
     }
 
+    /**
+     * @return void
+     */
     function dd()
     {
         dd($this->lastState->getHtml());
     }
 
+    /**
+     * @return $this
+     */
     function tap($callback)
     {
         $callback($this);
@@ -278,6 +372,9 @@ class Testable
         return $this;
     }
 
+    /**
+     * @param string $property
+     */
     function __get($property)
     {
         if ($property === 'effects') return $this->lastState->getEffects();
@@ -287,6 +384,11 @@ class Testable
         return $this->instance()->$property;
     }
 
+    /**
+     * @param string $method
+     *
+     * @return $this
+     */
     function __call($method, $params)
     {
         if (static::hasMacro($method)) {


### PR DESCRIPTION
# The problem

The `Testable` class is missing PHPDoc type annotations, which limits the ability of IDEs to provide contextual suggestions and autocomplete when writing tests. More critically, at higher analysis levels, tools like PHPStan will report issues when chaining methods, since the return types are undocumented. This forces developers to manually re-specify the object type in order to continue chaining, adding unnecessary friction.

# The solution

This PR adds PHPDoc return types to the `Testable` class, making it easier to chain methods in tests without triggering static analysis warnings. It also improves IDE support and makes tests more ergonomic to write.

# The conversation

These annotations don’t affect runtime behavior but significantly improve the developer experience—especially in projects using strict static analysis. It’s a small change with a high impact on usability.
