### PR TITLE
Fix query string history state error handling

### DIFF
--- a/js/plugins/history/index.js
+++ b/js/plugins/history/index.js
@@ -143,7 +143,11 @@ function replace(url, key, object) {
 
     state.alpine[key] = unwrap(object)
 
-    window.history.replaceState(state, '', url.toString())
+    try {
+        window.history.replaceState(state, '', url.toString())
+    } catch (e) {
+        console.error(e)
+    }
 }
 
 function push(url, key, object) {
@@ -153,7 +157,11 @@ function push(url, key, object) {
 
     state = { alpine: {...state.alpine, ...{[key]: unwrap(object)}} }
 
-    window.history.pushState(state, '', url.toString())
+    try {
+        window.history.pushState(state, '', url.toString())
+    } catch (e) {
+        console.error(e)
+    }
 }
 
 function unwrap(object) {


### PR DESCRIPTION
# The scenario

Currently if you have a bunch of components or props that all use the `#[Url]` attribute, or if you are using `wire:navigate` and navigate between pages too quickly, then on Firefox and Safari the below errors are thrown.

**Firefox**
<img width="724" alt="image" src="https://github.com/user-attachments/assets/3745f5e7-312c-4073-81b1-dcf0cdc773f5" />

**Safari**
<img width="710" alt="image" src="https://github.com/user-attachments/assets/e8693521-b539-4cbd-a5e2-36fad34431aa" />

**Main component**
```blade
<?php

use Livewire\Volt\Component;

new class extends Component {
    //
}; ?>

<div>
    @foreach (range(1, 100) as $item)
        <div wire:key="{{ $item }}">
            <livewire:history wire:key="history-{{ $item }}" />
        </div>
    @endforeach
</div>
```

**History component**
<?php

use Livewire\Attributes\Url;
use Livewire\Volt\Component;

new class extends Component {
    #[Url(history: true)]
    public $search;
}; ?>

<div>
    <input wire:model.live="search" placeholder="Search" />
</div>
```

# The problem

The issue is that there are throttling limits on the browser history API for Firefox and Safari.

For Firefox, the limit is 100 times per 30 seconds.

For Safari, the limit is 100 times per 10 seconds.

Typically the people seeing this issue are using Filament. This is because Filament has a trait `InteractsWithActions` which are on a lot of components.

```php
trait InteractsWithActions
{
    // ...

    #[Url(as: 'action')]
    public $defaultAction = null;

    #[Url(as: 'actionArguments')]
    public $defaultActionArguments = null;

    // ...
}
```

If those components are then included in a loop, say in a table, then when each of those components are initialised and the history state tracking is set up for each of these properties, then each property is pushing to the browser history causing this error to be thrown.

At the moment though, we don't have any error handling around this, so when this error is hit, Livewire stops functioning.

```js
function replace(url, key, object) {
    let state = window.history.state || {}

    if (! state.alpine) state.alpine = {}

    state.alpine[key] = unwrap(object)

    window.history.replaceState(state, '', url.toString())
}
```

This error can apparently also happen when using wire:navigate. But when I had a look at how the history state is implemented in `wire:navigate` it already has error handling. So I suspect that it's just properties initialising their history state after a `wire:navigate` that is causing the issue.

# The solution

There currently is another open PR #9059 to solve this issue.

The solution presented in that PR is to do a comparison check to see if the state has actually changed before pushing/ replacing the history state.

I'm not sure if `JSON.stringify()` is the best way to do the comparison or not, but for multiple components that are all initialised the same query string property, implementing a check to see if anything has changed before pushing to the history state is a good idea.

They have only implemented this for `replace()` but not for `push()`. So I think it should also be implemented in `push()`, I will update that PR.

**This PR**

But I also think we should add some error handling, that way Livewire will still function even if the history throttle gets hit.

```js
function replace(url, key, object) {
    //...

    try {
        window.history.replaceState(state, '', url.toString())
    } catch (e) {
        console.error(e)
    }
}
```

This is what I have implemented in this PR.

I do believe a combination of both would be best though.

If the throttle limit gets hit though, with either implementation, history state changes will be lost. This can be seen as the query string isn't updated. Not sure if we should implement a history state queue or something that takes the throttle into consideration. But these PRs are a step in the right direction and stops Livewire crashing.

Fixes #7746