### PR TITLE
Fix stack overflow when transmitting large payloads

### DIFF
--- a/src/Features/SupportLargePayloads/BrowserTest.php
+++ b/src/Features/SupportLargePayloads/BrowserTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Livewire\Features\SupportLargePayloads;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class BrowserTest extends \Tests\BrowserTestCase
+{
+    /**
+     * Test that large payloads (300KB+) can be sent without causing
+     * "Maximum call stack size exceeded" errors.
+     *
+     * This regression test ensures the fix for the fingerprint getter
+     * in js/request/action.js continues to work. The original bug used
+     * String.fromCharCode(...array) which failed with arrays > ~125k elements.
+     */
+    public function test_can_send_large_payload_without_stack_overflow()
+    {
+        Livewire::visit(
+            new class extends Component {
+                public $receivedLength = 0;
+
+                public function saveData($data)
+                {
+                    $this->receivedLength = strlen($data);
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button dusk="send">Send Large Payload</button>
+                        <span dusk="result">{{ $receivedLength }}</span>
+                    </div>
+
+                    @script
+                    <script>
+                        document.querySelector('[dusk="send"]').addEventListener('click', () => {
+                            // Generate a 300KB payload (similar to a base64-encoded image)
+                            // This size previously caused stack overflow in the fingerprint getter
+                            let largePayload = 'x'.repeat(300 * 1024);
+
+                            $wire.call('saveData', largePayload);
+                        });
+                    </script>
+                    @endscript
+                    HTML;
+                }
+            }
+        )
+            ->waitForLivewireToLoad()
+            ->assertSeeIn('@result', '0')
+            ->click('@send')
+            ->waitForTextIn('@result', '307200')
+            ->assertSeeIn('@result', '307200')
+            ->assertConsoleLogHasNoErrors();
+    }
+}


### PR DESCRIPTION
The fingerprint getter in action.js used String.fromCharCode(...array) with the spread operator, which fails when payloads exceed ~125KB due to JavaScript's argument limit. This caused "Maximum call stack size exceeded" errors when sending large data like base64-encoded images.

The fix processes the encoded bytes in 8KB chunks, avoiding the spread operator limit while maintaining the same fingerprint output.

Fixes #9747
