### PR TITLE
Fix failing browser tests

### DIFF
--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -1041,11 +1041,8 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_it_handles_query_string_params_without_values()
     {
-        $id = 'a'.str()->random(10);
-
-        DuskTestable::createBrowser($id, [
-            $id => new class extends Component
-            {
+        DuskTestable::create([
+            new class extends Component {
                 #[Url]
                 public $foo;
 
@@ -1064,8 +1061,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                     HTML;
                 }
             }
-        ])
-        ->visit('/livewire-dusk/'.$id.'?flag')
+        ], queryParams: ['flag' => true])
         ->assertQueryStringMissing('foo')
         ->waitForLivewire()->click('@setButton')
         ->assertSeeIn('@output', '\'bar\'')

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -1039,29 +1039,39 @@ class BrowserTest extends \Tests\BrowserTestCase
         });
     }
 
-    public function test_it_handles_query_string_params_without_values()
+    public function test_it_handles_query_string_params_without_values_and_does_not_throw_a_console_error()
     {
-        DuskTestable::create([
-            new class extends Component {
-                #[Url]
-                public $foo;
+        $componentClass = new class extends Component
+        {
+            #[Url]
+            public $foo;
 
-                public function setFoo()
-                {
-                    $this->foo = 'bar';
-                }
-
-                public function render()
-                {
-                    return <<<'HTML'
-                    <div>
-                        <button wire:click="setFoo" dusk="setButton">Set foo</button>
-                        <span dusk="output">@js($foo)</span>
-                    </div>
-                    HTML;
-                }
+            public function setFoo()
+            {
+                $this->foo = 'bar';
             }
-        ], queryParams: ['flag' => true])
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="setFoo" dusk="setButton">Set foo</button>
+                    <span dusk="output">@js($foo)</span>
+                </div>
+                HTML;
+            }
+        };
+
+        $id = 'a'.substr(md5(str()->beforeLast($componentClass::class, '$')), 0, 8);
+
+        DuskTestable::createBrowser($id, [
+            $id => $componentClass
+        ])
+        // It's essential for this test that `flag`, in the query string below, is set
+        // but has no value. That is why class and ID are manually set up above...
+        ->visit('/livewire-dusk/'.$id.'?flag')
+
+        // Now just test the component still functions without any console errors...
         ->assertQueryStringMissing('foo')
         ->waitForLivewire()->click('@setButton')
         ->assertSeeIn('@output', '\'bar\'')

--- a/src/Features/SupportWireRef/BrowserTest.php
+++ b/src/Features/SupportWireRef/BrowserTest.php
@@ -178,7 +178,6 @@ class BrowserTest extends \Tests\BrowserTestCase
             }
         ])
             ->waitForLivewireToLoad()
-            ->tinker()
             ->waitForLivewire()->click('@send-button')
             // Wait for children to update...
             ->pause(50)


### PR DESCRIPTION
Fixes two failing tests by updating legacy component registration and removing a `tinker()` call.

After https://github.com/livewire/livewire/pull/9556 and this PR are merged the entire test suite should run without errors.