### PR TITLE
Fix error when resolving non-namespaced component classes

### DIFF
--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -333,11 +333,14 @@ class Finder
 
         // If using a self-named component in a sub folder, remove the '.[last_segment]' so the name is the subfolder name...
         $segments = explode('.', $fullName);
-        $lastSegment = end($segments);
-        $secondToLastSegment = $segments[count($segments) - 2];
 
-        if ($secondToLastSegment && $lastSegment === $secondToLastSegment) {
-            $fullName = $fullName->replaceLast('.' . $lastSegment, '');
+        if (count($segments) >= 2) {
+            $lastSegment = end($segments);
+            $secondToLastSegment = $segments[count($segments) - 2];
+
+            if ($secondToLastSegment && $lastSegment === $secondToLastSegment) {
+                $fullName = $fullName->replaceLast('.' . $lastSegment, '');
+            }
         }
 
         $classNamespaces = collect($this->classNamespaces)

--- a/src/Finder/UnitTest.php
+++ b/src/Finder/UnitTest.php
@@ -549,4 +549,23 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertNull($path);
     }
+
+    public function test_can_resolve_single_segment_class_name()
+    {
+        $finder = new Finder();
+
+        $finder->addComponent(class: SingleSegmentComponent::class);
+
+        $name = $finder->normalizeName(SingleSegmentComponent::class);
+
+        $this->assertEquals('lw' . crc32(SingleSegmentComponent::class), $name);
+    }
+}
+
+class SingleSegmentComponent extends Component
+{
+    public function render()
+    {
+        return '<div>Single segment component</div>';
+    }
 }


### PR DESCRIPTION
# The Scenario

Using a Livewire component class defined without a namespace causes an error:

```
Undefined array key -1 at Finder.php:337
```

This happens when testing a component defined directly in a test file:

```php
class CustomCard extends Component
{
    public function render()
    {
        return '<div></div>';
    }
}

Livewire::test(CustomCard::class);
```

# The Problem

In `generateNameFromClass`, the code tries to access `$segments[count($segments) - 2]` to check for self-named components in subfolders. When a class has no namespace, its name becomes a single dot-separated segment (e.g., `custom-card`), and `count($segments) - 2` equals `-1`.

```php
$segments = explode('.', $fullName);
$lastSegment = end($segments);
$secondToLastSegment = $segments[count($segments) - 2]; // Error when count is 1
```

# The Solution

Check that there are at least 2 segments before attempting to access the second-to-last one:

```php
if (count($segments) >= 2) {
    $lastSegment = end($segments);
    $secondToLastSegment = $segments[count($segments) - 2];

    if ($secondToLastSegment && $lastSegment === $secondToLastSegment) {
        $fullName = $fullName->replaceLast('.' . $lastSegment, '');
    }
}
```
