### PR TITLE
fixes a bug when big int is converted to float in scientific notation inside url query params

### DIFF
--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -62,7 +62,7 @@ class BaseUrl extends LivewireAttribute
 
         $decoded = is_array($initialValue)
             ? json_decode(json_encode($initialValue), true)
-            : json_decode($initialValue ?? '', true);
+            : json_decode($initialValue ?? '', true, flags: JSON_BIGINT_AS_STRING);
 
         // If only part of an array is present in the query string,
         // we want to merge instead of override the value...

--- a/src/Tests/UrlAttributeBigNumberUnitTest.php
+++ b/src/Tests/UrlAttributeBigNumberUnitTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Livewire\Tests;
+
+use Livewire\Attributes\Url;
+use Livewire\Livewire;
+
+class UrlAttributeBigNumberUnitTest extends \Tests\TestCase
+{
+    public function test_large_numbers_in_url_remain_strings()
+    {
+        $search = '22000010620000001134';
+
+        Livewire::withQueryParams(['search' => $search])
+            ->test(BigNumberUrlComponent::class)
+            ->assertSetStrict('search', $search);
+    }
+}
+
+class BigNumberUrlComponent extends \Tests\TestComponent
+{
+    #[Url]
+    public string $search = '';
+}


### PR DESCRIPTION
The issue is pretty obvious to see on filament demo page https://demo.filamentphp.com/shop/products/products
try to search for this string "22000010620000001134" - it will search correctly and update url to `https://demo.filamentphp.com/shop/products/products?search=22000010620000001134` 
but then try to refresh the page (or copy paste the url to another tab) and the url will change to `https://demo.filamentphp.com/shop/products/products?search=2.200001062E%2B19` obviously - not what you would expect to happen. search string must stay string, not be converted to float in scientific notation. 

This PR fixes the problem, but I personally don't like the soultion. Whole approach of json-decoding url params seems off. What if i want to search actual json like string "[]"?.. well, right now now it will fail misarably with error 500. What about searching for some truth? :) let's search for string "true": `https://demo.filamentphp.com/shop/products/products?search=true` and right now it gets converted to "1": `https://demo.filamentphp.com/shop/products/products?search=1`. so this PR is an invitation to discuss better solution i guess :))
this PR fixes a problem with long ints (which is a serious problem for my project) but does not address bigger issue. it would be nice if someone familiar with overall architecture of livewire take a look at this more deeply.



1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
it's a bug

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
yes, " bug-url-screws-big-ints"

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
nope. 

4️⃣ Does it include tests? (Required)
yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
above

