### PR TITLE
add `wire:model` to `$attributes`

### DIFF
--- a/src/Features/SupportNestingComponents/UnitTest.php
+++ b/src/Features/SupportNestingComponents/UnitTest.php
@@ -104,6 +104,35 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertContains($children, $component->snapshot['memo']);
     }
+
+    public function test_child_component_has_wire_model_attribute_inside_attribute_bag()
+    {
+        app('livewire')->test([
+            new class extends Component {
+                public $foo = '';
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                         <livewire:child wire:model="foo" />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <div {{ $attributes }}></div>
+                    </div>
+                    HTML;
+                }
+            }
+        ])
+        ->assertSeeHtml('wire:model="foo"');
+    }
 }
 
 class ParentComponentForNestingChildStub extends Component

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -98,7 +98,7 @@ class HandleComponents extends Mechanism
 
         foreach ($params as $key => $value) {
             $processedKey = $key;
-            
+
             // Convert only kebab-case params to camelCase for matching...
             if (str($processedKey)->contains('-')) {
                 $processedKey = str($processedKey)->camel()->toString();
@@ -106,6 +106,9 @@ class HandleComponents extends Mechanism
 
             // Check if this is a reserved param
             if ($this->isReservedParam($key)) {
+                $componentParams[$key] = $value;
+            } elseif (str_starts_with($key, 'wire:model')) {
+                $htmlAttributes[$key] = $value;
                 $componentParams[$key] = $value;
             }
 
@@ -128,7 +131,7 @@ class HandleComponents extends Mechanism
     protected function isReservedParam($key)
     {
         $exact = ['lazy', 'defer', 'lazy.bundle', 'defer.bundle', 'wire:ref'];
-        $startsWith = ['@', 'wire:model'];
+        $startsWith = ['@'];
 
         // Check exact matches
         if (in_array($key, $exact)) {


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

yes.
I don't see anyone discusses this.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

no

4️⃣ Does it include tests? (Required)

yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Livewire V4 introduce `$slot` and `$attributes` so it looks like blade component in general.
But if we make component i.e. input component with validation error, it need wire:model to know the validation key error.

Thanks for contributing! 🙌
