### PR TITLE
[4.x] Fix uploaded file storage using default filesystem disk

### DIFF
--- a/src/Features/SupportFileUploads/BrowserTest.php
+++ b/src/Features/SupportFileUploads/BrowserTest.php
@@ -26,7 +26,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
             function save()
             {
-                $this->photo->storeAs('photos', 'photo.png');
+                $this->photo->storeAs('photos', 'photo.png', 'tmp-for-tests');
             }
 
             function render() { return <<<'HTML'
@@ -82,7 +82,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
             function save()
             {
-                $this->photo->storeAs('photos', 'photo.png');
+                $this->photo->storeAs('photos', 'photo.png', 'tmp-for-tests');
             }
 
             function render() { return <<<'HTML'

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -176,7 +176,7 @@ class TemporaryUploadedFile extends UploadedFile
     {
         $options = $this->parseOptions($options);
 
-        $disk = Arr::pull($options, 'disk') ?: $this->disk;
+        $disk = Arr::pull($options, 'disk') ?: config('filesystems.default');
 
         $newPath = trim($path.'/'.$name, '/');
 


### PR DESCRIPTION
# The Scenario

When using Livewire's file uploads with a separate temporary upload disk configured, calling `store()` or `storeAs()` without specifying a disk stores the file to the temporary upload disk instead of the application's default filesystem disk.

For example, a user might configure temporary uploads to use the `local` disk (private storage) for security, while setting `FILESYSTEM_DISK=public` for permanent storage. When they call `$file->store('images')`, they expect the file to go to the `public` disk, but it goes to `local` instead.

```php
// config/livewire.php
'temporary_file_upload' => [
    'disk' => 'local', // Secure temporary storage
],
```

```env
FILESYSTEM_DISK=public
```

```php
<?php

use Livewire\Component;
use Livewire\WithFileUploads;

new class extends Component {
    use WithFileUploads;

    public $photo;

    public function save()
    {
        // User expects this to use the public disk (FILESYSTEM_DISK)
        // But it uses the local disk (temporary_file_upload.disk) instead
        $this->photo->store('images');
    }
}; ?>

<div>
    <input type="file" wire:model="photo">
    <button wire:click="save">Save</button>
</div>
```

# The Problem

In `TemporaryUploadedFile::storeAs()`, when no disk is specified, the code falls back to `$this->disk` which is the temporary upload disk:

```php
$disk = Arr::pull($options, 'disk') ?: $this->disk;
```

The `$this->disk` property represents where the temporary file is stored during upload, not where the user wants to permanently store files. This contradicts Laravel's behaviour where `store()` without a disk uses `config('filesystems.default')`.

# The Solution

Changed the fallback to use `config('filesystems.default')` instead of `$this->disk`:

```php
$disk = Arr::pull($options, 'disk') ?: config('filesystems.default');
```

This aligns with Laravel's behaviour and allows users to configure separate disks for temporary uploads (security) and permanent storage.

**Note:** This is a small breaking change for anyone relying on `store()` without a disk to use the temporary upload disk. However, this was arguably a bug, and the fix aligns with Laravel's conventions. Users who need the previous behaviour can explicitly pass the disk: `$file->store('images', 'local')`.

Fixes #9902