### PR TITLE
[4.x] Add toJSON() to $wire and Component to support JSON.stringify()

### DIFF
--- a/js/$wire.js
+++ b/js/$wire.js
@@ -67,6 +67,12 @@ export function generateWireObject(component, state) {
                 return getProperty(component, property)
             } else if (property in state) {
                 return state[property]
+            } else if (property === 'toJSON') {
+                // Tools like Laravel Boost call JSON.stringify() on objects
+                // (e.g. for browser console logging). Without this, the Proxy
+                // fallback would send "toJSON" as a server-side method call,
+                // throwing a MethodNotFoundException.
+                return () => component.toJSON()
             } else if (! ['then'].includes(property)) {
                 return getFallback(component)(property)
             }

--- a/js/component.js
+++ b/js/component.js
@@ -301,6 +301,19 @@ export class Component {
         return this.jsActions
     }
 
+    // Called by JSON.stringify() on both $wire (via the Proxy) and the
+    // Component instance directly. Without this, stringifying a Component
+    // throws a circular reference error (el <-> component). Tools like
+    // Laravel Boost trigger this when logging objects to the browser console.
+    toJSON() {
+        return {
+            id: this.id,
+            name: this.name,
+            key: this.key,
+            data: Object.fromEntries(Object.entries(this.ephemeral)),
+        }
+    }
+
     addCleanup(cleanup) {
         this.cleanups.push(cleanup)
     }

--- a/src/Features/SupportJsComponent/BrowserTest.php
+++ b/src/Features/SupportJsComponent/BrowserTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Livewire\Features\SupportJsComponent;
+
+use Livewire\Livewire;
+
+// Tools like Laravel Boost call JSON.stringify() on objects they encounter
+// (e.g. when logging to the browser console). Without a toJSON() method,
+// stringifying $wire triggers the Proxy's getter traps which fires a server
+// request for a non-existent "toJSON" PHP method, and stringifying the
+// Component instance hits a circular reference (el <-> component).
+//
+// Both $wire and Component now define toJSON() to return a clean, serialisable
+// snapshot so that JSON.stringify() works safely in these scenarios.
+
+class BrowserTest extends \Tests\BrowserTestCase
+{
+    public function test_wire_can_be_json_stringified_without_triggering_server_request()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $title = 'Taylor';
+
+                public $count = 0;
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <button dusk="stringify" @click="window.result = JSON.stringify($wire)">Stringify</button>
+
+                    <span dusk="count" wire:text="count"></span>
+                </div>
+                HTML; }
+        })
+        ->waitForLivewireToLoad()
+        ->click('@stringify')
+        ->assertSeeIn('@count', '0')
+        // Assert id, name, and key are present in the output...
+        ->assertScript('(() => { let r = JSON.parse(window.result); return "id" in r && "name" in r && "key" in r })()', true)
+        // Replace dynamic values with fixed strings so we can assert the full structure...
+        ->assertScript('(() => { let r = JSON.parse(window.result); r.id = "ID"; r.name = "NAME"; r.key = "KEY"; return JSON.stringify(r) })()',
+            json_encode([
+                'id' => 'ID',
+                'name' => 'NAME',
+                'key' => 'KEY',
+                'data' => [
+                    'title' => 'Taylor',
+                    'count' => 0,
+                ],
+            ]),
+        )
+        ;
+    }
+
+    public function test_component_can_be_json_stringified_without_circular_reference_error()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $title = 'Taylor';
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <button dusk="stringify" @click="
+                        let component = $wire.__instance;
+                        window.result = JSON.stringify(component);
+                    ">Stringify</button>
+                </div>
+                HTML; }
+        })
+        ->waitForLivewireToLoad()
+        ->click('@stringify')
+        // Assert id, name, and key are present in the output...
+        ->assertScript('(() => { let r = JSON.parse(window.result); return "id" in r && "name" in r && "key" in r })()', true)
+        // Replace dynamic values with fixed strings so we can assert the full structure...
+        ->assertScript('(() => { let r = JSON.parse(window.result); r.id = "ID"; r.name = "NAME"; r.key = "KEY"; return JSON.stringify(r) })()',
+            json_encode([
+                'id' => 'ID',
+                'name' => 'NAME',
+                'key' => 'KEY',
+                'data' => [
+                    'title' => 'Taylor',
+                ],
+            ]),
+        )
+        ;
+    }
+}


### PR DESCRIPTION
# The Scenario

When using Laravel Boost alongside Livewire, any server-side exception in a Livewire component causes a cascading error that masks the original problem. Instead of seeing the actual `Undefined variable $myMissingVar` error, the developer sees:

```
Livewire\Exceptions\MethodNotFoundException
Unable to call component method. Public method [toJSON] not found on component
```

The original error is completely hidden and replaced by this unrelated method not found error.

The component doesn't need to do anything special to trigger this — it just needs to throw an exception while being loaded as a lazy component.

<img width="4932" height="2840" alt="Screenshot 2026-01-29 at 08 44 29PM@2x" src="https://github.com/user-attachments/assets/77bb5e15-8dbe-4b94-9d35-c5a451c8d74b" />

```blade
<livewire:my-component lazy />
```

```php
<?php

use Livewire\Component;

new class extends Component
{
    //
};
?>

<div>
    {{ $myMissingVar }}
</div>
```

# The Problem

Laravel Boost injects a browser logger script that intercepts console output and global errors, serialises them with `JSON.stringify()`, and sends them back to the server (stored in `storage/logs/browser.log`) for AI agent analysis via MCP tools. When a lazy Livewire component fails to load due to a server-side exception, the following chain of events occurs:

1. The lazy component sends a request to the server to load itself
2. The component throws an exception during render (e.g. `Undefined variable $myMissingVar`)
3. The server returns a 500 error response
4. The browser fires an unhandled promise rejection from the failed Livewire request
5. Boost's browser logger captures the rejection and calls `JSON.stringify()` on the error object to serialise it for logging
6. The error's `reason` object contains the DOM element (`el`), which has `$wire` and `__livewire` (the `Component` instance) attached to it
7. `JSON.stringify()` looks for a `toJSON()` method on `$wire` — the `$wire` Proxy has no handler for this, so it falls through to the server-side method call fallback
8. Livewire sends a request to call `toJSON` as a PHP method on the component, which throws `MethodNotFoundException`
9. This second error replaces the original error page, hiding the actual problem from the developer

Even after handling `toJSON` on the `$wire` Proxy, `JSON.stringify()` still hits the `Component` instance (via `el.__livewire`), which has a circular reference (`el` → `__livewire` → `el`), causing a `TypeError: Converting circular structure to JSON`.

This happens automatically without the developer doing anything explicit — just having Boost installed alongside Livewire is enough to trigger it on any server-side error.

# The Solution

Added a `toJSON()` method to both the `$wire` Proxy and the `Component` class that returns a clean, serialisable snapshot of the component:

```js
{
    id: this.id,
    name: this.name,
    key: this.key,
    data: Object.fromEntries(Object.entries(this.ephemeral)),
}
```

**On `$wire`** (`js/$wire.js`): The Proxy's `get` trap now intercepts the `toJSON` property access and delegates to `Component.toJSON()` instead of falling through to the server-side method call fallback.

**On `Component`** (`js/component.js`): The `toJSON()` method returns the component's identity and current data without including circular references (`el`, `snapshot`, reactive proxies, etc.).

This means `JSON.stringify()` works safely on both `$wire` and the `Component` instance, whether called explicitly by developers or implicitly by tools like Laravel Boost.

<img width="4932" height="2840" alt="Screenshot 2026-01-29 at 08 59 44PM@2x" src="https://github.com/user-attachments/assets/67fe40f4-3379-4b60-bf02-70366a3ae028" />

**Security note:** The serialised component data (public properties, id, name, key) ends up in Boost's browser logs at `storage/logs/browser.log`. This is acceptable because Boost only runs in `local` environments (or when `APP_DEBUG=true`), and the data exposed is the same public property data that is already present in the HTML response via Livewire's snapshot attribute.

Fixes: #9859