### PR TITLE
Update isSynthetic function to fix bug where subject[1] is null

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -170,6 +170,7 @@ export function isSynthetic(subject) {
     return Array.isArray(subject)
         && subject.length === 2
         && typeof subject[1] === 'object'
+        && subject[1] !== null
         && Object.keys(subject[1]).includes('s')
 }
 


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Bug for edge cases.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
no

4️⃣ Does it include tests? (Required)
no

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

The source code contains the below utility function

```javascript
export function isSynthetic(subject) {
    return Array.isArray(subject)
        && subject.length === 2
        && typeof subject[1] === 'object'
        && Object.keys(subject[1]).includes('s')
}
```

This contains a bug when the argument `subject` is an array of length 2 with `subject[1] = null`.

This causes the expression `typeof subject[1] === 'object'` to evaluate to `true` but the next expression `Object.keys(subject[1]).includes('s')` throws the following error:

```Uncaught (in promise) TypeError: Cannot convert undefined or null to object```

The proposed change is the add another expression to check that `subject[1] ` does not equal null.
```javascript
export function isSynthetic(subject) {
    return Array.isArray(subject)
        && subject.length === 2
        && typeof subject[1] === 'object'
        && subject[1] !== null
        && Object.keys(subject[1]).includes('s')
}
```

Thanks for contributing! 🙌
