### PR TITLE
[4.x] Add package development documentation

### DIFF
--- a/docs/__nav.md
+++ b/docs/__nav.md
@@ -84,6 +84,7 @@ Advanced:
     CSP: { uri: /docs/4.x/csp, file: /csp.md }
     JavaScript: { uri: /docs/4.x/javascript, file: /javascript.md }
     Synthesizers: { uri: /docs/4.x/synthesizers, file: /synthesizers.md }
+    Package Development: { uri: /docs/4.x/packages, file: /packages.md }
     Contribution Guide: { uri: /docs/4.x/contribution-guide, file: /contribution-guide.md }
 Packages:
     Volt: { uri: /docs/4.x/volt, file: /volt.md }

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -59,3 +59,7 @@ public function render()
 ```blade
 <livewire:mypackage::counter />
 ```
+
+## File naming
+
+The ⚡ emoji prefix used in Livewire component filenames can cause issues with Composer when publishing packages. For package development, avoid using the bolt emoji in your component filenames—use `counter.blade.php` instead of `⚡counter.blade.php`.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,0 +1,61 @@
+To include Livewire components in a Laravel package, you'll need to register them in your package's service provider.
+
+## Single-file and multi-file components
+
+For single-file (SFC) and multi-file (MFC) components, use `addNamespace` in your service provider's `boot()` method:
+
+```php
+use Livewire\Livewire;
+
+public function boot(): void
+{
+    Livewire::addNamespace(
+        namespace: 'mypackage',
+        viewPath: __DIR__ . '/../resources/views/livewire',
+    );
+}
+```
+
+This registers all SFC and MFC components in your package's `resources/views/livewire` directory under the `mypackage` namespace.
+
+**Usage:**
+
+```blade
+<livewire:mypackage::counter />
+<livewire:mypackage::users.table />
+```
+
+## Class-based components
+
+For class-based components, you'll need to provide additional parameters and register your views with Laravel:
+
+```php
+use Livewire\Livewire;
+
+public function boot(): void
+{
+    Livewire::addNamespace(
+        namespace: 'mypackage',
+        classNamespace: 'MyVendor\\MyPackage\\Livewire',
+        classPath: __DIR__ . '/Livewire',
+        classViewPath: __DIR__ . '/../resources/views/livewire',
+    );
+
+    $this->loadViewsFrom(__DIR__ . '/../resources/views', 'my-package');
+}
+```
+
+Your component's `render()` method should reference the view using Laravel's package namespace syntax:
+
+```php
+public function render()
+{
+    return view('my-package::livewire.counter');
+}
+```
+
+**Usage:**
+
+```blade
+<livewire:mypackage::counter />
+```


### PR DESCRIPTION
# The Scenario

Developers building Laravel packages that include Livewire components are struggling to register their components correctly. They try various approaches documented in different places, but can't get their package components to work in consuming applications.

# The Problem

There's no dedicated documentation explaining how to register Livewire components from packages. The existing documentation covers programmatic registration for applications, but doesn't address the specific patterns needed for package development—particularly around namespacing and the differences between SFC/MFC and class-based components.

# The Solution

Add a dedicated "Package Development" documentation page under the Advanced section that covers:

- Registering single-file and multi-file components using `addNamespace`
- Registering class-based components with the additional parameters required
- When `loadViewsFrom` is needed (only for class-based components)

Fixes: https://github.com/livewire/livewire/discussions/9615
Fixes: https://github.com/livewire/livewire/discussions/9701
Fixes: https://github.com/livewire/livewire/discussions/9841