### PR TITLE
Add Testable PHPDoc @template type for targeted component

### DIFF
--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -9,7 +9,11 @@ use Livewire\Features\SupportEvents\TestsEvents;
 use Illuminate\Support\Traits\Macroable;
 use BackedEnum;
 
-/** @mixin \Illuminate\Testing\TestResponse */
+/**
+ * @template TComponent of \Livewire\Component
+ *
+ * @mixin \Illuminate\Testing\TestResponse
+ */
 
 class Testable
 {
@@ -27,13 +31,13 @@ class Testable
     ) {}
 
     /**
-     * @param string $name
+     * @param class-string<TComponent>|TComponent|string|array<array-key, \Livewire\Component> $name
      * @param array $params
      * @param array $fromQueryString
      * @param array $cookies
      * @param array $headers
      *
-     * @return static
+     * @return static<TComponent>
      */
     static function create($name, $params = [], $fromQueryString = [], $cookies = [], $headers = [])
     {
@@ -320,6 +324,9 @@ class Testable
         return $this->lastState->getSnapshotData();
     }
 
+    /**
+     * @return TComponent
+     */
     function instance()
     {
         return $this->lastState->getComponent();

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -216,6 +216,14 @@ class LivewireManager
         return $this;
     }
 
+    /**
+     * @template TComponent of \Livewire\Component
+     *
+     * @param class-string<TComponent>|TComponent|string|array<array-key, \Livewire\Component> $name
+     * @param array $params
+     *
+     * @return Testable<TComponent>
+     */
     function test($name, $params = [])
     {
         return Testable::create(


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Not related to a discussion (minimal PHPDoc changes).

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

4️⃣ Does it include tests? (Required)
Not applicable (PHPDoc only).

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Consider the following test code :
```php
$component = Livewire::test(Counter::class)

expect($component->instance()->hasOverflow())->toBeTrue();
```

The `hasOverflow` method is now autocompleted & referenced by the IDE.