### PR TITLE
Fix single-file components with 10+ islands breaking

### DIFF
--- a/src/Compiler/Parser/Parser.php
+++ b/src/Compiler/Parser/Parser.php
@@ -11,7 +11,9 @@ class Parser
         $replacements = [];
 
         $contents = preg_replace_callback($islandsPattern, function($matches) use (&$replacements) {
-            $key = 'ISLANDREPLACEMENT:' . count($replacements);
+            // Use brackets around the number to prevent substring matching issues
+            // e.g. "ISLANDREPLACEMENT:[1]" won't match as part of "ISLANDREPLACEMENT:[10]"
+            $key = 'ISLANDREPLACEMENT:[' . count($replacements) . ']';
 
             $replacements[$key] = $matches[0];
 

--- a/src/Features/SupportIslands/BrowserTest.php
+++ b/src/Features/SupportIslands/BrowserTest.php
@@ -7,6 +7,13 @@ use Livewire\Livewire;
 
 class BrowserTest extends BrowserTestCase
 {
+    public static function tweakApplicationHook()
+    {
+        return function () {
+            app('livewire.finder')->addLocation(viewPath: __DIR__ . '/fixtures');
+        };
+    }
+
     public function test_island_directive()
     {
         Livewire::visit([new class extends \Livewire\Component {
@@ -750,6 +757,25 @@ class BrowserTest extends BrowserTestCase
             ->waitForLivewire()->click('@increment')
             // Now the island should show the updated count (including the renderless increment)...
             ->assertSeeIn('@island-count', 'Count: 3')
+            ;
+    }
+
+    public function test_more_than_ten_islands_using_single_file_component()
+    {
+        Livewire::visit('twelve-islands')
+            ->assertSee('island test 1')
+            ->assertSee('island test 2')
+            ->assertSee('island test 3')
+            ->assertSee('island test 4')
+            ->assertSee('island test 5')
+            ->assertSee('island test 6')
+            ->assertSee('island test 7')
+            ->assertSee('island test 8')
+            ->assertSee('island test 9')
+            ->assertSee('island test 10')
+            ->assertSee('island test 11')
+            ->assertDontSee('STARTISLAND')
+            ->assertDontSee('ENDISLAND')
             ;
     }
 }

--- a/src/Features/SupportIslands/fixtures/twelve-islands.blade.php
+++ b/src/Features/SupportIslands/fixtures/twelve-islands.blade.php
@@ -1,0 +1,57 @@
+<?php
+
+new class extends Livewire\Component {
+    public int $count = 0;
+
+    public function increment()
+    {
+        $this->count++;
+    }
+};
+?>
+
+<div>
+    @island
+    island test 1
+    @endisland
+
+    @island
+    island test 2
+    @endisland
+
+    @island
+    island test 3
+    @endisland
+
+    @island
+    island test 4
+    @endisland
+
+    @island
+    island test 5
+    @endisland
+
+    @island
+    island test 6
+    @endisland
+
+    @island
+    island test 7
+    @endisland
+
+    @island
+    island test 8
+    @endisland
+
+    @island
+    island test 9
+    @endisland
+
+    @island
+    island test 10
+    @endisland
+
+    @island
+    island test 11
+    @endisland
+</div>


### PR DESCRIPTION
# The Scenario

When using more than 10 `@island` directives in a single-file Livewire component, the rendered output becomes corrupted with internal placeholder markers appearing in the HTML:

```php
<?php

new class extends Livewire\Component {
    public int $count = 0;
};
?>

<div>
    @island
    island test 1
    @endisland

    @island
    island test 2
    @endisland

    <!-- ... islands 3-10 ... -->

    @island
    island test 11
    @endisland
</div>
```

Output with 11 islands:

```
[STARTISLAND:1:1]() island test 1 [ENDISLAND:1] [STARTISLAND:2:1]() island test 2 [ENDISLAND:1] [STARTISLAND:3:1]() island test 3 [ENDISLAND:1] [STARTISLAND:4:1]() island test 4 [ENDISLAND:1] [STARTISLAND:5:1]() island test 5 [ENDISLAND:1] [STARTISLAND:6:1]() island test 6 [ENDISLAND:1] [STARTISLAND:7:1]() island test 7 [ENDISLAND:1] [STARTISLAND:8:1]() island test 8 [ENDISLAND:1] [STARTISLAND:9:1]() island test 9 [ENDISLAND:1] [STARTISLAND:10:1]() island test 10 [ENDISLAND:1] [STARTISLAND:11:1]() island test 2 @endisland0
```

# The Problem

In `src/Compiler/Parser/Parser.php`, the `extractPlaceholderPortion` method temporarily replaces `@island...@endisland` blocks with placeholder keys during parsing:

```php
$key = 'ISLANDREPLACEMENT:' . count($replacements);
// Creates: ISLANDREPLACEMENT:0, ISLANDREPLACEMENT:1, ..., ISLANDREPLACEMENT:10
```

When restoring these placeholders using `str_replace`, the key `ISLANDREPLACEMENT:1` is a **substring** of `ISLANDREPLACEMENT:10`. So when replacing `ISLANDREPLACEMENT:1` with its content, it also corrupts `ISLANDREPLACEMENT:10`:

```
ISLANDREPLACEMENT:10 → [content of island 2]0
```

This causes the island markers to never be properly replaced, leaving the internal `[STARTISLAND:...]` markers in the output.

# The Solution

Changed the placeholder key format to use brackets around the number, ensuring no key can be a substring of another:

```php
$key = 'ISLANDREPLACEMENT:[' . count($replacements) . ']';
// Creates: ISLANDREPLACEMENT:[0], ISLANDREPLACEMENT:[1], ..., ISLANDREPLACEMENT:[10]
```

Now `ISLANDREPLACEMENT:[1]` cannot match as part of `ISLANDREPLACEMENT:[10]`.

Fixes: https://github.com/livewire/livewire/discussions/9740