### PR TITLE
[4.x] Allow `wire:loading` with `wire:target` to cross island boundaries

### DIFF
--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -81,8 +81,10 @@ function whenTargetsArePartOfRequest(component, el, targets, inverted, [ startLo
             return
         }
 
-        // If no island is found, see if the message has an action for the component and return if not...
-        if (! island && ! message.hasActionForComponent()) {
+        // If no island is found and no explicit targets are set, only show loading
+        // for component-scoped requests. When targets are set, allow loading to
+        // respond to any request (including island-scoped) that matches the target...
+        if (! island && targets.length === 0 && ! message.hasActionForComponent()) {
             return
         }
 

--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -74,18 +74,21 @@ function whenTargetsArePartOfRequest(component, el, targets, inverted, [ startLo
     return interceptMessage(({ message, onSend, onSuccess, onFinish }) => {
         if (component !== message.component) return
 
-        let island = closestIsland(el)
+        // When explicit targets are set via wire:target, skip island scope filtering
+        // and let the target matching handle scoping. This allows wire:loading to
+        // respond to any request containing the target, regardless of island boundaries...
+        if (targets.length === 0) {
+            let island = closestIsland(el)
 
-        // If an island is found, see if the message has an action for the island and return if not...
-        if (island && ! message.hasActionForIsland(island)) {
-            return
-        }
+            // If an island is found, see if the message has an action for the island and return if not...
+            if (island && ! message.hasActionForIsland(island)) {
+                return
+            }
 
-        // If no island is found and no explicit targets are set, only show loading
-        // for component-scoped requests. When targets are set, allow loading to
-        // respond to any request (including island-scoped) that matches the target...
-        if (! island && targets.length === 0 && ! message.hasActionForComponent()) {
-            return
+            // If no island is found, see if the message has an action for the component and return if not...
+            if (! island && ! message.hasActionForComponent()) {
+                return
+            }
         }
 
         let matches = true

--- a/src/Features/SupportWireLoading/BrowserTest.php
+++ b/src/Features/SupportWireLoading/BrowserTest.php
@@ -738,7 +738,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertVisible('@component-loading-targeted')
             ->assertMissing('@component-loading-targeted-other')
             ->assertMissing('@island-loading')
-            ->assertMissing('@island-loading-targeted')
+            ->assertVisible('@island-loading-targeted')
             ->assertMissing('@island-loading-targeted-other')
 
             // Wait for the component request to finish...
@@ -1075,7 +1075,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             ;
     }
 
-    public function test_wire_loading_with_target_inside_island_does_not_show_for_component_scoped_request()
+    public function test_wire_loading_with_target_inside_island_shows_for_component_scoped_request()
     {
         Livewire::visit([
             new class extends \Livewire\Component {
@@ -1110,7 +1110,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             // Wait for the debounce (150ms) and the Livewire request to start...
             ->pause(300)
             ->assertVisible('@outside-loading')
-            ->assertMissing('@island-loading')
+            ->assertVisible('@island-loading')
 
             // Wait for the Livewire request to finish...
             ->waitUntilMissingText('Loading...')


### PR DESCRIPTION
# The Scenario

When using `wire:model.live` on an input that targets a specific island via `wire:island`, `wire:loading` indicators with `wire:target` outside the island are not triggered. The loading state only works inside the island, or only outside if the `wire:island` attribute is removed — but never both simultaneously.

```blade
<div wire:loading.class="loading" wire:target="search">
    <input type="text" wire:model.live="search" wire:island="posts" />
</div>

@island(name: 'posts', always: true)
    @foreach($this->posts as $post)
        <div wire:loading.class="loading" wire:target="search">
            Post {{ $post->id }}
        </div>
    @endforeach
@endisland
```

# The Problem

In `js/directives/wire-loading.js`, the `whenTargetsArePartOfRequest` function applies island scope filtering before checking whether the message matches the specified `wire:target`. When a `wire:loading` element is outside an island, it calls `message.hasActionForComponent()` which returns `false` for island-scoped messages (because all actions have `metadata.island` set). Conversely, when a `wire:loading` element is inside an island, `message.hasActionForIsland()` returns `false` for component-scoped messages. In both cases, the function bails out early — even though the message payload contains the exact property the `wire:target` is looking for.

# The Solution

When explicit targets are set via `wire:target`, skip the island scope filtering entirely and let the target matching in the `onSend` callback handle scoping instead. The `wire:target` already narrows scope to specific properties/methods, so the island filtering is redundant and prevents legitimate cross-boundary loading states.

Untargeted `wire:loading` indicators (without `wire:target`) continue to respect island scope isolation as before.

```js
// Before:
let island = closestIsland(el)

if (island && ! message.hasActionForIsland(island)) {
    return
}

if (! island && ! message.hasActionForComponent()) {
    return
}

// After:
if (targets.length === 0) {
    let island = closestIsland(el)

    if (island && ! message.hasActionForIsland(island)) {
        return
    }

    if (! island && ! message.hasActionForComponent()) {
        return
    }
}
```

Fixes: #9877