### PR TITLE
Fix getUpdateUri() failing when routes are cached

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -37,16 +37,7 @@ class HandleRequests extends Mechanism
 
     protected function updateRouteExists()
     {
-        // Check if a route with name ending in 'livewire.update' already exists.
-        // Custom routes can have prefixes (e.g., 'tenant.livewire.update') so we
-        // need to check for routes ending with 'livewire.update', not just exact matches.
-        foreach (Route::getRoutes()->getRoutes() as $route) {
-            if (str($route->getName())->endsWith('livewire.update')) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->findUpdateRoute() !== null;
     }
 
     function getUriPrefix()
@@ -56,9 +47,28 @@ class HandleRequests extends Mechanism
 
     function getUpdateUri()
     {
+        // When routes are cached, $this->updateRoute may be null because
+        // setUpdateRoute() was never called (the route already existed).
+        // In this case, find the route from the router.
+        $route = $this->updateRoute ?? $this->findUpdateRoute();
+
         return (string) str(
-            route($this->updateRoute->getName(), [], false)
+            route($route->getName(), [], false)
         )->start('/');
+    }
+
+    protected function findUpdateRoute()
+    {
+        // Find the route with name ending in 'livewire.update'.
+        // Custom routes can have prefixes (e.g., 'tenant.livewire.update')
+        // so we check for routes ending with 'livewire.update', not just exact matches.
+        foreach (Route::getRoutes()->getRoutes() as $route) {
+            if (str($route->getName())->endsWith('livewire.update')) {
+                return $route;
+            }
+        }
+
+        return null;
     }
 
     function skipRequestPayloadTamperingMiddleware()

--- a/tests/Unit/Mechanisms/HandleRequests/CachedRoutesTest.php
+++ b/tests/Unit/Mechanisms/HandleRequests/CachedRoutesTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit\Mechanisms\HandleRequests;
+
+use Illuminate\Foundation\Testing\WithCachedRoutes;
+use Illuminate\Support\Facades\Route;
+use Livewire\Livewire;
+use Livewire\Component;
+use Livewire\Mechanisms\HandleRequests\EndpointResolver;
+use Livewire\Mechanisms\HandleRequests\HandleRequests;
+use Tests\TestCase;
+
+class CachedRoutesTest extends TestCase
+{
+    use WithCachedRoutes;
+
+    public function test_get_update_uri_works_with_cached_routes()
+    {
+        // When routes are cached, HandleRequests::$updateRoute is null because
+        // the route already exists in the router and setUpdateRoute() is not called.
+        // getUpdateUri() should still work by falling back to route lookup.
+        $uri = app('livewire')->getUpdateUri();
+
+        $this->assertEquals(EndpointResolver::updatePath(), $uri);
+    }
+
+    public function test_livewire_testing_works_with_cached_routes()
+    {
+        // This test ensures that Livewire::test() works when routes are cached,
+        // which requires getUpdateUri() to work correctly.
+        Livewire::test(CachedRoutesTestComponent::class)
+            ->call('increment')
+            ->assertSet('count', 1);
+    }
+
+    public function test_get_update_uri_works_when_update_route_is_null()
+    {
+        // Simulate the scenario where routes are loaded from cache and
+        // HandleRequests::$updateRoute was never set. This happens when:
+        // 1. Routes are cached and loaded by Laravel
+        // 2. HandleRequests::boot() sees the route exists via updateRouteExists()
+        // 3. setUpdateRoute() is never called, so $updateRoute remains null
+
+        // Create a fresh HandleRequests instance to simulate fresh boot
+        $handleRequests = new HandleRequests;
+        $handleRequests->register();
+
+        // The route already exists from the previous test/Livewire boot,
+        // so updateRouteExists() will return true and setUpdateRoute() won't be called
+        $handleRequests->boot();
+
+        // This should work even though $updateRoute is null
+        $uri = $handleRequests->getUpdateUri();
+
+        $this->assertEquals(EndpointResolver::updatePath(), $uri);
+    }
+}
+
+class CachedRoutesTestComponent extends Component
+{
+    public $count = 0;
+
+    public function increment()
+    {
+        $this->count++;
+    }
+
+    public function render()
+    {
+        return '<div>{{ $count }}</div>';
+    }
+}


### PR DESCRIPTION
# The Scenario

When using Livewire's testing helpers with Laravel's `WithCachedRoutes` trait (common in parallel testing), tests fail with an error after upgrading from v3.7.4 to v3.7.5:

```
Error: Call to a member function getName() on null

at vendor/livewire/livewire/src/LivewireManager.php:136
```

This affects both standard PHPUnit tests using `Livewire::test()` and Pest tests using the `livewire()` helper - the issue is triggered by `WithCachedRoutes`, not the testing framework.

```php
class MyTest extends TestCase
{
    use WithCachedRoutes;  // This triggers the bug

    public function test_component()
    {
        // Fails in v3.7.5 when making subsequent requests
        Livewire::test(MyComponent::class)
            ->call('save')  // Error: Call to a member function getName() on null
            ->assertSuccessful();
    }
}
```

# The Problem

Commit `9abb4cf2` added a check in `HandleRequests::boot()` to prevent duplicate route registration when routes are cached:

```php
if (! $this->updateRoute && ! $this->updateRouteExists()) {
    app($this::class)->setUpdateRoute(function ($handle) {
        return Route::post(EndpointResolver::updatePath(), $handle)->middleware('web');
    });
}
```

This correctly prevents duplicate registration, but has a side effect: when routes ARE cached and loaded by Laravel, the `livewire.update` route already exists in the router, so `setUpdateRoute()` is never called and `$this->updateRoute` remains `null`.

When `getUpdateUri()` is subsequently called (e.g., by Livewire's testing helpers during `->call()`, `->set()`, etc.), it tries to access `$this->updateRoute->getName()` which fails because `$this->updateRoute` is `null`.

# The Solution

Modified `getUpdateUri()` to fall back to finding the route from the router when `$this->updateRoute` is null:

```php
function getUpdateUri()
{
    // When routes are cached, $this->updateRoute may be null because
    // setUpdateRoute() was never called (the route already existed).
    // In this case, find the route from the router.
    $route = $this->updateRoute ?? $this->findUpdateRoute();

    return (string) str(
        route($route->getName(), [], false)
    )->start('/');
}
```

Also refactored `updateRouteExists()` to use the new `findUpdateRoute()` method to avoid code duplication.

Fixes: #9807