### PR TITLE
[4.x] Expose dispatchEl and dispatchRef on $wire object

### DIFF
--- a/js/$wire.js
+++ b/js/$wire.js
@@ -1,5 +1,5 @@
 import { cancelUpload, removeUpload, upload, uploadMultiple } from './features/supportFileUploads'
-import { dispatch, dispatchSelf, dispatchTo, listen } from '@/events'
+import { dispatch, dispatchEl, dispatchRef, dispatchSelf, dispatchTo, listen } from '@/events'
 import { generateEntangleFunction } from '@/features/supportEntangle'
 import { findComponentByEl } from '@/store'
 import { dataGet, dataSet } from '@/utils'
@@ -49,6 +49,8 @@ let aliases = {
     'interceptRequest': '$interceptRequest',
     'dispatchTo': '$dispatchTo',
     'dispatchSelf': '$dispatchSelf',
+    'dispatchEl': '$dispatchEl',
+    'dispatchRef': '$dispatchRef',
     'removeUpload': '$removeUpload',
     'cancelUpload': '$cancelUpload',
     'uploadMultiple': '$uploadMultiple',
@@ -303,6 +305,8 @@ wireProperty('$hook', (component) => (name, callback) => {
 wireProperty('$dispatch', (component) => (...params) => dispatch(component, ...params))
 wireProperty('$dispatchSelf', (component) => (...params) => dispatchSelf(component, ...params))
 wireProperty('$dispatchTo', () => (...params) => dispatchTo(...params))
+wireProperty('$dispatchEl', (component) => (...params) => dispatchEl(component, ...params))
+wireProperty('$dispatchRef', (component) => (...params) => dispatchRef(component, ...params))
 wireProperty('$upload', (component) => (...params) => upload(component, ...params))
 wireProperty('$uploadMultiple', (component) => (...params) => uploadMultiple(component, ...params))
 wireProperty('$removeUpload', (component) => (...params) => removeUpload(component, ...params))

--- a/src/Features/SupportEvents/BrowserTest.php
+++ b/src/Features/SupportEvents/BrowserTest.php
@@ -342,4 +342,88 @@ class BrowserTest extends BrowserTestCase
             ->pause(100)
             ->assertConsoleLogHasNoErrors();
     }
+
+    public function test_can_dispatch_to_element_using_wire_dispatch_el()
+    {
+        Livewire::visit(new class extends Component {
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button x-on:click="$wire.dispatchEl('#target', 'foo', { message: 'bar' })" dusk="button">Dispatch to element</button>
+
+                    <div id="target" x-data="{ message: 'initial' }" @foo="message = $event.detail.message">
+                        <span x-text="message" dusk="output"></span>
+                    </div>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@output', 'initial')
+            ->click('@button')
+            ->waitForTextIn('@output', 'bar');
+    }
+
+    public function test_can_dispatch_to_element_using_wire_dispatch_ref()
+    {
+        Livewire::visit(new class extends Component {
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button x-on:click="$wire.dispatchRef('target', 'foo', { message: 'bar' })" dusk="button">Dispatch to ref</button>
+
+                    <div wire:ref="target" x-data="{ message: 'initial' }" @foo="message = $event.detail.message">
+                        <span x-text="message" dusk="output"></span>
+                    </div>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@output', 'initial')
+            ->click('@button')
+            ->waitForTextIn('@output', 'bar');
+    }
+
+    public function test_can_dispatch_to_element_using_wire_click_dispatch_el()
+    {
+        Livewire::visit(new class extends Component {
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$dispatchEl('#target', 'foo', { message: 'baz' })" dusk="button">Dispatch to element</button>
+
+                    <div id="target" x-data="{ message: 'initial' }" @foo="message = $event.detail.message">
+                        <span x-text="message" dusk="output"></span>
+                    </div>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@output', 'initial')
+            ->click('@button')
+            ->waitForTextIn('@output', 'baz');
+    }
+
+    public function test_can_dispatch_to_element_using_wire_click_dispatch_ref()
+    {
+        Livewire::visit(new class extends Component {
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$dispatchRef('target', 'foo', { message: 'baz' })" dusk="button">Dispatch to ref</button>
+
+                    <div wire:ref="target" x-data="{ message: 'initial' }" @foo="message = $event.detail.message">
+                        <span x-text="message" dusk="output"></span>
+                    </div>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@output', 'initial')
+            ->click('@button')
+            ->waitForTextIn('@output', 'baz');
+    }
 }


### PR DESCRIPTION
# The Scenario

A user wants to dispatch an event to a specific DOM element from the client side (JavaScript/Alpine). They can do this from PHP using method chaining:

```php
$this->dispatch('post-removed')->el("#post-{$post->id}");
$this->dispatch('foo')->ref('myRef');
```

However, when trying to do the same from the client side, the methods are not available:

```blade
{{-- These don't work --}}
<button x-on:click="$wire.dispatchEl('#target', 'foo', { message: 'bar' })">...</button>
<button wire:click="$dispatchRef('target', 'foo')">...</button>
```

# The Problem

The `dispatchEl` and `dispatchRef` functions exist in `js/events.js` and are used internally when processing server-dispatched events (via `->el()` or `->ref()`), but they were not exposed on the `$wire` object for client-side use.

# The Solution

Added `dispatchEl` and `dispatchRef` to the `$wire` object by:

1. Importing the functions in `js/$wire.js`
2. Registering them as wire properties (`$dispatchEl`, `$dispatchRef`)
3. Adding aliases so users can use either `dispatchEl` or `$dispatchEl`

Now users can dispatch events to specific elements from both Alpine and wire directives:

```blade
{{-- Using Alpine --}}
<button x-on:click="$wire.dispatchEl('#target', 'foo', { message: 'bar' })">...</button>
<button x-on:click="$wire.dispatchRef('target', 'foo', { message: 'bar' })">...</button>

{{-- Using wire: directives --}}
<button wire:click="$dispatchEl('#target', 'foo', { message: 'bar' })">...</button>
<button wire:click="$dispatchRef('target', 'foo', { message: 'bar' })">...</button>
```

Fixes: #9829