### PR TITLE
Add support for testing SFC and MFC

### DIFF
--- a/src/Features/SupportSingleAndMultiFileComponents/BrowserTest.php
+++ b/src/Features/SupportSingleAndMultiFileComponents/BrowserTest.php
@@ -10,20 +10,14 @@ class BrowserTest extends \Tests\BrowserTestCase
     public static function tweakApplicationHook()
     {
         return function () {
-            app('livewire.finder')->addComponent('sfc-scripts', path: __DIR__ . '/fixtures/sfc-scripts.blade.php');
-
-            Route::livewire('/sfc-scripts', 'sfc-scripts');
+            app('livewire.finder')->addLocation(path: __DIR__ . '/fixtures');
         };
     }
 
     public function test_single_file_component_script()
     {
-        $this->browse(function ($browser) {
-            $browser
-                ->visit('/sfc-scripts')
-                ->waitForLivewireToLoad()
-                ->assertSeeIn('@foo', 'baz')
-            ;
-        });
+        Livewire::visit('sfc-scripts')
+            ->waitForLivewireToLoad()
+            ->assertSeeIn('@foo', 'baz');
     }
 }


### PR DESCRIPTION
This PR makes it possible to test SFC/MFC components in the browser using `Livewire::visit('component-name')`, which was previously only possible by setting up a separate full-page component route, as can be seen in the modified test.

This is because strings passed into `Livewire::visit()` were considered to be a component class, which was then registered under a random unique id. The id was then used as a route parameter for the automatically generated dusk route.

This PR enables testing components by their registered name by checking if a string is a class. If not, the name of the component will be used instead of generating a unique id. The component name is then passed into the dusk route which will resolve the component using `Livewire::new()` in `Livewire\Features\SupportTesting\ShowDuskComponent`
