### PR TITLE
Fix Echo channels not being left during wire:navigate

### DIFF
--- a/js/features/supportLaravelEcho.js
+++ b/js/features/supportLaravelEcho.js
@@ -52,14 +52,16 @@ on('effect', ({ component, effects }) => {
                         dispatchSelf(component, event, [e])
                     })
 
-                    // @todo: add listener cleanup...
+                    component.addCleanup(() => {
+                        window.Echo.leave(channel)
+                    })
                 } else{
                     let handler = e => dispatchSelf(component, event, [e])
 
                     window.Echo.join(channel).listen(event_name, handler)
 
                     component.addCleanup(() => {
-                        window.Echo.leaveChannel(channel)
+                        window.Echo.leave(channel)
                     })
                 }
             } else if (channel_type == 'notification') {
@@ -67,7 +69,9 @@ on('effect', ({ component, effects }) => {
                     dispatchSelf(component, event, [notification])
                 })
 
-                // @todo: add listener cleanup...
+                component.addCleanup(() => {
+                    window.Echo.private(channel).stopListening('.Illuminate\\Notifications\\Events\\BroadcastNotificationCreated')
+                })
             } else {
                 console.warn('Echo channel type not yet supported')
             }

--- a/src/Features/SupportEvents/fake-echo.js
+++ b/src/Features/SupportEvents/fake-echo.js
@@ -1,5 +1,6 @@
 
 window.fakeEchoListeners = []
+window.fakeEchoLeftChannels = []
 
 class FakeChannel {
     constructor(channel) {
@@ -53,10 +54,24 @@ class FakePresenceChannel extends FakeChannel {
     }
 
     here(callback) {
+        window.fakeEchoListeners.push({
+            channel: this.channel,
+            event: 'here',
+            type: this.type,
+            callback,
+        })
+
         return this
     }
 
     joining(callback) {
+        window.fakeEchoListeners.push({
+            channel: this.channel,
+            event: 'joining',
+            type: this.type,
+            callback,
+        })
+
         return this
     }
 
@@ -65,6 +80,13 @@ class FakePresenceChannel extends FakeChannel {
     }
 
     leaving(callback) {
+        window.fakeEchoListeners.push({
+            channel: this.channel,
+            event: 'leaving',
+            type: this.type,
+            callback,
+        })
+
         return this
     }
 }
@@ -84,6 +106,22 @@ class FakeEcho {
 
     encryptedPrivate(channel) {
         return new FakePrivateChannel(channel);
+    }
+
+    leave(channel) {
+        window.fakeEchoLeftChannels.push(channel)
+
+        window.fakeEchoListeners = window.fakeEchoListeners.filter(i => {
+            return i.channel !== channel
+        })
+    }
+
+    leaveChannel(channel) {
+        window.fakeEchoLeftChannels.push(channel)
+
+        window.fakeEchoListeners = window.fakeEchoListeners.filter(i => {
+            return i.channel !== channel
+        })
     }
 
     socketId() {


### PR DESCRIPTION
## Summary

Fixes #9941

- Presence channel `here`/`joining`/`leaving` handlers had no cleanup callbacks registered, so Echo channels were never left when components were destroyed during `wire:navigate` SPA navigation
- Fixed regular presence event cleanup to use `Echo.leave()` instead of `Echo.leaveChannel()` which doesn't handle channel name prefixes correctly
- Added missing cleanup for notification listeners

## Test plan

- [x] Added browser test: presence channel is left when navigating away with `wire:navigate`
- [x] Added browser test: regular channel listeners are cleaned up when navigating away with `wire:navigate`
- [x] Existing Echo browser tests still pass
- [x] Existing Echo unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)