### PR TITLE
Update wire-model.md to clarify model.fill behaviour

### DIFF
--- a/docs/wire-model.md
+++ b/docs/wire-model.md
@@ -101,7 +101,7 @@ Any changes made to the text input will be automatically synchronized with the `
 ## All available modifiers
 
  Modifier          | Description
--------------------|-------------------------------------------------------------------------
+-------------------|------------------------------------------------------------------------------------
  `.live`           | Send updates as a user types
  `.blur`           | Only send updates on the `blur` event
  `.change`         | Only send updates on the `change` event
@@ -110,7 +110,7 @@ Any changes made to the text input will be automatically synchronized with the `
  `.throttle.[?]ms` | Throttle network request updates by the specified millisecond interval
  `.number`         | Cast the text value of an input to `int` on the server
  `.boolean`        | Cast the text value of an input to `bool` on the server
- `.fill`           | Use the initial value provided by a "value" HTML attribute on page-load
+ `.fill`           | Use the initial value provided by a "value" HTML attribute or autofill on page-load
 
 ## Input fields
 


### PR DESCRIPTION
### Update wire-model.md docs to clarify model.fill behaviour as also allowing browser autofill to work

Fields with wire:model alone will briefly flash the browser autofilled data before being set to empty by Livewire. 
Using wire:model.fill allows the browser to autofill the fields as expected and this behaviour isn't documented.

Examples:

Autofill working -

```html
<input type="email" name="email" id="email" autocomplete="on" wire:model.fill="email" placeholder="name@website.com" required="">
<input type="password" name="password" id="password" autocomplete="on" wire:model.fill="password" placeholder="••••••••" required="">
```

Autofill not working (Brief flash of autofilled data and then cleared by livewire) -

```html
<input type="email" name="email" id="email" autocomplete="on" wire:model="email" placeholder="name@website.com" required="">
<input type="password" name="password" id="password" autocomplete="on" wire:model="password" placeholder="••••••••" required="">
```