### PR TITLE
[4.x] Fix Race Condition in Component Cache Writes

### DIFF
--- a/src/Compiler/CacheManager.php
+++ b/src/Compiler/CacheManager.php
@@ -116,7 +116,9 @@ class CacheManager
         $this->ensureCacheDirectoryExists();
         File::makeDirectory($this->cacheDirectory . '/classes', 0777, true, true);
 
-        File::put($classPath, $contents);
+        // Use atomic write to prevent race conditions when multiple
+        // concurrent requests try to compile the same component.
+        File::replace($classPath, $contents);
     }
 
     public function writeViewFile(string $sourcePath, string $contents): void
@@ -126,7 +128,7 @@ class CacheManager
         $this->ensureCacheDirectoryExists();
         File::makeDirectory($this->cacheDirectory . '/views', 0777, true, true);
 
-        File::put($viewPath, $contents);
+        File::replace($viewPath, $contents);
 
         $this->mutateFileModificationTime($viewPath);
     }
@@ -138,7 +140,7 @@ class CacheManager
         $this->ensureCacheDirectoryExists();
         File::makeDirectory($this->cacheDirectory . '/scripts', 0777, true, true);
 
-        File::put($scriptPath, $contents);
+        File::replace($scriptPath, $contents);
     }
 
     public function writeStyleFile(string $sourcePath, string $contents): void
@@ -148,7 +150,7 @@ class CacheManager
         $this->ensureCacheDirectoryExists();
         File::makeDirectory($this->cacheDirectory . '/styles', 0777, true, true);
 
-        File::put($stylePath, $contents);
+        File::replace($stylePath, $contents);
     }
 
     public function writeGlobalStyleFile(string $sourcePath, string $contents): void
@@ -158,7 +160,7 @@ class CacheManager
         $this->ensureCacheDirectoryExists();
         File::makeDirectory($this->cacheDirectory . '/styles', 0777, true, true);
 
-        File::put($stylePath, $contents);
+        File::replace($stylePath, $contents);
     }
 
     public function writePlaceholderFile(string $sourcePath, string $contents): void
@@ -168,7 +170,7 @@ class CacheManager
         $this->ensureCacheDirectoryExists();
         File::makeDirectory($this->cacheDirectory . '/placeholders', 0777, true, true);
 
-        File::put($placeholderPath, $contents);
+        File::replace($placeholderPath, $contents);
 
         $this->mutateFileModificationTime($placeholderPath);
     }
@@ -180,7 +182,7 @@ class CacheManager
         $this->ensureCacheDirectoryExists();
         File::makeDirectory($this->cacheDirectory . '/views', 0777, true, true);
 
-        File::put($viewPath, $contents);
+        File::replace($viewPath, $contents);
 
         $this->mutateFileModificationTime($viewPath);
     }


### PR DESCRIPTION
## The Problem

When multiple requests hit an uncached Livewire component at the same time, you get:

```
TypeError: Cannot use "::class" on int
```

This happens after fresh deployments when bots or users hit your site simultaneously.

## Why It Happens

In `CacheManager.php`, all write methods used `File::put()`:

```php
File::put($classPath, $contents);
```

This is not atomic. When two requests try to compile the same component:

1. Request A starts writing the file
2. Request B overwrites it mid-write
3. Request A reads the half-written file
4. PHP returns `1` instead of the class instance
5. `$instance::class` crashes

## The Fix

Use `File::replace()` which writes to a temp file first, then renames atomically:

```php
File::replace($classPath, $contents);
```

Rename operations are atomic on POSIX systems - the file is either fully there or not.

This fix applies to all cache write methods:
- `writeClassFile()` - the critical one causing the crash
- `writeViewFile()`
- `writeScriptFile()`
- `writeStyleFile()`
- `writeGlobalStyleFile()`
- `writePlaceholderFile()`
- `writeIslandFile()`

## Real Example

This error occurred in production with a footer component:

```
Cannot use "::class" on int (View: footer.blade.php)
```

The footer had `<livewire:footer-links />`. After deployment, Googlebot hit multiple pages simultaneously, triggering the race condition.