### PR TITLE
Update EloquentModelSynth.php

### DIFF
--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -71,7 +71,9 @@ class EloquentModelSynth extends Synth
         } else {
             $model = $this->loadModel($meta);
         }
-
+        if (!$model) {
+            throw new ModelNotFoundException();
+        }
         if (isset($meta['relations'])) {
             foreach($meta['relations'] as $relationKey) {
                 if (! isset($data[$relationKey])) continue;


### PR DESCRIPTION
Fix bug when trying to delete a non existing model

Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
no

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
yes

4️⃣ Does it include tests? (Required)
no need

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This produces a confusing, low-level error and leaves the user stuck until a full page refresh. See related discussion in #7987 and prior PR #8047; maintainers indicated a clearer, domain-level error (e.g., `ModelNotFound`) would be preferable to the current TypeError.  

---

## Steps to Reproduce

1. Enable `legacy_model_binding` in `config/livewire.php`.
2. Create two models: `Child` belongsTo `Parent`.
3. In a Livewire component, expose a public legacy-bound `Child $child` property (e.g., via route model binding or lookup in `mount()`).
4. Render an "Edit Child" form (component remains mounted).
5. Open two tabs
6. In the first delete the parent
7. In another browser/tab delete the `Child` 
8. Get the error Livewire\Features\SupportLegacyModels\EloquentModelSynth::setDataOnModel(): Argument #1 ($model) must be of type Illuminate\Database\Eloquent\Model, null given, called in vendor\livewire\livewire\src\Features\SupportLegacyModels\EloquentModelSynth.php on line 94
Thanks for contributing! 🙌
