### PR TITLE
[4.x] Fix `#[Url]` properties corrupted by scientific notation overflow

### DIFF
--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -70,6 +70,14 @@ class BaseUrl extends LivewireAttribute
             $decoded = $this->recursivelyMergeArraysWithoutAppendingDuplicateValues($original, $decoded);
         }
 
+        // If json_decode produced a non-finite float (INF, -INF, NAN),
+        // it means the value looked like scientific notation with an
+        // overflowing exponent (e.g. "123456e7890"). Fall back to
+        // the original string to avoid data corruption...
+        if (is_float($decoded) && ! is_finite($decoded)) {
+            $decoded = null;
+        }
+
         // Handle empty strings differently depending on if this
         // field is considered "nullable" by typehint or API.
         if ($initialValue === null) {

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -123,4 +123,42 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame($largeNumber, $component->instance()->filters['id']);
         $this->assertSame('active', $component->instance()->filters['status']);
     }
+
+    function test_scientific_notation_strings_are_preserved_from_query_string()
+    {
+        $component = Livewire::withQueryParams([
+            'filter' => '123456e7890',
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public string $filter = '';
+        });
+
+        $this->assertSame('123456e7890', $component->instance()->filter);
+    }
+
+    function test_negative_scientific_notation_strings_are_preserved_from_query_string()
+    {
+        $component = Livewire::withQueryParams([
+            'filter' => '-123456e7890',
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public string $filter = '';
+        });
+
+        $this->assertSame('-123456e7890', $component->instance()->filter);
+    }
+
+    function test_small_scientific_notation_values_still_decode_correctly()
+    {
+        $component = Livewire::withQueryParams([
+            'value' => '1e2',
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public $value;
+        });
+
+        // Small scientific notation values are valid JSON numbers
+        // and should decode normally (1e2 = 100.0)...
+        $this->assertSame(100.0, $component->instance()->value);
+    }
 }


### PR DESCRIPTION
# The Scenario

When a `#[Url]`-bound string property receives a query string value that resembles scientific notation with a large exponent (e.g. `123456e7890`), the property value is corrupted to `INF` instead of preserving the original string.

```php
use Livewire\Attributes\Url;
use Livewire\Component;

class Test extends Component
{
    #[Url]
    public string $filter = '';
}
```

Visiting `/test?filter=123456e7890` results in `$this->filter` being set to `INF` instead of `"123456e7890"`.

# The Problem

In `BaseUrl::setPropertyFromQueryString()`, query string values are passed through `json_decode` to handle structured values (arrays, booleans, numbers). When the string `"123456e7890"` is decoded, `json_decode` interprets it as a valid JSON number in scientific notation. Since the exponent overflows, PHP produces `INF` (infinity). The existing fallback logic only checks for `null` (a failed decode), so `INF` is treated as a successful decode and used as the property value.

The `JSON_BIGINT_AS_STRING` flag added in #9711 doesn't help here — it only affects big integers, not scientific notation numbers.

# The Solution

After `json_decode`, check if the result is a non-finite float (`INF`, `-INF`, or `NAN`) using `is_float()` and `is_finite()`. If the decoded value is non-finite, reset it to `null` so the existing fallback logic preserves the original string value. This is safe because non-finite floats can never be valid JSON decode results from well-formed input — they only arise from overflow during decode.

Fixes: https://github.com/livewire/livewire/discussions/9866