### PR TITLE
Fix incorrect variable in mergeQueuedUpdates causing queued updates to be lost

### DIFF
--- a/js/component.js
+++ b/js/component.js
@@ -117,7 +117,7 @@ export class Component {
         // priority against ephemeral updates that have happend since them...
         Object.entries(this.queuedUpdates).forEach(([updateKey, updateValue]) => {
             Object.entries(diff).forEach(([diffKey, diffValue]) => {
-                if (diffKey.startsWith(updateValue)) {
+                if (diffKey.startsWith(updateKey)) {
                     delete diff[diffKey]
                 }
             })

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -221,11 +221,6 @@ class BrowserTest extends BrowserTestCase
                 'baz' => 'qux',
             ];
 
-            public function showValues()
-            {
-                // This action triggers a server round-trip
-            }
-
             public function render()
             {
                 return <<<'BLADE'
@@ -236,7 +231,7 @@ class BrowserTest extends BrowserTestCase
                         <button
                             dusk="clear-both"
                             type="button"
-                            x-on:click="$wire.set('parent.foo', ''); $wire.set('parent.baz', ''); $wire.showValues()"
+                            x-on:click="$wire.set('parent.foo', ''); $wire.set('parent.baz', ''); $wire.commit()"
                         >
                             Clear Both
                         </button>

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -212,4 +212,43 @@ class BrowserTest extends BrowserTestCase
             ->waitForLivewire()->select('@parent', 'foo')
             ->assertSelected('@child', 'bar');
     }
+
+    public function test_multiple_wire_set_calls_to_empty_string_are_all_sent_to_server()
+    {
+        Livewire::visit(new class extends Component {
+            public array $parent = [
+                'foo' => 'bar',
+                'baz' => 'qux',
+            ];
+
+            public function showValues()
+            {
+                // This action triggers a server round-trip
+            }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <span dusk="foo">{{ $parent['foo'] }}</span>
+                        <span dusk="baz">{{ $parent['baz'] }}</span>
+
+                        <button
+                            dusk="clear-both"
+                            type="button"
+                            x-on:click="$wire.set('parent.foo', ''); $wire.set('parent.baz', ''); $wire.showValues()"
+                        >
+                            Clear Both
+                        </button>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertSeeIn('@foo', 'bar')
+            ->assertSeeIn('@baz', 'qux')
+            ->waitForLivewire()->click('@clear-both')
+            ->assertDontSeeIn('@foo', 'bar')
+            ->assertDontSeeIn('@baz', 'qux')
+        ;
+    }
 }


### PR DESCRIPTION
## Description

In `mergeQueuedUpdates()`, the condition `diffKey.startsWith(updateValue)` incorrectly uses the update's **value** instead of its **key** when checking if a diff entry should be removed.

This causes a critical bug when `updateValue` is an empty string: since every string starts with an empty string (`"foo".startsWith("")` returns `true`), ALL diff entries are incorrectly deleted, causing other queued updates to be lost.

### Example scenario that fails before this fix:

1. User has two inputs bound via `$wire.set('parent.foo', '')` and `$wire.set('parent.baz', '')`
2. Both are cleared (set to empty string `""`)
3. When the request is made, only the last update is sent because the first one was erroneously deleted from the diff

### The fix

Changes `diffKey.startsWith(updateValue)` to `diffKey.startsWith(updateKey)` so that nested properties are correctly identified by their key path (e.g., `'parent.foo'`) rather than their value.

## Checklist

- [x] Is this something that was discussed before? **Yes: https://github.com/livewire/livewire/discussions/7872**
- [x] Did you create a branch for your fix/feature? **Yes: `fix-merge-queued-updates-variable`**
- [x] Does this PR include unrelated changes? **No**
- [x] Does it include tests? **Yes - Browser test added to `SupportDataBinding/BrowserTest.php`**