### PR TITLE
Replace string interpolation

### DIFF
--- a/js/directives/wire-wildcard.js
+++ b/js/directives/wire-wildcard.js
@@ -68,7 +68,7 @@ on('directive.init', ({ el, directive, cleanup, component }) => {
                         let params = Array.isArray(livewireOptions.defaultParams)
                             ? livewireOptions.defaultParams
                             : [livewireOptions.defaultParams]
-                        expression = `${expression}(${params.map(p => JSON.stringify(p)).join(', ')})`
+                        expression = expression + '(' + params.map((p) => JSON.stringify(p)).join(", ") + ')'
                     }
 
                     evaluateActionExpression(el, expression, { scope: { $event: e } })

--- a/js/directives/wire-wildcard.js
+++ b/js/directives/wire-wildcard.js
@@ -68,7 +68,7 @@ on('directive.init', ({ el, directive, cleanup, component }) => {
                         let params = Array.isArray(livewireOptions.defaultParams)
                             ? livewireOptions.defaultParams
                             : [livewireOptions.defaultParams]
-                        expression = expression + '(' + params.map((p) => JSON.stringify(p)).join(", ") + ')'
+                        expression = expression + '(' + params.map((p) => JSON.stringify(p)).join(', ') + ')'
                     }
 
                     evaluateActionExpression(el, expression, { scope: { $event: e } })


### PR DESCRIPTION
I started seeing this error in Sentry after upgrading from Livewire v3 to v4.0.1. Only seems to affect older browsers - like iOS 15/16. Makes it a little hard to replicate, however with some help from Claude I think I identified the culprit.

```
Alpine Expression Error: Invalid regular expression: invalid group specifier name

Expression: "function (l){n.eventContext=l,n.wire=a.$wire;let I=()=>{O2(a,()=>{var H;if(n.value==="submit"){let ae=l.submitter||t.querySelector('button[type="submit"], input[type="submit"]');cl({el:t,directive:n,targetEl:ae})}else cl({el:t,directive:n});let A=(H=l.detail)==null?void 0:H.livewire;A!=null&&A.interceptAction&&BC(A.interceptAction);let $=n.expression;if((A==null?void 0:A.defaultParams)!==void 0&&!$.includes("(")){let ae=Array.isArray(A.defaultParams)?A.defaultParams:[A.defaultParams];$="".concat($,"(").concat(ae.map(_e=>JSON.stringify(_e)).join(", "),")")}qs(t,$,{scope:{$event:l}})})};t.__livewire_confirm?t.__livewire_confirm(()=>{I()},()=>{l.stopImmediatePropagation()}):I()}"

 [object HTMLFormElement]
```

My understanding is that the older browsers don't understand string interpolation as well and get confused by the `$`. I can see this interpolation was only introduced recently and there doesn't appear to be widespread use of interpolation in the code base. So the PR simply makes this code more bare-bones.