### PR TITLE
Fix JS/CSS module loading for nested namespaced components

### DIFF
--- a/js/features/supportCssModules.js
+++ b/js/features/supportCssModules.js
@@ -6,7 +6,7 @@ let loadedStyles = new Set()
 on('effect', ({ component, effects }) => {
     // Handle scoped styles
     if (effects.styleModule) {
-        let encodedName = component.name.replace('.', '--').replace('::', '---').replace(':', '----')
+        let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
         let path = `${getUriPrefix()}/css/${encodedName}.css?v=${effects.styleModule}`
 
         if (!loadedStyles.has(path)) {
@@ -17,7 +17,7 @@ on('effect', ({ component, effects }) => {
 
     // Handle global styles
     if (effects.globalStyleModule) {
-        let encodedName = component.name.replace('.', '--').replace('::', '---').replace(':', '----')
+        let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
         let path = `${getUriPrefix()}/css/${encodedName}.global.css?v=${effects.globalStyleModule}`
 
         if (!loadedStyles.has(path)) {

--- a/js/features/supportJsModules.js
+++ b/js/features/supportJsModules.js
@@ -7,7 +7,7 @@ on('effect', ({ component, effects }) => {
     let scriptModuleHash = effects.scriptModule
 
     if (scriptModuleHash) {
-        let encodedName = component.name.replace('.', '--').replace('::', '---').replace(':', '----')
+        let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
         let path = `${getUriPrefix()}/js/${encodedName}.js?v=${scriptModuleHash}`
 
         pendingComponentAssets.set(component, Alpine.reactive({

--- a/src/Features/SupportCssModules/BrowserTest.php
+++ b/src/Features/SupportCssModules/BrowserTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Livewire\Features\SupportCssModules;
+
+use Livewire\Livewire;
+
+class BrowserTest extends \Tests\BrowserTestCase
+{
+    public static function tweakApplicationHook()
+    {
+        return function () {
+            app('livewire.finder')->addNamespace('testns', viewPath: __DIR__ . '/fixtures');
+        };
+    }
+
+    public function test_nested_namespaced_component_loads_css_module()
+    {
+        // This tests that components with multiple dots in their path
+        // (e.g., testns::nested.component.index) correctly load their CSS modules.
+        // Regression test for: https://github.com/livewire/livewire/discussions/9614
+        Livewire::visit('testns::nested.component.index')
+            ->waitForLivewireToLoad()
+            // Pause for a moment to allow the stylesheet to be loaded...
+            ->pause(100)
+            // If the CSS loaded correctly, the element will have red text
+            ->assertScript("getComputedStyle(document.querySelector('[dusk=\"target\"]')).color === 'rgb(255, 0, 0)'");
+    }
+}

--- a/src/Features/SupportCssModules/fixtures/nested/component/index.blade.php
+++ b/src/Features/SupportCssModules/fixtures/nested/component/index.blade.php
@@ -1,0 +1,16 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <div dusk="target" class="test-styled">styled</div>
+</div>
+
+<style>
+    .test-styled {
+        color: rgb(255, 0, 0);
+    }
+</style>

--- a/src/Features/SupportJsModules/BrowserTest.php
+++ b/src/Features/SupportJsModules/BrowserTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Livewire\Features\SupportJsModules;
+
+use Livewire\Livewire;
+
+class BrowserTest extends \Tests\BrowserTestCase
+{
+    public static function tweakApplicationHook()
+    {
+        return function () {
+            app('livewire.finder')->addNamespace('testns', viewPath: __DIR__ . '/fixtures');
+        };
+    }
+
+    public function test_nested_namespaced_component_loads_js_module()
+    {
+        // This tests that components with multiple dots in their path
+        // (e.g., testns::nested.component.index) correctly load their JS modules.
+        // Regression test for: https://github.com/livewire/livewire/discussions/9614
+        Livewire::visit('testns::nested.component.index')
+            ->waitForLivewireToLoad()
+            // Pause for a moment to allow the script to be loaded...
+            ->pause(100)
+            // If the JS loaded correctly, it will have set the text to 'js-loaded'
+            ->assertSeeIn('@target', 'js-loaded');
+    }
+}

--- a/src/Features/SupportJsModules/fixtures/nested/component/index.blade.php
+++ b/src/Features/SupportJsModules/fixtures/nested/component/index.blade.php
@@ -1,0 +1,14 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <div dusk="target">waiting</div>
+</div>
+
+<script>
+    this.$el.querySelector('[dusk="target"]').textContent = 'js-loaded';
+</script>


### PR DESCRIPTION
# The Scenario

When using deeply nested namespaced components with `<script>` or `<style>` tags, the JavaScript and CSS modules fail to load with a 404 error.

```php
<?php

new class extends Livewire\Component {
    //
};
?>

<div>
    <h1>Hello</h1>
</div>

<script>
    console.log('loaded')
</script>
```

```php
// Route definition
Route::livewire('/test', 'pages::global.testing.management.index');
```

The browser console shows:
```
GET https://example.com/livewire-xxx/js/pages---global--testing.management.index.js 404 (Not Found)
```

# The Problem

JavaScript's `String.replace()` method without a regex global flag only replaces the **first occurrence** of a pattern.

```js
// js/features/supportJsModules.js
let encodedName = component.name.replace('.', '--').replace('::', '---').replace(':', '----')
```

For a component named `pages::global.testing.management.index`:
1. `.replace('.', '--')` → `pages::global--testing.management.index` (only first dot replaced!)
2. `.replace('::', '---')` → `pages---global--testing.management.index`

The resulting URL still contains literal dots (`testing.management.index`), which breaks the route matching for the JS/CSS module endpoints.

# The Solution

Use regex with the global flag to replace **all** occurrences:

```js
let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
```

This fix was applied to both `js/features/supportJsModules.js` and `js/features/supportCssModules.js`.

Fixes: https://github.com/livewire/livewire/discussions/9614
Fixes: https://github.com/livewire/livewire/discussions/9685