### PR TITLE
Unify internal and user-defined debounce on `wire:model`

### DIFF
--- a/src/Tests/WireModelBrowserTest.php
+++ b/src/Tests/WireModelBrowserTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Livewire\Tests;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class WireModelBrowserTest extends \Tests\BrowserTestCase
+{
+    public function test_debounces_requests_on_input_elements_by_default()
+    {
+        Livewire::visit(new class extends Component {
+            public $foo;
+
+            public function updated()
+            {
+                $this->js('window.requests++');
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div x-init="window.requests = 0">
+                    <input type="text" wire:model.live="foo" dusk="input">
+                    <span wire:text="foo" dusk="text"></span>
+                </div>
+                HTML;
+            }
+        })
+            ->typeSlowly('@input', 'livewire', 50)
+            ->assertSeeIn('@text', 'livewire') // wire:text should update immediately
+            ->pause(200) // Wait for the request to be handled
+            ->assertScript('window.requests', 1); // Only one request was sent
+    }
+
+    public function test_debounces_requests_with_custom_duration()
+    {
+        Livewire::visit(new class extends Component {
+            public $foo;
+
+            public function updated()
+            {
+                $this->js('window.requests++');
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div x-init="window.requests = 0">
+                    <input type="text" wire:model.live.debounce.250ms="foo" dusk="input">
+                    <span wire:text="foo" dusk="text"></span>
+                </div>
+                HTML;
+            }
+        })
+            ->typeSlowly('@input', 'livewire', 50)
+            ->assertSeeIn('@text', 'livewire') // wire:text should update immediately
+            ->pause(300) // Wait for the request to be handled
+            ->assertScript('window.requests', 1); // Only one request was sent
+    }
+
+    public function test_throttles_requests_with_custom_duration()
+    {
+        Livewire::visit(new class extends Component {
+            public $foo;
+
+            public function updated()
+            {
+                $this->js('window.requests++');
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div x-init="window.requests = 0">
+                    <input type="text" wire:model.live.throttle.250ms="foo" dusk="input">
+                    <span wire:text="foo" dusk="text"></span>
+                </div>
+                HTML;
+            }
+        })
+            ->typeSlowly('@input', 'livewire', 50) // 400ms total
+            ->assertSeeIn('@text', 'livewire') // wire:text should update immediately
+            ->pause(200) // Wait for the request to be handled
+            ->assertScript('window.requests', 2); // Two requests: after 250ms and 500ms
+    }
+}


### PR DESCRIPTION
## The scenario

Imagine you're building a custom text editor:

```html
<x-custom-editor wire:model.live="content" />

<!-- Preview -->
<div wire:text="content"></div>
```

The editor fires `input` events, which means we can use `wire:model.live` to sync the changes to the backend as the user types, and display a preview using `wire:text`.

## The problem

The above setup works well but sends a backend request with every keystroke.

This can be prevented by adding a `.debounce.150ms` modifier, mimicking the default Livewire behavior on a native `input` element with `wire:model.live` — where a 150ms debounce is added by default.

```html
<x-custom-editor wire:model.live.debounce.150ms="content" />

<!-- Preview -->
<div wire:text="content"></div>
```

However there is an important difference in how the "internal" and custom debounce works:

* Native input w/ internal debounce - `wire:text` is updated immediately after every keystroke
* Custom editor w/ user-defined debounce - `wire:text` is only updated when the user stops typing

This difference comes from the following code:

```js
let debouncedUpdate = isRealtimeInput(el) && ! isDebounced && isLive
    ? debounce(update, 150) // Internal debounce function
    : update

// ...

['x-model' + getModifierTail(modifiers)]() { // Custom debounce is forwarded to Alpine
    return {
        set(value) {
            dataSet(component.$wire, expression, value)

            isLive && (! isLazy) && (! onBlur) && debouncedUpdate()
        },
    }
}

```

Because the custom debounce is handled by Alpine, it will debounce the entire event handler, which includes the `dataSet` function that updates the ephemeral state on the frontend which is then displayed by `wire:text`.

This breaks the "optimistic update" effect of `wire:text`.

## The solution

This PR updates the `.debounce` and `.throttle` modifiers to use internal functions instead, and the modifiers will be removed from the modifier trail that is forwarded to Alpine.