### PR TITLE
Improved Exception Messages for Nested Components

### DIFF
--- a/src/Mechanisms/ExtendBlade/ExtendBlade.php
+++ b/src/Mechanisms/ExtendBlade/ExtendBlade.php
@@ -14,20 +14,28 @@ class ExtendBlade extends Mechanism
     protected $renderCounter = 0;
 
     protected static $livewireComponents = [];
+    protected static $livewireViews = [];
 
-    function startLivewireRendering($component)
+    function startLivewireRendering($component, $view = null)
     {
         static::$livewireComponents[] = $component;
+        static::$livewireViews[] = $view;
     }
 
     function endLivewireRendering()
     {
         array_pop(static::$livewireComponents);
+        array_pop(static::$livewireViews);
     }
 
     static function currentRendering()
     {
         return end(static::$livewireComponents);
+    }
+
+    static function currentRenderingView()
+    {
+        return end(static::$livewireViews);
     }
 
     static function isRenderingLivewireComponent()
@@ -40,7 +48,7 @@ class ExtendBlade extends Mechanism
         Blade::directive('this', fn() => "window.Livewire.find('{{ \$_instance->getId() }}')");
 
         on('render', function ($target, $view) {
-            $this->startLivewireRendering($target);
+            $this->startLivewireRendering($target, $view);
 
             $undo = $this->livewireifyBladeCompiler();
 
@@ -73,6 +81,7 @@ class ExtendBlade extends Mechanism
             app()->singleton(DeterministicBladeKeys::class);
 
             static::$livewireComponents = [];
+            static::$livewireViews = [];
         });
 
         // We're using "precompiler" as a hook for the point in time when

--- a/src/Mechanisms/ExtendBlade/UnitTest.php
+++ b/src/Mechanisms/ExtendBlade/UnitTest.php
@@ -16,6 +16,14 @@ use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Clear render stack between tests to ensure test isolation
+        \Livewire\Mechanisms\HandleComponents\HandleComponents::$renderStack = [];
+    }
+
     public function test_livewire_only_directives_apply_to_livewire_components_and_not_normal_blade()
     {
         Livewire::directive('foo', function ($expression) {
@@ -301,6 +309,7 @@ class UnitTest extends \Tests\TestCase
             \Illuminate\Support\Facades\Blade::render('@php throw new \Exception("Test error"); @endphp');
         } catch (ErrorException $e) {
             $message = $e->getMessage();
+
             // The implementation checks isRenderingLivewireComponent() before enhancing
             // If component context appears, it means the check failed or we're in a component context
             // In a clean state, this should not happen
@@ -322,6 +331,7 @@ class UnitTest extends \Tests\TestCase
             Livewire::test(ClassBasedComponentWithExceptionStub::class);
         } catch (ErrorException $e) {
             $message = $e->getMessage();
+
             $this->assertStringContainsString('(Component:', $message);
             $this->assertStringContainsString('Undefined variable', $message);
 
@@ -403,9 +413,6 @@ class UnitTest extends \Tests\TestCase
             if ($e instanceof ErrorException) {
                 $message = $e->getMessage();
 
-                // Debug output - uncomment to see the exception message
-                // $this->fail("DEBUG - Exception Message:\n\n{$message}");
-
                 $this->assertStringContainsString('(Component:', $message);
                 $this->assertStringContainsString('Undefined variable', $message);
 
@@ -454,6 +461,7 @@ class UnitTest extends \Tests\TestCase
         } catch (\Throwable $e) {
             if ($e instanceof ErrorException) {
                 $message = $e->getMessage();
+
                 $this->assertStringContainsString('(Component:', $message);
                 $this->assertStringContainsString('Undefined variable', $message);
             }
@@ -475,6 +483,7 @@ class UnitTest extends \Tests\TestCase
         } catch (\Throwable $e) {
             if ($e instanceof ErrorException) {
                 $message = $e->getMessage();
+
                 $this->assertStringContainsString('(Component:', $message);
                 $this->assertStringContainsString('Undefined variable', $message);
             }


### PR DESCRIPTION
## Description
This PR enhances standard Blade `ErrorException` messages by appending Livewire component context. When an exception occurs within a nested component, the error message now includes the component hierarchy and the resolved view or class path. This makes debugging significantly easier, especially in deep component trees where the compiled Blade path is unhelpful.

All feedback is of course welcome!

## Examples

**Before:**
```
ErrorException
storage/framework/views/livewire/views/e56c1bbe.blade.php:8
Undefined variable $bannerItemsss
```

**After:**
```
Livewire\Exceptions\PropertyNotFoundException
vendor/livewire/livewire/src/Component.php:137
Property [$bannerssss] not found on component: [home.hero-banner] (View: resources/views/components/home/hero-banner/hero-banner.blade.php) (Component: [home.home -> home.hero-banner])
```

## Tests added

```
php vendor/bin/phpunit src/Mechanisms/ExtendBlade/UnitTest.php --filter test_exception_message --testdox
PHPUnit 11.5.44 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.27
Configuration: /var/www/html/phpunit.xml.dist

............                                                      12 / 12 (100%)

Time: 00:00.206, Memory: 16.00 MB

Unit (Livewire\Mechanisms\ExtendBlade\Unit)
 ✔ Exception message includes component context for single component
 ✔ Exception message includes component hierarchy for nested components
 ✔ Exception message includes view path when available
 ✔ Exception message not enhanced when already contains component context
 ✔ Exception message not enhanced for non livewire views
 ✔ Exception message includes component context for class based component
 ✔ Exception message format matches expected pattern
 ✔ Exception message includes component hierarchy for deeply nested components
 ✔ Exception message works with single file component
 ✔ Exception message works with multi file component
 ✔ Exception message property not found includes component context
 ✔ Exception message property not found includes hierarchy for nested components

OK (12 tests, 65 assertions)

```
