### PR TITLE
Fix headers added via request hook not being sent with requests

### DIFF
--- a/js/request/index.js
+++ b/js/request/index.js
@@ -276,9 +276,13 @@ function sendMessages() {
             }
         })
 
+        let cachedOptions = null
+
         Object.defineProperty(request, 'options', {
             get() {
-                return {
+                if (cachedOptions) return cachedOptions
+
+                cachedOptions = {
                     method: 'POST',
                     body: JSON.stringify(request.payload),
                     headers: {
@@ -287,6 +291,8 @@ function sendMessages() {
                     },
                     signal: request.controller.signal,
                 }
+
+                return cachedOptions
             }
         })
     })


### PR DESCRIPTION
# The Scenario

When using Laravel Echo with Livewire v4, calling `broadcast()->toOthers()` no longer excludes the current user from receiving the broadcast. All users receive it—including the one who triggered it.

```php
<?php

use Livewire\Component;
use App\Events\OrderUpdated;

class OrderManager extends Component
{
    public $orderId;
    
    public function updateStatus($status)
    {
        Order::find($this->orderId)->update(['status' => $status]);
        
        // This should notify OTHER browser tabs/users, not the current one
        broadcast(new OrderUpdated($this->orderId))->toOthers();
    }
}
```

This is a regression from Livewire v3 where `toOthers()` worked as expected.

# The Problem

Laravel Echo identifies the current user's connection via the `X-Socket-ID` header. This header is added by Livewire's Echo support (`js/features/supportLaravelEcho.js`):

```js
on('request', ({ options }) => {
    if (window.Echo) {
        options.headers['X-Socket-ID'] = window.Echo.socketId()
    }
})
```

The `request` event is triggered in `js/request/legacy.js`:

```js
trigger('request', {
    url: request.uri,
    options: request.options,  // <-- Getter returns Object A
    // ...
})
```

Later, the actual fetch happens in `js/request/index.js`:

```js
let responsePromise = fetch(request.uri, request.options)  // <-- Getter returns Object B
```

The problem is that `request.options` was defined as a getter returning a **new object every call**:

```js
Object.defineProperty(request, 'options', {
    get() {
        return {  // <-- New object every time
            method: 'POST',
            body: JSON.stringify(request.payload),
            headers: { ... },
            signal: request.controller.signal,
        }
    }
})
```

So the Echo hook modifies Object A, but `fetch()` receives Object B—without the `X-Socket-ID` header.

# The Solution

Cache the options object on first access:

```js
let cachedOptions = null

Object.defineProperty(request, 'options', {
    get() {
        if (cachedOptions) return cachedOptions

        cachedOptions = {
            method: 'POST',
            body: JSON.stringify(request.payload),
            headers: { ... },
            signal: request.controller.signal,
        }

        return cachedOptions
    }
})
```

Now the same object is returned on every access, so headers added by hooks persist to `fetch()`.

Fixes: https://github.com/livewire/livewire/discussions/9749