### PR TITLE
fix: validate snapshot before accessing array keys in update method

### DIFF
--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -175,6 +175,10 @@ class HandleComponents extends Mechanism
 
     public function update($snapshot, $updates, $calls)
     {
+        if (! is_array($snapshot) || ! isset($snapshot['data'], $snapshot['memo'])) {
+            throw new \InvalidArgumentException('Invalid Livewire snapshot');
+        }
+
         $data = $snapshot['data'];
         $memo = $snapshot['memo'];
 


### PR DESCRIPTION
## Summary

This PR fixes a crash in `HandleComponents::update()` when the `$snapshot` parameter is null or invalid.

### The Problem

When a request to `/livewire/update` contains invalid JSON in the snapshot field, `json_decode` returns `null`. The `update()` method then attempts to access `$snapshot['data']` and `$snapshot['memo']` without validating that the snapshot is a valid array, causing:

```
ErrorException: Trying to access array offset on null
at vendor/livewire/livewire/src/Mechanisms/HandleComponents/HandleComponents.php:88
```

### The Fix

Add validation at the beginning of `update()` method to ensure the snapshot is a valid array with required keys:

```php
if (! is_array($snapshot) || ! isset($snapshot['data'], $snapshot['memo'])) {
    throw new \InvalidArgumentException('Invalid Livewire snapshot');
}
```

This provides a clear error message instead of a cryptic "array offset on null" error.

Fixes #9752

## Test plan

- [x] Invalid/null snapshots now throw a descriptive `InvalidArgumentException`
- [ ] Valid snapshots continue to work normally
- [ ] Edge cases with malformed requests are handled gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)