### PR TITLE
[4.x] Cache resolved routes to prevent binding resolution issues for bundled child components

### DIFF
--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -207,19 +207,6 @@ class SupportPageComponents extends ComponentHook
             app('router')->substituteImplicitBindingsUsing(function ($container, $route, $default) {
                 // If the current route is a Livewire page component...
                 if ($componentClass = static::routeActionIsAPageComponent($route)) {
-                    // If we're processing a child component (not the page component),
-                    // skip binding resolution - child components don't need route bindings
-                    // and the models are already hydrated from the snapshot.
-                    $currentComponentName = \Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware::$currentComponentName;
-
-                    if ($currentComponentName) {
-                        $currentComponentClass = app('livewire.factory')->resolveComponentClass($currentComponentName);
-
-                        if ($currentComponentClass !== $componentClass) {
-                            return;
-                        }
-                    }
-
                     // Resolve and set all page component parameters to the current route...
                     (new \Livewire\Drawer\ImplicitRouteBinding($container))
                         ->resolveAllParameters($route, new $componentClass);

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -207,6 +207,19 @@ class SupportPageComponents extends ComponentHook
             app('router')->substituteImplicitBindingsUsing(function ($container, $route, $default) {
                 // If the current route is a Livewire page component...
                 if ($componentClass = static::routeActionIsAPageComponent($route)) {
+                    // If we're processing a child component (not the page component),
+                    // skip binding resolution - child components don't need route bindings
+                    // and the models are already hydrated from the snapshot.
+                    $currentComponentName = \Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware::$currentComponentName;
+
+                    if ($currentComponentName) {
+                        $currentComponentClass = app('livewire.factory')->resolveComponentClass($currentComponentName);
+
+                        if ($currentComponentClass !== $componentClass) {
+                            return;
+                        }
+                    }
+
                     // Resolve and set all page component parameters to the current route...
                     (new \Livewire\Drawer\ImplicitRouteBinding($container))
                         ->resolveAllParameters($route, new $componentClass);

--- a/src/Mechanisms/PersistentMiddleware/BrowserTest.php
+++ b/src/Mechanisms/PersistentMiddleware/BrowserTest.php
@@ -79,7 +79,6 @@ class BrowserTest extends BrowserTestCase
             Route::get('/with-authorization/{post}/inline-auth', Component::class)
                 ->middleware(['web', 'auth', 'can:update,post']);
 
-            // Register components for route-bound child component test
             Livewire::component('page-with-reactive-child', PageComponentWithReactiveChild::class);
             Livewire::component('child-with-reactive', ChildComponentWithReactive::class);
             Livewire::component('page-with-modelable-child', PageComponentWithModelableChild::class);

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -149,14 +149,14 @@ class PersistentMiddleware extends Mechanism
 
     protected function getRouteFromRequest($request)
     {
-        $path = $request->path();
+        $cacheKey = $request->method() . '|' . $request->path();
 
-        // Reuse cached route if available for this path. This ensures that route
-        // bindings resolved during the first component's middleware run are
-        // available for subsequent child components on the same path, preventing
-        // re-resolution of deleted models (which would 404).
-        if (isset($this->cachedRoutes[$path])) {
-            $route = $this->cachedRoutes[$path];
+        // Reuse cached route if available for this method and path. This ensures
+        // that route bindings resolved during the first component's middleware
+        // run are available for subsequent child components on the same route,
+        // preventing re-resolution of deleted models (which would 404).
+        if (isset($this->cachedRoutes[$cacheKey])) {
+            $route = $this->cachedRoutes[$cacheKey];
             $request->setRouteResolver(fn() => $route);
 
             return $route;
@@ -169,7 +169,7 @@ class PersistentMiddleware extends Mechanism
             return null;
         }
 
-        $this->cachedRoutes[$path] = $route;
+        $this->cachedRoutes[$cacheKey] = $route;
 
         return $route;
     }


### PR DESCRIPTION
# The Scenario

When a Livewire page component with route model binding has child components using `#[Reactive]` or `#[Modelable]`, deleting the route-bound model causes a 404 error. Clicking "Delete Post" in the example below results in a 404 instead of showing the updated title.

![Screenshot 2026-02-05 at 12 56 04PM](https://github.com/user-attachments/assets/b647a762-a8f8-443d-9c55-bd980f4a90df)

```php
<?php
// Route: /posts/{post}

use App\Models\Post;
use Livewire\Attributes\Reactive;
use Livewire\Component;

new class extends Component {
    public Post $post;
    public $title = 'My Post';

    public function delete()
    {
        $this->post->delete();
        $this->title = 'Deleted';
    }
};
?>

<div>
    <livewire:child-component :$title />
    <button wire:click="delete">Delete Post</button>
</div>
```

```php
<?php

use Livewire\Attributes\Reactive;
use Livewire\Component;

new class extends Component {
    #[Reactive]
    public $title;
};
?>

<div>{{ $title }}</div>
```

# The Problem

During a Livewire update request Livewire creates a fake request and resolves the original route so any PersistentMiddleware, such as `SubstituteBindings`, can be reapplied to the current request,

When child components use `#[Reactive]` or `#[Modelable]`, they're bundled into the same HTTP request as the parent. For each component in the request, a fake request is created and middleware are applied.

Both parent and child components store the same original path in their snapshot (e.g., `/posts/1`), so both try to resolve that same route and bindings as part of their fake request.

The problem arises if the parent has resolved the route-bound model and then deleted it. When the child tries to resolve the route-bound model, as part of its fake request, the model can't be found and a 404 is thrown.

# The Solution

The solution is to allow the parent to resolve the route and any bindings (such as resolved model instances) and then cache that route in the PesistentMiddleware feature. Then when any child components go to resolve the route, it will check the cache first and use the already resolved route, if available.

Laravel's binding logic checks `$parameterValue instanceof UrlRoutable` and skips re-resolution for already-resolved models, that way the cached route's bindings are preserved even after the model is deleted.

![Screenshot 2026-02-05 at 12 54 37PM](https://github.com/user-attachments/assets/719da0f6-f713-4989-b4f5-3ad899ec7e87)

Fixes #9804