### PR TITLE
Add documentation about the js directive

### DIFF
--- a/docs/alpine.md
+++ b/docs/alpine.md
@@ -253,6 +253,16 @@ By default, changes are deferred until the next Livewire request. Use `.live` to
 <div x-data="{ open: $wire.entangle('showDropdown').live }">
 ```
 
+## Using the `@js` directive
+
+If you need to output PHP data for use in Alpine directly, you can use the `@js` directive.
+
+```blade
+<div x-data="{ posts: @js($posts) }">
+    ...
+</div>
+```
+
 ## Manually bundling Alpine in your JavaScript build
 
 By default, Livewire and Alpine's JavaScript is injected onto each Livewire page automatically.

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -607,6 +607,18 @@ You can sync component state with localStorage using `$watch`:
 </script>
 ```
 
+### Using the `@js` directive
+
+If you need to output PHP data for use in JavaScript directly, you can use the `@js` directive.
+
+```blade
+<script>
+    let posts = @js($posts)
+
+    // "posts" will now be a JavaScript array of post data from PHP.
+</script>
+```
+
 ## Best practices
 
 ### Component scripts vs global scripts


### PR DESCRIPTION
I've added documentation about using the `@js` directive. I'm aware that the directive is part of Laravel but I think it's still quite valuable to have documented in the context of Livewire and Alpine.

Also note that this was documented in the previous version of Livewire:

* [Inline Scripts](https://laravel-livewire.com/docs/2.x/inline-scripts#using-js-directive)
* [AlpineJS](https://laravel-livewire.com/docs/2.x/alpine-js#js-directive)