### PR TITLE
Remove invalid void return

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -111,7 +111,7 @@ function before($name, $callback) {
 }
 
 function off($name, $callback) {
-    return app(\Livewire\EventBus::class)->off($name, $callback);
+    app(\Livewire\EventBus::class)->off($name, $callback);
 }
 
 function memoize($target) {


### PR DESCRIPTION
It's not valid to return void, in this case it was automatically cast to null since there isn't any return type on the parent function but better fix it now then it becoming an issue later.
