### PR TITLE
Use JSON encoding instead of HTML encoding for the object ID

### DIFF
--- a/src/Mechanisms/ExtendBlade/ExtendBlade.php
+++ b/src/Mechanisms/ExtendBlade/ExtendBlade.php
@@ -37,7 +37,7 @@ class ExtendBlade extends Mechanism
 
     function boot()
     {
-        Blade::directive('this', fn() => "window.Livewire.find('{{ \$_instance->getId() }}')");
+        Blade::directive('this', fn() => "window.Livewire.find(@json(\$_instance->getId()))");
 
         on('render', function ($target, $view) {
             $this->startLivewireRendering($target);


### PR DESCRIPTION
# The problem

The `@this` Blade directive currently renders the component ID using:

```php
window.Livewire.find('{{ $_instance->getId() }}')
```

This uses HTML encoding (`e()`), which can lead to subtle issues if the component ID ever includes characters that get escaped (e.g., `&`, `"`, `<`, `>`). While unlikely in most cases, it's not robust.

# The solution

This PR switches the directive to use `@json()` instead of string interpolation:

```php
> window.Livewire.find(@json($_instance->getId()))
```

This ensures the component ID is safely and correctly encoded for use in JavaScript, avoiding any potential edge cases with special characters.

# The conversation

This is a safer default, especially as Livewire becomes more dynamic and interacts more deeply with JavaScript. It's a small change, but improves reliability and removes assumptions about what characters are safe in the ID.
