### PR TITLE
Fix getUpdateUri() not resolving URI parameters

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -49,7 +49,7 @@ class HandleRequests extends Mechanism
         // In this case, find the route from the router.
         $route = $this->updateRoute ?? $this->findUpdateRoute();
 
-        return (string) str($route->uri())->start('/');
+        return (string) str(app('url')->toRoute($route, [], false))->start('/');
     }
 
     protected function findUpdateRoute()


### PR DESCRIPTION
Use toRoute() instead of uri() so URL::defaults() are substituted for custom routes with URI parameters (e.g. /{tenant}/livewire/update).

Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
