### PR TITLE
Fix getUpdateUri() failing when routes are cached

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -33,23 +33,33 @@ class HandleRequests extends Mechanism
 
     protected function updateRouteExists()
     {
-        // Check if a route with name ending in 'livewire.update' already exists.
-        // Custom routes can have prefixes (e.g., 'tenant.livewire.update') so we
-        // need to check for routes ending with 'livewire.update', not just exact matches.
-        foreach (Route::getRoutes()->getRoutes() as $route) {
-            if (str($route->getName())->endsWith('livewire.update')) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->findUpdateRoute() !== null;
     }
 
     function getUpdateUri()
     {
+        // When routes are cached, $this->updateRoute may be null because
+        // setUpdateRoute() was never called (the route already existed).
+        // In this case, find the route from the router.
+        $route = $this->updateRoute ?? $this->findUpdateRoute();
+
         return (string) str(
-            route($this->updateRoute->getName(), [], false)
+            route($route->getName(), [], false)
         )->start('/');
+    }
+
+    protected function findUpdateRoute()
+    {
+        // Find the route with name ending in 'livewire.update'.
+        // Custom routes can have prefixes (e.g., 'tenant.livewire.update')
+        // so we check for routes ending with 'livewire.update', not just exact matches.
+        foreach (Route::getRoutes()->getRoutes() as $route) {
+            if (str($route->getName())->endsWith('livewire.update')) {
+                return $route;
+            }
+        }
+
+        return null;
     }
 
     function skipRequestPayloadTamperingMiddleware()

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -55,4 +55,19 @@ class UnitTest extends TestCase
         });
         $this->assertCount(1, $livewireUpdateRoutes);
     }
+
+    public function test_get_update_uri_works_when_update_route_property_is_null(): void
+    {
+        // Simulate the cached routes scenario where routes are loaded from cache
+        // and HandleRequests::$updateRoute was never set because setUpdateRoute()
+        // was not called (the route already existed in the router).
+        $handleRequests = new HandleRequests();
+        $handleRequests->register();
+        $handleRequests->boot();
+
+        // This should work even though $updateRoute is null by finding the route from the router
+        $uri = $handleRequests->getUpdateUri();
+
+        $this->assertEquals('/livewire/update', $uri);
+    }
 }


### PR DESCRIPTION
# The Scenario

When using Livewire's testing helpers with Laravel's `WithCachedRoutes` trait (common in parallel testing), tests fail with an error after upgrading from v3.7.4 to v3.7.5:

```
Error: Call to a member function getName() on null

at vendor/livewire/livewire/src/LivewireManager.php:136
```

This affects both standard PHPUnit tests using `Livewire::test()` and Pest tests using the `livewire()` helper - the issue is triggered by `WithCachedRoutes`, not the testing framework.

```php
class MyTest extends TestCase
{
    use WithCachedRoutes;  // This triggers the bug

    public function test_component()
    {
        // Fails in v3.7.5 when making subsequent requests
        Livewire::test(MyComponent::class)
            ->call('save')  // Error: Call to a member function getName() on null
            ->assertSuccessful();
    }
}
```

# The Problem

Commit `9abb4cf2` added a check in `HandleRequests::boot()` to prevent duplicate route registration when routes are cached:

```php
if (! $this->updateRoute && ! $this->updateRouteExists()) {
    app($this::class)->setUpdateRoute(function ($handle) {
        return Route::post('/livewire/update', $handle)->middleware('web');
    });
}
```

This correctly prevents duplicate registration, but has a side effect: when routes ARE cached and loaded by Laravel, the `livewire.update` route already exists in the router, so `setUpdateRoute()` is never called and `$this->updateRoute` remains `null`.

When `getUpdateUri()` is subsequently called (e.g., by Livewire's testing helpers during `->call()`, `->set()`, etc.), it tries to access `$this->updateRoute->getName()` which fails because `$this->updateRoute` is `null`.

# The Solution

Modified `getUpdateUri()` to fall back to finding the route from the router when `$this->updateRoute` is null:

```php
function getUpdateUri()
{
    // When routes are cached, $this->updateRoute may be null because
    // setUpdateRoute() was never called (the route already existed).
    // In this case, find the route from the router.
    $route = $this->updateRoute ?? $this->findUpdateRoute();

    return (string) str(
        route($route->getName(), [], false)
    )->start('/');
}
```

Also refactored `updateRouteExists()` to use the new `findUpdateRoute()` method to avoid code duplication.

Fixes: #9807