### PR TITLE
Fix `@island` directives inside Blade comments being processed

### DIFF
--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -46,19 +46,11 @@ class IslandCompiler
         }
 
         // Strip Blade comments so @island directives inside them are ignored...
-        $comments = [];
-        $contents = preg_replace_callback('/\{\{--(.*?)--\}\}/s', function ($match) use (&$comments) {
-            $placeholder = '[BLADE_COMMENT:' . count($comments) . ']';
-            $comments[] = $match[0];
-            return $placeholder;
-        }, $this->mutableContents);
+        [$contents, $comments] = $this->stripBladeComments($this->mutableContents);
 
         $result = $compiler->compileStatementsMadePublic($contents);
 
-        // Restore Blade comments...
-        $result = preg_replace_callback('/\[BLADE_COMMENT:(\d+)\]/', function ($match) use ($comments) {
-            return $comments[(int) $match[1]];
-        }, $result);
+        $result = $this->restoreBladeComments($result, $comments);
 
         for ($i=$maxNestingLevel; $i >= $currentNestingLevel; $i--) {
             $result = preg_replace_callback('/(\[STARTISLAND:([0-9]+):' . $i . '\])\((.*?)\)(.*?)(\[ENDISLAND:' . $i . '\])/s', function ($matches) use ($i) {
@@ -160,6 +152,26 @@ PHP;
         return app('livewire.compiler')->cacheManager->getHash(
             $this->pathSignature,
         );
+    }
+
+    protected function stripBladeComments(string $contents): array
+    {
+        $comments = [];
+
+        $contents = preg_replace_callback('/\{\{--(.*?)--\}\}/s', function ($match) use (&$comments) {
+            $placeholder = '[BLADE_COMMENT:' . count($comments) . ']';
+            $comments[] = $match[0];
+            return $placeholder;
+        }, $contents);
+
+        return [$contents, $comments];
+    }
+
+    protected function restoreBladeComments(string $contents, array $comments): string
+    {
+        return preg_replace_callback('/\[BLADE_COMMENT:(\d+)\]/', function ($match) use ($comments) {
+            return $comments[(int) $match[1]];
+        }, $contents);
     }
 
     public function getHackedBladeCompiler()

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -235,4 +235,44 @@ class UnitTest extends TestCase
             ->assertSee('data: not set')
             ->call('refreshWithData');
     }
+
+    public function test_commented_out_island_directives_do_not_affect_content()
+    {
+        Livewire::test(new class extends \Livewire\Component {
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    {{-- @island(defer: true) --}}
+                        This content should be visible
+                    {{-- @endisland --}}
+                </div>
+                HTML;
+            }
+        })
+            ->assertSee('This content should be visible')
+            ->assertDontSee('@island')
+            ->assertDontSee('@endisland');
+    }
+
+    public function test_commented_out_island_with_livewire_component_inside()
+    {
+        Livewire::component('inner-component', new class extends \Livewire\Component {
+            public function render() {
+                return '<span>Inner component rendered</span>';
+            }
+        });
+
+        Livewire::test(new class extends \Livewire\Component {
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    {{-- @island(defer: true) --}}
+                        <livewire:inner-component />
+                    {{-- @endisland --}}
+                </div>
+                HTML;
+            }
+        })
+            ->assertSee('Inner component rendered');
+    }
 }


### PR DESCRIPTION
# The Scenario

A user comments out an `@island` directive using Blade comments to temporarily disable it:

```blade
{{-- @island(defer: true) --}}
    <p>Some content here</p>
    <livewire:my-component />
{{-- @endisland --}}
```

They expect the content between the commented directives to render normally (just without the island behaviour), but instead the content disappears entirely.

# The Problem

The `IslandCompiler` uses a custom Blade compiler extension to find and process `@island` and `@endisland` directives. However, Blade's `compileStatements` method uses a regex that matches `@directive` patterns regardless of whether they're inside Blade comments.

When the compiler finds `@island` inside `{{-- @island --}}`, it still processes it:
1. The content between the commented `@island` and `@endisland` gets extracted to a cached island file
2. The original content is replaced with just `@island(token: '...')` which remains inside the comment
3. Since the `@island` directive is commented out, it never executes
4. The user's content has been removed and nothing renders

# The Solution

Before processing island directives, the compiler now temporarily replaces Blade comments with placeholders. After processing, the comments are restored. This ensures that `@island` directives inside comments are completely ignored, matching the expected behaviour of other Blade directives.

Fixes: https://github.com/livewire/livewire/discussions/9834