### PR TITLE
[4.x] Fix form object properties being overwritten by concurrent server updates

### DIFF
--- a/js/component.js
+++ b/js/component.js
@@ -92,8 +92,7 @@ export class Component {
         let newData = extractData(deepClone(snapshot.data))
 
         Object.entries(dirty).forEach(([key, value]) => {
-            let rootKey = key.split('.')[0]
-            this.reactive[rootKey] = newData[rootKey]
+            dataSet(this.reactive, key, value)
         })
         // Object.entries(this.ephemeral).forEach(([key, value]) => {
         //     if (! deeplyEqual(this.ephemeral[key], newData[key])) {

--- a/js/component.js
+++ b/js/component.js
@@ -1,4 +1,4 @@
-import { dataSet, deepClone, diff, diffAndConsolidate, extractData} from '@/utils'
+import { dataSet, deepClone, diffAndConsolidate, extractData} from '@/utils'
 import { generateWireObject } from '@/$wire'
 import { findComponentByEl, findComponent, hasComponent } from '@/store'
 import { trigger } from '@/hooks'
@@ -79,7 +79,7 @@ export class Component {
 
         let newCanonical = extractData(deepClone(snapshot.data))
 
-        let dirty = diff(updatedOldCanonical, newCanonical)
+        let dirty = diffAndConsolidate(updatedOldCanonical, newCanonical)
 
         this.snapshotEncoded = snapshotEncoded
 
@@ -88,8 +88,6 @@ export class Component {
         this.effects = effects
 
         this.canonical = extractData(deepClone(snapshot.data))
-
-        let newData = extractData(deepClone(snapshot.data))
 
         Object.entries(dirty).forEach(([key, value]) => {
             dataSet(this.reactive, key, value)

--- a/js/component.js
+++ b/js/component.js
@@ -89,7 +89,19 @@ export class Component {
 
         this.canonical = extractData(deepClone(snapshot.data))
 
+        let newData = extractData(deepClone(snapshot.data))
+
         Object.entries(dirty).forEach(([key, value]) => {
+            let rootKey = key.split('.')[0]
+
+            // If the root-level type changed (e.g., empty array → object),
+            // we can't use dataSet on the existing reactive value, so
+            // replace the entire root key with the new data instead...
+            if (key !== rootKey && Array.isArray(this.reactive[rootKey]) !== Array.isArray(newData[rootKey])) {
+                this.reactive[rootKey] = newData[rootKey]
+                return
+            }
+
             dataSet(this.reactive, key, value)
         })
         // Object.entries(this.ephemeral).forEach(([key, value]) => {

--- a/src/Features/SupportFormObjects/BrowserTest.php
+++ b/src/Features/SupportFormObjects/BrowserTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Livewire\Features\SupportFormObjects;
+
+use Livewire\Component;
+use Livewire\Form;
+use Livewire\Livewire;
+
+class BrowserTest extends \Tests\BrowserTestCase
+{
+    public function test_form_object_property_is_not_overwritten_by_concurrent_server_update_to_sibling_property()
+    {
+        Livewire::visit(new class extends Component {
+            public FormWithTwoFieldsStub $form;
+
+            public function slowAction()
+            {
+                usleep(500 * 1000); // 500ms
+
+                $this->form->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" dusk="message" wire:model="form.message">
+
+                    <button dusk="slow" wire:click="slowAction">Slow</button>
+
+                    <span dusk="count">{{ $form->count }}</span>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@count', '0')
+        // Trigger the slow server action...
+        ->click('@slow')
+        // While the request is in-flight, type into the message field...
+        ->pause(100)
+        ->type('@message', 'typed during request')
+        // Wait for the slow action to complete...
+        ->waitForTextIn('@count', '1')
+        // The message field should still have what the user typed...
+        ->assertInputValue('@message', 'typed during request')
+        ;
+    }
+}
+
+class FormWithTwoFieldsStub extends Form
+{
+    public string $message = '';
+    public int $count = 0;
+}


### PR DESCRIPTION
# The Scenario

When using a Livewire Form object with multiple fields — for example, a message textarea and a file upload input — if the user is typing into one field while a concurrent server request modifies another property on the same form object (e.g., a file finishes uploading), the user's input is overwritten with stale state from the server.

This is particularly noticeable with file uploads because they trigger a `_finishUpload` request after the upload completes, but the same behaviour occurs with any concurrent server request that modifies a property inside a form object.

The user selects a file, then starts typing in the textarea. When the upload finishes and the server response arrives, the textarea is reset to whatever value `form.message` had when the request was sent — losing everything the user typed during the upload.

> **Note:** This was reported against v3, but this PR targets v4 (`main`). We need to decide whether to backport to 3.x as well.

```php
class MessageForm extends Form
{
    public string $message = '';
    public array $attachments = [];
}
```

```blade
<input type="file" wire:model="form.attachments">
<textarea wire:model="form.message"></textarea>
```

# The Problem

In `mergeNewSnapshot` in `js/component.js`, when a dirty key is a nested path like `form.attachments`, the code extracts the root key (`form`) and replaces the **entire** reactive object at that root:

```javascript
Object.entries(dirty).forEach(([key, value]) => {
    let rootKey = key.split('.')[0]
    this.reactive[rootKey] = newData[rootKey]
})
```

So even though only `form.attachments` changed on the server, `this.reactive['form']` is replaced wholesale with the server's version — which has a stale `form.message` value from the time the request was sent, not the user's current input.

Top-level component properties don't have this problem because there's no nesting — replacing `this.reactive['message']` only affects that single property. Form objects are uniquely affected because they group multiple properties under a single root key.

# The Solution

Three changes in `mergeNewSnapshot`:

1. **Switch from `diff` to `diffAndConsolidate`** for computing dirty keys. The old `diff` function produces flat dot-notated paths with `__rm__` markers for removed keys (e.g., `items.2: '__rm__'`), which can't be applied granularly. `diffAndConsolidate` consolidates to the parent level when array sizes change (so removals like `items` going from 3 to 2 elements are handled as a single `items` replacement), but keeps granular paths when only individual properties change (e.g., `form.attachments` stays as `form.attachments` instead of being grouped into `form`).

2. **Use `dataSet` to apply dirty values at their specific path** rather than extracting the root key and replacing the entire object:

```javascript
Object.entries(dirty).forEach(([key, value]) => {
    dataSet(this.reactive, key, value)
})
```

3. **Fall back to root-key replacement when the type changes** (e.g., empty array `[]` → associative object `{'first-component': []}`). `diffAndConsolidate` intentionally avoids consolidating these type conversions, producing granular diffs. But `dataSet` would set string keys on the existing reactive array, which doesn't work in JS. When this mismatch is detected, the entire root key is replaced instead.

Together, this means: when only `form.attachments` changes on the server, only `form.attachments` is updated in the reactive data — preserving `form.message` with the user's current input. Array resizing and type changes are still handled correctly by consolidating or replacing at the appropriate level.

Fixes: https://github.com/livewire/livewire/discussions/9610