### PR TITLE
Smart wire keys fixes

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -147,6 +147,19 @@ return [
 
     /*
     |---------------------------------------------------------------------------
+    | Smart Wire Keys
+    |---------------------------------------------------------------------------
+    |
+    | Livewire uses loops and keys used within loops to generate smart keys that
+    | are applied to nested components that don't have them. This makes using
+    | nested components more reliable by ensuring that they all have keys.
+    |
+    */
+
+    'smart_wire_keys' => true,
+
+    /*
+    |---------------------------------------------------------------------------
     | Pagination Theme
     |---------------------------------------------------------------------------
     |

--- a/src/Features/SupportCompiledWireKeys/BrowserTest.php
+++ b/src/Features/SupportCompiledWireKeys/BrowserTest.php
@@ -337,6 +337,8 @@ class BrowserTest extends \Tests\BrowserTestCase
     // https://github.com/livewire/livewire/discussions/5935#discussioncomment-11265936
     public function test_scenario_2_keys_in_groups_failing()
     {
+        $this->markTestSkipped('This is skipped because we have decided to not add smart wire keys to nested components if they already have a key. If this scenario keeps being a problem, we can look at fixing this in the future.');
+
         Livewire::visit([
             new #[\Livewire\Attributes\On('number-updated')] class () extends Component {
                 public function render()

--- a/src/Mechanisms/RenderComponent.php
+++ b/src/Mechanisms/RenderComponent.php
@@ -22,6 +22,10 @@ class RenderComponent extends Mechanism
             return '';
         }, $expression);
 
+        if (is_null($key)) {
+            $key = 'null';    
+        }
+
         $deterministicBladeKey = app(\Livewire\Mechanisms\ExtendBlade\DeterministicBladeKeys::class)->generate();
         $deterministicBladeKey = "'{$deterministicBladeKey}'";
 
@@ -32,7 +36,9 @@ class RenderComponent extends Mechanism
 };
 [\$__name, \$__params] = \$__split($expression);
 
-\$key = \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::generateKey($deterministicBladeKey, $key);
+\$key = $key;
+
+\$key ??= \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::generateKey($deterministicBladeKey, $key);
 
 \$__html = app('livewire')->mount(\$__name, \$__params, \$key);
 


### PR DESCRIPTION
This PR adds a config option to allow smart wire keys to be disabled.

It also changes smart keys so they aren't applied to components if the component already has a key specified for now. This ensures that components can have unique keys on the page and be drag/dropped without any issues.