### PR TITLE
[4.x] Fix form object `#[Validate]` attributes losing rules on consolidated updates

### DIFF
--- a/src/Features/SupportFormObjects/FormObjectSynth.php
+++ b/src/Features/SupportFormObjects/FormObjectSynth.php
@@ -41,28 +41,14 @@ class FormObjectSynth extends Synth {
         $existing = data_get($this->context->component, $this->path);
 
         if ($existing instanceof Form && $existing instanceof $meta['class']) {
-            foreach ($data as $key => $child) {
-                if ($child === null && Utils::propertyIsTypedAndUninitialized($existing, $key)) {
-                    continue;
-                }
-
-                $existing->$key = $hydrateChild($key, $child);
-            }
-
-            return $existing;
+            return $this->hydrateFormProperties($existing, $data, $hydrateChild);
         }
 
         $form = new $meta['class']($this->context->component, $this->path);
 
         $callBootMethod = static::bootFormObject($this->context->component, $form, $this->path);
 
-        foreach ($data as $key => $child) {
-            if ($child === null && Utils::propertyIsTypedAndUninitialized($form, $key)) {
-                continue;
-            }
-
-            $form->$key = $hydrateChild($key, $child);
-        }
+        $this->hydrateFormProperties($form, $data, $hydrateChild);
 
         $callBootMethod();
 
@@ -87,5 +73,18 @@ class FormObjectSynth extends Synth {
         return function () use ($form) {
             wrap($form)->boot();
         };
+    }
+
+    protected function hydrateFormProperties($form, $data, $hydrateChild)
+    {
+        foreach ($data as $key => $child) {
+            if ($child === null && Utils::propertyIsTypedAndUninitialized($form, $key)) {
+                continue;
+            }
+
+            $form->$key = $hydrateChild($key, $child);
+        }
+
+        return $form;
     }
 }


### PR DESCRIPTION
# The Scenario

When using a form object with `#[Validate]` attributes and deferred `wire:model`, submitting the form for the first time with all fields correctly populated throws a `MissingRulesException` — even though the validation rules are properly defined on the form.

It works correctly when there's a validation error to fix first (e.g. leaving a required field empty), because in that case only the corrected field is sent as an individual update rather than a consolidated one.

```
Missing [$rules/rules()] property/method on: [App\Livewire\Forms\ExampleForm].
```

```php
<?php

use App\Livewire\Forms\ExampleForm;
use Livewire\Component;

new class extends Component
{
    public ExampleForm $form;

    public function submit(): void
    {
        $validated = $this->form->validate();
    }
};
?>
<form wire:submit.prevent="submit">
    <input wire:model="form.name" />
    <input wire:model="form.email" />
    <button type="submit">Submit</button>
</form>
```

```php
<?php

namespace App\Livewire\Forms;

use Livewire\Attributes\Validate;
use Livewire\Form;

class ExampleForm extends Form
{
    #[Validate(['required', 'string', 'min:10', 'max:75'])]
    public ?string $name = null;

    #[Validate(['required', 'email', 'max:255'])]
    public ?string $email = null;
}
```

# The Problem

When **all** form fields change from their initial values in a single request (common on first submit with deferred `wire:model`), the JavaScript diff algorithm consolidates the individual field updates (`form.name`, `form.email`) into a single parent-level update (`form`). On the server, this consolidated update triggers `FormObjectSynth::hydrate()` a second time during `updateProperties()` — after `SupportAttributes::boot()` has already run. This creates a **new** form object instance whose `#[Validate]` attributes never have their `boot()` methods called, leaving `rulesFromOutside` empty and causing `MissingRulesException`.

The consolidation in `diffAndConsolidate()` (`js/utils.js`) happens when all children of an object change, which is the common case when every form field goes from its default value (e.g. `null`) to a user-provided value on first submit.

When only some fields change (e.g. correcting a single validation error), the diff sends individual dot-notation updates like `form.name`, which go through `recursivelySetValue()` and modify the **existing** form object — so the booted attribute state is preserved and validation works.

# The Solution

In `FormObjectSynth::hydrate()`, before creating a new form instance, check if a properly initialised form already exists at the same path on the component. If it does, reuse it and just update its properties. This preserves the booted attribute state (validation rules, messages, custom attributes, etc.) that was set up during the initial hydration cycle, rather than discarding it by creating a fresh instance.

Fixes: #9860