### PR TITLE
[4.x] Fix multiple named slots broken when slot contains a nested Livewire component

### DIFF
--- a/src/Features/SupportSlots/UnitTest.php
+++ b/src/Features/SupportSlots/UnitTest.php
@@ -39,6 +39,116 @@ class UnitTest extends \Tests\TestCase
         ;
     }
 
+    public function test_multiple_named_slots()
+    {
+        Livewire::test([
+            new class extends \Livewire\Component {
+                public function render() { return <<<'HTML'
+                    <div>
+                        <livewire:child>
+                            <livewire:slot name="first">
+                                First slot content
+                            </livewire:slot>
+                            <livewire:slot name="second">
+                                Second slot content
+                            </livewire:slot>
+                        </livewire:child>
+                    </div>
+                HTML; }
+            },
+            'child' => new class extends \Livewire\Component {
+                public function render() { return <<<'HTML'
+                    <div>
+                        @if ($slots->has('first'))
+                            <div id="first">{{ $slots['first'] }}</div>
+                        @endif
+
+                        @if ($slots->has('second'))
+                            <div id="second">{{ $slots['second'] }}</div>
+                        @endif
+                    </div>
+                HTML; }
+            },
+        ])
+        ->assertSee('First slot content')
+        ->assertSee('Second slot content')
+        ;
+    }
+
+    public function test_single_named_slot_with_nested_livewire_component()
+    {
+        Livewire::test([
+            new class extends \Livewire\Component {
+                public function render() { return <<<'HTML'
+                    <div>
+                        <livewire:child>
+                            <livewire:slot name="actions">
+                                <livewire:nested />
+                            </livewire:slot>
+                        </livewire:child>
+                    </div>
+                HTML; }
+            },
+            'child' => new class extends \Livewire\Component {
+                public function render() { return <<<'HTML'
+                    <div>
+                        @if ($slots->has('actions'))
+                            <div id="actions">{{ $slots['actions'] }}</div>
+                        @endif
+                    </div>
+                HTML; }
+            },
+            'nested' => new class extends \Livewire\Component {
+                public function render() { return <<<'HTML'
+                    <div>Nested content</div>
+                HTML; }
+            },
+        ])
+        ->assertSee('Nested content')
+        ;
+    }
+
+    public function test_multiple_named_slots_with_nested_livewire_component()
+    {
+        Livewire::test([
+            new class extends \Livewire\Component {
+                public function render() { return <<<'HTML'
+                    <div>
+                        <livewire:child>
+                            <livewire:slot name="first">
+                                First slot content
+                            </livewire:slot>
+                            <livewire:slot name="second">
+                                <livewire:nested />
+                            </livewire:slot>
+                        </livewire:child>
+                    </div>
+                HTML; }
+            },
+            'child' => new class extends \Livewire\Component {
+                public function render() { return <<<'HTML'
+                    <div>
+                        @if ($slots->has('first'))
+                            <div id="first">{{ $slots['first'] }}</div>
+                        @endif
+
+                        @if ($slots->has('second'))
+                            <div id="second">{{ $slots['second'] }}</div>
+                        @endif
+                    </div>
+                HTML; }
+            },
+            'nested' => new class extends \Livewire\Component {
+                public function render() { return <<<'HTML'
+                    <div>Nested component content</div>
+                HTML; }
+            },
+        ])
+        ->assertSee('First slot content')
+        ->assertSee('Nested component content')
+        ;
+    }
+
     public function test_slot_with_short_attribute_syntax()
     {
         Livewire::test([

--- a/src/Mechanisms/RenderComponent.php
+++ b/src/Mechanisms/RenderComponent.php
@@ -62,7 +62,6 @@ unset(\$__name);
 unset(\$__params);
 unset(\$__componentSlots);
 unset(\$__split);
-if (isset(\$__slots)) unset(\$__slots);
 ?>
 EOT;
     }


### PR DESCRIPTION
# The Scenario

When using multiple named slots, and one of the slots contains a nested Livewire component, only the last named slot is rendered. Earlier named slots are silently lost. For example, given a parent that passes two named slots — `checkbox` and `edit` — where the `edit` slot contains a nested Livewire component, only the `edit` slot renders. `$slots->has('checkbox')` returns `false`. Removing the `edit` slot makes `checkbox` work again — only one named slot works at a time.

```blade
<livewire:post :post="$post">
    <livewire:slot name="checkbox">
        hello
    </livewire:slot>
    <livewire:slot name="edit">
        <livewire:post-form :post="$post" />
    </livewire:slot>
</livewire:post>
```

```blade
{{-- post component template --}}
<tr>
    <td>
        @if ($slots->has('checkbox'))
            {{-- This never renders — $slots->has('checkbox') is false --}}
            {{ $slots['checkbox'] }}
        @endif
    </td>
    <td>
        {{ $slots["edit"] }}
    </td>
</tr>
```

# The Problem

In `RenderComponent.php`, the compiled `@livewire` Blade directive unconditionally runs `unset($__slots)` after mounting a component. When a self-closing Livewire tag like `<livewire:post-form />` is rendered inside a slot's output buffer, this destroys the parent scope's `$__slots` array — wiping out any named slots that were already collected.

The execution flow:

1. `$__slots = []` — initialised by `<livewire:post>` opening tag
2. `$__slots["checkbox"] = ...` — first named slot collected
3. Second slot starts capturing with `ob_start()`
4. `<livewire:post-form />` mounts → `unset($__slots)` — **destroys the array containing `checkbox`**
5. Second slot ends → `$__slots["edit"] = ...` — creates a **new** `$__slots` with only `edit`
6. Only `edit` and `default` survive; `checkbox` is lost

A single named slot with a nested component works fine because `$__slots` is still empty when the `unset` runs — the slot content hasn't been collected yet at that point.

# The Solution

Removed the `unset($__slots)` line from `RenderComponent.php`. The `$__slots` variable lifecycle is already properly managed by the compiled opening/closing tag pairs through their save-to-`$__slotsOriginal`/restore pattern. The extra `unset` was redundant for the normal case and destructive when a self-closing Livewire tag appeared inside a named slot.

Fixes: #9851