### PR TITLE
Revert Breaking Change to Enum Validation in 3.6.2

### DIFF
--- a/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
@@ -13,10 +13,6 @@ class EnumSynth extends Synth {
         return is_subclass_of($type, 'BackedEnum');
     }
 
-    static function unwrapForValidation($target) {
-        return $target->value;
-    }
-
     static function hydrateFromType($type, $value) {
         if ($value === '') return null;
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Mechanisms\HandleComponents\Synthesizers\Tests;
 
+use Illuminate\Validation\Rule;
 use Livewire\Livewire;
 use Tests\TestComponent;
 use ValueError;
@@ -34,7 +35,7 @@ class EnumUnitTest extends \Tests\TestCase
         Livewire::test(ComponentWithValidatedEnum::class)
             ->call('save')
             ->assertHasErrors('enum')
-            ->set('enum', ValidatedEnum::TEST->value)
+            ->set('enum', ValidatedEnum::TEST)
             ->call('save')
             ->assertHasNoErrors();
     }
@@ -88,12 +89,16 @@ class ComponentWithValidatedEnum extends TestComponent
     public function rules()
     {
         return [
-            'enum' => ['required', 'in:' . collect(ValidatedEnum::cases())->pluck('value')->implode(',')],
+            'enum' => ['required', Rule::enum(ValidatedEnum::class)],
         ];
     }
 
     public function save()
     {
-        $this->validate();
+        $validatedData = $this->validate();
+        // Check that the validated enum is still an Enum value
+        if (!($this->enum instanceof ValidatedEnum)) {
+            throw new \Exception('The type of Enum has been changed.');
+        }
     }
 }

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -35,7 +35,7 @@ class EnumUnitTest extends \Tests\TestCase
         Livewire::test(ComponentWithValidatedEnum::class)
             ->call('save')
             ->assertHasErrors('enum')
-            ->set('enum', ValidatedEnum::TEST)
+            ->set('enum', ValidatedEnum::TEST->value)
             ->call('save')
             ->assertHasNoErrors();
     }


### PR DESCRIPTION
* Revert changes to EnumSynth.php from https://github.com/livewire/livewire/pull/9231

* Update EnumUnitTest.php to test bahaviour of Enums not being converted to their backing value

Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes, discussion at https://github.com/livewire/livewire/discussions/9236 and on the PR at https://github.com/livewire/livewire/pull/9231 confirms multiple people are affected by this change

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

Yes, changed the test that was added in 3.6.2 to test for proper Enum validation

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

A breaking change was introduced in 3.6.2 to the way that Enums are validated. The Enum was converted into its backing value (string or int) before being validated. As demonstrated in comments on the PR and in the discussion, this broke several different validation strategies for Enums.

This restores the previous and expected behaviour of validating Enums as Enums. 

Thanks for contributing! 🙌
