### PR TITLE
Class based computed handlers and dynamic computed keys

### DIFF
--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -83,46 +83,46 @@ class BaseComputed extends Attribute
 
     protected function handlePersistedGet()
     {
-        if($this->persist === true) {
-            return (new DefaultPersistHandler($this))->handleGet();
+        $handlerClass = DefaultPersistHandler::class;
+
+        if (is_string($this->persist) && class_exists($this->persist)) {
+            $handlerClass = $this->persist;
         }
 
-        if(is_string($this->persist) && class_exists($this->persist)) {
-            return (new $this->persist($this))->handleGet();
-        }
+        return (new $handlerClass($this))->handleGet();
     }
 
     protected function handleCachedGet()
     {
-        if($this->cache === true) {
-            return (new DefaultCacheHandler($this))->handleGet();
+        $handlerClass = DefaultCacheHandler::class;
+
+        if (is_string($this->cache) && class_exists($this->cache)) {
+            $handlerClass = $this->cache;
         }
 
-        if(is_string($this->cache) && class_exists($this->cache)) {
-            return (new $this->cache($this))->handleGet();
-        }
+        return (new $handlerClass($this))->handleGet();
     }
 
     protected function handlePersistedUnset()
     {
-        if($this->persist === true) {
-            (new DefaultPersistHandler($this))->handleUnset();
+        $handlerClass = DefaultPersistHandler::class;
+
+        if (is_string($this->persist) && class_exists($this->persist)) {
+            $handlerClass = $this->persist;
         }
 
-        if(is_string($this->persist) && class_exists($this->persist)) {
-            (new $this->persist($this))->handleUnset();
-        }
+        (new $handlerClass($this))->handleUnset();
     }
 
     protected function handleCachedUnset()
     {
-        if($this->cache === true) {
-            (new DefaultCacheHandler($this))->handleUnset();
+        $handlerClass = DefaultCacheHandler::class;
+
+        if (is_string($this->cache) && class_exists($this->cache)) {
+            $handlerClass = $this->cache;
         }
 
-        if(is_string($this->cache) && class_exists($this->cache)) {
-            (new $this->cache($this))->handleUnset();
-        }
+        (new $handlerClass($this))->handleUnset();
     }
 
 

--- a/src/Features/SupportComputed/ComputedHandler.php
+++ b/src/Features/SupportComputed/ComputedHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Livewire\Features\SupportComputed;
+
+use Illuminate\Support\Facades\Cache;
+
+abstract class ComputedHandler
+{
+    public $seconds;
+    public $tags;
+
+    public function __construct(
+        public BaseComputed $computed,
+    ) {
+        $this->seconds ??= $computed->seconds;
+        $this->tags ??= $computed->tags;
+    }
+
+    abstract protected function generateKey();
+
+    public function handleGet()
+    {
+        $key = $this->generateKey();
+
+        $closure = fn () => $this->computed->evaluateComputed();
+
+        return match(Cache::supportsTags() && !empty($this->tags)) {
+            true => Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
+            default => Cache::remember($key, $this->seconds, $closure)
+        };
+    }
+
+    public function handleUnset()
+    {
+        $key = $this->generateKey();
+
+        Cache::forget($key);
+    }
+
+    public function replaceDynamicPlaceholders($key)
+    {
+        return preg_replace_callback('/\{(.*)\}/U', function ($matches) {
+            return data_get($this->computed->getComponent(), $matches[1], function () use ($matches) {
+                throw new \Exception('Unable to evaluate dynamic cache key placeholder: '.$matches[0]);
+            });
+        }, $key);
+    }
+}

--- a/src/Features/SupportComputed/ComputedHandler.php
+++ b/src/Features/SupportComputed/ComputedHandler.php
@@ -34,12 +34,16 @@ abstract class ComputedHandler
     {
         $key = $this->computed->key ?: $this->generateKey();
 
-        Cache::forget($key);
+        if (Cache::supportsTags() && !empty($this->tags)) {
+            Cache::tags($this->tags)->forget($key);
+        } else {
+            Cache::forget($key);
+        }
     }
 
     public function replaceDynamicPlaceholders($key)
     {
-        return preg_replace_callback('/\{(.*)\}/U', function ($matches) {
+        return preg_replace_callback('/\{([^}]+)\}/', function ($matches) {
             return data_get($this->computed->getComponent(), $matches[1], function () use ($matches) {
                 throw new \Exception('Unable to evaluate dynamic cache key placeholder: '.$matches[0]);
             });

--- a/src/Features/SupportComputed/ComputedHandler.php
+++ b/src/Features/SupportComputed/ComputedHandler.php
@@ -20,7 +20,7 @@ abstract class ComputedHandler
 
     public function handleGet()
     {
-        $key = $this->computed->key ?: $this->generateKey();
+        $key = $this->getKey();
 
         $closure = fn () => $this->computed->evaluateComputed();
 
@@ -32,7 +32,7 @@ abstract class ComputedHandler
 
     public function handleUnset()
     {
-        $key = $this->computed->key ?: $this->generateKey();
+        $key = $this->getKey();
 
         if (Cache::supportsTags() && !empty($this->tags)) {
             Cache::tags($this->tags)->forget($key);
@@ -41,7 +41,12 @@ abstract class ComputedHandler
         }
     }
 
-    public function replaceDynamicPlaceholders($key)
+    private function getKey()
+    {
+        return $this->computed->key ? $this->replaceDynamicPlaceholders($this->computed->key) : $this->generateKey();
+    }
+
+    private function replaceDynamicPlaceholders($key)
     {
         return preg_replace_callback('/\{([^}]+)\}/', function ($matches) {
             return data_get($this->computed->getComponent(), $matches[1], function () use ($matches) {

--- a/src/Features/SupportComputed/ComputedHandler.php
+++ b/src/Features/SupportComputed/ComputedHandler.php
@@ -20,7 +20,7 @@ abstract class ComputedHandler
 
     public function handleGet()
     {
-        $key = $this->generateKey();
+        $key = $this->computed->key ?: $this->generateKey();
 
         $closure = fn () => $this->computed->evaluateComputed();
 
@@ -32,7 +32,7 @@ abstract class ComputedHandler
 
     public function handleUnset()
     {
-        $key = $this->generateKey();
+        $key = $this->computed->key ?: $this->generateKey();
 
         Cache::forget($key);
     }

--- a/src/Features/SupportComputed/DefaultCacheHandler.php
+++ b/src/Features/SupportComputed/DefaultCacheHandler.php
@@ -6,8 +6,6 @@ class DefaultCacheHandler extends ComputedHandler
 {
     protected function generateKey()
     {
-        if ($this->computed->key) return $this->computed->key;
-
         return $this->replaceDynamicPlaceholders('lw_computed.'.$this->computed->getComponent()->getName().'.'.$this->computed->getName());
     }
 }

--- a/src/Features/SupportComputed/DefaultCacheHandler.php
+++ b/src/Features/SupportComputed/DefaultCacheHandler.php
@@ -6,6 +6,6 @@ class DefaultCacheHandler extends ComputedHandler
 {
     protected function generateKey()
     {
-        return $this->replaceDynamicPlaceholders('lw_computed.'.$this->computed->getComponent()->getName().'.'.$this->computed->getName());
+        return 'lw_computed.'.$this->computed->getComponent()->getName().'.'.$this->computed->getName();
     }
 }

--- a/src/Features/SupportComputed/DefaultCacheHandler.php
+++ b/src/Features/SupportComputed/DefaultCacheHandler.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Livewire\Features\SupportComputed;
+
+class DefaultCacheHandler extends ComputedHandler
+{
+    protected function generateKey()
+    {
+        if ($this->computed->key) return $this->computed->key;
+
+        return $this->replaceDynamicPlaceholders('lw_computed.'.$this->computed->getComponent()->getName().'.'.$this->computed->getName());
+    }
+}

--- a/src/Features/SupportComputed/DefaultPersistHandler.php
+++ b/src/Features/SupportComputed/DefaultPersistHandler.php
@@ -6,6 +6,6 @@ class DefaultPersistHandler extends ComputedHandler
 {
     protected function generateKey()
     {
-        return $this->replaceDynamicPlaceholders('lw_computed.'.$this->computed->getComponent()->getId().'.'.$this->computed->getName());
+        return 'lw_computed.'.$this->computed->getComponent()->getId().'.'.$this->computed->getName();
     }
 }

--- a/src/Features/SupportComputed/DefaultPersistHandler.php
+++ b/src/Features/SupportComputed/DefaultPersistHandler.php
@@ -6,8 +6,6 @@ class DefaultPersistHandler extends ComputedHandler
 {
     protected function generateKey()
     {
-        if ($this->computed->key) return $this->computed->key;
-
         return $this->replaceDynamicPlaceholders('lw_computed.'.$this->computed->getComponent()->getId().'.'.$this->computed->getName());
     }
 }

--- a/src/Features/SupportComputed/DefaultPersistHandler.php
+++ b/src/Features/SupportComputed/DefaultPersistHandler.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Livewire\Features\SupportComputed;
+
+class DefaultPersistHandler extends ComputedHandler
+{
+    protected function generateKey()
+    {
+        if ($this->computed->key) return $this->computed->key;
+
+        return $this->replaceDynamicPlaceholders('lw_computed.'.$this->computed->getComponent()->getId().'.'.$this->computed->getName());
+    }
+}


### PR DESCRIPTION
This PR adds the option to use class-based computed handlers and continues work on an existing PR to allow dynamic computed keys ([https://github.com/livewire/livewire/pull/8784](https://github.com/livewire/livewire/pull/8784)).

### Class-Based Handlers for Computed Properties

In some situations, you may want more control over the cache/persist behavior of computed properties. For example, you might want to use a custom cache key based on the currently authenticated user and adjust the cache duration based on specific conditions.

This PR allows you to pass a class to both the `cache` and `persist` attributes of computed properties.

```php
#[Computed(cache: ChangeLogCache::class)]
public function changeLogs()
{
    return auth()->user()->changelog()->latest()->take(8)->get(['title', 'created_at']);
}

#[Computed(persist: ChangeLogCache::class)]
public function changeLogs()
{
    // ...
}
```

The class must implement the `generateKey` method, where you can define your custom cache key.

```php
use Livewire\Features\SupportComputed\ComputedHandler;

class ChangeLogCache extends ComputedHandler
{
    public $seconds = 20;
    public $tags = 'example';

    protected function generateKey()
    {
        return 'changelog.' . auth()->id();
    }
}
```

This is particularly useful for caching component data across multiple requests and pages that rely on the same cached data—while giving you more control. For example, you can cache based on the current authenticated user, whereas the current implementation would serve the same cache to all users.

If you want, you can still set the `seconds` or `tags` inline as you normally would—the class-based properties will take precedence:

```php
#[Computed(cache: ChangeLogCache::class, seconds: 20, tags: 'example')]
public function changeLogs()
{
    // ...
}
```

### Dynamic Computed Keys

In addition, this PR includes support for dynamic computed keys, as introduced in [https://github.com/livewire/livewire/pull/8784](https://github.com/livewire/livewire/pull/8784):

```php
public Page $page;

#[Computed(cache: true, key: 'page-components-{page.id}')]
public function pageComponents(): array
{
    // Build something dynamically here
    return [..];
}
```

This PR does not introduce any breaking changes and is covered by existing tests. I’ll add extra tests for the class-based approach if we decide to move forward with this feature 😄