### PR TITLE
Fix passing data into view function

### DIFF
--- a/src/Compiler/Parser/Parser.php
+++ b/src/Compiler/Parser/Parser.php
@@ -87,9 +87,9 @@ class Parser
             $position = $lastMatch[1];
             return substr_replace($contents, <<<PHP
 
-    protected function view()
+    protected function view(\$data = [])
     {
-        return app('view')->file('{$viewFileName}');
+        return app('view')->file('{$viewFileName}', \$data);
     }
 }
 PHP

--- a/src/Compiler/UnitTest.php
+++ b/src/Compiler/UnitTest.php
@@ -53,7 +53,7 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertStringContainsString('new class extends Component', $classContents);
         $this->assertStringContainsString('use Livewire\Component;', $classContents);
-        $this->assertStringContainsString("return app('view')->file('view-path.blade.php');", $classContents);
+        $this->assertStringContainsString("return app('view')->file('view-path.blade.php', \$data);", $classContents);
         $this->assertStringNotContainsString('new class extends Component', $viewContents);
         $this->assertStringNotContainsString('new class extends Component', $scriptContents);
         $this->assertStringContainsString("console.log('Hello from script');", $scriptContents);
@@ -76,7 +76,7 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertStringContainsString('new class extends Component', $classContents);
         $this->assertStringContainsString('use Livewire\Component;', $classContents);
-        $this->assertStringContainsString("return app('view')->file('view-path.blade.php');", $classContents);
+        $this->assertStringContainsString("return app('view')->file('view-path.blade.php', \$data);", $classContents);
         $this->assertStringNotContainsString('new class extends Component', $viewContents);
         // Script should NOT be extracted when wrapped in @script/@endscript
         $this->assertNull($scriptContents);
@@ -99,7 +99,7 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertStringContainsString('new class extends Component', $classContents);
         $this->assertStringContainsString('use Livewire\Component;', $classContents);
-        $this->assertStringContainsString("return app('view')->file('view-path.blade.php');", $classContents);
+        $this->assertStringContainsString("return app('view')->file('view-path.blade.php', \$data);", $classContents);
         $this->assertStringNotContainsString('new class extends Component', $viewContents);
 
         // Only the root-level script should be extracted
@@ -122,7 +122,7 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertStringContainsString('new class extends Component', $classContents);
         $this->assertStringContainsString('use Livewire\Component;', $classContents);
-        $this->assertStringContainsString("return app('view')->file('view-path.blade.php');", $classContents);
+        $this->assertStringContainsString("return app('view')->file('view-path.blade.php', \$data);", $classContents);
         $this->assertStringNotContainsString('new class extends Component', $viewContents);
 
         // Scripts inside @assets/@endassets should NOT be extracted
@@ -207,7 +207,7 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertStringContainsString('new class extends Component', $classContents);
         $this->assertStringContainsString('use Livewire\Component;', $classContents);
-        $this->assertStringContainsString("return app('view')->file('view-path.blade.php');", $classContents);
+        $this->assertStringContainsString("return app('view')->file('view-path.blade.php', \$data);", $classContents);
         $this->assertStringNotContainsString('new class extends Component', $viewContents);
         $this->assertStringNotContainsString('new class extends Component', $scriptContents);
         $this->assertStringContainsString("console.log('Hello from script');", $scriptContents);

--- a/src/Features/SupportSingleAndMultiFileComponents/UnitTest.php
+++ b/src/Features/SupportSingleAndMultiFileComponents/UnitTest.php
@@ -25,4 +25,12 @@ class UnitTest extends \Tests\TestCase
             ->call('increment')
             ->assertSee('Count: 2');
     }
+
+    public function test_sfc_component_includes_the_view_method_and_data_is_passed_to_the_view()
+    {
+        app('livewire.finder')->addLocation(path: __DIR__ . '/fixtures');
+
+        Livewire::test('sfc-component-with-render-and-data')
+            ->assertSee('Message: Hello World');
+    }
 }

--- a/src/Features/SupportSingleAndMultiFileComponents/fixtures/sfc-component-with-render-and-data.blade.php
+++ b/src/Features/SupportSingleAndMultiFileComponents/fixtures/sfc-component-with-render-and-data.blade.php
@@ -1,0 +1,16 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component
+{
+    public function render()
+    {
+        return $this->view([
+            'message' => 'Hello World',
+        ]);
+    }
+};
+?>
+
+<div>Message: {{ $message }}</div>


### PR DESCRIPTION
# The scenario

Currently it is documented that in a SFC data can be passed into the view through the `$this->view()` call in the render method, but it doesn't work and throws an error. It's documented here https://livewire.laravel.com/docs/4.x/components#passing-data-directly

<img width="2948" height="1482" alt="Screenshot 2025-10-29 at 08 40 21PM@2x" src="https://github.com/user-attachments/assets/6205bafd-6883-44cf-b5bf-b778351d5a66" />

```blade
<?php

use Livewire\Component;

new class extends Component {
    public function render()
    {
        return $this->view(['message' => 'Hello world']);
    }
};

?>

<div>
    Message: {{ $message }}
</div>
```

# The problem

The issue is that it's documented that data can be passed into `$this->view();` but the signature of the method added in the parser doesn't have any parameters.

```php
protected function injectViewMethod(string $contents, string $viewFileName): string
{
    $pattern = '/}(\s*);/';
    preg_match_all($pattern, $contents, $matches, PREG_OFFSET_CAPTURE);
    $lastMatch = end($matches[0]);

    if ($lastMatch) {
        $position = $lastMatch[1];
        return substr_replace($contents, <<<PHP

protected function view()
{
    return app('view')->file('{$viewFileName}');
}
}
PHP
        , $position, 1);
    }

    return $contents;
}
```

# The solution

The solution is to add an optional `$data = []` parameter to the generated view method.

```php
protected function view(\$data = [])
{
    return app('view')->file('{$viewFileName}', \$data);
}
```

Now it all works as documented.

<img width="682" height="188" alt="Screenshot 2025-10-29 at 08 43 26PM@2x" src="https://github.com/user-attachments/assets/22f8e9f6-3daf-4926-82f1-f922ff4e4c70" />

Fixes livewire/livewire#9521
