### PR TITLE
Drop PHP 8.1 support and bump minimum PHP and Laravel versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,17 +60,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: [11.*, 12.*]
         exclude:
           - php: 8.5
             laravel: 10.*
           - php: 8.4
             laravel: 10.*
-          - php: 8.1
-            laravel: 11.*
-          - php: 8.1
-            laravel: 12.*
 
     name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -9,23 +9,22 @@
     }
   ],
   "require": {
-    "php": "^8.1",
-    "illuminate/database": "^10.0|^11.0|^12.0",
-    "illuminate/routing": "^10.0|^11.0|^12.0",
-    "illuminate/support": "^10.0|^11.0|^12.0",
-    "illuminate/validation": "^10.0|^11.0|^12.0",
+    "php": "^8.2",
+    "illuminate/database": "^11.0|^12.0",
+    "illuminate/routing": "^11.0|^12.0",
+    "illuminate/support": "^11.0|^12.0",
+    "illuminate/validation": "^11.0|^12.0",
     "league/mime-type-detection": "^1.9",
-    "symfony/console": "^6.0|^7.0",
-    "symfony/http-kernel": "^6.2|^7.0",
+    "symfony/console": "^7.4|^8.0",
+    "symfony/http-kernel": "^7.4|^8.0",
     "laravel/prompts": "^0.1.24|^0.2|^0.3"
   },
   "require-dev": {
-    "psy/psysh": "^0.11.22|^0.12",
     "mockery/mockery": "^1.3.1",
     "phpunit/phpunit": "^10.4|^11.5",
-    "laravel/framework": "^10.15.0|^11.0|^12.0",
-    "orchestra/testbench": "^8.21.0|^9.0|^10.0",
-    "orchestra/testbench-dusk": "^8.24|^9.1|^10.0",
+    "laravel/framework": "^11.0|^12.0",
+    "orchestra/testbench": "^9.0|^10.0",
+    "orchestra/testbench-dusk": "^9.1|^10.0",
     "calebporzio/sushi": "^2.1"
   },
   "autoload": {


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Yes
2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes
3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
4️⃣ Does it include tests? (Required)
No

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This pull request updates the minimum supported PHP and Laravel versions and aligns all related dependencies and the test matrix accordingly.

As part of this change, support for PHP 8.1 has been removed, as it has reached end of life per the official PHP support policy.