### PR TITLE
Add model IDs to smart keys

### DIFF
--- a/src/Features/SupportCompiledWireKeys/SupportCompiledWireKeys.php
+++ b/src/Features/SupportCompiledWireKeys/SupportCompiledWireKeys.php
@@ -84,8 +84,14 @@ class SupportCompiledWireKeys extends ComponentHook
         ];
     }
     
-    public static function startLoop($index) {
+    public static function startLoop($index, $loopData) {
         static::$currentLoop['index'] = $index;
+        
+        $value = \Illuminate\Support\Collection::wrap($loopData)->values()[$index];
+
+        if ($value instanceof \Illuminate\Database\Eloquent\Model) {
+            static::$currentLoop['key'] = $value->getKey();
+        }
     }
 
     public static function endLoop() {

--- a/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
@@ -154,7 +154,7 @@ class SupportMorphAwareBladeCompilation extends ComponentHook
         if (static::$shouldInjectLoopMarkers && static::isLoop($found)) {
             $prefix .= '<?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::openLoop(); ?>';
 
-            $suffix .= '<?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoop($loop->index); ?>';
+            $suffix .= '<?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoop($loop->index, $__currentLoopData); ?>';
         }
 
         if ($prefix === '' && $suffix === '') {


### PR DESCRIPTION
This PR is a follow up to PR #9310 to see if we can support detecting Eloquent Model keys in a loop and use that as the key for nested child components.

> explore auto model ->getKey() type deal (will be sick if it doesn't eat up runtime perf)

Had a look into doing this, but it's not as simple as we'd think because we don't know what the variable name is for the value in the loop.

For example, it could be `@foreach ($users as $key => $user)` and so the value variable is `$user`, but it could be `$newUser` or anything really depending on what the developer specifies.

If I do a dump of all available variables, we can see `$user` and `$key` but no direct way for us to get the current iteration's value.

![image](https://github.com/user-attachments/assets/6333f695-e471-4bd7-ae52-284bf0709c0d)

We could use the `$_currentLoopData` combined with `$loop->index` to get the value that way.

So doing this works:

```php
public static function startLoop($index, $loopData) {
    static::$currentLoop['index'] = $index;

    $value = \Illuminate\Support\Collection::wrap($loopData)->values()[$index];

    if ($value instanceof \Illuminate\Database\Eloquent\Model) {
        static::$currentLoop['key'] = $value->getKey();
    }
}
```

But this is being run at the start of every iteration of each loop. We need to wrap the $loopData in a collection as it could be a collection or an array, and we can't call `array_values()` on a collection instance, so we do that to get the values and then we can get the value using the index.

Doing a quick test with Debugbar, if rendering 10,000 users with each user being a nested component, without this model lookup it runs in ~19.6s. Where as with this lookup runs in ~20.1s, so it's about 0.5 secs slower which is ~2.6% slower.

If I profile this, without this PR, this is how long `startLoop()` takes:

<img width="1081" alt="image" src="https://github.com/user-attachments/assets/276fb202-e7a7-450b-b58a-1358cce14336" />

And with it:

<img width="1093" alt="image" src="https://github.com/user-attachments/assets/37b44903-81db-4dc3-b0df-6588b2390040" />

The the method itself is now quite a bit slower, but in terms of as a percentage of the overall request, without it the method is 0.00% of the request and with it the method is 1.4% of the request.


**Note**
One other thing to note about this, is that it doesn't add the detected Eloquent Model key to the root element in the loop. It only makes note of it for constructing a `smart_wire_key` for nested child components.