### PR TITLE
Add types to HandlesEvents

### DIFF
--- a/src/Features/SupportEvents/HandlesEvents.php
+++ b/src/Features/SupportEvents/HandlesEvents.php
@@ -6,12 +6,22 @@ use function Livewire\store;
 
 trait HandlesEvents
 {
+    /** @var array<string> */
     protected $listeners = [];
 
+    /**
+     * @return array<string>
+     */
     protected function getListeners() {
         return $this->listeners;
     }
 
+    /**
+     * @param string $event 
+     * @param mixed... $params 
+     *
+     * @return Event 
+     */
     public function dispatch($event, ...$params)
     {
         $event = new Event($event, $params);


### PR DESCRIPTION
This resolves warnings when type checking is enabled on projects that use Livewire when they specify the $listeners for a component.