### PR TITLE
Add wire:current.ignore

### DIFF
--- a/docs/navigate.md
+++ b/docs/navigate.md
@@ -158,6 +158,12 @@ You can also use plain CSS to style active links:
 }
 ```
 
+If you would like to disable this behavior while still using `wire:navigate`, you may add the `wire:current.ignore` directive:
+
+```blade
+<a href="/posts" wire:navigate wire:current.ignore>Posts</a>
+```
+
 #### Using the `wire:current` directive
 
 Alternatively, you can use Livewire's `wire:current` directive to add CSS classes to the currently active link:

--- a/js/directives/wire-current.js
+++ b/js/directives/wire-current.js
@@ -15,7 +15,10 @@ globalDirective('current', ({ el, directive, cleanup }) => {
     let options = {
         exact: directive.modifiers.includes('exact'),
         strict: directive.modifiers.includes('strict'),
+        ignore: directive.modifiers.includes('ignore'),
     }
+
+    if (options.ignore) return
 
     // Fragment hrefs aren't supported as of yet...
     if (expression.startsWith('#')) return

--- a/js/features/supportDataCurrent.js
+++ b/js/features/supportDataCurrent.js
@@ -20,7 +20,7 @@ function updateNavigateLinks() {
     document.querySelectorAll(wireNavigateSelector).forEach(el => {
         // If the element has `wire:current` then the user might want to specify strict or 
         // exact matching, so we will just return early so we don't override that...
-        if (el.hasAttribute('wire:current')) return
+        if (Array.from(el.attributes).some(attr => attr.name.startsWith('wire:current'))) return
 
         // Fragment hrefs aren't supported...
         let href = el.getAttribute('href')

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -1220,11 +1220,18 @@ class BrowserTest extends \Tests\BrowserTestCase
                 ->assertAttribute('@link.to.first.no.wire.current', 'data-current', '')
                 ->assertAttributeMissing('@link.to.second.no.wire.current', 'data-current')
 
+                ->assertAttributeMissing('@link.to.first.wire.current.ignore', 'data-current')
+                ->assertAttributeMissing('@link.to.second.wire.current.ignore', 'data-current')
+
                 ->click('@link.to.second.no.wire.current')
                 ->waitForText('On second')
 
                 ->assertAttributeMissing('@link.to.first.no.wire.current', 'data-current')
                 ->assertAttribute('@link.to.second.no.wire.current', 'data-current', '')
+
+                ->assertAttributeMissing('@link.to.first.wire.current.ignore', 'data-current')
+                ->assertAttributeMissing('@link.to.second.wire.current.ignore', 'data-current')
+
                 ;
         });
     }
@@ -1275,6 +1282,9 @@ class FirstPage extends Component
 
             <a href="/first" wire:navigate dusk="link.to.first.no.wire.current">First (no wire:current)</a>
             <a href="/second" wire:navigate dusk="link.to.second.no.wire.current">Second (no wire:current)</a>
+
+            <a href="/first" wire:navigate wire:current.ignore dusk="link.to.first.wire.current.ignore">First (wire:current.ignore)</a>
+            <a href="/second" wire:navigate wire:current.ignore dusk="link.to.second.wire.current.ignore">Second (wire:current.ignore)</a>
 
             @script
             <script>
@@ -1339,6 +1349,9 @@ class SecondPage extends Component
 
             <a href="/first" wire:navigate dusk="link.to.first.no.wire.current">First (no wire:current)</a>
             <a href="/second" wire:navigate dusk="link.to.second.no.wire.current">Second (no wire:current)</a>
+
+            <a href="/first" wire:navigate wire:current.ignore dusk="link.to.first.wire.current.ignore">First (wire:current.ignore)</a>
+            <a href="/second" wire:navigate wire:current.ignore dusk="link.to.second.wire.current.ignore">Second (wire:current.ignore)</a>
 
             @persist('foo')
                 <div x-data="{ count: 1 }">


### PR DESCRIPTION
# The scenario

Imagine you have a `x-nav-link` component that supports `wire:navigate`, meaning it adds active styling based on the `data-current` attribute. Now let's say you need to force the active styling for a specific use case, so you add an `current` prop:

```blade
<x-nav-link href="/homepage" wire:navigate :current="$isHomepageSubpage">Homepage</x-nav-link>
<x-nav-link href="/profile" wire:navigate>Profile</x-nav-link>
<x-nav-link href="/settings" wire:navigate>Settings</x-nav-link>

<!-- resources/views/components/nav-link.blade.php -->
@props(['current' => false])

<a {{ $attributes }} @if ($current) data-current @endif class="data-current:text-red-500">
    {{ $slot}}
</a>
```

# The problem

The above example won't work because in v4 `data-current` is automatically managed on all links that have `wire:navigate`. Therefore, even though the `data-current` attribute was manually added on to the element, it will be removed as soon as the page loads.

This came from an issue on Flux: https://github.com/livewire/flux/issues/2233

Where if you have a sidebar link with wire:navigate, overriding the `current` attribute will have no effect.

`<flux:sidebar.item href="/homepage" wire:navigate :current="$isHomepageSubpage">`

# The solution

One could refactor their code to apply the active styling without `data-current:` if the `current` prop is present, however that would lead to duplicated tailwind classes and goes against the idea of this feature, which encourages styling based on the data attribute.

I propose adding a new `ignore` modifier to `wire:current`.

This could be used in the following way:

```blade
<!-- resources/views/components/nav-link.blade.php -->
@props(['current' => false])

<a {{ $attributes }} @if ($current) data-current wire:current.ignore @endif class="data-current:text-red-500">
    {{ $slot}}
</a>
```

When this attribute is present on a link, Livewire will never add or remove the `data-current` attribute automatically.