### PR TITLE
[4.x] Expand SecurityPolicy denylist

### DIFF
--- a/src/Mechanisms/HandleComponents/SecurityPolicy.php
+++ b/src/Mechanisms/HandleComponents/SecurityPolicy.php
@@ -19,13 +19,23 @@ class SecurityPolicy
 
         // Known serialization gadgets
         'Illuminate\Broadcasting\PendingBroadcast',
+        'Illuminate\Broadcasting\BroadcastEvent',
         'Illuminate\Foundation\Testing\PendingCommand',
 
         // Queue jobs - could execute arbitrary code
         'Illuminate\Queue\CallQueuedClosure',
+        'Illuminate\Queue\Jobs\Job',
+
+        // Mail - could send arbitrary emails
+        'Illuminate\Mail\Mailable',
 
         // Notifications - could send arbitrary notifications
         'Illuminate\Notifications\Notification',
+
+        // Known exploit chain gadgets (Synacktiv disclosure)
+        'GuzzleHttp\Psr7\FnStream',
+        'League\Flysystem\UrlGeneration\ShardedPrefixPublicUrlGenerator',
+        'Laravel\Prompts\Terminal',
     ];
 
     /**

--- a/src/Mechanisms/HandleComponents/SecurityPolicyUnitTest.php
+++ b/src/Mechanisms/HandleComponents/SecurityPolicyUnitTest.php
@@ -55,6 +55,54 @@ class SecurityPolicyUnitTest extends \Tests\TestCase
         SecurityPolicy::validateClass(\DateTimeImmutable::class);
     }
 
+    public function test_rejects_broadcast_event_class()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not allowed to be instantiated');
+
+        SecurityPolicy::validateClass(\Illuminate\Broadcasting\BroadcastEvent::class);
+    }
+
+    public function test_rejects_queue_job_class()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not allowed to be instantiated');
+
+        SecurityPolicy::validateClass(\Illuminate\Queue\Jobs\Job::class);
+    }
+
+    public function test_rejects_mailable_class()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not allowed to be instantiated');
+
+        SecurityPolicy::validateClass(\Illuminate\Mail\Mailable::class);
+    }
+
+    public function test_rejects_guzzle_fn_stream_class()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not allowed to be instantiated');
+
+        SecurityPolicy::validateClass('GuzzleHttp\Psr7\FnStream');
+    }
+
+    public function test_rejects_flysystem_sharded_prefix_url_generator_class()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not allowed to be instantiated');
+
+        SecurityPolicy::validateClass('League\Flysystem\UrlGeneration\ShardedPrefixPublicUrlGenerator');
+    }
+
+    public function test_rejects_laravel_prompts_terminal_class()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not allowed to be instantiated');
+
+        SecurityPolicy::validateClass('Laravel\Prompts\Terminal');
+    }
+
     public function test_get_denied_classes_returns_list()
     {
         $denied = SecurityPolicy::getDeniedClasses();
@@ -62,5 +110,11 @@ class SecurityPolicyUnitTest extends \Tests\TestCase
         $this->assertIsArray($denied);
         $this->assertContains('Illuminate\Console\Command', $denied);
         $this->assertContains('Symfony\Component\Process\Process', $denied);
+        $this->assertContains('Illuminate\Broadcasting\BroadcastEvent', $denied);
+        $this->assertContains('Illuminate\Queue\Jobs\Job', $denied);
+        $this->assertContains('Illuminate\Mail\Mailable', $denied);
+        $this->assertContains('GuzzleHttp\Psr7\FnStream', $denied);
+        $this->assertContains('League\Flysystem\UrlGeneration\ShardedPrefixPublicUrlGenerator', $denied);
+        $this->assertContains('Laravel\Prompts\Terminal', $denied);
     }
 }


### PR DESCRIPTION
# The Scenario

Following Synacktiv's public disclosure of CVE-2025-54068 and associated exploitation tooling, the exploit chain documentation names several classes that can be leveraged to achieve remote code execution when an attacker has a valid `APP_KEY`. These classes were not on Livewire's synthesiser denylist.

# The Problem

The `SecurityPolicy` denylist only blocked 7 classes. Some of the classes explicitly used in the Synacktiv exploit chain were missing:

- `GuzzleHttp\Psr7\FnStream` — provides a `__toString` to arbitrary function call gadget
- `League\Flysystem\UrlGeneration\ShardedPrefixPublicUrlGenerator` — provides an `array_map` trigger gadget
- `Illuminate\Broadcasting\BroadcastEvent` — provides `dispatchNextJobInChain()` to `unserialize()` (notably, only `PendingBroadcast` was blocked, but `BroadcastEvent` is the class actually instantiated in the exploit chain)
- `Laravel\Prompts\Terminal` — used for clean `exit()` to avoid error logging
- `Illuminate\Queue\Jobs\Job` — queue job execution base class
- `Illuminate\Mail\Mailable` — could be used to send arbitrary emails

# The Solution

Added all 6 classes to the `SecurityPolicy` denylist in `src/Mechanisms/HandleComponents/SecurityPolicy.php`. Since `validateClass()` uses `is_a()` with `allow_string: true`, this also blocks any subclasses of these entries (e.g. any concrete queue job class is blocked via the `Job` base class entry).

Added unit tests verifying each new denylist entry is rejected, and updated the existing `test_get_denied_classes_returns_list` test to assert the new entries are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)