### PR TITLE
[3.x] Fix `colocateCommitsByComponent` crash with in-flight `wire:model` child commits

### DIFF
--- a/js/features/supportPropsAndModelables.js
+++ b/js/features/supportPropsAndModelables.js
@@ -43,6 +43,10 @@ function colocateCommitsByComponent(pools, component, foreignComponent) {
 
     let foreignPool = findPoolWithComponent(pools, foreignComponent)
 
+    // If the foreign component isn't in any of the current pools (e.g. it's
+    // already part of an in-flight request), skip colocating...
+    if (! foreignPool) return
+
     let foreignCommit = foreignPool.findCommitByComponent(foreignComponent)
 
     // Delete needs to come before add in case there are the same pool...

--- a/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
+++ b/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
@@ -300,7 +300,7 @@ class BrowserTest extends \Tests\BrowserTestCase
         ])
         ->click('@input')
         ->keys('@input', 'foo')
-        ->clickAtXPath('//body')
+        ->clickAtXPath('//body') // Blur the input so the child's commit is sent separately...
         ->waitForLivewire()->click('@refresh')
         ->assertConsoleLogHasNoErrors()
         ;

--- a/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
+++ b/src/Features/SupportWireModelingNestedComponents/BrowserTest.php
@@ -268,6 +268,84 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertSeeNothingIn('@child.ephemeral', '')
         ;
     }
+    public function test_can_submit_parent_form_while_modelable_child_input_is_focused()
+    {
+        Livewire::visit([
+            new class extends \Livewire\Component {
+                public $items = [];
+
+                public $saved = false;
+
+                public function mount()
+                {
+                    $this->items = [
+                        1 => ['name' => 'one', 'value' => 'foo'],
+                        2 => ['name' => 'two', 'value' => 'bar'],
+                    ];
+                }
+
+                public function save()
+                {
+                    $this->saved = true;
+                }
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <form wire:submit="save">
+                        @foreach($items as $key => $item)
+                            <livewire:child wire:model="items.{{ $key }}" wire:key="item-{{ $key }}" />
+                        @endforeach
+                        <button type="submit" dusk="save">Save</button>
+                    </form>
+                    <span dusk="saved">{{ $saved ? 'yes' : 'no' }}</span>
+                </div>
+                HTML; }
+            },
+            'child' => new class extends \Livewire\Component {
+                #[BaseModelable]
+                public $data = [];
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <input type="text" wire:model.blur="data.name" dusk="name-{{ $data['name'] ?? '' }}" />
+                    <input type="text" wire:model.blur="data.value" dusk="value-{{ $data['value'] ?? '' }}" />
+                </div>
+                HTML; }
+            },
+        ])
+        ->assertSeeIn('@saved', 'no')
+        // Type into a child input (this does not blur yet)
+        ->type('@name-one', 'updated')
+        ->pause(50)
+        // Delay the first fetch response so the child's blur commit stays
+        // in-flight when the parent's submit commit is pooled...
+        ->tap(fn ($b) => $b->script("
+            var origFetch = window.fetch;
+            var fetchCount = 0;
+            window.fetch = function() {
+                fetchCount++;
+                if (fetchCount === 1) {
+                    return origFetch.apply(this, arguments).then(function(r) {
+                        return new Promise(function(resolve) {
+                            setTimeout(function() { resolve(r); }, 500);
+                        });
+                    });
+                }
+                return origFetch.apply(this, arguments);
+            };
+        "))
+        // Simulate a real mouse click: blur fires on mousedown, then submit
+        // fires on click — separated by more than the 5ms commit buffer.
+        ->tap(fn ($b) => $b->script("
+            document.activeElement.blur();
+            setTimeout(function() {
+                document.querySelector('[dusk=\"save\"]').click();
+            }, 10);
+        "))
+        ->pause(3000)
+        ->assertSeeIn('@saved', 'yes')
+        ;
+    }
 }
 
 class CreatePost extends Form


### PR DESCRIPTION
Tests are failing due to an unrelated issue. See PR #9951 first and once that is merged, merge 3.x into this PR to make sure all tests pass.

# The Scenario

When using nested child components with `wire:model` and `#[Modelable]`, submitting a parent form while a child input is still focused throws a JavaScript error:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'findCommitByComponent')
  at colocateCommitsByComponent (livewire.js)
```

This happens intermittently when clicking a Save button without first blurring out of a child input. The blur fires on mousedown and the submit fires on click — separated by enough time for the child's commit to be sent as a separate request before the parent's commit is pooled.

```blade
<?php
use Livewire\Attributes\Modelable;
use Livewire\Component;

// Parent component
new class extends Component {
    public array $items = [
        1 => ['name' => 'Item One', 'value' => 'foo'],
        2 => ['name' => 'Item Two', 'value' => 'bar'],
    ];

    public function save() { /* ... */ }
};
?>

<form wire:submit="save">
    @foreach($items as $key => $item)
        <livewire:child-input
            wire:key="item-{{ $key }}"
            wire:model="items.{{ $key }}"
        />
    @endforeach

    <button type="submit">Save</button>
</form>
```

```blade
<?php
use Livewire\Attributes\Modelable;
use Livewire\Component;

// Child component
new class extends Component {
    #[Modelable]
    public ?array $data = null;
};
?>

<div>
    <input type="text" wire:model.blur="data.name">
    <input type="text" wire:model.blur="data.value">
</div>
```

# The Problem

In v3.7.0, deduplication logic was added to `corraleCommitsIntoPools` to skip commits for components that already have an in-flight request:

```js
if (this.findPoolWithComponent(commit.component)) continue
```

When a user clicks Save while a child input is focused, the following happens:

1. Blur fires on the child input → child commit is created and sent in its own pool (added to `this.pools`)
2. Submit fires on the parent → parent commit is created
3. During `commit.pooling`, `child.$wire.$commit()` creates a new commit for each child with bindings
4. In `corraleCommitsIntoPools`, the new child commit is **skipped** because `this.findPoolWithComponent(child)` finds the child in the in-flight pool
5. `commit.pooled` calls `colocateCommitsByComponent` to move the child into the parent's pool, but `findPoolWithComponent(pools, child)` returns `undefined` because the child was never added to the local pools
6. `undefined.findCommitByComponent(child)` throws the error

# The Solution

Added a null check in `colocateCommitsByComponent` — if the child component isn't in any of the current local pools (because it's already part of an in-flight request), skip colocating rather than crashing. The child's update will be processed by its own in-flight request, and the parent's submit proceeds independently.

Fixes #9682
Fixes #9930