### PR TITLE
Fix pagination path

### DIFF
--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -63,6 +63,7 @@ class SupportPagination extends ComponentHook
 
     protected function setPathResolvers()
     {
+        // Setting the path resolver here on the default paginator also works for the cursor paginator...
         Paginator::currentPathResolver(function () {
             return Livewire::originalPath();
         });

--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -7,6 +7,7 @@ use Livewire\WithPagination;
 use Livewire\Features\SupportQueryString\SupportQueryString;
 use Livewire\ComponentHookRegistry;
 use Livewire\ComponentHook;
+use Livewire\Livewire;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\Cursor;
@@ -34,6 +35,8 @@ class SupportPagination extends ComponentHook
 
     function boot()
     {
+        $this->setPathResolvers();
+
         $this->setPageResolvers();
 
         $this->overrideDefaultPaginationViews();
@@ -56,6 +59,13 @@ class SupportPagination extends ComponentHook
 
         Paginator::defaultView($this->paginationView());
         Paginator::defaultSimpleView($this->paginationSimpleView());
+    }
+
+    protected function setPathResolvers()
+    {
+        Paginator::currentPathResolver(function () {
+            return Livewire::originalPath();
+        });
     }
 
     protected function setPageResolvers()


### PR DESCRIPTION
# The scenario

If you want to use anchor tags in place of pagination buttons, so users can `cmd+click` to open them in a new tab, then currently after a Livewire request the pagination URLs are prefixed with the Livewire update path.

**First request**
<img width="967" alt="image" src="https://github.com/user-attachments/assets/14769ec3-1915-4522-ac96-b7f0a5ba813b" />

**Subsequent request**
<img width="961" alt="image" src="https://github.com/user-attachments/assets/4b98e607-f494-4853-b8a1-869f1ba71dfb" />

# The problem

The issue is that after a Livewire's request is made, the request URL is Livewire's endpoint. So when the paginator is generating the pagination URLs, it's using the current request's path.

# The solution

The solution is to set a path resolver for the paginator that makes use of Livewire's `Livewire::originalPath()`, which will ensure that the paginator uses the original path instead of current request path when generating the pagination URLs.

```php
protected function setPathResolvers()
{
    // Setting the path resolver here on the default paginator also works for the cursor paginator...
    Paginator::currentPathResolver(function () {
        return Livewire::originalPath();
    });
}
```

Now the URLs are generated as expected.

I also checked to make sure cursor paginator also works the same way and it makes use of the path resolver set on the default paginator, as there is no `currentPathResolver()` method directly on the `CursorPaginator` class.

**Subsequent request**
<img width="963" alt="image" src="https://github.com/user-attachments/assets/e6afa184-cd38-4703-a173-480ca7d6a1e9" />
