### PR TITLE
Add failing test for `#[Js]` attribute 

### DIFF
--- a/src/Features/SupportJsEvaluation/BrowserTest.php
+++ b/src/Features/SupportJsEvaluation/BrowserTest.php
@@ -279,4 +279,42 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertScript('window.test === "through backend js method with params: foo, bar"')
         ;
     }
+
+    public function test_can_call_a_defined_js_from_another_method_using_the_js_attribute()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $count = 0;
+
+                public function increment()
+                {
+                    $this->count++;
+                    $this->incrementUpdateMessage();
+                }
+
+                #[\Livewire\Attributes\Js]
+                public function incrementUpdateMessage()
+                {
+                    return "alert('Count updated') ";
+                }
+
+                public function render()
+                {
+                    return <<<'BLADE'
+                        <div>
+                            <h2>Counter : {{ $count }}</h2>
+                            <button wire:click="increment" dusk="increment">Increment</button>
+                        </div>
+                    BLADE;
+                }
+            }
+        )
+            ->waitForLivewire()
+            ->click('@increment')
+            ->pause(1000)
+            ->assertDialogOpened('Count updated')
+            ->acceptDialog()
+            ->waitForText('Counter : 1')
+        ;
+    }
 }


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

No

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No unrelated changes. 

4️⃣ Does it include tests? (Required)

Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This PR introduces a failing test to highlight an issue with Livewire’s #[Js] attribute when the JS-decorated method is invoked from another PHP method.

**Current behavior (problem)**

The incrementUpdateMessage() method is marked with `#[Js]`, but when it is called from inside another Livewire method (increment()),
the returned JavaScript is not executed on the client

As a result:

- assertDialogOpened('Count updated') fails
- No browser alert is triggered

**Expected behavior**

When a method decorated with `#[Js]` is called from another Livewire action, The JavaScript returned by the `#[Js]` method should be executed on the client.


Here's the wirebox link: https://wirebox.app/b/4q0je

Thanks for contributing! 🙌
