### PR TITLE
Add missing `wire:intersect` and `wire:ref` entries to sidebar navigation in docs

### DIFF
--- a/docs/__nav.md
+++ b/docs/__nav.md
@@ -43,8 +43,10 @@ HTML Directives:
     wire:transition: { uri: /docs/4.x/wire-transition, file: /wire-transition.md }
     wire:init: { uri: /docs/4.x/wire-init, file: /wire-init.md }
     wire:poll: { uri: /docs/4.x/wire-poll, file: /wire-poll.md }
+    wire:intersect: {uri: /docs/4.x/wire-intersect, file: /wire-intersect.md}
     wire:offline: { uri: /docs/4.x/wire-offline, file: /wire-offline.md }
     wire:ignore: { uri: /docs/4.x/wire-ignore, file: /wire-ignore.md }
+    wire:ref: { uri: /docs/4.x/wire-ref, file: /wire-ref.md }
     wire:replace: { uri: /docs/4.x/wire-replace, file: /wire-replace.md }
     wire:show: { uri: /docs/4.x/wire-show, file: /wire-show.md }
     wire:sort: { uri: /docs/4.x/wire-sort, file: /wire-sort.md }

--- a/docs/__nav.md
+++ b/docs/__nav.md
@@ -42,8 +42,8 @@ HTML Directives:
     wire:confirm: { uri: /docs/4.x/wire-confirm, file: /wire-confirm.md }
     wire:transition: { uri: /docs/4.x/wire-transition, file: /wire-transition.md }
     wire:init: { uri: /docs/4.x/wire-init, file: /wire-init.md }
+    wire:intersect: { uri: /docs/4.x/wire-intersect, file: /wire-intersect.md }
     wire:poll: { uri: /docs/4.x/wire-poll, file: /wire-poll.md }
-    wire:intersect: {uri: /docs/4.x/wire-intersect, file: /wire-intersect.md}
     wire:offline: { uri: /docs/4.x/wire-offline, file: /wire-offline.md }
     wire:ignore: { uri: /docs/4.x/wire-ignore, file: /wire-ignore.md }
     wire:ref: { uri: /docs/4.x/wire-ref, file: /wire-ref.md }


### PR DESCRIPTION
This PR fixes a documentation accessibility issue where `wire:intersect` & wire:ref documentation exists but cannot be accessed due to missing navigation entry.

Now [docs/4.x] -> /wire-intersect and /wire-ref redirect to /quickstart