### PR TITLE
Fix bigint values from query string being truncated into scientific notation

### DIFF
--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -61,7 +61,7 @@ class BaseUrl extends LivewireAttribute
         if ($initialValue === $nonExistentValue) return;
 
         $decoded = is_array($initialValue)
-            ? json_decode(json_encode($initialValue), true)
+            ? json_decode(json_encode($initialValue), true, flags: JSON_BIGINT_AS_STRING)
             : json_decode($initialValue ?? '', true, flags: JSON_BIGINT_AS_STRING);
 
         // If only part of an array is present in the query string,

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -62,7 +62,7 @@ class BaseUrl extends LivewireAttribute
 
         $decoded = is_array($initialValue)
             ? json_decode(json_encode($initialValue), true)
-            : json_decode($initialValue ?? '', true);
+            : json_decode($initialValue ?? '', true, flags: JSON_BIGINT_AS_STRING);
 
         // If only part of an array is present in the query string,
         // we want to merge instead of override the value...

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -94,4 +94,18 @@ class UnitTest extends \Tests\TestCase
         $this->assertEquals('noexist', $component->instance()->exists);
         $this->assertEquals('', $component->instance()->noexists);
     }
+
+    function test_large_numbers_are_preserved_from_query_string()
+    {
+        $largeNumber = '74350194073086909398128';
+
+        $component = Livewire::withQueryParams([
+            'tableSearch' => $largeNumber,
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public $tableSearch;
+        });
+
+        $this->assertSame($largeNumber, $component->instance()->tableSearch);
+    }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed?
Yes. Currently, when a very large integer is passed via the query string and processed through `BaseUrl::setPropertyFromQueryString`, it is cast into **scientific notation** due to json_decode behavior. This causes data loss and unexpected values in Livewire components.

Did you create a discussion about it first?
No, should I still create a discussion?

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes, this PR was created from a feature branch, not main.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Currently, Livewire’s `BaseUrl::setPropertyFromQueryString()` decodes query string values using:
```
$decoded = is_array($initialValue)
    ? json_decode(json_encode($initialValue), true)
    : json_decode($initialValue ?? '', true);
```

When a large numeric string (e.g. `74350194073086909398128`) is passed in the query string,
**json_decode()** casts it into a PHP float, resulting in **scientific notation** (`7.4350194073087E+22`) and a loss of precision.

This PR fixes the issue by using **JSON_BIGINT_AS_STRING** when decoding non-array values:
```
$decoded = is_array($initialValue)
    ? json_decode(json_encode($initialValue), true)
    : json_decode($initialValue ?? '', true, flags: JSON_BIGINT_AS_STRING);
```

Why this is useful?
- Prevents silent data corruption when working with large IDs, transaction numbers, or other bigint values in query strings.
- Ensures consistency between original query string input and Livewire component state.
