### PR TITLE
Fix duplicate island fragments in batched requests

### DIFF
--- a/src/Features/SupportIslands/HandlesIslands.php
+++ b/src/Features/SupportIslands/HandlesIslands.php
@@ -111,14 +111,17 @@ trait HandlesIslands
         foreach ($islands as $island) {
             if ($island['name'] === $name) {
 
+                $token = $island['token'];
+
+                if (! $token) continue;
+
+                // Skip if this island was already rendered in this request...
+                if ($this->islandAlreadyRendered($name, $token)) continue;
+
                 // If the island is lazy, we need to mount it, but to ensure any nested islands render,
                 // we need to set the `$islandsHaveMounted` flag to false and reset it back after the
                 // lazy island is mounted...
                 $finish = $this->mountIfNeedsMounting($mount);
-
-                $token = $island['token'];
-
-                if (! $token) continue;
 
                 // Pass runtime $with as __runtimeWith so it overrides directive's with
                 $data = empty($with) ? [] : ['__runtimeWith' => $with];
@@ -135,6 +138,17 @@ trait HandlesIslands
                 $finish();
             }
         }
+    }
+
+    protected function islandAlreadyRendered($name, $token)
+    {
+        foreach ($this->renderedIslandFragments as $fragment) {
+            if (str_contains($fragment, "name={$name}|token={$token}")) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function streamIsland($name, $content = null, $mode = 'morph', $with = [])


### PR DESCRIPTION
## Summary

- When multiple component calls in a single request target the same island (e.g. a `wire:model.live` property update + a method call both scoped to the same island), `renderIsland()` was called once per call, producing duplicate fragments in the `islandFragments` response array.
- Added deduplication check in `renderIsland()` — if an island with the same name+token was already rendered during the current request, it skips re-rendering.

Fixes #9911

## Test plan

- [x] Added unit test that simulates two calls targeting the same island in one request and asserts only one fragment is returned
- [x] All existing island unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)