### PR TITLE
[4.x] Configurable cache path

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -118,6 +118,23 @@ return [
     'view_path' => resource_path('views/livewire'),
 
     /*
+    |--------------------------------------------------------------------------
+    | Cache Path
+    |--------------------------------------------------------------------------
+    |
+    | This value is used to specify where Livewire stores compiled component
+    | views and other cached artifacts generated during the rendering process.
+    | These files are managed internally by Livewire and should not be edited
+    | manually.
+    |
+    | Changing this path may be useful if you want to customize storage layout
+    | or isolate Livewire cache from other framework caches.
+    |
+    */
+
+    'cache_path' => storage_path('framework/views/livewire'),
+
+    /*
     |---------------------------------------------------------------------------
     | Temporary File Uploads
     |---------------------------------------------------------------------------

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -43,7 +43,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->app->singleton('livewire.compiler', function () {
             return new Compiler(
                 new CacheManager(
-                    storage_path('framework/views/livewire')
+                    config('livewire.cache_path', storage_path('framework/views/livewire'))
                 )
             );
         });


### PR DESCRIPTION
## Description

This PR introduces a new `cache_path` configuration option that allows explicitly configuring where Livewire stores its compiled component views.

### Why this change is needed

Previously, Livewire always relied on an implicit path:

```php
storage_path('framework/views/livewire')
```

This path was hardcoded at the point of `CacheManager` instantiation, making it impossible to:

* Relocate Livewire’s compiled view cache
* Isolate Livewire cache from other framework caches
* Adapt Livewire to custom filesystem layouts (e.g. read-only containers, shared volumes, multi-tenant setups)

By exposing `cache_path` as a configuration option, Livewire becomes more flexible without changing any default behavior.

### What changed

A new config value was added:

```php
'cache_path' => storage_path('framework/views/livewire'),
```

And it is now used when initializing the compiler:

```php
$this->app->singleton('livewire.compiler', function () {
    return new Compiler(
        new CacheManager(
            config('livewire.cache_path', storage_path('framework/views/livewire'))
        )
    );
});
```

If the option is not set, Livewire falls back to the previous hardcoded path, ensuring full backward compatibility.

### Additional notes

* No breaking changes
* Default behavior remains unchanged
* This change is fully backward compatible

This makes Livewire’s caching behavior explicit, configurable, and easier to reason about for advanced setups.