### PR TITLE
Remove v4 beta warnings from documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,13 +9,10 @@ Before installing Livewire, make sure you have:
 
 ## Install Livewire
 
-> [!warning] Livewire v4 is currently in beta
-> Livewire v4 is still in active development and not yet stable. It's recommended to test thoroughly in a development environment before upgrading production applications. Breaking changes may occur between beta releases.
-
 To install Livewire, open your terminal and navigate to your Laravel application directory, then run the following command:
 
 ```shell
-composer require livewire/livewire:^4.0@beta
+composer require livewire/livewire
 ```
 
 That's it! Livewire uses Laravel's package auto-discovery, so no additional setup is required.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,13 +12,10 @@ Before we start, make sure you have the following installed:
 
 ## Install Livewire
 
-> [!warning] Livewire v4 is currently in beta
-> Livewire v4 is still in active development and not yet stable. It's recommended to test thoroughly in a development environment before upgrading production applications. Breaking changes may occur between beta releases.
-
 From the root directory of your Laravel app, run the following [Composer](https://getcomposer.org/) command:
 
 ```shell
-composer require livewire/livewire:^4.0@beta
+composer require livewire/livewire
 ```
 
 ## Create a layout

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -2,18 +2,15 @@
 
 Livewire v4 introduces several improvements and optimizations while maintaining backward compatibility wherever possible. This guide will help you upgrade from Livewire v3 to v4.
 
-> [!warning] Livewire v4 is currently in beta
-> Livewire v4 is still in active development and not yet stable. It's recommended to test thoroughly in a development environment before upgrading production applications. Breaking changes may occur between beta releases.
-
 > [!tip] Smooth upgrade path
 > Most applications can upgrade to v4 with minimal changes. The breaking changes are primarily configuration updates and method signature changes that only affect advanced usage.
 
 ## Installation
 
-Update your `composer.json` to require Livewire v4 beta:
+Update your `composer.json` to require Livewire v4:
 
 ```bash
-composer require livewire/livewire:^4.0@beta
+composer require livewire/livewire:^4.0
 ```
 
 After updating, clear your application's cache:


### PR DESCRIPTION
## Summary
- Remove beta warning callouts from `installation.md`, `upgrading.md`, `quickstart.md`
- Update composer require commands to remove `@beta` flag

## Test plan
- [x] Verify installation docs show `composer require livewire/livewire` without `@beta`
- [x] Verify upgrading docs show `composer require livewire/livewire:^4.0` without `@beta`
- [x] Verify quickstart docs show `composer require livewire/livewire` without `@beta`
- [x] Verify no beta warning callouts appear in these pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)