### PR TITLE
[4.x] Fix wire:transition stacking context and dialog z-index bugs

### DIFF
--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -2,9 +2,25 @@ import { globalDirective } from "@/directives"
 
 let defaultName = 'match-element'
 
+// No-op — viewTransitionName is now set dynamically by transitionDomMutation()
+// to avoid creating permanent stacking contexts...
 globalDirective('transition', ({ el, directive, cleanup }) => {
-    el.style.viewTransitionName = directive.expression || defaultName
+    //
 })
+
+function setTransitionNames(root) {
+    root.querySelectorAll('[wire\\:transition]').forEach(el => {
+        if (! el.style.viewTransitionName) {
+            el.style.viewTransitionName = el.getAttribute('wire:transition') || defaultName
+        }
+    })
+}
+
+function clearTransitionNames(root) {
+    root.querySelectorAll('[wire\\:transition]').forEach(el => {
+        el.style.viewTransitionName = ''
+    })
+}
 
 export async function transitionDomMutation(fromEl, toEl, callback, options = {}) {
     // Skip transitions entirely if requested...
@@ -18,18 +34,13 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
         return callback()
     }
 
-    // After a morph, newly added wire:transition elements need their viewTransitionName
-    // set synchronously. Alpine's MutationObserver would normally handle this, but its
-    // internal queueMicrotask batching delays processing by one microtask hop — and the
-    // View Transitions API's "activate" step captures the new DOM state in between,
-    // before Alpine has a chance to initialize the directive...
-    let ensureTransitionNames = () => {
-        fromEl.querySelectorAll('[wire\\:transition]').forEach(el => {
-            if (! el.style.viewTransitionName) {
-                el.style.viewTransitionName = el.getAttribute('wire:transition') || defaultName
-            }
-        })
-    }
+    // Skip entirely if a modal dialog is already open (transitions behind
+    // a dialog are invisible to the user and the ::view-transition pseudo-
+    // elements would paint above the dialog during animation)...
+    if (document.querySelector('dialog:modal')) return callback()
+
+    // Set transition names right before the transition starts (not permanently)...
+    setTransitionNames(fromEl)
 
     // Disable root transitions for the page...
     let style = document.createElement('style')
@@ -57,7 +68,12 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
     let update = () => {
         callback()
 
-        ensureTransitionNames()
+        // After a morph, newly added wire:transition elements need their viewTransitionName
+        // set synchronously. Alpine's MutationObserver would normally handle this, but its
+        // internal queueMicrotask batching delays processing by one microtask hop — and the
+        // View Transitions API's "activate" step captures the new DOM state in between,
+        // before Alpine has a chance to initialize the directive...
+        setTransitionNames(fromEl)
     }
 
     let transitionConfig = { update }
@@ -67,21 +83,48 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
         transitionConfig.types = [options.type]
     }
 
+    let cleanup = () => {
+        style.remove()
+        clearTransitionNames(fromEl)
+    }
+
+    // Watch for modal dialogs opening during the transition (e.g., via Alpine x-effect).
+    // ::view-transition pseudo-elements paint above the top layer, so elements with
+    // wire:transition would visually appear above dialog modals during animation.
+    // This observer catches showModal() the instant it sets the `open` attribute
+    // and skips the transition before the browser paints a frame...
+    let skipOnDialog = (transition) => {
+        let observer = new MutationObserver(() => {
+            if (document.querySelector('dialog:modal')) {
+                transition.skipTransition()
+                observer.disconnect()
+            }
+        })
+
+        observer.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ['open'],
+            subtree: true,
+        })
+
+        transition.finished.finally(() => observer.disconnect())
+    }
+
     try {
         let transition = document.startViewTransition(transitionConfig)
 
-        transition.finished.finally(() => {
-            style.remove()
-        })
+        skipOnDialog(transition)
+
+        transition.finished.finally(cleanup)
 
         await transition.updateCallbackDone
     } catch (e) {
         // Firefox 144+ supports View Transitions but only with a callback, not a config object (no transition types support)
         let transition = document.startViewTransition(update)
 
-        transition.finished.finally(() => {
-            style.remove()
-        })
+        skipOnDialog(transition)
+
+        transition.finished.finally(cleanup)
 
         await transition.updateCallbackDone
     }


### PR DESCRIPTION
## Summary

- **Permanent stacking contexts:** `wire:transition` was setting `viewTransitionName` on init and never clearing it. Per spec, any element with `viewTransitionName != none` creates a stacking context at all times — breaking `backdrop-filter: blur()`, z-index sibling relationships, etc. Now names are only set during active transitions and cleared after `transition.finished`.
- **Transition pseudo-elements painting above dialogs:** During view transitions, the `::view-transition` pseudo-element tree paints above the top layer (where `<dialog>` modals live). A `MutationObserver` now watches for `dialog[open]` during transitions and calls `skipTransition()` before the browser paints a frame.

## Changes

**`js/directives/wire-transition.js`**
- Directive callback is now a no-op — `viewTransitionName` is set dynamically by `transitionDomMutation()` instead of permanently on init
- Names are set right before `startViewTransition()` and cleared in `transition.finished.finally()`
- Early-exit when `dialog:modal` is already present
- `skipOnDialog()` MutationObserver skips transitions the instant a modal dialog opens during morph

**`src/Features/SupportTransitions/BrowserTest.php`**
- `test_wire_transition_names_are_cleared_after_transition_completes` — verifies `viewTransitionName` is `''` after a transition finishes (fails without fix: name stays `'transition'` permanently)
- `test_transition_is_skipped_when_dialog_opens_during_morph` — verifies no animations are running after a dialog opens during morph (fails without fix: 2s animations keep playing with cards above dialog)

## Test plan

- [ ] `test_can_transition_blade_conditional_dom_segments` — existing test still passes
- [ ] `test_elements_the_contain_transition_are_displayed_on_page_load` — existing test still passes
- [ ] `test_can_transition_dynamic_component_swap` — existing test still passes (names set synchronously in update callback)
- [ ] `test_wire_transition_names_are_cleared_after_transition_completes` — new regression test
- [ ] `test_transition_is_skipped_when_dialog_opens_during_morph` — new regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)