### PR TITLE
Only check checksum rate limit once per request

### DIFF
--- a/src/Mechanisms/HandleComponents/Checksum.php
+++ b/src/Mechanisms/HandleComponents/Checksum.php
@@ -39,8 +39,6 @@ class Checksum {
             return;
         }
 
-        $request->attributes->set('livewire_rate_limit_checked', true);
-
         $key = static::rateLimitKey();
 
         if (RateLimiter::tooManyAttempts($key, static::$maxFailures)) {
@@ -51,6 +49,8 @@ class Checksum {
                 'Too many invalid Livewire requests. Please try again later.'
             );
         }
+
+        $request->attributes->set('livewire_rate_limit_checked', true);
     }
 
     protected static function recordFailure()

--- a/src/Mechanisms/HandleComponents/Checksum.php
+++ b/src/Mechanisms/HandleComponents/Checksum.php
@@ -32,6 +32,15 @@ class Checksum {
 
     protected static function enforceRateLimit()
     {
+        $request = request();
+
+        // Only check the rate limit once per request (not once per component)
+        if ($request->attributes->get('livewire_rate_limit_checked')) {
+            return;
+        }
+
+        $request->attributes->set('livewire_rate_limit_checked', true);
+
         $key = static::rateLimitKey();
 
         if (RateLimiter::tooManyAttempts($key, static::$maxFailures)) {


### PR DESCRIPTION
# The Scenario

Users with multiple Livewire components on a page notice excessive database queries when using a database cache driver. Every action triggers multiple identical queries like:

```sql
select * from "cache" where "key" in ('laravel_cache_livewire-checksum-failures:127.0.0.1')
```

The number of queries multiplies with the number of components:
- 1 component = 1 query
- 3 components = 3 queries
- 10 components = 10 queries

This is especially problematic when components communicate via events (`#[On('event')]`) or use `#[Reactive]` props, as a single user action can trigger updates across multiple components.

# The Problem

In `Checksum::verify()`, the `enforceRateLimit()` method is called for every component that gets verified during a request:

```php
static function verify($snapshot) {
    static::enforceRateLimit(); // Called for EVERY component
    // ...
}
```

The `enforceRateLimit()` method calls `RateLimiter::tooManyAttempts()` which queries the cache store each time. Since all components on a page share the same IP address, this check only needs to happen once per request, not once per component.

# The Solution

Use Symfony's request attributes (which Laravel inherits) to track whether the rate limit has already been checked for the current request:

```php
protected static function enforceRateLimit()
{
    $request = request();

    if ($request->attributes->get('livewire_rate_limit_checked')) {
        return;
    }

    $key = static::rateLimitKey();

    if (RateLimiter::tooManyAttempts($key, static::$maxFailures)) {
        // ... throw TooManyRequestsHttpException
    }

    $request->attributes->set('livewire_rate_limit_checked', true);
}
```

Fixes: #9779
Fixes: #9828
Fixes: #9836