### PR TITLE
Modify command for generating test files

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -53,7 +53,7 @@ Now Pest will recognize and run tests located next to your components when you r
 You can generate a test file alongside a component by appending the `--test` flag to the `make:livewire` command:
 
 ```shell
-php artisan make:livewire post.create --test
+php artisan make:livewire post.create --mfc --test
 ```
 
 For multi-file components, this will create a test file at `resources/views/components/post/create.test.php`:


### PR DESCRIPTION
Updated command in the documentation to include '--mfc' flag for test file generation. Without adding this flag, no test file is generated, which was kind of confusing for me 😅.

I created a [discussion](https://github.com/livewire/livewire/discussions/9598) for commentary on how to handle generating `--test` flags for single-file components.
