### PR TITLE
Support wire:click.renderless modifier within islands

### DIFF
--- a/src/Features/SupportIslands/SupportIslands.php
+++ b/src/Features/SupportIslands/SupportIslands.php
@@ -47,7 +47,7 @@ class SupportIslands extends ComponentHook
         }
 
         // if metadata contains an island, then we should render it...
-        return function (...$params) use ($island, $componentContext, $mount) {
+        return function (...$params) use ($island, $componentContext, $mount, $metadata) {
             ['name' => $name, 'mode' => $mode] = $island;
 
             $islands = $this->component->getIslands();
@@ -55,6 +55,11 @@ class SupportIslands extends ComponentHook
             $islands = array_filter($islands, fn ($island) => $island['name'] === $name);
 
             if (empty($islands)) return;
+
+            // Support `Wire:click.renderless`...
+            if ($metadata['renderless'] ?? false) {
+                return;
+            }
 
             // If #[Renderless] attribute was used, don't render the island...
             if ($this->storeGet('skipIslandsRender', false)) return;


### PR DESCRIPTION
# The Scenario

When using `wire:island.append` for patterns like infinite scrolling, clicking an action button inside the appended content (e.g., a bookmark button) causes the island to re-render, losing all the appended content.

```php
class PostFeed extends Component
{
    public $posts;

    public function mount()
    {
        $this->posts = Post::take(10)->get();
    }

    public function loadMore()
    {
        $this->posts = Post::skip(count($this->posts))->take(10)->get();
    }

    public function bookmark($postId)
    {
        // Toggle bookmark...
    }

    public function render()
    {
        return <<<'HTML'
        <div>
            @island(name: 'posts')
                @foreach($posts as $post)
                    <div>
                        {{ $post->title }}
                        <button wire:click="bookmark({{ $post->id }})" wire:island="posts">
                            Bookmark
                        </button>
                    </div>
                @endforeach
            @endisland

            <button wire:click="loadMore" wire:island.append="posts">Load More</button>
        </div>
        HTML;
    }
}
```

When "Load More" is clicked multiple times, additional posts are appended. However, clicking "Bookmark" on any post causes the entire island to re-render with only the first page of posts, losing pages 2+.

The workaround is to use `wire:click.renderless` to prevent the re-render, but this modifier was not being respected within islands.

# The Problem

The `wire:click.renderless` modifier correctly sets `metadata.renderless = true` in JavaScript, but `SupportIslands::call()` was not checking for this metadata flag. It only checked for the `#[Renderless]` PHP attribute (via `skipIslandsRender` in the component store).

# The Solution

Added a check for the `renderless` metadata flag in `SupportIslands::call()` before rendering the island. When the `.renderless` modifier is used on a `wire:click` (or similar) directive, the island rendering is now skipped, matching the behaviour of the `#[Renderless]` attribute.

```php
// Support `Wire:click.renderless`...
if ($metadata['renderless'] ?? false) {
    return;
}
```

Fixes: https://github.com/livewire/livewire/discussions/9786