### PR TITLE
[WIP] Adds type safe methods for properties

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -113,6 +113,30 @@ trait InteractsWithProperties
         return $beforeReset;
     }
 
+    /**
+     * @return string
+     */
+    public function pullString($property)
+    {
+        $value = $this->getPropertyValue($property);
+
+        $this->reset($property);
+
+        return is_string($value) ? $value : '';
+    }
+
+    /**
+     * @return int
+     */
+    public function pullInt($property)
+    {
+        $value = $this->getPropertyValue($property);
+
+        $this->reset($property);
+
+        return intval($value);
+    }
+
     public function only($properties)
     {
         $results = [];


### PR DESCRIPTION
let's say we are dispatching any event with the same name where we use any properties with concating with some prifix.

```php
$this->dispatch('chat:updated.'.$this->pull('chatId'));

// This will gonna fail PhpStan...
//  ------ -----------------------------------------------------------------------------
//  Line   Livewire\Chats\Save.php
//  ------ -----------------------------------------------------------------------------
//  65     Binary operation "." between 'chat:updated.' and mixed results in an error.
//         🪪  binaryOp.invalid
// ------ -----------------------------------------------------------------------------
```

but if we have some methods like `pullString`, `pullInt` and other similar methods, it can help to pass the PhpStan with convenient of dev.

```php
$this->dispatch('chat:updated.'.(string) $this->pullInt('chatId'));
$this->dispatch('chat:updated.'.$this->pullString('chatId'));
```