### PR TITLE
Fix trait mount hooks not receiving route parameters

### DIFF
--- a/src/Features/SupportLifecycleHooks/UnitTest.php
+++ b/src/Features/SupportLifecycleHooks/UnitTest.php
@@ -57,6 +57,33 @@ class UnitTest extends \Tests\TestCase
             ->assertSetStrict('memo', 'boottraitboottraitinitializehydratebootedtraitbooted');
     }
 
+    public function test_trait_mount_hooks_receive_parameters_not_declared_in_component_mount()
+    {
+        // This test ensures that trait mount hooks can receive parameters
+        // even if the component's mount() method doesn't declare them.
+        // This is important for route-model binding scenarios where
+        // a trait's mountMyTrait(Post $post) should receive the Post
+        // without the component's mount() needing to also declare it.
+        $component = Livewire::test(ComponentWithTraitMountParameter::class, [
+            'foo' => 'value-for-foo',
+            'bar' => 'value-for-bar',
+        ]);
+
+        $this->assertSame('value-for-foo', $component->foo);
+        $this->assertSame('value-for-bar', $component->bar);
+    }
+
+    public function test_trait_mount_hooks_receive_parameters_when_component_has_no_mount()
+    {
+        // This test ensures that trait mount hooks receive parameters
+        // even when the component has no mount() method at all.
+        $component = Livewire::test(ComponentWithoutMountButTraitMountParameter::class, [
+            'traitParam' => 'trait-value',
+        ]);
+
+        $this->assertSame('trait-value', $component->traitParam);
+    }
+
     public function test_boot_method_supports_dependency_injection()
     {
         Livewire::test(ComponentWithBootMethodDI::class)
@@ -616,4 +643,45 @@ class ForLifecycleHooks extends TestComponent
     {
         $this->lifecycles['rendered']++;
     }
+}
+
+trait TraitWithMountParameter
+{
+    public $bar;
+
+    public function mountTraitWithMountParameter($bar)
+    {
+        $this->bar = $bar;
+    }
+}
+
+class ComponentWithTraitMountParameter extends TestComponent
+{
+    use TraitWithMountParameter;
+
+    public $foo;
+
+    // Note: mount() only declares $foo, not $bar
+    // $bar should still be passed to the trait's mountTraitWithMountParameter($bar)
+    public function mount($foo)
+    {
+        $this->foo = $foo;
+    }
+}
+
+trait TraitWithMountParameterNoComponentMount
+{
+    public $traitParam;
+
+    public function mountTraitWithMountParameterNoComponentMount($traitParam)
+    {
+        $this->traitParam = $traitParam;
+    }
+}
+
+class ComponentWithoutMountButTraitMountParameter extends TestComponent
+{
+    use TraitWithMountParameterNoComponentMount;
+
+    // No mount() method - trait should still receive its parameter
 }


### PR DESCRIPTION
# The Scenario

Trait mount hooks should receive route-model bound parameters without the component needing to redeclare them:

```php
trait WithPost
{
    public Post $post;

    public function mountWithPost(Post $post)
    {
        $this->post = $post;
    }
}

class ShowPost extends Component
{
    use WithPost;

    public function mount()
    {
        // Component does not need $post directly
    }
}
```

```php
Route::get(/posts/{post}, ShowPost::class);
```

This worked in v3. In v4, the trait hook no longer receives the parameter unless the component also declares it:

```php
// v4 workaround - declaring unused parameter just to pass it through
public function mount(Post $post): void
{
}
```

# The Problem

The `separateParamsAndAttributes()` method filters incoming parameters, keeping only those matching:
1. Component public properties
2. Parameters declared in the component `mount()` method signature
3. Numeric keys

The `getMountMethodParameters()` method only inspected the component own `mount()` method - it had no awareness of trait mount hooks like `mountWithPost()`, so their parameters were filtered out before reaching those hooks.

# The Solution

Modified `getMountMethodParameters()` to also scan trait mount hook parameters. The method now:

1. Gets parameters from the component own `mount()` method (if it exists)
2. Uses `class_uses_recursive()` to find all traits used by the component
3. For each trait, checks if a `mount{TraitName}` method exists
4. If so, adds that method parameters to the allowed list
5. Returns unique parameter names to avoid duplicates

This ensures route parameters are preserved and passed through to trait mount hooks even when the component `mount()` method does not explicitly declare them.

Fixes: #9769