### PR TITLE
Fix View Transitions API compatibility for Firefox

### DIFF
--- a/docs/wire-transition.md
+++ b/docs/wire-transition.md
@@ -191,7 +191,7 @@ Livewire automatically respects the user's `prefers-reduced-motion` setting. Whe
 View Transitions are supported in Chrome 111+, Edge 111+, and Safari 18+. In browsers that don't support View Transitions, elements will appear and disappear without animation—the functionality still works, just without the visual transition.
 
 > [!warning] Firefox has limited support
-> Firefox 128+ supports basic view transitions, but does not support transition types (`forward`/`backward`). If you use transition types, Firefox will fall back to the default crossfade animation.
+> Firefox 144+ supports basic view transitions, but does not support transition types (`forward`/`backward`).
 
 [View browser support on caniuse.com →](https://caniuse.com/view-transitions)
 

--- a/docs/wire-transition.md
+++ b/docs/wire-transition.md
@@ -191,7 +191,7 @@ Livewire automatically respects the user's `prefers-reduced-motion` setting. Whe
 View Transitions are supported in Chrome 111+, Edge 111+, and Safari 18+. In browsers that don't support View Transitions, elements will appear and disappear without animation—the functionality still works, just without the visual transition.
 
 > [!warning] Firefox has limited support
-> Firefox 144+ supports basic view transitions, but does not support transition types (`forward`/`backward`).
+> Firefox 144+ supports basic view transitions, but does not support transition types.
 
 [View browser support on caniuse.com →](https://caniuse.com/view-transitions)
 

--- a/docs/wire-transition.md
+++ b/docs/wire-transition.md
@@ -190,6 +190,9 @@ Livewire automatically respects the user's `prefers-reduced-motion` setting. Whe
 
 View Transitions are supported in Chrome 111+, Edge 111+, and Safari 18+. In browsers that don't support View Transitions, elements will appear and disappear without animation—the functionality still works, just without the visual transition.
 
+> [!warning] Firefox has limited support
+> Firefox 128+ supports basic view transitions, but does not support transition types (`forward`/`backward`). If you use transition types, Firefox will fall back to the default crossfade animation.
+
 [View browser support on caniuse.com →](https://caniuse.com/view-transitions)
 
 ## See also

--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -59,7 +59,7 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
 
         await transition.updateCallbackDone
     } catch (e) {
-        // Firefox 128+ supports View Transitions but only with a callback, not a config object (no transition types support)
+        // Firefox 144+ supports View Transitions but only with a callback, not a config object (no transition types support)
         let transition = document.startViewTransition(() => callback())
 
         transition.finished.finally(() => {

--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -13,6 +13,11 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
     // Only transition if there is a [wire:transition] element within either the from or to elements...
     if (! fromEl.querySelector('[wire\\:transition]') && ! toEl.querySelector('[wire\\:transition]')) return callback()
 
+    // Check if View Transitions API is supported...
+    if (typeof document.startViewTransition !== 'function') {
+        return callback()
+    }
+
     // Disable root transitions for the page...
     let style = document.createElement('style')
 
@@ -45,11 +50,22 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
         transitionConfig.types = [options.type]
     }
 
-    let transition = document.startViewTransition(transitionConfig)
+    try {
+        let transition = document.startViewTransition(transitionConfig)
 
-    transition.finished.finally(() => {
-        style.remove()
-    })
+        transition.finished.finally(() => {
+            style.remove()
+        })
 
-    await transition.updateCallbackDone
+        await transition.updateCallbackDone
+    } catch (e) {
+        // Firefox 128+ supports View Transitions but only with a callback, not a config object (no transition types support)
+        let transition = document.startViewTransition(() => callback())
+
+        transition.finished.finally(() => {
+            style.remove()
+        })
+
+        await transition.updateCallbackDone
+    }
 }


### PR DESCRIPTION
# The Scenario

When using `wire:transition` in Firefox, the browser throws a JavaScript error and Livewire components break completely:

```
Uncaught (in promise) TypeError: Document.startViewTransition: Argument 1 is not callable.
```

```php
<?php

use Livewire\Component;

new class extends Component {
    public $show = false;
}; ?>

<div>
    <button wire:click="$toggle('show')">Toggle</button>

    @if ($show)
        <div wire:transition>Test</div>
    @endif
</div>
```

In Chrome/Safari, clicking the button works and the element transitions smoothly. In Firefox, clicking the button causes a JS error and nothing updates.

# The Problem

Firefox 144+ supports the View Transitions API but only with a **callback function**, not the newer **configuration object** format.

The current implementation passes a config object:

```js
let transitionConfig = {
    update: () => callback(),
}
if (options.type) {
    transitionConfig.types = [options.type]
}
let transition = document.startViewTransition(transitionConfig)
```

Firefox expects a callable function as the first argument, not an object with an `update` property.

# The Solution

1. Add an early return check for browsers that don't support `startViewTransition` at all
2. Try the config object format first, then fall back to the callback-only format for Firefox

This means Firefox gets view transitions too — just without support for transition types.

Fixes: https://github.com/livewire/livewire/discussions/9707