### PR TITLE
Allow replacement of Drawer\Utils using the service container

### DIFF
--- a/src/ComponentHookRegistry.php
+++ b/src/ComponentHookRegistry.php
@@ -56,7 +56,7 @@ class ComponentHookRegistry
         }
 
         on('update', function ($component, $fullPath, $newValue) {
-            $propertyName = Utils::beforeFirstDot($fullPath);
+            $propertyName = app(Utils::class)::beforeFirstDot($fullPath);
 
             return static::proxyCallToHooks($component, 'callUpdate')($propertyName, $fullPath, $newValue);
         });

--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -9,15 +9,15 @@ trait InteractsWithProperties
 {
     public function hasProperty($prop)
     {
-        return property_exists($this, Utils::beforeFirstDot($prop));
+        return property_exists($this, app(Utils::class)::beforeFirstDot($prop));
     }
 
     public function getPropertyValue($name)
     {
-        $value = $this->{Utils::beforeFirstDot($name)};
+        $value = $this->{app(Utils::class)::beforeFirstDot($name)};
 
-        if (Utils::containsDots($name)) {
-            return data_get($value, Utils::afterFirstDot($name));
+        if (app(Utils::class)::containsDots($name)) {
+            return data_get($value, app(Utils::class)::afterFirstDot($name));
         }
 
         return $value;
@@ -32,7 +32,7 @@ trait InteractsWithProperties
         }
 
         foreach ($values as $key => $value) {
-            if (in_array(Utils::beforeFirstDot($key), $publicProperties)) {
+            if (in_array(app(Utils::class)::beforeFirstDot($key), $publicProperties)) {
                 data_set($this, $key, $value);
             }
         }
@@ -133,6 +133,6 @@ trait InteractsWithProperties
 
     public function all()
     {
-        return Utils::getPublicPropertiesDefinedOnSubclass($this);
+        return app(Utils::class)::getPublicPropertiesDefinedOnSubclass($this);
     }
 }

--- a/src/Drawer/BaseUtils.php
+++ b/src/Drawer/BaseUtils.php
@@ -31,10 +31,6 @@ class BaseUtils
             ->filter(function ($property) {
                 return $property->isPublic() && ! $property->isStatic() && $property->isDefault();
             })
-            // TODO exclude based on Unreadable attribute
-            ->filter(function ($property) {
-                return 'variable1' !== $property->getName();
-            })
             ->filter($filter ?? fn () => true)
             ->mapWithKeys(function ($property) use ($target) {
                 // Ensures typed property is initialized in PHP >=7.4, if so, return its value,

--- a/src/Drawer/BaseUtils.php
+++ b/src/Drawer/BaseUtils.php
@@ -31,6 +31,10 @@ class BaseUtils
             ->filter(function ($property) {
                 return $property->isPublic() && ! $property->isStatic() && $property->isDefault();
             })
+            // TODO exclude based on Unreadable attribute
+            ->filter(function ($property) {
+                return 'variable1' !== $property->getName();
+            })
             ->filter($filter ?? fn () => true)
             ->mapWithKeys(function ($property) use ($target) {
                 // Ensures typed property is initialized in PHP >=7.4, if so, return its value,

--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -88,7 +88,7 @@ class ImplicitRouteBinding
 
     public function getPublicPropertyTypes($component)
     {
-        return collect(Utils::getPublicPropertiesDefinedOnSubclass($component))
+        return collect(app(Utils::class)::getPublicPropertiesDefinedOnSubclass($component))
             ->map(function ($value, $name) use ($component) {
                 return Reflector::getParameterClassName(new \ReflectionProperty($component, $name));
             });

--- a/src/Features/SupportEvents/EchoBrowserTest.php
+++ b/src/Features/SupportEvents/EchoBrowserTest.php
@@ -14,7 +14,7 @@ class EchoBrowserTest extends BrowserTestCase
     public function test_can_listen_for_echo_event()
     {
         Route::get('/dusk/fake-echo', function () {
-            return Utils::pretendResponseIsFile(__DIR__.'/fake-echo.js');
+            return app(Utils::class)::pretendResponseIsFile(__DIR__.'/fake-echo.js');
         });
 
         Livewire::visit(new class extends Component {
@@ -46,7 +46,7 @@ class EchoBrowserTest extends BrowserTestCase
     public function test_can_listen_for_echo_event_with_payload()
     {
         Route::get('/dusk/fake-echo', function () {
-            return Utils::pretendResponseIsFile(__DIR__.'/fake-echo.js');
+            return app(Utils::class)::pretendResponseIsFile(__DIR__.'/fake-echo.js');
         });
 
         Livewire::visit(new class extends Component {
@@ -80,7 +80,7 @@ class EchoBrowserTest extends BrowserTestCase
     // public function test_echo_listeners_are_torn_down_when_navigating_pages_using_wire_navigate()
     // {
     //     Route::get('/dusk/fake-echo', function () {
-    //         return Utils::pretendResponseIsFile(__DIR__.'/fake-echo.js');
+    //         return app(Utils::class)::pretendResponseIsFile(__DIR__.'/fake-echo.js');
     //     });
 
     //     Route::get('/second-page', function (){

--- a/src/Features/SupportFileUploads/FilePreviewController.php
+++ b/src/Features/SupportFileUploads/FilePreviewController.php
@@ -19,6 +19,6 @@ class FilePreviewController implements HasMiddleware
     {
         abort_unless(request()->hasValidSignature(), 401);
 
-        return Utils::pretendPreviewResponseIsPreviewFile($filename);
+        return app(Utils::class)::pretendPreviewResponseIsPreviewFile($filename);
     }
 }

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -115,15 +115,15 @@ class Form implements Arrayable
 
     public function hasProperty($prop)
     {
-        return property_exists($this, Utils::beforeFirstDot($prop));
+        return property_exists($this, app(Utils::class)::beforeFirstDot($prop));
     }
 
     public function getPropertyValue($name)
     {
-        $value = $this->{Utils::beforeFirstDot($name)};
+        $value = $this->{app(Utils::class)::beforeFirstDot($name)};
 
-        if (Utils::containsDots($name)) {
-            return data_get($value, Utils::afterFirstDot($name));
+        if (app(Utils::class)::containsDots($name)) {
+            return data_get($value, app(Utils::class)::afterFirstDot($name));
         }
 
         return $value;
@@ -138,7 +138,7 @@ class Form implements Arrayable
         }
 
         foreach ($values as $key => $value) {
-            if (in_array(Utils::beforeFirstDot($key), $publicProperties)) {
+            if (in_array(app(Utils::class)::beforeFirstDot($key), $publicProperties)) {
                 data_set($this, $key, $value);
             }
         }
@@ -189,6 +189,6 @@ class Form implements Arrayable
 
     public function toArray()
     {
-        return Utils::getPublicProperties($this);
+        return app(Utils::class)::getPublicProperties($this);
     }
 }

--- a/src/Features/SupportFormObjects/FormObjectSynth.php
+++ b/src/Features/SupportFormObjects/FormObjectSynth.php
@@ -34,7 +34,7 @@ class FormObjectSynth extends Synth {
         $callBootMethod = static::bootFormObject($this->context->component, $form, $this->path);
 
         foreach ($data as $key => $child) {
-            if ($child === null && Utils::propertyIsTypedAndUninitialized($form, $key)) {
+            if ($child === null && app(Utils::class)::propertyIsTypedAndUninitialized($form, $key)) {
                 continue;
             }
 
@@ -48,7 +48,7 @@ class FormObjectSynth extends Synth {
 
     function set(&$target, $key, $value)
     {
-        if ($value === null && Utils::propertyIsTyped($target, $key) && ! Utils::getProperty($target, $key)->getType()->allowsNull()) {
+        if ($value === null && app(Utils::class)::propertyIsTyped($target, $key) && ! app(Utils::class)::getProperty($target, $key)->getType()->allowsNull()) {
             unset($target->$key);
         } else {
             $target->$key = $value;

--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -125,7 +125,7 @@ class SupportLazyLoading extends ComponentHook
             $viewContext->extractFromEnvironment($view->getFactory());
         });
 
-        $html = Utils::insertAttributesIntoHtmlRoot($html, [
+        $html = app(Utils::class)::insertAttributesIntoHtmlRoot($html, [
             ((isset($params['lazy']) and $params['lazy'] === 'on-load') ? 'x-init' : 'x-intersect') => '$wire.__lazyLoad(\''.$encoded.'\')',
         ]);
 
@@ -148,9 +148,9 @@ class SupportLazyLoading extends ComponentHook
 
         $viewOrString = wrap($component)->withFallback($placeholderHtml)->placeholder($params);
 
-        $properties = Utils::getPublicPropertiesDefinedOnSubclass($component);
+        $properties = app(Utils::class)::getPublicPropertiesDefinedOnSubclass($component);
 
-        $view = Utils::generateBladeView($viewOrString, $properties);
+        $view = app(Utils::class)::generateBladeView($viewOrString, $properties);
 
         return $view;
     }

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -72,7 +72,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             Route::get('/second-tracked-asset', SecondTrackedAssetPage::class)->middleware('web');
 
             Route::get('/test-navigate-asset.js', function () {
-                return Utils::pretendResponseIsFile(__DIR__ . '/test-views/test-navigate-asset.js');
+                return app(Utils::class)::pretendResponseIsFile(__DIR__ . '/test-views/test-navigate-asset.js');
             });
 
             Route::get('/parent', ParentComponent::class)->middleware('web');

--- a/src/Features/SupportNestedComponentListeners/SupportNestedComponentListeners.php
+++ b/src/Features/SupportNestedComponentListeners/SupportNestedComponentListeners.php
@@ -37,7 +37,7 @@ class SupportNestedComponentListeners extends ComponentHook
 
             if (! $attributes) return;
 
-            $replaceHtml(Utils::insertAttributesIntoHtmlRoot($html, $attributes));
+            $replaceHtml(app(Utils::class)::insertAttributesIntoHtmlRoot($html, $attributes));
         };
     }
 

--- a/src/Features/SupportNestingComponents/SupportNestingComponents.php
+++ b/src/Features/SupportNestingComponents/SupportNestingComponents.php
@@ -91,7 +91,7 @@ class SupportNestingComponents extends ComponentHook
     static function setParametersToMatchingProperties($component, $params)
     {
         // Assign all public component properties that have matching parameters.
-        collect(array_intersect_key($params, Utils::getPublicPropertiesDefinedOnSubclass($component)))
+        collect(array_intersect_key($params, app(Utils::class)::getPublicPropertiesDefinedOnSubclass($component)))
             ->each(function ($value, $property) use ($component) {
                 $component->{$property} = $value;
             });

--- a/src/Features/SupportScriptsAndAssets/BrowserTest.php
+++ b/src/Features/SupportScriptsAndAssets/BrowserTest.php
@@ -13,7 +13,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     {
         return function () {
             Route::get('/non-livewire-asset.js', function () {
-                return Utils::pretendResponseIsFile(__DIR__.'/non-livewire-asset.js');
+                return app(Utils::class)::pretendResponseIsFile(__DIR__.'/non-livewire-asset.js');
             });
 
             Route::get('/non-livewire-assets', function () {
@@ -146,7 +146,7 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_assets_can_be_loaded()
     {
         Route::get('/test.js', function () {
-            return Utils::pretendResponseIsFile(__DIR__.'/test.js');
+            return app(Utils::class)::pretendResponseIsFile(__DIR__.'/test.js');
         });
 
         Livewire::visit(new class extends \Livewire\Component {

--- a/src/Features/SupportTesting/ComponentState.php
+++ b/src/Features/SupportTesting/ComponentState.php
@@ -45,7 +45,7 @@ class ComponentState
     }
 
     function untupleify($payload) {
-        $value = Utils::isSyntheticTuple($payload) ? $payload[0] : $payload;
+        $value = app(Utils::class)::isSyntheticTuple($payload) ? $payload[0] : $payload;
 
         if (is_array($value)) {
             foreach ($value as $key => $child) {

--- a/src/Features/SupportTesting/InitialRender.php
+++ b/src/Features/SupportTesting/InitialRender.php
@@ -41,8 +41,8 @@ class InitialRender extends Render
         // Set "original" to Blade view for assertions like "assertViewIs()"...
         $response->original = $componentView;
 
-        $snapshot = Utils::extractAttributeDataFromHtml($html, 'wire:snapshot');
-        $effects = Utils::extractAttributeDataFromHtml($html, 'wire:effects');
+        $snapshot = app(Utils::class)::extractAttributeDataFromHtml($html, 'wire:snapshot');
+        $effects = app(Utils::class)::extractAttributeDataFromHtml($html, 'wire:effects');
 
         return new ComponentState($componentInstance, $response, $componentView, $html, $snapshot, $effects);
     }

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -169,7 +169,7 @@ trait HandlesValidation
 
         return collect($this->getRules())
             ->filter(function ($value, $key) use ($name) {
-                return Utils::beforeFirstDot($key) === $name;
+                return app(Utils::class)::beforeFirstDot($key) === $name;
             });
     }
 
@@ -222,7 +222,7 @@ trait HandlesValidation
             ->keys()
             ->each(function($ruleKey) use ($data) {
                 throw_unless(
-                    array_key_exists(Utils::beforeFirstDot($ruleKey), $data),
+                    array_key_exists(app(Utils::class)::beforeFirstDot($ruleKey), $data),
                     new \Exception('No property found for validation: ['.$ruleKey.']')
                 );
             });
@@ -457,7 +457,7 @@ trait HandlesValidation
         $toShorten = [];
 
         foreach ($rules as $key => $value) {
-            $propertyName = Utils::beforeFirstDot($key);
+            $propertyName = app(Utils::class)::beforeFirstDot($key);
 
             if ($data[$propertyName] instanceof Model) {
                 $toShorten[] = $key;
@@ -471,7 +471,7 @@ trait HandlesValidation
     {
         foreach ($ruleKeys as $key) {
             if (str($key)->snake()->replace('_', ' ')->is($validator->getDisplayableAttribute($key))) {
-                $validator->addCustomAttributes([$key => $validator->getDisplayableAttribute(Utils::afterFirstDot($key))]);
+                $validator->addCustomAttributes([$key => $validator->getDisplayableAttribute(app(Utils::class)::afterFirstDot($key))]);
             }
         }
     }
@@ -500,7 +500,7 @@ trait HandlesValidation
 
     protected function getDataForValidation($rules)
     {
-        return Utils::getPublicPropertiesDefinedOnSubclass($this);
+        return app(Utils::class)::getPublicPropertiesDefinedOnSubclass($this);
     }
 
     protected function unwrapDataForValidation($data)

--- a/src/Features/SupportValidation/SupportValidation.php
+++ b/src/Features/SupportValidation/SupportValidation.php
@@ -20,7 +20,7 @@ class SupportValidation extends ComponentHook
     {
         $errors = (new ViewErrorBag)->put('default', $this->component->getErrorBag());
 
-        $revert = Utils::shareWithViews('errors', $errors);
+        $revert = app(Utils::class)::shareWithViews('errors', $errors);
 
         return function () use ($revert) {
             // After the component has rendered, let's revert our global
@@ -37,7 +37,7 @@ class SupportValidation extends ComponentHook
         // and not from custom validators (Validator::make) that were run.
         $context->addMemo('errors', collect($errors)
             ->filter(function ($value, $key) {
-                return Utils::hasProperty($this->component, $key);
+                return app(Utils::class)::hasProperty($this->component, $key);
             })
             ->toArray()
         );

--- a/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
+++ b/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
@@ -72,7 +72,7 @@ class SupportWireModelingNestedComponents extends ComponentHook
 
             // Attach the necessary Alpine directives so that the child and
             // parent's JS, ephemeral, values are bound.
-            $replaceHtml(Utils::insertAttributesIntoHtmlRoot($html, [
+            $replaceHtml(app(Utils::class)::insertAttributesIntoHtmlRoot($html, [
                 $directive =>  '$parent.'.$outer,
                 'x-modelable' => '$wire.'.$inner,
             ]));

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -77,7 +77,7 @@ class FrontendAssets extends Mechanism
 
     public function returnJavaScriptAsFile()
     {
-        return Utils::pretendResponseIsFile(
+        return app(Utils::class)::pretendResponseIsFile(
             config('app.debug')
                 ? __DIR__.'/../../../dist/livewire.js'
                 : __DIR__.'/../../../dist/livewire.min.js'
@@ -86,7 +86,7 @@ class FrontendAssets extends Mechanism
 
     public function maps()
     {
-        return Utils::pretendResponseIsFile(__DIR__.'/../../../dist/livewire.min.js.map');
+        return app(Utils::class)::pretendResponseIsFile(__DIR__.'/../../../dist/livewire.min.js.map');
     }
 
     public static function styles($options = [])
@@ -186,7 +186,7 @@ class FrontendAssets extends Mechanism
 
         $updateUri = app('livewire')->getUpdateUri();
 
-        $extraAttributes = Utils::stringifyHtmlAttributes(
+        $extraAttributes = app(Utils::class)::stringifyHtmlAttributes(
             app(static::class)->scriptTagAttributes,
         );
 

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -62,7 +62,7 @@ class HandleComponents extends Mechanism
 
         trigger('destroy', $component, $context);
 
-        $html = Utils::insertAttributesIntoHtmlRoot($html, [
+        $html = app(Utils::class)::insertAttributesIntoHtmlRoot($html, [
             'wire:snapshot' => $snapshot,
             'wire:effects' => $context->effects,
         ]);
@@ -160,7 +160,7 @@ class HandleComponents extends Mechanism
 
     protected function dehydrateProperties($component, $context)
     {
-        $data = Utils::getPublicPropertiesDefinedOnSubclass($component);
+        $data = app(Utils::class)::getPublicPropertiesDefinedOnSubclass($component);
 
         foreach ($data as $key => $value) {
             $data[$key] = $this->dehydrate($value, $context, $key);
@@ -171,7 +171,7 @@ class HandleComponents extends Mechanism
 
     protected function dehydrate($target, $context, $path)
     {
-        if (Utils::isAPrimitive($target)) return $target;
+        if (app(Utils::class)::isAPrimitive($target)) return $target;
 
         $synth = $this->propertySynth($target, $context, $path);
 
@@ -200,7 +200,7 @@ class HandleComponents extends Mechanism
 
     protected function hydrate($valueOrTuple, $context, $path)
     {
-        if (! Utils::isSyntheticTuple($value = $tuple = $valueOrTuple)) return $value;
+        if (! app(Utils::class)::isSyntheticTuple($value = $tuple = $valueOrTuple)) return $value;
 
         [$value, $meta] = $tuple;
 
@@ -223,7 +223,7 @@ class HandleComponents extends Mechanism
 
             if (! $html) return;
 
-            return Utils::insertAttributesIntoHtmlRoot($html, [
+            return app(Utils::class)::insertAttributesIntoHtmlRoot($html, [
                 'wire:id' => $component->getId(),
             ]);
         }
@@ -233,8 +233,8 @@ class HandleComponents extends Mechanism
         return $this->trackInRenderStack($component, function () use ($component, $view, $properties) {
             $finish = trigger('render', $component, $view, $properties);
 
-            $revertA = Utils::shareWithViews('__livewire', $component);
-            $revertB = Utils::shareWithViews('_instance', $component); // @deprecated
+            $revertA = app(Utils::class)::shareWithViews('__livewire', $component);
+            $revertB = app(Utils::class)::shareWithViews('_instance', $component); // @deprecated
 
             $viewContext = new ViewContext;
 
@@ -245,7 +245,7 @@ class HandleComponents extends Mechanism
 
             $revertA(); $revertB();
 
-            $html = Utils::insertAttributesIntoHtmlRoot($html, [
+            $html = app(Utils::class)::insertAttributesIntoHtmlRoot($html, [
                 'wire:id' => $component->getId(),
             ]);
 
@@ -271,9 +271,9 @@ class HandleComponents extends Mechanism
             ? wrap($component)->render()
             : View::file($viewPath . '/' . $fileName . '.blade.php');
 
-        $properties = Utils::getPublicPropertiesDefinedOnSubclass($component);
+        $properties = app(Utils::class)::getPublicPropertiesDefinedOnSubclass($component);
 
-        $view = Utils::generateBladeView($viewOrString, $properties);
+        $view = app(Utils::class)::generateBladeView($viewOrString, $properties);
 
         return [ $view, $properties ];
     }
@@ -314,7 +314,7 @@ class HandleComponents extends Mechanism
         $finish = trigger('update', $component, $path, $value);
 
         // Ensure that it's a public property, not on the base class first...
-        if (! in_array($property, array_keys(Utils::getPublicPropertiesDefinedOnSubclass($component)))) {
+        if (! in_array($property, array_keys(app(Utils::class)::getPublicPropertiesDefinedOnSubclass($component)))) {
             throw new PublicPropertyNotFoundException($property, $component->getName());
         }
 
@@ -349,8 +349,8 @@ class HandleComponents extends Mechanism
 
         $childKey = str($path)->afterLast('.');
 
-        if ($parent && is_object($parent) && property_exists($parent, $childKey) && Utils::propertyIsTyped($parent, $childKey)) {
-            $type = Utils::getProperty($parent, $childKey)->getType();
+        if ($parent && is_object($parent) && property_exists($parent, $childKey) && app(Utils::class)::propertyIsTyped($parent, $childKey)) {
+            $type = app(Utils::class)::getProperty($parent, $childKey)->getType();
 
             $types = $type instanceof ReflectionUnionType ? $type->getTypes() : [$type];
 
@@ -370,7 +370,7 @@ class HandleComponents extends Mechanism
 
         $first = array_shift($segments);
 
-        [$data, $meta] = Utils::isSyntheticTuple($raw) ? $raw : [$raw, null];
+        [$data, $meta] = app(Utils::class)::isSyntheticTuple($raw) ? $raw : [$raw, null];
 
         if ($path !== '') {
             $value = $data[$first] ?? null;
@@ -458,7 +458,7 @@ class HandleComponents extends Mechanism
                 continue;
             }
 
-            $methods = Utils::getPublicMethodsDefinedBySubClass($root);
+            $methods = app(Utils::class)::getPublicMethodsDefinedBySubClass($root);
 
             // Also remove "render" from the list...
             $methods =  array_values(array_diff($methods, ['render']));

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -95,7 +95,7 @@ class PersistentMiddleware extends Mechanism
         // Only send through pipeline if there are middleware found
         if (is_null($middleware)) return;
 
-        Utils::applyMiddleware($request, $middleware);
+        app(Utils::class)::applyMiddleware($request, $middleware);
     }
 
     protected function makeFakeRequest()


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Might be, didn't asked.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

One PR only

4️⃣ Does it include tests? (Required)

Not currently. Don't think it's required.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.


TLDR; Allow to use enhanced Utils class in my code.


Story:

In my project, I have livewire component inheritance.

The parent class is a "Student" class. The child is a "Teacher".
The "Teacher" share almost the same view and functionality as the "Student".

BUT, the "Teacher" has more features. This can easily be done by adding code to the component class.
Also the "Teacher", sometimes, must also have LESS features; something that the "Student" can see/do should not be done by the "Teacher".

In PHP, class overloading allows you to make a property/method MORE visible, not less.

The goal is to share as much code between the "Student" component and the "Teacher" component by using inheritance.

For example, we have a component representing a Questionnaire. The "Student" must be able to answer it.
The "Teacher" has pretty much the same template. But he must not be able to answer the questionnaire, not just by hiding the input fields/buttons, but by really blocking the execution of the code used by the student.

In a Livewire component, my understanding is that there is 2 main things that the javascript frontend can call/read: public methods and public properties.

For public methods, overloading the methods in the child component (Teacher) and throwing an exception block the teacher from calling the methods it should not be allowed to run. This covers all CRUD cases (Create, Read, Update & Delete) on the public methods.

But for public properties, it's a lot more tricky.

Throwing exceptions in livewire hooks doesn't work because the public property lookup is done even if it's not used anywhere in the "Teacher" template. The "Teacher" component becomes useless because while loading, the public property is found and the hook exception is thrown, crashing even the first rendering.

One way tthat I found that is working is to replace the "getPublicProperties" static method in Livewire\Drawer\BaseUtils class.
This makes the public property behave like a protected property. The blade can still render it (more on that later), but the javascript can no longer fetch/set the property value.

But the Livewire\Drawer\Utils class is called directly (without using the service container); not allowing me to replace it with my enhanced version.

Using Laravel service container to get the class fixes that problem; I can now simply bind my enhanced version in my application service provider.

@calebporzio I don't know if tests are required. Also, I could create documentation explaining a little bit Livewire component inheritance and how to add & remove feature in child components.

N.B. My enhanced version adds a filter that check the remaining public properties for an attribute I created called "Unreadable".
This way I can easily, in the child (Teacher) component, disable which public variables I don't want anymore by simply adding a PHP attribute. Obviously, the child (Teacher) blade template must also be adapted to remove all usage of these variables. It can be done through Laravel blade component slots or even better, by using policies/gates to check if the user has access to read the value.