### PR TITLE
add make command defaults

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -71,6 +71,7 @@ return [
     'make_command' => [
         'type' => 'sfc', // Options: 'sfc', 'mfc', 'class'
         'emoji' => true, // Options: true, false
+        'defaults' => [], // Options: 'test', 'js'
     ],
 
     /*

--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -186,7 +186,7 @@ class MakeCommand extends Command
         $this->files->put($path, $content);
 
         // Create test file if --test flag is present
-        if ($this->option('test')) {
+        if ($this->option('test') || in_array('test', config('livewire.make_command.defaults', []), true)) {
             $testPath = $this->getSingleFileComponentTestPath($path);
             $testContent = $this->buildSingleFileComponentTest($name);
             $this->files->put($testPath, $testContent);

--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -247,11 +247,11 @@ class MakeCommand extends Command
         $this->files->put($classPath, $classContent);
         $this->files->put($viewPath, $viewContent);
 
-        if ($this->option('test')) {
+        if ($this->option('test') || in_array('test', config('livewire.make_command.defaults', []), true)) {
             $this->files->put($testPath, $testContent);
         }
 
-        if ($this->option('js')) {
+        if ($this->option('js') || in_array('js', config('livewire.make_command.defaults', []), true)) {
             $this->files->put($jsPath, $jsContent);
         }
 

--- a/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
@@ -65,6 +65,19 @@ class MakeCommandUnitTest extends \Tests\TestCase
         $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.js')));
     }
 
+    public function test_multi_file_component_with_javascript_when_js_is_in_make_command_defaults()
+    {
+        $this->app['config']->set('livewire.make_command.defaults', ['js']);
+        
+        Artisan::call('make:livewire', ['name' => 'foo', '--mfc' => true]);
+
+        $this->assertTrue(File::isDirectory($this->livewireComponentsPath('⚡foo')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.php')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.blade.php')));
+        $this->assertFalse(File::exists($this->livewireComponentsPath('⚡foo/foo.test.php')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.js')));
+    }
+
     public function test_class_based_component_is_created_with_class_flag()
     {
         Artisan::call('make:livewire', ['name' => 'foo', '--class' => true]);
@@ -389,6 +402,20 @@ class MakeCommandUnitTest extends \Tests\TestCase
         $this->assertStringContainsString('foo', $testContent);
     }
 
+    public function test_single_file_component_with_test_in_make_command_defaults_creates_test_file()
+    {
+        $this->app['config']->set('livewire.make_command.defaults', ['test']);
+        
+        Artisan::call('make:livewire', ['name' => 'foo']);
+
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo.blade.php')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo.test.php')));
+
+        $testContent = File::get($this->livewireComponentsPath('⚡foo.test.php'));
+        $this->assertStringContainsString("it('renders successfully'", $testContent);
+        $this->assertStringContainsString('foo', $testContent);
+    }
+
     public function test_single_file_component_with_test_flag_without_emoji()
     {
         $this->app['config']->set('livewire.make_command.emoji', false);
@@ -400,9 +427,31 @@ class MakeCommandUnitTest extends \Tests\TestCase
         $this->assertFalse(File::exists($this->livewireComponentsPath('⚡bar.test.php')));
     }
 
+    public function test_single_file_component_with_test_in_make_command_defaults_without_emoji()
+    {
+        $this->app['config']->set('livewire.make_command.emoji', false);
+        $this->app['config']->set('livewire.make_command.defaults', ['test']);
+
+        Artisan::call('make:livewire', ['name' => 'bar']);
+
+        $this->assertTrue(File::exists($this->livewireComponentsPath('bar.blade.php')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('bar.test.php')));
+        $this->assertFalse(File::exists($this->livewireComponentsPath('⚡bar.test.php')));
+    }
+
     public function test_nested_single_file_component_with_test_flag()
     {
         Artisan::call('make:livewire', ['name' => 'admin.users', '--test' => true]);
+
+        $this->assertTrue(File::exists($this->livewireComponentsPath('admin/⚡users.blade.php')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('admin/⚡users.test.php')));
+    }
+
+    public function test_nested_single_file_component_with_test_in_make_command_defaults()
+    {
+        $this->app['config']->set('livewire.make_command.defaults', ['test']);
+        
+        Artisan::call('make:livewire', ['name' => 'admin.users']);
 
         $this->assertTrue(File::exists($this->livewireComponentsPath('admin/⚡users.blade.php')));
         $this->assertTrue(File::exists($this->livewireComponentsPath('admin/⚡users.test.php')));


### PR DESCRIPTION
This PR introduces the option to configure defaults for the make command.

```php
'make_command' => [
    (...)
    'defaults' => [], // Options: 'js', 'test'
],
```