### PR TITLE
Add `ddErrors()` Helper to `TestsValidation` Trait

### DIFF
--- a/src/Features/SupportValidation/TestsValidation.php
+++ b/src/Features/SupportValidation/TestsValidation.php
@@ -26,6 +26,11 @@ trait TestsValidation
         return new MessageBag;
     }
 
+    function ddErrors()
+    {
+        dd($this->errors());
+    }
+
     function failedRules()
     {
         $validator = store($this->target)->get('testing.validator');


### PR DESCRIPTION
# Add `ddErrors()` Helper to `TestsValidation` Trait

## Overview

This PR introduces a new helper method, `ddErrors()`, to the `Livewire\Features\SupportValidation\TestsValidation` trait.

## Changes

- **New Method:** `ddErrors()`
  - This method provides a simple shortcut to dump and die (`dd()`) the current validation errors returned by `errors()`.
  - Useful for debugging validation issues in Livewire test components.

## Usage Example

```php
Livewire::test(CalendarEventForm::class)
  ->call('submit')
  ->ddErrors() // Dumps the MessageBag with errors
  ->assertHasNoErrors();
```

## Motivation

- Improves developer experience during test writing and debugging by making it easier to inspect validation errors directly.
- Keeps assertions and debugging tools in one place, encouraging better testing workflows.

## No Breaking Changes

- This addition is fully backwards compatible. No existing functionality is changed.