### PR TITLE
Allow forwarding wire:model using

### DIFF
--- a/src/ComponentHookRegistry.php
+++ b/src/ComponentHookRegistry.php
@@ -36,13 +36,13 @@ class ComponentHookRegistry
         static::$components = new WeakMap;
 
         foreach (static::$componentHooks as $hook) {
-            on('mount', function ($component, $params, $key, $parent) use ($hook) {
+            on('mount', function ($component, $params, $key, $parent, $attributes) use ($hook) {
                 if (! $hook = static::initializeHook($hook, $component)) {
                     return;
                 }
 
                 $hook->callBoot();
-                $hook->callMount($params, $parent);
+                $hook->callMount($params, $parent, $attributes);
             });
 
             on('hydrate', function ($component, $memo) use ($hook) {

--- a/src/Features/SupportNestingComponents/SupportNestingComponents.php
+++ b/src/Features/SupportNestingComponents/SupportNestingComponents.php
@@ -12,12 +12,12 @@ class SupportNestingComponents extends ComponentHook
 {
     static function provide()
     {
-        on('pre-mount', function ($name, $params, $key, $parent, $hijack, $slots) {
+        on('pre-mount', function ($name, $params, $key, $parent, $hijack, $slots, $attributes) {
             // If this has already been rendered spoof it...
             if ($parent && static::hasPreviouslyRenderedChild($parent, $key)) {
                 [$tag, $childId] = static::getPreviouslyRenderedChild($parent, $key);
 
-                $finish = trigger('mount.stub', $tag, $childId, $params, $parent, $key, $slots);
+                $finish = trigger('mount.stub', $tag, $childId, $params, $parent, $key, $slots, $attributes);
 
                 $idAttribute = " wire:id=\"{$childId}\"";
                 $nameAttribute = " wire:name=\"{$name}\"";

--- a/src/Features/SupportWireModelingNestedComponents/BaseModelable.php
+++ b/src/Features/SupportWireModelingNestedComponents/BaseModelable.php
@@ -8,13 +8,13 @@ use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 #[\Attribute]
 class BaseModelable extends LivewireAttribute
 {
-    public function mount($params, $parent)
+    public function mount($params, $parent, $attributes)
     {
         if (! $parent) return;
 
         $outer = null;
 
-        foreach ($params as $key => $value) {
+        foreach ($attributes as $key => $value) {
             if (str($key)->startsWith('wire:model')) {
                 $outer = $value;
                 store($this->component)->push('bindings-directives', $key, $value);

--- a/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
+++ b/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
@@ -268,6 +268,29 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertSeeNothingIn('@child.ephemeral', '')
         ;
     }
+
+    public function test_can_still_forward_wire_model_attribute()
+    {
+        Livewire::visit([
+            new class extends \Livewire\Component {
+                public function render() { return <<<'HTML'
+                <div>
+                    <livewire:child wire:model="foo" class="foo" />
+                </div>
+                HTML; }
+            },
+            'child' => new class extends \Livewire\Component {
+                public function render() { return <<<'HTML'
+                <div {{ $attributes }} dusk="child">
+                    <!-- ... -->
+                </div>
+                HTML; }
+            },
+        ])
+        ->assertAttribute('@child', 'wire:model', 'foo')
+        ->assertAttribute('@child', 'class', 'foo')
+        ;
+    }
 }
 
 class CreatePost extends Form

--- a/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
+++ b/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
@@ -19,8 +19,8 @@ class SupportWireModelingNestedComponents extends ComponentHook
         // with wire:model on it, and that child has already been mounted
         // in a previous request, capture the value being passed in so we
         // can later set the child's property if it exists in this request.
-        on('mount.stub', function ($tag, $id, $params, $parent, $key) {
-            $outer = collect($params)->first(function ($value, $key) {
+        on('mount.stub', function ($tag, $id, $params, $parent, $key, $slots, $attributes) {
+            $outer = collect($attributes)->first(function ($value, $key) {
                 return str($key)->startsWith('wire:model');
             });
 


### PR DESCRIPTION
## The situation

Blade components support attribute forwarding, making it simple to forward an attribute like `wire:model` onto a component element like so:

```blade
<x-input wire:model="foo" />

<!-- Component definition: -->
@props([])

<input type="text" {{ $attributes }}>

<!-- Results in: -->
<input type="text" wire:model="foo">
```

Now that Livewire 4 users can forward attributes using `$attributes`, they would expect the same thing.

However, this isn't supported for `wire:model`.

A component like the following will NOT work:

```blade
<livewire:input wire:model="foo" />

<!-- Component definition: -->
<?php

new class extends Livewire\Component {};
?>

<input type="text" {{ $attributes }}>

<!-- Results in: -->
<input type="text">
```

Livewire will forward most attributes, but it will NOT forward `wire:model` in the `$attributes` bag.

## The problem

The reason this is happening, is Livewire treats a few attributes as special.

When you pass `wire:model="foo"` to a Livewire component, it expects that you are using `#[Modelable]` on a property on that component.

Therefore, Livewire was built such that it will consider `wire:model` a component parameter and not a regular HTML attribute.

## The solution

I think the ideal solution is that Livewire considers `wire:model` an HTML attribute like any other and re-work Livewire internals to look inside `$attributes` for `wire:model` rather than what it does currently (look inside `$params`).
