### PR TITLE
Change lazy bundle to be a modifier

### DIFF
--- a/docs/lazy.md
+++ b/docs/lazy.md
@@ -283,16 +283,18 @@ class Revenue extends Component
 
 Now, if there are ten `Revenue` components on the same page, when the page loads, all ten updates will be bundled and sent to the server as a single network request.
 
-You can also enable bundling inline when rendering a component:
+### Using the bundle modifier
+
+You can also enable bundling inline when rendering a component using the bundle modifier:
 
 ```blade
-<livewire:revenue lazy lazy:bundle />
+<livewire:revenue lazy.bundle />
 ```
 
 This also works with deferred components:
 
 ```blade
-<livewire:revenue defer defer:bundle />
+<livewire:revenue defer.bundle />
 ```
 
 Or using the attribute:

--- a/docs/upgrade-guide-scratch-file.md
+++ b/docs/upgrade-guide-scratch-file.md
@@ -55,7 +55,7 @@ not sure where to note but view-based component files are prefixed withemojis by
 - `.renderless` is now an avaialble modifier like .async as an alternative to the existing #[Renderless] action/method attribute
 - CSP-mode. If you set `csp_safe` to true in your config livewire will now use the alpine CSP build and your whole app will avoid unsafe eval violations. there are many restrictions when using this mode. you can no longer put complex js or global expressions like: `wire:click="doSomething($event.detail.foo)"` or global things like `wire:click="redirectHere(window.location.href)"`
 - defer loading in addition to lazy. <livewire:component defer> attribute #[Defer] attribute for class (same signatures as lazy)
-- can use additional `lazy:bundle` or `defer:bundle` additional syntax to flag the lazy load to bundle multiple lazy loads instead of them being isolated/parralel. There's also `#[Defer|Lazy(bundle: true)]` for this.
+- can use additional `lazy.bundle` or `defer.bundle` additional syntax to flag the lazy load to bundle multiple lazy loads instead of them being isolated/parralel. There's also `#[Defer|Lazy(bundle: true)]` for this.
 -kinda big one. view-based components can have <script></script> at the bottom with now `@script` wrapper and they work differently. their source is made available via a faux js file to frontend so caching and native module code can work. also they automatically bind this. ($wire is what this is ) and $wire is still available but this. is preferred.
 
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -423,8 +423,8 @@ class Revenue extends Component { ... }
 Control whether multiple lazy/deferred components load in parallel or bundled together:
 
 ```blade
-<livewire:revenue lazy lazy:bundle />
-<livewire:expenses defer defer:bundle />
+<livewire:revenue lazy.bundle />
+<livewire:expenses defer.bundle />
 ```
 
 ```php

--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -334,6 +334,206 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_lazy_components_are_not_bundled_by_default()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public function render() {
+                    return <<<'HTML'
+                    <div>
+                        <livewire:child1 lazy />
+                        <livewire:child2 lazy />
+                        <livewire:child3 lazy />
+                    </div>
+                    @script
+                    <script>
+                        window.requestCount = 0
+
+                        Livewire.interceptRequest(({ onSend }) => {
+                            onSend(() => window.requestCount++)
+                        })
+                    </script>
+                    @endscript
+                    HTML;
+                }
+            },
+            'child1' => new class extends Component {
+                public function render() {
+                    return '<div>Child 1</div>';
+                }
+            },
+            'child2' => new class extends Component {
+                public function render() {
+                    return '<div>Child 2</div>';
+                }
+            },
+            'child3' => new class extends Component {
+                public function render() {
+                    return '<div>Child 3</div>';
+                }
+            }
+        ])
+        ->waitForLivewireToLoad()
+
+        ->waitForText('Child 1')
+        ->waitForText('Child 2')
+        ->waitForText('Child 3')
+
+        // Lazy components should be isolated by default, making separate requests
+        ->assertScript('window.requestCount', 3)
+        ;
+    }
+
+    public function test_lazy_bundle_bundles_multiple_lazy_components_into_single_request()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public function render() {
+                    return <<<'HTML'
+                    <div>
+                        <livewire:child1 lazy.bundle />
+                        <livewire:child2 lazy.bundle />
+                        <livewire:child3 lazy.bundle />
+                    </div>
+                    @script
+                    <script>
+                        window.requestCount = 0
+
+                        Livewire.interceptRequest(({ onSend }) => {
+                            onSend(() => window.requestCount++)
+                        })
+                    </script>
+                    @endscript
+                    HTML;
+                }
+            },
+            'child1' => new class extends Component {
+                public function render() {
+                    return '<div>Child 1</div>';
+                }
+            },
+            'child2' => new class extends Component {
+                public function render() {
+                    return '<div>Child 2</div>';
+                }
+            },
+            'child3' => new class extends Component {
+                public function render() {
+                    return '<div>Child 3</div>';
+                }
+            }
+        ])
+        ->waitForLivewireToLoad()
+
+        ->waitForText('Child 1')
+        ->waitForText('Child 2')
+        ->waitForText('Child 3')
+
+        // All three lazy components should be bundled into a single request
+        ->assertScript('window.requestCount', 1)
+        ;
+    }
+
+    public function test_defer_components_are_not_bundled_by_default()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public function render() {
+                    return <<<'HTML'
+                    <div>
+                        <livewire:child1 defer />
+                        <livewire:child2 defer />
+                        <livewire:child3 defer />
+                    </div>
+                    @script
+                    <script>
+                        window.requestCount = 0
+
+                        Livewire.interceptRequest(({ onSend }) => {
+                            onSend(() => window.requestCount++)
+                        })
+                    </script>
+                    @endscript
+                    HTML;
+                }
+            },
+            'child1' => new class extends Component {
+                public function render() {
+                    return '<div>Child 1</div>';
+                }
+            },
+            'child2' => new class extends Component {
+                public function render() {
+                    return '<div>Child 2</div>';
+                }
+            },
+            'child3' => new class extends Component {
+                public function render() {
+                    return '<div>Child 3</div>';
+                }
+            }
+        ])
+        ->waitForLivewireToLoad()
+
+        ->waitForText('Child 1')
+        ->waitForText('Child 2')
+        ->waitForText('Child 3')
+
+        // Defer components should be isolated by default, making separate requests
+        ->assertScript('window.requestCount', 3)
+        ;
+    }
+
+    public function test_defer_bundle_bundles_multiple_defer_components_into_single_request()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public function render() {
+                    return <<<'HTML'
+                    <div>
+                        <livewire:child1 defer.bundle />
+                        <livewire:child2 defer.bundle />
+                        <livewire:child3 defer.bundle />
+                    </div>
+                    @script
+                    <script>
+                        window.requestCount = 0
+
+                        Livewire.interceptRequest(({ onSend }) => {
+                            onSend(() => window.requestCount++)
+                        })
+                    </script>
+                    @endscript
+                    HTML;
+                }
+            },
+            'child1' => new class extends Component {
+                public function render() {
+                    return '<div>Child 1</div>';
+                }
+            },
+            'child2' => new class extends Component {
+                public function render() {
+                    return '<div>Child 2</div>';
+                }
+            },
+            'child3' => new class extends Component {
+                public function render() {
+                    return '<div>Child 3</div>';
+                }
+            }
+        ])
+        ->waitForLivewireToLoad()
+
+        ->waitForText('Child 1')
+        ->waitForText('Child 2')
+        ->waitForText('Child 3')
+
+        // All three defer components should be bundled into a single request
+        ->assertScript('window.requestCount', 1)
+        ;
+    }
+
 }
 
 class Page extends Component {

--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -51,13 +51,17 @@ class SupportLazyLoading extends ComponentHook
         $isolate = true;
 
         if (isset($params['lazy']) && $params['lazy']) $shouldBeLazy = true;
+        if (isset($params['lazy.bundle']) && $params['lazy.bundle']) $shouldBeLazy = true;
         if (isset($params['defer']) && $params['defer']) $shouldBeLazy = true;
+        if (isset($params['defer.bundle']) && $params['defer.bundle']) $shouldBeLazy = true;
 
         if (isset($params['lazy']) && $params['lazy'] === 'on-load') $isDeferred = true;
+        if (isset($params['lazy.bundle']) && $params['lazy.bundle'] === 'on-load') $isDeferred = true;
         if (isset($params['defer']) && $params['defer']) $isDeferred = true;
+        if (isset($params['defer.bundle']) && $params['defer.bundle']) $isDeferred = true;
 
-        if (isset($params['lazy:bundle']) && $params['lazy:bundle']) $isolate = false;
-        if (isset($params['defer:bundle']) && $params['defer:bundle']) $isolate = false;
+        if (isset($params['lazy.bundle']) && $params['lazy.bundle']) $isolate = false;
+        if (isset($params['defer.bundle']) && $params['defer.bundle']) $isolate = false;
 
         $reflectionClass = new \ReflectionClass($this->component);
         $lazyAttribute = $reflectionClass->getAttributes(\Livewire\Attributes\Lazy::class)[0] ?? null;

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -127,7 +127,7 @@ class HandleComponents extends Mechanism
 
     protected function isReservedParam($key)
     {
-        $exact = ['lazy', 'defer', 'lazy:bundle', 'defer:bundle', 'wire:ref'];
+        $exact = ['lazy', 'defer', 'lazy.bundle', 'defer.bundle', 'wire:ref'];
         $startsWith = ['@', 'wire:model'];
 
         // Check exact matches


### PR DESCRIPTION
Instead of `<livewire:foo lazy lazy:bundle />` we now use `<livewire:foo lazy.bundle />`.
And same for defer `<livewire:foo defer.bundle />`.