### PR TITLE
Add Volt route and test migration steps to upgrade guide

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -466,12 +466,12 @@ Replace all instances of `Livewire\Volt\Volt` with `Livewire\Livewire` and chang
 // Before (Volt)
 use Livewire\Volt\Volt;
 
-Volt::test('counter')...
+Volt::test('counter')
 
 // After (Livewire v4)
 use Livewire\Livewire;
 
-Livewire::test('counter')...
+Livewire::test('counter')
 ```
 
 ### Remove Volt service provider

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -442,6 +442,42 @@ use Livewire\Component;
 new class extends Component { ... }
 ```
 
+### Update route definitions
+
+Replace `Volt::route()` with `Route::livewire()` in your routes files:
+
+```php
+// Before (Volt)
+use Livewire\Volt\Volt;
+
+Volt::route('/dashboard', 'dashboard');
+
+// After (Livewire v4)
+use Illuminate\Support\Facades\Route;
+
+Route::livewire('/dashboard', 'dashboard');
+```
+
+### Update test files
+
+Replace all instances of `Livewire\Volt\Volt` with `Livewire\Livewire` and change `Volt::test()` to `Livewire::test()`:
+
+```php
+// Before (Volt)
+use Livewire\Volt\Volt;
+
+Volt::test('counter')
+    ->call('increment')
+    ->assertSee('1');
+
+// After (Livewire v4)
+use Livewire\Livewire;
+
+Livewire::test('counter')
+    ->call('increment')
+    ->assertSee('1');
+```
+
 ### Remove Volt service provider
 
 Delete the Volt service provider file:

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -466,16 +466,12 @@ Replace all instances of `Livewire\Volt\Volt` with `Livewire\Livewire` and chang
 // Before (Volt)
 use Livewire\Volt\Volt;
 
-Volt::test('counter')
-    ->call('increment')
-    ->assertSee('1');
+Volt::test('counter')...
 
 // After (Livewire v4)
 use Livewire\Livewire;
 
-Livewire::test('counter')
-    ->call('increment')
-    ->assertSee('1');
+Livewire::test('counter')...
 ```
 
 ### Remove Volt service provider


### PR DESCRIPTION
# The Scenario

A developer is migrating from Volt to native Livewire v4 single-file components. They follow the upgrade guide and update their component imports, remove the Volt service provider, and uninstall the package. However, their application breaks because they also have:

- Routes using `Volt::route()` 
- Tests using `Volt::test()`

These weren't mentioned in the upgrade guide.

# The Problem

The "Upgrading Volt" section of the upgrade guide was missing two important migration steps:

1. Route definitions using `Volt::route()` need to be changed to `Route::livewire()`
2. Test files using `Livewire\Volt\Volt` and `Volt::test()` need to be updated to use `Livewire\Livewire` and `Livewire::test()`

# The Solution

Add two new subsections to the "Upgrading Volt" section documenting these changes with clear before/after code examples.

Fixes: https://github.com/livewire/livewire/discussions/9738