### PR TITLE
Add support AlpineJs x-ref directive to pagination view

### DIFF
--- a/src/Features/SupportPagination/views/bootstrap.blade.php
+++ b/src/Features/SupportPagination/views/bootstrap.blade.php
@@ -5,7 +5,7 @@ if (! isset($scrollTo)) {
 
 $scrollIntoViewJsSnippet = ($scrollTo !== false)
     ? <<<JS
-       (\$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).scrollIntoView()
+       (\$refs.$scrollTo || \$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).scrollIntoView()
     JS
     : '';
 @endphp

--- a/src/Features/SupportPagination/views/simple-bootstrap.blade.php
+++ b/src/Features/SupportPagination/views/simple-bootstrap.blade.php
@@ -5,7 +5,7 @@ if (! isset($scrollTo)) {
 
 $scrollIntoViewJsSnippet = ($scrollTo !== false)
     ? <<<JS
-       (\$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).scrollIntoView()
+       (\$refs.$scrollTo || \$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).scrollIntoView()
     JS
     : '';
 @endphp

--- a/src/Features/SupportPagination/views/simple-tailwind.blade.php
+++ b/src/Features/SupportPagination/views/simple-tailwind.blade.php
@@ -5,7 +5,7 @@ if (! isset($scrollTo)) {
 
 $scrollIntoViewJsSnippet = ($scrollTo !== false)
     ? <<<JS
-       (\$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).scrollIntoView()
+       (\$refs.$scrollTo || \$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).scrollIntoView()
     JS
     : '';
 @endphp

--- a/src/Features/SupportPagination/views/tailwind.blade.php
+++ b/src/Features/SupportPagination/views/tailwind.blade.php
@@ -5,7 +5,7 @@ if (! isset($scrollTo)) {
 
 $scrollIntoViewJsSnippet = ($scrollTo !== false)
     ? <<<JS
-       (\$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).scrollIntoView()
+       (\$refs.$scrollTo || \$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).scrollIntoView()
     JS
     : '';
 @endphp


### PR DESCRIPTION
This PR adds support for [AlpineJs](https://alpinejs.dev/directives/ref) `x-ref` directive to pagination view, especially for `scrollTo` functionality.

By default, this is livewire pagination view setup for `scrollTo` functionality
```blade
@php
if (! isset($scrollTo)) {
    $scrollTo = 'body';
}

$scrollIntoViewJsSnippet = ($scrollTo !== false)
    ? <<<JS
       (\$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).scrollIntoView()
    JS
    : '';
@endphp
```
```php
// example
<div id="myElement"></div>
...
...
$users->links(data: ['scrollTo' => '#myElement'])
```
With this PR, `scrollTo` selector can be used with `x-ref` directive
```php
@php
if (! isset($scrollTo)) {
    $scrollTo = 'body';
}

$scrollIntoViewJsSnippet = ($scrollTo !== false)
    ? <<<JS
       (\$refs.$scrollTo || \$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).scrollIntoView()
    JS
    : '';
@endphp
```
```php
// example
<div x-ref="myElement"></div>
...
...
$users->links(data: ['scrollTo' => 'myElement'])
```
