### PR TITLE
Fix class-based component generation when using root views path

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -2,18 +2,18 @@
 
 namespace Livewire\Features\SupportConsoleCommands\Commands;
 
-use Illuminate\Support\Str;
-use Livewire\Finder\Finder;
-use Illuminate\Console\Command;
-use Livewire\Compiler\Compiler;
 use function Laravel\Prompts\text;
-use Illuminate\Foundation\Inspiring;
 use function Laravel\Prompts\confirm;
-use Illuminate\Filesystem\Filesystem;
-use Livewire\Compiler\Parser\SingleFileParser;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Livewire\Finder\Finder;
+use Livewire\Compiler\Parser\SingleFileParser;
+use Livewire\Compiler\Compiler;
+use Illuminate\Support\Str;
+use Illuminate\Foundation\Inspiring;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Console\Command;
 
 #[AsCommand(name: 'make:livewire')]
 class MakeCommand extends Command
@@ -226,10 +226,10 @@ class MakeCommand extends Command
         }
 
         // Define file paths
-        $classPath = $directory.'/'.$componentName.'.php';
-        $viewPath = $directory.'/'.$componentName.'.blade.php';
-        $testPath = $directory.'/'.$componentName.'.test.php';
-        $jsPath = $directory.'/'.$componentName.'.js';
+        $classPath = $directory . '/' . $componentName . '.php';
+        $viewPath = $directory . '/' . $componentName . '.blade.php';
+        $testPath = $directory . '/' . $componentName . '.test.php';
+        $jsPath = $directory . '/' . $componentName . '.js';
 
         // Check if we're upgrading from a single-file component
         $sfcPath = $this->finder->resolveSingleFileComponentPathForCreation($name);
@@ -307,8 +307,8 @@ class MakeCommand extends Command
         }
 
         if (! empty($namespaceSegments)) {
-            $namespace .= '\\'.collect($namespaceSegments)
-                ->map(fn ($segment) => Str::studly($segment))
+            $namespace .= '\\' . collect($namespaceSegments)
+                ->map(fn($segment) => Str::studly($segment))
                 ->implode('\\');
         }
 
@@ -316,7 +316,7 @@ class MakeCommand extends Command
         $viewNamespace = $this->extractViewNamespace($viewPath);
 
         $viewName = collect($segments)
-            ->map(fn ($segment) => Str::kebab($segment))
+            ->map(fn($segment) => Str::kebab($segment))
             ->prepend($viewNamespace)
             ->filter()
             ->implode('.');
@@ -365,7 +365,7 @@ class MakeCommand extends Command
         $stub = $this->files->get($this->getStubPath('livewire-mfc-test.stub'));
 
         $componentName = collect(explode('.', $name))
-            ->map(fn ($segment) => Str::kebab($segment))
+            ->map(fn($segment) => Str::kebab($segment))
             ->implode('.');
 
         $stub = str_replace('[component-name]', $componentName, $stub);
@@ -390,7 +390,7 @@ class MakeCommand extends Command
         $stub = $this->files->get($this->getStubPath('livewire-mfc-test.stub'));
 
         $componentName = collect(explode('.', $name))
-            ->map(fn ($segment) => Str::kebab($segment))
+            ->map(fn($segment) => Str::kebab($segment))
             ->implode('.');
 
         $stub = str_replace('[component-name]', $componentName, $stub);
@@ -402,19 +402,19 @@ class MakeCommand extends Command
     {
         $segments = explode('.', $name);
 
-        $className = Str::studly(end($segments)).'Test';
+        $className = Str::studly(end($segments)) . 'Test';
 
         $namespaceSegments = array_slice($segments, 0, -1);
 
         $path = base_path('tests/Feature/Livewire');
 
         if (! empty($namespaceSegments)) {
-            $path .= '/'.collect($namespaceSegments)
-                ->map(fn ($segment) => Str::studly($segment))
+            $path .= '/' . collect($namespaceSegments)
+                ->map(fn($segment) => Str::studly($segment))
                 ->implode('/');
         }
 
-        return $path.'/'.$className.'.php';
+        return $path . '/' . $className . '.php';
     }
 
     protected function buildClassBasedComponentTest(string $name): string
@@ -423,7 +423,7 @@ class MakeCommand extends Command
         $stub = $this->files->get($this->getStubPath('livewire-mfc-test.stub'));
 
         $componentName = collect(explode('.', $name))
-            ->map(fn ($segment) => Str::kebab($segment))
+            ->map(fn($segment) => Str::kebab($segment))
             ->implode('.');
 
         $stub = str_replace('[component-name]', $componentName, $stub);
@@ -433,13 +433,13 @@ class MakeCommand extends Command
 
     protected function getStubPath(string $stub): string
     {
-        $customPath = $this->laravel->basePath('stubs/'.$stub);
+        $customPath = $this->laravel->basePath('stubs/' . $stub);
 
         if ($this->files->exists($customPath)) {
             return $customPath;
         }
 
-        return __DIR__.'/'.$stub;
+        return __DIR__ . '/' . $stub;
     }
 
     protected function ensureDirectoryExists(string $path): void
@@ -461,8 +461,8 @@ class MakeCommand extends Command
         }
 
         // Remove the base views path to get the relative path
-        $relativePath = str_replace($viewsPath.DIRECTORY_SEPARATOR, '', $viewPath);
-        $relativePath = str_replace($viewsPath.'/', '', $relativePath);
+        $relativePath = str_replace($viewsPath . DIRECTORY_SEPARATOR, '', $viewPath);
+        $relativePath = str_replace($viewsPath . '/', '', $relativePath);
 
         // Convert directory separators to dots for the namespace
         return str_replace(['/', '\\'], '.', $relativePath);
@@ -505,7 +505,7 @@ class MakeCommand extends Command
                 $componentName = str_replace(['⚡', '⚡︎', '⚡️'], '', $componentName);
             }
 
-            $testPath = $mfcPath.'/'.$componentName.'.test.php';
+            $testPath = $mfcPath . '/' . $componentName . '.test.php';
 
             if ($this->files->exists($testPath)) {
                 $this->components->error('Test file already exists.');

--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -2,18 +2,18 @@
 
 namespace Livewire\Features\SupportConsoleCommands\Commands;
 
-use function Laravel\Prompts\text;
-use function Laravel\Prompts\confirm;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Attribute\AsCommand;
-use Livewire\Finder\Finder;
-use Livewire\Compiler\Parser\SingleFileParser;
-use Livewire\Compiler\Compiler;
 use Illuminate\Support\Str;
-use Illuminate\Foundation\Inspiring;
-use Illuminate\Filesystem\Filesystem;
+use Livewire\Finder\Finder;
 use Illuminate\Console\Command;
+use Livewire\Compiler\Compiler;
+use function Laravel\Prompts\text;
+use Illuminate\Foundation\Inspiring;
+use function Laravel\Prompts\confirm;
+use Illuminate\Filesystem\Filesystem;
+use Livewire\Compiler\Parser\SingleFileParser;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
 
 #[AsCommand(name: 'make:livewire')]
 class MakeCommand extends Command
@@ -226,10 +226,10 @@ class MakeCommand extends Command
         }
 
         // Define file paths
-        $classPath = $directory . '/' . $componentName . '.php';
-        $viewPath = $directory . '/' . $componentName . '.blade.php';
-        $testPath = $directory . '/' . $componentName . '.test.php';
-        $jsPath = $directory . '/' . $componentName . '.js';
+        $classPath = $directory.'/'.$componentName.'.php';
+        $viewPath = $directory.'/'.$componentName.'.blade.php';
+        $testPath = $directory.'/'.$componentName.'.test.php';
+        $jsPath = $directory.'/'.$componentName.'.js';
 
         // Check if we're upgrading from a single-file component
         $sfcPath = $this->finder->resolveSingleFileComponentPathForCreation($name);
@@ -302,21 +302,23 @@ class MakeCommand extends Command
             $namespace = $classNamespaceDetails['classNamespace'];
             $viewPath = $classNamespaceDetails['classViewPath'];
         } else {
-            $namespace = 'App\\Livewire';
+            $namespace = config('livewire.class_namespace', 'App\\Livewire');
             $viewPath = config('livewire.view_path', resource_path('views/livewire'));
         }
 
         if (! empty($namespaceSegments)) {
-            $namespace .= '\\' . collect($namespaceSegments)
-                ->map(fn($segment) => Str::studly($segment))
+            $namespace .= '\\'.collect($namespaceSegments)
+                ->map(fn ($segment) => Str::studly($segment))
                 ->implode('\\');
         }
 
         // Get the configured view path and extract the view namespace from it
         $viewNamespace = $this->extractViewNamespace($viewPath);
 
-        $viewName = $viewNamespace . '.' . collect($segments)
-            ->map(fn($segment) => Str::kebab($segment))
+        $viewName = collect($segments)
+            ->map(fn ($segment) => Str::kebab($segment))
+            ->prepend($viewNamespace)
+            ->filter()
             ->implode('.');
 
         $stub = str_replace('[namespace]', $namespace, $stub);
@@ -363,7 +365,7 @@ class MakeCommand extends Command
         $stub = $this->files->get($this->getStubPath('livewire-mfc-test.stub'));
 
         $componentName = collect(explode('.', $name))
-            ->map(fn($segment) => Str::kebab($segment))
+            ->map(fn ($segment) => Str::kebab($segment))
             ->implode('.');
 
         $stub = str_replace('[component-name]', $componentName, $stub);
@@ -388,7 +390,7 @@ class MakeCommand extends Command
         $stub = $this->files->get($this->getStubPath('livewire-mfc-test.stub'));
 
         $componentName = collect(explode('.', $name))
-            ->map(fn($segment) => Str::kebab($segment))
+            ->map(fn ($segment) => Str::kebab($segment))
             ->implode('.');
 
         $stub = str_replace('[component-name]', $componentName, $stub);
@@ -400,19 +402,19 @@ class MakeCommand extends Command
     {
         $segments = explode('.', $name);
 
-        $className = Str::studly(end($segments)) . 'Test';
+        $className = Str::studly(end($segments)).'Test';
 
         $namespaceSegments = array_slice($segments, 0, -1);
 
         $path = base_path('tests/Feature/Livewire');
 
         if (! empty($namespaceSegments)) {
-            $path .= '/' . collect($namespaceSegments)
-                ->map(fn($segment) => Str::studly($segment))
+            $path .= '/'.collect($namespaceSegments)
+                ->map(fn ($segment) => Str::studly($segment))
                 ->implode('/');
         }
 
-        return $path . '/' . $className . '.php';
+        return $path.'/'.$className.'.php';
     }
 
     protected function buildClassBasedComponentTest(string $name): string
@@ -421,7 +423,7 @@ class MakeCommand extends Command
         $stub = $this->files->get($this->getStubPath('livewire-mfc-test.stub'));
 
         $componentName = collect(explode('.', $name))
-            ->map(fn($segment) => Str::kebab($segment))
+            ->map(fn ($segment) => Str::kebab($segment))
             ->implode('.');
 
         $stub = str_replace('[component-name]', $componentName, $stub);
@@ -431,13 +433,13 @@ class MakeCommand extends Command
 
     protected function getStubPath(string $stub): string
     {
-        $customPath = $this->laravel->basePath('stubs/' . $stub);
+        $customPath = $this->laravel->basePath('stubs/'.$stub);
 
         if ($this->files->exists($customPath)) {
             return $customPath;
         }
 
-        return __DIR__ . '/' . $stub;
+        return __DIR__.'/'.$stub;
     }
 
     protected function ensureDirectoryExists(string $path): void
@@ -454,9 +456,13 @@ class MakeCommand extends Command
         // e.g., resource_path('views/not-livewire') => 'not-livewire'
         $viewsPath = resource_path('views');
 
+        if ($viewPath === $viewsPath) {
+            return '';
+        }
+
         // Remove the base views path to get the relative path
-        $relativePath = str_replace($viewsPath . DIRECTORY_SEPARATOR, '', $viewPath);
-        $relativePath = str_replace($viewsPath . '/', '', $relativePath);
+        $relativePath = str_replace($viewsPath.DIRECTORY_SEPARATOR, '', $viewPath);
+        $relativePath = str_replace($viewsPath.'/', '', $relativePath);
 
         // Convert directory separators to dots for the namespace
         return str_replace(['/', '\\'], '.', $relativePath);
@@ -499,7 +505,7 @@ class MakeCommand extends Command
                 $componentName = str_replace(['⚡', '⚡︎', '⚡️'], '', $componentName);
             }
 
-            $testPath = $mfcPath . '/' . $componentName . '.test.php';
+            $testPath = $mfcPath.'/'.$componentName.'.test.php';
 
             if ($this->files->exists($testPath)) {
                 $this->components->error('Test file already exists.');

--- a/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
@@ -855,4 +855,47 @@ class MakeCommandUnitTest extends \Tests\TestCase
         // Ensure no component was created in the fallback location
         $this->assertFalse(File::exists($this->livewireComponentsPath('admin/⚡users.blade.php')));
     }
+
+    public function test_class_based_component_uses_class_namespace_from_config()
+    {
+        $this->app['config']->set('livewire.class_namespace', 'App\\Components');
+        $this->app[Kernel::class]->call('make:livewire', ['name' => 'foo', '--class' => true]);
+
+        // File is still created in default path, but namespace in content uses config
+        $classContent = File::get($this->livewireClassesPath('Foo.php'));
+
+        $this->assertStringContainsString('namespace App\Components;', $classContent);
+    }
+
+    public function test_class_based_component_with_views_as_root_path_has_correct_view_name()
+    {
+        // Set view_path to root views folder (not a subdirectory like views/livewire)
+        $this->app['config']->set('livewire.view_path', resource_path('views'));
+        $this->app[Kernel::class]->call('make:livewire', ['name' => 'foo', '--class' => true]);
+
+        $classContent = File::get($this->livewireClassesPath('Foo.php'));
+
+        // Should be view('foo') not view('.foo') or an absolute path
+        $this->assertStringContainsString("view('foo')", $classContent);
+        $this->assertStringNotContainsString("view('.foo')", $classContent);
+
+        // Ensure view is created in root views folder
+        $this->assertTrue(File::exists(resource_path('views/foo.blade.php')));
+    }
+
+    public function test_class_based_nested_component_with_views_as_root_path_has_correct_view_name()
+    {
+        // Set view_path to root views folder
+        $this->app['config']->set('livewire.view_path', resource_path('views'));
+        $this->app[Kernel::class]->call('make:livewire', ['name' => 'admin.dashboard', '--class' => true]);
+
+        $classContent = File::get($this->livewireClassesPath('Admin/Dashboard.php'));
+
+        // Should be view('admin.dashboard') not view('.admin.dashboard')
+        $this->assertStringContainsString("view('admin.dashboard')", $classContent);
+        $this->assertStringNotContainsString("view('.admin.dashboard')", $classContent);
+
+        // Ensure view is created in correct location
+        $this->assertTrue(File::exists(resource_path('views/admin/dashboard.blade.php')));
+    }
 }


### PR DESCRIPTION
The Livewire class-based component was incorrectly loading the view using an absolute filesystem path.
This has been fixed by using the proper relative view path, as required by Laravel, ensuring correct component rendering across environments.
```php artisan livewire:make teste --class```

<img width="488" height="86" alt="image" src="https://github.com/user-attachments/assets/79efd001-c4bb-453c-95db-9d859c677216" />


And also fixed how the Livewire config namespace is resolved.
The namespace was previously hardcoded `(App\\Livewire)` and is now correctly retrieved from the `livewire.class_namespace` config value, with a fallback to the default.
