### PR TITLE
Fix lazy and defer false not working

### DIFF
--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -67,13 +67,17 @@ class SupportLazyLoading extends ComponentHook
         $lazyAttribute = $reflectionClass->getAttributes(\Livewire\Attributes\Lazy::class)[0] ?? null;
         $deferAttribute = $reflectionClass->getAttributes(\Livewire\Attributes\Defer::class)[0] ?? null;
 
-        if ($lazyAttribute) $shouldBeLazy = true;
-        if ($deferAttribute) $shouldBeLazy = true;
-        if ($deferAttribute) $isDeferred = true;
+        // Apply attributes only if the corresponding param is not explicitly false...
+        $lazyDisabled = isset($params['lazy']) && $params['lazy'] === false;
+        $deferDisabled = isset($params['defer']) && $params['defer'] === false;
+
+        if ($lazyAttribute && ! $lazyDisabled) $shouldBeLazy = true;
+        if ($deferAttribute && ! $deferDisabled) $shouldBeLazy = true;
+        if ($deferAttribute && ! $deferDisabled) $isDeferred = true;
 
         // If Livewire::withoutLazyLoading()...
         if (static::$disableWhileTesting) return;
-        // If `:lazy="false"` or no lazy loading is included at all...
+        // If no lazy loading is included at all...
         if (! $shouldBeLazy) return;
 
         if ($lazyAttribute) {

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportLazyLoading;
 
 use Illuminate\Support\Facades\Route;
+use Livewire\Attributes\Defer;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Lazy;
 use Livewire\Component;
@@ -43,10 +44,50 @@ class UnitTest extends \Tests\TestCase
         ->assertDontSee('Loading...')
         ->assertSee('Hello world!');
     }
+
+    public function test_can_disable_lazy_loading_with_lazy_false_parameter()
+    {
+        Livewire::test(BasicLazyComponent::class, ['lazy' => false])
+            ->assertDontSee('Loading...')
+            ->assertSee('Hello world!');
+    }
+
+    public function test_can_disable_deferred_loading_with_defer_false_parameter()
+    {
+        Livewire::test(BasicDeferComponent::class, ['defer' => false])
+            ->assertDontSee('Loading...')
+            ->assertSee('Hello world!');
+    }
+
+    public function test_lazy_false_does_not_affect_defer_attribute()
+    {
+        Livewire::test(BasicDeferComponent::class, ['lazy' => false])
+            ->assertSee('Loading...')
+            ->assertDontSee('Hello world!');
+    }
+
+    public function test_defer_false_does_not_affect_lazy_attribute()
+    {
+        Livewire::test(BasicLazyComponent::class, ['defer' => false])
+            ->assertSee('Loading...')
+            ->assertDontSee('Hello world!');
+    }
 }
 
 #[Lazy]
 class BasicLazyComponent extends Component {
+    public function placeholder() {
+        return '<div>Loading...</div>';
+    }
+
+    public function render()
+    {
+        return '<div>Hello world!</div>';
+    }
+}
+
+#[Defer]
+class BasicDeferComponent extends Component {
     public function placeholder() {
         return '<div>Loading...</div>';
     }


### PR DESCRIPTION
# The Scenario

When testing a Livewire component that has the `#[Lazy]` attribute, passing `lazy="false"` to disable lazy loading in a test doesn't work:

```php
#[Lazy]
class MyComponent extends Component
{
    public function placeholder()
    {
        return '<div>Loading...</div>';
    }

    public function render()
    {
        return '<div>Hello world!</div>';
    }
}
```

```php
// Expected: Renders "Hello world!" immediately
// Actual: Renders "Loading..." placeholder
Livewire::test(MyComponent::class, ['lazy' => false])
    ->assertSee('Hello world!');
```

The same issue occurs with `#[Defer]` and `defer="false"`.

# The Problem

In `SupportLazyLoading.php`, the `mount` method checks for the `#[Lazy]` and `#[Defer]` attributes and sets `$shouldBeLazy = true` unconditionally:

```php
if ($lazyAttribute) $shouldBeLazy = true;
if ($deferAttribute) $shouldBeLazy = true;
```

The explicit `false` parameter is never checked, so the attribute always takes precedence.

# The Solution

Added checks to respect explicit `false` parameters before applying the attributes:

```php
$lazyDisabled = isset($params['lazy']) && $params['lazy'] === false;
$deferDisabled = isset($params['defer']) && $params['defer'] === false;

if ($lazyAttribute && ! $lazyDisabled) $shouldBeLazy = true;
if ($deferAttribute && ! $deferDisabled) $shouldBeLazy = true;
```

This ensures:
- `lazy="false"` only disables the `#[Lazy]` attribute, not `#[Defer]`
- `defer="false"` only disables the `#[Defer]` attribute, not `#[Lazy]`