### PR TITLE
Fix anonymous class return regex

### DIFF
--- a/src/Compiler/Parser/Parser.php
+++ b/src/Compiler/Parser/Parser.php
@@ -52,8 +52,17 @@ class Parser
 
     protected function ensureAnonymousClassHasReturn(string $contents): string
     {
-        if (preg_match('/^(?!.*\breturn\s+).*\bnew\s+class\s+extends\s+Component/m', $contents)) {
-            return preg_replace('/^(\s*)(new\s+class\s+extends\s+Component)/m', '$1return $2', $contents, 1);
+        // Find the position of the first "new"...
+        if (preg_match('/\bnew\b/', $contents, $newMatch, PREG_OFFSET_CAPTURE)) {
+            $newPosition = $newMatch[0][1];
+
+            // Check if "return new" exists and find where "new" starts in that match...
+            $hasReturnNew = preg_match('/\breturn\s+(new\b)/', $contents, $returnNewMatch, PREG_OFFSET_CAPTURE);
+
+            // If "return new" does not exist or "new" is not at the same position as "return new", add "return"...
+            if (!$hasReturnNew || $returnNewMatch[1][1] !== $newPosition) {
+                $contents = substr_replace($contents, 'return ', $newPosition, 0);
+            }
         }
 
         return $contents;

--- a/src/Compiler/UnitTest.php
+++ b/src/Compiler/UnitTest.php
@@ -2,12 +2,12 @@
 
 namespace Livewire\Compiler;
 
-use Illuminate\Support\Facades\File;
-use Livewire\Compiler\CacheManager;
-use Livewire\Compiler\Compiler;
-use Livewire\Compiler\Parser\MultiFileParser;
-use Livewire\Compiler\Parser\SingleFileParser;
 use Livewire\Component;
+use Livewire\Compiler\Parser\SingleFileParser;
+use Livewire\Compiler\Parser\MultiFileParser;
+use Livewire\Compiler\Compiler;
+use Livewire\Compiler\CacheManager;
+use Illuminate\Support\Facades\File;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class UnitTest extends \Tests\TestCase

--- a/src/Compiler/UnitTest.php
+++ b/src/Compiler/UnitTest.php
@@ -2,12 +2,13 @@
 
 namespace Livewire\Compiler;
 
-use Livewire\Component;
-use Livewire\Compiler\Parser\SingleFileParser;
-use Livewire\Compiler\Parser\MultiFileParser;
-use Livewire\Compiler\Compiler;
-use Livewire\Compiler\CacheManager;
 use Illuminate\Support\Facades\File;
+use Livewire\Compiler\CacheManager;
+use Livewire\Compiler\Compiler;
+use Livewire\Compiler\Parser\MultiFileParser;
+use Livewire\Compiler\Parser\SingleFileParser;
+use Livewire\Component;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -214,7 +215,7 @@ class UnitTest extends \Tests\TestCase
     public function test_can_parse_mfc_component()
     {
         $compiler = new Compiler(new CacheManager($this->cacheDir));
-        
+
         $parser = MultiFileParser::parse($compiler, __DIR__ . '/Fixtures/mfc-component');
 
         $classContents = $parser->generateClassContents('view-path.blade.php');
@@ -334,5 +335,220 @@ class UnitTest extends \Tests\TestCase
         $viewContents = file_get_contents($cacheManager->getViewPath($sourcePath));
 
         $this->assertStringContainsString('<span>{{ $message }}</span>', $viewContents);
+    }
+
+    #[DataProvider('classReturnProvider')]
+    public function test_anonymous_class_has_return_statement_added_if_required($classContents, $expectedOutput)
+    {
+        $parser = new SingleFileParser(
+            path: '',
+            contents: '',
+            scriptPortion: null,
+            classPortion: $classContents,
+            placeholderPortion: null,
+            viewPortion: '',
+        );
+
+        $generatedClassContents = $parser->generateClassContents();
+
+        $this->assertEquals($expectedOutput, $generatedClassContents);
+    }
+
+    public static function classReturnProvider()
+    {
+        return [
+            [
+                <<<'EOT'
+                <?php
+
+                return new class extends \Livewire\Component
+                {
+                    public $message = 'Hello World';
+                };
+                ?>
+                EOT,
+                <<<'EOT'
+                <?php
+
+                return new class extends \Livewire\Component
+                {
+                    public $message = 'Hello World';
+                };
+
+                EOT,
+            ],
+            [
+                <<<'EOT'
+                <?php
+
+                new class extends \Livewire\Component
+                {
+                    public $message = 'Hello World';
+                };
+                ?>
+                EOT,
+                <<<'EOT'
+                <?php
+
+                return new class extends \Livewire\Component
+                {
+                    public $message = 'Hello World';
+                };
+
+                EOT,
+            ],
+            [
+                <<<'EOT'
+                <?php
+
+                return new class extends \Livewire\Component
+                {
+                    public $message = 'Hello World';
+                };
+                ?>
+                EOT,
+                <<<'EOT'
+                <?php
+
+                return new class extends \Livewire\Component
+                {
+                    public $message = 'Hello World';
+                };
+
+                EOT,
+            ],
+            [
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                new class extends Component {
+                    public function getData()
+                    {
+                        return new Collection([]);
+                    }
+                };
+                ?>
+                EOT,
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                return new class extends Component {
+                    public function getData()
+                    {
+                        return new Collection([]);
+                    }
+                };
+
+                EOT,
+            ],
+            [
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                new class extends Component {
+                    public function getData()
+                    {
+                        return new class extends Model {
+                            protected $table = 'users';
+                        };
+                    }
+                };
+                ?>
+                EOT,
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                return new class extends Component {
+                    public function getData()
+                    {
+                        return new class extends Model {
+                            protected $table = 'users';
+                        };
+                    }
+                };
+
+                EOT,
+            ],
+            [
+                <<<'EOT'
+                <?php
+
+                use Livewire\Attributes\Layout;
+                use Livewire\Component;
+
+                new #[Layout('layouts.app')] class extends Component {
+                    public function getData()
+                    {
+                        return new class extends Model {
+                            protected $table = 'users';
+                        };
+                    }
+                };
+                ?>
+                EOT,
+                <<<'EOT'
+                <?php
+
+                use Livewire\Attributes\Layout;
+                use Livewire\Component;
+
+                return new #[Layout('layouts.app')] class extends Component {
+                    public function getData()
+                    {
+                        return new class extends Model {
+                            protected $table = 'users';
+                        };
+                    }
+                };
+
+                EOT,
+            ],
+            [
+                <<<'EOT'
+                <?php
+
+                use Livewire\Attributes\Layout;
+                use Livewire\Component;
+
+                new
+                #[Layout('layouts.app')]
+                class extends Component {
+                    public function getData()
+                    {
+                        return new class extends Model {
+                            protected $table = 'users';
+                        };
+                    }
+                };
+                ?>
+                EOT,
+                <<<'EOT'
+                <?php
+
+                use Livewire\Attributes\Layout;
+                use Livewire\Component;
+
+                return new
+                #[Layout('layouts.app')]
+                class extends Component {
+                    public function getData()
+                    {
+                        return new class extends Model {
+                            protected $table = 'users';
+                        };
+                    }
+                };
+
+                EOT,
+            ],
+        ];
     }
 }


### PR DESCRIPTION
This is an extension of PR #9602.

# The scenario

Currently if you have single file component like the below, it's throwing an error.

<img width="2086" height="788" alt="Screenshot 2025-12-06 at 09 05 05AM@2x" src="https://github.com/user-attachments/assets/6c99ac06-df02-4903-a5c4-115ee00dace0" />

```blade
<?php

new class extends Livewire\Component {
    public int $count = 1;

    public function increment()
    {
        $this->count++;
    }
};
?>

<div>
    <span>Count: {{ $count }}</span>
    <button wire:click="increment">Increment</button>
</div>
```

# The problem

The issue is that the regex in that PR was too strict and didn't account for different scenarios like `extends Livewire\Component` as well as extensions of other custom classes.

# The solution

This PR improves the regex to look for the first `new` like the original implementation did but also gets it's position. It then tries to find `return new` and compares the position of the new in that match with the position of the first new. If they don't match, then it means that we need to add `return ` to the beginning of the class.

I've also added a bunch of tests for this with different scenarios, which should make it easier to add more edge cases later if we run into them.