### PR TITLE
Shard browser tests for faster PR feedback

### DIFF
--- a/.github/scripts/get-browser-test-shard.php
+++ b/.github/scripts/get-browser-test-shard.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Distributes browser test files across shards using greedy bin-packing.
+ * Usage: php get-browser-test-shard.php <shard_index> <total_shards>
+ */
+
+$shardIndex = (int) ($argv[1] ?? 0);
+$totalShards = (int) ($argv[2] ?? 4);
+
+$files = [];
+$srcDir = __DIR__ . '/../../src';
+
+// Recursively find all *BrowserTest.php files
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($srcDir, RecursiveDirectoryIterator::SKIP_DOTS)
+);
+
+foreach ($iterator as $file) {
+    if ($file->isFile() && preg_match('/BrowserTest\.php$/', $file->getFilename())) {
+        $content = file_get_contents($file->getPathname());
+        preg_match_all('/function\s+test_/m', $content, $matches);
+        $files[] = ['path' => $file->getRealPath(), 'tests' => count($matches[0])];
+    }
+}
+
+usort($files, fn($a, $b) => $b['tests'] <=> $a['tests']);
+
+$shards = array_fill(0, $totalShards, ['files' => [], 'weight' => 0]);
+foreach ($files as $file) {
+    $minIdx = 0;
+    for ($i = 1; $i < $totalShards; $i++) {
+        if ($shards[$i]['weight'] < $shards[$minIdx]['weight']) {
+            $minIdx = $i;
+        }
+    }
+    $shards[$minIdx]['files'][] = $file['path'];
+    $shards[$minIdx]['weight'] += $file['tests'];
+}
+
+echo implode(' ', $shards[$shardIndex]['files']);

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   js-tests:
     runs-on: ubuntu-latest
-    name: JavaScript Tests
+    name: 1. JavaScript
 
     steps:
       - name: Checkout
@@ -50,7 +50,7 @@ jobs:
       - name: Run JavaScript tests
         run: npm run test:run
 
-  build:
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -67,7 +67,63 @@ jobs:
           - php: 8.1
             laravel: 12.*
 
-    name: Laravel:${{ matrix.laravel }} / PHP:${{ matrix.php }}
+    name: 2. Unit - L${{ matrix.laravel }} - PHP ${{ matrix.php }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, iconv, intl, zip, pdo_sqlite
+          tools: composer:v2
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          restore-keys: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-
+
+      - name: Install Composer dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --dev
+          composer update --prefer-stable --no-interaction
+
+      - name: Setup dusk/chrome
+        run: vendor/bin/dusk-updater detect --no-interaction
+
+      - name: Run Unit tests
+        run: vendor/bin/phpunit --testsuite Unit
+        env:
+          RUNNING_IN_CI: true
+
+  browser-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        laravel: [10.*, 11.*, 12.*]
+        shard: [1, 2, 3]
+        exclude:
+          - php: 8.5
+            laravel: 10.*
+          - php: 8.4
+            laravel: 10.*
+          - php: 8.1
+            laravel: 11.*
+          - php: 8.1
+            laravel: 12.*
+
+    name: 3. Browser ${{ matrix.shard }} - L${{ matrix.laravel }} - PHP ${{ matrix.php }}
 
     steps:
       - name: Checkout
@@ -129,27 +185,104 @@ jobs:
         if: steps.build-assets.outcome == 'success'
         run: vendor/bin/dusk-updater detect --no-interaction
 
-      - name: Run Unit tests
-        if: steps.build-assets.outcome == 'success'
-        run: vendor/bin/phpunit --testsuite Unit
-        env:
-          RUNNING_IN_CI: true
+      - name: Get shard test files
+        id: shard
+        run: echo "files=$(php .github/scripts/get-browser-test-shard.php $(( ${{ matrix.shard }} - 1 )) 3)" >> $GITHUB_OUTPUT
 
-      - name: Run Browser tests
-        if: (success() || failure()) && steps.build-assets.outcome == 'success'
-        run: vendor/bin/phpunit --testsuite Browser
+      - name: Run Browser tests (Shard ${{ matrix.shard }})
+        if: steps.build-assets.outcome == 'success'
+        run: vendor/bin/phpunit ${{ steps.shard.outputs.files }}
         env:
           RUNNING_IN_CI: true
 
       - name: Run Cancel Upload test
-        if: (success() || failure()) && steps.build-assets.outcome == 'success'
+        if: matrix.shard == 1 && steps.build-assets.outcome == 'success'
         run: FORCE_RUN=1 vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload"
         env:
           RUNNING_IN_CI: true
           FORCE_RUN: 1
 
+  legacy-browser-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        laravel: [10.*, 11.*, 12.*]
+        exclude:
+          - php: 8.5
+            laravel: 10.*
+          - php: 8.4
+            laravel: 10.*
+          - php: 8.1
+            laravel: 11.*
+          - php: 8.1
+            laravel: 12.*
+
+    name: 4. Legacy - L${{ matrix.laravel }} - PHP ${{ matrix.php }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, iconv, intl, zip, pdo_sqlite
+          tools: composer:v2
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          restore-keys: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-
+
+      - name: Install Composer dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --dev
+          composer update --prefer-stable --no-interaction
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Clone Alpine ${{ env.ALPINE_BRANCH }} branch
+        run: git clone --depth=1 --branch=${{ env.ALPINE_BRANCH }} https://github.com/alpinejs/alpine.git /tmp/alpine
+
+      - name: Build Alpine assets
+        run: |
+          cd /tmp/alpine
+          npm ci
+          npm run build
+
+      - name: Link Alpine packages to Livewire
+        run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
+
+      - name: Check Alpine packages are linked
+        run: npm list
+
+      - name: Build Livewire assets
+        id: build-assets
+        run: npm run build
+
+      - name: Setup dusk/chrome
+        if: steps.build-assets.outcome == 'success'
+        run: vendor/bin/dusk-updater detect --no-interaction
+
       - name: Run Legacy Browser tests
-        if: (success() || failure()) && steps.build-assets.outcome == 'success'
+        if: steps.build-assets.outcome == 'success'
         run: vendor/bin/phpunit --testsuite LegacyBrowser
         env:
           RUNNING_IN_CI: true

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -1,0 +1,155 @@
+name: Test Main
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "docs/**"
+      - "README.md"
+
+env:
+  ALPINE_BRANCH: main
+
+jobs:
+  js-tests:
+    runs-on: ubuntu-latest
+    name: JavaScript Tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Clone Alpine ${{ env.ALPINE_BRANCH }} branch
+        run: git clone --depth=1 --branch=${{ env.ALPINE_BRANCH }} https://github.com/alpinejs/alpine.git /tmp/alpine
+
+      - name: Build Alpine assets
+        run: |
+          cd /tmp/alpine
+          npm ci
+          npm run build
+
+      - name: Link Alpine packages to Livewire
+        run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
+
+      - name: Check Alpine packages are linked
+        run: npm list
+
+      - name: Build Livewire assets
+        run: npm run build
+
+      - name: Run JavaScript tests
+        run: npm run test:run
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        laravel: [10.*, 11.*, 12.*]
+        exclude:
+          - php: 8.5
+            laravel: 10.*
+          - php: 8.4
+            laravel: 10.*
+          - php: 8.1
+            laravel: 11.*
+          - php: 8.1
+            laravel: 12.*
+
+    name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, iconv, intl, zip, pdo_sqlite
+          tools: composer:v2
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          restore-keys: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-
+
+      - name: Install Composer dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --dev
+          composer update --prefer-stable --no-interaction
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Clone Alpine ${{ env.ALPINE_BRANCH }} branch
+        run: git clone --depth=1 --branch=${{ env.ALPINE_BRANCH }} https://github.com/alpinejs/alpine.git /tmp/alpine
+
+      - name: Build Alpine assets
+        run: |
+          cd /tmp/alpine
+          npm ci
+          npm run build
+
+      - name: Link Alpine packages to Livewire
+        run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
+
+      - name: Check Alpine packages are linked
+        run: npm list
+
+      - name: Build Livewire assets
+        id: build-assets
+        run: npm run build
+
+      - name: Setup dusk/chrome
+        if: steps.build-assets.outcome == 'success'
+        run: vendor/bin/dusk-updater detect --no-interaction
+
+      - name: Run Unit tests
+        if: steps.build-assets.outcome == 'success'
+        run: vendor/bin/phpunit --testsuite Unit
+        env:
+          RUNNING_IN_CI: true
+
+      - name: Run Browser tests
+        if: (success() || failure()) && steps.build-assets.outcome == 'success'
+        run: vendor/bin/phpunit --testsuite Browser
+        env:
+          RUNNING_IN_CI: true
+
+      - name: Run Cancel Upload test
+        if: (success() || failure()) && steps.build-assets.outcome == 'success'
+        run: FORCE_RUN=1 vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload"
+        env:
+          RUNNING_IN_CI: true
+          FORCE_RUN: 1
+
+      - name: Run Legacy Browser tests
+        if: (success() || failure()) && steps.build-assets.outcome == 'success'
+        run: vendor/bin/phpunit --testsuite LegacyBrowser
+        env:
+          RUNNING_IN_CI: true

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -67,7 +67,7 @@ jobs:
           - php: 8.1
             laravel: 12.*
 
-    name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
+    name: Laravel:${{ matrix.laravel }} / PHP:${{ matrix.php }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -12,9 +12,9 @@ env:
   ALPINE_BRANCH: main
 
 jobs:
-  js-tests:
+  build-assets:
     runs-on: ubuntu-latest
-    name: 1. JavaScript
+    name: 0. Build Assets
 
     steps:
       - name: Checkout
@@ -41,11 +41,55 @@ jobs:
       - name: Link Alpine packages to Livewire
         run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
 
-      - name: Check Alpine packages are linked
-        run: npm list
-
       - name: Build Livewire assets
         run: npm run build
+
+      - name: Upload built assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: livewire-assets
+          path: dist/
+          retention-days: 1
+
+      - name: Upload Alpine packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: alpine-packages
+          path: /tmp/alpine/packages/
+          retention-days: 1
+
+  js-tests:
+    needs: build-assets
+    runs-on: ubuntu-latest
+    name: 1. JavaScript
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download Alpine packages
+        uses: actions/download-artifact@v4
+        with:
+          name: alpine-packages
+          path: /tmp/alpine/packages/
+
+      - name: Link Alpine packages to Livewire
+        run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
+
+      - name: Download built assets
+        uses: actions/download-artifact@v4
+        with:
+          name: livewire-assets
+          path: dist/
 
       - name: Run JavaScript tests
         run: npm run test:run
@@ -106,6 +150,7 @@ jobs:
           RUNNING_IN_CI: true
 
   browser-tests:
+    needs: build-assets
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -153,36 +198,13 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --dev
           composer update --prefer-stable --no-interaction
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Download built assets
+        uses: actions/download-artifact@v4
         with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install npm dependencies
-        run: npm ci
-
-      - name: Clone Alpine ${{ env.ALPINE_BRANCH }} branch
-        run: git clone --depth=1 --branch=${{ env.ALPINE_BRANCH }} https://github.com/alpinejs/alpine.git /tmp/alpine
-
-      - name: Build Alpine assets
-        run: |
-          cd /tmp/alpine
-          npm ci
-          npm run build
-
-      - name: Link Alpine packages to Livewire
-        run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
-
-      - name: Check Alpine packages are linked
-        run: npm list
-
-      - name: Build Livewire assets
-        id: build-assets
-        run: npm run build
+          name: livewire-assets
+          path: dist/
 
       - name: Setup dusk/chrome
-        if: steps.build-assets.outcome == 'success'
         run: vendor/bin/dusk-updater detect --no-interaction
 
       - name: Get shard test files
@@ -190,19 +212,19 @@ jobs:
         run: echo "files=$(php .github/scripts/get-browser-test-shard.php $(( ${{ matrix.shard }} - 1 )) 3)" >> $GITHUB_OUTPUT
 
       - name: Run Browser tests (Shard ${{ matrix.shard }})
-        if: steps.build-assets.outcome == 'success'
         run: vendor/bin/phpunit ${{ steps.shard.outputs.files }}
         env:
           RUNNING_IN_CI: true
 
       - name: Run Cancel Upload test
-        if: matrix.shard == 1 && steps.build-assets.outcome == 'success'
+        if: matrix.shard == 1
         run: FORCE_RUN=1 vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload"
         env:
           RUNNING_IN_CI: true
           FORCE_RUN: 1
 
   legacy-browser-tests:
+    needs: build-assets
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -249,40 +271,16 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --dev
           composer update --prefer-stable --no-interaction
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Download built assets
+        uses: actions/download-artifact@v4
         with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install npm dependencies
-        run: npm ci
-
-      - name: Clone Alpine ${{ env.ALPINE_BRANCH }} branch
-        run: git clone --depth=1 --branch=${{ env.ALPINE_BRANCH }} https://github.com/alpinejs/alpine.git /tmp/alpine
-
-      - name: Build Alpine assets
-        run: |
-          cd /tmp/alpine
-          npm ci
-          npm run build
-
-      - name: Link Alpine packages to Livewire
-        run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
-
-      - name: Check Alpine packages are linked
-        run: npm list
-
-      - name: Build Livewire assets
-        id: build-assets
-        run: npm run build
+          name: livewire-assets
+          path: dist/
 
       - name: Setup dusk/chrome
-        if: steps.build-assets.outcome == 'success'
         run: vendor/bin/dusk-updater detect --no-interaction
 
       - name: Run Legacy Browser tests
-        if: steps.build-assets.outcome == 'success'
         run: vendor/bin/phpunit --testsuite LegacyBrowser
         env:
           RUNNING_IN_CI: true

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -26,22 +26,40 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Get Alpine commit hash
+        id: alpine-hash
+        run: echo "hash=$(git ls-remote https://github.com/alpinejs/alpine.git refs/heads/${{ env.ALPINE_BRANCH }} | cut -f1)" >> $GITHUB_OUTPUT
+
+      - name: Cache built assets
+        id: cache-assets
+        uses: actions/cache@v4
+        with:
+          path: |
+            dist/
+            /tmp/alpine/packages/
+          key: built-assets-${{ github.sha }}-alpine-${{ steps.alpine-hash.outputs.hash }}
+
       - name: Install dependencies
+        if: steps.cache-assets.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Clone Alpine ${{ env.ALPINE_BRANCH }} branch
+        if: steps.cache-assets.outputs.cache-hit != 'true'
         run: git clone --depth=1 --branch=${{ env.ALPINE_BRANCH }} https://github.com/alpinejs/alpine.git /tmp/alpine
 
       - name: Build Alpine assets
+        if: steps.cache-assets.outputs.cache-hit != 'true'
         run: |
           cd /tmp/alpine
           npm ci
           npm run build
 
       - name: Link Alpine packages to Livewire
+        if: steps.cache-assets.outputs.cache-hit != 'true'
         run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
 
       - name: Build Livewire assets
+        if: steps.cache-assets.outputs.cache-hit != 'true'
         run: npm run build
 
       - name: Upload built assets
@@ -95,6 +113,7 @@ jobs:
         run: npm run test:run
 
   unit-tests:
+    needs: build-assets
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -34,9 +34,7 @@ jobs:
         id: cache-assets
         uses: actions/cache@v4
         with:
-          path: |
-            dist/
-            /tmp/alpine/packages/
+          path: dist/
           key: built-assets-${{ github.sha }}-alpine-${{ steps.alpine-hash.outputs.hash }}
 
       - name: Install dependencies
@@ -69,13 +67,6 @@ jobs:
           path: dist/
           retention-days: 1
 
-      - name: Upload Alpine packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: alpine-packages
-          path: /tmp/alpine/packages/
-          retention-days: 1
-
   js-tests:
     needs: build-assets
     runs-on: ubuntu-latest
@@ -93,15 +84,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Download Alpine packages
-        uses: actions/download-artifact@v4
-        with:
-          name: alpine-packages
-          path: /tmp/alpine/packages/
-
-      - name: Link Alpine packages to Livewire
-        run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
 
       - name: Download built assets
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -1,12 +1,6 @@
-name: Test
+name: Test PRs
 
 on:
-  push:
-    branches:
-      - "**"
-    paths-ignore:
-      - "docs/**"
-      - "README.md"
   pull_request:
     types: [ready_for_review, synchronize, opened]
     paths-ignore:
@@ -60,17 +54,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*]
-        exclude:
-          - php: 8.5
-            laravel: 10.*
-          - php: 8.4
-            laravel: 10.*
-          - php: 8.1
-            laravel: 11.*
-          - php: 8.1
-            laravel: 12.*
+        php: [8.4, 8.5]
+        laravel: [11.*, 12.*]
 
     name: Unit PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
 
@@ -115,18 +100,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.4, 8.5]
+        laravel: [11.*, 12.*]
         shard: [0, 1, 2, 3]
-        exclude:
-          - php: 8.5
-            laravel: 10.*
-          - php: 8.4
-            laravel: 10.*
-          - php: 8.1
-            laravel: 11.*
-          - php: 8.1
-            laravel: 12.*
 
     name: Browser PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }} / Shard:${{ matrix.shard }}
 
@@ -212,17 +188,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*]
-        exclude:
-          - php: 8.5
-            laravel: 10.*
-          - php: 8.4
-            laravel: 10.*
-          - php: 8.1
-            laravel: 11.*
-          - php: 8.1
-            laravel: 12.*
+        php: [8.4, 8.5]
+        laravel: [11.*, 12.*]
 
     name: Legacy PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
 

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -11,9 +11,9 @@ env:
   ALPINE_BRANCH: main
 
 jobs:
-  js-tests:
+  build-assets:
     runs-on: ubuntu-latest
-    name: 1. JavaScript
+    name: 0. Build Assets
 
     steps:
       - name: Checkout
@@ -40,11 +40,55 @@ jobs:
       - name: Link Alpine packages to Livewire
         run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
 
-      - name: Check Alpine packages are linked
-        run: npm list
-
       - name: Build Livewire assets
         run: npm run build
+
+      - name: Upload built assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: livewire-assets
+          path: dist/
+          retention-days: 1
+
+      - name: Upload Alpine packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: alpine-packages
+          path: /tmp/alpine/packages/
+          retention-days: 1
+
+  js-tests:
+    needs: build-assets
+    runs-on: ubuntu-latest
+    name: 1. JavaScript
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download Alpine packages
+        uses: actions/download-artifact@v4
+        with:
+          name: alpine-packages
+          path: /tmp/alpine/packages/
+
+      - name: Link Alpine packages to Livewire
+        run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
+
+      - name: Download built assets
+        uses: actions/download-artifact@v4
+        with:
+          name: livewire-assets
+          path: dist/
 
       - name: Run JavaScript tests
         run: npm run test:run
@@ -96,6 +140,7 @@ jobs:
           RUNNING_IN_CI: true
 
   browser-tests:
+    needs: build-assets
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -134,36 +179,13 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --dev
           composer update --prefer-stable --no-interaction
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Download built assets
+        uses: actions/download-artifact@v4
         with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install npm dependencies
-        run: npm ci
-
-      - name: Clone Alpine ${{ env.ALPINE_BRANCH }} branch
-        run: git clone --depth=1 --branch=${{ env.ALPINE_BRANCH }} https://github.com/alpinejs/alpine.git /tmp/alpine
-
-      - name: Build Alpine assets
-        run: |
-          cd /tmp/alpine
-          npm ci
-          npm run build
-
-      - name: Link Alpine packages to Livewire
-        run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
-
-      - name: Check Alpine packages are linked
-        run: npm list
-
-      - name: Build Livewire assets
-        id: build-assets
-        run: npm run build
+          name: livewire-assets
+          path: dist/
 
       - name: Setup dusk/chrome
-        if: steps.build-assets.outcome == 'success'
         run: vendor/bin/dusk-updater detect --no-interaction
 
       - name: Get shard test files
@@ -171,19 +193,19 @@ jobs:
         run: echo "files=$(php .github/scripts/get-browser-test-shard.php $(( ${{ matrix.shard }} - 1 )) 3)" >> $GITHUB_OUTPUT
 
       - name: Run Browser tests (Shard ${{ matrix.shard }})
-        if: steps.build-assets.outcome == 'success'
         run: vendor/bin/phpunit ${{ steps.shard.outputs.files }}
         env:
           RUNNING_IN_CI: true
 
       - name: Run Cancel Upload test
-        if: matrix.shard == 1 && steps.build-assets.outcome == 'success'
+        if: matrix.shard == 1
         run: FORCE_RUN=1 vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload"
         env:
           RUNNING_IN_CI: true
           FORCE_RUN: 1
 
   legacy-browser-tests:
+    needs: build-assets
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -221,40 +243,16 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --dev
           composer update --prefer-stable --no-interaction
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Download built assets
+        uses: actions/download-artifact@v4
         with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install npm dependencies
-        run: npm ci
-
-      - name: Clone Alpine ${{ env.ALPINE_BRANCH }} branch
-        run: git clone --depth=1 --branch=${{ env.ALPINE_BRANCH }} https://github.com/alpinejs/alpine.git /tmp/alpine
-
-      - name: Build Alpine assets
-        run: |
-          cd /tmp/alpine
-          npm ci
-          npm run build
-
-      - name: Link Alpine packages to Livewire
-        run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
-
-      - name: Check Alpine packages are linked
-        run: npm list
-
-      - name: Build Livewire assets
-        id: build-assets
-        run: npm run build
+          name: livewire-assets
+          path: dist/
 
       - name: Setup dusk/chrome
-        if: steps.build-assets.outcome == 'success'
         run: vendor/bin/dusk-updater detect --no-interaction
 
       - name: Run Legacy Browser tests
-        if: steps.build-assets.outcome == 'success'
         run: vendor/bin/phpunit --testsuite LegacyBrowser
         env:
           RUNNING_IN_CI: true

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -102,7 +102,7 @@ jobs:
       matrix:
         php: [8.4, 8.5]
         laravel: [11.*, 12.*]
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2]
 
     name: Browser PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }} / Shard:${{ matrix.shard }}
 
@@ -168,7 +168,7 @@ jobs:
 
       - name: Get shard test files
         id: shard
-        run: echo "files=$(php .github/scripts/get-browser-test-shard.php ${{ matrix.shard }} 4)" >> $GITHUB_OUTPUT
+        run: echo "files=$(php .github/scripts/get-browser-test-shard.php ${{ matrix.shard }} 3)" >> $GITHUB_OUTPUT
 
       - name: Run Browser tests (Shard ${{ matrix.shard }})
         if: steps.build-assets.outcome == 'success'

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   js-tests:
     runs-on: ubuntu-latest
-    name: JavaScript Tests
+    name: 1. JavaScript
 
     steps:
       - name: Checkout
@@ -57,7 +57,7 @@ jobs:
         php: [8.4, 8.5]
         laravel: [11.*, 12.*]
 
-    name: Unit PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
+    name: 2. Unit - PHP ${{ matrix.php }} - L${{ matrix.laravel }}
 
     steps:
       - name: Checkout
@@ -102,9 +102,9 @@ jobs:
       matrix:
         php: [8.4, 8.5]
         laravel: [11.*, 12.*]
-        shard: [0, 1, 2]
+        shard: [1, 2, 3]
 
-    name: Browser PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }} / Shard:${{ matrix.shard }}
+    name: 3. Browser ${{ matrix.shard }} - PHP ${{ matrix.php }} - L${{ matrix.laravel }}
 
     steps:
       - name: Checkout
@@ -168,7 +168,7 @@ jobs:
 
       - name: Get shard test files
         id: shard
-        run: echo "files=$(php .github/scripts/get-browser-test-shard.php ${{ matrix.shard }} 3)" >> $GITHUB_OUTPUT
+        run: echo "files=$(php .github/scripts/get-browser-test-shard.php $(( ${{ matrix.shard }} - 1 )) 3)" >> $GITHUB_OUTPUT
 
       - name: Run Browser tests (Shard ${{ matrix.shard }})
         if: steps.build-assets.outcome == 'success'
@@ -177,7 +177,7 @@ jobs:
           RUNNING_IN_CI: true
 
       - name: Run Cancel Upload test
-        if: matrix.shard == 0 && steps.build-assets.outcome == 'success'
+        if: matrix.shard == 1 && steps.build-assets.outcome == 'success'
         run: FORCE_RUN=1 vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload"
         env:
           RUNNING_IN_CI: true
@@ -191,7 +191,7 @@ jobs:
         php: [8.4, 8.5]
         laravel: [11.*, 12.*]
 
-    name: Legacy PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
+    name: 4. Legacy - PHP ${{ matrix.php }} - L${{ matrix.laravel }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -25,22 +25,40 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Get Alpine commit hash
+        id: alpine-hash
+        run: echo "hash=$(git ls-remote https://github.com/alpinejs/alpine.git refs/heads/${{ env.ALPINE_BRANCH }} | cut -f1)" >> $GITHUB_OUTPUT
+
+      - name: Cache built assets
+        id: cache-assets
+        uses: actions/cache@v4
+        with:
+          path: |
+            dist/
+            /tmp/alpine/packages/
+          key: built-assets-${{ github.sha }}-alpine-${{ steps.alpine-hash.outputs.hash }}
+
       - name: Install dependencies
+        if: steps.cache-assets.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Clone Alpine ${{ env.ALPINE_BRANCH }} branch
+        if: steps.cache-assets.outputs.cache-hit != 'true'
         run: git clone --depth=1 --branch=${{ env.ALPINE_BRANCH }} https://github.com/alpinejs/alpine.git /tmp/alpine
 
       - name: Build Alpine assets
+        if: steps.cache-assets.outputs.cache-hit != 'true'
         run: |
           cd /tmp/alpine
           npm ci
           npm run build
 
       - name: Link Alpine packages to Livewire
+        if: steps.cache-assets.outputs.cache-hit != 'true'
         run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
 
       - name: Build Livewire assets
+        if: steps.cache-assets.outputs.cache-hit != 'true'
         run: npm run build
 
       - name: Upload built assets
@@ -94,6 +112,7 @@ jobs:
         run: npm run test:run
 
   unit-tests:
+    needs: build-assets
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -33,9 +33,7 @@ jobs:
         id: cache-assets
         uses: actions/cache@v4
         with:
-          path: |
-            dist/
-            /tmp/alpine/packages/
+          path: dist/
           key: built-assets-${{ github.sha }}-alpine-${{ steps.alpine-hash.outputs.hash }}
 
       - name: Install dependencies
@@ -68,13 +66,6 @@ jobs:
           path: dist/
           retention-days: 1
 
-      - name: Upload Alpine packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: alpine-packages
-          path: /tmp/alpine/packages/
-          retention-days: 1
-
   js-tests:
     needs: build-assets
     runs-on: ubuntu-latest
@@ -92,15 +83,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Download Alpine packages
-        uses: actions/download-artifact@v4
-        with:
-          name: alpine-packages
-          path: /tmp/alpine/packages/
-
-      - name: Link Alpine packages to Livewire
-        run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
 
       - name: Download built assets
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -57,7 +57,7 @@ jobs:
         php: [8.4, 8.5]
         laravel: [11.*, 12.*]
 
-    name: 2. Unit - PHP ${{ matrix.php }} - L${{ matrix.laravel }}
+    name: 2. Unit - L${{ matrix.laravel }} - PHP ${{ matrix.php }}
 
     steps:
       - name: Checkout
@@ -104,7 +104,7 @@ jobs:
         laravel: [11.*, 12.*]
         shard: [1, 2, 3]
 
-    name: 3. Browser ${{ matrix.shard }} - PHP ${{ matrix.php }} - L${{ matrix.laravel }}
+    name: 3. Browser ${{ matrix.shard }} - L${{ matrix.laravel }} - PHP ${{ matrix.php }}
 
     steps:
       - name: Checkout
@@ -191,7 +191,7 @@ jobs:
         php: [8.4, 8.5]
         laravel: [11.*, 12.*]
 
-    name: 4. Legacy - PHP ${{ matrix.php }} - L${{ matrix.laravel }}
+    name: 4. Legacy - L${{ matrix.laravel }} - PHP ${{ matrix.php }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,9 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --dev
           composer update --prefer-stable --no-interaction
 
+      - name: Setup dusk/chrome
+        run: vendor/bin/dusk-updater detect --no-interaction
+
       - name: Run Unit tests
         run: vendor/bin/phpunit --testsuite Unit
         env:
@@ -209,10 +212,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2]
-        laravel: [11.*]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        laravel: [10.*, 11.*, 12.*]
+        exclude:
+          - php: 8.5
+            laravel: 10.*
+          - php: 8.4
+            laravel: 10.*
+          - php: 8.1
+            laravel: 11.*
+          - php: 8.1
+            laravel: 12.*
 
-    name: Legacy Browser Tests
+    name: Legacy PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Run JavaScript tests
         run: npm run test:run
 
-  build:
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -72,7 +72,60 @@ jobs:
           - php: 8.1
             laravel: 12.*
 
-    name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
+    name: Unit PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, iconv, intl, zip, pdo_sqlite
+          tools: composer:v2
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          restore-keys: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-
+
+      - name: Install Composer dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --dev
+          composer update --prefer-stable --no-interaction
+
+      - name: Run Unit tests
+        run: vendor/bin/phpunit --testsuite Unit
+        env:
+          RUNNING_IN_CI: true
+
+  browser-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        laravel: [10.*, 11.*, 12.*]
+        shard: [0, 1, 2, 3]
+        exclude:
+          - php: 8.5
+            laravel: 10.*
+          - php: 8.4
+            laravel: 10.*
+          - php: 8.1
+            laravel: 11.*
+          - php: 8.1
+            laravel: 12.*
+
+    name: Browser PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }} / Shard:${{ matrix.shard }}
 
     steps:
       - name: Checkout
@@ -134,27 +187,95 @@ jobs:
         if: steps.build-assets.outcome == 'success'
         run: vendor/bin/dusk-updater detect --no-interaction
 
-      - name: Run Unit tests
-        if: steps.build-assets.outcome == 'success'
-        run: vendor/bin/phpunit --testsuite Unit
-        env:
-          RUNNING_IN_CI: true
+      - name: Get shard test files
+        id: shard
+        run: echo "files=$(php .github/scripts/get-browser-test-shard.php ${{ matrix.shard }} 4)" >> $GITHUB_OUTPUT
 
-      - name: Run Browser tests
-        if: (success() || failure()) && steps.build-assets.outcome == 'success'
-        run: vendor/bin/phpunit --testsuite Browser
+      - name: Run Browser tests (Shard ${{ matrix.shard }})
+        if: steps.build-assets.outcome == 'success'
+        run: vendor/bin/phpunit ${{ steps.shard.outputs.files }}
         env:
           RUNNING_IN_CI: true
 
       - name: Run Cancel Upload test
-        if: (success() || failure()) && steps.build-assets.outcome == 'success'
+        if: matrix.shard == 0 && steps.build-assets.outcome == 'success'
         run: FORCE_RUN=1 vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload"
         env:
           RUNNING_IN_CI: true
           FORCE_RUN: 1
 
+  legacy-browser-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.2]
+        laravel: [11.*]
+
+    name: Legacy Browser Tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, iconv, intl, zip, pdo_sqlite
+          tools: composer:v2
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          restore-keys: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-
+
+      - name: Install Composer dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --dev
+          composer update --prefer-stable --no-interaction
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Clone Alpine ${{ env.ALPINE_BRANCH }} branch
+        run: git clone --depth=1 --branch=${{ env.ALPINE_BRANCH }} https://github.com/alpinejs/alpine.git /tmp/alpine
+
+      - name: Build Alpine assets
+        run: |
+          cd /tmp/alpine
+          npm ci
+          npm run build
+
+      - name: Link Alpine packages to Livewire
+        run: npm link /tmp/alpine/packages/alpinejs /tmp/alpine/packages/anchor /tmp/alpine/packages/collapse /tmp/alpine/packages/focus /tmp/alpine/packages/intersect /tmp/alpine/packages/mask /tmp/alpine/packages/morph /tmp/alpine/packages/persist /tmp/alpine/packages/resize /tmp/alpine/packages/csp /tmp/alpine/packages/sort
+
+      - name: Check Alpine packages are linked
+        run: npm list
+
+      - name: Build Livewire assets
+        id: build-assets
+        run: npm run build
+
+      - name: Setup dusk/chrome
+        if: steps.build-assets.outcome == 'success'
+        run: vendor/bin/dusk-updater detect --no-interaction
+
       - name: Run Legacy Browser tests
-        if: (success() || failure()) && steps.build-assets.outcome == 'success'
+        if: steps.build-assets.outcome == 'success'
         run: vendor/bin/phpunit --testsuite LegacyBrowser
         env:
           RUNNING_IN_CI: true


### PR DESCRIPTION
## Summary

- **test-prs.yml** - Runs on pull requests with a reduced matrix (PHP 8.4-8.5, Laravel 11-12) and sharded browser tests for fast feedback (~25 jobs)
- **test-main.yml** - Runs on push to main with the full matrix (PHP 8.1-8.5, Laravel 10-12) to ensure complete coverage after merge (~12 jobs)

## Changes

- Renamed `test.yml` → `test-main.yml` with original full test suite, triggered only on main branch
- Created `test-prs.yml` with reduced PHP/Laravel matrix and browser test sharding (4 shards), triggered only on PRs

## Why

- Tests currently take 8+ minutes to run, making PR feedback slow
- Sharding browser tests across 4 parallel runners reduces wall-clock time to ~2-3 minutes