### PR TITLE
Fix morph markers in scripts

### DIFF
--- a/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
@@ -682,6 +682,30 @@ class UnitTest extends \Tests\TestCase
                 </div>
                 HTML
             ],
+            37 => [
+                2,
+                <<<'HTML'
+                <div>
+                    <div id="label">
+                        @if (now()->dayName === 'Friday')
+                            Friday
+                        @endif
+                    </div>
+
+                    <script type="text/javascript">
+                        @if (now()->dayName === 'Friday')
+                            document.getElementById('label').style.color = 'red';
+                        @endif
+                    </script>
+
+                    <div id="label">
+                        @if (now()->dayName === 'Friday')
+                            Friday
+                        @endif
+                    </div>
+                </div>
+                HTML
+            ],
         ];
     }
 

--- a/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
@@ -236,7 +236,7 @@ class UnitTest extends \Tests\TestCase
         $output = $this->render('<livewire:foo />');
 
         $this->assertStringContainsString('Test', $output);
-        
+
         // When the template is rendered, there should be 1 loop in the stack, which will be a count of 0 so we don't have an offset compared to the loop indexes...
         $this->assertEquals(0, SupportCompiledWireKeys::$currentLoop['count']);
     }
@@ -650,7 +650,7 @@ class UnitTest extends \Tests\TestCase
                 </div>
                 HTML
             ],
-            34 => [
+            35 => [
                 0,
                 <<<'HTML'
                 <div>
@@ -664,12 +664,30 @@ class UnitTest extends \Tests\TestCase
                 </div>
                 HTML
             ],
+            36 => [
+                1,
+                <<<'HTML'
+                <div>
+                    <div id="label">
+                        @if (now()->dayName === 'Friday')
+                            Friday
+                        @endif
+                    </div>
+
+                    <script type="text/javascript">
+                        @if (now()->dayName === 'Friday')
+                            document.getElementById('label').style.color = 'red';
+                        @endif
+                    </script>
+                </div>
+                HTML
+            ],
         ];
     }
 
     protected function reloadFeatures()
     {
-        // We need to remove these two precompilers so we can test if the 
+        // We need to remove these two precompilers so we can test if the
         // feature is disabled and whether they get registered again...
         $precompilers = \Livewire\invade(app('blade.compiler'))->precompilers;
 
@@ -678,7 +696,7 @@ class UnitTest extends \Tests\TestCase
 
             $closureClass = (new \ReflectionFunction($precompiler))->getClosureScopeClass()->getName();
 
-            return $closureClass !== SupportCompiledWireKeys::class 
+            return $closureClass !== SupportCompiledWireKeys::class
                 && $closureClass !== SupportMorphAwareBladeCompilation::class;
         });
 


### PR DESCRIPTION
# The scenario

Currently if there are two Blade conditionals in a file, one in the HTML and the other inside a script tag, that are the same - the script tag won't function and morph markers will be output within the script. For example, the text in the screenshot below should be red if the script was actually running and not throwing errors.

<img width="1228" height="978" alt="Screenshot 2025-12-17 at 06 13 53PM@2x" src="https://github.com/user-attachments/assets/baa8df3f-763e-450e-92f1-fe126576c202" />

```blade
<?php

use Livewire\Component;

new class extends Component
{
    public $today = 'Friday';
};
?>

<div>
    <div id="label">
        @if ($today === 'Friday')
            Friday
        @endif
    </div>

    <script type="text/javascript">
        @if ($today === 'Friday')
            document.getElementById('label').style.color = 'red';
        @endif
    </script>
</div>
```

# The problem

The problem is that we are individually matching directives and running a check to see if they are in a script tag. If they are, the match is skipped.

But when it comes to adding the morph markers to the directives, we are doing a `preg_replace` which replaces all instances of the match. This means that in the scenario above, even though we skipped the `@if` within the script tag for matching, it's still getting updated.

# The solution

The solution is to take the position of the match and us that to replace the string at that point.

To do this, I had to reverse the processing order, otherwise the matched positions will be incorrect after the first replacement.

Now the script to highlight the text in red is running because it no longer has morph markers in it.

<img width="1228" height="978" alt="Screenshot 2025-12-17 at 06 12 22PM@2x" src="https://github.com/user-attachments/assets/3b6ae5ab-4b1b-4d25-b003-91a0e6c1b6e3" />
