### PR TITLE
[4.x] Fix wire:model with large numeric keys creating massive arrays

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -119,10 +119,11 @@ export function dataSet(object, key, value) {
         object[firstSegment] = {}
     }
 
-    // If we're about to set a numeric key on an array, convert to object.
+    // If we're about to set a numeric key that would create null gaps, convert to object.
     // This prevents JavaScript from filling intermediate indices with nulls
     // (e.g., arr[1000] = true creates 1000 null entries in a JS array).
-    if (isArray(object[firstSegment]) && isNumeric(nextSegment)) {
+    // We only convert when the key would create gaps (key > length), not when appending.
+    if (isArray(object[firstSegment]) && isNumeric(nextSegment) && parseInt(nextSegment) > object[firstSegment].length) {
         object[firstSegment] = Object.assign({}, object[firstSegment])
     }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -113,12 +113,24 @@ export function dataSet(object, key, value) {
 
     let firstSegment = segments.shift()
     let restOfSegments = segments.join('.')
+    let nextSegment = segments[0]
 
     if (object[firstSegment] === undefined) {
         object[firstSegment] = {}
     }
 
+    // If we're about to set a numeric key on an empty array, convert to object.
+    // This prevents JavaScript from filling intermediate indices with nulls
+    // (e.g., arr[1000] = true creates 1000 null entries in a JS array).
+    if (isArray(object[firstSegment]) && object[firstSegment].length === 0 && isNumeric(nextSegment)) {
+        object[firstSegment] = {}
+    }
+
     dataSet(object[firstSegment], restOfSegments, value)
+}
+
+function isNumeric(subject) {
+    return ! isNaN(parseInt(subject))
 }
 
 /**

--- a/js/utils.js
+++ b/js/utils.js
@@ -119,11 +119,11 @@ export function dataSet(object, key, value) {
         object[firstSegment] = {}
     }
 
-    // If we're about to set a numeric key on an empty array, convert to object.
+    // If we're about to set a numeric key on an array, convert to object.
     // This prevents JavaScript from filling intermediate indices with nulls
     // (e.g., arr[1000] = true creates 1000 null entries in a JS array).
-    if (isArray(object[firstSegment]) && object[firstSegment].length === 0 && isNumeric(nextSegment)) {
-        object[firstSegment] = {}
+    if (isArray(object[firstSegment]) && isNumeric(nextSegment)) {
+        object[firstSegment] = Object.assign({}, object[firstSegment])
     }
 
     dataSet(object[firstSegment], restOfSegments, value)

--- a/js/utils.js
+++ b/js/utils.js
@@ -124,7 +124,7 @@ export function dataSet(object, key, value) {
     // (e.g., arr[1000] = true creates 1000 null entries in a JS array).
     // We only convert when the key would create gaps (key > length), not when appending.
     if (isArray(object[firstSegment]) && isNumeric(nextSegment) && parseInt(nextSegment) > object[firstSegment].length) {
-        object[firstSegment] = Object.assign({}, object[firstSegment])
+        object[firstSegment] = { ...object[firstSegment] }
     }
 
     dataSet(object[firstSegment], restOfSegments, value)

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -739,4 +739,27 @@ class BrowserTest extends BrowserTestCase
             ->assertSeeIn('@output', '["first","updated"]')
         ;
     }
+
+    function test_wire_model_with_large_numeric_key_on_non_empty_array_preserves_data()
+    {
+        Livewire::visit(new class extends Component {
+            public array $data = ['a', 'b'];
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <input dusk="checkbox" type="checkbox" wire:model.live="data.1000">
+
+                        <span dusk="output">{{ json_encode($data) }}</span>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertSeeIn('@output', '["a","b"]')
+            ->waitForLivewire()->check('@checkbox')
+            // Should preserve existing data and add the new key without creating massive array
+            ->assertSeeIn('@output', '{"0":"a","1":"b","1000":true}')
+        ;
+    }
 }


### PR DESCRIPTION
# The Scenario

When using `wire:model` to bind to an array property with a large numeric key, Livewire creates a massive array filled with `null` values, causing the request payload to exceed size limits.

For example, checking the checkbox below causes Livewire to send an array with 1001 elements (indices 0-999 filled with `null`, then `true` at index 1000). With larger IDs, this triggers:

```
Livewire request payload is too large (1414KB). Maximum allowed size is 1024KB.
```

```php
<?php

use Livewire\Component;

class Example extends Component
{
    public array $data = [];
}
?>

<div>
    <input type="checkbox" wire:model.live="data.1000">
</div>
```

# The Problem

The `dataSet` function in `js/utils.js` sets values using JavaScript's native property assignment. When the target is an array and the key is numeric, JavaScript automatically expands the array to accommodate that index, filling all intermediate positions with empty slots (which serialize as `null` in JSON):

```javascript
let arr = []
arr[1000] = true
console.log(arr.length)        // 1001
console.log(JSON.stringify(arr)) // [null,null,null,...,null,true]
```

This differs from PHP's associative arrays, where `['1000' => true]` remains sparse.

# The Solution

Added a check in `dataSet` to detect when setting a numeric key would create null gaps (index > array length). When this happens, the array is converted to an object before setting the value.

When `wire:model="data.1000"` triggers, `dataSet` is called:

```javascript
dataSet(component, "data.1000", true)
```

Inside the function, the path is split into segments:
- `firstSegment` = `"data"`
- `nextSegment` = `"1000"`

So `object[firstSegment]` refers to `component["data"]` — the array property. The fix checks if this is an array and if the next segment (`1000`) would create gaps, then converts it to an object first:

```javascript
if (isArray(object[firstSegment]) && isNumeric(nextSegment) && parseInt(nextSegment) > object[firstSegment].length) {
    object[firstSegment] = { ...object[firstSegment] }
}
```

This means:
- `data.1000` on `[]` → converts to `{}`, then sets key `1000`: `{"1000": true}`
- `data.1000` on `['a', 'b']` → converts to `{0: 'a', 1: 'b'}`, then sets key `1000`: `{"0": "a", "1": "b", "1000": true}`
- `data.1` on `['a', 'b']` → no conversion needed (updating existing index), stays as array: `["a", "updated"]`

Fixes #9908