### PR TITLE
[4.x] Fix `@assets` not loading before script module in lazy-loaded SFCs

### DIFF
--- a/src/Features/SupportJsModules/SupportJsModules.php
+++ b/src/Features/SupportJsModules/SupportJsModules.php
@@ -7,6 +7,8 @@ use Livewire\ComponentHook;
 use Livewire\Drawer\Utils;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
 
+use function Livewire\store;
+
 class SupportJsModules extends ComponentHook
 {
     static function provide()
@@ -42,7 +44,18 @@ class SupportJsModules extends ComponentHook
 
     public function dehydrate($context)
     {
-        if (! $context->isMounting()) return;
+        // Don't add scriptModule effect during lazy-loading placeholder mount.
+        // The component's view isn't rendered yet, so @assets won't have run.
+        // The scriptModule will be added when __lazyLoad triggers the real mount.
+        if (store($this->component)->get('isLazyLoadMounting') === true) return;
+
+        // Add scriptModule effect during:
+        // 1. Normal component mounting ($context->isMounting())
+        // 2. Lazy-loaded component hydration (when __lazyLoad runs)
+        $isNormalMount = $context->isMounting();
+        $isLazyLoadHydration = store($this->component)->get('isLazyLoadHydrating') === true;
+
+        if (! $isNormalMount && ! $isLazyLoadHydration) return;
 
         if (method_exists($this->component, 'scriptModuleSrc')) {
             $path = $this->component->scriptModuleSrc();

--- a/src/Features/SupportScriptsAndAssets/BrowserTest.php
+++ b/src/Features/SupportScriptsAndAssets/BrowserTest.php
@@ -398,41 +398,6 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
-    public function test_remote_assets_can_be_loaded_from_a_lazy_loaded_component_using_script_directive()
-    {
-        Livewire::visit([new class extends \Livewire\Component {
-            public function render() { return <<<'HTML'
-            <div>
-                <span dusk="output" x-text="'foo'"></span>
-
-                <livewire:child lazy />
-            </div>
-            HTML; }
-        },
-        'child' => new #[\Livewire\Attributes\Lazy] class extends \Livewire\Component {
-            public function render() { return <<<'HTML'
-            <div>
-                <input type="text" data-picker>
-            </div>
-
-            @assets
-                <script src="https://cdn.jsdelivr.net/npm/pikaday/pikaday.js"></script>
-                <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/pikaday/css/pikaday.css">
-            @endassets
-
-            @script
-                <script>
-                    window.datePicker = new Pikaday({ field: $wire.$el.querySelector('[data-picker]') });
-                </script>
-            @endscript
-            HTML; }
-        },
-        ])
-        ->waitForTextIn('@output', 'foo')
-        ->waitUntil('!! window.datePicker === true')
-        ;
-    }
-
     public function test_remote_assets_can_be_loaded_from_a_lazy_loaded_sfc_component()
     {
         // Tests that @assets are loaded before script module runs in lazy-loaded SFC components.

--- a/src/Features/SupportScriptsAndAssets/fixtures/lazy-with-assets.blade.php
+++ b/src/Features/SupportScriptsAndAssets/fixtures/lazy-with-assets.blade.php
@@ -1,0 +1,23 @@
+<?php
+
+use Livewire\Component;
+use Livewire\Attributes\Lazy;
+
+new #[Lazy] class extends Component
+{
+    //
+};
+?>
+
+<div>
+    <input type="text" data-picker>
+</div>
+
+@assets
+<script src="https://cdn.jsdelivr.net/npm/pikaday/pikaday.js"></script>
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/pikaday/css/pikaday.css">
+@endassets
+
+<script>
+    window.datePicker = new Pikaday({ field: $wire.$el.querySelector('[data-picker]') });
+</script>


### PR DESCRIPTION
# The Scenario

When using a single-file component with the `#[Lazy]` attribute that loads external dependencies via `@assets` and uses them in a raw `<script>` tag, the script fails with a reference error because the assets haven't loaded yet:

```
Uncaught (in promise) ReferenceError: Pikaday is not defined
    at Proxy.run (testcomponent.js?v=618585553:3:5)
```

```blade
<?php

use Livewire\Component;
use Livewire\Attributes\Lazy;

new #[Lazy] class extends Component
{
    //
};
?>

<div>
    <input type="text" data-picker>
</div>

@assets
<script src="https://cdn.jsdelivr.net/npm/pikaday/pikaday.js" defer></script>
<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/pikaday/css/pikaday.css">
@endassets

<script>
    new Pikaday({ field: $wire.$el.querySelector('[data-picker]') });
</script>
```

# The Problem

In single-file components, raw `<script>` tags are compiled into separate JavaScript modules that get loaded via dynamic `import()`. The `scriptModule` effect controls when this module is loaded and executed.

The issue is in `SupportJsModules::dehydrate()` at `src/Features/SupportJsModules/SupportJsModules.php:43-55`:

```php
public function dehydrate($context)
{
    if (! $context->isMounting()) return;

    if (method_exists($this->component, 'scriptModuleSrc')) {
        // ... adds scriptModule effect
    }
}
```

When a component has `#[Lazy]`, the mount lifecycle runs twice:
1. **Initial page load**: `$context->isMounting()` is true, but `skipRender()` is called so the view (including `@assets`) never renders. The `scriptModule` effect is added to the placeholder.
2. **Lazy load (`__lazyLoad`)**: The component actually renders with `@assets`, but `$context->isMounting()` is false so the `scriptModule` effect isn't added.

This causes the script module to run during the initial page load (before assets are loaded) instead of during the lazy load (after assets are loaded).

# The Solution

Modified `SupportJsModules::dehydrate()` to:
1. Skip adding the `scriptModule` effect when the component is in lazy-loading placeholder state (`isLazyLoadMounting`)
2. Add the `scriptModule` effect when the component is hydrated via `__lazyLoad` (`isLazyLoadHydrating`)

This ensures the script module only runs after the component has actually rendered and its `@assets` have been loaded.

Fixes #9916