### PR TITLE
[4.x] Add $wire.$island() API for calling methods scoped to islands

### DIFF
--- a/docs/islands.md
+++ b/docs/islands.md
@@ -295,51 +295,17 @@ The polling is scoped to the island — only the island will refresh every 3 sec
 
 ## Triggering islands from JavaScript
 
-You can trigger island updates from Alpine or JavaScript using `$wire.$island()`. This returns a `$wire`-like object where any method you call will only re-render the named island:
+The `wire:island` directive only works alongside Livewire action directives like `wire:click`. To scope an action to an island from Alpine or JavaScript, use `$wire.$island()`:
 
 ```blade
-<?php // resources/views/components/⚡activity-feed.blade.php
-
-use Livewire\Attributes\Computed;
-use Livewire\Component;
-use App\Models\Activity;
-
-new class extends Component {
-    public $page = 1;
-
-    public function loadMore()
-    {
-        $this->page++;
-    }
-
-    #[Computed]
-    public function activities()
-    {
-        return Activity::latest()
-            ->forPage($this->page, 10)
-            ->get();
-    }
-};
-?>
-
-<div>
-    @island(name: 'feed')
-        @foreach ($this->activities as $activity)
-            <x-activity-item wire:key="{{ $activity->id }}" :activity="$activity" />
-        @endforeach
-    @endisland
-
-    <button type="button" x-on:click="$wire.$island('feed').loadMore()">
-        Load more
-    </button>
-</div>
+<button type="button" x-on:click="$wire.$island('feed').loadMore()">
+    Load more
+</button>
 ```
 
-This is equivalent to using `wire:click="loadMore" wire:island="feed"`, but gives you the flexibility of Alpine expressions and JavaScript logic.
+This is equivalent to `wire:click="loadMore" wire:island="feed"`, but gives you the flexibility of Alpine expressions and JavaScript logic.
 
-### Append and prepend from JavaScript
-
-To use append or prepend mode, pass a `mode` option:
+Append and prepend modes are supported via an options parameter:
 
 ```blade
 <button type="button" x-on:click="$wire.$island('feed', { mode: 'append' }).loadMore()">
@@ -347,12 +313,12 @@ To use append or prepend mode, pass a `mode` option:
 </button>
 ```
 
-### Refreshing an island from JavaScript
+Any `$wire` method works with `$island()`, including `$refresh()`, `$set()`, and `$toggle()`:
 
-To refresh an island without calling a specific method, use `$refresh()`:
-
-```js
-$wire.$island('revenue').$refresh()
+```blade
+<button type="button" x-on:click="$wire.$island('revenue').$refresh()">
+    Refresh revenue
+</button>
 ```
 
 ## Considerations

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -791,8 +791,9 @@ let $wire = {
     // Usage: Alpine.$watch('count', (value, old) => { ... })
     $watch(name, callback) { ... },
 
-    // Return a $wire-like object scoped to an island...
-    // Any method called on it will only re-render the named island.
+    // Scope the next action to a named island...
+    // Returns $wire so you can chain any method call.
+    // The chained action will only re-render the named island.
     // Usage: $wire.$island('revenue').$refresh()
     // Usage: $wire.$island('feed', { mode: 'append' }).loadMore()
     $island(name, options = {}) { ... },

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -791,6 +791,12 @@ let $wire = {
     // Usage: Alpine.$watch('count', (value, old) => { ... })
     $watch(name, callback) { ... },
 
+    // Return a $wire-like object scoped to an island...
+    // Any method called on it will only re-render the named island.
+    // Usage: $wire.$island('revenue').$refresh()
+    // Usage: $wire.$island('feed', { mode: 'append' }).loadMore()
+    $island(name, options = {}) { ... },
+
     // Refresh a component by sending a message to the server
     // to re-render the HTML and swap it into the page...
     $refresh() { ... },

--- a/js/$wire.js
+++ b/js/$wire.js
@@ -242,7 +242,7 @@ wireProperty('$call', (component) => async (method, ...params) => {
 })
 
 wireProperty('$island', (component) => (name, options = {}) => {
-    setNextActionMetadata({ island: { name, ...options } })
+    setNextActionMetadata({ island: { name, mode: 'morph', ...options } })
 
     return component.$wire
 })

--- a/js/$wire.js
+++ b/js/$wire.js
@@ -5,7 +5,7 @@ import { findComponentByEl } from '@/store'
 import { dataGet, dataSet } from '@/utils'
 import Alpine from 'alpinejs'
 import { on as hook } from './hooks'
-import { fireAction, interceptComponentAction, interceptComponentMessage, interceptComponentRequest } from '@/request'
+import { fireAction, setNextActionMetadata, interceptComponentAction, interceptComponentMessage, interceptComponentRequest } from '@/request'
 import { getErrorsObject } from '@/features/supportErrors'
 import { findRefEl } from '@/features/supportRefs'
 import { checkDirty } from './directives/wire-dirty'
@@ -241,10 +241,10 @@ wireProperty('$call', (component) => async (method, ...params) => {
     return await component.$wire[method](...params)
 })
 
-wireProperty('$island', (component) => async (name, options = {}) => {
-    return fireAction(component, '$refresh', [], {
-        island: { name, ...options },
-    })
+wireProperty('$island', (component) => (name, options = {}) => {
+    setNextActionMetadata({ island: { name, ...options } })
+
+    return component.$wire
 })
 
 wireProperty('$entangle', (component) => (name, live = false) => {

--- a/src/Features/SupportIslands/BrowserTest.php
+++ b/src/Features/SupportIslands/BrowserTest.php
@@ -793,6 +793,106 @@ class BrowserTest extends BrowserTestCase
             ;
     }
 
+    public function test_wire_island_calls_method_scoped_to_island()
+    {
+        Livewire::visit([new class extends \Livewire\Component {
+            public $count = 0;
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    @island(name: 'foo')
+                        <div dusk="island-count">Count: {{ $count }}</div>
+                    @endisland
+
+                    <button type="button" x-on:click="$wire.$island('foo').increment()" dusk="island-increment">Increment Island</button>
+
+                    <div dusk="root-count">Root count: {{ $count }}</div>
+                </div>
+                HTML;
+            }
+        }])
+            ->assertSeeIn('@island-count', 'Count: 0')
+            ->assertSeeIn('@root-count', 'Root count: 0')
+            ->waitForLivewire()->click('@island-increment')
+            ->assertSeeIn('@island-count', 'Count: 1')
+            ->assertSeeIn('@root-count', 'Root count: 0')
+            ;
+    }
+
+    public function test_wire_island_refresh_scoped_to_island()
+    {
+        Livewire::visit([new class extends \Livewire\Component {
+            public $count = 0;
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    @island(name: 'foo')
+                        <div dusk="island-count">Count: {{ $count }}</div>
+                    @endisland
+
+                    <button type="button" wire:click="increment" dusk="root-increment">Increment</button>
+
+                    <button type="button" x-on:click="$wire.$island('foo').$refresh()" dusk="island-refresh">Refresh Island</button>
+
+                    <div dusk="root-count">Root count: {{ $count }}</div>
+                </div>
+                HTML;
+            }
+        }])
+            ->assertSeeIn('@island-count', 'Count: 0')
+            ->assertSeeIn('@root-count', 'Root count: 0')
+            ->waitForLivewire()->click('@root-increment')
+            ->assertSeeIn('@island-count', 'Count: 0')
+            ->assertSeeIn('@root-count', 'Root count: 1')
+            ->waitForLivewire()->click('@island-refresh')
+            ->assertSeeIn('@island-count', 'Count: 1')
+            ->assertSeeIn('@root-count', 'Root count: 1')
+            ;
+    }
+
+    public function test_wire_island_with_append_mode()
+    {
+        Livewire::visit([new class extends \Livewire\Component {
+            public $count = 0;
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    <div dusk="foo-island">
+                        @island(name: 'foo')<div>Count: {{ $count }}</div>@endisland
+                    </div>
+
+                    <button type="button" x-on:click="$wire.$island('foo', { mode: 'append' }).increment()" dusk="append-increment">Append</button>
+                    <button type="button" x-on:click="$wire.$island('foo', { mode: 'prepend' }).increment()" dusk="prepend-increment">Prepend</button>
+                </div>
+                HTML;
+            }
+        }])
+            ->assertSourceHas('<div>Count: 0</div>')
+            ->waitForLivewire()->click('@append-increment')
+            ->assertSourceHas('<div>Count: 0</div><div>Count: 1</div>')
+            ->waitForLivewire()->click('@prepend-increment')
+            ->assertSourceHas('<div>Count: 2</div><div>Count: 0</div><div>Count: 1</div>')
+            ;
+    }
+
     public function test_more_than_ten_islands_using_single_file_component()
     {
         Livewire::visit('twelve-islands')


### PR DESCRIPTION
# The Scenario

When using `wire:click` with `wire:island`, scoping an action to a specific island works seamlessly:

```blade
<button wire:click="loadMore" wire:island.append="feed">Load more</button>
```

However, when triggering component methods from Alpine via `$wire`, there's no equivalent way to scope the call to a specific island:

```blade
{{-- How do you scope this to only re-render the "feed" island? --}}
<button x-on:click="$wire.loadMore()">Load more</button>
```

Users are forced to reach for internal APIs like `Livewire.fireAction()` with manually constructed metadata:

```js
Livewire.fireAction(this.$wire.__instance, 'loadMore', [], {
    island: { name: 'feed', mode: 'append' }
})
```

# The Problem

`$wire.$island()` exists but is undocumented. Its current implementation only supports refreshing an island — it directly fires a `$refresh` action and returns a Promise, so there's no way to call an arbitrary method through it:

```js
wireProperty('$island', (component) => async (name, options = {}) => {
    return fireAction(component, '$refresh', [], {
        island: { name, ...options },
    })
})
```

# The Solution

Change `$wire.$island('name')` to set island metadata on the next action using the existing `setNextActionMetadata` mechanism, then return `$wire`. Since JavaScript is single-threaded, the chained method call picks up the metadata before anything else can fire:

```js
wireProperty('$island', (component) => (name, options = {}) => {
    setNextActionMetadata({ island: { name, ...options } })

    return component.$wire
})
```

This means every `$wire` method works naturally — `$set`, `$toggle`, `$refresh`, `$commit`, and arbitrary method calls all get island-scoped automatically:

```js
$wire.$island('posts').loadMore()
$wire.$island('feed', { mode: 'append' }).loadMore()
$wire.$island('revenue').$refresh()
$wire.$island('settings').$set('theme', 'dark')
```

No backend changes were needed — the PHP side already handles island metadata on any method call.

Also adds documentation for the `$island()` API in both `islands.md` and `javascript.md`.

Fixes: #9654