### PR TITLE
Change facade to reference class directly

### DIFF
--- a/src/Livewire.php
+++ b/src/Livewire.php
@@ -37,6 +37,6 @@ class Livewire extends Facade
 {
     public static function getFacadeAccessor()
     {
-        return 'livewire';
+        return \Livewire\LivewireManager::class;
     }
 }


### PR DESCRIPTION
This makes it easier to navigate from  the facade to the underlying class since you can now click on it rather then have to guess at what the alias is for.
