### PR TITLE
show @livewireScriptConfig at top of page in documentation example

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -127,12 +127,12 @@ To address this issue, we need to inform Livewire that we want to use the ESM (E
 <head>
     <!-- ... -->
     @livewireStyles
+    @livewireScriptConfig <!-- [tl! highlight] -->
     @vite(['resources/js/app.js'])
 </head>
 <body>
     {{ $slot }}
 
-    @livewireScriptConfig <!-- [tl! highlight] -->
 </body>
 </html>
 ```


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
It seems to be an issue others are facing, I commented in this discussion https://github.com/livewire/livewire/discussions/9181

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
no

4️⃣ Does it include tests? (Required)
No, it's a documentation change

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
I was importing Livewire into my app.js to listen for events, but this was causing livewire to boot twice with `Livewire.start()`. The auto-injected script appears to look for a window variable that was being declared too late when I put `livewireScriptConfig` at the bottom of the body.

Thanks for contributing! 🙌
