### PR TITLE
Fix `data-current` to use exact matching

### DIFF
--- a/js/features/supportDataCurrent.js
+++ b/js/features/supportDataCurrent.js
@@ -12,9 +12,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
 function updateNavigateLinks() {
     let currentUrl = new URL(window.location.href)
+    let options = {
+        exact: true,
+    }
 
     // Find all links with any wire:navigate variation
     document.querySelectorAll(wireNavigateSelector).forEach(el => {
+        // If the element has `wire:current` then the user might want to specify strict or 
+        // exact matching, so we will just return early so we don't override that...
+        if (el.hasAttribute('wire:current')) return
+
         // Fragment hrefs aren't supported...
         let href = el.getAttribute('href')
 
@@ -24,7 +31,7 @@ function updateNavigateLinks() {
             let hrefUrl = new URL(href, window.location.href)
 
             // Check if this link matches the current URL (using default partial matching)
-            if (pathMatches(hrefUrl, currentUrl)) {
+            if (pathMatches(hrefUrl, currentUrl, options)) {
                 el.setAttribute('data-current', '')
             } else {
                 el.removeAttribute('data-current')


### PR DESCRIPTION
# The scenario

Currently if you have 3 routes like the following:

```php
Route::livewire('admin', 'playground')->name('admin.dashboard');
Route::livewire('admin/pages', 'playground')->name('admin.pages-index');
Route::livewire('admin/users', 'playground')->name('admin.users-index');
```

And have 3 links, all with some form of `data-current` styling.

```blade
<a wire:current.exact class="data-current:font-bold" href="{{ route('admin.dashboard') }}" wire:navigate>Dashboard</a>
<a wire:current.exact class="data-current:font-bold" href="{{ route('admin.pages-index') }}" wire:navigate>Pages</a>
<a wire:current.exact class="data-current:font-bold" href="{{ route('admin.users-index') }}" wire:navigate>Users</a>
```

If you browse to either the pages or the users routes, the Dashboard link is also receiving `data-current` styles.

![Screenshot 2025-11-27 at 04 38 31PM](https://github.com/user-attachments/assets/8d9e115c-efd5-427a-9373-4c1ca6dbe103)

```blade
<?php

use Livewire\Component;

new class extends Component {
    //
}; ?>

<div>
    <a wire:current.exact class="data-current:font-bold" href="{{ route('admin.dashboard') }}" wire:navigate>Dashboard</a>
    <a wire:current.exact class="data-current:font-bold" href="{{ route('admin.pages-index') }}" wire:navigate>Pages</a>
    <a wire:current.exact class="data-current:font-bold" href="{{ route('admin.users-index') }}" wire:navigate>Users</a>
</div>
```

# The problem

The problem is that the `data-current` feature is using the `pathMatch()` function from `wire:current`. This means that by default, it's using a partial match strategy.

# The solution

The solution is to change the `data-current` feature to use exact matching instead of partial matches. Now everything works as expected.

There may be times when you want partial matching or strict matching, in that case the best solution is to add `wire:current` to the element to enable these. But I found that the implementation in `data-current` overwrote anything that `wire:current` set. So I've added a return early in `data-current` if the element contains `wire:current`, so `wire:current` can handle it instead.

![Screenshot 2025-11-27 at 04 37 36PM](https://github.com/user-attachments/assets/f52cb88a-eaff-40d9-935f-f69efda126f6)

Fixes livewire/flux#2129
Fixes livewire/flux#2182