### PR TITLE
[4.x] Navigate view transitions

### DIFF
--- a/js/directives/wire-navigate.js
+++ b/js/directives/wire-navigate.js
@@ -7,6 +7,17 @@ export let wireNavigateSelectors = [
     '[wire\\:navigate\\.preserve-scroll]',
     '[wire\\:navigate\\.preserve-scroll\\.hover]',
     '[wire\\:navigate\\.hover\\.preserve-scroll]',
+    '[wire\\:navigate\\.transition]',
+    '[wire\\:navigate\\.transition\\.hover]',
+    '[wire\\:navigate\\.hover\\.transition]',
+    '[wire\\:navigate\\.transition\\.preserve-scroll]',
+    '[wire\\:navigate\\.preserve-scroll\\.transition]',
+    '[wire\\:navigate\\.transition\\.hover\\.preserve-scroll]',
+    '[wire\\:navigate\\.transition\\.preserve-scroll\\.hover]',
+    '[wire\\:navigate\\.hover\\.transition\\.preserve-scroll]',
+    '[wire\\:navigate\\.hover\\.preserve-scroll\\.transition]',
+    '[wire\\:navigate\\.preserve-scroll\\.transition\\.hover]',
+    '[wire\\:navigate\\.preserve-scroll\\.hover\\.transition]',
 ]
 
 // Combined selector for querying all wire:navigate elements
@@ -19,6 +30,17 @@ let attributeMap = {
     'wire:navigate.preserve-scroll': 'x-navigate.preserve-scroll',
     'wire:navigate.preserve-scroll.hover': 'x-navigate.preserve-scroll.hover',
     'wire:navigate.hover.preserve-scroll': 'x-navigate.hover.preserve-scroll',
+    'wire:navigate.transition': 'x-navigate.transition',
+    'wire:navigate.transition.hover': 'x-navigate.transition.hover',
+    'wire:navigate.hover.transition': 'x-navigate.hover.transition',
+    'wire:navigate.transition.preserve-scroll': 'x-navigate.transition.preserve-scroll',
+    'wire:navigate.preserve-scroll.transition': 'x-navigate.preserve-scroll.transition',
+    'wire:navigate.transition.hover.preserve-scroll': 'x-navigate.transition.hover.preserve-scroll',
+    'wire:navigate.transition.preserve-scroll.hover': 'x-navigate.transition.preserve-scroll.hover',
+    'wire:navigate.hover.transition.preserve-scroll': 'x-navigate.hover.transition.preserve-scroll',
+    'wire:navigate.hover.preserve-scroll.transition': 'x-navigate.hover.preserve-scroll.transition',
+    'wire:navigate.preserve-scroll.transition.hover': 'x-navigate.preserve-scroll.transition.hover',
+    'wire:navigate.preserve-scroll.hover.transition': 'x-navigate.preserve-scroll.hover.transition',
 }
 
 // Register all selectors with Alpine

--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -13,11 +13,12 @@ let enablePersist = true
 let showProgressBar = true
 let restoreScroll = true
 let autofocus = false
+let enableTransition = false
 
 export default function (Alpine) {
 
     Alpine.navigate = (url, options = {}) => {
-        let { preserveScroll = false } = options
+        let { preserveScroll = false, transition = false } = options
 
         let destination = createUrlObjectFromString(url)
 
@@ -27,11 +28,15 @@ export default function (Alpine) {
 
         if (prevented) return
 
-        navigateTo(destination, { preserveScroll })
+        navigateTo(destination, { preserveScroll, transition })
     }
 
     Alpine.navigate.disableProgressBar = () => {
         showProgressBar = false
+    }
+
+    Alpine.navigate.enableTransition = () => {
+        enableTransition = true
     }
 
     Alpine.addInitSelector(() => `[${Alpine.prefixed('navigate')}]`)
@@ -40,6 +45,8 @@ export default function (Alpine) {
         let shouldPrefetchOnHover = modifiers.includes('hover')
 
         let preserveScroll = modifiers.includes('preserve-scroll')
+
+        let transition = modifiers.includes('transition')
 
         shouldPrefetchOnHover && whenThisLinkIsHoveredFor(el, 60, () => {
             let destination = extractDestinationFromLink(el)
@@ -71,13 +78,15 @@ export default function (Alpine) {
 
                 if (prevented) return
 
-                navigateTo(destination, { preserveScroll })
+                navigateTo(destination, { preserveScroll, transition })
             })
         })
     })
 
-    function navigateTo(destination, { preserveScroll = false, shouldPushToHistoryState = true }) {
+    function navigateTo(destination, { preserveScroll = false, shouldPushToHistoryState = true, transition = false }) {
         showProgressBar && showAndStartProgressBar()
+
+        let shouldTransition = transition || enableTransition
 
         fetchHtmlOrUsePrefetchedHtml(destination, (html, finalDestination) => {
             fireEventForOtherLibrariesToHookInto('alpine:navigating')
@@ -122,7 +131,7 @@ export default function (Alpine) {
                             showProgressBar && finishAndHideProgressBar()
                         })
                     })
-                })
+                }, { transition: shouldTransition })
             })
         }, () => {
             showProgressBar && finishAndHideProgressBar()
@@ -188,7 +197,7 @@ export default function (Alpine) {
 
                         fireEventForOtherLibrariesToHookInto('alpine:navigated')
                     })
-                })
+                }, { transition: enableTransition })
             })
         },
     )

--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -109,7 +109,7 @@ export default function (Alpine) {
                     replaceUrl(finalDestination, html)
                 }
 
-                swapCurrentPageWithNewHtml(html, (afterNewScriptsAreDoneLoading) => {
+                swapCurrentPageWithNewHtml(html, (afterNewScriptsAreDoneLoading, transitionFinished) => {
                     removeAnyLeftOverStaleTeleportTargets(document.body)
 
                     enablePersist && putPersistantElementsBack((persistedEl, newStub) => {
@@ -127,8 +127,10 @@ export default function (Alpine) {
 
                             nowInitializeAlpineOnTheNewPage(Alpine)
 
-                            fireEventForOtherLibrariesToHookInto('alpine:navigated')
-                            showProgressBar && finishAndHideProgressBar()
+                            transitionFinished.then(() => {
+                                fireEventForOtherLibrariesToHookInto('alpine:navigated')
+                                showProgressBar && finishAndHideProgressBar()
+                            })
                         })
                     })
                 }, { transition: shouldTransition })
@@ -178,7 +180,7 @@ export default function (Alpine) {
                     packUpPersistedPopovers(persistedEl)
                 })
 
-                swapCurrentPageWithNewHtml(html, () => {
+                swapCurrentPageWithNewHtml(html, (afterNewScriptsAreDoneLoading, transitionFinished) => {
                     removeAnyLeftOverStaleProgressBars()
 
                     removeAnyLeftOverStaleTeleportTargets(document.body)
@@ -195,7 +197,9 @@ export default function (Alpine) {
 
                         nowInitializeAlpineOnTheNewPage(Alpine)
 
-                        fireEventForOtherLibrariesToHookInto('alpine:navigated')
+                        transitionFinished.then(() => {
+                            fireEventForOtherLibrariesToHookInto('alpine:navigated')
+                        })
                     })
                 }, { transition: enableTransition })
             })

--- a/js/plugins/navigate/page.js
+++ b/js/plugins/navigate/page.js
@@ -32,9 +32,9 @@ export function swapCurrentPageWithNewHtml(html, andThen, options = {}) {
         document.body.replaceWith(newBody)
 
         Alpine.destroyTree(oldBody)
-
-        andThen(i => afterRemoteScriptsHaveLoaded = i)
     }
+
+    let transitionFinished = Promise.resolve()
 
     if (options.transition && document.startViewTransition) {
         // Inject styles to handle view transitions properly
@@ -52,12 +52,14 @@ export function swapCurrentPageWithNewHtml(html, andThen, options = {}) {
 
         let transition = document.startViewTransition(() => swap())
 
-        transition.finished.finally(() => {
+        transitionFinished = transition.finished.finally(() => {
             style.remove()
         })
     } else {
         swap()
     }
+
+    andThen(i => afterRemoteScriptsHaveLoaded = i, transitionFinished)
 }
 
 function prepNewBodyScriptTagsToRun(newBody, oldBodyScriptTagHashes) {

--- a/js/plugins/navigate/page.js
+++ b/js/plugins/navigate/page.js
@@ -6,7 +6,7 @@ let attributesExemptFromScriptTagHashing = [
     'aria-hidden',
 ]
 
-export function swapCurrentPageWithNewHtml(html, andThen) {
+export function swapCurrentPageWithNewHtml(html, andThen, options = {}) {
     let newDocument = (new DOMParser()).parseFromString(html, "text/html")
     let newHtml = newDocument.documentElement
     let newBody = document.adoptNode(newDocument.body)
@@ -28,11 +28,36 @@ export function swapCurrentPageWithNewHtml(html, andThen) {
 
     let oldBody = document.body
 
-    document.body.replaceWith(newBody)
+    let swap = () => {
+        document.body.replaceWith(newBody)
 
-    Alpine.destroyTree(oldBody)
+        Alpine.destroyTree(oldBody)
 
-    andThen(i => afterRemoteScriptsHaveLoaded = i)
+        andThen(i => afterRemoteScriptsHaveLoaded = i)
+    }
+
+    if (options.transition && document.startViewTransition) {
+        // Inject styles to handle view transitions properly
+        let style = document.createElement('style')
+
+        style.textContent = `
+            @media (prefers-reduced-motion: reduce) {
+                ::view-transition-group(*), ::view-transition-old(*), ::view-transition-new(*) {
+                    animation: none !important;
+                }
+            }
+        `
+
+        document.head.appendChild(style)
+
+        let transition = document.startViewTransition(() => swap())
+
+        transition.finished.finally(() => {
+            style.remove()
+        })
+    } else {
+        swap()
+    }
 }
 
 function prepNewBodyScriptTagsToRun(newBody, oldBodyScriptTagHashes) {


### PR DESCRIPTION
WIP

![Screenshot 2026-01-09 at 08 45 00PM](https://github.com/user-attachments/assets/a765cf8b-a60d-4416-867c-99ec37c47762)

**First page**
```blade
<?php

use Livewire\Attributes\Url;
use Livewire\Component;

new class extends Component {
    //
}; ?>

<div>
    <flux:link href="/playground2" wire:navigate.transition>Playground 2</flux:link>

    <div class="h-screen flex items-center justify-center">
        <div wire:transition="bob">Bob</div>
    </div>
</div>

<style global>
  ::view-transition-group(bob) {
    animation-duration: 500ms;
    animation-timing-function: ease;
  }
</style>
```

**Second page**
```blade
<?php

use Livewire\Component;

new class extends Component {
    //
} ?>

<div class="flex items-center">
    <div wire:transition="bob">Bob</div>
</div>
```