### PR TITLE
Fixed example in components doc

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -220,7 +220,7 @@ If you are looping through an array that is rendering Livewire components you ma
     @foreach ($posts as $post)
         <livewire:post-item :$post :key="$post->id">
 
-        @livewire(PostItem::class, ['post' => $post], key($post->id))
+        @livewire(PostItem::class, ['post' => $post], $post->id)
     @endforeach
 </div>
 ```


### PR DESCRIPTION
Fixed the example. It does not make sense to call `key()` on what is probably going to be a value of type int.