### PR TITLE
Add synth for html string

### DIFF
--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -17,6 +17,7 @@ class HandleComponents extends Mechanism
         Synthesizers\CarbonSynth::class,
         Synthesizers\CollectionSynth::class,
         Synthesizers\StringableSynth::class,
+        Synthesizers\HtmlStringSynth::class,
         Synthesizers\EnumSynth::class,
         Synthesizers\StdClassSynth::class,
         Synthesizers\ArraySynth::class,

--- a/src/Mechanisms/HandleComponents/Synthesizers/HtmlStringSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/HtmlStringSynth.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
+
+use Illuminate\Support\HtmlString;
+
+class HtmlStringSynth extends Synth {
+    public static $key = 'html';
+
+    static function match($target) {
+        return $target instanceof HtmlString;
+    }
+
+    function dehydrate($target) {
+        return [$target->__toString(), []];
+    }
+
+    function hydrate($value) {
+        return new HtmlString($value);
+    }
+}


### PR DESCRIPTION
If you use the new `AsHtmlString` cast on a model attribute that was added in [v12.4](https://laravel-news.com/laravel-12-4-0) you will get:

```exception
Property type not supported in Livewire for property: [{}]
```

This makes Livewire work with `HtmlString`s seamlessly.