### PR TITLE
fix: view:cache command issue when v3 component folder doesn't exist

### DIFF
--- a/src/Features/SupportConsoleCommands/Tests/CacheCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/CacheCommandUnitTest.php
@@ -25,7 +25,11 @@ class CacheCommandUnitTest extends \Tests\TestCase
         $this->app->instance('blade.compiler', null);
         $this->app->instance('view', null);
 
-        File::ensureDirectoryExists(resource_path('views').'/layouts');
+        $layoutsPath = resource_path('views').'/layouts';
+        $pagesPath = resource_path('views').'/pages';
+
+        File::ensureDirectoryExists($layoutsPath);
+        File::ensureDirectoryExists($pagesPath);
 
         // Create the Livewire v4 components folder
         File::ensureDirectoryExists($this->livewireComponentsPath());
@@ -37,6 +41,7 @@ class CacheCommandUnitTest extends \Tests\TestCase
         $exitCode = Artisan::call('view:cache');
         $this->assertEquals(0, $exitCode);
 
-        File::deleteDirectory(resource_path('views').'/layouts');
+        File::deleteDirectory($layoutsPath);
+        File::deleteDirectory($pagesPath);
     }
 }

--- a/src/Features/SupportConsoleCommands/Tests/CacheCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/CacheCommandUnitTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Livewire\Features\SupportConsoleCommands\Tests;
+
+
+use Illuminate\Support\Facades\Artisan;
+use Livewire\LivewireServiceProvider;
+use Illuminate\Support\Facades\File;
+
+class CacheCommandUnitTest extends \Tests\TestCase
+{
+    public function setUp(): void
+    {
+        // Create a livewire v4 components folder before laravel registers service provider
+        parent::setUp();
+
+        // Ensure components are cleared before each test...
+        $this->makeACleanSlate();
+    }
+
+    public function test_view_cache_command_is_working_when_livewire_v3_views_folder_does_not_exist()
+    {
+        // Clear instances which were booted in LivewireServiceProvider
+        $this->app->instance('livewire.finder', null);
+        $this->app->instance('blade.compiler', null);
+        $this->app->instance('view', null);
+
+        // Create the Livewire v4 components folder
+        File::ensureDirectoryExists($this->livewireComponentsPath());
+
+        // Boot LivewireServiceProvider again
+        $provider = $this->app->getProvider(LivewireServiceProvider::class);
+        $provider->boot();
+
+        $exitCode = Artisan::call('view:cache');
+        $this->assertEquals(0, $exitCode);
+    }
+}

--- a/src/Features/SupportConsoleCommands/Tests/CacheCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/CacheCommandUnitTest.php
@@ -25,6 +25,8 @@ class CacheCommandUnitTest extends \Tests\TestCase
         $this->app->instance('blade.compiler', null);
         $this->app->instance('view', null);
 
+        File::ensureDirectoryExists(resource_path('views').'/layouts');
+
         // Create the Livewire v4 components folder
         File::ensureDirectoryExists($this->livewireComponentsPath());
 
@@ -34,5 +36,7 @@ class CacheCommandUnitTest extends \Tests\TestCase
 
         $exitCode = Artisan::call('view:cache');
         $this->assertEquals(0, $exitCode);
+
+        File::deleteDirectory(resource_path('views').'/layouts');
     }
 }

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -146,11 +146,6 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
         // Register view-based component locations and namespaces...
 
         foreach (config('livewire.component_locations', []) as $location) {
-            // Only register directories that actually exist to avoid errors during view:cache.
-            if (! is_dir($location)) {
-                continue;
-            }
-
             app('livewire.finder')->addLocation(path: $location);
             app('blade.compiler')->anonymousComponentPath($location);
             app('view')->addLocation($location);


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

I don't see anyone discusses this issue, after I moved all my Livewire component to new v4 location, I found If I execute `php artisan view:cache` will face an issue said `resources/views/livewire` directory doesn't exist.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No. 

4️⃣ Does it include tests? (Required)

Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

After I moved all my components to new v4 location, `php artisan view:cache` command will fail and show `resources/views/livewire directory doesn't exist` error. I can simply avoid this error by modify `config/livewire.php`.

```php
'component_locations' => [
    resource_path('views/components'),
    // remove old v3 components path
    // resource_path('views/livewire'),
],
```

For the good compatibility, I think this error is a little weird here, if `resources/views/livewire` directory doesn't exist, we should ignore it.

So I add a folder existing check in `src/LivewireServiceProvider.php`.

```php
// src/LivewireServiceProvider.php

// Adapt v4 config to v3 config...

// Check component locations exist or not
$componentLocations = config('livewire.component_locations', [
    resource_path('views/components'),
    resource_path('views/livewire'),
]);

$existingComponentLocations = [];

// Check component folders exist or not
foreach ($componentLocations as $location) {
    if (is_dir($location)) {
        $existingComponentLocations[] = $location;
    }
}

// if component locations is an empty array, set it back to default
if ($existingComponentLocations === []) {
    $existingComponentLocations = [
        resource_path('views/components'),
        resource_path('views/livewire'),
    ];
}

config()->set(
    'livewire.component_locations',
    $existingComponentLocations
);
```