### PR TITLE
Fix duplicate route registration when using custom Livewire update route

### DIFF
--- a/src/Mechanisms/HandleRequests/CustomUpdateRouteUnitTest.php
+++ b/src/Mechanisms/HandleRequests/CustomUpdateRouteUnitTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class CustomUpdateRouteUnitTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            \Livewire\LivewireServiceProvider::class,
+            CustomUpdateRouteServiceProvider::class,
+        ];
+    }
+
+    public function test_only_one_livewire_update_route_is_registered_with_custom_update_routes(): void
+    {
+        $livewireUpdateRoutes = collect(Route::getRoutes()->getRoutes())->filter(function ($route) {
+            return str($route->getName())->endsWith('livewire.update');
+        });
+
+        $this->assertCount(1, $livewireUpdateRoutes);
+        $this->assertEquals('custom/livewire/update', $livewireUpdateRoutes->first()->uri());
+    }
+}
+
+// Service provider that sets custom route during boot (after Livewire's boot)
+class CustomUpdateRouteServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        Livewire::setUpdateRoute(function ($handle) {
+            return Route::post('/custom/livewire/update', $handle)->middleware('web');
+        });
+    }
+}

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -15,12 +15,14 @@ class HandleRequests extends Mechanism
 
     function boot()
     {
-        // Only set it if another provider hasn't already set it....
-        if (! $this->updateRoute) {
-            app($this::class)->setUpdateRoute(function ($handle) {
-                return Route::post('/livewire/update', $handle)->middleware('web');
-            });
-        }
+        // Only set it if another provider or routes file haven't already set it....
+        app()->booted(function () {
+            if (! $this->updateRoute) {
+                app($this::class)->setUpdateRoute(function ($handle) {
+                    return Route::post('/livewire/update', $handle)->middleware('web');
+                });
+            }
+        });
 
         $this->skipRequestPayloadTamperingMiddleware();
     }

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
 use Tests\TestCase;
 
@@ -20,6 +21,15 @@ class UnitTest extends TestCase
         $this->assertEmpty($result['components']);
         $this->assertIsArray($result['assets']);
         $this->assertEmpty($result['assets']);
+    }
 
+    public function test_default_livewire_update_route_is_registered(): void
+    {
+        $livewireUpdateRoutes = collect(Route::getRoutes()->getRoutes())->filter(function ($route) {
+            return str($route->getName())->endsWith('livewire.update');
+        });
+
+        $this->assertCount(1, $livewireUpdateRoutes);
+        $this->assertEquals('livewire/update', $livewireUpdateRoutes->first()->uri());
     }
 }


### PR DESCRIPTION
## Summary
Fixes a break introduced in Laravel v12.29.0 which changed behavior so that two routes can no longer have the same name. This caused a collision when using a custom Livewire update route, as both the custom and default routes were being registered with the `livewire.update` name.

This PR ensures that only a single Livewire update route is ever registered, regardless of whether a custom route is configured or not.

- Wraps default route registration in `app()->booted()` to defer it until after all service providers have booted
- This deferral is necessary because custom update routes can be set in either service providers or routes files, both of which run after Livewire's service provider boots
- The deferred check skips default route registration if a custom route was already set, guaranteeing only one update route exists

## Test plan
- [x] Added test to verify only one route is registered when using custom update route
- [x] Added test to verify default route is registered when no custom route is set
- [x] Verified test fails when `app()->booted()` wrapper is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)