### PR TITLE
[4.x] Invalid Typed Query String Check

### DIFF
--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -95,7 +95,11 @@ class BaseUrl extends LivewireAttribute
             }
             // Validate the type compatibility non-strictly
             if (!$this->strict){
-                $validator = Validator::make([$this->getSubName()=>$value],[$this->getSubName()=>(string)$this->type]);
+                $rule = $this->type->getName();
+                if ($this->nullable){
+                    $rule .= '|nullable';
+                }
+                $validator = Validator::make([$this->getSubName()=>$value],[$this->getSubName()=>$rule]);
                 if ($validator->fails()) {
                     $this->component->addError($this->getSubName(),'The value type is not compatible.');
                     return;

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -91,7 +91,13 @@ class BaseUrl extends LivewireAttribute
         }
         // Validate the type compatibility non-strictly
         if (!$this->strict){
-            Validator::make([$this->getSubName()=>$value],[$this->getSubName()=>(string)$this->type])->validate();
+            $validator = Validator::make([$this->getSubName()=>$value],[$this->getSubName()=>(string)$this->type]);
+            if ($validator->fails()) {
+                session()->flash('errors', new \Illuminate\Support\MessageBag([
+                    $this->getSubName() => ['The value type must be '.$this->type]
+                ]) );
+                return;
+            }
         }
         $this->setValue($value, $this->nullable);
     }

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -93,9 +93,7 @@ class BaseUrl extends LivewireAttribute
         if (!$this->strict){
             $validator = Validator::make([$this->getSubName()=>$value],[$this->getSubName()=>(string)$this->type]);
             if ($validator->fails()) {
-                session()->flash('errors', new \Illuminate\Support\MessageBag([
-                    $this->getSubName() => ['The value type must be '.$this->type]
-                ]) );
+                $this->component->addError($this->getSubName(),'The value type is not compatible.');
                 return;
             }
         }

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -151,5 +151,31 @@ class UnitTest extends \Tests\TestCase
             public ?string $test = null;
         })->assertStatus(200)->assertHasNoErrors();
     }
-
+    function test_it_can_handle_union_typed_property()
+    {
+        Livewire::withQueryParams([
+            'test'=>'fake'
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public string|int $test = '';
+        })->assertStatus(200)->assertHasNoErrors();
+        Livewire::withQueryParams([
+            'test'=>['fake']
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public string|int $test = '';
+        })->assertStatus(400);
+        Livewire::withQueryParams([
+            'test'=>'fake'
+        ])->test(new class extends TestComponent {
+            #[BaseUrl(strict: false)]
+            public string|int $test = '';
+        })->assertStatus(200)->assertHasNoErrors();
+        Livewire::withQueryParams([
+            'test'=>['fake']
+        ])->test(new class extends TestComponent {
+            #[BaseUrl(strict: false)]
+            public string|int $test = '';
+        })->assertStatus(200)->assertHasErrors();
+    }
 }

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -125,13 +125,15 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame('active', $component->instance()->filters['status']);
     }
 
-    function test_it_can_check_value_type(){
+    function test_return_400_error_on_invalid_type_input(){
         Livewire::withQueryParams([
             'test'=>['fake']
         ])->test(new class extends TestComponent {
             #[BaseUrl]
             public string $test = '';
         })->assertStatus(400);
+    }
+    function test_return_error_on_invalid_type_input(){
 
         Livewire::withQueryParams([
             'test'=>['fake']
@@ -139,5 +141,15 @@ class UnitTest extends \Tests\TestCase
             #[BaseUrl(strict: false)]
             public string $test = '';
         })->assertStatus(200)->assertHasErrors('test');
+
     }
+    function test_return_no_error_on_nullable_typed_property(){
+        Livewire::withQueryParams([
+            'test'=>null
+        ])->test(new class extends TestComponent {
+            #[BaseUrl(strict:false)]
+            public ?string $test = null;
+        })->assertStatus(200)->assertHasNoErrors();
+    }
+
 }

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -138,6 +138,6 @@ class UnitTest extends \Tests\TestCase
         ])->test(new class extends TestComponent {
             #[BaseUrl(strict: false)]
             public string $test = '';
-        })->assertStatus(200)->assertHasError('test');
+        })->assertStatus(200)->assertHasErrors('test');
     }
 }

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportQueryString;
 
+use HttpException;
 use Livewire\Livewire;
 use Tests\TestComponent;
 
@@ -122,5 +123,21 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertSame($largeNumber, $component->instance()->filters['id']);
         $this->assertSame('active', $component->instance()->filters['status']);
+    }
+
+    function test_it_can_check_value_type(){
+        Livewire::withQueryParams([
+            'test'=>['fake']
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public string $test = '';
+        })->assertStatus(400);
+
+        Livewire::withQueryParams([
+            'test'=>['fake']
+        ])->test(new class extends TestComponent {
+            #[BaseUrl(strict: false)]
+            public string $test = '';
+        })->assertStatus(200)->assertHasError('test');
     }
 }


### PR DESCRIPTION
As discussed [here](https://github.com/livewire/livewire/discussions/9451), the livewire throw 500 error when a user send array instead of a string or an int in the query string. 

Throwing a 500 error when a user sends invalid data is not a good idea. We must either return status code 400 or 422, or we just ignore that value and return an error to the user that your input is not correct.

I've added a strict mode to the URL attribute so users can change the behavior of the framework. By default, we abort with status code 400 instead of 500 since it's not a server error but a user input error and a bad request from the user. 

Or if it's not strict, we validate the type of the user input according to the type of the property.

Since I am not sure that this change is good enough,I did not add documentation for it. Please let me know if it's good or the api need changes so I can add this feature to the doc.