### PR TITLE
Fix ClassMorphViolationException for Eloquent collections when enforceMorphMap is active

### DIFF
--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -7,6 +7,7 @@ use Livewire\Mechanisms\HandleComponents\ComponentContext;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\ClassMorphViolationException;
 
 class EloquentCollectionSynth extends Synth {
     use SerializesAndRestoresModelIdentifiers, IsLazy;
@@ -39,7 +40,16 @@ class EloquentCollectionSynth extends Synth {
          *
          * If no alias is found, this just returns the class name
          */
-        $modelAlias = $modelClass ? (new $modelClass)->getMorphClass() : null;
+        if ($modelClass) {
+            try {
+                $modelAlias = (new $modelClass)->getMorphClass();
+            } catch (ClassMorphViolationException $e) {
+                // If the model is not using morph classes, this exception is thrown
+                $modelAlias = $modelClass;
+            }
+        } else {
+            $modelAlias = null;
+        }
 
         $meta = [];
 

--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -211,6 +211,26 @@ class UnitTest extends \Tests\TestCase
         Relation::requireMorphMap(false);
     }
 
+    public function test_it_does_not_trigger_ClassMorphViolationException_for_collections_when_morph_map_is_enforced()
+    {
+        // reset morph
+        Relation::morphMap([], false);
+        Relation::requireMorphMap();
+
+        $component = Livewire::test(new class extends TestComponent {
+            public Collection $articles;
+
+            public function mount()
+            {
+                $this->articles = Article::all();
+            }
+        });
+
+        $this->assertEquals(Article::class, $component->snapshot['data']['articles'][1]['modelClass']);
+
+        Relation::requireMorphMap(false);
+    }
+
     public function test_model_synth_rejects_non_model_classes()
     {
         $this->expectException(\Exception::class);


### PR DESCRIPTION
When using Relation::enforceMorphMap() in Laravel, the getMorphClass() method throws a ClassMorphViolationException for models that don't have a defined morph entry. This fix wraps the getMorphClass() call in EloquentCollectionSynth in a try-catch block to fall back to the class name, matching the existing behavior in ModelSynth and EloquentModelSynth.

Fixes #6862
