### PR TITLE
Fix morph markers generation on Octane

### DIFF
--- a/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
@@ -17,8 +17,8 @@ class SupportMorphAwareBladeCompilation extends ComponentHook
     public static function provide()
     {
         on('flush-state', function () {
-            static::$shouldInjectConditionalMarkers = false;
-            static::$shouldInjectLoopMarkers = false;
+            static::$shouldInjectConditionalMarkers = config('livewire.inject_morph_markers', true);
+            static::$shouldInjectLoopMarkers = config('livewire.inject_morph_markers', true);
         });
 
         static::$shouldInjectConditionalMarkers = config('livewire.inject_morph_markers', true);


### PR DESCRIPTION
@joshhanley I think a bug was introduced as part of this MR https://github.com/livewire/livewire/pull/9310

When testing a few things on our app with some unreleased changes (see https://github.com/livewire/livewire/pull/9302#issuecomment-2963618427) , I realized morph markers were not generated anymore. I'm not sure why a flush-state listener was setup here because it is config driven, I can only assume that it was only for testing purposes, but during testing you are using `reloadFeatures` which effectively re-register hooks and reload config, which does not happen in a real-life situation with an Octane app. So what is happening really is that both `shouldInjectConditionalMarkers` and `shouldInjectLoopMarkers` are immediately set to `false` when using Octane, regardless of the config values.