### PR TITLE
Add return docblock for Testable `invade()` method

### DIFF
--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -340,11 +340,7 @@ class Testable
     }
 
     /**
-     * @template T of \Livewire\Component
-     *
-     * @param  T  $obj
-     *
-     * @return T
+     * @return \Livewire\Component
      */
     function invade()
     {

--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -339,6 +339,13 @@ class Testable
         return $this->lastState->getComponent();
     }
 
+    /**
+     * @template T of \Livewire\Component
+     *
+     * @param  T  $obj
+     *
+     * @return T
+     */
     function invade()
     {
         return \Livewire\invade($this->lastState->getComponent());


### PR DESCRIPTION
These docblocks provide some better autocomplete when using the `invade()` function during testing.

![afbeelding](https://github.com/user-attachments/assets/e8b12fbc-29a9-471b-949b-6e814c5b72ac)

Thanks!