### PR TITLE
Control wire:model client-side sync timing with modifiers

### DIFF
--- a/docs/alpine.md
+++ b/docs/alpine.md
@@ -118,7 +118,7 @@ Here is an example of using Alpine to listen for a "blur" event on an input and 
 </form>
 ```
 
-Typically, you would just use `wire:model.blur="title"` in this situation, however, it's helpful for demonstration purposes how you can achieve this using Alpine.
+Typically, you would just use `wire:model.live.blur="title"` in this situation, however, it's helpful for demonstration purposes how you can achieve this using Alpine.
 
 #### Passing parameters
 

--- a/docs/attribute-modelable.md
+++ b/docs/attribute-modelable.md
@@ -101,7 +101,7 @@ The parent can use wire:model modifiers, and they'll work as expected:
 <livewire:todo-input wire:model.live="todo" />
 
 {{-- Update on blur --}}
-<livewire:todo-input wire:model.blur="todo" />
+<livewire:todo-input wire:model.live.blur="todo" />
 
 {{-- Debounce updates --}}
 <livewire:todo-input wire:model.live.debounce.500ms="todo" />

--- a/docs/attribute-validate.md
+++ b/docs/attribute-validate.md
@@ -73,10 +73,10 @@ new class extends Component {
 ?>
 
 <div>
-    <input type="email" wire:model.blur="email">
+    <input type="email" wire:model.live.blur="email">
     @error('email') <span>{{ $message }}</span> @enderror
 
-    <input type="password" wire:model.blur="password">
+    <input type="password" wire:model.live.blur="password">
     @error('password') <span>{{ $message }}</span> @enderror
 </div>
 ```
@@ -241,22 +241,22 @@ new class extends Component {
 
     <form wire:submit="submit">
         <div>
-            <input type="text" wire:model.blur="name" placeholder="Your name">
+            <input type="text" wire:model.live.blur="name" placeholder="Your name">
             @error('name') <span class="error">{{ $message }}</span> @enderror
         </div>
 
         <div>
-            <input type="email" wire:model.blur="email" placeholder="Your email">
+            <input type="email" wire:model.live.blur="email" placeholder="Your email">
             @error('email') <span class="error">{{ $message }}</span> @enderror
         </div>
 
         <div>
-            <input type="text" wire:model.blur="subject" placeholder="Subject">
+            <input type="text" wire:model.live.blur="subject" placeholder="Subject">
             @error('subject') <span class="error">{{ $message }}</span> @enderror
         </div>
 
         <div>
-            <textarea wire:model.blur="message" placeholder="Your message"></textarea>
+            <textarea wire:model.live.blur="message" placeholder="Your message"></textarea>
             @error('message') <span class="error">{{ $message }}</span> @enderror
         </div>
 

--- a/docs/dirty.md
+++ b/docs/dirty.md
@@ -41,13 +41,13 @@ By adding the `.remove` modifier to `wire:dirty`, you can instead show an elemen
 
 ## Targeting property updates
 
-Imagine you are using `wire:model.blur` to update a property on the server immediately after a user leaves an input field. In this scenario, you can provide a "dirty" indication for only that property by adding `wire:target` to the element that contains the `wire:dirty` directive.
+Imagine you are using `wire:model.live.blur` to update a property on the server immediately after a user leaves an input field. In this scenario, you can provide a "dirty" indication for only that property by adding `wire:target` to the element that contains the `wire:dirty` directive.
 
 Here is an example of only showing a dirty indication when the title property has been changed:
 
 ```blade
 <form wire:submit="update">
-    <input wire:model.blur="title">
+    <input wire:model.live.blur="title">
 
     <div wire:dirty wire:target="title">Unsaved title...</div> <!-- [tl! highlight] -->
 
@@ -62,6 +62,5 @@ Often, instead of toggling entire elements, you may want to toggle individual CS
 Below is an example where a user types into an input field and the border becomes yellow, indicating an "unsaved" state. Then, when the user tabs away from the field, the border is removed, indicating that the state has been saved on the server:
 
 ```blade
-<input wire:model.blur="title" wire:dirty.class="border-yellow-500">
+<input wire:model.live.blur="title" wire:dirty.class="border-yellow-500">
 ```
-

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -485,7 +485,7 @@ class PostForm extends Form
 }
 ```
 
-Now if the `$title` property is updated before the form is submitted—like when using [`wire:model.blur`](/docs/4.x/wire-model#updating-on-blur-event)—the validation for `$title` will be run.
+Now if the `$title` property is updated before the form is submitted—like when using [`wire:model.live.blur`](/docs/4.x/wire-model#updating-on-blur-event)—the validation for `$title` will be run.
 
 ### Showing a loading indicator
 
@@ -537,7 +537,7 @@ For most cases, `wire:model.live` is fine for real-time form field updating; how
 If instead of sending network requests as a user types, you want to instead only send the request when a user "tabs" out of the text input (also referred to as "blurring" an input), you can use the `.blur` modifier instead:
 
 ```blade
-<input type="text" wire:model.blur="title" >
+<input type="text" wire:model.live.blur="title" >
 ```
 
 Now the component class on the server won't be updated until the user presses tab or clicks away from the text input.
@@ -549,7 +549,7 @@ Sometimes, you may want to show validation errors as the user fills out the form
 Livewire handles this sort of thing automatically. By using `.live` or `.blur` on `wire:model`, Livewire will send network requests as the user fills out the form. Each of those network requests will run the appropriate validation rules before updating each property. If validation fails, the property won't be updated on the server and a validation message will be shown to the user:
 
 ```blade
-<input type="text" wire:model.blur="title">
+<input type="text" wire:model.live.blur="title">
 
 <div>
     @error('title') <span class="error">{{ $message }}</span> @enderror
@@ -602,12 +602,12 @@ new class extends Component {
 ?>
 
 <form wire:submit>
-    <input type="text" wire:model.blur="title">
+    <input type="text" wire:model.live.blur="title">
     <div>
         @error('title') <span class="error">{{ $message }}</span> @enderror
     </div>
 
-    <input type="text" wire:model.blur="content">
+    <input type="text" wire:model.live.blur="content">
     <div>
         @error('content') <span class="error">{{ $message }}</span> @enderror
     </div>
@@ -631,7 +631,7 @@ For example, if a user visits a `post.edit` page and starts modifying the title 
 Livewire provides the `wire:dirty` directive to allow you to toggle elements or modify classes when an input's value diverges from the server-side component:
 
 ```blade
-<input type="text" wire:model.blur="title" wire:dirty.class="border-yellow">
+<input type="text" wire:model.live.blur="title" wire:dirty.class="border-yellow">
 ```
 
 In the above example, when a user types into the input field, a yellow border will appear around the field. When the user tabs away, the network request is sent and the border will disappear; signaling to them that the input has been persisted and is no longer "dirty".

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -207,7 +207,9 @@ Common migrations:
 |-----------|------------------------------|
 | `wire:model.blur` | `wire:model.live.blur` |
 | `wire:model.change` | `wire:model.live.change` |
-| `wire:model.lazy` | `wire:model.live.change` |
+
+> [!info] `.lazy` is backwards compatible
+> `wire:model.lazy` continues to work as it did in v3—no migration needed.
 
 New capabilities in v4:
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -181,6 +181,49 @@ In v3, Livewire component tags would render even without being properly closed. 
 
 These changes may affect certain parts of your application depending on which features you use.
 
+### `wire:model` modifiers now control ephemeral sync timing
+
+In v3, modifiers like `.blur` and `.change` only controlled when network requests were sent—the input's value was always synced to the component's ephemeral (client-side) state immediately as the user typed.
+
+In v4, these modifiers now control when the client-side state syncs. This gives you full control over both layers:
+
+- Modifiers **before** `.live` control client-side (x-model) sync timing
+- Modifiers **after** `.live` control network request timing
+
+```blade
+<!-- Before (v3) - .blur delayed network, but ephemeral synced immediately -->
+<input wire:model.blur="title">
+
+<!-- After (v4) - .blur delays ephemeral sync, and NO network (no .live) -->
+<input wire:model.blur="title">
+
+<!-- To get v3 behavior (ephemeral immediate, network on blur): -->
+<input wire:model.live.blur="title">
+```
+
+Common migrations:
+
+| v3 Syntax | v4 Equivalent (same behavior) |
+|-----------|------------------------------|
+| `wire:model.blur` | `wire:model.live.blur` |
+| `wire:model.change` | `wire:model.live.change` |
+| `wire:model.lazy` | `wire:model.live.change` |
+
+New capabilities in v4:
+
+```blade
+<!-- Ephemeral syncs on blur only, no network -->
+<input wire:model.blur="title">
+
+<!-- Ephemeral syncs on blur OR enter, then network fires -->
+<input wire:model.blur.enter.live="title">
+
+<!-- Ephemeral on blur, network debounced 500ms after -->
+<input wire:model.blur.live.debounce.500ms="title">
+```
+
+[Learn more about wire:model modifiers →](/docs/4.x/wire-model#modifier-layering)
+
 ### `wire:transition` now uses View Transitions API
 
 In v3, `wire:transition` was a wrapper around Alpine's `x-transition` directive, supporting modifiers like `.opacity`, `.scale`, `.duration.200ms`, and `.origin.top`.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -275,13 +275,13 @@ Real-time validation is the term used for when you validate a user's input as th
 
 By using `#[Validate]` attributes directly on Livewire properties, any time a network request is sent to update a property's value on the server, the provided validation rules will be applied.
 
-This means to provide a real-time validation experience for your users on a specific input, no extra backend work is required. The only thing that is required is using `wire:model.live` or `wire:model.blur` to instruct Livewire to trigger network requests as the fields are filled out.
+This means to provide a real-time validation experience for your users on a specific input, no extra backend work is required. The only thing that is required is using `wire:model.live` or `wire:model.live.blur` to instruct Livewire to trigger network requests as the fields are filled out.
 
-In the below example, `wire:model.blur` has been added to the text input. Now, when a user types in the field and then tabs or clicks away from the field, a network request will be triggered with the updated value and the validation rules will run:
+In the below example, `wire:model.live.blur` has been added to the text input. Now, when a user types in the field and then tabs or clicks away from the field, a network request will be triggered with the updated value and the validation rules will run:
 
 ```blade
 <form wire:submit="save">
-    <input type="text" wire:model.blur="title">
+    <input type="text" wire:model.live.blur="title">
 
     <!-- -->
 </form>

--- a/docs/wire-dirty.md
+++ b/docs/wire-dirty.md
@@ -41,13 +41,13 @@ By adding the `.remove` modifier to `wire:dirty`, you can instead show an elemen
 
 ## Targeting property updates
 
-Imagine you are using `wire:model.blur` to update a property on the server immediately after a user leaves an input field. In this scenario, you can provide a "dirty" indication for only that property by adding `wire:target` to the element that contains the `wire:dirty` directive.
+Imagine you are using `wire:model.live.blur` to update a property on the server immediately after a user leaves an input field. In this scenario, you can provide a "dirty" indication for only that property by adding `wire:target` to the element that contains the `wire:dirty` directive.
 
 Here is an example of only showing a dirty indication when the title property has been changed:
 
 ```blade
 <form wire:submit="update">
-    <input wire:model.blur="title">
+    <input wire:model.live.blur="title">
 
     <div wire:dirty wire:target="title">Unsaved title...</div> <!-- [tl! highlight] -->
 
@@ -62,7 +62,7 @@ Often, instead of toggling entire elements, you may want to toggle individual CS
 Below is an example where a user types into an input field and the border becomes yellow, indicating an "unsaved" state. Then, when the user tabs away from the field, the border is removed, indicating that the state has been saved on the server:
 
 ```blade
-<input wire:model.blur="title" wire:dirty.class="border-yellow-500">
+<input wire:model.live.blur="title" wire:dirty.class="border-yellow-500">
 ```
 
 ## Using the `$dirty` expression

--- a/docs/wire-loading.md
+++ b/docs/wire-loading.md
@@ -100,7 +100,7 @@ You may find yourself in a situation where you would like `wire:loading` to reac
 
 ```blade
 <form wire:submit="save">
-    <input type="text" wire:model.blur="title">
+    <input type="text" wire:model.live.blur="title">
 
     <!-- ... -->
 

--- a/docs/wire-model.md
+++ b/docs/wire-model.md
@@ -307,7 +307,7 @@ wire:model="propertyName"
 | `.blur` | Only update on blur |
 | `.change` | Only update on change |
 | `.enter` | Only update on enter key |
-| `.lazy` | Alias for `.change` |
+| `.lazy` | Update on change and send network request (v3 compatible) |
 | `.debounce.Xms` | Debounce updates (use with `.live`) |
 | `.throttle.Xms` | Throttle updates (use with `.live`) |
 | `.number` | Cast value to `int` on the server |

--- a/docs/wire-model.md
+++ b/docs/wire-model.md
@@ -68,7 +68,7 @@ To send property updates to the server as a user types into an input-field, you 
 
 By default, when using `wire:model.live`, Livewire adds a 150 millisecond debounce to server updates. This means if a user is continually typing, Livewire will wait until the user stops typing for 150 milliseconds before sending a request.
 
-You can customize this timing by appending `.debounce.Xms` to the input. Here is an example of changing the debounce to 250 milliseconds:
+You can customize this timing by appending `.debounce.Xms` after `.live`. Here is an example of changing the debounce to 250 milliseconds:
 
 ```html
 <input type="text" wire:model.live.debounce.250ms="title">
@@ -76,27 +76,39 @@ You can customize this timing by appending `.debounce.Xms` to the input. Here is
 
 ### Updating on "blur" event
 
-By appending the `.blur` modifier, Livewire will only send network requests with property updates when a user clicks away from an input, or presses the tab key to move to the next input.
-
-Adding `.blur` is helpful for scenarios where you want to update the server more frequently, but not as a user types. For example, real-time validation is a common instance where `.blur` is helpful.
+The `.blur` modifier delays syncing until the user clicks away from the input:
 
 ```html
 <input type="text" wire:model.blur="title">
 ```
 
-### Updating on "change" event
-
-There are times when the behavior of `.blur` isn't exactly what you want and instead `.change` is.
-
-For example, if you want to run validation every time a select input is changed, by adding `.change`, Livewire will send a network request and validate the property as soon as a user selects a new option. As opposed to `.blur` which will only update the server after the user tabs away from the select input.
+To also send a network request on blur, add `.live`:
 
 ```html
-<select wire:model.change="title">
-    <!-- ... -->
-</select>
+<input type="text" wire:model.blur.live="title">
 ```
 
-Any changes made to the text input will be automatically synchronized with the `$title` property in your Livewire component.
+### Updating on "change" event
+
+The `.change` modifier triggers on the change event, which is useful for select elements:
+
+```html
+<select wire:model.change="state">...</select>
+
+<!-- With network request -->
+<select wire:model.change.live="state">...</select>
+```
+
+### Updating on "enter" key
+
+The `.enter` modifier syncs when the user presses the Enter key:
+
+```html
+<input type="text" wire:model.enter="search">
+
+<!-- With network request -->
+<input type="text" wire:model.enter.live="search">
+```
 
 ## Input fields
 
@@ -291,14 +303,15 @@ wire:model="propertyName"
 
 | Modifier | Description |
 |----------|-------------|
-| `.live` | Send updates as a user types |
-| `.blur` | Only send updates on the `blur` event |
-| `.change` | Only send updates on the `change` event |
+| `.live` | Send updates to the server |
+| `.blur` | Only update on blur |
+| `.change` | Only update on change |
+| `.enter` | Only update on enter key |
 | `.lazy` | Alias for `.change` |
-| `.live.debounce` | Debounces live updates by 150ms (use `.live.debounce.500ms` for a custom duration) |
-| `.live.throttle` | Throttles updates to specified interval (use `.live.throttle.500ms` for a custom duration) |
-| `.preserve-scroll` | Maintains scroll position during updates (use with `.live`) |
-| `.number` | Casts text value to `int` on the server |
-| `.boolean` | Casts text value to `bool` on the server |
-| `.fill` | Uses initial value from HTML `value` attribute on page load |
-| `.deep` | Also listen for events bubbling up from child elements |
+| `.debounce.Xms` | Debounce updates (use with `.live`) |
+| `.throttle.Xms` | Throttle updates (use with `.live`) |
+| `.number` | Cast value to `int` on the server |
+| `.boolean` | Cast value to `bool` on the server |
+| `.fill` | Use initial value from HTML `value` attribute |
+| `.deep` | Also listen to events from child elements |
+| `.preserve-scroll` | Maintain scroll position during updates |

--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -4,7 +4,6 @@ import { findComponentByEl } from '@/store'
 import { dataGet, dataSet } from '@/utils'
 import { setNextActionMetadata, setNextActionOrigin } from '@/request'
 import Alpine from 'alpinejs'
-// Action is no longer needed - wire:model uses $commit which creates its own actions
 
 directive('model', ({ el, directive, component, cleanup }) => {
     // @todo: will need to probaby do this further upstream i just don't want to bog down the entire lifecycle right now...
@@ -26,18 +25,34 @@ directive('model', ({ el, directive, component, cleanup }) => {
         return handleFileUpload(el, expression, component, cleanup)
     }
 
-    if (! modifiers.includes('self') && ! modifiers.includes('deep')) {
-        // Make wire:model self-binding by default...
-        modifiers.push('self')
+    // Split modifiers at .live boundary
+    // Modifiers BEFORE .live control ephemeral (x-model) sync timing
+    // Modifiers AFTER .live control network request timing
+    let liveIndex = modifiers.indexOf('live')
+    let isLive = liveIndex !== -1
+    let ephemeralModifiers = isLive ? modifiers.slice(0, liveIndex) : modifiers.slice()
+    let networkModifiers = isLive ? modifiers.slice(liveIndex + 1) : []
+
+    // Add self/deep modifier for event propagation control
+    if (! ephemeralModifiers.includes('self') && ! ephemeralModifiers.includes('deep')) {
+        ephemeralModifiers.push('self')
     }
 
-    let isLive = modifiers.includes('live')
-    let isLazy = modifiers.includes('lazy') || modifiers.includes('change')
-    let onBlur = modifiers.includes('blur')
-    let isDebounced = modifiers.includes('debounce')
-    let isThrottled = modifiers.includes('throttle')
+    // Extract ephemeral trigger modifiers (these control when x-model syncs)
+    let ephemeralOnBlur = ephemeralModifiers.includes('blur')
+    let ephemeralOnChange = ephemeralModifiers.includes('change') || ephemeralModifiers.includes('lazy')
+    let ephemeralOnEnter = ephemeralModifiers.includes('enter')
+    let hasEphemeralTriggers = ephemeralOnBlur || ephemeralOnChange || ephemeralOnEnter
 
-    // Trigger a network request (only if .live or .lazy is added to wire:model)...
+    // Extract network trigger modifiers
+    let networkOnBlur = networkModifiers.includes('blur')
+    let networkOnChange = networkModifiers.includes('change') || networkModifiers.includes('lazy')
+    let networkOnEnter = networkModifiers.includes('enter')
+    let hasNetworkTriggers = networkOnBlur || networkOnChange || networkOnEnter
+    let isDebounced = networkModifiers.includes('debounce')
+    let isThrottled = networkModifiers.includes('throttle')
+
+    // Trigger a network request
     let update = () => {
         setNextActionOrigin({ el, directive })
 
@@ -52,39 +67,59 @@ directive('model', ({ el, directive, component, cleanup }) => {
 
     let debouncedUpdate = update
 
-    if ((isLive && isRealtimeInput(el)) || isDebounced) {
-        debouncedUpdate = debounce(debouncedUpdate, parseModifierDuration(modifiers, 'debounce') || 150)
+    // Apply debounce/throttle from network modifiers
+    if ((isLive && ! hasNetworkTriggers && isRealtimeInput(el)) || isDebounced) {
+        debouncedUpdate = debounce(debouncedUpdate, parseModifierDuration(networkModifiers, 'debounce') || 150)
     }
 
     if (isThrottled) {
-        debouncedUpdate = throttle(debouncedUpdate, parseModifierDuration(modifiers, 'throttle') || 150)
+        debouncedUpdate = throttle(debouncedUpdate, parseModifierDuration(networkModifiers, 'throttle') || 150)
     }
 
-    Alpine.bind(el, {
-        ['@change']() {
-            isLazy && update()
-        },
-        ['@blur']() {
-            onBlur && update()
-        },
-        ['x-model' + getModifierTail(modifiers)]() {
-            return {
-                get() {
-                    return dataGet(component.$wire, expression)
-                },
-                set(value) {
-                    dataSet(component.$wire, expression, value)
+    // Build the bindings object
+    let bindings = {}
 
-                    isLive && (! isLazy) && (! onBlur) && debouncedUpdate()
-                },
-            }
+    // Network event listeners (for modifiers after .live)
+    if (isLive && networkOnBlur) {
+        bindings['@blur'] = () => update()
+    }
+
+    if (isLive && networkOnChange) {
+        bindings['@change'] = () => update()
+    }
+
+    if (isLive && networkOnEnter) {
+        bindings['@keydown.enter'] = () => update()
+    }
+
+    // Build x-model modifier tail from ephemeral modifiers
+    let xModelTail = getModifierTail(ephemeralModifiers)
+
+    bindings['x-model' + xModelTail] = () => {
+        return {
+            get() {
+                return dataGet(component.$wire, expression)
+            },
+            set(value) {
+                dataSet(component.$wire, expression, value)
+
+                // If .live is present and no specific network triggers, fire on every ephemeral sync
+                if (isLive && ! hasNetworkTriggers) {
+                    debouncedUpdate()
+                }
+            },
         }
-    })
+    }
+
+    Alpine.bind(el, bindings)
 })
 
 function getModifierTail(modifiers) {
+    // Filter out Livewire-specific modifiers that shouldn't go to x-model
+    // Keep: blur, change, lazy, enter, self, deep, number, boolean, trim, fill
+    // Remove: defer, live, debounce, throttle (and their durations)
     modifiers = modifiers.filter(i => ! [
-        'lazy', 'defer'
+        'defer', 'live'
     ].includes(i))
 
     if (modifiers.includes('debounce')) {

--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -34,7 +34,10 @@ directive('model', ({ el, directive, component, cleanup }) => {
     let networkModifiers = isLive ? modifiers.slice(liveIndex + 1) : []
 
     // Add self/deep modifier for event propagation control
-    if (! ephemeralModifiers.includes('self') && ! ephemeralModifiers.includes('deep')) {
+    if (
+        ! (ephemeralModifiers.includes('self') || networkModifiers.includes('self'))
+        && ! (ephemeralModifiers.includes('deep') || networkModifiers.includes('deep'))
+    ) {
         ephemeralModifiers.push('self')
     }
 

--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -40,6 +40,8 @@ directive('model', ({ el, directive, component, cleanup }) => {
 
     // For .lazy backwards compat, trigger network on change
     if (hasLazyWithoutLive) {
+        // Remove 'lazy' from ephemeralModifiers for .lazy backwards compat
+        ephemeralModifiers = ephemeralModifiers.filter(m => m !== 'lazy')
         networkModifiers.push('change')
     }
 

--- a/legacy_tests/Browser/DataBinding/AutoFill/view.blade.php
+++ b/legacy_tests/Browser/DataBinding/AutoFill/view.blade.php
@@ -5,7 +5,7 @@
     <form action="{{ url()->current() }}" method="GET">
         <label for="email">Email</label>
 
-        <input name="email" id="email" type="email" autocomplete="on" dusk="email" wire:model.blur="email">
+        <input name="email" id="email" type="email" autocomplete="on" dusk="email" wire:model.blur.live="email">
 
         <label for="password">Password</label>
 

--- a/legacy_tests/Browser/DataBinding/InputTextarea/view.blade.php
+++ b/legacy_tests/Browser/DataBinding/InputTextarea/view.blade.php
@@ -3,7 +3,7 @@
     <button wire:click="updateFooTo('changed')" dusk="foo.change">Change Foo</button>
     <button wire:click="$set('showFooClass', true)" dusk="foo.add-class">Add Class</button>
 
-    <textarea wire:model.blur="baz" dusk="baz"></textarea><span dusk="baz.output">{{ $baz }}</span>
+    <textarea wire:model.live.blur="baz" dusk="baz"></textarea><span dusk="baz.output">{{ $baz }}</span>
 
     <textarea wire:model="bob" dusk="bob"></textarea><span dusk="bob.output">{{ $bob }}</span>
     <button type="button" wire:click="$refresh" dusk="refresh">Refresh</button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,18 @@
             "name": "laravel-livewire",
             "license": "MIT",
             "dependencies": {
-                "@alpinejs/anchor": "^3.15.4",
-                "@alpinejs/collapse": "^3.15.4",
-                "@alpinejs/csp": "^3.15.4",
-                "@alpinejs/focus": "^3.15.4",
-                "@alpinejs/intersect": "^3.15.4",
-                "@alpinejs/mask": "^3.15.4",
-                "@alpinejs/morph": "^3.15.4",
-                "@alpinejs/persist": "^3.15.4",
-                "@alpinejs/resize": "^3.15.4",
-                "@alpinejs/sort": "^3.15.4",
+                "@alpinejs/anchor": "^3.15.5",
+                "@alpinejs/collapse": "^3.15.5",
+                "@alpinejs/csp": "^3.15.5",
+                "@alpinejs/focus": "^3.15.5",
+                "@alpinejs/intersect": "^3.15.5",
+                "@alpinejs/mask": "^3.15.5",
+                "@alpinejs/morph": "^3.15.5",
+                "@alpinejs/persist": "^3.15.5",
+                "@alpinejs/resize": "^3.15.5",
+                "@alpinejs/sort": "^3.15.5",
                 "@vue/reactivity": "^3.2.45",
-                "alpinejs": "^3.15.4",
+                "alpinejs": "^3.15.5",
                 "nprogress": "^0.2.0"
             },
             "devDependencies": {
@@ -29,21 +29,21 @@
             }
         },
         "node_modules/@alpinejs/anchor": {
-            "version": "3.15.4",
-            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.15.4.tgz",
-            "integrity": "sha512-HTPgAMpWSLjjhLbHsL+WWrUwQfNmA4Ahf7Ch2KkMHeoUf/QgYLJOQbc61V5Vf+S9Qtw63uJubdYo/l1xnmnPog==",
+            "version": "3.15.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.15.5.tgz",
+            "integrity": "sha512-tKu56iLZJdOXs0IU29MRPsmRJXJHb50Ou95Rzwo3MLkwXAvHob6CYgt4cAQp9/Qla8fvJQgrb/UlOYrMGIsmHw==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/collapse": {
-            "version": "3.15.4",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.15.4.tgz",
-            "integrity": "sha512-yXJ68i3z4TatceD3VblicYZr0wD3UtYQvFw20ML/53iww+vAXTH/smgHrtvgyq3Ju4c21aVrRqCvXRnkxIsQVQ==",
+            "version": "3.15.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.15.5.tgz",
+            "integrity": "sha512-vKXl/AC5kuy0LcZwElFwk4cZxxbl/DcqJRJOJmNZkQdT6CVLCwgl86ZyDL3crN1ECmVrYbQpKGHahC7ze1VJ4A==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/csp": {
-            "version": "3.15.4",
-            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.15.4.tgz",
-            "integrity": "sha512-S8LyVp3BR+Yp9hbUl6HlOcopEDFBqtOdtOtJT6i++ziJk0WPMG482bGZvTI7+4hEwpC7N9y1+mXoNb7ryfGm2A==",
+            "version": "3.15.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.15.5.tgz",
+            "integrity": "sha512-0bueMnF/9mXUGHgX2n9Dzcd0PH5nh/oNzpTgG4/0/Svm19DMDNb444NXhTsrBNaa+p46xG49CO16z8o1nDyjbg==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -65,9 +65,9 @@
             "license": "MIT"
         },
         "node_modules/@alpinejs/focus": {
-            "version": "3.15.4",
-            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.15.4.tgz",
-            "integrity": "sha512-ggzUN4/wACPOc+MpQTX0XP7vcdm+XWug3SHZoH3uX6P9ptReYP5yyyKD/XgEJRwSdGi3TZKah1qXb5bJQKTIaQ==",
+            "version": "3.15.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.15.5.tgz",
+            "integrity": "sha512-5HHI1HBFzl3Ac4QoZxRUgWkEopLPNOebYGV1PH388sO4WcbhBkY4N0AMVRo2N/A6fw2V6Au4T7jU5d4p1F3ztw==",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^6.9.4",
@@ -75,45 +75,45 @@
             }
         },
         "node_modules/@alpinejs/intersect": {
-            "version": "3.15.4",
-            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.15.4.tgz",
-            "integrity": "sha512-BbhyRN/x1rvJZxb67pfqpEQblfBNhHr/j0rksCAx/b/ibMTyaRyRUv0COo41OKSMEsRVwI6/FZYChZ43zJkYLg==",
+            "version": "3.15.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.15.5.tgz",
+            "integrity": "sha512-O4Xq4RZE5JFQ1zLxfKkQsgmkMKs2YZ5FDW62bjVtK8t06F3/gq6VTT7RQiCIF+HN3Tv6paCyAvxo2K7CjqYgQw==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/mask": {
-            "version": "3.15.4",
-            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.15.4.tgz",
-            "integrity": "sha512-mRqlcCcHXG1Al/y0z4CKxQoKYNHowBizxvSs72Qb5H0yzLWp6GIgUKzTzUXoDBoKvvGAq4vj/coeFq2VhVIhFQ==",
+            "version": "3.15.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.15.5.tgz",
+            "integrity": "sha512-TdYzc+kUhMpRfTKTY9YK7JhpDNh794ahJXpv4cNTBj7wRFlyGD6jZhkhnF4bZLPuwctGXIggV3SUh7dA2YzofA==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/morph": {
-            "version": "3.15.4",
-            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.15.4.tgz",
-            "integrity": "sha512-7tbimDhg7QNYTNKDhHBkZA3xJDgvqVI70B5FmHUvTfTFlD5f7ijNF1yyqyUtHXKMsCItjq1SGuq2i2YC4+LQpg==",
+            "version": "3.15.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.15.5.tgz",
+            "integrity": "sha512-eyws1q7xoUlR38od+vcEi3LTk5A8E825BW2+MhKu38Ar1BNOYj8m5aUFFkoeUS42BAqiRoFvg4l08YxLwqSW5g==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/persist": {
-            "version": "3.15.4",
-            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.15.4.tgz",
-            "integrity": "sha512-PdSpPTh8sUN8a3S2BoJWpXbod68RqjuW9QGtDp0LJclAFERVjLLx2K5YzQSSg5IDQJV9OMiknSpzcEYeZPwLNw==",
+            "version": "3.15.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.15.5.tgz",
+            "integrity": "sha512-COUYM1ji0tvWkj4jL0Ov7vI8jgenzm6V9l7cWuKlLpkCjuXpP6opwubkc319hjhT+CKQZMA5HvrsJIqaC0/0sQ==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/resize": {
-            "version": "3.15.4",
-            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.15.4.tgz",
-            "integrity": "sha512-hpvJdeRXTKh7P802fI3hLGcI/mPLQJls9Hkez9KWAUE3J2rv5/FRltiRbJQxcAMxSVtWPzNTytd5CnalBeXvBw==",
+            "version": "3.15.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.15.5.tgz",
+            "integrity": "sha512-YXFVmRP8cUQsRQcssw/sOlHKSRfHb39KvVl2ffbhksgcUZ6bWe53hqff+gXTdwH0feEmDr86UYrRNbi34S3jnA==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/sort": {
-            "version": "3.15.4",
-            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.15.4.tgz",
-            "integrity": "sha512-CzvqGo0BkqDn3aO6PYL33jBn3oLhQUdE4qTocfvbh6WbrGIKe2l8nqQAIbags0kG1zGgoJO3dFv33xq2fTC+5Q==",
+            "version": "3.15.5",
+            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.15.5.tgz",
+            "integrity": "sha512-y9On6dcvayrSN6P3l6HuTCLvvZQF5s2uhBDzRm5YL/TioUBUlVNZ7PdweShMB+O245X3cNRzjPQg+zLn/RVTKQ==",
             "license": "MIT"
         },
         "node_modules/@asamuzakjp/css-color": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.5.tgz",
-            "integrity": "sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+            "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -121,13 +121,13 @@
                 "@csstools/css-color-parser": "^3.1.0",
                 "@csstools/css-parser-algorithms": "^3.0.5",
                 "@csstools/css-tokenizer": "^3.0.4",
-                "lru-cache": "^11.2.1"
+                "lru-cache": "^11.2.4"
             }
         },
         "node_modules/@asamuzakjp/dom-selector": {
-            "version": "6.6.1",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.6.1.tgz",
-            "integrity": "sha512-8QT9pokVe1fUt1C8IrJketaeFOdRfTOS96DL3EBjE8CRZm3eHnwMlQe2NPoOSEYPwJ5Q25uYoX1+m9044l3ysQ==",
+            "version": "6.7.6",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+            "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -135,7 +135,7 @@
                 "bidi-js": "^1.0.3",
                 "css-tree": "^3.1.0",
                 "is-potential-custom-element-name": "^1.0.1",
-                "lru-cache": "^11.2.2"
+                "lru-cache": "^11.2.4"
             }
         },
         "node_modules/@asamuzakjp/nwsapi": {
@@ -241,9 +241,9 @@
             }
         },
         "node_modules/@csstools/css-syntax-patches-for-csstree": {
-            "version": "1.0.14",
-            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
-            "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+            "version": "1.0.26",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+            "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
             "dev": true,
             "funding": [
                 {
@@ -255,13 +255,7 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
-            "license": "MIT-0",
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "postcss": "^8.4"
-            }
+            "license": "MIT-0"
         },
         "node_modules/@csstools/css-tokenizer": {
             "version": "3.0.4",
@@ -284,9 +278,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
-            "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
             "cpu": [
                 "ppc64"
             ],
@@ -301,9 +295,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
-            "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
             "cpu": [
                 "arm"
             ],
@@ -318,9 +312,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
-            "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
             "cpu": [
                 "arm64"
             ],
@@ -335,9 +329,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
-            "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
             "cpu": [
                 "x64"
             ],
@@ -352,9 +346,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
-            "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
             "cpu": [
                 "arm64"
             ],
@@ -369,9 +363,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
-            "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
             "cpu": [
                 "x64"
             ],
@@ -386,9 +380,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
-            "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
             "cpu": [
                 "arm64"
             ],
@@ -403,9 +397,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
-            "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
             "cpu": [
                 "x64"
             ],
@@ -420,9 +414,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
-            "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
             "cpu": [
                 "arm"
             ],
@@ -437,9 +431,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
-            "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
             "cpu": [
                 "arm64"
             ],
@@ -454,9 +448,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
-            "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
             "cpu": [
                 "ia32"
             ],
@@ -488,9 +482,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
-            "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
             "cpu": [
                 "mips64el"
             ],
@@ -505,9 +499,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
-            "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
             "cpu": [
                 "ppc64"
             ],
@@ -522,9 +516,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
-            "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
             "cpu": [
                 "riscv64"
             ],
@@ -539,9 +533,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
-            "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
             "cpu": [
                 "s390x"
             ],
@@ -556,9 +550,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
-            "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
             "cpu": [
                 "x64"
             ],
@@ -573,9 +567,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
-            "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
             "cpu": [
                 "arm64"
             ],
@@ -590,9 +584,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
-            "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
             "cpu": [
                 "x64"
             ],
@@ -607,9 +601,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
-            "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
             "cpu": [
                 "arm64"
             ],
@@ -624,9 +618,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
-            "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
             "cpu": [
                 "x64"
             ],
@@ -641,9 +635,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
-            "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
             "cpu": [
                 "arm64"
             ],
@@ -658,9 +652,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
-            "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
             "cpu": [
                 "x64"
             ],
@@ -675,9 +669,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
-            "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
             "cpu": [
                 "arm64"
             ],
@@ -692,9 +686,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
-            "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
             "cpu": [
                 "ia32"
             ],
@@ -709,9 +703,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
-            "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
             "cpu": [
                 "x64"
             ],
@@ -733,9 +727,9 @@
             "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
-            "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.56.0.tgz",
+            "integrity": "sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==",
             "cpu": [
                 "arm"
             ],
@@ -747,9 +741,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
-            "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.56.0.tgz",
+            "integrity": "sha512-lfbVUbelYqXlYiU/HApNMJzT1E87UPGvzveGg2h0ktUNlOCxKlWuJ9jtfvs1sKHdwU4fzY7Pl8sAl49/XaEk6Q==",
             "cpu": [
                 "arm64"
             ],
@@ -761,9 +755,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
-            "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.56.0.tgz",
+            "integrity": "sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==",
             "cpu": [
                 "arm64"
             ],
@@ -775,9 +769,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
-            "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.56.0.tgz",
+            "integrity": "sha512-1vXe1vcMOssb/hOF8iv52A7feWW2xnu+c8BV4t1F//m9QVLTfNVpEdja5ia762j/UEJe2Z1jAmEqZAK42tVW3g==",
             "cpu": [
                 "x64"
             ],
@@ -789,9 +783,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
-            "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.56.0.tgz",
+            "integrity": "sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==",
             "cpu": [
                 "arm64"
             ],
@@ -803,9 +797,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
-            "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.56.0.tgz",
+            "integrity": "sha512-KNa6lYHloW+7lTEkYGa37fpvPq+NKG/EHKM8+G/g9WDU7ls4sMqbVRV78J6LdNuVaeeK5WB9/9VAFbKxcbXKYg==",
             "cpu": [
                 "x64"
             ],
@@ -817,9 +811,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
-            "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.56.0.tgz",
+            "integrity": "sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==",
             "cpu": [
                 "arm"
             ],
@@ -831,9 +825,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
-            "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.56.0.tgz",
+            "integrity": "sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==",
             "cpu": [
                 "arm"
             ],
@@ -845,9 +839,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
-            "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.56.0.tgz",
+            "integrity": "sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==",
             "cpu": [
                 "arm64"
             ],
@@ -859,9 +853,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
-            "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.56.0.tgz",
+            "integrity": "sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==",
             "cpu": [
                 "arm64"
             ],
@@ -873,9 +867,23 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
-            "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.56.0.tgz",
+            "integrity": "sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.56.0.tgz",
+            "integrity": "sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==",
             "cpu": [
                 "loong64"
             ],
@@ -887,9 +895,23 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
-            "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.56.0.tgz",
+            "integrity": "sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.56.0.tgz",
+            "integrity": "sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==",
             "cpu": [
                 "ppc64"
             ],
@@ -901,9 +923,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
-            "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.56.0.tgz",
+            "integrity": "sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==",
             "cpu": [
                 "riscv64"
             ],
@@ -915,9 +937,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
-            "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.56.0.tgz",
+            "integrity": "sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -929,9 +951,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
-            "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.56.0.tgz",
+            "integrity": "sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==",
             "cpu": [
                 "s390x"
             ],
@@ -943,9 +965,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
-            "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.56.0.tgz",
+            "integrity": "sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==",
             "cpu": [
                 "x64"
             ],
@@ -957,9 +979,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
-            "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.56.0.tgz",
+            "integrity": "sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==",
             "cpu": [
                 "x64"
             ],
@@ -970,10 +992,24 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.56.0.tgz",
+            "integrity": "sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
-            "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.56.0.tgz",
+            "integrity": "sha512-LhN/Reh+7F3RCgQIRbgw8ZMwUwyqJM+8pXNT6IIJAqm2IdKkzpCh/V9EdgOMBKuebIrzswqy4ATlrDgiOwbRcQ==",
             "cpu": [
                 "arm64"
             ],
@@ -985,9 +1021,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
-            "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.56.0.tgz",
+            "integrity": "sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==",
             "cpu": [
                 "arm64"
             ],
@@ -999,9 +1035,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
-            "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.56.0.tgz",
+            "integrity": "sha512-vSSgny54D6P4vf2izbtFm/TcWYedw7f8eBrOiGGecyHyQB9q4Kqentjaj8hToe+995nob/Wv48pDqL5a62EWtg==",
             "cpu": [
                 "ia32"
             ],
@@ -1013,9 +1049,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
-            "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.56.0.tgz",
+            "integrity": "sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==",
             "cpu": [
                 "x64"
             ],
@@ -1027,9 +1063,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
-            "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.56.0.tgz",
+            "integrity": "sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==",
             "cpu": [
                 "x64"
             ],
@@ -1041,13 +1077,14 @@
             ]
         },
         "node_modules/@types/chai": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-            "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/deep-eql": "*"
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
             }
         },
         "node_modules/@types/deep-eql": {
@@ -1180,18 +1217,18 @@
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.22",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.22.tgz",
-            "integrity": "sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A==",
+            "version": "3.5.27",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.27.tgz",
+            "integrity": "sha512-vvorxn2KXfJ0nBEnj4GYshSgsyMNFnIQah/wczXlsNXt+ijhugmW+PpJ2cNPe4V6jpnBcs0MhCODKllWG+nvoQ==",
             "license": "MIT",
             "dependencies": {
-                "@vue/shared": "3.5.22"
+                "@vue/shared": "3.5.27"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.22",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.22.tgz",
-            "integrity": "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==",
+            "version": "3.5.27",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.27.tgz",
+            "integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==",
             "license": "MIT"
         },
         "node_modules/agent-base": {
@@ -1205,9 +1242,9 @@
             }
         },
         "node_modules/alpinejs": {
-            "version": "3.15.4",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.4.tgz",
-            "integrity": "sha512-lDpOdoVo0bhFjgl310k1qw3kbpUYwM/v0WByvAchsO93bl3o1rrgr0P/ssx3CimwEtNfXbmwKbtHbqTRCTTH9g==",
+            "version": "3.15.5",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.5.tgz",
+            "integrity": "sha512-l1R4em/uCUr7eJimcO/b0L1+H2tVcB1Y7cQ3d+pzwVnv0zWs7gw4MhwdsLjfLccWV2iH0ahlfaJWitNRFOZdvQ==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -1289,9 +1326,9 @@
             }
         },
         "node_modules/check-error": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+            "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1313,30 +1350,41 @@
             }
         },
         "node_modules/cssstyle": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.1.tgz",
-            "integrity": "sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==",
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+            "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@asamuzakjp/css-color": "^4.0.3",
-                "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
-                "css-tree": "^3.1.0"
+                "@asamuzakjp/css-color": "^4.1.1",
+                "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+                "css-tree": "^3.1.0",
+                "lru-cache": "^11.2.4"
             },
             "engines": {
                 "node": ">=20"
             }
         },
         "node_modules/data-urls": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
-            "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+            "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^15.0.0"
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^15.1.0"
             },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/data-urls/node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=20"
             }
@@ -1790,9 +1838,9 @@
             }
         },
         "node_modules/expect-type": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
-            "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1910,21 +1958,21 @@
             "license": "MIT"
         },
         "node_modules/jsdom": {
-            "version": "27.0.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
-            "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+            "version": "27.0.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+            "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@asamuzakjp/dom-selector": "^6.5.4",
-                "cssstyle": "^5.3.0",
+                "@asamuzakjp/dom-selector": "^6.7.2",
+                "cssstyle": "^5.3.1",
                 "data-urls": "^6.0.0",
-                "decimal.js": "^10.5.0",
+                "decimal.js": "^10.6.0",
                 "html-encoding-sniffer": "^4.0.0",
                 "http-proxy-agent": "^7.0.2",
                 "https-proxy-agent": "^7.0.6",
                 "is-potential-custom-element-name": "^1.0.1",
-                "parse5": "^7.3.0",
+                "parse5": "^8.0.0",
                 "rrweb-cssom": "^0.8.0",
                 "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
@@ -1933,8 +1981,8 @@
                 "webidl-conversions": "^8.0.0",
                 "whatwg-encoding": "^3.1.1",
                 "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^15.0.0",
-                "ws": "^8.18.2",
+                "whatwg-url": "^15.1.0",
+                "ws": "^8.18.3",
                 "xml-name-validator": "^5.0.0"
             },
             "engines": {
@@ -1957,19 +2005,19 @@
             "license": "MIT"
         },
         "node_modules/lru-cache": {
-            "version": "11.2.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-            "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+            "version": "11.2.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+            "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
             }
         },
         "node_modules/magic-string": {
-            "version": "0.30.19",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-            "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2016,9 +2064,9 @@
             "license": "MIT"
         },
         "node_modules/parse5": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+            "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2115,9 +2163,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.52.4",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
-            "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.56.0.tgz",
+            "integrity": "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2131,28 +2179,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.52.4",
-                "@rollup/rollup-android-arm64": "4.52.4",
-                "@rollup/rollup-darwin-arm64": "4.52.4",
-                "@rollup/rollup-darwin-x64": "4.52.4",
-                "@rollup/rollup-freebsd-arm64": "4.52.4",
-                "@rollup/rollup-freebsd-x64": "4.52.4",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
-                "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
-                "@rollup/rollup-linux-arm64-gnu": "4.52.4",
-                "@rollup/rollup-linux-arm64-musl": "4.52.4",
-                "@rollup/rollup-linux-loong64-gnu": "4.52.4",
-                "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
-                "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
-                "@rollup/rollup-linux-riscv64-musl": "4.52.4",
-                "@rollup/rollup-linux-s390x-gnu": "4.52.4",
-                "@rollup/rollup-linux-x64-gnu": "4.52.4",
-                "@rollup/rollup-linux-x64-musl": "4.52.4",
-                "@rollup/rollup-openharmony-arm64": "4.52.4",
-                "@rollup/rollup-win32-arm64-msvc": "4.52.4",
-                "@rollup/rollup-win32-ia32-msvc": "4.52.4",
-                "@rollup/rollup-win32-x64-gnu": "4.52.4",
-                "@rollup/rollup-win32-x64-msvc": "4.52.4",
+                "@rollup/rollup-android-arm-eabi": "4.56.0",
+                "@rollup/rollup-android-arm64": "4.56.0",
+                "@rollup/rollup-darwin-arm64": "4.56.0",
+                "@rollup/rollup-darwin-x64": "4.56.0",
+                "@rollup/rollup-freebsd-arm64": "4.56.0",
+                "@rollup/rollup-freebsd-x64": "4.56.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.56.0",
+                "@rollup/rollup-linux-arm-musleabihf": "4.56.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.56.0",
+                "@rollup/rollup-linux-arm64-musl": "4.56.0",
+                "@rollup/rollup-linux-loong64-gnu": "4.56.0",
+                "@rollup/rollup-linux-loong64-musl": "4.56.0",
+                "@rollup/rollup-linux-ppc64-gnu": "4.56.0",
+                "@rollup/rollup-linux-ppc64-musl": "4.56.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.56.0",
+                "@rollup/rollup-linux-riscv64-musl": "4.56.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.56.0",
+                "@rollup/rollup-linux-x64-gnu": "4.56.0",
+                "@rollup/rollup-linux-x64-musl": "4.56.0",
+                "@rollup/rollup-openbsd-x64": "4.56.0",
+                "@rollup/rollup-openharmony-arm64": "4.56.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.56.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.56.0",
+                "@rollup/rollup-win32-x64-gnu": "4.56.0",
+                "@rollup/rollup-win32-x64-msvc": "4.56.0",
                 "fsevents": "~2.3.2"
             }
         },
@@ -2208,9 +2259,9 @@
             "license": "MIT"
         },
         "node_modules/std-env": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-            "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
             "dev": true,
             "license": "MIT"
         },
@@ -2302,22 +2353,22 @@
             }
         },
         "node_modules/tldts": {
-            "version": "7.0.17",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.17.tgz",
-            "integrity": "sha512-Y1KQBgDd/NUc+LfOtKS6mNsC9CCaH+m2P1RoIZy7RAPo3C3/t8X45+zgut31cRZtZ3xKPjfn3TkGTrctC2TQIQ==",
+            "version": "7.0.19",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+            "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.0.17"
+                "tldts-core": "^7.0.19"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/tldts-core": {
-            "version": "7.0.17",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.17.tgz",
-            "integrity": "sha512-DieYoGrP78PWKsrXr8MZwtQ7GLCUeLxihtjC1jZsW1DnvSMdKPitJSe8OSYDM2u5H6g3kWJZpePqkp43TfLh0g==",
+            "version": "7.0.19",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+            "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
             "dev": true,
             "license": "MIT"
         },
@@ -2348,9 +2399,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.3.6",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
-            "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+            "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2446,9 +2497,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
-            "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
             "cpu": [
                 "loong64"
             ],
@@ -2463,9 +2514,9 @@
             }
         },
         "node_modules/vite/node_modules/esbuild": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
-            "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -2476,32 +2527,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.10",
-                "@esbuild/android-arm": "0.25.10",
-                "@esbuild/android-arm64": "0.25.10",
-                "@esbuild/android-x64": "0.25.10",
-                "@esbuild/darwin-arm64": "0.25.10",
-                "@esbuild/darwin-x64": "0.25.10",
-                "@esbuild/freebsd-arm64": "0.25.10",
-                "@esbuild/freebsd-x64": "0.25.10",
-                "@esbuild/linux-arm": "0.25.10",
-                "@esbuild/linux-arm64": "0.25.10",
-                "@esbuild/linux-ia32": "0.25.10",
-                "@esbuild/linux-loong64": "0.25.10",
-                "@esbuild/linux-mips64el": "0.25.10",
-                "@esbuild/linux-ppc64": "0.25.10",
-                "@esbuild/linux-riscv64": "0.25.10",
-                "@esbuild/linux-s390x": "0.25.10",
-                "@esbuild/linux-x64": "0.25.10",
-                "@esbuild/netbsd-arm64": "0.25.10",
-                "@esbuild/netbsd-x64": "0.25.10",
-                "@esbuild/openbsd-arm64": "0.25.10",
-                "@esbuild/openbsd-x64": "0.25.10",
-                "@esbuild/openharmony-arm64": "0.25.10",
-                "@esbuild/sunos-x64": "0.25.10",
-                "@esbuild/win32-arm64": "0.25.10",
-                "@esbuild/win32-ia32": "0.25.10",
-                "@esbuild/win32-x64": "0.25.10"
+                "@esbuild/aix-ppc64": "0.25.12",
+                "@esbuild/android-arm": "0.25.12",
+                "@esbuild/android-arm64": "0.25.12",
+                "@esbuild/android-x64": "0.25.12",
+                "@esbuild/darwin-arm64": "0.25.12",
+                "@esbuild/darwin-x64": "0.25.12",
+                "@esbuild/freebsd-arm64": "0.25.12",
+                "@esbuild/freebsd-x64": "0.25.12",
+                "@esbuild/linux-arm": "0.25.12",
+                "@esbuild/linux-arm64": "0.25.12",
+                "@esbuild/linux-ia32": "0.25.12",
+                "@esbuild/linux-loong64": "0.25.12",
+                "@esbuild/linux-mips64el": "0.25.12",
+                "@esbuild/linux-ppc64": "0.25.12",
+                "@esbuild/linux-riscv64": "0.25.12",
+                "@esbuild/linux-s390x": "0.25.12",
+                "@esbuild/linux-x64": "0.25.12",
+                "@esbuild/netbsd-arm64": "0.25.12",
+                "@esbuild/netbsd-x64": "0.25.12",
+                "@esbuild/openbsd-arm64": "0.25.12",
+                "@esbuild/openbsd-x64": "0.25.12",
+                "@esbuild/openharmony-arm64": "0.25.12",
+                "@esbuild/sunos-x64": "0.25.12",
+                "@esbuild/win32-arm64": "0.25.12",
+                "@esbuild/win32-ia32": "0.25.12",
+                "@esbuild/win32-x64": "0.25.12"
             }
         },
         "node_modules/vitest": {
@@ -2591,9 +2642,9 @@
             }
         },
         "node_modules/webidl-conversions": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
-            "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -2604,6 +2655,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
             "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2655,9 +2707,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.19.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+            "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
         "vitest": "^3.2.4"
     },
     "dependencies": {
-        "@alpinejs/anchor": "^3.15.4",
-        "@alpinejs/collapse": "^3.15.4",
-        "@alpinejs/csp": "^3.15.4",
-        "@alpinejs/focus": "^3.15.4",
-        "@alpinejs/intersect": "^3.15.4",
-        "@alpinejs/mask": "^3.15.4",
-        "@alpinejs/morph": "^3.15.4",
-        "@alpinejs/persist": "^3.15.4",
-        "@alpinejs/resize": "^3.15.4",
-        "@alpinejs/sort": "^3.15.4",
+        "@alpinejs/anchor": "^3.15.5",
+        "@alpinejs/collapse": "^3.15.5",
+        "@alpinejs/csp": "^3.15.5",
+        "@alpinejs/focus": "^3.15.5",
+        "@alpinejs/intersect": "^3.15.5",
+        "@alpinejs/mask": "^3.15.5",
+        "@alpinejs/morph": "^3.15.5",
+        "@alpinejs/persist": "^3.15.5",
+        "@alpinejs/resize": "^3.15.5",
+        "@alpinejs/sort": "^3.15.5",
         "@vue/reactivity": "^3.2.45",
-        "alpinejs": "^3.15.4",
+        "alpinejs": "^3.15.5",
         "nprogress": "^0.2.0"
     }
 }

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -310,7 +310,7 @@ class BrowserTest extends BrowserTestCase
             {
                 return <<<'BLADE'
                     <div>
-                        <input dusk="input" type="text" wire:model.change="title" />
+                        <input dusk="input" type="text" wire:model.change.live="title" />
                         <span dusk="ephemeral" x-text="$wire.title"></span>
                         <span dusk="server">{{ $title }}</span>
                         <button dusk="blur-target">Blur Target</button>

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -256,7 +256,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 {
                     return <<<'HTML'
                     <div>
-                        <select dusk="filter1" wire:model.change="filter1">
+                        <select dusk="filter1" wire:model.change.live="filter1">
                             <option value="">All</option>
                             <option value="some">Some</option>
                             <option value="none">None</option>
@@ -270,7 +270,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                               @break
                             @endswitch
                         </div>
-                        <select dusk="filter2" wire:model.change="filter2">
+                        <select dusk="filter2" wire:model.change.live="filter2">
                             <option value="all">All</option>
                             <option value="some">Some</option>
                             <option value="none">None</option>


### PR DESCRIPTION
## Summary

**This is a breaking change.**

`wire:model` modifiers like `.blur`, `.change`, and `.enter` now control **client-side** sync timing, not just network timing. The `.live` modifier acts as a delimiter between client-side and network modifiers.

## Breaking Change

**Before (v4.0):**
```blade
<input wire:model.blur="title">
```
- Client-side state (`$wire.title`) updates immediately as user types
- Network request fires on blur

**After (this PR):**
```blade
<input wire:model.blur="title">
```
- Client-side state updates on blur
- No network request (no `.live`)

**Migration:**
```blade
<!-- Old behavior: add .live before .blur -->
<input wire:model.live.blur="title">
```

> **Note:** `wire:model.lazy` remains backwards compatible—no changes needed.

## Why This Breaking Change?

Currently, there's no way to control **when client-side state syncs**. Alpine's `x-model` supports modifiers like `.enter`, `.blur`, and `.change` to control this, but Livewire's `wire:model` has always synced client-side state immediately—modifiers only affected network timing.

With Livewire 4's more powerful frontend (`wire:text`, `wire:show`, `$wire` reactivity), this limitation matters more than ever.

**Example use case:** Imagine width/height inputs for resizing an element. With the old behavior, as a user types "1200" into the width field, the UI reacts to "1", then "12", then "120", then "1200"—jarring and broken.

Now you can do:
```blade
<input wire:model.blur="width">
```
The value only updates when the user finishes typing and tabs away. Clean.

Or sync on Enter key:
```blade
<input wire:model.enter="search">
```

Or combine them:
```blade
<input wire:model.blur.enter="title">
```

## The New Mental Model

Modifiers **before** `.live` control client-side sync timing. Modifiers **after** `.live` control network timing.

```blade
wire:model.blur.live.debounce.500ms
         ^^^^      ^^^^^^^^^^^^^^
         │         └── Network: debounced 500ms
         └── Client-side: syncs on blur
```

## Why Now?

Livewire 4 is two weeks old. If we don't make this change now, we're locked into the current behavior for potentially years. The migration is simple (add `.live` before your modifier), and this unlocks an entire class of UI patterns that weren't possible before.
