### PR TITLE
Fix event name in the testing docs.

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -575,7 +575,7 @@ class PostCountBadgeTest extends TestCase
 }
 ```
 
-Sometimes it may come in handy to assert that an event was dispatched with one or more parameters. Let's have a look at a component called `ShowPosts` that dispatches an event called `banner-message` with a parameter called `message`:
+Sometimes it may come in handy to assert that an event was dispatched with one or more parameters. Let's have a look at a component called `ShowPosts` that dispatches an event called `notify` with a parameter called `message`:
 
 ```php
 <?php


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
No, is just a very small fix in a .md file.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes. The branch is called **fix-event-name-docs**.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, just the small fix.

4️⃣ Does it include tests? (Required)
No needed.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
In the docs about testing events, the text says "Let's have a look at a component called ShowPosts that dispatches an event called **banner-message** with a parameter called message", but in the example the event that is being tested it's called notify. I fixed the event name in the text to be consistent with the example. 

Thanks for contributing! 🙌
