### PR TITLE
Fix smart wire keys rendering views that match the key string

### DIFF
--- a/src/Features/SupportCompiledWireKeys/SupportCompiledWireKeys.php
+++ b/src/Features/SupportCompiledWireKeys/SupportCompiledWireKeys.php
@@ -102,7 +102,14 @@ class SupportCompiledWireKeys extends ComponentHook
 
     public static function processElementKey($keyString, $data)
     {
-        $key = Blade::render($keyString, $data);
+        // If the key string matches an existing view name, return it as-is.
+        // This prevents Blade::render() from incorrectly rendering a view
+        // when the user just wants a literal string key like "account".
+        if (view()->exists($keyString)) {
+            $key = $keyString;
+        } else {
+            $key = Blade::render($keyString, $data);
+        }
 
         static::$currentLoop['key'] = $key;
     }

--- a/src/Features/SupportCompiledWireKeys/UnitTest.php
+++ b/src/Features/SupportCompiledWireKeys/UnitTest.php
@@ -648,6 +648,15 @@ class UnitTest extends \Tests\TestCase
         );
     }
 
+    public function test_plain_string_key_matching_view_name_is_not_rendered_as_view()
+    {
+        // "show-name" is an existing test view in tests/views/show-name.blade.php
+        // Using it as a wire:key should return the literal string, not render the view
+        SupportCompiledWireKeys::processElementKey('show-name', []);
+
+        $this->assertEquals('show-name', SupportCompiledWireKeys::$currentLoop['key']);
+    }
+
     public function test_we_can_open_a_loop()
     {
         SupportCompiledWireKeys::openLoop();


### PR DESCRIPTION
# The scenario

When using a `wire:key` with a value that matches an existing view:

```blade
{{-- resources/views/welcome.blade.php --}}
<div wire:key="account">
```

```blade
{{-- resources/views/account.blade.php --}}
<?php echo '> here'; die(); // Starting the string with > to close the outer div so that 'here' is actually displayed... ?>
```

The view will get rendered.

In the case above "here" will be displayed on the page.

# The problem

In `SupportCompiledWireKeys::processElementKey()`, `Blade::render($keyString, $data)` is called to evaluate Blade syntax in keys like `wire:key="{{ $item->id }}"`.

However, when a string that matches a view name is passed to `Blade::render()`, it renders the view instead of returning the literal string.

# The solution
Before calling `Blade::render()`, check if the key string matches an existing view name using `view()->exists()`. If it does, return the string as-is since the user clearly wants a literal key, not to render a view.

```php
public static function processElementKey($keyString, $data)
{
    if (view()->exists($keyString)) {
        $key = $keyString;
    } else {
        $key = Blade::render($keyString, $data);
    }

    static::$currentLoop['key'] = $key;
}