### PR TITLE
[4.x] Fix syntax error when @script blocks start with comments

### DIFF
--- a/js/features/supportScriptsAndAssets.js
+++ b/js/features/supportScriptsAndAssets.js
@@ -37,6 +37,13 @@ on('effect', ({ component, effects }) => {
             onlyIfScriptHasntBeenRunAlreadyForThisComponent(component, key, () => {
                 let scriptContent = extractScriptTagContent(content)
 
+                // Always wrap @script content in an IIFE since it's multi-statement code.
+                // Alpine's evaluator tries to detect let/const at the start, but doesn't
+                // account for leading comments which causes syntax errors.
+                scriptContent = scriptContent.includes('await')
+                    ? `(async()=>{ ${scriptContent} })()`
+                    : `(()=>{ ${scriptContent} })()`
+
                 Alpine.dontAutoEvaluateFunctions(() => {
                     evaluateExpression(component.el, scriptContent, {
                         context: component.$wire,

--- a/src/Features/SupportScriptsAndAssets/BrowserTest.php
+++ b/src/Features/SupportScriptsAndAssets/BrowserTest.php
@@ -372,4 +372,27 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertDontSeeIn('@output', 'evaluated')
         ;
     }
+
+    public function test_scripts_with_comments_before_let_declarations_work()
+    {
+        Livewire::visit(new class extends \Livewire\Component {
+            public function render() { return <<<'HTML'
+            <div>
+                <div dusk="output"></div>
+            </div>
+
+            @script
+                <script>
+                    // This comment before let used to cause a syntax error
+                    let message = 'success'
+
+                    document.querySelector('[dusk="output"]').textContent = message
+                </script>
+            @endscript
+            HTML; }
+        })
+            ->waitForText('success')
+            ->assertSeeIn('@output', 'success')
+        ;
+    }
 }


### PR DESCRIPTION
# The Scenario

When using `@script` blocks with a comment before a variable declaration, page load fails with a JavaScript syntax error: `SyntaxError: Unexpected identifier 'pendingFormData'`

```php
class MyComponent extends Component
{
    public function render()
    {
        return <<<'HTML'
        <div>
            <span>Hello</span>
        </div>

        @script
        <script>
            // Store form data when submitted
            let pendingFormData = null
        </script>
        @endscript
        HTML;
    }
}
```

# The Problem

Alpine's `normalRawEvaluator` function uses regex to detect if an expression starts with `let` or `const`:

```javascript
/^(let|const)\s/.test(expression.trim())
```

When this matches, Alpine wraps the expression in an Immediately Invoked Function Expression (IIFE) so it can be executed as statements rather than as a single expression. The issue is that `trim()` only removes whitespace, not comments. So when a comment precedes the `let` declaration:

```javascript
// Store form data when submitted
let pendingFormData = null
```

The trimmed expression starts with `//`, not `let`, so the regex doesn't match. Without the IIFE wrapping, Alpine generates code like this:

```javascript
let __result = // Store form data when submitted
let pendingFormData = null
```

The line comment consumes the assignment (`__result =`), leaving a bare `let pendingFormData = null` statement that can't be used as the right-hand side of an assignment.

# The Solution

Wrap `@script` content in an IIFE before passing it to Alpine's evaluator. Since `@script` blocks are always multi-statement code intended to run as statements, they should always be wrapped rather than relying on Alpine's detection logic.

The fix handles both sync and async cases:
- `(()=>{ ... })()` for synchronous code
- `(async()=>{ ... })()` for code containing `await`

Fixes: https://github.com/livewire/livewire/discussions/9849