### PR TITLE
Fix resolveMissingComponent not working with Octane

### DIFF
--- a/src/Factory/Factory.php
+++ b/src/Factory/Factory.php
@@ -6,6 +6,7 @@ use Livewire\Exceptions\ComponentNotFoundException;
 use Livewire\Compiler\Compiler;
 use Livewire\Finder\Finder;
 use Livewire\Component;
+use function Livewire\on;
 
 class Factory
 {
@@ -16,7 +17,11 @@ class Factory
     public function __construct(
         protected Finder $finder,
         protected Compiler $compiler,
-    ) {}
+    ) {
+        on('flush-state', function () {
+            $this->resolvedComponentCache = [];
+        });
+    }
 
     public function create($name, $id = null): Component
     {

--- a/src/Factory/Factory.php
+++ b/src/Factory/Factory.php
@@ -70,7 +70,7 @@ class Factory
         if (! $class || ! class_exists($class) || ! is_subclass_of($class, Component::class)) {
             foreach ($this->missingComponentResolvers as $resolver) {
                 if ($class = $resolver($name)) {
-                    $this->finder->addComponent($name, $class);
+                    $this->finder->addComponent(name: $name, class: $class);
 
                     break;
                 }

--- a/src/Factory/Factory.php
+++ b/src/Factory/Factory.php
@@ -6,7 +6,6 @@ use Livewire\Exceptions\ComponentNotFoundException;
 use Livewire\Compiler\Compiler;
 use Livewire\Finder\Finder;
 use Livewire\Component;
-use function Livewire\on;
 
 class Factory
 {
@@ -17,11 +16,7 @@ class Factory
     public function __construct(
         protected Finder $finder,
         protected Compiler $compiler,
-    ) {
-        on('flush-state', function () {
-            $this->resolvedComponentCache = [];
-        });
-    }
+    ) {}
 
     public function create($name, $id = null): Component
     {

--- a/src/Factory/UnitTest.php
+++ b/src/Factory/UnitTest.php
@@ -187,4 +187,23 @@ class UnitTest extends \Tests\TestCase
         $this->assertEquals('simple-component', $factory->resolveComponentName(SimpleComponent::class));
         $this->assertEquals('simple-component', $factory->resolveComponentName($component));
     }
+
+    public function test_resolved_missing_component_is_cached_in_finder()
+    {
+        $finder = new Finder();
+        $compiler = new Compiler(new CacheManager($this->cacheDir));
+        $factory = new Factory($finder, $compiler);
+
+        $factory->resolveMissingComponent(function ($name) {
+            if ($name === 'custom.component') {
+                return SimpleComponent::class;
+            }
+
+            return null;
+        });
+
+        $factory->create('custom.component');
+
+        $this->assertEquals(SimpleComponent::class, $finder->resolveClassComponentClassName('custom.component'));
+    }
 }

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -48,7 +48,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
             );
         });
 
-        $this->app->scoped('livewire.factory', function ($app) {
+        $this->app->singleton('livewire.factory', function ($app) {
             return new Factory(
                 $app['livewire.finder'],
                 $app['livewire.compiler']


### PR DESCRIPTION
# The Scenario

When using `Livewire::resolveMissingComponent()` to dynamically resolve components from a custom namespace, resolved components fail with `ComponentNotFoundException` on subsequent requests when running with Laravel Octane.

This affects any package or application code that uses `resolveMissingComponent`, including Laravel Volt which relies on this feature for its component resolution.

```php
// AppServiceProvider.php
public function boot(): void
{
    Livewire::resolveMissingComponent(function ($name) {
        if (Str::startsWith($name, 'app.')) {
            return 'App\\Wire\\' . Str::studly(Str::after($name, 'app.'));
        }

        return null;
    });
}
```

```php
// app/Wire/Appearance.php
namespace App\Wire;

use Livewire\Component;

class Appearance extends Component
{
    public function render()
    {
        return view('livewire.settings.appearance');
    }
}
```

```blade
{{-- dashboard.blade.php --}}
<livewire:app.appearance />
```

# The Problem

The `livewire.factory` binding was registered as `scoped`, meaning it gets recreated on each Octane request. Resolver callbacks registered during the service provider's `boot()` method were stored in the Factory instance, but since `boot()` only runs once per Octane worker and the scoped Factory is recreated on each request, the resolvers were lost.

Upon investigating this and testing with Octane, we discovered an additional issue: when a missing component resolver returned a class, the call to `addComponent($name, $class)` was passing `$class` to the `$viewPath` parameter instead of the `$class` parameter due to positional argument ordering:

```php
public function addComponent($name = null, $viewPath = null, $class = null): void
```

This meant resolved components were being cached as view components instead of class components in the Finder, so subsequent requests couldn't find them even when the Finder persisted.

# The Solution

1. Changed `livewire.factory` from a `scoped` binding to a `singleton` binding, matching the pattern used by other Livewire mechanisms.

2. Fixed the `addComponent` call to use named arguments: `addComponent(name: $name, class: $class)`, ensuring resolved components are correctly cached as class components in the Finder.

## Implications of the singleton change

The Factory has two properties affected by this change:

- **`$missingComponentResolvers`**: These callbacks are registered once during `boot()` and should persist across requests. The singleton binding ensures they remain available.

- **`$resolvedComponentCache`**: This cache maps component names to their resolved class names. We considered adding a `flush-state` handler to clear this between requests, but found it unnecessary. The Finder singleton already maintains its own persistent cache (`$classComponents`) without flushing, so the Factory's cache is consistent with this behaviour. Flushing it would only cause the Factory to re-query the Finder, which returns the same cached result anyway.

Fixes: https://github.com/livewire/livewire/discussions/9797