### PR TITLE
Escape script directive in docs

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -531,8 +531,8 @@ When a user clicks the heart button, the following sequence occurs:
 
 This provides instant visual feedback while ensuring the bookmark state is properly persisted.
 
-> [!warning] Class-based components need @script wrapper
-> The examples above use bare `<script>` tags, which work for single-file and multi-file components. If you're using class-based components, you must wrap your script tags with the `@script` directive:
+> [!warning] Class-based components need @@script wrapper
+> The examples above use bare `<script>` tags, which work for single-file and multi-file components. If you're using class-based components, you must wrap your script tags with the `@@script` directive:
 > ```blade
 > @@script
 > <script>


### PR DESCRIPTION
<img width="1432" height="737" alt="SCR-20260121-bgmz" src="https://github.com/user-attachments/assets/85797540-48d2-4092-bddd-c47335031724" />

```diff
- > [!warning] Class-based components need @script wrapper
+ > [!warning] Class-based components need @@script wrapper
- > ...you must wrap your script tags with the `@script` directive:
+ > ...you must wrap your script tags with the `@@script` directive:
```