### PR TITLE
Restore .gitignore creation when cache directory is lazily recreated

### DIFF
--- a/src/Compiler/CacheManager.php
+++ b/src/Compiler/CacheManager.php
@@ -113,6 +113,7 @@ class CacheManager
 
         $classPath = $this->getClassPath($sourcePath);
 
+        $this->ensureCacheDirectoryExists();
         File::ensureDirectoryExists($this->cacheDirectory . '/classes');
 
         File::put($classPath, $contents);
@@ -122,6 +123,7 @@ class CacheManager
     {
         $viewPath = $this->getViewPath($sourcePath);
 
+        $this->ensureCacheDirectoryExists();
         File::ensureDirectoryExists($this->cacheDirectory . '/views');
 
         File::put($viewPath, $contents);
@@ -133,6 +135,7 @@ class CacheManager
     {
         $scriptPath = $this->getScriptPath($sourcePath);
 
+        $this->ensureCacheDirectoryExists();
         File::ensureDirectoryExists($this->cacheDirectory . '/scripts');
 
         File::put($scriptPath, $contents);
@@ -142,6 +145,7 @@ class CacheManager
     {
         $stylePath = $this->getStylePath($sourcePath);
 
+        $this->ensureCacheDirectoryExists();
         File::ensureDirectoryExists($this->cacheDirectory . '/styles');
 
         File::put($stylePath, $contents);
@@ -151,6 +155,7 @@ class CacheManager
     {
         $stylePath = $this->getGlobalStylePath($sourcePath);
 
+        $this->ensureCacheDirectoryExists();
         File::ensureDirectoryExists($this->cacheDirectory . '/styles');
 
         File::put($stylePath, $contents);
@@ -160,6 +165,7 @@ class CacheManager
     {
         $placeholderPath = $this->getPlaceholderPath($sourcePath);
 
+        $this->ensureCacheDirectoryExists();
         File::ensureDirectoryExists($this->cacheDirectory . '/placeholders');
 
         File::put($placeholderPath, $contents);
@@ -171,6 +177,7 @@ class CacheManager
     {
         $viewPath = $this->getViewPath($sourcePath);
 
+        $this->ensureCacheDirectoryExists();
         File::ensureDirectoryExists($this->cacheDirectory . '/views');
 
         File::put($viewPath, $contents);
@@ -182,6 +189,21 @@ class CacheManager
     {
         if (function_exists('opcache_invalidate')) {
             opcache_invalidate($sourcePath, true);
+        }
+    }
+
+    protected function ensureCacheDirectoryExists(): void
+    {
+        // Same approach as Blade's Compiler::ensureCompiledDirectoryExists()
+        // @see \Illuminate\View\Compilers\Compiler::ensureCompiledDirectoryExists()
+        if (! is_dir($this->cacheDirectory)) {
+            File::makeDirectory($this->cacheDirectory, 0777, true, true);
+        }
+
+        $gitignorePath = $this->cacheDirectory . '/.gitignore';
+
+        if (! file_exists($gitignorePath)) {
+            File::put($gitignorePath, "*\n!.gitignore");
         }
     }
 
@@ -200,8 +222,16 @@ class CacheManager
 
     public function clearCompiledFiles($output = null): void
     {
-        if (is_dir($this->cacheDirectory)) {
-            File::deleteDirectory($this->cacheDirectory);
+        try {
+            if (is_dir($this->cacheDirectory)) {
+                File::deleteDirectory($this->cacheDirectory);
+            }
+        } catch (\Exception $e) {
+            // Silently fail to avoid breaking view:clear if there's an issue
+            // But we can log it if output is available
+            if ($output && method_exists($output, 'writeln')) {
+                $output->writeln("<comment>Note: Could not clear Livewire compiled files.</comment>");
+            }
         }
     }
 }

--- a/src/Compiler/UnitTest.php
+++ b/src/Compiler/UnitTest.php
@@ -381,6 +381,32 @@ class UnitTest extends \Tests\TestCase
         $this->assertInstanceOf(Component::class, new $class);
     }
 
+    public function test_gitignore_is_created_when_cache_directory_is_lazily_recreated()
+    {
+        $cacheManager = new CacheManager($this->cacheDir);
+        $compiler = new Compiler($cacheManager);
+
+        // Compile a component to create the cache directories
+        $compiler->compile(__DIR__ . '/Fixtures/sfc-component.blade.php');
+
+        // Verify the .gitignore exists
+        $this->assertFileExists($this->cacheDir . '/.gitignore');
+        $this->assertEquals("*\n!.gitignore", file_get_contents($this->cacheDir . '/.gitignore'));
+
+        // Clear the compiled files
+        $cacheManager->clearCompiledFiles();
+
+        // Verify the cache directory is deleted (including .gitignore)
+        $this->assertFalse(is_dir($this->cacheDir));
+
+        // Compile again - this should lazily recreate the directories AND .gitignore
+        $compiler->compile(__DIR__ . '/Fixtures/sfc-component.blade.php');
+
+        // Verify the .gitignore was recreated
+        $this->assertFileExists($this->cacheDir . '/.gitignore');
+        $this->assertEquals("*\n!.gitignore", file_get_contents($this->cacheDir . '/.gitignore'));
+    }
+
     #[DataProvider('classReturnProvider')]
     public function test_anonymous_class_has_return_statement_added_if_required($classContents, $expectedOutput)
     {


### PR DESCRIPTION
# The Scenario

After PR #9787 was merged, the Livewire cache directory (`storage/framework/views/livewire`) no longer includes a `.gitignore` file when lazily recreated. This means compiled cache files could accidentally be committed to version control if someone has a custom cache path outside of `storage/`.

```php
// After running artisan view:clear, the cache directory is deleted
// On next request, directories are lazily recreated but .gitignore is missing
```

# The Problem

PR #9787 correctly removed the eager directory recreation to fix permission issues when running `artisan optimize:clear` as a different user. However, it also removed the `.gitignore` creation that was previously happening in `clearCompiledFiles()`.

The old approach was inconsistent anyway - the `.gitignore` was only created when cache was cleared, not on initial directory creation.

# The Solution

Add an `ensureCacheDirectoryExists()` helper method that:

1. Creates the cache directory with `0777` permissions (matching Blade's `Compiler::ensureCompiledDirectoryExists()`)
2. Creates a `.gitignore` file with `*\n!.gitignore` (matching Laravel's skeleton)

This method is called from all write methods before creating subdirectories, ensuring the `.gitignore` is always present regardless of how the cache directory came to exist.

Also restores the try-catch block in `clearCompiledFiles()` to prevent breaking `view:clear` if there are permission issues.

Fixes: #9787 (follow-up)