### PR TITLE
FIX #9507 : Split classname@methods according to last @ as classnames…

### DIFF
--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -233,8 +233,8 @@ class SupportPageComponents extends ComponentHook
         if (! $uses) return;
 
         if (is_string($uses)) {
-            $class = str($uses)->before('@')->toString();
-            $method = str($uses)->after('@')->toString();
+            $class = str($uses)->beforeLast('@')->toString();
+            $method = str($uses)->afterLast('@')->toString();
 
             if (is_subclass_of($class, \Livewire\Component::class) && $method === '__invoke') {
                 return $class;


### PR DESCRIPTION
… for anonymous objects have a @

Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
No, it's a fix

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes, I did

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
Non, just one change

4️⃣ Does it include tests? (Required)
Passes all tests

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.



See Issue 9507 :

```php
<?php

use App\Models\User;
use Illuminate\Support\Facades\Route;
use Livewire\Component;


// create an anonymous class that extends Component
$anonymous = new class extends Component {

    public User $user;

    public function render()
    {
        return <<<HTML
        <div>
            <h1>User: {{ \$this->user->name }}</h1>
        </div>
        HTML;
    }
};


// get the class name of the anonymous class
$method = get_class( $anonymous ).'@__invoke';  // => Livewire\Component@anonymous\/tmp/laravel/routes/web.php:9$a0@__invoke

// create a route that uses the anonymous class, parameters are know bounds to Authorize middleware
Route::get('/buggy/{user}', $method)->middleware('can:view,user');
```

Thanks for contributing! 🙌
