### PR TITLE
WIP - Snapshot missing error

### DIFF
--- a/src/Features/SupportTesting/DuskBrowserMacros.php
+++ b/src/Features/SupportTesting/DuskBrowserMacros.php
@@ -505,4 +505,46 @@ class DuskBrowserMacros
             return $this;
         };
     }
+
+    public function assertConsoleLogHasNoErrors()
+    {
+        return function(){
+            $logs = $this->driver->manage()->getLog('browser');
+
+            $errors = [];
+            foreach ($logs as $log) {
+                if (! isset($log['message']) || ! isset($log['level']) || $log['level'] !== 'SEVERE') continue;
+
+                // Ignore favicon.ico
+                if(str($log['message'])->contains('favicon.ico')) continue;
+
+                $errors[] = $log['message'];
+            }
+
+            PHPUnit::assertEmpty($errors, "Console log contained errors: " . implode(", ", $errors));
+
+            return $this;
+        };
+    }
+
+    public function assertConsoleLogHasErrors()
+    {
+        return function(){
+            $logs = $this->driver->manage()->getLog('browser');
+
+            $errors = [];
+            foreach ($logs as $log) {
+                if (! isset($log['message']) || ! isset($log['level']) || $log['level'] !== 'SEVERE') continue;
+
+                // Ignore favicon.ico
+                if(str($log['message'])->contains('favicon.ico')) continue;
+
+                $errors[] = $log['message'];
+            }
+
+            PHPUnit::assertNotEmpty($errors, "Console log contained no errors");
+
+            return $this;
+        };
+    }
 }

--- a/src/Tests/SnapshotMissingBrowserTest.php
+++ b/src/Tests/SnapshotMissingBrowserTest.php
@@ -118,6 +118,7 @@ class SnapshotMissingBrowserTest extends \Tests\BrowserTestCase
     }
 
     // https://github.com/livewire/livewire/discussions/8921
+    // https://github.com/livewire/livewire/discussions/5935#discussioncomment-11265936
     public function test_scenario_2_keys_in_groups_failing()
     {
         Livewire::visit([
@@ -280,6 +281,13 @@ class SnapshotMissingBrowserTest extends \Tests\BrowserTestCase
     }
 
     // https://github.com/livewire/livewire/discussions/8877
+    // https://github.com/livewire/livewire/discussions/8800
+    // https://github.com/livewire/livewire/discussions/5935#discussioncomment-7091189
+    // https://github.com/livewire/livewire/discussions/8928
+    // https://github.com/livewire/livewire/discussions/8658
+    // https://github.com/livewire/livewire/discussions/8575
+    // https://github.com/livewire/livewire/discussions/6698
+    // https://github.com/livewire/livewire/discussions/6698#discussioncomment-7432437
     public function test_scenario_3_keys_on_nested_in_div_failing_2_no_key_on_loop_root_element()
     {
         Livewire::visit([

--- a/src/Tests/SnapshotMissingBrowserTest.php
+++ b/src/Tests/SnapshotMissingBrowserTest.php
@@ -168,4 +168,224 @@ class SnapshotMissingBrowserTest extends \Tests\BrowserTestCase
             ->assertSee('2-1')
             ->assertSee('2-2');
     }
+
+    // https://github.com/livewire/livewire/discussions/8877
+    public function test_scenario_3_keys_on_nested_in_div_passing()
+    {
+        Livewire::visit([
+            new class () extends Component {
+                public $prepend = false;
+
+                #[\Livewire\Attributes\Computed]
+                public function numbers()
+                {
+                    if ($this->prepend) {
+                        return range(0, 2);
+                    }
+
+                    return range(1, 2);
+                }
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="$toggle('prepend')" dusk="prepend">Prepend</button>
+                        <div>
+                            @foreach ($this->numbers as $index => $number)
+                                <div wire:key="{{ $number }}">
+                                    <livewire:child :$number :key="$number" />
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class () extends Component {
+                public $number;
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        {{ $number }}
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->waitForLivewireToLoad()
+            ->assertSee('1')
+            ->assertSee('2')
+            ->waitForLivewire()->click('@prepend')
+            ->assertConsoleLogHasNoErrors()
+            ->assertSee('0')
+            ->assertSee('1')
+            ->assertSee('2');
+    }
+
+    // https://github.com/livewire/livewire/discussions/8877
+    public function test_scenario_3_keys_on_nested_in_div_failing_1_no_key_on_nested_component()
+    {
+        Livewire::visit([
+            new class () extends Component {
+                public $prepend = false;
+
+                #[\Livewire\Attributes\Computed]
+                public function numbers()
+                {
+                    if ($this->prepend) {
+                        return range(0, 2);
+                    }
+
+                    return range(1, 2);
+                }
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="$toggle('prepend')" dusk="prepend">Prepend</button>
+                        <div>
+                            @foreach ($this->numbers as $index => $number)
+                                <div wire:key="{{ $number }}">
+                                    <livewire:child :$number />
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class () extends Component {
+                public $number;
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        {{ $number }}
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->waitForLivewireToLoad()
+            ->assertSee('1')
+            ->assertSee('2')
+            ->waitForLivewire()->click('@prepend')
+            ->assertConsoleLogHasNoErrors()
+            ->assertSee('0')
+            ->assertSee('1')
+            ->assertSee('2');
+    }
+
+    // https://github.com/livewire/livewire/discussions/8877
+    public function test_scenario_3_keys_on_nested_in_div_failing_2_no_key_on_loop_root_element()
+    {
+        Livewire::visit([
+            new class () extends Component {
+                public $prepend = false;
+
+                #[\Livewire\Attributes\Computed]
+                public function numbers()
+                {
+                    if ($this->prepend) {
+                        return range(0, 2);
+                    }
+
+                    return range(1, 2);
+                }
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="$toggle('prepend')" dusk="prepend">Prepend</button>
+                        <div>
+                            @foreach ($this->numbers as $index => $number)
+                                <div>
+                                    <livewire:child :$number :key="$number" />
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class () extends Component {
+                public $number;
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        {{ $number }}
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->waitForLivewireToLoad()
+            ->assertSee('1')
+            ->assertSee('2')
+            ->waitForLivewire()->click('@prepend')
+            ->assertConsoleLogHasNoErrors()
+            ->assertSee('0')
+            ->assertSee('1')
+            ->assertSee('2');
+    }
+
+    // https://github.com/livewire/livewire/discussions/8921
+    public function test_scenario_3_keys_on_nested_in_div_failing_3_incorrect_key_on_loop_root_element()
+    {
+        Livewire::visit([
+            new class () extends Component {
+                public $prepend = false;
+
+                #[\Livewire\Attributes\Computed]
+                public function numbers()
+                {
+                    if ($this->prepend) {
+                        return range(0, 2);
+                    }
+
+                    return range(1, 2);
+                }
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="$toggle('prepend')" dusk="prepend">Prepend</button>
+                        <div>
+                            @foreach ($this->numbers as $index => $number)
+                                <div wire:key="number">
+                                    <livewire:child :$number :key="$number" />
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class () extends Component {
+                public $number;
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        {{ $number }}
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->waitForLivewireToLoad()
+            ->assertSee('1')
+            ->assertSee('2')
+            ->waitForLivewire()->click('@prepend')
+            ->assertConsoleLogHasNoErrors()
+            ->assertSee('0')
+            ->assertSee('1')
+            ->assertSee('2');
+    }
 }

--- a/src/Tests/SnapshotMissingBrowserTest.php
+++ b/src/Tests/SnapshotMissingBrowserTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Livewire\Tests;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class SnapshotMissingBrowserTest extends \Tests\BrowserTestCase
+{
+    // https://github.com/livewire/livewire/discussions/9037
+    public function test_scenario_1_different_root_element_with_lazy_passing()
+    {
+        Livewire::visit([
+            new class () extends Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <livewire:child lazy />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class () extends Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>child</div>
+                    HTML;
+                }
+            },
+        ])
+            ->waitForLivewire()
+            ->waitForText('child')
+            ->assertSee('child')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    // https://github.com/livewire/livewire/discussions/9037
+    public function test_scenario_1_different_root_element_with_lazy_failing()
+    {
+        Livewire::visit([
+            new class () extends Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <livewire:child lazy />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class () extends Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                    <section>child</section>
+                    HTML;
+                }
+            },
+        ])
+            ->waitForLivewire()
+            ->waitForText('child')
+            ->assertSee('child')
+            ->assertConsoleLogHasNoErrors();
+    }
+}

--- a/src/Tests/SnapshotMissingBrowserTest.php
+++ b/src/Tests/SnapshotMissingBrowserTest.php
@@ -421,8 +421,8 @@ class SnapshotMissingBrowserTest extends \Tests\BrowserTestCase
                         <button wire:click="$toggle('changeNumbers')" dusk="changeNumbers">Change numbers</button>
                         <div>
                             @foreach ($this->numbers as $index => $number)
-                                <div wire:key="number">
-                                    <livewire:child :$number :key="$number" />
+                                <div wire:key="{{ $number }}">
+                                    <livewire:child :$number :key="$index" />
                                 </div>
                             @endforeach
                         </div>

--- a/src/Tests/SnapshotMissingBrowserTest.php
+++ b/src/Tests/SnapshotMissingBrowserTest.php
@@ -288,6 +288,8 @@ class SnapshotMissingBrowserTest extends \Tests\BrowserTestCase
     // https://github.com/livewire/livewire/discussions/8575
     // https://github.com/livewire/livewire/discussions/6698
     // https://github.com/livewire/livewire/discussions/6698#discussioncomment-7432437
+    // https://github.com/livewire/livewire/discussions/7193
+    // https://github.com/livewire/livewire/discussions/5802
     public function test_scenario_3_keys_on_nested_in_div_failing_2_no_key_on_loop_root_element()
     {
         Livewire::visit([


### PR DESCRIPTION
# The scenario

Currently there a bunch of scenarios which can trigger the "Snapshot missing on Livewire component" error.

<img width="643" alt="image" src="https://github.com/user-attachments/assets/b2d38637-6fa7-49d5-a7ec-451fd7b35eaf" />

This PR is a compilation of tests outlining the different scenarios people have run into that I could find in the Livewire discussions in this repo.

## Common scenarios that trigger the error
- Lazy child component with a different root element
```html
<div>
	<livewire:child lazy />
</div>

<!-- Child -->
<section>child</section>
```

- Two different elements with child components that have the same key
```html
<div>
	<button wire:click="$refresh">Refresh</button>
    <h1>Section 1</h1>
    <div>
        @foreach (range(1, 2) as $number)
            <livewire:child section="1" :$number :key="$number" />
        @endforeach
    </div>

    <h1>Section 2</h1>
    <div>
        @foreach (range(1, 2) as $number)
            <livewire:child section="2" :$number :key="$number" />
        @endforeach
    </div>
</div>
```

- Missing keys on the root element in a loop or any child components within that loop
```html
<div>
    @foreach($users as $user)
        <div>
            <livewire:child :key="$user->id" />
        </div>
    @endforeach
</div>

<!-- or -->
<div>
    @foreach($users as $user)
        <div wire:key="{{ $user->id }}">
            <livewire:child />
        </div>
    @endforeach
</div>
```

- Conditionally removing elements using javascript
```html
<div>
    <div x-init="$el.remove()">
        {{ __('Javascript required') }}
    </div>
    <button wire:click="$toggle('showContents')" dusk="showContents">Show/Hide</button>
    <div x-show="$wire.showContents" wire:key="container">
        <livewire:child wire:key="test" />
    </div>
</div>
```

- Adding `:key` has confused people as they are expecting that to work on elements too. Having `wire:key` and `:key` isn't straight forward and people aren't sure when to use each.
  https://github.com/livewire/livewire/discussions/7602#discussioncomment-7960775

```blade
<div>
    @foreach($users as $user)
        <div :key="$user->id">
            <livewire:child :key="$user->id" />
        </div>
    @endforeach
</div>
```

- Cloudflare `remove_whitespace_between_tags` as it minify's the html which then causes issues with morphing - https://github.com/livewire/livewire/discussions/6704