### PR TITLE
Add navigate `onSwap`

### DIFF
--- a/docs/navigate.md
+++ b/docs/navigate.md
@@ -163,7 +163,6 @@ Each page navigation triggers three lifecycle hooks:
 
 * `livewire:navigate`
 * `livewire:navigating`
-* `livewire:navigating:swap`
 * `livewire:navigated`
 
 It's important to note that these hooks events are dispatched on navigations of all types. This includes manual navigation using `Livewire.navigate()`, redirecting with navigation enabled, and back and forward button presses in the browser.
@@ -193,19 +192,19 @@ document.addEventListener('livewire:navigate', (event) => {
     context.cached
 })
 
-document.addEventListener('livewire:navigating', () => {
-    // Triggered when new HTML is about to swapped onto the page...
+document.addEventListener('livewire:navigating', (e) => {
+    // Triggered when new HTML is about to be swapped onto the page...
 
     // This is a good place to mutate any HTML before the page
     // is navigated away from...
-})
 
-document.addEventListener('livewire:navigating:swap', () => {
-    // Triggered when new HTML is swapped onto the page
-    // but before new scripts are loaded...
-
+    // You can register an onSwap callback to run code after the
+    // new HTML is swapped onto the page but before scripts are loaded.
     // This is a good place to apply critical styles such as dark mode
     // to prevent flickering...
+    e.detail.onSwap(() => {
+        // ...
+    })
 })
 
 document.addEventListener('livewire:navigated', () => {

--- a/docs/navigate.md
+++ b/docs/navigate.md
@@ -163,9 +163,10 @@ Each page navigation triggers three lifecycle hooks:
 
 * `livewire:navigate`
 * `livewire:navigating`
+* `livewire:navigating:swap`
 * `livewire:navigated`
 
-It's important to note that these three hooks events are dispatched on navigations of all types. This includes manual navigation using `Livewire.navigate()`, redirecting with navigation enabled, and back and forward button presses in the browser.
+It's important to note that these hooks events are dispatched on navigations of all types. This includes manual navigation using `Livewire.navigate()`, redirecting with navigation enabled, and back and forward button presses in the browser.
 
 Here's an example of registering listeners for each of these events:
 
@@ -197,6 +198,14 @@ document.addEventListener('livewire:navigating', () => {
 
     // This is a good place to mutate any HTML before the page
     // is navigated away from...
+})
+
+document.addEventListener('livewire:navigating:swap', () => {
+    // Triggered when new HTML is swapped onto the page
+    // but before new scripts are loaded...
+
+    // This is a good place to apply critical styles such as dark mode
+    // to prevent flickering...
 })
 
 document.addEventListener('livewire:navigated', () => {

--- a/js/features/supportNavigate.js
+++ b/js/features/supportNavigate.js
@@ -3,7 +3,6 @@ shouldHideProgressBar() && Alpine.navigate.disableProgressBar()
 
 document.addEventListener('alpine:navigate', e => forwardEvent('livewire:navigate', e))
 document.addEventListener('alpine:navigating', e => forwardEvent('livewire:navigating', e))
-document.addEventListener('alpine:navigating:swap', e => forwardEvent('livewire:navigating:swap', e))
 document.addEventListener('alpine:navigated', e => forwardEvent('livewire:navigated', e))
 
 function forwardEvent(name, original) {

--- a/js/features/supportNavigate.js
+++ b/js/features/supportNavigate.js
@@ -3,6 +3,7 @@ shouldHideProgressBar() && Alpine.navigate.disableProgressBar()
 
 document.addEventListener('alpine:navigate', e => forwardEvent('livewire:navigate', e))
 document.addEventListener('alpine:navigating', e => forwardEvent('livewire:navigating', e))
+document.addEventListener('alpine:navigating:swap', e => forwardEvent('livewire:navigating:swap', e))
 document.addEventListener('alpine:navigated', e => forwardEvent('livewire:navigated', e))
 
 function forwardEvent(name, original) {

--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -76,7 +76,12 @@ export default function (Alpine) {
         showProgressBar && showAndStartProgressBar()
 
         fetchHtmlOrUsePrefetchedHtml(destination, (html, finalDestination) => {
-            fireEventForOtherLibrariesToHookInto('alpine:navigating')
+            // Fire the navigating event, allowing listeners to register onSwap callbacks
+            let swapCallbacks = []
+
+            fireEventForOtherLibrariesToHookInto('alpine:navigating', {
+                onSwap: (callback) => swapCallbacks.push(callback)
+            })
 
             restoreScroll && storeScrollInformationInHtmlBeforeNavigatingAway()
 
@@ -106,7 +111,8 @@ export default function (Alpine) {
 
                     !preserveScroll && restoreScrollPositionOrScrollToTop()
 
-                    fireEventForOtherLibrariesToHookInto('alpine:navigating:swap')
+                    // Invoke any callbacks registered via onSwap during the navigating event
+                    swapCallbacks.forEach(callback => callback())
 
                     afterNewScriptsAreDoneLoading(() => {
                         andAfterAllThis(() => {
@@ -152,11 +158,16 @@ export default function (Alpine) {
             // the back button is hit, and not AFTER:
             storeScrollInformationInHtmlBeforeNavigatingAway()
 
-            // This ensures the current HTML has the latest snapshot
-            fireEventForOtherLibrariesToHookInto('alpine:navigating')
+            // Fire the navigating event, allowing listeners to register onSwap callbacks
+            let swapCallbacks = []
 
-            // Only update the snapshot and not the history state as the history state
-            // has already changed to the new page due to the popstate event
+            fireEventForOtherLibrariesToHookInto('alpine:navigating', {
+                onSwap: (callback) => swapCallbacks.push(callback)
+            })
+
+            // Update the snapshot (not the history state, as the history state has
+            // already changed to the new page due to the popstate event).
+            // This ensures the current HTML has the latest snapshot.
             updateCurrentPageHtmlInSnapshotCacheForLaterBackButtonClicks(currentPageUrl, currentPageKey)
 
             preventAlpineFromPickingUpDomChanges(Alpine, andAfterAllThis => {
@@ -176,6 +187,9 @@ export default function (Alpine) {
                     })
 
                     restoreScrollPositionOrScrollToTop()
+
+                    // Invoke any callbacks registered via onSwap during the navigating event
+                    swapCallbacks.forEach(callback => callback())
 
                     andAfterAllThis(() => {
                         autofocus && autofocusElementsWithTheAutofocusAttribute()

--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -106,6 +106,8 @@ export default function (Alpine) {
 
                     !preserveScroll && restoreScrollPositionOrScrollToTop()
 
+                    fireEventForOtherLibrariesToHookInto('alpine:navigating:swap')
+
                     afterNewScriptsAreDoneLoading(() => {
                         andAfterAllThis(() => {
                             setTimeout(() => {


### PR DESCRIPTION
When hooking into `livewire:navigated` to apply critical styles such as dark mode, the event might be delayed due to scripts being loaded.

This will result in flickering, which can be observed on Flux docs:

https://github.com/user-attachments/assets/c457f3c5-b4cb-4791-82ac-7dd84aa90d0f

The Editor page loads a separate script file for the component.

As such, the `Flux.applyAppearance()`, called in `livewire:navigated` listener, isn't called quickly enough.

This PR adds a new `livewire:navigating:swap` hook which is called immediately after the HTML is swapped but before scripts are fully loaded.

Using the new event fixes the issue:

https://github.com/user-attachments/assets/a3d6080c-ccd5-44d6-b801-f20c95af7cd9