### PR TITLE
Fix: keep version control over asset_url

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -250,7 +250,7 @@ class FrontendAssets extends Mechanism
         }
 
         $publishedManifest = json_decode(file_get_contents(public_path('vendor/livewire/manifest.json')), true);
-        $versionedFileName = $publishedManifest['/livewire.js'];
+        $version = $publishedManifest['/livewire.js'];
 
         $isCsp = app('livewire')->isCspSafe();
 
@@ -260,9 +260,12 @@ class FrontendAssets extends Mechanism
             $fileName = $isCsp ? '/livewire.csp.min.js' : '/livewire.min.js';
         }
 
-        $versionedFileName = "{$fileName}?id={$versionedFileName}";
+        $versionedFileName = "{$fileName}?id={$version}";
 
-        $assertUrl = config('livewire.asset_url')
+        $configuredUrl = config('livewire.asset_url');
+        $versionedConfiguredUrl = $configuredUrl ? "{$configuredUrl}?id={$version}" : null;
+
+        $assertUrl = $versionedConfiguredUrl
             ?? (app('livewire')->isRunningServerless()
                 ? rtrim(config('app.asset_url'), '/')."/vendor/livewire$versionedFileName"
                 : url("vendor/livewire{$versionedFileName}")


### PR DESCRIPTION
## This PR fixes an inconsistency in how Livewire applies versioning to its asset URLs.

The method `Livewire\Mechanisms\FrontendAssets\FrontendAssets::js()` always appends the build version (`?id=...`) to `config('livewire.asset_url')`.
However, the `usePublishedAssetsIfAvailable()` method does **not** apply the same versioning logic when a custom `asset_url` is configured. As a result, the published asset URL loses its version hash, causing stale assets to be loaded or cached incorrectly.

This update ensures that `config('livewire.asset_url')` also receives the `?id={version}` suffix when resolving published assets, restoring consistent versioning across both methods.

This brings the behavior of `usePublishedAssetsIfAvailable()` in line with the versioning logic already used in `FrontendAssets::js()`.