### PR TITLE
Fix long filenames in file uploads

### DIFF
--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -124,4 +124,21 @@ class FileUploadConfiguration
     {
         return config('livewire.temporary_file_upload.max_upload_time') ?: 5;
     }
+
+    public static function storeTemporaryFile($file, $disk)
+    {
+        $filename = TemporaryUploadedFile::generateHashName($file);
+        $metaFilename = $filename . '.json';
+        
+        Storage::disk($disk)->put('/'.static::path($metaFilename), json_encode([
+            'name' => $file->getClientOriginalName(),
+            'type' => $file->getMimeType(),
+            'size' => $file->getSize(),
+            'hash' => $file->hashName(),
+        ]));
+
+        return $file->storeAs('/'.static::path(), $filename, [
+            'disk' => $disk
+        ]);
+    }
 }

--- a/src/Features/SupportFileUploads/FileUploadController.php
+++ b/src/Features/SupportFileUploads/FileUploadController.php
@@ -42,11 +42,7 @@ class FileUploadController implements HasMiddleware
         ])->validate();
 
         $fileHashPaths = collect($files)->map(function ($file) use ($disk) {
-            $filename = TemporaryUploadedFile::generateHashNameWithOriginalNameEmbedded($file);
-
-            return $file->storeAs('/'.FileUploadConfiguration::path(), $filename, [
-                'disk' => $disk
-            ]);
+            return FileUploadConfiguration::storeTemporaryFile($file, $disk);
         });
 
         // Strip out the temporary upload directory from the paths.

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -347,7 +347,8 @@ class UnitTest extends \Tests\TestCase
             ->set('photo', $file2)
             ->call('upload', 'uploaded-avatar2.png');
 
-        $this->assertCount(2, FileUploadConfiguration::storage()->allFiles());
+        // 4 files because we have 2 files and 2 meta files...
+        $this->assertCount(4, FileUploadConfiguration::storage()->allFiles());
 
         // Make temporary files look 2 days old.
         foreach (FileUploadConfiguration::storage()->allFiles() as $fileShortPath) {
@@ -358,7 +359,8 @@ class UnitTest extends \Tests\TestCase
             ->set('photo', $file3)
             ->call('upload', 'uploaded-avatar3.png');
 
-        $this->assertCount(1, FileUploadConfiguration::storage()->allFiles());
+        // 2 files because we have 1 file and 1 meta file...
+        $this->assertCount(2, FileUploadConfiguration::storage()->allFiles());
     }
 
     public function test_temporary_files_older_than_24_hours_are_not_cleaned_up_if_configuration_specifies()
@@ -379,7 +381,8 @@ class UnitTest extends \Tests\TestCase
             ->set('photo', $file2)
             ->call('upload', 'uploaded-avatar2.png');
 
-        $this->assertCount(2, FileUploadConfiguration::storage()->allFiles());
+        // 4 files because we have 2 files and 2 meta files...
+        $this->assertCount(4, FileUploadConfiguration::storage()->allFiles());
 
         // Make temporary files look 2 days old.
         foreach (FileUploadConfiguration::storage()->allFiles() as $fileShortPath) {
@@ -390,7 +393,8 @@ class UnitTest extends \Tests\TestCase
             ->set('photo', $file3)
             ->call('upload', 'uploaded-avatar3.png');
 
-        $this->assertCount(3, FileUploadConfiguration::storage()->allFiles());
+        // 6 files because we have 2 files and 4 meta files...
+        $this->assertCount(6, FileUploadConfiguration::storage()->allFiles());
     }
 
     public function test_temporary_files_older_than_24_hours_are_not_cleaned_up_on_every_new_upload_when_using_S3()
@@ -411,7 +415,8 @@ class UnitTest extends \Tests\TestCase
             ->set('photo', $file2)
             ->call('upload', 'uploaded-avatar2.png');
 
-        $this->assertCount(2, FileUploadConfiguration::storage()->allFiles());
+        // 4 files because we have 2 files and 2 meta files...
+        $this->assertCount(4, FileUploadConfiguration::storage()->allFiles());
 
         // Make temporary files look 2 days old.
         foreach (FileUploadConfiguration::storage()->allFiles() as $fileShortPath) {
@@ -422,7 +427,8 @@ class UnitTest extends \Tests\TestCase
             ->set('photo', $file3)
             ->call('upload', 'uploaded-avatar3.png');
 
-        $this->assertCount(3, FileUploadConfiguration::storage()->allFiles());
+        // 6 files because we have 2 files and 4 meta files...
+        $this->assertCount(6, FileUploadConfiguration::storage()->allFiles());
     }
 
     public function test_S3_can_be_configured_so_that_temporary_files_older_than_24_hours_are_cleaned_up_automatically()

--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -300,23 +300,7 @@ class Testable
             return $this;
         }
 
-        // We are going to encode the original file size, mimeType and hashName in the filename
-        // so when we create a new TemporaryUploadedFile instance we can fake the
-        // same file size, mimeType and hashName set for the original file upload.
-        $newFileHashes = collect($files)->zip($fileHashes)->mapSpread(function ($file, $fileHash) {
-            // MimeTypes contain slashes, so we replace them with underscores to ensure the filename is valid.
-            $escapedMimeType = (string) str($file->getMimeType())->replace('/', '_');
-
-            return (string) str($fileHash)->replaceFirst('.', "-hash={$file->hashName()}-mimeType={$escapedMimeType}-size={$file->getSize()}.");
-        })->toArray();
-
-        collect($fileHashes)->zip($newFileHashes)->mapSpread(function ($fileHash, $newFileHash) use ($storage) {
-            $storage->move('/'.\Livewire\Features\SupportFileUploads\FileUploadConfiguration::path($fileHash), '/'.\Livewire\Features\SupportFileUploads\FileUploadConfiguration::path($newFileHash));
-        });
-
-        // Now we finish the upload with a final call to the Livewire component
-        // with the temporarily uploaded file path.
-        $this->call('_finishUpload', $name, $newFileHashes, $isMultiple);
+        $this->call('_finishUpload', $name, $fileHashes, $isMultiple);
 
         return $this;
     }


### PR DESCRIPTION
# The scenario

Currently if a user tries to upload a file with a long file name, a `UnableToWriteFile` exception is thrown.

![image](https://github.com/user-attachments/assets/0cbdcb25-4a53-450b-a477-f4655064ccdf)

Which is caught and then a `UnableToRetrieveMetadata` exception is thrown.

![image](https://github.com/user-attachments/assets/a9b78211-4a74-4364-9993-6c24f9aee95b)

# The problem

The issue is that most file systems have a maximum filename length of 255 characters (macOS, Windows, and Linux).

But that is just for the filename length, full file-paths (file path + file name + file extension) can be longer. MacOS has a max full file-path of 1024 characters and Linux has a max of 4096 characters. But Windows has a max of 260 characters.

This issue occurs across all operating systems, but it's most common on Windows due to the small full file-path. What that means is typically a user's `livewire-tmp` directory, might have a path like `C:\laragon\www\myapp\storage\app\livewire-tmp\` which is already 46 characters out of 260 and that doesn't include the filename.

When Livewire uploads a file to the `livewire-tmp` directory, it generates a hased filename which includes the original filename embedded within it.

The hash consists of:
- 30 random characters
- `-meta` string
- a base 64 encoding of the original filename and extension
- the original file extension

For example if the original filename and extension is 150 characters long, when base64 encoded it becomes 200 characters long. Add the 30 random characters, `-meta` and the file extension, let's say `.png` and it's already 239 characters and that's before we even add the `livewire-tmp` directory path. So if we add the 46 characters from the example path above, we end up with 285 characters which is over the limited for Windows.

So why do we even need to encode and add the original filename to the temporary file name hash?

The reason is because it's the simplest way to store the original filename so it goes along with the temporary file. The temporary file name hash can be decoded to retrieve the original filename, which might be used in the UI, for saving, or for number of other reasons.

# The solution

To fix this problem, we need to remove the filename from the temporary file name hash and instead store it somewhere else.

There are two realistic options:
1. Store a mapping between the hashed temporary file name and the original filename in a meta data file
2. Find a way to store it on the `TemporaryUploadedFile` class

This PR implements option 1 and stores the original filename in a `.json` meta data file.

It's similar to PR #9172 which stored the data in a `meta/` folder in a file named the same as the original file. But the main difference is that PR would truncate the filename if it ended up too long. Where as this PR always uses the meta file.

I also explored option 2 in PR #9350 by storing the original file name as a property on `TemporaryUploadedFile`, but found that it required significant changes in multiple files and how data was structured, so decided to stop on that.

### Implementation details
With this PR, when a temporary file is uploaded, a corresponding meta file will be generated.

For example, when a file get's uploaded the `livewire-tmp` directory will now have two files in it:
- `L7obxpYUiNJmegxfKCkLPxEOWtGgZO1ZwXQgQeVS.png`
- `L7obxpYUiNJmegxfKCkLPxEOWtGgZO1ZwXQgQeVS.png.json`

The first file is the actual file. Where as the second (ending in `.json`) is the meta file.

The meta file contains the following information:
- name - original client name
- type - mimetype
- size - size of file
- hash - Laravel's hash of the original file

I have extracted the logic for creating a temporary file and it's meta file into a method on the `FileUploadConfiguration::storeTemporaryFile();`. I did this as it already has information like storage and disk, which simplifies the implementation. Ideally I would want it on the `TemporaryUploadedFile` class as a `store()` method, but `store` and `storeAs` already exist.

One thing to note is that I experimented with using Laravel's hash (as stored in the meta file above), but it attempts to read the file's mimetype from the file contents and changes the file extension on the end of the hash to suit. This is different to how Livewire has been handling it, so have kept our hash name implementation and just simplified it to not include the file name in the hash.

### Testable
I was able to clean up the `Testable` upload configuration to use the meta file now too. Previously it would inject file size,  mime type, and Laravel's file hash into the file name which ran the risk of the same file name too long issue.

I have made sure though that there is backwards compatibility with any temporary files, that may exist that won't have the new meta file generated, by ensuring all meta information look ups fall back to using the filename if no meta file is found.

### S3 compatibility

I have not touched the S3 implementation, so it is still encoding the filename in the hash. I tested this PR with S3 to ensure that everything is still working as expected and it is.

The reason I opted to leave filename encoding in S3, is because it has no restriction on the filename as such, instead it has a restriction of 1024 characters for the key name of the object in the store (which is essentially the relative path + file name), which I believe would be sufficient.

I also found that uploading a meta file to S3 would require it to be reworked as it would need to be uploaded in a separate API call, either when the signed URL is being generated, or as a second sideload (which would require a second signed URL).

Because of that, I have opted to leave it as is for now. I have added a test which ensures Livewire will happily read the original filename from the file hash if no meta file exists.