### PR TITLE
Detect CSP Nonce from Vite and inject automatically

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Mechanisms\FrontendAssets;
 
+use Illuminate\Support\Facades\Vite;
 use Livewire\Drawer\Utils;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Blade;
@@ -93,7 +94,8 @@ class FrontendAssets extends Mechanism
     {
         app(static::class)->hasRenderedStyles = true;
 
-        $nonce = isset($options['nonce']) ? "nonce=\"{$options['nonce']}\" data-livewire-style" : '';
+        $nonce = static::nonce($options);
+        $nonce = $nonce ? "{$nonce} data-livewire-style" : '';
 
         $progressBarColor = config('livewire.navigate.progress_bar_color', '#2299dd');
 
@@ -178,7 +180,7 @@ class FrontendAssets extends Mechanism
 
         $assetWarning = null;
 
-        $nonce = isset($options['nonce']) ? "nonce=\"{$options['nonce']}\"" : '';
+        $nonce = static::nonce($options['nonce']);
 
         [$url, $assetWarning] = static::usePublishedAssetsIfAvailable($url, $manifest, $nonce);
 
@@ -199,7 +201,7 @@ class FrontendAssets extends Mechanism
     {
         app(static::class)->hasRenderedScripts = true;
 
-        $nonce = isset($options['nonce']) ? " nonce=\"{$options['nonce']}\"" : '';
+        $nonce = static::nonce($options['nonce']);
 
         $progressBar = config('livewire.navigate.show_progress_bar', true) ? '' : 'data-no-progress-bar';
 
@@ -211,7 +213,7 @@ class FrontendAssets extends Mechanism
         ]);
 
         return <<<HTML
-        <script{$nonce} data-navigate-once="true">window.livewireScriptConfig = {$attributes};</script>
+        <script {$nonce} data-navigate-once="true">window.livewireScriptConfig = {$attributes};</script>
         HTML;
     }
 
@@ -253,5 +255,12 @@ class FrontendAssets extends Mechanism
     protected static function minify($subject)
     {
         return preg_replace('~(\v|\t|\s{2,})~m', '', $subject);
+    }
+
+    protected static function nonce($options = [])
+    {
+        $nonce = $options['nonce'] ?? Vite::cspNonce();
+
+        return $nonce ? "nonce=\"{$nonce}\"" : '';
     }
 }

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -180,7 +180,7 @@ class FrontendAssets extends Mechanism
 
         $assetWarning = null;
 
-        $nonce = static::nonce($options['nonce']);
+        $nonce = static::nonce($options);
 
         [$url, $assetWarning] = static::usePublishedAssetsIfAvailable($url, $manifest, $nonce);
 
@@ -201,7 +201,7 @@ class FrontendAssets extends Mechanism
     {
         app(static::class)->hasRenderedScripts = true;
 
-        $nonce = static::nonce($options['nonce']);
+        $nonce = static::nonce($options);
 
         $progressBar = config('livewire.navigate.show_progress_bar', true) ? '' : 'data-no-progress-bar';
 


### PR DESCRIPTION
Following on from https://github.com/livewire/flux/issues/1951, the issue is Livewire automatically injects itself onto the page without honouring the CSP Nonce defined in Vite.

This PR allows Livewire to detect when there is a Nonce (`Vite::cspNonce()` returns `null` if no Nonce has been set), and injects it into the script and style tags. This should only inject a nonce when one hasn't already been provided manually via `$options`, and when it has been initiated by the user, making it backwards compatible.