### PR TITLE
[3.x] Fix smart wire keys with duplicate foreach sources

### DIFF
--- a/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
@@ -121,9 +121,16 @@ class SupportMorphAwareBladeCompilation extends ComponentHook
                 && str($match[0])->endsWith(')')
                 && ! static::hasEvenNumberOfParentheses($match[0])
             ) {
-                if (($after = str($template)->after($match[0])->toString()) === $template) {
+                // Use position-based approach to find the text after the current match,
+                // rather than searching for the match string (which could find an earlier
+                // occurrence if the same pattern appears multiple times in the template)...
+                $afterPosition = $matchPosition + strlen($match[0]);
+
+                if ($afterPosition >= strlen($template)) {
                     break;
                 }
+
+                $after = substr($template, $afterPosition);
 
                 $rest = str($after)->before(')');
 

--- a/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
@@ -779,6 +779,30 @@ class UnitTest extends \Tests\TestCase
                 </{!! $tagName !!}>
                 HTML
             ],
+            // GitHub discussion #9776 comment by @gdebrauwer: multiple foreach loops with
+            // identical source expressions but different iteration syntax (with/without $key =>)
+            44 => [
+                3,
+                <<<'HTML'
+                <div>
+                    <div>
+                        @foreach (\App\Models\User::all() as $locale)
+                            <div></div>
+                        @endforeach
+                    </div>
+                    <div>
+                        @foreach (\App\Models\User::all() as $index => $locale)
+                            <div></div>
+                        @endforeach
+                    </div>
+                    <div>
+                        @foreach (\App\Models\User::all() as $locale)
+                            <div></div>
+                        @endforeach
+                    </div>
+                </div>
+                HTML
+            ],
         ];
     }
 


### PR DESCRIPTION
# The Scenario

When using multiple `@foreach` loops with identical source expressions (e.g., `User::all()`) but different iteration syntax (some with `$key => $value`, some without), users encounter the error "Trying to access array offset on null":

```php
<?php

use Livewire\Component;

new class extends Component {
    //
}
?>

<div>
    <div>
        @foreach (\App\Models\User::all() as $locale)
            <div></div>
        @endforeach
    </div>
    <div>
        @foreach (\App\Models\User::all() as $index => $locale)
            <div></div>
        @endforeach
    </div>
    <div>
        @foreach (\App\Models\User::all() as $locale)
            <div></div>
        @endforeach
    </div>
</div>
```

# The Problem

When extending a regex match to balance parentheses in `SupportMorphAwareBladeCompilation::compileDirectives()`, the code used `str($template)->after($match[0])` to find the text after the current match. This finds the **first** occurrence of the match string in the template, not the occurrence at the current position.

When multiple `@foreach` loops share the same prefix (e.g., `@foreach (\App\Models\User::all()`), the code would incorrectly extend the match using content from an earlier loop. For example, the second loop's match would be extended to `as $locale)` instead of `as $index => $locale)`, causing the pattern to fail when injecting loop markers. This resulted in `openLoop()` not being added for that loop while `closeLoop()` was still added, causing a stack imbalance.

# The Solution

Use position-based substring instead of string searching to find the text after the current match:

```php
$afterPosition = $matchPosition + strlen($match[0]);

if ($afterPosition >= strlen($template)) {
    break;
}

$after = substr($template, $afterPosition);
```

This ensures we always look at the content after the **current** match position, not the first occurrence of the match string.

Fixes #9776