### PR TITLE
Fixes lazy loaded components with islands within blade components.

### DIFF
--- a/src/Features/SupportIslands/BrowserTest.php
+++ b/src/Features/SupportIslands/BrowserTest.php
@@ -4,7 +4,6 @@ namespace Livewire\Features\SupportIslands;
 
 use Tests\BrowserTestCase;
 use Livewire\Livewire;
-use Illuminate\Support\Facades\Blade;
 
 class BrowserTest extends BrowserTestCase
 {
@@ -12,7 +11,6 @@ class BrowserTest extends BrowserTestCase
     {
         return function () {
             app('livewire.finder')->addLocation(viewPath: __DIR__ . '/fixtures');
-            Blade::anonymousComponentPath(__DIR__ . '/fixtures/components');
         };
     }
 
@@ -323,7 +321,7 @@ class BrowserTest extends BrowserTestCase
             ;
     }
 
-    public function test_island_inside_blade_component_renders_after_lazy_parent_load()
+    public function test_island_renders_inside_lazy_loaded_component()
     {
         Livewire::visit([
             new class extends \Livewire\Component {
@@ -337,27 +335,20 @@ class BrowserTest extends BrowserTestCase
                 }
             },
             'lazy-parent' => new class extends \Livewire\Component {
-                public function mount()
-                {
-                    usleep(250000); // 250ms
-                }
-
                 public function render()
                 {
                     return <<<'HTML'
                     <div>
-                        <div dusk="lazy-parent-loaded">Lazy Parent Loaded</div>
-
-                        <x-island-wrapper />
+                        @island
+                            <div dusk="island-content">Island loaded</div>
+                        @endisland
                     </div>
                     HTML;
                 }
             },
         ])
-            ->assertNotPresent('@island-content')
-            ->waitForText('Lazy Parent Loaded')
-            ->assertPresent('@island-content')
-            ->assertSeeIn('@island-content', 'Island content ready');
+            ->waitFor('@island-content')
+            ->assertSeeIn('@island-content', 'Island loaded');
     }
 
     public function test_named_islands()

--- a/src/Features/SupportIslands/BrowserTest.php
+++ b/src/Features/SupportIslands/BrowserTest.php
@@ -329,12 +329,12 @@ class BrowserTest extends BrowserTestCase
                 {
                     return <<<'HTML'
                     <div>
-                        <livewire:lazy-parent lazy />
+                        <livewire:child lazy />
                     </div>
                     HTML;
                 }
             },
-            'lazy-parent' => new class extends \Livewire\Component {
+            'child' => new class extends \Livewire\Component {
                 public function render()
                 {
                     return <<<'HTML'

--- a/src/Features/SupportIslands/SupportIslands.php
+++ b/src/Features/SupportIslands/SupportIslands.php
@@ -85,6 +85,8 @@ class SupportIslands extends ComponentHook
 
     public function hydrate($memo)
     {
+        if (($memo['lazyLoaded'] ?? null) === false) return;
+
         $this->component->markIslandsAsMounted();
 
         $islands = $memo['islands'] ?? null;

--- a/src/Features/SupportIslands/fixtures/components/island-wrapper.blade.php
+++ b/src/Features/SupportIslands/fixtures/components/island-wrapper.blade.php
@@ -1,0 +1,5 @@
+<div>
+    @island
+        <div dusk="island-content">Island content ready</div>
+    @endisland
+</div>

--- a/src/Features/SupportIslands/fixtures/components/island-wrapper.blade.php
+++ b/src/Features/SupportIslands/fixtures/components/island-wrapper.blade.php
@@ -1,5 +1,0 @@
-<div>
-    @island
-        <div dusk="island-content">Island content ready</div>
-    @endisland
-</div>


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Fixes a bug – at least I believe the functionality I'm trying to achieve is intended. Here's the architecture:

Lazy loaded livewire component -> Blade component -> Island

In this situation, the island doesn't load regardless of whether it's lazy, deferred or not.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yeah, new branch.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No, one commit for the test changes, one commit for the fix.

4️⃣ Does it include tests? (Required)

Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Found a bug where if a lazy/deferred Livewire component has blade components within them which then also have islands (lazy, deferred or otherwise), the islands fail to load at all. See the failing test as an example. I can elaborate a bit more if needed.