### PR TITLE
Fix redirect to component class when using Route::livewire()

### DIFF
--- a/src/Features/SupportRedirects/SupportRedirects.php
+++ b/src/Features/SupportRedirects/SupportRedirects.php
@@ -2,7 +2,9 @@
 
 namespace Livewire\Features\SupportRedirects;
 
+use Illuminate\Support\Facades\Route;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
+use Livewire\Features\SupportRouting\LivewirePageController;
 use Livewire\ComponentHook;
 use Livewire\Component;
 use function Livewire\on;
@@ -52,7 +54,7 @@ class SupportRedirects extends ComponentHook
         $usingNavigate = $this->storeGet('redirectUsingNavigate');
 
         if (is_subclass_of($to, Component::class)) {
-            $to = url()->action($to);
+            $to = static::resolveComponentUrl($to);
         }
 
         if ($to && ! app(HandleRequests::class)->isLivewireRequest()) {
@@ -67,5 +69,40 @@ class SupportRedirects extends ComponentHook
         if (! $context->isMounting()) {
             static::$atLeastOneMountedComponentHasRedirected = true;
         }
+    }
+
+    public static function resolveComponentUrl(string $componentClass): string
+    {
+        // First try using Laravel's action URL resolver (works when component is registered directly on route)
+        try {
+            return url()->action($componentClass);
+        } catch (\InvalidArgumentException $e) {
+            // Component wasn't registered directly as a route action, continue to search routes
+        }
+
+        // Search through all routes to find one that uses this component via Route::livewire()
+        foreach (Route::getRoutes() as $route) {
+            $uses = $route->action['uses'] ?? null;
+
+            if (! is_string($uses)) continue;
+
+            // Check if this route uses LivewirePageController (indicates Route::livewire() was used)
+            if (str_contains($uses, LivewirePageController::class)) {
+                $routeComponent = $route->defaults['_livewire_component'] ?? null;
+
+                if (! $routeComponent) continue;
+
+                // Resolve the component class name (handles both class strings and component names)
+                $resolvedClass = is_string($routeComponent) && class_exists($routeComponent)
+                    ? $routeComponent
+                    : app('livewire.factory')->resolveComponentClass($routeComponent);
+
+                if ($resolvedClass === $componentClass) {
+                    return url($route->uri());
+                }
+            }
+        }
+
+        throw new \InvalidArgumentException("Unable to resolve URL for Livewire component [{$componentClass}]. Make sure the component is registered as a route.");
     }
 }

--- a/src/Features/SupportRedirects/TestsRedirects.php
+++ b/src/Features/SupportRedirects/TestsRedirects.php
@@ -11,7 +11,7 @@ trait TestsRedirects
     public function assertRedirect($uri = null)
     {
         if (is_subclass_of($uri, Component::class)) {
-            $uri = url()->action($uri);
+            $uri = SupportRedirects::resolveComponentUrl($uri);
         }
 
         if (! app('livewire')->isLivewireRequest()) {
@@ -36,7 +36,7 @@ trait TestsRedirects
     public function assertRedirectContains($uri)
     {
         if (is_subclass_of($uri, Component::class)) {
-            $uri = url()->action($uri);
+            $uri = SupportRedirects::resolveComponentUrl($uri);
         }
 
         if (! app('livewire')->isLivewireRequest()) {

--- a/src/Features/SupportRedirects/UnitTest.php
+++ b/src/Features/SupportRedirects/UnitTest.php
@@ -70,6 +70,21 @@ class UnitTest extends \Tests\TestCase
         ->assertRedirect('/test');
     }
 
+    public function test_can_redirect_to_component_registered_with_route_livewire_macro()
+    {
+        Route::livewire('/dashboard', TriggersRedirectStub::class);
+
+        Livewire::test(new class extends TestComponent {
+            function triggerRedirect()
+            {
+                $this->redirect(TriggersRedirectStub::class, navigate: true);
+            }
+        })
+        ->call('triggerRedirect')
+        ->assertRedirect(TriggersRedirectStub::class)
+        ->assertRedirect('/dashboard');
+    }
+
     public function test_redirect_helper()
     {
         $component = Livewire::test(TriggersRedirectStub::class);


### PR DESCRIPTION
# The Scenario

When using `Route::livewire()` to register a full-page component and then attempting to redirect to that component using its class name, the redirect fails with an error.

```php
// routes/web.php
Route::livewire('/dashboard', Dashboard::class)->name('dashboard');
```

```php
<?php

use Livewire\Component;

class CreatePost extends Component
{
    public function save()
    {
        // Save logic...

        $this->redirect(Dashboard::class, navigate: true);
    }
}
?>

<form wire:submit="save">
    <!-- form fields -->
    <button type="submit">Save</button>
</form>
```

The redirect throws: `InvalidArgumentException: Action App\Livewire\Dashboard not defined.`

# The Problem

When redirecting to a component class, the code uses Laravel's `url()->action()` to resolve the class to a URL. This works when the component is registered directly on a route (`Route::get('/dashboard', Dashboard::class)`), but fails when using `Route::livewire()`.

The `Route::livewire()` macro registers `LivewirePageController` as the route action and stores the component in a route default parameter (`_livewire_component`). Since the component class isn't the actual route action, `url()->action()` can't find it.

# The Solution

Added a `resolveComponentUrl()` method that first tries Laravel's `url()->action()` (for directly registered components), and if that fails, searches through all routes to find one using `LivewirePageController` where the `_livewire_component` default matches the target component class.

Fixes: #9746