### PR TITLE
Verify release token before checksum

### DIFF
--- a/src/Features/SupportReleaseTokens/SupportReleaseTokens.php
+++ b/src/Features/SupportReleaseTokens/SupportReleaseTokens.php
@@ -14,9 +14,9 @@ class SupportReleaseTokens extends ComponentHook
             $context->addMemo('release', ReleaseToken::generate($component));
         });
 
-        // Use `snapshot-verified` to run the check before any component properties are hydrated
-        // but after the snapshot has been verified to ensure it hasn't been tampered with...
-        on('snapshot-verified', function ($snapshot) {
+        // Verify the release token before verifying the snapshot checksum, as we don't want to trigger a checksum
+        // failure if the release token doesn't match as there may be intentional changes in the snapshot...
+        on('checksum.verify', function ($checksum, $snapshot) {
             ReleaseToken::verify($snapshot);
         });
     }

--- a/src/Features/SupportReleaseTokens/UnitTest.php
+++ b/src/Features/SupportReleaseTokens/UnitTest.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportReleaseTokens;
 use Livewire\Component;
 use Livewire\Exceptions\LivewireReleaseTokenMismatchException;
 use Livewire\Livewire;
+use Livewire\Mechanisms\HandleComponents\Checksum;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -61,6 +62,45 @@ class UnitTest extends \Tests\TestCase
 
         $component->refresh()
             ->assertStatus(419);
+    }
+
+    public function test_release_token_is_verified_before_checksum_so_old_snapshots_get_proper_error()
+    {
+        // This test simulates a request from an old browser session (pre-v3.7.1) where:
+        // 1. The snapshot contains memo.children (which old snapshots had)
+        // 2. The snapshot does NOT contain memo.release (which didn't exist)
+        // 3. The checksum was computed WITH memo.children (like old Livewire did)
+        //
+        // Since PR #9339, new Livewire strips memo.children before computing checksums,
+        // so an old snapshot's checksum would fail verification. However, we want users
+        // to see LivewireReleaseTokenMismatchException (prompting a refresh) instead of
+        // CorruptComponentPayloadException (which is confusing).
+        //
+        // The fix moves release token verification to the checksum.verify hook, which
+        // fires BEFORE the checksum comparison, ensuring the proper error is thrown...
+        $this->expectException(LivewireReleaseTokenMismatchException::class);
+
+        app('livewire')->component('component-with-release-token', ComponentWithReleaseToken::class);
+
+        // Build a snapshot WITHOUT memo.release (simulating pre-v3.7.1)
+        // but WITH memo.children (which old snapshots included)...
+        $snapshot = [
+            'memo' => [
+                'name' => 'component-with-release-token',
+                'id' => 'test-id',
+                'children' => ['child-1' => ['id' => 'child-1', 'tag' => 'div']],
+            ],
+            'data' => [],
+        ];
+
+        // Generate checksum WITH children included (like old Livewire did before PR #9339)...
+        $hashKey = app('encrypter')->getKey();
+        $snapshot['checksum'] = hash_hmac('sha256', json_encode($snapshot), $hashKey);
+
+        // When we verify this snapshot, the release token check should fire first
+        // (via checksum.verify hook) and throw LivewireReleaseTokenMismatchException,
+        // NOT CorruptComponentPayloadException from the checksum mismatch...
+        Checksum::verify($snapshot);
     }
 }
 

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -17,7 +17,11 @@ class HandleRequests extends Mechanism
     {
         // Only set it if another provider or routes file haven't already set it....
         app()->booted(function () {
-            if (! $this->updateRoute) {
+            // Check both instance state and router to handle cached routes scenario.
+            // When routes are cached and loaded, $this->updateRoute will be null but
+            // the route already exists in the router. This prevents duplicate registration
+            // which Laravel v12.29.0+ treats as an error.
+            if (! $this->updateRoute && ! $this->updateRouteExists()) {
                 app($this::class)->setUpdateRoute(function ($handle) {
                     return Route::post('/livewire/update', $handle)->middleware('web');
                 });
@@ -25,6 +29,20 @@ class HandleRequests extends Mechanism
         });
 
         $this->skipRequestPayloadTamperingMiddleware();
+    }
+
+    protected function updateRouteExists()
+    {
+        // Check if a route with name ending in 'livewire.update' already exists.
+        // Custom routes can have prefixes (e.g., 'tenant.livewire.update') so we
+        // need to check for routes ending with 'livewire.update', not just exact matches.
+        foreach (Route::getRoutes()->getRoutes() as $route) {
+            if (str($route->getName())->endsWith('livewire.update')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     function getUpdateUri()

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -32,4 +32,27 @@ class UnitTest extends TestCase
         $this->assertCount(1, $livewireUpdateRoutes);
         $this->assertEquals('livewire/update', $livewireUpdateRoutes->first()->uri());
     }
+
+    public function test_duplicate_route_is_not_registered_when_livewire_update_route_already_exists(): void
+    {
+        // Verify that only one livewire.update route exists initially
+        $livewireUpdateRoutes = collect(Route::getRoutes()->getRoutes())->filter(function ($route) {
+            return str($route->getName())->endsWith('livewire.update');
+        });
+        $this->assertCount(1, $livewireUpdateRoutes);
+
+        // Simulate what happens during cached routes scenario: create a new HandleRequests
+        // instance (which has $updateRoute = null) and call boot() again
+        $newHandleRequests = new HandleRequests();
+        $newHandleRequests->boot();
+
+        // Manually trigger the booted callback since we're already past the boot phase
+        app()->booted(function () {});
+
+        // Verify that still only one livewire.update route exists (no duplicate)
+        $livewireUpdateRoutes = collect(Route::getRoutes()->getRoutes())->filter(function ($route) {
+            return str($route->getName())->endsWith('livewire.update');
+        });
+        $this->assertCount(1, $livewireUpdateRoutes);
+    }
 }


### PR DESCRIPTION
# The Scenario

After upgrading from Livewire v3.6.4 to v3.7.1, users began seeing a surge of `CorruptComponentPayloadException` errors in their error tracking systems. These errors appeared immediately after the upgrade with no code changes, affecting users who had browser tabs open from before the upgrade.

```php
Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException

Livewire encountered corrupt data when trying to hydrate a component.
Ensure that the [name, id, data] of the Livewire component wasn't tampered with between requests.
```

The errors naturally resolved after a couple of weeks as cached browser sessions expired.

# The Problem

PR #9339 removed `memo.children` from the checksum calculation:

```php
// In Checksum::generate()
unset($snapshot['memo']['children']);
```

When a user has a browser tab open from before the upgrade, their snapshot has a checksum that was computed WITH `memo.children` included. When this old snapshot is sent to the new Livewire version, the checksum verification fails because the new code strips `memo.children` before computing the comparison checksum.

PR #9326 introduced release tokens specifically to handle these version mismatch scenarios gracefully by throwing a 419 `LivewireReleaseTokenMismatchException` that prompts the user to refresh. However, the release token verification was implemented on the `snapshot-verified` hook, which fires AFTER checksum verification. This meant the checksum mismatch error was thrown first, before the release token could be checked.

# The Solution

Move release token verification from the `snapshot-verified` hook to the `checksum.verify` hook, which fires BEFORE the checksum comparison:

```php
// Before (fires after checksum passes)
on('snapshot-verified', function ($snapshot) {
    ReleaseToken::verify($snapshot);
});

// After (fires before checksum comparison)
on('checksum.verify', function ($checksum, $snapshot) {
    ReleaseToken::verify($snapshot);
});
```

Now when a stale browser session sends a request:
1. `Checksum::verify()` is called
2. The `checksum.verify` hook fires first
3. `ReleaseToken::verify()` detects the missing/invalid release token
4. `LivewireReleaseTokenMismatchException` is thrown (419 status)
5. The user sees a clear message prompting them to refresh

This ensures release tokens work as intended, catching stale sessions before the confusing `CorruptComponentPayloadException` can be thrown.

Fixes: #9663