### PR TITLE
[4.x] Fix duplicate query for route-bound models on update requests

### DIFF
--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -5,6 +5,8 @@ namespace Livewire\Features\SupportModels;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\Route;
+use Livewire\Drawer\Utils;
 use Livewire\Livewire;
 use Sushi\Sushi;
 use Tests\TestComponent;
@@ -247,6 +249,46 @@ class UnitTest extends \Tests\TestCase
         // This should throw because stdClass doesn't extend Model
         $synth->hydrate(null, ['class' => \stdClass::class]);
     }
+
+    public function test_route_bound_models_are_not_queried_twice_on_update()
+    {
+        Route::livewire('/test-articles/{article}', RouteModelBindingComponent::class)
+            ->middleware('web');
+
+        // GET the page to mount the component and get a valid snapshot
+        $response = $this->withoutExceptionHandling()->get('/test-articles/1');
+        $response->assertOk();
+        $response->assertSee('First');
+
+        // Extract snapshot from the rendered HTML
+        $html = $response->getContent();
+        $snapshot = Utils::extractAttributeDataFromHtml($html, 'wire:snapshot');
+        $encodedSnapshot = json_encode($snapshot);
+
+        // Flush state from the initial render
+        app('livewire')->flushState();
+
+        // Enable query log and clear it
+        Article::resolveConnection()->enableQueryLog();
+        Article::resolveConnection()->flushQueryLog();
+
+        // POST to the update endpoint to trigger an update request
+        $this->post(app('livewire')->getUpdateUri(), [
+            'components' => [
+                [
+                    'snapshot' => $encodedSnapshot,
+                    'calls' => [['method' => '$refresh', 'params' => [], 'path' => '']],
+                    'updates' => [],
+                ],
+            ],
+        ])->assertOk();
+
+        // Count queries to the articles table — should only be one, not two
+        $queryLog = Article::resolveConnection()->getQueryLog();
+        $articleQueries = array_filter($queryLog, fn ($q) => str_contains($q['query'], 'articles'));
+
+        $this->assertCount(1, array_values($articleQueries));
+    }
 }
 
 #[\Attribute]
@@ -277,4 +319,14 @@ class Article extends Model
         ['title' => 'First'],
         ['title' => 'Second'],
     ];
+}
+
+class RouteModelBindingComponent extends \Livewire\Component
+{
+    public Article $article;
+
+    public function render()
+    {
+        return '<div>{{ $article->title }}</div>';
+    }
 }


### PR DESCRIPTION
# The Scenario

When using `Route::livewire` with route model binding, every Livewire update request queries each route-bound model twice — once from `SubstituteBindings` middleware re-running via `PersistentMiddleware`, and again from `ModelSynth` restoring the model from the snapshot.

| Source | Query |
|---|---|
| `SubstituteBindings` | `select * from "posts" where "id" = '1' limit 1` |
| `ModelSynth` | `select * from "posts" where "posts"."id" = 1 limit 1` |

```php
// routes/web.php
Route::livewire('/posts/{post}', 'show-post');
```

```php
<?php

use App\Models\Post;
use Livewire\Component;

new class extends Component {
    public Post $post;

    public function save(): void {}
};

?>

<div>
    <p>Post: {{ $this->post->title }}</p>
    <button wire:click="save">Save</button>
</div>
```

# The Problem

During an update request, `HandleComponents::fromSnapshot()` triggers two independent systems that both query the same models:

1. `trigger('snapshot-verified')` fires `PersistentMiddleware`, which creates a fake request matching the original route and re-runs `SubstituteBindings`. This calls `ImplicitRouteBinding::resolveParameter()` which queries each route-bound model.

2. `hydrateProperties()` calls `ModelSynth::hydrate()`, which creates a lazy proxy that queries each model via `newQueryForRestoration()`.

These two systems have no shared state — the models resolved by `SubstituteBindings` are stored on the route parameters but are never made available to `ModelSynth`, so it independently queries the same models again.

# The Solution

After `PersistentMiddleware` runs `SubstituteBindings`, the resolved model instances are now collected from the route parameters and stored in a lookup table. `ModelSynth::hydrate()` checks this lookup before querying the database — if a matching model (same class and key) has already been resolved by route binding, it reuses that instance instead of making a duplicate query.

```php
// If this model was already resolved by route binding (via
// SubstituteBindings middleware), reuse it to avoid a duplicate query.
$resolvedModel = app(PersistentMiddleware::class)->getResolvedRouteModel($class, $key);

if ($resolvedModel) {
    return $resolvedModel;
}
```

Fixes https://github.com/livewire/livewire/discussions/9924