### PR TITLE
Add callback support to Route::livewire

### DIFF
--- a/src/Features/SupportRouting/LivewirePageController.php
+++ b/src/Features/SupportRouting/LivewirePageController.php
@@ -8,7 +8,11 @@ class LivewirePageController
     {
         $component = request()->route()->defaults['_livewire_component'];
 
-        $instance = is_object($component)
+        if ($component instanceof \Closure) {
+            $component = $component();
+        }
+
+        $instance = is_object($component) && !($component instanceof \Closure)
             ? $component
             : app('livewire')->new($component);
 

--- a/src/Features/SupportRouting/SupportRouting.php
+++ b/src/Features/SupportRouting/SupportRouting.php
@@ -10,7 +10,7 @@ class SupportRouting extends ComponentHook
     public static function provide()
     {
         Route::macro('livewire', function ($uri, $component) {
-            if (is_object($component)) {
+            if (is_object($component) && !($component instanceof \Closure)) {
                 app('livewire')->addComponent($component);
             }
 

--- a/src/Features/SupportRouting/UnitTest.php
+++ b/src/Features/SupportRouting/UnitTest.php
@@ -185,6 +185,43 @@ class UnitTest extends TestCase
             ->get('/posts/1')
             ->assertForbidden();
     }
+
+    public function test_can_use_closure_to_dynamically_select_component()
+    {
+        Route::livewire('/dashboard', function () {
+            return ComponentForRouting::class;
+        });
+
+        $this
+            ->withoutExceptionHandling()
+            ->get('/dashboard')
+            ->assertSee('Component for routing');
+    }
+
+    public function test_can_use_closure_with_condition_logic_to_select_component()
+    {
+        Route::livewire('/role-based', function () {
+            return rand(0, 1) === 1 ? ComponentForRouting::class : ComponentForRoutingWithParams::class;
+        });
+
+        $response = $this->get('/role-based');
+
+        $this->assertContains($response->getContent(), ['Component for routing', '<div>']);
+    }
+
+    public function test_can_use_closure_with_string_component_name()
+    {
+        Livewire::component('component-for-routing', ComponentForRouting::class);
+
+        Route::livewire('/dashboard', function () {
+            return 'component-for-routing';
+        });
+
+        $this
+            ->withoutExceptionHandling()
+            ->get('/dashboard')
+            ->assertSee('Component for routing');
+    }
 }
 
 class ComponentForRouting extends Component


### PR DESCRIPTION
Allows passing a closure to `Route::livewire` for dynamic component selection based on runtime conditions like user roles.

Usage Example

```php
Route::livewire('/dashboard', function () {
    return match (auth()->user()->role) {
        'admin' => 'pages::admin.dashboard',
        'manager' => 'pages::manager.dashboard',
        default => 'pages::user.dashboard',
    };
})->name('dashboard');
```