### PR TITLE
Fix component scripts

### DIFF
--- a/js/features/supportJsModules.js
+++ b/js/features/supportJsModules.js
@@ -1,11 +1,12 @@
 import { on } from '@/hooks'
+import { getUriPrefix } from '@/utils'
 
 on('effect', ({ component, effects }) => {
     let scriptModuleHash = effects.scriptModule
 
     if (scriptModuleHash) {
         let encodedName = component.name.replace('.', '--').replace('::', '---').replace(':', '----')
-        let path = `/livewire/js/${encodedName}.js?v=${scriptModuleHash}`
+        let path = `${getUriPrefix()}/js/${encodedName}.js?v=${scriptModuleHash}`
 
         import(path).then(module => {
             module.run.call(component.$wire, component.$wire, component.$wire.js);

--- a/js/utils.js
+++ b/js/utils.js
@@ -220,6 +220,13 @@ export function getNonce() {
 }
 
 /**
+ * Livewire's encoded URI prefix...
+ */
+export function getUriPrefix() {
+    return document.querySelector('[data-uri-prefix]')?.getAttribute('data-uri-prefix') ?? window.livewireScriptConfig['uri-prefix'] ?? null
+}
+
+/**
  * Livewire's update URI. This is configurable via Livewire::setUpdateRoute(...)
  */
 export function getUpdateUri() {

--- a/js/utils.js
+++ b/js/utils.js
@@ -223,7 +223,7 @@ export function getNonce() {
  * Livewire's encoded URI prefix...
  */
 export function getUriPrefix() {
-    return document.querySelector('[data-uri-prefix]')?.getAttribute('data-uri-prefix') ?? window.livewireScriptConfig['uri-prefix'] ?? null
+    return document.querySelector('[data-uri-prefix]')?.getAttribute('data-uri-prefix') ?? window.livewireScriptConfig['uriPrefix'] ?? null
 }
 
 /**

--- a/src/Features/SupportJsEvaluation/BrowserTest.php
+++ b/src/Features/SupportJsEvaluation/BrowserTest.php
@@ -150,6 +150,9 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_can_define_js_actions_though_dollar_js_magic_in_a_sfc_script()
     {
         Livewire::visit('sfc-component-with-dollar-js-magic')
+            ->waitForLivewireToLoad()
+            // Pause for a moment to allow the script to be loaded...
+            ->pause(100)
             ->click('@test')
             ->assertScript('window.test === "through dollar js"')
         ;
@@ -158,6 +161,9 @@ class BrowserTest extends \Tests\BrowserTestCase
     public function test_can_define_js_actions_though_dollar_js_magic_on_a_mfc_script()
     {
         Livewire::visit('mfc-component-with-dollar-js-magic')
+            ->waitForLivewireToLoad()
+            // Pause for a moment to allow the script to be loaded...
+            ->pause(100)
             ->click('@test')
             ->assertScript('window.test === "through dollar js"')
         ;

--- a/src/Features/SupportSingleAndMultiFileComponents/BrowserTest.php
+++ b/src/Features/SupportSingleAndMultiFileComponents/BrowserTest.php
@@ -18,6 +18,8 @@ class BrowserTest extends \Tests\BrowserTestCase
     {
         Livewire::visit('sfc-scripts')
             ->waitForLivewireToLoad()
+            // Pause for a moment to allow the script to be loaded...
+            ->pause(100)
             ->assertSeeIn('@foo', 'baz');
     }
 }

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -160,6 +160,11 @@ class LivewireManager
         return app(HandleRequests::class)->setUpdateRoute($callback);
     }
 
+    function getUriPrefix()
+    {
+        return app(HandleRequests::class)->getUriPrefix();
+    }
+
     function getUpdateUri()
     {
         return app(HandleRequests::class)->getUpdateUri();

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -209,6 +209,8 @@ class FrontendAssets extends Mechanism
 
         $progressBar = config('livewire.navigate.show_progress_bar', true) ? '' : 'data-no-progress-bar';
 
+        $uriPrefix = app('livewire')->getUriPrefix();
+
         $updateUri = app('livewire')->getUpdateUri();
 
         $extraAttributes = Utils::stringifyHtmlAttributes(
@@ -216,7 +218,7 @@ class FrontendAssets extends Mechanism
         );
 
         return <<<HTML
-        {$assetWarning}<script src="{$url}" {$nonce} {$progressBar} data-csrf="{$token}" data-update-uri="{$updateUri}" {$extraAttributes}></script>
+        {$assetWarning}<script src="{$url}" {$nonce} {$progressBar} data-csrf="{$token}" data-uri-prefix="{$uriPrefix}" data-update-uri="{$updateUri}" {$extraAttributes}></script>
         HTML;
     }
 
@@ -231,6 +233,7 @@ class FrontendAssets extends Mechanism
         $attributes = json_encode([
             'csrf' => app()->has('session.store') ? csrf_token() : '',
             'uri' => app('livewire')->getUpdateUri(),
+            'uriPrefix' => app('livewire')->getUriPrefix(),
             'progressBar' => $progressBar,
             'nonce' => isset($options['nonce']) ? $options['nonce'] : '',
         ]);

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -28,6 +28,11 @@ class HandleRequests extends Mechanism
         $this->skipRequestPayloadTamperingMiddleware();
     }
 
+    function getUriPrefix()
+    {
+        return EndpointResolver::prefix();
+    }
+
     function getUpdateUri()
     {
         return (string) str(


### PR DESCRIPTION
# The scenario

Currently component scripts aren't loading and are throwing the following error.

<img width="1746" height="178" alt="Screenshot 2025-12-06 at 12 33 01PM@2x" src="https://github.com/user-attachments/assets/e3578d92-4a63-4948-a0dd-896bcc101e8f" />

# The problem

The issue is that we've added support for encoded endpoints, but the component script loader is still trying to load from `/livewire/js/{component}`.

```js
let path = `/livewire/js/${encodedName}.js?v=${scriptModuleHash}`
```

# The solution

This PR adds support for sending the encoded prefix `/livewire-{hash}` to the front end as a data attribute `data-uri-prefix` on Livewire's `<script>` tag or as a parameter called `uriPrefix` on the `livewireScriptConfig`.

That then allows `supportJsModules` to use that encoded prefix.

```js
let path = `${getUriPrefix()}/js/${encodedName}.js?v=${scriptModuleHash}`
```