### PR TITLE
[4.x] Fix S3 file uploads breaking when `throw` is enabled on the S3 disk

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -235,7 +235,9 @@ class TemporaryUploadedFile extends UploadedFile
         if (is_null($this->metaFileData)) {
             $this->metaFileData = [];
 
-            if ($contents = $this->storage->get($this->path.'.json')) {
+            // S3 uploads don't have a meta file — the original filename is
+            // embedded in the file path instead, so skip the lookup entirely.
+            if (! FileUploadConfiguration::isUsingS3() && $contents = $this->storage->get($this->path.'.json')) {
                 $contents = json_decode($contents, true);
 
                 $this->metaFileData = $contents;


### PR DESCRIPTION
# The Scenario

When uploading files to S3 with Livewire, if the S3 filesystem disk has `'throw' => true` configured, the upload fails with an `UnableToReadFile` exception when trying to preview or access the uploaded file.

The error occurs when calling `temporaryUrl()` or `getClientOriginalName()` on the uploaded file. The file itself uploads to S3 successfully, but the component blows up immediately afterwards trying to read a `.json` metadata file that doesn't exist on S3.

```
League\Flysystem\UnableToReadFile: Unable to read file from location: temporary/e9uMt5x4ol0rYKCYLRxrxsyD6HOcQA-metaVW50aXRsZWQuanBn-.jpg.json.
```

```php
<?php

use Livewire\WithFileUploads;
use Livewire\Attributes\Validate;
use Livewire\Component;

class extends Component {
    use WithFileUploads;

    #[Validate('nullable|image|max:5120')]
    public $photo;
}; ?>

<div>
    <input type="file" wire:model="photo">

    @if ($photo)
        <img src="{{ $photo->temporaryUrl() }}">
    @endif
</div>
```

```php
// config/filesystems.php
's3' => [
    'driver' => 's3',
    // ...
    'throw' => true, // This causes the issue
],
```

# The Problem

In #9360, a `.json` metadata sidecar file was introduced alongside temporary uploads to fix long filename issues. This metadata file is created for local uploads via `FileUploadConfiguration::storeTemporaryFile()`, but S3 uploads were intentionally left unchanged — they upload directly from the browser to S3 via a pre-signed URL, so no `.json` file is ever created on S3.

The `metaFileData()` method in `TemporaryUploadedFile` unconditionally calls `$this->storage->get($this->path.'.json')` to look for this metadata file. When the file doesn't exist:

- With `'throw' => false` (Laravel's default): `Storage::get()` returns `null`, and the code gracefully falls back to extracting the original filename from the file path
- With `'throw' => true`: `Storage::get()` throws `League\Flysystem\UnableToReadFile`, and the fallback never gets a chance to run

# The Solution

Skip the `.json` metadata file lookup entirely when using S3, since S3 uploads never create one. The original filename is already embedded in the S3 file path via `generateHashNameWithOriginalNameEmbedded()`, and `extractOriginalNameFromFilePath()` handles extracting it.

Fixes: #9774