### PR TITLE
[3.x] Fix catch-all routes intercepting Livewire update requests

### DIFF
--- a/src/Mechanisms/HandleRequests/CustomUpdateRouteUnitTest.php
+++ b/src/Mechanisms/HandleRequests/CustomUpdateRouteUnitTest.php
@@ -15,14 +15,15 @@ class CustomUpdateRouteUnitTest extends TestCase
         ];
     }
 
-    public function test_only_one_livewire_update_route_is_registered_with_custom_update_routes(): void
+    public function test_custom_route_is_used_for_url_generation(): void
     {
+        // Both default and custom routes exist (with different names to avoid collision)
         $livewireUpdateRoutes = collect(Route::getRoutes()->getRoutes())->filter(function ($route) {
             return str($route->getName())->endsWith('livewire.update');
         });
 
-        $this->assertCount(1, $livewireUpdateRoutes);
-        $this->assertEquals('custom/livewire/update', $livewireUpdateRoutes->first()->uri());
+        $this->assertCount(2, $livewireUpdateRoutes);
+        $this->assertEquals('/custom/livewire/update', Livewire::getUpdateUri());
     }
 }
 

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -46,10 +46,8 @@ class UnitTest extends TestCase
         $newHandleRequests = new HandleRequests();
         $newHandleRequests->boot();
 
-        // Manually trigger the booted callback since we're already past the boot phase
-        app()->booted(function () {});
-
         // Verify that still only one livewire.update route exists (no duplicate)
+        // The updateRouteExists() check in boot() prevents duplicate registration
         $livewireUpdateRoutes = collect(Route::getRoutes()->getRoutes())->filter(function ($route) {
             return str($route->getName())->endsWith('livewire.update');
         });

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -54,6 +54,21 @@ class UnitTest extends TestCase
         $this->assertCount(1, $livewireUpdateRoutes);
     }
 
+    public function test_catch_all_route_does_not_intercept_livewire_update_requests(): void
+    {
+        // Register a catch-all route (simulating what happens in routes files)
+        Route::any('{all?}', function () {
+            return 'catch-all';
+        })->where('all', '.*');
+
+        // Livewire's update route should still be matched
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->post('/livewire/update', ['components' => []]);
+
+        $response->assertOk();
+        $this->assertArrayHasKey('components', $response->json());
+    }
+
     public function test_get_update_uri_works_when_update_route_property_is_null(): void
     {
         // Simulate the cached routes scenario where routes are loaded from cache


### PR DESCRIPTION
# The Scenario

When using a catch-all route in your Laravel application, Livewire update requests fail because the catch-all route intercepts them before they reach Livewire's update endpoint.

```php
// routes/web.php
Route::any('{all?}', function () {
    return 'Catch all';
})->where('all', '.*');
```

```php
<?php

use Livewire\Component;

class Counter extends Component
{
    public $count = 0;

    public function increment()
    {
        $this->count++;
    }
}

?>

<div>
    <button wire:click="increment">+</button>
    <span>{{ $count }}</span>
</div>
```

Clicking the button results in the catch-all route handling the request instead of Livewire.

# The Problem

After PR #9699 introduced `app()->booted()` deferral to fix duplicate route name collisions (Laravel v12.29.0+), a new issue emerged: catch-all routes defined in routes files were intercepting Livewire update requests because the default Livewire route was registered AFTER the routes files loaded.

The route registration order was:
1. Livewire's `boot()` runs and schedules route registration via `app()->booted()`
2. Routes files load (via RouteServiceProvider)
3. Catch-all routes are registered
4. `app()->booted()` callback fires, registering Livewire route AFTER the catch-all

Since Laravel matches routes in order of registration, the catch-all route matched first.

# The Solution

1. **Remove `app()->booted()` deferral** - Register the default route immediately in `boot()` so it's positioned before any catch-all routes in routes files

2. **Use a different name for the default route** - Name it `default.livewire.update` instead of `livewire.update` to avoid name collision with custom routes

3. **Update `findUpdateRoute()` to prioritise custom routes** - When both routes exist, return the custom route for URL generation

This ensures:
- The Livewire route is registered before routes files load
- Custom routes can still override the default without name collisions
- URL generation uses the custom route when one is defined

Fixes https://github.com/livewire/livewire/discussions/9228