### PR TITLE
Add type information to Component::getId()

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -33,6 +33,7 @@ abstract class Component
     use HandlesPageComponents;
     use HandlesDisablingBackButtonCache;
 
+    /** @var string */
     protected $__id;
     protected $__name;
 
@@ -41,11 +42,18 @@ abstract class Component
         return $this->getId();
     }
 
+    /**
+     * @param string $id
+     * @return void
+     */
     function setId($id)
     {
         $this->__id = $id;
     }
 
+    /**
+     * @return string
+     */
     function getId()
     {
         return $this->__id;


### PR DESCRIPTION
# The problem

PHPStan reports warnings when using `@this` in Blade views because the return type of `getId()` on the `Component` class is not explicitly defined. This results in type errors when the value is passed to functions like `e()`, which expects a specific set of types:

> Parameter #1 $value of function e expects  
> BackedEnum|float|Illuminate\Contracts\Support\DeferringDisplayableValue|Illuminate\Contracts\Support\Htmlable|int|string|null, mixed given.

This happens because `@this` compiles to:  
`window.Livewire.find('<?php echo e($_instance->getId()); ?>')`  
Without a known return type, static analysis can't safely assume it's valid.

# The solution

This PR adds a return type to `getId()` on the `Component` class, improving compatibility with PHPStan and making Livewire easier to work with in statically analyzed codebases. There’s no change to behavior—just improved developer experience.

# The conversation

This is part of a broader effort to add type information across Livewire to reduce static analysis issues. Happy to adjust the return type or approach if there’s a preferred alternative.
