### PR TITLE
Add `Route::macro()` return type

### DIFF
--- a/src/Features/SupportRouting/SupportRouting.php
+++ b/src/Features/SupportRouting/SupportRouting.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportRouting;
 
+use Illuminate\Routing\Route as IlluminateRoute;
 use Illuminate\Support\Facades\Route;
 use Livewire\ComponentHook;
 
@@ -9,7 +10,7 @@ class SupportRouting extends ComponentHook
 {
     public static function provide()
     {
-        Route::macro('livewire', function ($uri, $component) {
+        Route::macro('livewire', function ($uri, $component): IlluminateRoute {
             if (is_object($component)) {
                 app('livewire')->addComponent($component);
             }


### PR DESCRIPTION
Adding the return types provides better support for larastan(phpstan), without it, you get the following phpstan error, phpstan: Cannot call method name() on mixed.