### PR TITLE
[4.x] Fix JS objects passed as functions in `wire:click` `$js` expressions

### DIFF
--- a/js/$wire.js
+++ b/js/$wire.js
@@ -114,7 +114,23 @@ Alpine.magic('wire', (el, { cleanup }) => {
                 return generateEntangleFunction(component, cleanup)
             }
 
-            return component.$wire[property]
+            let result = component.$wire[property]
+
+            // If the property isn't a known $wire property, state, or alias,
+            // it will resolve to the method fallback (a function that fires a
+            // server action). Before returning this fallback, check if the
+            // property exists in Alpine's scope chain (e.g. an x-for variable).
+            // This allows wire:click="$js.select(user)" to correctly pass
+            // Alpine-scoped variables instead of treating them as server methods...
+            if (result?.__livewire_method_fallback) {
+                let scope = Alpine.mergeProxies(Alpine.closestDataStack(el))
+
+                if (property in scope) {
+                    return scope[property]
+                }
+            }
+
+            return result
         },
 
         set(target, property, value) {
@@ -344,21 +360,27 @@ export function overrideMethod(component, method, callback) {
     overriddenMethods.set(component, obj)
 }
 
-wireFallback((component) => (property) => (...params) => {
-    // If this method is passed directly to a Vue or Alpine
-    // event listener (@click="someMethod") without using
-    // parens, strip out the automatically added event.
-    if (params.length === 1 && params[0] instanceof Event) {
-        params = []
-    }
-
-    if (overriddenMethods.has(component)) {
-        let overrides = overriddenMethods.get(component)
-
-        if (typeof overrides[property] === 'function') {
-            return overrides[property](params)
+wireFallback((component) => (property) => {
+    let fn = (...params) => {
+        // If this method is passed directly to a Vue or Alpine
+        // event listener (@click="someMethod") without using
+        // parens, strip out the automatically added event.
+        if (params.length === 1 && params[0] instanceof Event) {
+            params = []
         }
+
+        if (overriddenMethods.has(component)) {
+            let overrides = overriddenMethods.get(component)
+
+            if (typeof overrides[property] === 'function') {
+                return overrides[property](params)
+            }
+        }
+
+        return fireAction(component, property, params)
     }
 
-    return fireAction(component, property, params)
+    fn.__livewire_method_fallback = true
+
+    return fn
 })

--- a/js/evaluator.js
+++ b/js/evaluator.js
@@ -38,9 +38,10 @@ export function contextualizeExpression(expression, el) {
     let SKIP = ['JSON', 'true', 'false', 'null', 'undefined', 'this', '$wire', '$event']
     let strings = []
 
-    // Build a set of identifiers that exist in Alpine's scope chain
-    // (e.g. x-for variables) so we don't prefix them with $wire...
-    let alpineScope = el ? Alpine.mergeProxies(Alpine.closestDataStack(el)) : null
+    // Collect Alpine scopes within this component (stop at the component root)...
+    let alpineScope = el ? Alpine.mergeProxies(Alpine.closestDataStack(el, node => {
+        return node.hasAttribute && node.hasAttribute('wire:id')
+    })) : null
 
     // 1. Yank out string literals so we don't touch them
     let result = expression.replace(/(["'`])(?:(?!\1)[^\\]|\\.)*\1/g, (m) => {

--- a/src/Features/SupportJsEvaluation/BrowserTest.php
+++ b/src/Features/SupportJsEvaluation/BrowserTest.php
@@ -251,6 +251,40 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_can_pass_alpine_scoped_objects_to_js_actions_from_wire_click()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $items = [
+                    ['id' => 1, 'name' => 'first'],
+                    ['id' => 2, 'name' => 'second'],
+                ];
+
+                public function render() {
+                    return <<<'HTML'
+                        <div>
+                            <template x-for="item in $wire.items" :key="item.id">
+                                <button wire:click="$js.select(item)" dusk="select" x-text="item.name"></button>
+                            </template>
+                        </div>
+
+                        @script
+                        <script>
+                            this.$js.select = (item) => {
+                                window.selectedItem = JSON.stringify(item)
+                            }
+                        </script>
+                        @endscript
+                    HTML;
+                }
+            }
+        )
+        ->waitForText('first')
+        ->click('@select')
+        ->assertScript('JSON.parse(window.selectedItem).name === "first"')
+        ;
+    }
+
     public function test_can_call_a_defined_js_action_from_the_backend_using_the_js_method_with_params()
     {
         Livewire::visit(


### PR DESCRIPTION
# The Scenario

When iterating over a Livewire property with `x-for` and passing an iteration variable to a `$js` function via `wire:click`, the variable arrives as a function instead of the expected plain JavaScript object:

```php
<?php

use App\Models\User;
use Livewire\Component;

new class extends Component {
    public $users = [];

    public function mount()
    {
        $this->users = User::all()->toArray();
    }
};
?>
<div>
    <template x-for="user in $wire.users" :key="user.id">
        <div>
            <flux:heading size="lg" x-text="user.name"></flux:heading>
            <flux:button variant="primary" wire:click="$js.select(user)">
                Select
            </flux:button>
        </div>
    </template>
</div>

<script>
    this.$js.select = (user) => {
        console.log(typeof user) // "function" — expected "object"
    };
</script>
```

# The Problem

When `wire:click` processes an expression like `$js.select(user)`, the expression contextualiser in `js/evaluator.js` prefixes bare identifiers with `$wire.`, transforming it into `$wire.$js.select($wire.user)`.

Since `user` isn't a Livewire component property, alias, or registered `$wire` property, the `$wire` proxy's get handler falls through to the method fallback — which returns a callable function (designed to fire a server action). This callable is what gets passed to the `$js` function instead of the actual Alpine-scoped object from the `x-for` loop.

# The Solution

The expression contextualiser in `contextualizeExpression()` now receives the element and checks Alpine's scope chain via `Alpine.closestDataStack(el)` before prefixing an identifier with `$wire.`. If the identifier exists in Alpine's scope (e.g. an `x-for` iteration variable), it is left unprefixed so Alpine resolves it directly.

This keeps the fix isolated to `wire:click` expression processing rather than affecting all `$wire` property access.

Fixes: https://github.com/livewire/livewire/discussions/9881