### PR TITLE
Fix cache directory permissions when clearing compiled files

### DIFF
--- a/src/Compiler/CacheManager.php
+++ b/src/Compiler/CacheManager.php
@@ -200,38 +200,8 @@ class CacheManager
 
     public function clearCompiledFiles($output = null): void
     {
-        try {
-            $cacheDirectory = $this->cacheDirectory;
-
-            if (is_dir($cacheDirectory)) {
-                // Count files before clearing for informative output
-                $totalFiles = 0;
-                foreach (['classes', 'views', 'scripts', 'styles', 'placeholders'] as $subdir) {
-                    $path = $cacheDirectory . '/' . $subdir;
-                    if (is_dir($path)) {
-                        $totalFiles += count(glob($path . '/*'));
-                    }
-                }
-
-                // Use the same cleanup approach as our clear command
-                File::deleteDirectory($cacheDirectory);
-
-                // Recreate the directory structure
-                File::makeDirectory($cacheDirectory . '/classes', 0755, true);
-                File::makeDirectory($cacheDirectory . '/views', 0755, true);
-                File::makeDirectory($cacheDirectory . '/scripts', 0755, true);
-                File::makeDirectory($cacheDirectory . '/styles', 0755, true);
-                File::makeDirectory($cacheDirectory . '/placeholders', 0755, true);
-
-                // Recreate .gitignore
-                File::put($cacheDirectory . '/.gitignore', "*\n!.gitignore");
-            }
-        } catch (\Exception $e) {
-            // Silently fail to avoid breaking view:clear if there's an issue
-            // But we can log it if output is available
-            if ($output && method_exists($output, 'writeln')) {
-                $output->writeln("<comment>1Note: Could not clear Livewire compiled files.</comment>");
-            }
+        if (is_dir($this->cacheDirectory)) {
+            File::deleteDirectory($this->cacheDirectory);
         }
     }
 }


### PR DESCRIPTION
# The Scenario

When running `artisan optimize:clear` (or `view:clear`) as a different user than the web server (e.g., running as `root` while Apache runs as `www-data`), the Livewire cache directory ends up with incorrect ownership, causing 500 errors on subsequent requests.

```php
// User runs as root during deployment
php artisan optimize:clear

// Web server (www-data) can no longer write to the cache directory
// Results in permission denied errors
```

# The Problem

The `clearCompiledFiles()` method in `CacheManager.php` was deleting the entire cache directory and then immediately recreating the directory structure:

```php
File::deleteDirectory($cacheDirectory);

// Recreate the directory structure
File::makeDirectory($cacheDirectory . '/classes', 0755, true);
File::makeDirectory($cacheDirectory . '/views', 0755, true);
// ... etc
```

This caused the recreated directories to be owned by whoever ran the command, rather than the web server user.

# The Solution

Simply delete the directory without recreating it. Livewire already has lazy directory creation via `File::ensureDirectoryExists()` in all write methods (`writeClassFile`, `writeViewFile`, etc.), so directories will be recreated with correct permissions on the next web request by the web server user.

```php
public function clearCompiledFiles($output = null): void
{
    if (is_dir($this->cacheDirectory)) {
        File::deleteDirectory($this->cacheDirectory);
    }
}
```

Fixes: https://github.com/livewire/livewire/discussions/9745