### PR TITLE
Add `@vite-ignore` to suppress dynamic import warning

### DIFF
--- a/js/features/supportJsModules.js
+++ b/js/features/supportJsModules.js
@@ -15,7 +15,7 @@ on('effect', ({ component, effects }) => {
             afterLoaded: [],
         }))
 
-        import(path).then(module => {
+        import(/* @vite-ignore */ path).then(module => {
             module.run.call(component.$wire, component.$wire, component.$wire.js);
 
             pendingComponentAssets.get(component).loading = false


### PR DESCRIPTION
# The Scenario

When bundling Livewire's ESM distribution with Vite (e.g., importing it in `app.js`), developers see this warning in the console:

```
[vite] warning:
/path/to/livewire/dist/livewire.esm.js
10800|        afterLoaded: []
10801|      }));
10802|      import(path).then((module) => {
   |             ^^^^
The above dynamic import cannot be analyzed by Vite.
See https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations
for supported dynamic import formats. If this is intended to be left as-is, you can use
the /* @vite-ignore */ comment inside the import() call to suppress this warning.
```

This occurs when a page loads and uses features that trigger the JS module loading in `supportJsModules.js`.

# The Problem

Vite performs static analysis on dynamic `import()` statements to understand which modules might be loaded at runtime. In `supportJsModules.js`, the dynamic import uses a fully variable path:

```js
let path = `${getModuleUrl()}/js/${encodedName}.js?v=${scriptModuleHash}`
import(path).then(module => { ... })
```

Vite cannot analyse this because:
- The base URL comes from `getModuleUrl()` (unknown at build time)
- The component name is dynamic (unknown at build time)
- The hash comes from the server (unknown at build time)

This is intentional behaviour - the import is meant to load component JS modules at runtime based on server responses.

# The Solution

Added the `/* @vite-ignore */` comment inside the `import()` call to suppress the warning:

```js
import(/* @vite-ignore */ path).then(module => { ... })
```

This tells Vite "I know you can't analyse this, and that's intentional". The dynamic import continues to work at runtime - the comment only suppresses the build-time warning.

Fixes #9799