### PR TITLE
fix: Target class [Livewire\Mechanisms\ComponentRegistry] does not exist.

### DIFF
--- a/src/Mechanisms/ComponentRegistry.php
+++ b/src/Mechanisms/ComponentRegistry.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Livewire\Mechanisms;
+
+use Livewire\Component;
+use Livewire\Exceptions\ComponentNotFoundException;
+
+class ComponentRegistry extends Mechanism
+{
+    protected $missingComponentResolvers = [];
+    protected $nonAliasedClasses = [];
+    protected $aliases = [];
+
+    function component($name, $class = null)
+    {
+        if (is_null($class)) {
+            $this->nonAliasedClasses[] = $name;
+        } else {
+            $this->aliases[$name] = $class;
+        }
+    }
+
+    function new($nameOrClass, $id = null)
+    {
+        [$class, $name] = $this->getNameAndClass($nameOrClass);
+
+        $component = new $class;
+
+        $component->setId($id ?: str()->random(20));
+
+        $component->setName($name);
+
+        // // Parameters passed in automatically set public properties by the same name...
+        // foreach ($params as $key => $value) {
+        //     if (! property_exists($component, $key)) continue;
+
+        //     // Typed properties shouldn't be set back to "null". It will throw an error...
+        //     if ((new \ReflectionProperty($component, $key))->getType() && is_null($value)) continue;
+
+        //     $component->$key = $value;
+        // }
+
+        return $component;
+    }
+
+    function isDiscoverable($classOrName)
+    {
+        if (is_object($classOrName)) {
+            $classOrName = get_class($classOrName);
+        }
+
+        if (class_exists($name = $classOrName)) {
+            $name = $this->generateNameFromClass($classOrName);
+        }
+
+        $class = $this->generateClassFromName($name);
+
+        if (class_exists($class) && is_subclass_of($class, Component::class)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    function getName($nameOrClassOrComponent)
+    {
+        [$class, $name] = $this->getNameAndClass($nameOrClassOrComponent);
+
+        return $name;
+    }
+
+    function getClass($nameOrClassOrComponent)
+    {
+        [$class, $name] = $this->getNameAndClass($nameOrClassOrComponent);
+
+        return $class;
+    }
+
+    function resolveMissingComponent($resolver)
+    {
+        $this->missingComponentResolvers[] = $resolver;
+    }
+
+    protected function getNameAndClass($nameComponentOrClass)
+    {
+        // If a component itself was passed in, just take the class name...
+        $nameOrClass = is_object($nameComponentOrClass) ? $nameComponentOrClass::class : $nameComponentOrClass;
+
+        // If a component class was passed in, use that...
+        if (class_exists($nameOrClass)) {
+            $class = $nameOrClass;
+        // Otherwise, assume it was a simple name...
+        } else {
+            $class = $this->nameToClass($nameOrClass);
+
+            // If class can't be found, see if there is an index component in a subfolder...
+            if(! class_exists($class)) {
+                $class = $class . '\\Index';
+            }
+
+            if(! class_exists($class)) {
+                foreach ($this->missingComponentResolvers as $resolve) {
+                    if ($resolved = $resolve($nameOrClass)) {
+                        $this->component($nameOrClass, $resolved);
+
+                        $class = $this->aliases[$nameOrClass];
+
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Now that we have a class, we can check that it's actually a Livewire component...
+        if (! is_subclass_of($class, Component::class)) {
+            throw new ComponentNotFoundException(
+                "Unable to find component: [{$nameOrClass}]"
+            );
+        }
+
+        // Convert it to a name even if a name was passed in to make sure we're using deterministic names...
+        $name = $this->classToName($class);
+
+        return [$class, $name];
+    }
+
+    protected function nameToClass($name)
+    {
+        // Check the aliases...
+        if (isset($this->aliases[$name])) {
+            if (is_object($this->aliases[$name])) return $this->aliases[$name]::class;
+
+            return $this->aliases[$name];
+        }
+
+        // Hash check the non-aliased classes...
+        foreach ($this->nonAliasedClasses as $class) {
+            if (crc32($class) === $name) {
+                return $class;
+            }
+        }
+
+        // Reverse generate a class from a name...
+        return $this->generateClassFromName($name);
+    }
+
+    protected function classToName($class)
+    {
+        // Check the aliases...
+        $resolvedAliases = array_map(fn ($i) => is_object($i) ? get_class($i) : $i, $this->aliases);
+
+        if ($name = array_search($class, $resolvedAliases)) return $name;
+
+        // Check existance in non-aliased classes and hash...
+        foreach ($this->nonAliasedClasses as $oneOff) {
+            if (crc32($oneOff) === $hash = crc32($class)) {
+                return $hash;
+            }
+        }
+
+        // Generate name from class...
+        return $this->generateNameFromClass($class);
+    }
+
+    protected function generateClassFromName($name)
+    {
+        $rootNamespace = config('livewire.class_namespace');
+
+        $class = collect(str($name)->explode('.'))
+            ->map(fn ($segment) => (string) str($segment)->studly())
+            ->join('\\');
+
+        if (empty($rootNamespace)) {
+            return $class;
+        }
+
+        return '\\' . $rootNamespace . '\\' . $class;
+    }
+
+    protected function generateNameFromClass($class)
+    {
+        $namespace = str_replace(
+            ['/', '\\'],
+            '.',
+            trim(trim(config('livewire.class_namespace')), '\\')
+        );
+
+        $class = str_replace(
+            ['/', '\\'],
+            '.',
+            trim(trim($class, '/'), '\\')
+        );
+
+        $namespace = collect(explode('.', $namespace))
+            ->map(fn ($i) => \Illuminate\Support\Str::kebab($i))
+            ->implode('.');
+
+        $fullName = str(collect(explode('.', $class))
+            ->map(fn ($i) => \Illuminate\Support\Str::kebab($i))
+            ->implode('.'));
+
+        if ($fullName->startsWith('.')) {
+            $fullName = $fullName->substr(1);
+        }
+
+        // If using an index component in a sub folder, remove the '.index' so the name is the subfolder name...
+        if ($fullName->endsWith('.index')) {
+            $fullName = $fullName->replaceLast('.index', '');
+        }
+
+        if ($fullName->startsWith($namespace)) {
+            return (string) $fullName->substr(strlen($namespace) + 1);
+        }
+
+        return (string) $fullName;
+    }
+}

--- a/src/Mechanisms/Tests/ComponentRegistryUnitTest.php
+++ b/src/Mechanisms/Tests/ComponentRegistryUnitTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Livewire\Mechanisms\Tests;
+
+use Livewire\Livewire;
+use Livewire\Exceptions\ComponentNotFoundException;
+use Livewire\Exceptions\MethodNotFoundException;
+
+class ComponentRegistryUnitTest extends \Tests\TestCase
+{
+    public function test_calling_nonexistent_method_throws_method_not_found_exception_not_component_not_found()
+    {
+        $this->expectException(MethodNotFoundException::class);
+        $this->expectExceptionMessage('Public method [nonExistentMethod] not found on component');
+
+        Livewire::test(ComponentRegistryTestComponent::class)
+            ->call('nonExistentMethod');
+    }
+
+    public function test_component_can_be_instantiated_successfully()
+    {
+        $component = Livewire::test(ComponentRegistryTestComponent::class);
+
+        $component->assertSee('Component Registry Test');
+    }
+
+    public function test_calling_existing_method_works()
+    {
+        $component = Livewire::test(ComponentRegistryTestComponent::class);
+
+        $component->call('existingMethod')
+            ->assertSet('called', true);
+    }
+}
+
+class ComponentRegistryTestComponent extends \Livewire\Component
+{
+    public $called = false;
+
+    public function existingMethod()
+    {
+        $this->called = true;
+    }
+
+    public function render()
+    {
+        return app('view')->make('show-name', [
+            'name' => 'Component Registry Test',
+        ]);
+    }
+}


### PR DESCRIPTION
This is my first PR 😁

1️⃣ I don't know if it is something is that you wanted, because I don't know if ComponentRegistry was accidentally deleted, but it is required in Livewire 4 when it throws an error when a method doesn't exists.

2️⃣ Yes, I've created fix-component-registry branch

3️⃣ It doesn't contains unrelated changes

4️⃣ Yep, it includes tests!

5️⃣ Steps to reproduce:


```bash
php artisan livewire:make my.component
```

my/component.blade.php:

```blade
<button wire:click="notExists">
  Click me
</button>
```

Current output:

```
[ReflectionException] > [BindingResolutionException]

Target class [Livewire\Mechanisms\ComponentRegistry] does not exist.
```

So, I bringed back the file.

Fixed output:

```
Unable to call component method. Public method [notExists] not found on component
```