### PR TITLE
Add support for `optimize:clear` command in `ClearCachedFiles `

### DIFF
--- a/src/Mechanisms/ClearCachedFiles.php
+++ b/src/Mechanisms/ClearCachedFiles.php
@@ -6,10 +6,15 @@ class ClearCachedFiles extends Mechanism
 {
     function boot()
     {
-        // Hook into Laravel's view:clear command to also clear Livewire compiled files
+        // Hook into Laravel's view:clear and optimize:clear command to also clear Livewire compiled files
+        $eventCommands = [
+            'view:clear',
+            'optimize:clear',
+        ];
+
         if (app()->runningInConsole()) {
-            app('events')->listen(\Illuminate\Console\Events\CommandFinished::class, function ($event) {
-                if ($event->command === 'view:clear' && $event->exitCode === 0) {
+            app('events')->listen(\Illuminate\Console\Events\CommandFinished::class, function ($event) use ($eventCommands) {
+                if (in_array($event->command, $eventCommands) && $event->exitCode === 0) {
                     app('livewire.compiler')->clearCompiled($event->output);
                 }
             });


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

= No

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

= Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

= No

4️⃣ Does it include tests? (Required)

= No

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

= Livewire currently clears compiled component files when the `view:clear` command is executed. However, Laravel developers often use `optimize:clear`, which clears multiple caches including views.

Despite this, Livewire does not clear its compiled views on `optimize:clear`, resulting in outdated or stale Livewire compiled files after optimization resets.

Thanks for contributing! 🙌