### PR TITLE
Add return type to FrontendAssets `scripts()` and `styles()` methods

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -89,6 +89,9 @@ class FrontendAssets extends Mechanism
         return Utils::pretendResponseIsFile(__DIR__.'/../../../dist/livewire.min.js.map');
     }
 
+    /**
+     * @return string
+     */
     public static function styles($options = [])
     {
         app(static::class)->hasRenderedStyles = true;
@@ -135,6 +138,9 @@ class FrontendAssets extends Mechanism
         return static::minify($html);
     }
 
+    /**
+     * @return string
+     */
     public static function scripts($options = [])
     {
         app(static::class)->hasRenderedScripts = true;


### PR DESCRIPTION
# The problem

When analyzing Blade files with static analysis tools like PHPStan, calls to `<livewire:styles />` and `<livewire:scripts />` can produce warnings due to the lack of return types on the `FrontendAssets::styles()` and `FrontendAssets::script()` methods. Since the return type is unknown, tools can't verify that it's safe to echo or use in HTML output.

# The solution

This PR adds return types to the `styles()` and `script()` methods on `FrontendAssets`, allowing Blade directives like `<livewire:styles />` and `<livewire:scripts />` to be type-checked without errors or warnings.

# The conversation

This is part of an ongoing effort to improve static analysis compatibility across Livewire. Adding return types where possible helps catch actual issues and reduces noise in tools like PHPStan.
