### PR TITLE
[4.x] Fix `metaFileData()` skipping `.json` lookup in tests when default filesystem uses S3 driver

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -237,13 +237,20 @@ class TemporaryUploadedFile extends UploadedFile
 
             // S3 uploads don't have a meta file — the original filename is
             // embedded in the file path instead, so skip the lookup entirely.
-            if (! FileUploadConfiguration::isUsingS3() && $contents = $this->storage->get($this->path.'.json')) {
+            if (! $this->isActuallyUsingS3() && $contents = $this->storage->get($this->path.'.json')) {
                 $contents = json_decode($contents, true);
 
                 $this->metaFileData = $contents;
             }
         }
         return $this->metaFileData;
+    }
+
+    protected function isActuallyUsingS3(): bool
+    {
+        $diskConfig = config('filesystems.disks.' . $this->disk);
+
+        return is_array($diskConfig) && ($diskConfig['driver'] ?? null) === 's3';
     }
 
     public static function createFromLivewire($filePath)


### PR DESCRIPTION
# The Scenario

When an application's default filesystem is configured to use the S3 driver, file upload validation in Livewire tests breaks. Methods like `getSize()` and `getMimeType()` return incorrect values, causing validation rules to behave unexpectedly.

For example, creating a fake 1025KB image and validating it against `max:1024` should fail, but the test passes because `getSize()` returns the actual tiny file size (~695 bytes) instead of the fake 1025KB.

```php
<?php

use Livewire\Attributes\Validate;
use Livewire\WithFileUploads;
use Livewire\Volt\Component;

new class extends Component {
    use WithFileUploads;

    #[Validate('image|max:1024')]
    public $photo;

    public function save()
    {
        $this->validate();
        $this->photo->store(path: 'photos');
    }
};
?>

<form wire:submit="save">
    <input type="file" wire:model="photo">
    @error('photo') <span>{{ $message }}</span> @enderror
    <button type="submit">Save</button>
</form>
```

```php
it('rejects files larger than 1MB', function () {
    $file = UploadedFile::fake()->image('photo.jpg')->size(1025);

    Livewire::test('upload-photo')
        ->set('photo', $file)
        ->assertHasErrors(['photo' => 'max']); // Fails: "Component has no errors"
});
```

# The Problem

Commit `2a32686` added an S3 guard to `metaFileData()` in `TemporaryUploadedFile` to skip the `.json` meta file lookup for S3 uploads. However, `FileUploadConfiguration::isUsingS3()` checks the application's *configured* filesystem driver, not the *actual* disk being used.

During tests, Livewire always uses a local fake disk (`tmp-for-tests`), but if the app's default filesystem is configured for S3, `isUsingS3()` returns `true` and the `.json` lookup is skipped entirely — even though the meta file exists on the local fake disk.

Without the meta file data, `getSize()` and `getMimeType()` fall back to reading the actual file on disk, which returns incorrect values for fake files.

# The Solution

Added an `isActuallyUsingS3()` instance method that checks the *actual* disk's driver config rather than the globally configured disk:

```php
protected function isActuallyUsingS3(): bool
{
    $diskConfig = config('filesystems.disks.' . $this->disk);

    return is_array($diskConfig) && ($diskConfig['driver'] ?? null) === 's3';
}
```

This correctly returns `false` during tests (where `$this->disk` is `tmp-for-tests` with no config entry) and `true` in production when actually using an S3 disk.

Fixes #9909