### PR TITLE
History coordinator

### DIFF
--- a/js/plugins/history/coordinator.js
+++ b/js/plugins/history/coordinator.js
@@ -37,7 +37,6 @@ class HistoryCoordinator {
 
         try {
             // 640k character limit:
-            console.log('actually replacing state', state, url.toString())
             window.history.replaceState(state, '', url.toString())
         } catch (error) {
             let errorHandlers = this.errorHandlers
@@ -87,7 +86,6 @@ class HistoryCoordinator {
 
         try {
             // 640k character limit:
-            console.log('actually pushing state', state, url.toString())
             window.history.pushState(state, '', url.toString())
         } catch (error) {
             let errorHandlers = this.errorHandlers

--- a/js/plugins/history/coordinator.js
+++ b/js/plugins/history/coordinator.js
@@ -13,6 +13,11 @@ class HistoryCoordinator {
     }
 
     flushReplaces() {
+        if (this.pendingTimeout) {
+            clearTimeout(this.pendingTimeout)
+            this.pendingTimeout = null
+        }
+
         if (Object.keys(this.pendingUpdates).length === 0 || !this.pendingUrl) {
             return
         }
@@ -29,7 +34,6 @@ class HistoryCoordinator {
 
         this.pendingUpdates = {}
         this.pendingUrl = null
-        this.pendingTimeout = null
 
         try {
             // 640k character limit:

--- a/js/plugins/history/coordinator.js
+++ b/js/plugins/history/coordinator.js
@@ -8,6 +8,10 @@ class HistoryCoordinator {
         this.errorHandlers = {}
     }
 
+    getUrl() {
+        return this.pendingUrl ?? new URL(window.location.href)
+    }
+
     flushReplaces() {
         if (Object.keys(this.pendingUpdates).length === 0 || !this.pendingUrl) {
             return

--- a/js/plugins/history/coordinator.js
+++ b/js/plugins/history/coordinator.js
@@ -1,0 +1,99 @@
+import { unwrap } from "./utils"
+
+class HistoryCoordinator {
+    constructor() {
+        this.pendingUpdates = {}
+        this.pendingUrl = null
+        this.pendingTimeout = null
+        this.errorHandlers = {}
+    }
+
+    flushReplaces() {
+        if (Object.keys(this.pendingUpdates).length === 0 || !this.pendingUrl) {
+            return
+        }
+
+        let state = window.history.state || {}
+        if (!state.alpine) state.alpine = {}
+
+        state.alpine = {
+            ...state.alpine,
+            ...this.pendingUpdates
+        }
+
+        let url = this.pendingUrl
+
+        this.pendingUpdates = {}
+        this.pendingUrl = null
+        this.pendingTimeout = null
+
+        try {
+            // 640k character limit:
+            console.log('actually replacing state', state, url.toString())
+            window.history.replaceState(state, '', url.toString())
+        } catch (error) {
+            let errorHandlers = this.errorHandlers
+            this.errorHandlers = {}
+
+            Object.values(errorHandlers).forEach(
+                handler => typeof handler === 'function' && handler(error, url)
+            )
+
+            console.error(error)
+        }
+    }
+
+
+    replaceState(url, updates, errorHandlers = {}) {
+        this.errorHandlers = {...this.errorHandlers, ...errorHandlers}
+
+        Object.assign(this.pendingUpdates, unwrap(updates))
+
+        this.pendingUrl = url
+
+        if (!this.pendingTimeout) {
+            this.pendingTimeout = setTimeout(() => {
+                this.pendingTimeout = null
+                this.flushReplaces()
+            }, 0)
+        }
+    }
+
+    pushState(url, updates, errorHandlers = {}) {
+        this.errorHandlers = {...this.errorHandlers, ...errorHandlers}
+
+        if (this.pendingTimeout) {
+            clearTimeout(this.pendingTimeout)
+            this.pendingTimeout = null
+        }
+
+        // Flush any pending replaces first
+        if (Object.keys(this.pendingUpdates).length > 0) {
+            this.flushReplaces()
+        }
+
+        let state = window.history.state || {}
+        if (!state.alpine) state.alpine = {}
+
+        state = { alpine: { ...state.alpine, ...unwrap(updates) } }
+
+        try {
+            // 640k character limit:
+            console.log('actually pushing state', state, url.toString())
+            window.history.pushState(state, '', url.toString())
+        } catch (error) {
+            let errorHandlers = this.errorHandlers
+            this.errorHandlers = {}
+
+            Object.values(errorHandlers).forEach(
+                handler => typeof handler === 'function' && handler(error, url)
+            )
+
+            console.error(error)
+        }
+    }
+}
+
+let historyCoordinator = new HistoryCoordinator()
+
+export default historyCoordinator

--- a/js/plugins/history/coordinator.spec.js
+++ b/js/plugins/history/coordinator.spec.js
@@ -1,0 +1,146 @@
+import { describe, it, vi, expect } from 'vitest'
+import coordinator from './coordinator'
+
+describe('History Coordinator', () => {
+    it('should replace state', async () => {
+        let replaceSpy = vi.spyOn(window.history, 'replaceState')
+
+        coordinator.replaceState('/home', { foo: 'bar' })
+
+        // Coordinator pushes replace state to a batch, which gets flushed in a microtask, so we need to wait for it...
+        await new Promise(queueMicrotask)
+
+        expect(replaceSpy).toHaveBeenCalledOnce()
+        expect(replaceSpy).toHaveBeenCalledWith(
+          { alpine: { foo: 'bar' } },
+          '',
+          '/home'
+        )
+
+        expect(window.history.state).toEqual({ alpine: { foo: 'bar' } })
+    })
+
+    it('should only call replaceState once per batch', async () => {
+        let replaceSpy = vi.spyOn(window.history, 'replaceState')
+
+        coordinator.replaceState('/home', { foo: 'bar' })
+        coordinator.replaceState('/home', { foo: 'baz' })
+        coordinator.replaceState('/home', { foo: 'qux' })
+        coordinator.replaceState('/home', { foo: 'quux' })
+
+        await new Promise(queueMicrotask)
+
+        expect(replaceSpy).toHaveBeenCalledOnce()
+        expect(replaceSpy).toHaveBeenCalledWith(
+          { alpine: { foo: 'quux' } },
+          '',
+          '/home'
+        )
+
+        expect(window.history.state).toEqual({ alpine: { foo: 'quux' } })
+    })
+
+    it('should merge updates into the current state when calling replaceState', async () => {
+        window.history.replaceState({ alpine: { foo: 'bar' }, other: 'bob' }, '', '/home')
+
+        let replaceSpy = vi.spyOn(window.history, 'replaceState')
+
+        coordinator.replaceState('/home', { foo: 'baz' })
+
+        await new Promise(queueMicrotask)
+
+        expect(replaceSpy).toHaveBeenCalledOnce()
+        expect(replaceSpy).toHaveBeenCalledWith(
+          { alpine: { foo: 'baz' }, other: 'bob' },
+          '',
+          '/home'
+        )
+
+        expect(window.history.state).toEqual({ alpine: { foo: 'baz' }, other: 'bob' })
+    })
+
+    it('should push state', async () => {
+        let pushSpy = vi.spyOn(window.history, 'pushState')
+
+        coordinator.pushState('/home', { foo: 'bar' })
+
+        await new Promise(queueMicrotask)
+
+        expect(pushSpy).toHaveBeenCalledOnce()
+        expect(pushSpy).toHaveBeenCalledWith(
+          { alpine: { foo: 'bar' } },
+          '',
+          '/home'
+        )
+
+        expect(window.history.state).toEqual({ alpine: { foo: 'bar' } })
+    })
+
+    it('should flush pending replaces before pushing state', async () => {
+        let replaceSpy = vi.spyOn(window.history, 'replaceState')
+        let pushSpy = vi.spyOn(window.history, 'pushState')
+
+        coordinator.replaceState('/home', { foo: 'bar' })
+        coordinator.replaceState('/home', { foo: 'baz' })
+        coordinator.replaceState('/home', { foo: 'qux' })
+        coordinator.pushState('/other', { foo: 'quux' })
+
+        await new Promise(queueMicrotask)
+
+        expect(replaceSpy).toHaveBeenCalledOnce()
+        expect(replaceSpy).toHaveBeenCalledWith(
+          { alpine: { foo: 'qux' } },
+          '',
+          '/home'
+        )
+
+        expect(pushSpy).toHaveBeenCalledOnce()
+        expect(pushSpy).toHaveBeenCalledWith(
+          { alpine: { foo: 'quux' } },
+          '',
+          '/other'
+        )
+
+        expect(window.history.state).toEqual({ alpine: { foo: 'quux' } })
+    })
+
+    it('should replace the entire state when calling pushState', async () => {
+        window.history.pushState({ alpine: { foo: 'bar' }, other: 'bob' }, '', '/home')
+
+        let pushSpy = vi.spyOn(window.history, 'pushState')
+
+        coordinator.pushState('/home', { foo: 'baz' })
+
+        await new Promise(queueMicrotask)
+
+        expect(pushSpy).toHaveBeenCalledOnce()
+        expect(pushSpy).toHaveBeenCalledWith(
+          { alpine: { foo: 'baz' } },
+          '',
+          '/home'
+        )
+
+        expect(window.history.state).toEqual({ alpine: { foo: 'baz' } })
+    })
+
+    it('can have a custom error handler', async () => {
+        let error = new Error('test')
+        let url = '/home'
+        vi.spyOn(window.history, 'replaceState').mockImplementation(() => {
+          throw error
+        })
+
+        let errorHandler = vi.fn()
+
+        coordinator.addErrorHandler('test', errorHandler)
+
+        coordinator.replaceState(url, { foo: 'bar' })
+
+        await new Promise(queueMicrotask)
+
+        expect(errorHandler).toHaveBeenCalledOnce()
+        expect(errorHandler).toHaveBeenCalledWith(error, url)
+
+        expect(window.history.state).toEqual({ alpine: { foo: 'bar' } })
+    })
+})

--- a/js/plugins/history/index.js
+++ b/js/plugins/history/index.js
@@ -43,7 +43,7 @@ export default function history(Alpine) {
 export function track(name, initialSeedValue, alwaysShow = false, except = null) {
     let { has, get, set, remove } = queryStringUtils()
 
-    let url = new URL(window.location.href)
+    let url = historyCoordinator.getUrl()
     let isInitiallyPresentInUrl = has(url, name)
     let initialValue = isInitiallyPresentInUrl ? get(url, name) : initialSeedValue
     let initialValueMemo = JSON.stringify(initialValue)
@@ -61,7 +61,7 @@ export function track(name, initialSeedValue, alwaysShow = false, except = null)
     let update = (strategy, newValue) => {
         if (lock) return
 
-        let url = new URL(window.location.href)
+        let url = historyCoordinator.getUrl()
 
         // This block of code is what needs to be changed for this failing test to pass:
         if (! alwaysShow && ! isInitiallyPresentInUrl && hasReturnedToInitialValue(newValue)) {

--- a/js/plugins/history/index.js
+++ b/js/plugins/history/index.js
@@ -1,4 +1,6 @@
 import { isObjecty } from "@/utils"
+import historyCoordinator from "./coordinator"
+import { unwrap } from "./utils"
 
 export default function history(Alpine) {
     Alpine.magic('queryString', (el, { interceptor }) =>  {
@@ -137,37 +139,11 @@ export function track(name, initialSeedValue, alwaysShow = false, except = null)
 }
 
 function replace(url, key, object) {
-    let state = window.history.state || {}
-
-    if (! state.alpine) state.alpine = {}
-
-    state.alpine[key] = unwrap(object)
-
-    try {
-        window.history.replaceState(state, '', url.toString())
-    } catch (e) {
-        console.error(e)
-    }
+    historyCoordinator.replaceState(url, { [key]: object })
 }
 
 function push(url, key, object) {
-    let state = window.history.state || {}
-
-    if (! state.alpine) state.alpine = {}
-
-    state = { alpine: {...state.alpine, ...{[key]: unwrap(object)}} }
-
-    try {
-        window.history.pushState(state, '', url.toString())
-    } catch (e) {
-        console.error(e)
-    }
-}
-
-function unwrap(object) {
-    if (object === undefined) return undefined
-
-    return JSON.parse(JSON.stringify(object))
+    historyCoordinator.pushState(url, { [key]: object })
 }
 
 function queryStringUtils() {

--- a/js/plugins/history/utils.js
+++ b/js/plugins/history/utils.js
@@ -1,0 +1,5 @@
+export function unwrap(object) {
+    if (object === undefined) return undefined
+
+    return JSON.parse(JSON.stringify(object))
+}

--- a/js/plugins/history/utils.js
+++ b/js/plugins/history/utils.js
@@ -3,3 +3,30 @@ export function unwrap(object) {
 
     return JSON.parse(JSON.stringify(object))
 }
+
+export function batch(callback) {
+    let batch = {
+        queued: false,
+        updates: {},
+        add(updates) {
+            Object.assign(batch.updates, updates)
+
+            if (batch.queued) return
+
+            batch.queued = true
+
+            queueMicrotask(batch.flush)
+        },
+
+        flush() {
+            if (Object.keys(batch.updates).length) {
+                callback(batch.updates)
+            }
+
+            batch.queued = false
+            batch.updates = {}
+        },
+    }
+
+    return batch
+}

--- a/js/plugins/navigate/history.js
+++ b/js/plugins/navigate/history.js
@@ -61,7 +61,7 @@ let snapshotCache = {
 export function updateCurrentPageHtmlInHistoryStateForLaterBackButtonClicks() {
     // Create a history state entry for the initial page load.
     // (This is so later hitting back can restore this page).
-    let url = new URL(window.location.href, document.baseURI)
+    let url = historyCoordinator.getUrl()
 
     replaceUrl(url, document.documentElement.outerHTML)
 }

--- a/js/plugins/navigate/history.js
+++ b/js/plugins/navigate/history.js
@@ -59,10 +59,11 @@ let snapshotCache = {
 }
 
 export function updateCurrentPageHtmlInHistoryStateForLaterBackButtonClicks() {
+    // Get the URL with all querystring changes...
+    let url = historyCoordinator.getUrl()
+    
     // Create a history state entry for the initial page load.
     // (This is so later hitting back can restore this page).
-    let url = historyCoordinator.getUrl()
-
     replaceUrl(url, document.documentElement.outerHTML)
 }
 
@@ -123,16 +124,16 @@ function updateUrl(method, url, html) {
         ? snapshotCache.push(key, new Snapshot(url, html))
         : snapshotCache.replace(key = (snapshotCache.currentKey ?? key), new Snapshot(url, html))
 
-    let errorHandler = error => {
+    historyCoordinator.addErrorHandler('navigate', error => {
         if (error instanceof DOMException && error.name === 'SecurityError') {
             console.error(
                 "Livewire: You can't use wire:navigate with a link to a different root domain: " +
                     url
             )
         }
-    }
+    })
 
-    historyCoordinator[method](url, { snapshotIdx: key, url: url.toString() }, { navigate: errorHandler })
+    historyCoordinator[method](url, { snapshotIdx: key, url: url.toString() })
 
     snapshotCache.currentKey = key
     snapshotCache.currentUrl = url

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -43,6 +43,8 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertQueryStringMissing('tableFilters')
         ->type('@filter_1', 'test')
         ->waitForLivewire()
+        // Wait for the changes to be applied...
+        ->pause(5)
         ->assertScript(
             '(new URLSearchParams(window.location.search)).toString()',
             'tableFilters%5Bfilter_1%5D%5Bvalue%5D=test'
@@ -199,6 +201,8 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->type('@exclamation', 'foo!')
             ->type('@parentheses', 'foo(bar)')
             ->type('@asterisk', 'foo*')
+            // Wait for the changes to be applied...
+            ->pause(5)
             ->assertScript('return !! window.location.search.match(/exclamation=foo\!/)')
             ->assertScript('return !! window.location.search.match(/parentheses=foo\(bar\)/)')
             ->assertScript('return !! window.location.search.match(/asterisk=foo\*/)')


### PR DESCRIPTION
# The scenario

Currently if there are a bunch of properties with the `#[Url]` attribute loaded on the page, it can cause Firefox or Safari to throw an error like "Too many calls to Location or History APIs within a short timeframe.". This issue can also happen when using `wire:navigate`, if each of the pages have a bunch of `#[Url]` properties and the user navigates between pages quickly.

For example, if there are over 100 components in a loop and each of them use `#[Url]` it will cause this error.

<img width="4340" height="2798" alt="Screenshot 2025-12-17 at 06 19 09PM@2x" src="https://github.com/user-attachments/assets/3ac1219e-a4f2-436f-b918-57feee62e5a4" />

```blade
<?php

use Livewire\Attributes\Url;
use Livewire\Component;

new class extends Component {
    //    
}; ?>

<div>    
    <div>
        @foreach (range(1, 150) as $i)
            <livewire:child />
        @endforeach
    </div>
</div>
```

```blade
{{-- child.blade.php --}}
<?php

use Livewire\Attributes\Url;
use Livewire\Component;

new class extends Component {
    #[Url]
    public $foo = 'bar';
}; ?>

<div>
    Child: {{ $foo }}
</div>
```

# The problem

When Livewire initialises properties which should be tracked in the querystring, it loops through them one at a time, adds the query string controls and then calls `window.history.replaceState()`.

The issue is that there are throttling limits on the browser history API for Firefox and Safari.

For Firefox, the limit is 100 times per 30 seconds.

For Safari, the limit is 100 times per 10 seconds.

So because we are calling `replaceState()` for each initialised property, we are quickly hitting those rate limits, especially if there are 100 or more components in a loop using the `#[Url]` attribute.

```js
Object.entries(queryString).forEach(([key, value]) => {
    ...

    let { replace, push, pop } = track(as, initialValue, alwaysShow, except)

    ...
})

export function track(name, initialSeedValue, alwaysShow = false, except = null) {
    ...

    replace(url, name, { value: initialValue })

    ...
}

function replace(url, key, object) {
    let state = window.history.state || {}

    if (! state.alpine) state.alpine = {}

    state.alpine[key] = unwrap(object)

    try {
        window.history.replaceState(state, '', url.toString())
    } catch (e) {
        console.error(e)
    }
}
```

Navigate experiences the same problem because it also does a replaceHistory on page load, to push the state of the current page to the history. If loading the querystring on a previous page has used up the rate limit, the navigate request can also throw the error when it hits the history API.

# The solution

The solution is to abstract the native browser history API away behind a service and use it to batch updates to the history API into a single request, so that way we're not hitting the rate limiter on page loads.

This PR implements a HistoryCoordinator class which is used as a singleton.

What it does, is it captures all calls to `replaceState()` and merges the state from all the changes together and pushes them to the native history `replaceState()` on the next tick `setTimeout(() => {}, 0)`.

Replace state is the main problem, as it is what is being called on page initialisation from navigate and querystring.

But, this coordinator also has an implementation for `pushState()`.

The reason this exists is because if there is a call to `pushState()` while the coordinator is already buffering some `replaceState()` calls, then we need to push the replace state calls to the history API immediately and then we can call `pushState()`. This ensures that the history is maintained in the correct order.

The querystring (history plugin) and navigate have both been updated to use the coordinator to ensure they're all buffering in the same system.

Now we can load 100+ components with `#[Url]` props in Firefox and Safari and not run into any errors. It doesn't matter how many components and properties are using `#[Url]`, on page load, the native history `replaceState()` will be called only once.

<img width="4340" height="2798" alt="Screenshot 2025-12-17 at 06 42 25PM@2x" src="https://github.com/user-attachments/assets/e7473fe3-4627-4d83-ae9a-673219ba3595" />

Fixes livewire/livewire#7746