### PR TITLE
Fix SingleFileParser test after style support was added

### DIFF
--- a/src/Compiler/UnitTest.php
+++ b/src/Compiler/UnitTest.php
@@ -344,6 +344,8 @@ class UnitTest extends \Tests\TestCase
             path: '',
             contents: '',
             scriptPortion: null,
+            stylePortion: null,
+            globalStylePortion: null,
             classPortion: $classContents,
             placeholderPortion: null,
             viewPortion: '',


### PR DESCRIPTION
## Summary
- Adds missing `stylePortion` and `globalStylePortion` parameters to the `SingleFileParser` constructor call in the unit test
- Fixes test failures introduced by #9694

## Test plan
- [x] Run `phpunit --testsuite="Unit" src/Compiler/UnitTest.php` - all 7 data provider tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)