### PR TITLE
[4.x] Rename default update route to avoid `default` keyword conflict

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -25,7 +25,7 @@ class HandleRequests extends Mechanism
             app($this::class)->setUpdateRoute(function ($handle) {
                 return Route::post(EndpointResolver::updatePath(), $handle)
                     ->middleware('web')
-                    ->name('default.livewire.update');
+                    ->name('default-livewire.update');
             });
         }
 
@@ -65,7 +65,7 @@ class HandleRequests extends Mechanism
         foreach (Route::getRoutes()->getRoutes() as $route) {
             if (str($route->getName())->endsWith('livewire.update')) {
                 // If it's the default route, save it but keep looking for a custom one
-                if ($route->getName() === 'default.livewire.update') {
+                if ($route->getName() === 'default-livewire.update') {
                     $defaultRoute = $route;
                     continue;
                 }


### PR DESCRIPTION
# The Scenario

When using tools that generate frontend code based on route names — such as `laravel/wayfinder` — the Livewire update route name `default.livewire.update` causes a build failure. Because `default` is a reserved keyword in JavaScript/TypeScript, Wayfinder generates invalid code when it extracts the dot-separated segments as variable names:

```typescript
// resources/js/routes/default/index.ts
const default = {  // SyntaxError: 'default' is a reserved keyword
    livewire,
}
export default default
```

# The Problem

In `HandleRequests::boot()`, the built-in update route is registered with the name `default.livewire.update`. The `default.` prefix was introduced to give the built-in route a distinct name from custom routes set via `Livewire::setUpdateRoute()` (required since Laravel 12.30 where two routes cannot share the same name).

However, using `default` as a dot-separated segment means tools that map route name segments to code identifiers will produce invalid JavaScript/TypeScript, since `default` is a reserved keyword.

# The Solution

Rename the route from `default.livewire.update` to `default-livewire.update`. By using a hyphen instead of a dot, `default` is no longer a standalone segment that tools would extract as an identifier. The name still ends with `livewire.update`, so all existing matching logic (`endsWith('livewire.update')`, `named('*livewire.update')`) continues to work correctly, and custom routes still take priority over the default.

Fixes #9927