### PR TITLE
[4.x] Fix browser back/forward navigation breaking after page refresh

### DIFF
--- a/js/plugins/navigate/history.js
+++ b/js/plugins/navigate/history.js
@@ -107,7 +107,13 @@ export function whenTheBackOrForwardButtonIsClicked(
             let snapshot = snapshotCache.retrieve(alpine.snapshotIdx)
 
             handleHtml(snapshot.html, snapshot.url, snapshotCache.currentUrl, snapshotCache.currentKey)
+
+            snapshotCache.currentKey = alpine.snapshotIdx
+            snapshotCache.currentUrl = snapshot.url
         } else {
+            snapshotCache.currentKey = null
+            snapshotCache.currentUrl = null
+
             fallback(alpine.url)
         }
     })

--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -91,7 +91,10 @@ export default function (Alpine) {
 
             cleanupAlpineElementsOnThePageThatArentInsideAPersistedElement()
 
-            updateCurrentPageHtmlInHistoryStateForLaterBackButtonClicks()
+            // Only update the current page's history state if we're pushing to history.
+            // For popstate-triggered navigations (shouldPushToHistoryState = false),
+            // the history state has already changed and we shouldn't overwrite it.
+            shouldPushToHistoryState && updateCurrentPageHtmlInHistoryStateForLaterBackButtonClicks()
 
             preventAlpineFromPickingUpDomChanges(Alpine, andAfterAllThis => {
                 enablePersist && storePersistantElementsForLater(persistedEl => {
@@ -174,7 +177,7 @@ export default function (Alpine) {
             // Update the snapshot (not the history state, as the history state has
             // already changed to the new page due to the popstate event).
             // This ensures the current HTML has the latest snapshot.
-            updateCurrentPageHtmlInSnapshotCacheForLaterBackButtonClicks(currentPageUrl, currentPageKey)
+            updateCurrentPageHtmlInSnapshotCacheForLaterBackButtonClicks(currentPageKey, currentPageUrl)
 
             preventAlpineFromPickingUpDomChanges(Alpine, andAfterAllThis => {
                 enablePersist && storePersistantElementsForLater(persistedEl => {


### PR DESCRIPTION
# The Scenario

When using `wire:navigate`, browser back/forward navigation can become broken after refreshing the page. Users experience a specific sequence where the URL updates in the address bar but the page content doesn't change.

Reproduction steps:
1. Visit `/`
2. Click a `wire:navigate` link to `/about`
3. Refresh the page
4. Click the browser's Back button → works
5. Click the browser's Forward button → works
6. Click Back or Forward again → **URL changes but page content is stuck**

```php
// routes/web.php
Route::get('/', App\Livewire\Home::class);
Route::get('/about', App\Livewire\About::class);
```

```blade
<?php

use Livewire\Component;

new class extends Component {
    //
}

?>

<div>
    <h1>Home</h1>
    <a wire:navigate href="/about">Go to About</a>
</div>
```

```blade
<?php

use Livewire\Component;

new class extends Component {
    //
}

?>

<div>
    <h1>About</h1>
    <a wire:navigate href="/">Back to Home</a>
</div>
```

# The Problem

The `wire:navigate` system uses an in-memory `snapshotCache` to store page HTML for fast back/forward navigation. Each cache entry is keyed by a random identifier (e.g., `"/about-0.123"`) that's also stored in the browser's `history.state.alpine.snapshotIdx`.

When a page is refreshed, JavaScript reinitialises and the `snapshotCache` is wiped clean. However, the browser's history entries still contain the old snapshot keys from before the refresh. Three issues then cause navigation to break:

1. **`currentKey`/`currentUrl` never updated during popstate** — These tracking variables stay `null` after a refresh, causing `replaceUrl()` to generate new random keys instead of reusing existing ones. This corrupts the mapping between history entries and cache entries.

2. **Wrong history entry updated during fallback** — When a cache miss triggers `navigateTo()`, it calls `updateCurrentPageHtmlInHistoryStateForLaterBackButtonClicks()` which reads `window.location.href`. But after a popstate, that's already the *target* URL, so we update the wrong page's entry.

3. **Swapped parameters in cache update call** — `updateCurrentPageHtmlInSnapshotCacheForLaterBackButtonClicks(currentPageUrl, currentPageKey)` passed URL as the key and key as the URL. This caused `replace()` to fail its `has()` check and fall through to `push()`, creating duplicate entries and triggering premature evictions via `trim()`.

# The Solution

1. **Update `currentKey`/`currentUrl` after each popstate** — For cache hits, set them to the retrieved snapshot's key/URL. For cache misses, clear them to `null` so `replaceUrl()` generates a fresh key.

2. **Skip history update for popstate navigations** — Only call `updateCurrentPageHtmlInHistoryStateForLaterBackButtonClicks()` when `shouldPushToHistoryState` is `true`.

3. **Fix parameter order** — Change to `updateCurrentPageHtmlInSnapshotCacheForLaterBackButtonClicks(currentPageKey, currentPageUrl)`.

### Test adjustment

The `test_can_navigate_links_and_use_snapshot_cache_for_first_10_history_items` test was updated because it relied on the swapped parameters bug. That bug caused an extra cache entry on the first back press, triggering `trim()` and evicting page 4. With the fix, page 4 correctly stays cached (13 pages visited, limit of 10, so only pages 1-3 are evicted).

Fixes #9646