### PR TITLE
[3.x] Fix morph markers injected inside dynamic HTML tag names

### DIFF
--- a/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
@@ -498,7 +498,7 @@ class SupportMorphAwareBladeCompilation extends ComponentHook
             // Skip if this '<' doesn't start a valid HTML tag...
             // Valid: <tagname, </tagname, <!DOCTYPE
             // Invalid: < in "1 < 5", << operators, etc.
-            if (! preg_match('/^<(\/?[a-zA-Z]|![a-zA-Z])/', $segment)) {
+            if (! preg_match('/^<(\/?[a-zA-Z]|![a-zA-Z]|\/?(\{\{|\{!!))/', $segment)) {
                 $searchFrom = $bracketPos;
                 continue;
             }

--- a/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
@@ -753,6 +753,32 @@ class UnitTest extends \Tests\TestCase
                 <div @if($count > 5) class="many" @endif></div>
                 HTML
             ],
+            // GitHub issue #9900: dynamic Blade tag names with {{ }}
+            42 => [
+                0,
+                <<<'HTML'
+                <{{ $tagName }}
+                    @if ($condition)
+                        class="test-class"
+                    @endif
+                >
+                    Content
+                </{{ $tagName }}>
+                HTML
+            ],
+            // GitHub issue #9900: dynamic Blade tag names with {!! !!}
+            43 => [
+                0,
+                <<<'HTML'
+                <{!! $tagName !!}
+                    @if ($condition)
+                        class="test-class"
+                    @endif
+                >
+                    Content
+                </{!! $tagName !!}>
+                HTML
+            ],
         ];
     }
 
@@ -902,6 +928,28 @@ class UnitTest extends \Tests\TestCase
                 '<div data-value="it\'s < than" |@if(true)>',
             ],
 
+            // Dynamic Blade tag names
+            'dynamic tag with {{ }}' => [
+                true,
+                '<{{ $tagName }} class="foo" |@if(true)>',
+            ],
+            'dynamic closing tag with {{ }}' => [
+                true,
+                '</{{ $tagName }} |@if(true)>',
+            ],
+            'dynamic tag with {!! !!}' => [
+                true,
+                '<{!! $tagName !!} class="foo" |@if(true)>',
+            ],
+            'dynamic closing tag with {!! !!}' => [
+                true,
+                '</{!! $tagName !!} |@if(true)>',
+            ],
+            'multiline dynamic tag' => [
+                true,
+                "<{{ \$tagName }}\n    class=\"foo\"\n    |@if(true)\n>",
+            ],
+
             // =============================================
             // Outside HTML tags (should return false)
             // =============================================
@@ -1023,6 +1071,16 @@ class UnitTest extends \Tests\TestCase
             'after tag with < in parenthesised expression then closed' => [
                 false,
                 '<div @class([$x < 10 ? "a" : "b"])> |@if(true)',
+            ],
+
+            // Dynamic Blade tags that are properly closed
+            'after closed dynamic {{ }} tag' => [
+                false,
+                '<{{ $tagName }} class="foo"> |@if(true)',
+            ],
+            'after closed dynamic {!! !!} tag' => [
+                false,
+                '<{!! $tagName !!} class="foo"> |@if(true)',
             ],
 
             // PHP tags and HTML comments


### PR DESCRIPTION
# The Scenario

When using dynamic Blade tag names (a pattern used extensively in Filament), morph markers are incorrectly injected inside the HTML opening tag, breaking the HTML structure entirely. Attributes become malformed, CSS classes don't apply, and closing `>` brackets render as visible `&gt;` text.

```blade
<{{ $tagName }}
    @if ($condition)
        class="test-class"
    @endif
>
    Content
</{{ $tagName }}>
```

Instead of morph markers being placed between elements, they end up inside the opening tag:

```html
<div <!--[if="" block]=""><!--[endif]----><!--[if ENDBLOCK]><![endif]-->
    class="test-class"
>
```

# The Problem

PR #9863 replaced the forward-looking regex for detecting directives inside HTML tags with a backwards-looking `isInsideHtmlTag` method. This method searches backwards from the directive position to find the most recent `<` that could start an HTML tag, then uses a regex to validate it:

```php
if (! preg_match('/^<(\/?[a-zA-Z]|![a-zA-Z])/', $segment)) {
```

This only matches `<` followed by a letter (`<div`), slash-letter (`</div`), or exclamation-letter (`<!DOCTYPE`). It does not recognise `<{{` or `<{!!` as valid tag openers — the syntax Blade uses for dynamic tag names. Because of this, directives like `@if` inside a dynamic tag are treated as being outside any HTML tag, and morph markers are injected there.

# The Solution

The regex is updated to also recognise `<{{` and `<{!!` (and their closing-tag variants `</{{`, `</{!!`) as valid HTML tag openers:

```php
if (! preg_match('/^<(\/?[a-zA-Z]|![a-zA-Z]|\/?(\{\{|\{!!))/', $segment)) {
```

Fixes: #9900