### PR TITLE
Fix `_livewire_component` parameter leaking into URL during SPA navigation

### DIFF
--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -244,7 +244,7 @@ class SupportPageComponents extends ComponentHook
 
             // Case 2: Route::livewire macro usage (via LivewirePageController)
             if (str($uses)->contains(LivewirePageController::class)) {
-                $component = $route->defaults['_livewire_component'] ?? null;
+                $component = $action['livewire_component'] ?? null;
 
                 if (! $component) return false;
 

--- a/src/Features/SupportRouting/LivewirePageController.php
+++ b/src/Features/SupportRouting/LivewirePageController.php
@@ -6,7 +6,7 @@ class LivewirePageController
 {
     public function __invoke()
     {
-        $component = request()->route()->defaults['_livewire_component'];
+        $component = request()->route()->action['livewire_component'];
 
         $instance = is_object($component)
             ? $component

--- a/src/Features/SupportRouting/SupportRouting.php
+++ b/src/Features/SupportRouting/SupportRouting.php
@@ -14,8 +14,9 @@ class SupportRouting extends ComponentHook
                 app('livewire')->addComponent($component);
             }
 
-            return Route::get($uri, LivewirePageController::class)
-                ->defaults('_livewire_component', $component);
+            return tap(Route::get($uri, LivewirePageController::class), function ($route) use ($component) {
+                $route->action['livewire_component'] = $component;
+            });
         });
     }
 }


### PR DESCRIPTION
# The Scenario

When using the `Route::livewire()` macro for full-page components, an internal route parameter leaks into browser URLs during SPA-style navigation:

```php
Route::livewire('/products', 'pages::products.index')->name('products.index');
```

After navigating with `wire:navigate`, the URL becomes:

```
https://example.com/products?_livewire_component=pages::products.index
```

Instead of the expected:

```
https://example.com/products
```

# The Problem

The `Route::livewire()` macro was storing the component name using Laravel's route defaults mechanism:

```php
return Route::get($uri, LivewirePageController::class)
    ->defaults('_livewire_component', $component);
```

Route defaults are designed for default URL parameter values, which means they can be included in URL generation. During SPA navigation, when Livewire fetches the new page and uses `response.url` to update the browser history, this internal parameter was being exposed.

# The Solution

Store the component in the route's action array instead of route defaults:

```php
return tap(Route::get($uri, LivewirePageController::class), function ($route) use ($component) {
    $route->action['livewire_component'] = $component;
});
```

The action array is used for route configuration metadata (like route names, middleware, etc.) and is not involved in URL generation, so the parameter can never leak into URLs.

Fixes: https://github.com/livewire/livewire/discussions/9743