### PR TITLE
Docs: Remove duplicated "the" word from `wire-model.md`

### DIFF
--- a/docs/wire-model.md
+++ b/docs/wire-model.md
@@ -104,7 +104,7 @@ Any changes made to the text input will be automatically synchronized with the `
 -------------------|-------------------------------------------------------------------------
  `.live`           | Send updates as a user types
  `.blur`           | Only send updates on the `blur` event
- `.change`         | Only send updates on the the `change` event
+ `.change`         | Only send updates on the `change` event
  `.lazy`           | An alias for `.change`
  `.debounce.[?]ms` | Debounce the sending of updates by the specified millisecond delay
  `.throttle.[?]ms` | Throttle network request updates by the specified millisecond interval


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

It is a grammar error fix (duplicated word)

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Nope

4️⃣ Does it include tests? (Required)

Not needed

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Remove duplicated "the" word from `wire-model.md`

Thanks for contributing! 🙌
