### PR TITLE
Fix Blade conditional wire transitions

### DIFF
--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -6,9 +6,9 @@ globalDirective('transition', ({ el, directive, cleanup }) => {
     el.style.viewTransitionName = transitionName
 })
 
-export async function transitionDomMutation(component, callback) {
-    // Only transition if there is a [wire:transition] element within the component...
-    if (! component.el.querySelector('[wire\\:transition]')) return callback()
+export async function transitionDomMutation(fromEl, toEl, callback) {
+    // Only transition if there is a [wire:transition] element within either the from or to elements...
+    if (! fromEl.querySelector('[wire\\:transition]') && ! toEl.querySelector('[wire\\:transition]')) return callback()
 
     // Disable root transitions for the page...
     let style = document.createElement('style')

--- a/js/morph.js
+++ b/js/morph.js
@@ -64,7 +64,7 @@ export async function morph(component, el, html) {
         }
     })
 
-    await transitionDomMutation(component, () => {
+    await transitionDomMutation(el, to, () => {
         Alpine.morph(el, to, getMorphConfig(component))
     })
 
@@ -97,7 +97,7 @@ export async function morphFragment(component, startNode, endNode, toHTML) {
 
     trigger('island.morph', { startNode, endNode, component })
 
-    await transitionDomMutation(component, () => {
+    await transitionDomMutation(fromContainer, toContainer, () => {
         Alpine.morphBetween(startNode, endNode, toContainer, getMorphConfig(component))
     })
 


### PR DESCRIPTION
# The scenario

Since this commit [Add wire:transition](https://github.com/livewire/livewire/commit/7aeac916fe6f3ddbe218bca90fefc895817af617) there is a failing test for transitioning Blade conditionals.

<img width="1546" height="578" alt="Screenshot 2026-01-07 at 11 58 50AM@2x" src="https://github.com/user-attachments/assets/9dd427a2-15a1-4bc3-8a4f-e8083aba6bd9" />

# The problem

The issue is that the test relied on the previous implementation of `wire:transition` which impacted the element directly. Where as the new implementation makes use of view transitions, which impacts a pseudo element instead of the element directly. So the checks for opacity, etc, no longer work as these aren't changed on the element.

Also the duration modifier has been removed, so we can no longer rely on that.

# The solution

The solution is to refactor the test to work with view transitions.

During the refactoring though, I found that conditionally adding an element which has `wire:transition` on it, wasn't transitioning it in. But when removing the element, it was transitioning as expected. Hence the test was still failing.

The reason this was happening is because we're only looking to see if there is a `wire:transition` in the component's element currently. It doesn't factor in whether `wire:transition` may in the HTML that the component is going to be morphed to.

So I've changed `transitionDomMutation()` to check both from and to elements during morph to see if either contain `wire:transition`.

```js
export async function transitionDomMutation(fromEl, toEl, callback) {
    // Only transition if there is a [wire:transition] element within either the from or to elements...
    if (! fromEl.querySelector('[wire\\:transition]') && ! toEl.querySelector('[wire\\:transition]')) return callback()
    
    ...
}
```

Now everything is working as expected and Blade conditional elements can be transitioned in and out.