### PR TITLE
[4.x] Add missing stubs to `livewire:stubs` command

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/StubsCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/StubsCommand.php
@@ -56,6 +56,41 @@ class StubsCommand extends Command
             file_get_contents(__DIR__.'/livewire.attribute.stub')
         );
 
+        file_put_contents(
+            $stubsPath.'/livewire.layout.stub',
+            file_get_contents(__DIR__.'/livewire.layout.stub')
+        );
+
+        file_put_contents(
+            $stubsPath.'/livewire-sfc.stub',
+            file_get_contents(__DIR__.'/livewire-sfc.stub')
+        );
+
+        file_put_contents(
+            $stubsPath.'/livewire-mfc-class.stub',
+            file_get_contents(__DIR__.'/livewire-mfc-class.stub')
+        );
+
+        file_put_contents(
+            $stubsPath.'/livewire-mfc-view.stub',
+            file_get_contents(__DIR__.'/livewire-mfc-view.stub')
+        );
+
+        file_put_contents(
+            $stubsPath.'/livewire-mfc-test.stub',
+            file_get_contents(__DIR__.'/livewire-mfc-test.stub')
+        );
+
+        file_put_contents(
+            $stubsPath.'/livewire-mfc-js.stub',
+            file_get_contents(__DIR__.'/livewire-mfc-js.stub')
+        );
+
+        file_put_contents(
+            $stubsPath.'/livewire-mfc-css.stub',
+            file_get_contents(__DIR__.'/livewire-mfc-css.stub')
+        );
+
         $this->info('Stubs published successfully.');
     }
 }

--- a/src/Features/SupportConsoleCommands/Tests/StubCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/StubCommandUnitTest.php
@@ -25,6 +25,13 @@ class StubCommandUnitTest extends \Tests\TestCase
         $this->assertTrue(File::exists($this->stubsPath('livewire.pest.stub')));
         $this->assertTrue(File::exists($this->stubsPath('livewire.form.stub')));
         $this->assertTrue(File::exists($this->stubsPath('livewire.attribute.stub')));
+        $this->assertTrue(File::exists($this->stubsPath('livewire.layout.stub')));
+        $this->assertTrue(File::exists($this->stubsPath('livewire-sfc.stub')));
+        $this->assertTrue(File::exists($this->stubsPath('livewire-mfc-class.stub')));
+        $this->assertTrue(File::exists($this->stubsPath('livewire-mfc-view.stub')));
+        $this->assertTrue(File::exists($this->stubsPath('livewire-mfc-test.stub')));
+        $this->assertTrue(File::exists($this->stubsPath('livewire-mfc-js.stub')));
+        $this->assertTrue(File::exists($this->stubsPath('livewire-mfc-css.stub')));
     }
 
     public function test_component_is_created_with_view_and_class_custom_default_stubs()


### PR DESCRIPTION
# The Scenario

When running `php artisan livewire:stubs` to customise the stubs used by `make:livewire`, only the legacy stubs are published. The newer stubs for single-file components, multi-file components, and layouts are missing — so users can't customise them.

```bash
php artisan livewire:stubs
# Only publishes 7 of 14 stubs
```

# The Problem

The `StubsCommand` was last updated when Form and Attribute stubs were added, but it was never updated to include the stubs added since then. The `MakeCommand` and `LayoutCommand` both already check the user's `stubs/` directory for overrides (via `getStubPath()` and `stubPath()` respectively), but since these newer stubs are never published there, users have no way to customise them.

The missing stubs:

- `livewire.layout.stub`
- `livewire-sfc.stub`
- `livewire-mfc-class.stub`
- `livewire-mfc-view.stub`
- `livewire-mfc-test.stub`
- `livewire-mfc-js.stub`
- `livewire-mfc-css.stub`

# The Solution

Added the 7 missing stubs to the `StubsCommand` so that all 14 stubs are now published when running `php artisan livewire:stubs`.

Fixes #9939