### PR TITLE
[3.x] Fix `$wire` returning no-op for elements in morph template tree

### DIFF
--- a/js/$wire.js
+++ b/js/$wire.js
@@ -86,8 +86,11 @@ Alpine.magic('wire', (el, { cleanup }) => {
     return new Proxy({}, {
         get(target, property) {
             if (! component) {
-                if (! el.isConnected) return () => {}
-                component = closestComponent(el)
+                try {
+                    component = closestComponent(el)
+                } catch (e) {
+                    return () => {}
+                }
             }
 
             if (['$entangle', 'entangle'].includes(property)) {
@@ -99,8 +102,11 @@ Alpine.magic('wire', (el, { cleanup }) => {
 
         set(target, property, value) {
             if (! component) {
-                if (! el.isConnected) return true
-                component = closestComponent(el)
+                try {
+                    component = closestComponent(el)
+                } catch (e) {
+                    return true
+                }
             }
 
             component.$wire[property] = value


### PR DESCRIPTION
# The Scenario

After PR #9933 was merged to fix a race condition where `$wire` throws on detached elements after morph, several existing browser tests started failing. Any feature that accesses `$wire` properties reactively — `wire:text`, `wire:model` on nested components, and Alpine `x-text="$wire.foo"` bindings — stopped updating after a Livewire round-trip.

```blade
<div>
    <div wire:text="text" dusk="label"></div>
    <button wire:click="$set('text', 'bar')" dusk="change">Change</button>
</div>
```

After clicking the button, the label stays empty instead of showing "bar".

# The Problem

The fix in #9933 added an `el.isConnected` guard to the `$wire` proxy:

```js
if (! component) {
    if (! el.isConnected) return () => {}
    component = closestComponent(el)
}
```

This is too aggressive. During morph, Alpine evaluates expressions on elements in the **"to" tree** — a document fragment built from the server-rendered HTML. These elements have `el.isConnected === false` because they're not attached to the document. However, `closestComponent(el)` would **succeed** for these elements because Livewire sets `__livewire` on the fragment's root element (`morph.js` line 39: `to.__livewire = component`), allowing `Alpine.findClosest()` to traverse up within the fragment and resolve the component.

The `isConnected` check short-circuited this valid resolution path, returning a no-op function `() => {}` instead of the real property value — breaking reactive bindings across the framework.

# The Solution

Replace the proactive `el.isConnected` check with a try/catch around `closestComponent(el)`:

```js
if (! component) {
    try {
        component = closestComponent(el)
    } catch (e) {
        return () => {}
    }
}
```

This lets `closestComponent` succeed for elements in the morph template tree (where the component is reachable via the fragment's `__livewire` root), while still returning a no-op for truly orphaned elements where `closestComponent` throws — which is the original bug #9933 fixed.

Fixes #9933