### PR TITLE
Drop real-time facade usage to support read-only filesystems

### DIFF
--- a/src/Facades/GenerateSignedUploadUrlFacade.php
+++ b/src/Facades/GenerateSignedUploadUrlFacade.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Livewire\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @internal
+ *
+ * @method static string forLocal()
+ * @method static string forS3($file, $visibility = 'private')
+ *
+ * @see \Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl
+ */
+class GenerateSignedUploadUrlFacade extends Facade
+{
+    public static function getFacadeAccessor()
+    {
+        return \Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl::class;
+    }
+}

--- a/src/Features/SupportFileUploads/SupportFileUploads.php
+++ b/src/Features/SupportFileUploads/SupportFileUploads.php
@@ -6,7 +6,7 @@ use function Livewire\on;
 use Livewire\ComponentHook;
 use Illuminate\Support\Facades\Route;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
-use Facades\Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl as GenerateSignedUploadUrlFacade;
+use Livewire\Facades\GenerateSignedUploadUrlFacade;
 
 class SupportFileUploads extends ComponentHook
 {

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -7,12 +7,12 @@ use Carbon\Carbon;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Livewire\WithFileUploads;
 use Livewire\Livewire;
+use Livewire\Facades\GenerateSignedUploadUrlFacade;
 use Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButtonCache;
 use League\Flysystem\PathTraversalDetected;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Http\UploadedFile;
-use Facades\Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl;
 use Illuminate\Http\Testing\FileFactory;
 use Illuminate\Support\Arr;
 use Tests\TestComponent;
@@ -441,7 +441,7 @@ class UnitTest extends \Tests\TestCase
     {
         config()->set('livewire.temporary_file_upload.middleware', DummyMiddleware::class);
 
-        $url = GenerateSignedUploadUrl::forLocal();
+        $url = GenerateSignedUploadUrlFacade::forLocal();
 
         try {
             $this->withoutExceptionHandling()->post($url);
@@ -454,7 +454,7 @@ class UnitTest extends \Tests\TestCase
     {
         config()->set('livewire.temporary_file_upload.middleware', ['throttle:60,1', DummyMiddleware::class]);
 
-        $url = GenerateSignedUploadUrl::forLocal();
+        $url = GenerateSignedUploadUrlFacade::forLocal();
 
         try {
             $this->withoutExceptionHandling()->post($url);

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -2,10 +2,10 @@
 
 namespace Livewire\Features\SupportFileUploads;
 
-use Facades\Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Http\UploadedFile;
 use Livewire\Attributes\Renderless;
+use Livewire\Facades\GenerateSignedUploadUrlFacade;
 
 trait WithFileUploads
 {
@@ -17,12 +17,12 @@ trait WithFileUploads
 
             $file = UploadedFile::fake()->create($fileInfo[0]['name'], $fileInfo[0]['size'] / 1024, $fileInfo[0]['type']);
 
-            $this->dispatch('upload:generatedSignedUrlForS3', name: $name, payload: GenerateSignedUploadUrl::forS3($file))->self();
+            $this->dispatch('upload:generatedSignedUrlForS3', name: $name, payload: GenerateSignedUploadUrlFacade::forS3($file))->self();
 
             return;
         }
 
-        $this->dispatch('upload:generatedSignedUrl', name: $name, url: GenerateSignedUploadUrl::forLocal())->self();
+        $this->dispatch('upload:generatedSignedUrl', name: $name, url: GenerateSignedUploadUrlFacade::forLocal())->self();
     }
 
     function _finishUpload($name, $tmpPath, $isMultiple, $append = true)


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Yes, you can find the discussion here: https://github.com/livewire/livewire/discussions/9687

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes, the branch is named `feature/no-real-time-facades`

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, the changes are only related to my feature.

4️⃣ Does it include tests? (Required)
Not yet

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
I'd like to run my app on a read-only filesystem. This makes sure no application code can be altered at runtime. However, Livewire uses real-time facades for file uploads. Real-time facades require a writeable directory and that directory will contain "executable" PHP files. This is something I'd like to prevent, hence the read-only filesystem. Currently in Livewire, the real-time facades are used for only one class, so we can easily create a normal facade for that. As a bonus, it will be (a little) better for perfomance as it requires less IO, the class can be added to the optimized class autoloader, pre-warmed with OPcache, etc.
