### PR TITLE
Fix snake case component params

### DIFF
--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -97,7 +97,12 @@ class HandleComponents extends Mechanism
         $mountParams = $this->getMountMethodParameters($component);
 
         foreach ($params as $key => $value) {
-            $camelKey = str($key)->camel()->toString();
+            $processedKey = $key;
+            
+            // Convert only kebab-case params to camelCase for matching...
+            if (str($processedKey)->contains('-')) {
+                $processedKey = str($processedKey)->camel()->toString();
+            }
 
             // Check if this is a reserved param
             if ($this->isReservedParam($key)) {
@@ -106,11 +111,11 @@ class HandleComponents extends Mechanism
 
             // Check if this maps to a component property or mount param
             elseif (
-                array_key_exists($camelKey, $componentProperties)
-                || in_array($camelKey, $mountParams)
+                array_key_exists($processedKey, $componentProperties)
+                || in_array($processedKey, $mountParams)
                 || is_numeric($key) // if the key is numeric, it's likely a mount parameter...
             ) {
-                $componentParams[$camelKey] = $value;
+                $componentParams[$processedKey] = $value;
             } else {
                 // Keep as HTML attribute (preserve kebab-case)
                 $htmlAttributes[$key] = $value;

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -198,6 +198,55 @@ class UnitTest extends \Tests\TestCase
             ])
         ;
     }
+
+    public function test_it_leaves_camel_case_params_when_matching_component_properties()
+    {
+        Livewire::test(
+            new class extends \Tests\TestComponent {
+                public $fooBar;
+            },
+            ['fooBar' => 'baz']
+            )
+        ->assertSet('fooBar', 'baz');
+    }
+
+    public function test_it_leaves_snake_case_params_when_matching_component_properties()
+    {
+        Livewire::test(
+            new class extends \Tests\TestComponent {
+                public $foo_bar;
+            },
+            ['foo_bar' => 'baz']
+        )
+        ->assertSet('foo_bar', 'baz');
+    }
+
+    public function test_it_converts_kebab_case_params_to_camel_case_when_matching_component_properties()
+    {
+        Livewire::test(
+            new class extends \Tests\TestComponent {
+                public $fooBar;
+
+                public function render()
+                {
+                    return '<div>fooBar: {{ $fooBar }}</div>';
+                }
+            },
+            ['foo-bar' => 'baz']
+        )
+        ->assertSet('fooBar', 'baz');
+    }
+
+    public function test_kebab_case_params_are_left_as_kebab_if_it_does_not_match_component_property_and_is_stored_in_html_attributes()
+    {
+        Livewire::test(
+            new class extends \Tests\TestComponent { },
+            ['data-foo' => 'bar']
+        )
+        ->tap(function ($component) {
+            $this->assertEquals(['data-foo' => 'bar'], $component->instance()->getHtmlAttributes());
+        });
+    }
 }
 
 class BasicComponent extends TestComponent


### PR DESCRIPTION
# The scenario

Currently, if you have snake_cased properties in your Livewire component and you pass them in as params `, they aren't being set on the component like they were in v3 and `$first_name` below is still `null`.

```blade
<?php

use Livewire\Component;

new class extends Component
{
    public $first_name;
};
?>

<div>
    {{ $first_name }}
</div>
```

```blade
<livewire:test first_name="foo" />
```

# The problem

The issue is that in v4, we have a method to separate params and html attributes. But that method is just converting all passed in props to camelCase, hence the snake_cased params in the component aren't being matched.

```php
protected function separateParamsAndAttributes($component, $params)
{
    ...

    foreach ($params as $key => $value) {
        $camelKey = str($key)->camel()->toString();

        ...
    }

    return [$componentParams, $htmlAttributes];
}
```

# The solution

I did some testing to see how Livewire v3 and Blade components work. For them, all camelCased and snake_case props are passed in, as is, to be matched with component params/props. But kebab-cased props are converted to camelCased first before they are matched.

The solution is to only convert props that are kebab-cased to camelCase and leaving the passed in camelCased and snake_cased props as they are.

Fixes livewire/livewire#9526