### PR TITLE
Fix parallel tests using WithCachedRoutes

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -21,7 +21,11 @@ class HandleRequests extends Mechanism
     {
         // Only set it if another provider or routes file haven't already set it....
         app()->booted(function () {
-            if (! $this->updateRoute) {
+            // Check both instance state and router to handle cached routes scenario.
+            // When routes are cached and loaded, $this->updateRoute will be null but
+            // the route already exists in the router. This prevents duplicate registration
+            // which Laravel v12.29.0+ treats as an error.
+            if (! $this->updateRoute && ! $this->updateRouteExists()) {
                 app($this::class)->setUpdateRoute(function ($handle) {
                     return Route::post(EndpointResolver::updatePath(), $handle)->middleware('web');
                 });
@@ -29,6 +33,20 @@ class HandleRequests extends Mechanism
         });
 
         $this->skipRequestPayloadTamperingMiddleware();
+    }
+
+    protected function updateRouteExists()
+    {
+        // Check if a route with name ending in 'livewire.update' already exists.
+        // Custom routes can have prefixes (e.g., 'tenant.livewire.update') so we
+        // need to check for routes ending with 'livewire.update', not just exact matches.
+        foreach (Route::getRoutes()->getRoutes() as $route) {
+            if (str($route->getName())->endsWith('livewire.update')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     function getUriPrefix()

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -33,4 +33,27 @@ class UnitTest extends TestCase
         $this->assertCount(1, $livewireUpdateRoutes);
         $this->assertEquals(ltrim(EndpointResolver::updatePath(), '/'), $livewireUpdateRoutes->first()->uri());
     }
+
+    public function test_duplicate_route_is_not_registered_when_livewire_update_route_already_exists(): void
+    {
+        // Verify that only one livewire.update route exists initially
+        $livewireUpdateRoutes = collect(Route::getRoutes()->getRoutes())->filter(function ($route) {
+            return str($route->getName())->endsWith('livewire.update');
+        });
+        $this->assertCount(1, $livewireUpdateRoutes);
+
+        // Simulate what happens during cached routes scenario: create a new HandleRequests
+        // instance (which has $updateRoute = null) and call boot() again
+        $newHandleRequests = new HandleRequests();
+        $newHandleRequests->boot();
+
+        // Manually trigger the booted callback since we're already past the boot phase
+        app()->booted(function () {});
+
+        // Verify that still only one livewire.update route exists (no duplicate)
+        $livewireUpdateRoutes = collect(Route::getRoutes()->getRoutes())->filter(function ($route) {
+            return str($route->getName())->endsWith('livewire.update');
+        });
+        $this->assertCount(1, $livewireUpdateRoutes);
+    }
 }


### PR DESCRIPTION
Original discussion: https://github.com/livewire/livewire/discussions/9757

When running parallel tests with WithCachedRoutes trait, routes are loaded from cache but HandleRequests instance is fresh (updateRoute is null). This caused duplicate route registration attempts since Laravel v12.29.0+ treats duplicate route names as an error.

The fix adds updateRouteExists() to check if any route with name ending in 'livewire.update' already exists in the router before attempting to register the default route. This handles both:
- Exact match: 'livewire.update'
- Prefixed custom routes: 'tenant.livewire.update'
