### PR TITLE
Add 'translate' prop to 'title' attribute

### DIFF
--- a/src/Features/SupportPageComponents/BaseTitle.php
+++ b/src/Features/SupportPageComponents/BaseTitle.php
@@ -9,5 +9,6 @@ class BaseTitle extends LivewireAttribute
 {
     function __construct(
         public $content,
+        public bool $translate = false,
     ) {}
 }

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -99,7 +99,7 @@ class SupportPageComponents extends ComponentHook
             }
 
             if ($titleAttr) {
-                $view->title($titleAttr->content);
+                $view->title($titleAttr->translate ? __($titleAttr->content) : $titleAttr->content);
             }
 
             $layoutConfig = $view->layoutConfig ?? new PageComponentConfig;

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -6,7 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Translation\Translator;
 use Livewire\Component;
 use Livewire\Livewire;
 
@@ -372,6 +375,19 @@ class UnitTest extends \Tests\TestCase
             ->assertSee('some-title');
     }
 
+    public function test_can_configure_title_using_translated_title_attribute()
+    {
+        Lang::addLines(['translatable.foo_title' => 'Translated Foo'], App::currentLocale());
+
+        Route::get('/configurable-layout', ComponentForTranslatedTitleAttribute::class);
+
+        $this
+            ->withoutExceptionHandling()
+            ->get('/configurable-layout')
+            ->assertSee('bob')
+            ->assertSee('Translated Foo');
+    }
+
     public function test_can_use_layout_slots_in_full_page_components()
     {
         Route::get('/configurable-layout', ComponentWithMultipleLayoutSlots::class);
@@ -707,6 +723,18 @@ class ComponentForTitleAttribute extends Component
     public $name = 'bob';
 
     #[BaseTitle('some-title')]
+    #[BaseLayout('layouts.app-with-title')]
+    public function render()
+    {
+        return view('show-name');
+    }
+}
+
+class ComponentForTranslatedTitleAttribute extends Component
+{
+    public $name = 'bob';
+
+    #[BaseTitle('translatable.foo_title', translate: true)]
     #[BaseLayout('layouts.app-with-title')]
     public function render()
     {


### PR DESCRIPTION
Currently, you can not use the `#[Title]` if you want to show a translated title based on the user's locale. This PR fixes that.

```php
#[Title('some_component.title', translate: true)]
class SomeComponent extends Component
{
    // ...
}
```
For backward compatibility, it is disabled by default.