### PR TITLE
Add a custom exception for when property assignment has a type error

### DIFF
--- a/src/Exceptions/PropertyAssignmentTypeException.php
+++ b/src/Exceptions/PropertyAssignmentTypeException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Livewire\Exceptions;
+
+use Exception;
+use Livewire\Component;
+use Livewire\Volt\Component as VoltComponent;
+use ReflectionClass;
+
+class PropertyAssignmentTypeException extends Exception
+{
+    use BypassViewHandler;
+
+    public function __construct(Component $component, string $levelName, mixed $value)
+    {
+        $value_string = gettype($value);
+
+        $reflection = new ReflectionClass($component);
+        $this->file = $reflection->getFileName() ?? $this->file;
+
+        $className = $reflection->getShortName();
+        if ($component instanceof VoltComponent) {
+            $className = str($this->file)->after(resource_path())->ltrim(DIRECTORY_SEPARATOR)->value();
+        }
+
+        $this->message = "Error assigning {$value_string} to {$levelName} on component {$className}";
+
+        if ($this->file && is_readable($this->file)) {
+            $lines = file($this->file);
+            foreach ($lines as $lineNumber => $line) {
+                if (str_contains($line, "\${$levelName}")) {
+                    $this->line = $lineNumber + 1;
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/Features/SupportAttributes/Attribute.php
+++ b/src/Features/SupportAttributes/Attribute.php
@@ -3,6 +3,8 @@
 namespace Livewire\Features\SupportAttributes;
 
 use Livewire\Component;
+use Livewire\Exceptions\PropertyAssignmentTypeException;
+use TypeError;
 
 abstract class Attribute
 {
@@ -66,21 +68,24 @@ abstract class Attribute
         }
 
         if ($enum = $this->tryingToSetStringOrIntegerToEnum($value)) {
-            if($nullable) {
+            if ($nullable) {
                 $value = $enum::tryFrom($value);
-            }
-
-            else {
+            } else {
                 $value = $enum::from($value);
             }
         }
 
-        data_set($this->component, $this->levelName, $value);
+        try {
+            data_set($this->component, $this->levelName, $value);
+        } catch (TypeError $e) {
+            throw new PropertyAssignmentTypeException($this->component, $this->levelName, $value);
+        }
     }
 
     protected function tryingToSetStringOrIntegerToEnum($subject)
     {
-        if (! is_string($subject) && ! is_int($subject)) return;
+        if (! is_string($subject) && ! is_int($subject))
+            return;
 
         $target = $this->subTarget ?? $this->component;
 


### PR DESCRIPTION
> 1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes this wanted/needed because the default error is ambiguous.  No I did not create a discussion.

> 2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes

> 3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Nope

> 4️⃣ Does it include tests? (Required)

Not sure how to add a test for an exception?

> 5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

I've run into this error multiple times before and seen a good number of people posting in Discord/X/etc about ambiguous errors like this being hard to pin down:

<img width="1402" height="841" alt="image" src="https://github.com/user-attachments/assets/65698136-0938-456d-8160-0ca76a9011a4" />

<br><br>

But with this custom exception we get a more exact error that leads straight to the issue:

<img width="1386" height="846" alt="image" src="https://github.com/user-attachments/assets/b79b06bb-e9eb-489e-b66e-f4ee8e4ac608" />


---

I would be happy to submit a test for this but I didn't see any existing ones for testing the other exceptions so I wasn't sure it was needed?

Also, I realize this is messing with the stack frames (changing files and line numbers) but I wasn't sure how else to do it.  If there is a better way, I'd be happy to help implement it.
