### PR TITLE
Auto-adjust pagination when current page becomes empty after deletion

### DIFF
--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -426,9 +426,39 @@ For visual-only loading states (like opacity changes), you can use Livewire's au
 
 [Learn more about loading states →](/docs/4.x/loading-states)
 
+# Auto-adjust Pagination After Deleting Items
+
+When working with paginated lists in Livewire, deleting the **last item on the current page** can leave the page empty. This can lead to a confusing user experience where an empty page is displayed.
+
+The **`adjustPageIfEmpty`** helper automatically moves the paginator to the previous page if the current page becomes empty, ensuring users always see data when it exists.
+
+```php
+use Livewire\Component;
+use Livewire\WithPagination;
+use App\Models\Post;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class PostsTable extends Component
+{
+    use WithPagination;
+
+    #[Computed()]
+    public function posts(): LengthAwarePaginator
+    {
+        return Post::paginate(10);
+    }
+
+    public function deleteQuestion(Post $post): void
+    {
+        $post->delete();
+
+        $this->adjustPageIfEmpty($this->posts);
+    }
+}
+```
+
 ## See also
 
 - **[URL Query Parameters](/docs/4.x/url)** — Sync pagination state with URL
 - **[Loading States](/docs/4.x/loading-states)** — Show feedback during page changes
 - **[Computed Properties](/docs/4.x/computed-properties)** — Efficiently query paginated data
-

--- a/src/Features/SupportPagination/HandlesPagination.php
+++ b/src/Features/SupportPagination/HandlesPagination.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportPagination;
 
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Str;
 
@@ -39,6 +40,13 @@ trait HandlesPagination
     public function resetPage($pageName = 'page')
     {
         $this->setPage(1, $pageName);
+    }
+
+    public function adjustPageIfEmpty(LengthAwarePaginator $paginator, string $pageName = 'page')
+    {
+        if ($paginator->isEmpty() && $this->getPage($pageName) > 1) {
+            $this->previousPage($pageName);
+        }
     }
 
     public function setPage($page, $pageName = 'page')


### PR DESCRIPTION
Adds a new helper method `adjustPageIfEmpty` to the `HandlesPagination` trait.

- Automatically moves the paginator to the previous page if the current page becomes empty after deleting an item.
- Works with any `LengthAwarePaginator`, including filtered or searched queries.
- Ensures smooth UX without showing empty pages.

This prevents users from seeing empty pages after deletion when using Livewire pagination.

### Updated HandlesPagination Trait

```php
<?php

namespace Livewire\Features\SupportPagination;

use Illuminate\Pagination\Paginator;
use Illuminate\Support\Str;
use Illuminate\Pagination\LengthAwarePaginator;

trait HandlesPagination
{
    // ... existing pagination methods ...

    public function adjustPageIfEmpty(LengthAwarePaginator $paginator, string $pageName = 'page')
    {
        if ($paginator->isEmpty() && $this->getPage($pageName) > 1) {
            $this->previousPage($pageName);
        }
    }
    // ... existing pagination methods ...
}
```

### Example usage
In a Livewire component:
```php
use Livewire\Component;
use Livewire\WithPagination;
use App\Models\Post;
use Illuminate\Pagination\LengthAwarePaginator;

class PostsTable extends Component
{
    use WithPagination;

    #[Computed()]
    public function posts(): LengthAwarePaginator
    {
        return Post::paginate(10);
    }

    public function deletePost(Post $post): void
    {
        $post->delete();

        $this->adjustPageIfEmpty($this->posts);
    }
}
