### PR TITLE
Fix incorrect `getValue()` exception message labelled with `set`

### DIFF
--- a/src/Features/SupportAttributes/Attribute.php
+++ b/src/Features/SupportAttributes/Attribute.php
@@ -53,7 +53,7 @@ abstract class Attribute
     function getValue()
     {
         if ($this->level !== AttributeLevel::PROPERTY) {
-            throw new \Exception('Can\'t set the value of a non-property attribute.');
+            throw new \Exception('Can\'t get the value of a non-property attribute.');
         }
 
         return data_get($this->component->all(), $this->levelName);


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
It is needed to enhance the understanding of errors that happen when using Livewire, but the fix is so tiny that it shouldn't need further discussions.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
No because there were no matching tests.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
The LivewireAttribute class exposes a getter and a setter for its value, which may be unaccessible in same cases, but the thrown exceptions have the same message.
