### PR TITLE
Backport wire:current.ignore

### DIFF
--- a/js/directives/wire-current.js
+++ b/js/directives/wire-current.js
@@ -15,7 +15,10 @@ globalDirective('current', ({ el, directive, cleanup }) => {
     let options = {
         exact: directive.modifiers.includes('exact'),
         strict: directive.modifiers.includes('strict'),
+        ignore: directive.modifiers.includes('ignore'),
     }
+
+    if (options.ignore) return
 
     // Fragment hrefs aren't supported as of yet...
     if (expression.startsWith('#')) return


### PR DESCRIPTION
In #9655, we added `wire:current.ignore` to v4, which is now also used in Flux.

Because this modifier wasn't implemented in v3, when a link has `wire:current.ignore`, it will act the same way as with `wire:current`, adding / removing the `data-current` attribute automatically.
