### PR TITLE
[4.x] Fix real-time validation not triggering for wildcard rules on array properties

### DIFF
--- a/src/Features/SupportValidation/BaseValidate.php
+++ b/src/Features/SupportValidation/BaseValidate.php
@@ -86,11 +86,17 @@ class BaseValidate extends LivewireAttribute
     {
         if ($this->onUpdate === false) return;
 
-        return function () {
+        return function () use ($fullPath) {
             // If this attribute is added to a "form object", we want to run
             // the validateOnly method on the form object, not the base component...
             $target = $this->subTarget ?: $this->component;
-            $name = $this->subTarget ? $this->getSubName() : $this->getName();
+
+            // Use the full path so that wildcard rules (e.g. 'items.*') are matched
+            // when validating nested properties (e.g. 'items.0'). For form objects,
+            // strip the form prefix to get the path relative to the form.
+            $name = $this->subTarget
+                ? $this->getSubName() . str($fullPath)->after($this->getName())
+                : $fullPath;
 
             // Here we have to run the form object validator from the context
             // of the base "wrapped" component so that validation works...


### PR DESCRIPTION
# The Scenario

When using the `#[Validate]` attribute on an array property with wildcard validation rules, real-time validation is not triggered when individual array items are updated. However, calling `$this->validate()` explicitly works correctly.

This is the documented approach for array validation in [validation.md](https://livewire.laravel.com/docs/validation#custom-key) and [uploads.md](https://livewire.laravel.com/docs/uploads#handling-multiple-files).

For example, a user uploading multiple files expects validation errors to appear immediately when a file exceeds the size limit:

```php
<?php

use Livewire\Attributes\Validate;
use Livewire\Component;
use Livewire\WithFileUploads;

new class extends Component
{
    use WithFileUploads;

    #[Validate([
        'images' => ['array'],
        'images.*' => ['image', 'max:2048'],
    ])]
    public array $images = [];

    public function save()
    {
        $this->validate();
        // ...
    }
};
?>

<form wire:submit="save">
    <input type="file" wire:model.live="images" multiple>
    @error('images.*') <span>{{ $message }}</span> @enderror
    <button type="submit">Upload</button>
</form>
```

When uploading a file larger than 2MB, the user expects to see a validation error immediately. Instead, no error appears until the form is submitted.

The same issue occurs when using the `rules()` method with a bare `#[Validate]` attribute:

```php
#[Validate]
public array $items = [];

public function rules()
{
    return [
        'items.*' => ['required', 'min:3'],
    ];
}
```

# The Problem

In `BaseValidate::update()`, when a property update triggers real-time validation, `validateOnly()` is called with just the property name (e.g., `items`) instead of the full path (e.g., `items.0`).

The `validateOnly()` method filters rules using pattern matching — `str($field)->is($rule)`. When called with `validateOnly('items')`, the rule `items.*` does not match because `items` does not match the pattern `items.*`. Only paths like `items.0` or `items.1` match wildcard rules.

# The Solution

Modified `BaseValidate::update()` to use the full path when calling `validateOnly()`. For form objects, the form prefix is stripped to get the path relative to the form.

This allows wildcard rules to match correctly during real-time validation while maintaining backwards compatibility with existing validation behaviour for scalar properties and form objects.

Fixes https://github.com/livewire/livewire/discussions/9905