### PR TITLE
Fix disable back button cache not being reset

### DIFF
--- a/src/Features/SupportDisablingBackButtonCache/DisableBackButtonCacheMiddleware.php
+++ b/src/Features/SupportDisablingBackButtonCache/DisableBackButtonCacheMiddleware.php
@@ -24,6 +24,10 @@ class DisableBackButtonCacheMiddleware
                 'Expires' => 'Fri, 01 Jan 1990 00:00:00 GMT',
                 'Cache-Control' => 'no-cache, must-revalidate, no-store, max-age=0, private',
             ]);
+
+            // We do flush this in the `SupportDisablingBackButtonCache` hook, but we 
+            // need to do it here as well to ensure that unit tests still work...
+            SupportDisablingBackButtonCache::$disableBackButtonCache = false;
         }
 
         return $response;

--- a/src/Features/SupportDisablingBackButtonCache/SupportDisablingBackButtonCache.php
+++ b/src/Features/SupportDisablingBackButtonCache/SupportDisablingBackButtonCache.php
@@ -4,12 +4,18 @@ namespace Livewire\Features\SupportDisablingBackButtonCache;
 
 use Livewire\ComponentHook;
 
+use function Livewire\on;
+
 class SupportDisablingBackButtonCache extends ComponentHook
 {
     public static $disableBackButtonCache = false;
 
     public static function provide()
     {
+        on('flush-state', function () {
+            static::$disableBackButtonCache = false;
+        });
+
         $kernel = app()->make(\Illuminate\Contracts\Http\Kernel::class);
 
         if ($kernel->hasMiddleware(DisableBackButtonCacheMiddleware::class)) {

--- a/src/Features/SupportDisablingBackButtonCache/UnitTest.php
+++ b/src/Features/SupportDisablingBackButtonCache/UnitTest.php
@@ -9,11 +9,9 @@ class UnitTest extends \Tests\TestCase
 {
     public function test_ensure_disable_browser_cache_middleware_is_not_applied_to_a_route_that_does_not_contain_a_component()
     {
-        $this->markTestSkipped(); // @todo: Josh Hanley?
-
         Route::get('test-route-without-livewire-component', function () { return 'ok'; });
 
-        $response = $this->get('test-route-without-livewire-component');
+        $response = $this->get('test-route-without-livewire-component')->assertSuccessful();
 
         // There are a couple of different headers applied in the middleware,
         // so just testing for one that isn't normally in a Laravel request
@@ -24,11 +22,29 @@ class UnitTest extends \Tests\TestCase
     {
         Route::get('test-route-containing-livewire-component', DisableBrowserCache::class);
 
-        $response = $this->get('test-route-containing-livewire-component');
+        $response = $this->get('test-route-containing-livewire-component')->assertSuccessful();
 
         // There are a couple of different headers applied in the middleware,
         // so just testing for one that isn't normally in a Laravel request
         $this->assertTrue($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
+    }
+
+    public function test_ensure_disable_browser_cache_middleware_is_disabled_after_a_livewire_request_so_no_following_non_livewire_requests_have_it_enabled()
+    {
+        Route::get('test-route-containing-livewire-component', DisableBrowserCache::class);
+        Route::get('test-route-without-livewire-component', function () { return 'ok'; });
+
+        $response = $this->get('test-route-containing-livewire-component')->assertSuccessful();
+
+        // There are a couple of different headers applied in the middleware,
+        // so just testing for one that isn't normally in a Laravel request
+        $this->assertTrue($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
+
+        $response = $this->get('test-route-without-livewire-component')->assertSuccessful();
+
+        // There are a couple of different headers applied in the middleware,
+        // so just testing for one that isn't normally in a Laravel request
+        $this->assertFalse($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
     }
 }
 


### PR DESCRIPTION
# The scenario

Currently if you have two tests in the same file, the first that tests a Livewire component and the second that tests a normal route, then the normal route test will still have the back button cache disabled from the Livewire request.

It's also likely that using Octane also has this issue, but I've not tested that.

# The problem

The issue is that for any long running instances like tests or Octane, if the disabled back button cache middleware is enabled by a Livewire request, it's not reverted at the end of the request. Looking at the `SupportDisablingBackButtonCache` code, there is no listener for `flush-state`.

# The solution

The solution is to implement a listener for `flush-state` in `SupportDisablingBackButtonCache` which should fix this for things like Octane.

But when I added a test for this, it still didn't fix the issue for unit tests.

The problem with a unit tests that hits an actual route in the application, and not a `Livewire::test()` instance, is that flushing doesn't happen when that route that contains a Livewire component is finished.

So to fix this, I've added code to the middleware which resets it after the middleware has made use of it. This should then ensure all requests start fresh. Technically, this would make the `flush-state` listener, I just added, redundant but I think it's good to keep both anyway.

Fixes livewire/livewire#8198