### PR TITLE
Add synths to query string

### DIFF
--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -165,15 +165,7 @@ class BaseUrl extends LivewireAttribute
             return $value;
         }
 
-        try {
-            return $synth::hydrateFromType($typeName, $value);
-        } catch (\Throwable $e) {
-            if ($this->nullable && $typeAllowsNull) {
-                return null;
-            }
-
-            throw $e;
-        }
+        return $synth::hydrateFromType($typeName, $value);
     }
 
     protected function recursivelyMergeArraysWithoutAppendingDuplicateValues(&$array1, &$array2)

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -639,7 +639,7 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
-    public function test_can_use_url_on_string_backed_enum_object_properties_with_initial_invalid_value_on_nullable()
+    public function test_throws_error_for_invalid_string_backed_enum_value_in_query_string()
     {
         Livewire::withQueryParams(['foo' => 'bar'])
             ->visit([
@@ -648,41 +648,21 @@ class BrowserTest extends \Tests\BrowserTestCase
                 #[Url(nullable: true)]
                 public ?StringBackedEnumForUrlTesting $foo;
 
-                public function change()
-                {
-                    $this->foo = StringBackedEnumForUrlTesting::Second;
-                }
-
-                public function unsetFoo()
-                {
-                    $this->foo = null;
-                }
-
                 public function render()
                 {
                     return <<<'HTML'
                     <div>
-                        <button wire:click="change" dusk="button">Change</button>
                         <h1 dusk="output">{{ $foo }}</h1>
-                        <button wire:click="unsetFoo" dusk="unsetButton">Unset foo</button>
                     </div>
                     HTML;
                 }
             },
         ])
-            ->assertQueryStringHas('foo', '')
-            ->assertSee('foo', null)
-            ->waitForLivewire()->click('@button')
-            ->assertQueryStringHas('foo', 'second')
-            ->assertSeeIn('@output', 'second')
-            ->refresh()
-            ->assertQueryStringHas('foo', 'second')
-            ->assertSeeIn('@output', 'second')
+            ->assertSee('"bar" is not a valid backing value')
         ;
     }
 
-
-    public function test_can_use_url_on_integer_backed_enum_object_properties_with_initial_invalid_value_on_nullable()
+    public function test_throws_error_for_invalid_integer_backed_enum_value_in_query_string()
     {
         Livewire::withQueryParams(['foo' => 5])
             ->visit([
@@ -691,36 +671,17 @@ class BrowserTest extends \Tests\BrowserTestCase
                 #[Url(nullable: true)]
                 public ?IntegerBackedEnumForUrlTesting $foo;
 
-                public function change()
-                {
-                    $this->foo = IntegerBackedEnumForUrlTesting::Second;
-                }
-
-                public function unsetFoo()
-                {
-                    $this->foo = null;
-                }
-
                 public function render()
                 {
                     return <<<'HTML'
                     <div>
-                        <button wire:click="change" dusk="button">Change</button>
                         <h1 dusk="output">{{ $foo }}</h1>
-                        <button wire:click="unsetFoo" dusk="unsetButton">Unset foo</button>
                     </div>
                     HTML;
                 }
             },
         ])
-            ->assertQueryStringHas('foo', '')
-            ->assertSee('foo', null)
-            ->waitForLivewire()->click('@button')
-            ->assertQueryStringHas('foo', '2')
-            ->assertSeeIn('@output', '2')
-            ->refresh()
-            ->assertQueryStringHas('foo', '2')
-            ->assertSeeIn('@output', '2')
+            ->assertSee('5 is not a valid backing value')
         ;
     }
 

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -347,6 +347,158 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_can_hydrate_typed_properties_from_query_string_using_url_attribute()
+    {
+        Livewire::withQueryParams([
+                'page' => '5',
+                'price' => '9.99',
+                'date' => '2024-01-15',
+                'form' => ['count' => '10', 'total' => '19.99', 'created' => '2024-02-20'],
+            ])
+            ->visit([
+                new class extends Component
+                {
+                    #[BaseUrl]
+                    public int $page = 1;
+
+                    #[BaseUrl]
+                    public float $price = 0.0;
+
+                    #[BaseUrl]
+                    public ?\Carbon\Carbon $date = null;
+
+                    #[BaseUrl]
+                    public TypedForm $form;
+
+                    public function render()
+                    {
+                        return <<<'HTML'
+                        <div>
+                            <h1 dusk="page">{{ $page }}</h1>
+                            <h1 dusk="page-type">{{ gettype($page) }}</h1>
+                            <h1 dusk="price">{{ $price }}</h1>
+                            <h1 dusk="price-type">{{ gettype($price) }}</h1>
+                            <h1 dusk="date">{{ $date?->format('Y-m-d') }}</h1>
+                            <h1 dusk="date-type">{{ $date ? get_class($date) : 'null' }}</h1>
+                            <h1 dusk="form-count">{{ $form->count }}</h1>
+                            <h1 dusk="form-count-type">{{ gettype($form->count) }}</h1>
+                            <h1 dusk="form-total">{{ $form->total }}</h1>
+                            <h1 dusk="form-total-type">{{ gettype($form->total) }}</h1>
+                            <h1 dusk="form-created">{{ $form->created?->format('Y-m-d') }}</h1>
+                            <h1 dusk="form-created-type">{{ $form->created ? get_class($form->created) : 'null' }}</h1>
+                        </div>
+                        HTML;
+                    }
+                },
+            ])
+            ->assertSeeIn('@page', '5')
+            ->assertSeeIn('@page-type', 'integer')
+            ->assertSeeIn('@price', '9.99')
+            ->assertSeeIn('@price-type', 'double')
+            ->assertSeeIn('@date', '2024-01-15')
+            ->assertSeeIn('@date-type', 'Carbon\Carbon')
+            ->assertSeeIn('@form-count', '10')
+            ->assertSeeIn('@form-count-type', 'integer')
+            ->assertSeeIn('@form-total', '19.99')
+            ->assertSeeIn('@form-total-type', 'double')
+            ->assertSeeIn('@form-created', '2024-02-20')
+            ->assertSeeIn('@form-created-type', 'Carbon\Carbon')
+        ;
+    }
+
+    public function test_can_hydrate_typed_properties_from_query_string_using_legacy_syntax()
+    {
+        Livewire::withQueryParams([
+                'page' => '5',
+                'price' => '9.99',
+                'date' => '2024-01-15',
+                'form' => ['count' => '10', 'total' => '19.99', 'created' => '2024-02-20'],
+            ])
+            ->visit([
+                new class extends Component
+                {
+                    protected $queryString = ['page', 'price', 'date', 'form'];
+
+                    public int $page = 1;
+
+                    public float $price = 0.0;
+
+                    public ?\Carbon\Carbon $date = null;
+
+                    public TypedForm $form;
+
+                    public function render()
+                    {
+                        return <<<'HTML'
+                        <div>
+                            <h1 dusk="page">{{ $page }}</h1>
+                            <h1 dusk="page-type">{{ gettype($page) }}</h1>
+                            <h1 dusk="price">{{ $price }}</h1>
+                            <h1 dusk="price-type">{{ gettype($price) }}</h1>
+                            <h1 dusk="date">{{ $date?->format('Y-m-d') }}</h1>
+                            <h1 dusk="date-type">{{ $date ? get_class($date) : 'null' }}</h1>
+                            <h1 dusk="form-count">{{ $form->count }}</h1>
+                            <h1 dusk="form-count-type">{{ gettype($form->count) }}</h1>
+                            <h1 dusk="form-total">{{ $form->total }}</h1>
+                            <h1 dusk="form-total-type">{{ gettype($form->total) }}</h1>
+                            <h1 dusk="form-created">{{ $form->created?->format('Y-m-d') }}</h1>
+                            <h1 dusk="form-created-type">{{ $form->created ? get_class($form->created) : 'null' }}</h1>
+                        </div>
+                        HTML;
+                    }
+                },
+            ])
+            ->assertSeeIn('@page', '5')
+            ->assertSeeIn('@page-type', 'integer')
+            ->assertSeeIn('@price', '9.99')
+            ->assertSeeIn('@price-type', 'double')
+            ->assertSeeIn('@date', '2024-01-15')
+            ->assertSeeIn('@date-type', 'Carbon\Carbon')
+            ->assertSeeIn('@form-count', '10')
+            ->assertSeeIn('@form-count-type', 'integer')
+            ->assertSeeIn('@form-total', '19.99')
+            ->assertSeeIn('@form-total-type', 'double')
+            ->assertSeeIn('@form-created', '2024-02-20')
+            ->assertSeeIn('@form-created-type', 'Carbon\Carbon')
+        ;
+    }
+
+    public function test_can_hydrate_typed_form_object_properties_with_url_attribute()
+    {
+        Livewire::withQueryParams([
+                'page' => '5',
+                'price' => '9.99',
+                'date' => '2024-01-15',
+            ])
+            ->visit([
+                new class extends Component
+                {
+                    public TypedFormWithUrlProperties $form;
+
+                    public function render()
+                    {
+                        return <<<'HTML'
+                        <div>
+                            <h1 dusk="page">{{ $form->page }}</h1>
+                            <h1 dusk="page-type">{{ gettype($form->page) }}</h1>
+                            <h1 dusk="price">{{ $form->price }}</h1>
+                            <h1 dusk="price-type">{{ gettype($form->price) }}</h1>
+                            <h1 dusk="date">{{ $form->date?->format('Y-m-d') }}</h1>
+                            <h1 dusk="date-type">{{ $form->date ? get_class($form->date) : 'null' }}</h1>
+                        </div>
+                        HTML;
+                    }
+                },
+            ])
+            ->assertSeeIn('@page', '5')
+            ->assertSeeIn('@page-type', 'integer')
+            ->assertSeeIn('@price', '9.99')
+            ->assertSeeIn('@price-type', 'double')
+            ->assertSeeIn('@date', '2024-01-15')
+            ->assertSeeIn('@date-type', 'Carbon\Carbon')
+        ;
+    }
+
     public function test_can_use_except_in_query_string_property()
     {
         Livewire::visit([
@@ -1187,6 +1339,27 @@ class FormObject extends \Livewire\Form
 
     #[\Livewire\Attributes\Url(as: 'aliased')]
     public $bob = 'lob';
+}
+
+class TypedForm extends \Livewire\Form
+{
+    public int $count = 0;
+
+    public float $total = 0.0;
+
+    public ?\Carbon\Carbon $created = null;
+}
+
+class TypedFormWithUrlProperties extends \Livewire\Form
+{
+    #[BaseUrl]
+    public int $page = 1;
+
+    #[BaseUrl]
+    public float $price = 0.0;
+
+    #[BaseUrl]
+    public ?\Carbon\Carbon $date = null;
 }
 
 enum StringBackedEnumForUrlTesting: string

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -670,7 +670,7 @@ class HandleComponents extends Mechanism
         return new $this->synthesizerTypeCache[$type]($context, $path);
     }
 
-    protected function getSynthesizerByType($type, $context, $path)
+    public function getSynthesizerByType($type, $context, $path)
     {
         foreach ($this->propertySynthesizers as $synth) {
             if ($synth::matchByType($type)) {


### PR DESCRIPTION
## The Problem

Previously, values loaded from the query string were always strings. If you had a typed property like `Carbon`, Livewire would throw an error when trying to assign the string value from the URL. Visiting `?created=2024-01-15` would result in:

<img width="2950" height="762" alt="Screenshot 2026-01-12 at 03 45 55PM@2x" src="https://github.com/user-attachments/assets/42000375-101f-4ce4-9cd7-386209c1ce7e" />


```php
<?php

use Carbon\Carbon;
use Livewire\Attributes\Url;
use Livewire\Component;

new class extends Component {
    #[Url]
    public Carbon $created;
}; ?>

<div>
    {{ $created }}
</div>
```

## The Solution

Query string values now pass through the appropriate synth based on the property's type hint:

- `?page=5` → integer `5`
- `?price=9.99` → float `9.99`
- `?date=2024-01-15` → Carbon instance

This works for:
1. **Component properties** with `#[Url]` attribute
2. **Component properties** with legacy `$queryString` syntax
3. **Form object properties** with individual `#[Url]` attributes

### Small breaking change

At the moment, there are tests which check and ensure that if an invalid enum value is provided, then the property is set to null rather than throwing an error.

- test_can_use_url_on_string_backed_enum_object_properties_with_initial_invalid_value_on_nullable
- test_can_use_url_on_integer_backed_enum_object_properties_with_initial_invalid_value_on_nullable

This doesn't seem right to me. I think if the value provided is incorrect for the type, then it should throw the error, not mark it as null instead, as I feel that would be unexpected for a user rather than getting an error if their query string value is wrong.

So I've changed the tests but I'm not 100% on this change. I will document it in the upgrade guide if we decide to go with it.

The nullable was added in PR #9140.

### Form Object Hydration

The key addition in this PR is the ability to hydrate an **entire form object** from the query string with proper type conversion for its properties.

Previously, you could only bind individual form properties to the URL:

```php
class MyForm extends Form
{
    #[Url]
    public int $page = 1;  // Each property needs its own #[Url]
}
```

Now you can bind the entire form and have all typed properties hydrated correctly:

```php
class Component extends Livewire\Component
{
    #[Url]
    public MyForm $form;  // Bind entire form to URL
}

class MyForm extends Form
{
    public int $count = 0;
    public float $total = 0.0;
    public ?Carbon $created = null;
}
```

Visiting `?form[count]=10&form[total]=19.99&form[created]=2024-01-15` will hydrate all properties with their correct types.

This PR originated from the ideas presented in https://github.com/livewire/livewire/pull/9318