### PR TITLE
Fix invalid `wire:stream` selector via escaping

### DIFF
--- a/js/features/supportStreaming.js
+++ b/js/features/supportStreaming.js
@@ -14,7 +14,7 @@ interceptMessage(({ message, onStream }) => {
         let targetEl = null
 
         if (type === 'directive') {
-            replaceEl = component.el.querySelector(`[wire\\:stream.replace="${name}"]`)
+            replaceEl = component.el.querySelector(`[wire\\:stream\\.replace="${name}"]`)
 
             if (replaceEl) {
                 targetEl = replaceEl

--- a/js/features/supportStreaming.js
+++ b/js/features/supportStreaming.js
@@ -14,7 +14,7 @@ interceptMessage(({ message, onStream }) => {
         let targetEl = null
 
         if (type === 'directive') {
-            replaceEl = component.el.querySelector(`[wire\\:stream\\.replace="${name}"]`)
+            const replaceEl = component.el.querySelector(`[wire\\:stream\\.replace="${name}"]`)
 
             if (replaceEl) {
                 targetEl = replaceEl


### PR DESCRIPTION
If you run this in your browser console you get an "is not a valid selector" error:
```js
document.querySelector(`[wire\\:stream.answer="answer"]`);
```

But if you change it to:
```js
document.querySelector(`[wire\\:stream\\.answer="answer"]`);
```

It works perfectly.