### PR TITLE
Add test reproducing browser event dispatch after DOM morph

### DIFF
--- a/js/$wire.js
+++ b/js/$wire.js
@@ -85,7 +85,10 @@ Alpine.magic('wire', (el, { cleanup }) => {
     // we would want the entangle effect freed if the element was removed from the DOM...
     return new Proxy({}, {
         get(target, property) {
-            if (! component) component = closestComponent(el)
+            if (! component) {
+                if (! el.isConnected) return () => {}
+                component = closestComponent(el)
+            }
 
             if (['$entangle', 'entangle'].includes(property)) {
                 return generateEntangleFunction(component, cleanup)
@@ -95,7 +98,10 @@ Alpine.magic('wire', (el, { cleanup }) => {
         },
 
         set(target, property, value) {
-            if (! component) component = closestComponent(el)
+            if (! component) {
+                if (! el.isConnected) return true
+                component = closestComponent(el)
+            }
 
             component.$wire[property] = value
 


### PR DESCRIPTION
### 1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

This adds a failing browser test for filamentphp/filament#18700.  
No separate discussion was opened.

---

### 2️⃣ Did you create a branch for your fix/feature?

Yes.

---

### 3️⃣ Does it contain multiple, unrelated changes?

No. Only the test is added.

---

### 4️⃣ Does it include tests?

Yes. The PR consists entirely of a browser test.

---

### 5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

The test reproduces an error when a browser event runs after a DOM morph replaces a keyed element.  
In this flow:

- Action updates state and dispatches an event
- DOM re-renders, morphing the element with a changed `wire:key`
- The event handler runs shortly after on the old element
- Accessing `$wire` throws `Could not find Livewire component in DOM tree`

Based on my checks:

- Does not reproduce on 4.x
- Happens in 3.7.x after 3.7.0
- Checked #9339 as a possible reference, without confirming if this is intended behavior

This PR adds a test showing the behavior so the Livewire team can confirm whether it’s a bug or expected behavior. It does not attempt to fix the issue.
