### PR TITLE
[4.x] Add `--css` flag and config support to `make:livewire` command

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -230,6 +230,7 @@ class MakeCommand extends Command
         $viewPath = $directory . '/' . $componentName . '.blade.php';
         $testPath = $directory . '/' . $componentName . '.test.php';
         $jsPath = $directory . '/' . $componentName . '.js';
+        $cssPath = $directory . '/' . $componentName . '.css';
 
         // Check if we're upgrading from a single-file component
         $sfcPath = $this->finder->resolveSingleFileComponentPathForCreation($name);
@@ -271,6 +272,11 @@ class MakeCommand extends Command
 
         if ($this->option('js') || config('livewire.make_command.with.js')) {
             $this->files->put($jsPath, $jsContent);
+        }
+
+        if ($this->option('css') || config('livewire.make_command.with.css')) {
+            $cssContent = $this->buildMultiFileComponentCss();
+            $this->files->put($cssPath, $cssContent);
         }
 
         $this->components->info(sprintf('Livewire component [%s] created successfully.', $directory));
@@ -376,6 +382,11 @@ class MakeCommand extends Command
     protected function buildMultiFileComponentJs(): string
     {
         return $this->files->get($this->getStubPath('livewire-mfc-js.stub'));
+    }
+
+    protected function buildMultiFileComponentCss(): string
+    {
+        return $this->files->get($this->getStubPath('livewire-mfc-css.stub'));
     }
 
     protected function getSingleFileComponentTestPath(string $sfcPath): string
@@ -580,6 +591,7 @@ class MakeCommand extends Command
             ['test', null, InputOption::VALUE_NONE, 'Create a test file'],
             ['emoji', null, InputOption::VALUE_REQUIRED, 'Use emoji in file/directory names (true or false)'],
             ['js', null, InputOption::VALUE_NONE, 'Create a JavaScript file for multi-file components'],
+            ['css', null, InputOption::VALUE_NONE, 'Create CSS files for multi-file components'],
         ];
     }
 }

--- a/src/Features/SupportConsoleCommands/Commands/livewire-mfc-css.stub
+++ b/src/Features/SupportConsoleCommands/Commands/livewire-mfc-css.stub
@@ -1,0 +1,1 @@
+/* Add your CSS here */

--- a/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
@@ -469,6 +469,36 @@ class MakeCommandUnitTest extends \Tests\TestCase
         $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.test.php')));
     }
 
+    public function test_multi_file_component_with_css_when_css_flag_provided()
+    {
+        Artisan::call('make:livewire', ['name' => 'foo', '--mfc' => true, '--css' => true]);
+
+        $this->assertTrue(File::isDirectory($this->livewireComponentsPath('⚡foo')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.php')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.blade.php')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.css')));
+    }
+
+    public function test_multi_file_component_with_css_when_configured_in_make_command_with()
+    {
+        $this->app['config']->set('livewire.make_command.with.css', true);
+
+        Artisan::call('make:livewire', ['name' => 'foo', '--mfc' => true]);
+
+        $this->assertTrue(File::isDirectory($this->livewireComponentsPath('⚡foo')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.php')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.blade.php')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.css')));
+    }
+
+    public function test_multi_file_component_without_css_by_default()
+    {
+        Artisan::call('make:livewire', ['name' => 'foo', '--mfc' => true]);
+
+        $this->assertTrue(File::isDirectory($this->livewireComponentsPath('⚡foo')));
+        $this->assertFalse(File::exists($this->livewireComponentsPath('⚡foo/foo.css')));
+    }
+
     public function test_multi_file_component_with_both_test_and_js_configured_in_make_command_with()
     {
         $this->app['config']->set('livewire.make_command.with.test', true);
@@ -481,6 +511,22 @@ class MakeCommandUnitTest extends \Tests\TestCase
         $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.blade.php')));
         $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.test.php')));
         $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.js')));
+    }
+
+    public function test_multi_file_component_with_all_options_configured_in_make_command_with()
+    {
+        $this->app['config']->set('livewire.make_command.with.test', true);
+        $this->app['config']->set('livewire.make_command.with.js', true);
+        $this->app['config']->set('livewire.make_command.with.css', true);
+
+        Artisan::call('make:livewire', ['name' => 'foo', '--mfc' => true]);
+
+        $this->assertTrue(File::isDirectory($this->livewireComponentsPath('⚡foo')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.php')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.blade.php')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.test.php')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.js')));
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo/foo.css')));
     }
 
     public function test_converting_single_file_to_multi_file_preserves_test_file()


### PR DESCRIPTION
# The Scenario

When using Livewire v4's `make_command` config to scaffold components with CSS files, the CSS file is never created — even when `css` is set to `true`:

```php
'make_command' => [
    'type' => 'mfc',
    'emoji' => true,
    'with' => [
        'js' => false,
        'css' => true, // This setting was ignored
        'test' => false,
    ],
],
```

Running `php artisan make:livewire foo --mfc` creates the `.php` and `.blade.php` files but never the `.css` file, regardless of the config setting.

# The Problem

The `make_command.with.css` config key existed in `config/livewire.php` but the `MakeCommand` never read it. There was also no `--css` command-line flag. The JS and test options were fully wired up (both `--js` flag and `make_command.with.js` config), but CSS was missed.

# The Solution

Added CSS file scaffolding to `MakeCommand` following the same pattern as JS:

- Added a `--css` command option
- Added a `livewire-mfc-css.stub` stub file (mirrors the JS stub pattern)
- Added `buildMultiFileComponentCss()` method
- Added logic in `createMultiFileComponent()` to create a `.css` file when the `--css` flag is passed or `make_command.with.css` is configured to `true`
- Added tests covering the `--css` flag, config-based creation, default behaviour (no CSS), and all options combined

Fixes: https://github.com/livewire/livewire/discussions/9868