### PR TITLE
Support wire:model on input fields inside dialog elements

### DIFF
--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -9,7 +9,16 @@ import Alpine from 'alpinejs'
 directive('model', ({ el, directive, component, cleanup }) => {
     // @todo: will need to probaby do this further upstream i just don't want to bog down the entire lifecycle right now...
     // this is to support slots properly...
-    component = findComponentByEl(el)
+    
+    // For elements inside a dialog, check if there's a stored component reference
+    // This is needed because showModal() moves dialogs to the top layer, breaking parent traversal
+    let dialog = el.closest('dialog')
+    
+    if (dialog && dialog.__livewireComponent) {
+        component = dialog.__livewireComponent
+    } else {
+        component = findComponentByEl(el)
+    }
 
     let { expression, modifiers } = directive
 

--- a/js/lifecycle.js
+++ b/js/lifecycle.js
@@ -84,6 +84,12 @@ export function start() {
             if (component) {
                 trigger('element.init', { el, component })
 
+                // Store component reference on dialog elements so children can find it
+                // This is needed because dialogs move to the top layer, breaking parent traversal
+                if (el.tagName && el.tagName.toLowerCase() === 'dialog') {
+                    el.__livewireComponent = component
+                }
+
                 directives.forEach(directive => {
                     trigger('directive.init', { el, component, directive, cleanup: (callback) => {
                         Alpine.onAttributeRemoved(el, directive.raw, callback)

--- a/js/morph.js
+++ b/js/morph.js
@@ -121,6 +121,12 @@ function getMorphConfig(component) {
 
             if (isntElement(el)) return
 
+            // Preserve dialog open state during morphing
+            // Dialog elements in the top layer lose their open state if we don't preserve it
+            if (el.tagName && el.tagName.toLowerCase() === 'dialog' && el.open) {
+                toEl.setAttribute('open', '')
+            }
+
             trigger('morph.updating', { el, toEl, component, skip, childrenOnly, skipChildren, skipUntil })
 
             // bypass DOM diffing for children by overwriting the content

--- a/src/Features/SupportWireModelOnDialogAndPopover/BrowserTest.php
+++ b/src/Features/SupportWireModelOnDialogAndPopover/BrowserTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Livewire\Features\SupportWireModelOnDialogAndPopover;
+
+use Tests\BrowserTestCase;
+use Livewire\Livewire;
+use Livewire\Component;
+
+class BrowserTest extends BrowserTestCase
+{
+    public function test_wire_model_works_inside_dialog()
+    {
+        Livewire::visit(new class extends Component {
+            public $username = '';
+            public $email = '';
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <button dusk="open-dialog" onclick="document.getElementById('testDialog').showModal()">
+                            Open Dialog
+                        </button>
+
+                        <dialog id="testDialog" dusk="dialog-content">
+                            <div style="padding: 20px;">
+                                <h2>Test Dialog</h2>
+
+                                <div style="margin-bottom: 10px;">
+                                    <label>Username (wire:model.blur)</label>
+                                    <input 
+                                        type="text" 
+                                        wire:model.blur="username"
+                                        dusk="username-input"
+                                    >
+                                    <div dusk="username-value">{{ $username }}</div>
+                                </div>
+
+                                <div style="margin-bottom: 10px;">
+                                    <label>Email (wire:model.live)</label>
+                                    <input 
+                                        type="email" 
+                                        wire:model.live="email"
+                                        dusk="email-input"
+                                    >
+                                    <div dusk="email-value">{{ $email }}</div>
+                                </div>
+
+                                <button type="button" onclick="document.getElementById('testDialog').close()">Close</button>
+                            </div>
+                        </dialog>
+                    </div>
+                BLADE;
+            }
+        })
+            ->click('@open-dialog')
+            ->pause(100)
+            ->type('@username-input', 'testuser')
+            ->click('@email-input') // Trigger blur on username
+            ->pause(200)
+            ->assertSeeIn('@username-value', 'testuser')
+            ->assertVisible('@dialog-content');
+    }
+
+    public function test_dialog_stays_open_during_wire_model_live_updates()
+    {
+        Livewire::visit(new class extends Component {
+            public $email = '';
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <button dusk="open-dialog" onclick="document.getElementById('testDialog').showModal()">
+                            Open Dialog
+                        </button>
+
+                        <dialog id="testDialog" dusk="dialog-content">
+                            <div style="padding: 20px;">
+                                <h2>Test Dialog</h2>
+                                
+                                <div style="margin-bottom: 10px;">
+                                    <label>Email (wire:model.live)</label>
+                                    <input 
+                                        type="email" 
+                                        wire:model.live="email"
+                                        dusk="email-input"
+                                    >
+                                    <div dusk="email-value">{{ $email }}</div>
+                                </div>
+
+                                <button type="button" onclick="document.getElementById('testDialog').close()">Close</button>
+                            </div>
+                        </dialog>
+                    </div>
+                BLADE;
+            }
+        })
+            ->click('@open-dialog')
+            ->pause(100)
+            ->type('@email-input', 'test@example.com')
+            ->pause(300)
+            ->assertVisible('@dialog-content')
+            ->assertSeeIn('@email-value', 'test@example.com')
+            ->assertVisible('@dialog-content');
+    }
+
+    public function test_can_submit_form_inside_dialog()
+    {
+        Livewire::visit(new class extends Component {
+            public $username = '';
+            public $email = '';
+            public $submitted = false;
+
+            public function submit()
+            {
+                $this->submitted = true;
+            }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <button dusk="open-dialog" onclick="document.getElementById('testDialog').showModal()">
+                            Open Dialog
+                        </button>
+
+                        <dialog id="testDialog" dusk="dialog-content">
+                            <div style="padding: 20px;">
+                                <h2>Test Dialog</h2>
+
+                                <form wire:submit="submit">
+                                    <div style="margin-bottom: 10px;">
+                                        <label>Username</label>
+                                        <input 
+                                            type="text" 
+                                            wire:model.blur="username"
+                                            dusk="username-input"
+                                        >
+                                    </div>
+
+                                    <div style="margin-bottom: 10px;">
+                                        <label>Email</label>
+                                        <input 
+                                            type="email" 
+                                            wire:model.live="email"
+                                            dusk="email-input"
+                                        >
+                                    </div>
+
+                                    <button type="submit" dusk="submit-button">Submit</button>
+                                </form>
+
+                                @if($submitted)
+                                    <div dusk="submitted" style="margin-top: 20px;">
+                                        <strong>Submitted!</strong><br>
+                                        Username: {{ $username }}<br>
+                                        Email: {{ $email }}
+                                    </div>
+                                @endif
+                            </div>
+                        </dialog>
+                    </div>
+                BLADE;
+            }
+        })
+            ->click('@open-dialog')
+            ->pause(100)
+            ->type('@username-input', 'john')
+            ->type('@email-input', 'john@example.com')
+            ->pause(200)
+            ->click('@submit-button')
+            ->pause(200)
+            ->assertSeeIn('@submitted', 'john')
+            ->assertSeeIn('@submitted', 'john@example.com');
+    }
+}


### PR DESCRIPTION
Fixes wire:model directives not working on input fields inside HTML5 <dialog> elements.

The issue: showModal() moves dialogs to the browser's top layer, breaking normal DOM parent traversal, causing wire:model to fail when finding the parent Livewire component.

Changes:
- js/lifecycle.js: Store component reference on dialog elements before top layer move
- js/directives/wire-model.js: Check for stored reference when element is inside a dialog
- js/morph.js: Preserve dialog open attribute during morphing to prevent auto-closing

Tests:
- Added 3 browser tests covering wire:model.blur, wire:model.live, and form submission
- All tests passing with CI=true for headless mode

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes, this is from the V4 roadmap.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes, the branch is fix/wire-model-inside-dialogs

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No, all changes are focused on making wire:model work inside dialog elements.
- lifecycle.js
- wire-model.js
- morph.js

4️⃣ Does it include tests? (Required)

Yes, added 3 browser tests in BrowserTest.php that cover wire:model.blur, wire:model.live, and form submission inside dialogs. All passing.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

When you use wire:model on an input inside a element, it fails silently. The problem is that dialog.showModal() moves the dialog to the browser’s top layer, which is outside the normal DOM tree. When wire:model tries to find the parent Livewire component using closest() or parentElement traversal, it fails because the dialog is no longer a descendant of the component.

The fix stores a reference to the component on the dialog element before it moves to the top layer (in lifecycle.js). Then when wire:model runs and can’t find a component the normal way, it checks if the element is inside a dialog and uses that stored reference instead (in wire-model.js). There’s also a small change in morph.js to preserve the dialog’s open attribute during updates so it doesn’t randomly close when wire:model.live triggers updates.

https://github.com/user-attachments/assets/67f4f1b6-d4cc-4f01-8c72-9746cb5c7845