### PR TITLE
Fix missing named argument on registering class based component in docs

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -433,7 +433,7 @@ use Livewire\Livewire;
 // Register an individual class-based component
 Livewire::addComponent(
     name: 'todos',
-    \App\Livewire\Todos::class
+    class: \App\Livewire\Todos::class
 );
 
 // Register a location for class-based components


### PR DESCRIPTION
it will throw error if  `class` argument is not added

<img width="922" height="249" alt="image" src="https://github.com/user-attachments/assets/04a3012e-0fc4-409a-afae-13cf1056d91e" />
