### PR TITLE
Fix creating components with unregistered namespaces

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -143,6 +143,15 @@ class MakeCommand extends Command
     {
         $path = $this->finder->resolveSingleFileComponentPathForCreation($name);
 
+        if ($path === null) {
+            [$namespace] = $this->finder->parseNamespaceAndName($name);
+            $this->components->error(sprintf(
+                "Namespace [%s] is not registered. Register it in config/livewire.php under 'component_namespaces' or use Livewire::addNamespace() in a service provider.",
+                $namespace
+            ));
+            return 1;
+        }
+
         // Check if we're converting from a multi-file component
         $mfcPath = $this->finder->resolveMultiFileComponentPath($name);
         if ($mfcPath && $this->files->exists($mfcPath) && $this->files->isDirectory($mfcPath)) {
@@ -200,6 +209,15 @@ class MakeCommand extends Command
     protected function createMultiFileComponent(string $name): int
     {
         $directory = $this->finder->resolveMultiFileComponentPathForCreation($name);
+
+        if ($directory === null) {
+            [$namespace] = $this->finder->parseNamespaceAndName($name);
+            $this->components->error(sprintf(
+                "Namespace [%s] is not registered. Register it in config/livewire.php under 'component_namespaces' or use Livewire::addNamespace() in a service provider.",
+                $namespace
+            ));
+            return 1;
+        }
 
         // Get the component name without emoji for file names inside the directory
         $componentName = basename($directory);
@@ -456,7 +474,7 @@ class MakeCommand extends Command
 
         // Check for single-file component
         $sfcPath = $finder->resolveSingleFileComponentPathForCreation($name);
-        if ($this->files->exists($sfcPath)) {
+        if ($sfcPath !== null && $this->files->exists($sfcPath)) {
             return true;
         }
 
@@ -498,7 +516,7 @@ class MakeCommand extends Command
 
         // Check for single-file component
         $sfcPath = $finder->resolveSingleFileComponentPathForCreation($name);
-        if ($this->files->exists($sfcPath)) {
+        if ($sfcPath !== null && $this->files->exists($sfcPath)) {
             $testPath = $this->getSingleFileComponentTestPath($sfcPath);
 
             if ($this->files->exists($testPath)) {

--- a/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
@@ -819,4 +819,40 @@ class MakeCommandUnitTest extends \Tests\TestCase
         $this->assertStringContainsString('.global-original', $finalContent);
         $this->assertStringContainsString('height: 100%', $finalContent);
     }
+
+    public function test_unregistered_namespace_shows_error_for_sfc()
+    {
+        // Try to create a component with an unregistered namespace
+        $exitCode = Artisan::call('make:livewire', ['name' => 'unregistered::foo']);
+
+        $this->assertEquals(1, $exitCode);
+        $this->assertStringContainsString('Namespace [unregistered] is not registered', Artisan::output());
+
+        // Ensure no component was created in the fallback location
+        $this->assertFalse(File::exists($this->livewireComponentsPath('⚡foo.blade.php')));
+    }
+
+    public function test_unregistered_namespace_shows_error_for_mfc()
+    {
+        // Try to create a multi-file component with an unregistered namespace
+        $exitCode = Artisan::call('make:livewire', ['name' => 'unknown::bar', '--mfc' => true]);
+
+        $this->assertEquals(1, $exitCode);
+        $this->assertStringContainsString('Namespace [unknown] is not registered', Artisan::output());
+
+        // Ensure no component was created in the fallback location
+        $this->assertFalse(File::isDirectory($this->livewireComponentsPath('⚡bar')));
+    }
+
+    public function test_unregistered_namespace_shows_error_for_nested_component()
+    {
+        // Try to create a nested component with an unregistered namespace
+        $exitCode = Artisan::call('make:livewire', ['name' => 'custom::admin.users']);
+
+        $this->assertEquals(1, $exitCode);
+        $this->assertStringContainsString('Namespace [custom] is not registered', Artisan::output());
+
+        // Ensure no component was created in the fallback location
+        $this->assertFalse(File::exists($this->livewireComponentsPath('admin/⚡users.blade.php')));
+    }
 }

--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -408,13 +408,18 @@ class Finder
             && file_exists($dir . '/' . $fileBaseName . '.blade.php');
     }
 
-    public function resolveSingleFileComponentPathForCreation(string $name): string
+    public function resolveSingleFileComponentPathForCreation(string $name): ?string
     {
         [$namespace, $componentName] = $this->parseNamespaceAndName($name);
 
         // Get the appropriate location
-        if ($namespace !== null && isset($this->viewNamespaces[$namespace])) {
-            $location = $this->viewNamespaces[$namespace];
+        if ($namespace !== null) {
+            if (isset($this->viewNamespaces[$namespace])) {
+                $location = $this->viewNamespaces[$namespace];
+            } else {
+                // Namespace specified but not registered
+                return null;
+            }
         } else {
             // Use the first configured component location or fallback
             $location = $this->viewLocations[0] ?? resource_path('views/components');
@@ -435,13 +440,18 @@ class Finder
         return $location . '/' . $leadingPath . $prefix . $lastSegment . '.blade.php';
     }
 
-    public function resolveMultiFileComponentPathForCreation(string $name): string
+    public function resolveMultiFileComponentPathForCreation(string $name): ?string
     {
         [$namespace, $componentName] = $this->parseNamespaceAndName($name);
 
         // Get the appropriate location
-        if ($namespace !== null && isset($this->viewNamespaces[$namespace])) {
-            $location = $this->viewNamespaces[$namespace];
+        if ($namespace !== null) {
+            if (isset($this->viewNamespaces[$namespace])) {
+                $location = $this->viewNamespaces[$namespace];
+            } else {
+                // Namespace specified but not registered
+                return null;
+            }
         } else {
             // Use the first configured component location or fallback
             $location = $this->viewLocations[0] ?? resource_path('views/components');

--- a/src/Finder/UnitTest.php
+++ b/src/Finder/UnitTest.php
@@ -550,6 +550,56 @@ class UnitTest extends \Tests\TestCase
         $this->assertNull($path);
     }
 
+    public function test_returns_null_for_unregistered_namespace_sfc_creation()
+    {
+        $finder = new Finder();
+
+        $finder->addNamespace('admin', viewPath: __DIR__ . '/Fixtures');
+
+        // Try to resolve a path for creation with an unregistered namespace
+        $path = $finder->resolveSingleFileComponentPathForCreation('unknown::some-component');
+
+        $this->assertNull($path);
+    }
+
+    public function test_returns_null_for_unregistered_namespace_mfc_creation()
+    {
+        $finder = new Finder();
+
+        $finder->addNamespace('admin', viewPath: __DIR__ . '/Fixtures');
+
+        // Try to resolve a path for creation with an unregistered namespace
+        $path = $finder->resolveMultiFileComponentPathForCreation('unknown::some-component');
+
+        $this->assertNull($path);
+    }
+
+    public function test_resolves_path_for_registered_namespace_sfc_creation()
+    {
+        $finder = new Finder();
+
+        $finder->addNamespace('admin', viewPath: __DIR__ . '/Fixtures');
+
+        $path = $finder->resolveSingleFileComponentPathForCreation('admin::new-component');
+
+        $this->assertNotNull($path);
+        $this->assertStringContainsString('Fixtures', $path);
+        $this->assertStringContainsString('new-component', $path);
+    }
+
+    public function test_resolves_path_for_registered_namespace_mfc_creation()
+    {
+        $finder = new Finder();
+
+        $finder->addNamespace('admin', viewPath: __DIR__ . '/Fixtures');
+
+        $path = $finder->resolveMultiFileComponentPathForCreation('admin::new-component');
+
+        $this->assertNotNull($path);
+        $this->assertStringContainsString('Fixtures', $path);
+        $this->assertStringContainsString('new-component', $path);
+    }
+
     public function test_can_resolve_single_segment_class_name()
     {
         $finder = new Finder();


### PR DESCRIPTION
Previously, when using an unregistered namespace like `posts::post.create` with the make:livewire command, the namespace was silently ignored and the component was created in the default location (views/components) instead of showing an error.

Now the command properly validates that the namespace is registered and shows a helpful error message explaining how to register custom namespaces either in config/livewire.php under 'component_namespaces' or programmatically via Livewire::addNamespace() in a service provider.

Changes:
- Finder::resolveSingleFileComponentPathForCreation() now returns null for unregistered namespaces (return type changed from string to ?string)
- Finder::resolveMultiFileComponentPathForCreation() same change
- MakeCommand now checks for null return and shows descriptive error
- Added tests for the new behavior

Fixes #9755
