### PR TITLE
[4.x] Highlight wire:model v4.1 change in upgrade guide

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -22,6 +22,18 @@ php artisan optimize:clear
 > [!info] View all changes on GitHub
 > For a complete overview of all code changes between v3 and v4, you can review the full diff on GitHub: [Compare 3.x to main →](https://github.com/livewire/livewire/compare/3.x...main)
 
+## Upgrading to v4.1 from v4.0
+
+### `wire:model` modifier behavior change
+
+Modifiers like `.blur` and `.change` now control when client-side state syncs, not just network timing. If you're using these modifiers and want the previous behavior, add `.live` before them (e.g., `wire:model.live.blur`).
+
+[See full details below →](#wiremodel-modifiers-now-control-client-side-sync-timing)
+
+---
+
+The following changes apply when upgrading from v3 to v4.
+
 ## High-impact changes
 
 These changes are most likely to affect your application and should be reviewed carefully.


### PR DESCRIPTION
# The Scenario

Users upgrading from v4.0 to v4.1 may not realise that `wire:model` modifiers like `.blur` and `.change` have changed behavior. The existing documentation for this change was buried in the "Medium-impact changes" section, which is primarily focused on v3 → v4 migration.

# The Problem

The upgrade guide didn't clearly distinguish between v3 → v4.0 changes and v4.0 → v4.1 changes. Users already on v4.0 had to read through the entire guide to find the one breaking change that affected them.

# The Solution

Added a new "Upgrading to v4.1 from v4.0" section near the top of the upgrade guide with a brief summary and link to the full details below. This makes it easy for v4.0 users to quickly find what changed, while keeping the detailed documentation in its logical place within the Medium-impact changes section.

Also added a horizontal rule and intro line to visually separate the v4.1 section from the v3 → v4 upgrade content.

<img width="3084" height="2086" alt="Screenshot 2026-01-28 at 01 03 28PM@2x" src="https://github.com/user-attachments/assets/00806685-8252-4511-b877-7f59806a4957" />
