### PR TITLE
Update forms.md

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -173,7 +173,7 @@ class CreatePost extends Component
         $this->validate();
 
         Post::create(
-            $this->form->all() // [tl! highlight]
+            $this->form->only(['title', 'content']) // [tl! highlight]
         );
 
         return $this->redirect('/posts');
@@ -225,7 +225,7 @@ class PostForm extends Form
     {
         $this->validate();
 
-        Post::create($this->all());
+        Post::create($this->only(['title', 'content']));
     }
 }
 ```
@@ -361,7 +361,7 @@ class PostForm extends Form
     {
         $this->validate();
 
-        Post::create($this->all());
+        Post::create($this->only(['title', 'content']));
 
         $this->reset(); // [tl! highlight]
     }
@@ -460,7 +460,7 @@ class PostForm extends Form
     {
         $this->validate();
 
-        $this->post->update($this->all());
+        $this->post->update($this->only(['title', 'content']));
 
         $this->reset();
     }
@@ -507,7 +507,7 @@ class PostForm extends Form
     {
         $this->validate();
 
-        $this->post->update($this->all());
+        $this->post->update($this->only(['title', 'content']));
 
         $this->reset();
     }

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -324,7 +324,7 @@ class PostForm extends Form
         $this->validate();
 
         $this->post->update(
-            $this->all()
+            $this->only(['title', 'content'])
         );
     }
 }

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -822,7 +822,7 @@ Because of `{{ $attributes }}`, when the HTML is rendered in the browser, `wire:
 
 `x-modelable="count"` tells Alpine to look for any `x-model` or `wire:model` statements and use "count" as the data to bind them to.
 
-Because `x-modelable` works for both `wire:model` and `x-model`, you can also use this Blade component interchangeably with Livewire and Alpine. For example, here's an example of using this Blade component in a purely Alpine context:
+Because `x-modelable` works for both `wire:model` and `x-model`, you can also use this Blade component interchangeably with Livewire and Alpine. Here’s an example of using this Blade component solely in an Alpine context:
 
 ```blade
 <x-input-counter x-model="quantity" />

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -822,7 +822,7 @@ Because of `{{ $attributes }}`, when the HTML is rendered in the browser, `wire:
 
 `x-modelable="count"` tells Alpine to look for any `x-model` or `wire:model` statements and use "count" as the data to bind them to.
 
-Because `x-modelable` works for both `wire:model` and `x-model`, you can also use this Blade component interchangeably with Livewire and Alpine. Here’s an example of using this Blade component solely in an Alpine context:
+Because `x-modelable` works for both `wire:model` and `x-model`, you can also use this Blade component interchangeably with Livewire and Alpine. Here’s an example of using this Blade component in a purely Alpine context:
 
 ```blade
 <x-input-counter x-model="quantity" />


### PR DESCRIPTION
Seems like we'd want `->only()` here instead of `->all()` since there's a `public Post $post` on this form. I may be off though. Thought, I'd raise it just in case.


1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Maybe? Thought I'd bring it up because I'm pretty sure this bit isn't correct.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes, GitHub created one for me since I used the web editor.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
No, since it's just a markdown change to the docs.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
With the previous version of this class in the docs, when calling update on the Post, won't `->all()` include the Post itself?

Previous version:
```php
class PostForm extends Form
{
    public ?Post $post;  // <<< Here we have a public $post that's populated when updating.
 
    #[Validate('required|min:5')]
    public $title = '';
 
    #[Validate('required|min:5')]
    public $content = '';
 
    public function setPost(Post $post)
    {
        $this->post = $post;
 
        $this->title = $post->title;
 
        $this->content = $post->content;
    }
 
    public function store()
    {
        $this->validate();
 
        Post::create($this->only(['title', 'content']));
    }
 
    public function update()
    {
        $this->validate();
 
        $this->post->update(
            $this->all() // <<< Shouldn't this `->all()` call include that post instance?
            // Instead, maybe we should use ->only() just like the `store()` case?
        );
    }
}
```
