### PR TITLE
Add support for `DUSK_HEADLESS_DISABLED` in .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ composer.lock
 .phpunit.result.cache
 .idea
 phpunit.xml
+.env
 
 # Files used to upload zips for early access folks
 upload-bin.sh

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -125,7 +125,17 @@ class BrowserTest extends BrowserTestCase
 > [!tip] Not sure how to write tests?
 > You can learn a lot by explore existing Unit and Browser tests to learn how tests are written. Even copying and pasting an existing test is a great starting point for writing your own test.
 
-#### 3. Preparing your pull request branch
+#### 3. Running the tests
+Before submitting your pull request, make sure your test passes. You can do so by running one of the following commands:
+
+```shell
+vendor/bin/phpunit --filter "test_can_make_method_a_computed" # To run a specific test
+vendor/bin/phpunit # To run all tests
+```
+
+By default, browser tests will run in headed mode. If you want to run them in headless mode, you can create a `.env` file in the root of the Livewire repository and add `DUSK_HEADLESS_DISABLED=false`.
+
+#### 4. Preparing your pull request branch
 Once you have completed your feature or failing test, it's time to submit your Pull Request (PR) to the Livewire repository. First, ensure that you commit your changes to a separate branch (avoid using `main`). To create a new branch, you can use the `git` command:
 
 ```shell
@@ -150,7 +160,7 @@ To github.com:Username/livewire.git
  * [new branch]        my-feature -> my-feature
 ```
 
-#### 4. Submitting your pull request
+#### 5. Submitting your pull request
 We're almost there! Open your web browser and navigate to your forked Livewire repository (`https://github.com/<your-username>/livewire`). In the center of your screen, you will see a new notification: "**my-feature had recent pushes 1 minute ago**" along with a button that says "**Compare & pull request**." Click the button to open the pull request form.
 
 In the form, provide a title that describes your pull request and then proceed to the description section. The text area already contains a predefined template. Try to answer every question:

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Artisan;
+use Orchestra\Testbench\Dusk\Options;
 
 class TestCase extends \Orchestra\Testbench\Dusk\TestCase
 {
@@ -11,6 +12,10 @@ class TestCase extends \Orchestra\Testbench\Dusk\TestCase
     {
         $this->afterApplicationCreated(function () {
             $this->makeACleanSlate();
+
+            if (env('DUSK_HEADLESS_DISABLED', true) == false) {
+                Options::withoutUI();
+            } 
         });
 
         $this->beforeApplicationDestroyed(function () {
@@ -84,5 +89,10 @@ class TestCase extends \Orchestra\Testbench\Dusk\TestCase
     protected function livewireTestsPath($path = '')
     {
         return base_path('tests/Feature/Livewire'.($path ? '/'.$path : ''));
+    }
+
+    protected function resolveApplication()
+    {
+        return parent::resolveApplication()->useEnvironmentPath(__DIR__.'/..');
     }
 }


### PR DESCRIPTION
Currently, browser tests run in headed mode by default, which makes it impossible to use the computer while the tests are running. This can be annoying, especially since the test suite requires few minutes to run. Unless I'm missing something obvious, there was no easy way to run the tests in headless mode by default.

This addition makes it possible to add an `.env` file in the Livewire repo with `DUSK_HEADLESS_DISABLED=false`. The env file will be gitignored and the default remained the same (= headed mode). This approach makes it possible to define a default behavior for your local setup without affecting the repo itself.

I've also added instructions for running tests to the Contribution Guide.