### PR TITLE
Fix persist directive docs

### DIFF
--- a/docs/directive-persist.md
+++ b/docs/directive-persist.md
@@ -77,11 +77,11 @@ Persisted elements should typically be placed outside Livewire components, commo
 
 ## Preserving scroll position
 
-For scrollable persisted elements, add `wire:scroll` to maintain scroll position:
+For scrollable persisted elements, add `wire:navigate:scroll` to maintain scroll position:
 
 ```blade
 @persist('scrollable-list')
-    <div class="overflow-y-scroll" wire:scroll>
+    <div class="overflow-y-scroll" wire:navigate:scroll>
         <!-- Scrollable content... -->
     </div>
 @endpersist


### PR DESCRIPTION
https://livewire.laravel.com/docs/4.x/navigate#preserving-scroll-position tells about `wire:navigate:scroll`, but in https://livewire.laravel.com/docs/4.x/directive-persist#preserving-scroll-position there is a `wire:scroll` attribute mentioned. First one is correct.