### PR TITLE
Fix race condition in cache directory creation

### DIFF
--- a/src/Compiler/CacheManager.php
+++ b/src/Compiler/CacheManager.php
@@ -114,7 +114,7 @@ class CacheManager
         $classPath = $this->getClassPath($sourcePath);
 
         $this->ensureCacheDirectoryExists();
-        File::ensureDirectoryExists($this->cacheDirectory . '/classes');
+        File::makeDirectory($this->cacheDirectory . '/classes', 0777, true, true);
 
         File::put($classPath, $contents);
     }
@@ -124,7 +124,7 @@ class CacheManager
         $viewPath = $this->getViewPath($sourcePath);
 
         $this->ensureCacheDirectoryExists();
-        File::ensureDirectoryExists($this->cacheDirectory . '/views');
+        File::makeDirectory($this->cacheDirectory . '/views', 0777, true, true);
 
         File::put($viewPath, $contents);
 
@@ -136,7 +136,7 @@ class CacheManager
         $scriptPath = $this->getScriptPath($sourcePath);
 
         $this->ensureCacheDirectoryExists();
-        File::ensureDirectoryExists($this->cacheDirectory . '/scripts');
+        File::makeDirectory($this->cacheDirectory . '/scripts', 0777, true, true);
 
         File::put($scriptPath, $contents);
     }
@@ -146,7 +146,7 @@ class CacheManager
         $stylePath = $this->getStylePath($sourcePath);
 
         $this->ensureCacheDirectoryExists();
-        File::ensureDirectoryExists($this->cacheDirectory . '/styles');
+        File::makeDirectory($this->cacheDirectory . '/styles', 0777, true, true);
 
         File::put($stylePath, $contents);
     }
@@ -156,7 +156,7 @@ class CacheManager
         $stylePath = $this->getGlobalStylePath($sourcePath);
 
         $this->ensureCacheDirectoryExists();
-        File::ensureDirectoryExists($this->cacheDirectory . '/styles');
+        File::makeDirectory($this->cacheDirectory . '/styles', 0777, true, true);
 
         File::put($stylePath, $contents);
     }
@@ -166,7 +166,7 @@ class CacheManager
         $placeholderPath = $this->getPlaceholderPath($sourcePath);
 
         $this->ensureCacheDirectoryExists();
-        File::ensureDirectoryExists($this->cacheDirectory . '/placeholders');
+        File::makeDirectory($this->cacheDirectory . '/placeholders', 0777, true, true);
 
         File::put($placeholderPath, $contents);
 
@@ -178,7 +178,7 @@ class CacheManager
         $viewPath = $this->getViewPath($sourcePath);
 
         $this->ensureCacheDirectoryExists();
-        File::ensureDirectoryExists($this->cacheDirectory . '/views');
+        File::makeDirectory($this->cacheDirectory . '/views', 0777, true, true);
 
         File::put($viewPath, $contents);
 
@@ -194,16 +194,16 @@ class CacheManager
 
     protected function ensureCacheDirectoryExists(): void
     {
-        // Same approach as Blade's Compiler::ensureCompiledDirectoryExists()
-        // @see \Illuminate\View\Compilers\Compiler::ensureCompiledDirectoryExists()
-        if (! is_dir($this->cacheDirectory)) {
-            File::makeDirectory($this->cacheDirectory, 0777, true, true);
-        }
+        File::makeDirectory($this->cacheDirectory, 0777, true, true);
 
         $gitignorePath = $this->cacheDirectory . '/.gitignore';
 
         if (! file_exists($gitignorePath)) {
-            File::put($gitignorePath, "*\n!.gitignore");
+            try {
+                File::put($gitignorePath, "*\n!.gitignore");
+            } catch (\Throwable) {
+                // Non-critical, ignore if another process created it
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes a race condition in `CacheManager` that can cause `mkdir(): File exists` errors during concurrent Livewire requests.

## Problem

When multiple Livewire requests concurrently compile components (e.g., after `view:clear`), the directory creation can fail:

1. Request A checks directory doesn't exist
2. Request B checks directory doesn't exist
3. Request B creates directory - succeeds
4. Request A tries to create directory - throws `mkdir(): File exists`

## Solution

Pass the `$force = true` parameter to `File::makeDirectory()`. This uses Laravel's built-in error suppression for mkdir operations, which is the intended way to handle this scenario.

```php
// Before
File::ensureDirectoryExists($this->cacheDirectory . '/classes');

// After
File::makeDirectory($this->cacheDirectory . '/classes', 0777, true, true);
```

The fourth parameter (`$force`) wraps the mkdir call with `@` to suppress errors when the directory already exists.

## Related

This is the same underlying issue addressed in https://github.com/laravel/framework/pull/58460 for `Filesystem::ensureDirectoryExists()`. If that fix is merged, these calls could be simplified back to `File::ensureDirectoryExists()`. Until then, this approach ensures Livewire works correctly regardless of the Laravel framework version.

## Impact

Backwards compatible. Directory creation behavior is unchanged, but concurrent requests no longer cause errors.