### PR TITLE
[4.x] Block lifecycle methods from being called via frontend calls

### DIFF
--- a/src/Features/SupportLifecycleHooks/SupportLifecycleHooks.php
+++ b/src/Features/SupportLifecycleHooks/SupportLifecycleHooks.php
@@ -99,12 +99,16 @@ class SupportLifecycleHooks extends ComponentHook
     public function call($methodName, $params, $returnEarly, $metadata)
     {
         $protectedMethods = [
-            'mount',
+            'mount*',
+            'boot*',
+            'booted*',
             'exception',
             'hydrate*',
             'dehydrate*',
             'updating*',
             'updated*',
+            'rendering',
+            'rendered',
             'scriptSrc',
         ];
 

--- a/src/Tests/ComponentsAreSecureUnitTest.php
+++ b/src/Tests/ComponentsAreSecureUnitTest.php
@@ -4,7 +4,6 @@ namespace Livewire\Tests;
 
 use Livewire\Features\SupportLifecycleHooks\DirectlyCallingLifecycleHooksNotAllowedException;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
-use Livewire\Mechanisms\HandleComponents\HandleComponents;
 use Livewire\Exceptions\PublicPropertyNotFoundException;
 use Livewire\Exceptions\MethodNotFoundException;
 use Tests\TestComponent;
@@ -114,6 +113,16 @@ class ComponentsAreSecureUnitTest extends \Tests\TestCase
         $component->runAction('boot');
     }
 
+    public function test_cannot_call_booted_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target', LifecycleMethodStub::class);
+        $component = app('livewire')->test('lifecycle-target');
+
+        $component->runAction('booted');
+    }
+
     public function test_cannot_call_hydrate_from_frontend()
     {
         $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
@@ -204,6 +213,16 @@ class ComponentsAreSecureUnitTest extends \Tests\TestCase
         $component->runAction('bootStubTrait');
     }
 
+    public function test_cannot_call_trait_booted_variant_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target-with-trait', LifecycleMethodStubWithTrait::class);
+        $component = app('livewire')->test('lifecycle-target-with-trait');
+
+        $component->runAction('bootedStubTrait');
+    }
+
     public function test_cannot_call_hydrate_property_variant_from_frontend()
     {
         $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
@@ -226,68 +245,6 @@ class ComponentsAreSecureUnitTest extends \Tests\TestCase
         $this->assertTrue(true);
     }
 
-    public function test_is_lifecycle_method_allows_regular_methods()
-    {
-        $this->assertFalse(HandleComponents::isLifecycleMethod('save'));
-        $this->assertFalse(HandleComponents::isLifecycleMethod('delete'));
-        $this->assertFalse(HandleComponents::isLifecycleMethod('submit'));
-        $this->assertFalse(HandleComponents::isLifecycleMethod('handleClick'));
-    }
-
-    public function test_is_lifecycle_method_does_not_block_methods_sharing_lifecycle_prefix()
-    {
-        // Without a component, trait-suffixed variants can't be checked,
-        // so only exact names and safe wildcard prefixes are blocked.
-        $this->assertFalse(HandleComponents::isLifecycleMethod('mountAction'));
-        $this->assertFalse(HandleComponents::isLifecycleMethod('mountSomeTrait'));
-        $this->assertFalse(HandleComponents::isLifecycleMethod('bootstrap'));
-        $this->assertFalse(HandleComponents::isLifecycleMethod('bootUp'));
-        $this->assertFalse(HandleComponents::isLifecycleMethod('bootedSomeTrait'));
-    }
-
-    public function test_is_lifecycle_method_blocks_trait_suffixed_variants_with_component()
-    {
-        $component = new LifecycleMethodStubWithTrait;
-
-        $this->assertTrue(HandleComponents::isLifecycleMethod('mountStubTrait', $component));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('bootStubTrait', $component));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('bootedStubTrait', $component));
-
-        // Non-matching trait suffix should not be blocked.
-        $this->assertFalse(HandleComponents::isLifecycleMethod('mountAction', $component));
-        $this->assertFalse(HandleComponents::isLifecycleMethod('mountSomeOtherTrait', $component));
-    }
-
-    public function test_is_lifecycle_method_blocks_exact_lifecycle_names()
-    {
-        $this->assertTrue(HandleComponents::isLifecycleMethod('mount'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('boot'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('booted'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('hydrate'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('dehydrate'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('updating'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('updated'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('rendering'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('rendered'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('exception'));
-    }
-
-    public function test_is_lifecycle_method_blocks_wildcard_property_hooks()
-    {
-        $this->assertTrue(HandleComponents::isLifecycleMethod('hydrateProperty'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('hydrateSomething'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('dehydrateProperty'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('dehydrateSomething'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('updatingName'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('updatedName'));
-    }
-
-    public function test_is_lifecycle_method_is_case_insensitive()
-    {
-        $this->assertTrue(HandleComponents::isLifecycleMethod('Mount'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('BOOT'));
-        $this->assertTrue(HandleComponents::isLifecycleMethod('Hydrate'));
-    }
 }
 
 class SecurityTargetStub extends TestComponent
@@ -318,6 +275,7 @@ class LifecycleMethodStub extends TestComponent
 
     public function mount() {}
     public function boot() {}
+    public function booted() {}
     public function hydrate() {}
     public function dehydrate() {}
     public function updatingName() {}

--- a/src/Tests/ComponentsAreSecureUnitTest.php
+++ b/src/Tests/ComponentsAreSecureUnitTest.php
@@ -2,7 +2,9 @@
 
 namespace Livewire\Tests;
 
+use Livewire\Features\SupportLifecycleHooks\DirectlyCallingLifecycleHooksNotAllowedException;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
+use Livewire\Mechanisms\HandleComponents\HandleComponents;
 use Livewire\Exceptions\PublicPropertyNotFoundException;
 use Livewire\Exceptions\MethodNotFoundException;
 use Tests\TestComponent;
@@ -91,6 +93,162 @@ class ComponentsAreSecureUnitTest extends \Tests\TestCase
         // If it worked, then an exception will be thrown that will fail the test.
         $component->runAction('someMethod');
     }
+
+    public function test_cannot_call_mount_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target', LifecycleMethodStub::class);
+        $component = app('livewire')->test('lifecycle-target');
+
+        $component->runAction('mount');
+    }
+
+    public function test_cannot_call_boot_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target', LifecycleMethodStub::class);
+        $component = app('livewire')->test('lifecycle-target');
+
+        $component->runAction('boot');
+    }
+
+    public function test_cannot_call_hydrate_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target', LifecycleMethodStub::class);
+        $component = app('livewire')->test('lifecycle-target');
+
+        $component->runAction('hydrate');
+    }
+
+    public function test_cannot_call_dehydrate_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target', LifecycleMethodStub::class);
+        $component = app('livewire')->test('lifecycle-target');
+
+        $component->runAction('dehydrate');
+    }
+
+    public function test_cannot_call_updating_hook_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target', LifecycleMethodStub::class);
+        $component = app('livewire')->test('lifecycle-target');
+
+        $component->runAction('updatingName');
+    }
+
+    public function test_cannot_call_updated_hook_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target', LifecycleMethodStub::class);
+        $component = app('livewire')->test('lifecycle-target');
+
+        $component->runAction('updatedName');
+    }
+
+    public function test_cannot_call_rendering_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target', LifecycleMethodStub::class);
+        $component = app('livewire')->test('lifecycle-target');
+
+        $component->runAction('rendering');
+    }
+
+    public function test_cannot_call_rendered_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target', LifecycleMethodStub::class);
+        $component = app('livewire')->test('lifecycle-target');
+
+        $component->runAction('rendered');
+    }
+
+    public function test_cannot_call_exception_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target', LifecycleMethodStub::class);
+        $component = app('livewire')->test('lifecycle-target');
+
+        $component->runAction('exception');
+    }
+
+    public function test_cannot_call_trait_mount_variant_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target', LifecycleMethodStub::class);
+        $component = app('livewire')->test('lifecycle-target');
+
+        $component->runAction('mountMyTrait');
+    }
+
+    public function test_cannot_call_trait_boot_variant_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target', LifecycleMethodStub::class);
+        $component = app('livewire')->test('lifecycle-target');
+
+        $component->runAction('bootMyTrait');
+    }
+
+    public function test_cannot_call_hydrate_property_variant_from_frontend()
+    {
+        $this->expectException(DirectlyCallingLifecycleHooksNotAllowedException::class);
+
+        app('livewire')->component('lifecycle-target', LifecycleMethodStub::class);
+        $component = app('livewire')->test('lifecycle-target');
+
+        $component->runAction('hydratePropertyName');
+    }
+
+    public function test_is_lifecycle_method_allows_regular_methods()
+    {
+        $this->assertFalse(HandleComponents::isLifecycleMethod('save'));
+        $this->assertFalse(HandleComponents::isLifecycleMethod('delete'));
+        $this->assertFalse(HandleComponents::isLifecycleMethod('submit'));
+        $this->assertFalse(HandleComponents::isLifecycleMethod('handleClick'));
+    }
+
+    public function test_is_lifecycle_method_blocks_all_lifecycle_prefixes()
+    {
+        $this->assertTrue(HandleComponents::isLifecycleMethod('mount'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('mountSomeTrait'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('boot'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('bootSomeTrait'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('hydrate'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('hydrateProperty'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('hydrateSomething'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('dehydrate'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('dehydrateProperty'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('dehydrateSomething'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('updating'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('updatingName'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('updated'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('updatedName'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('rendering'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('rendered'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('exception'));
+    }
+
+    public function test_is_lifecycle_method_is_case_insensitive()
+    {
+        $this->assertTrue(HandleComponents::isLifecycleMethod('Mount'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('BOOT'));
+        $this->assertTrue(HandleComponents::isLifecycleMethod('Hydrate'));
+    }
 }
 
 class SecurityTargetStub extends TestComponent
@@ -113,4 +271,24 @@ class UnsafeComponentStub extends TestComponent
     {
         throw new \Exception('Should not be able to acess me!');
     }
+}
+
+class LifecycleMethodStub extends TestComponent
+{
+    public $name = 'foo';
+
+    public function mount() {}
+    public function boot() {}
+    public function hydrate() {}
+    public function dehydrate() {}
+    public function updatingName() {}
+    public function updatedName() {}
+    public function rendering() {}
+    public function rendered() {}
+    public function exception($e) {}
+    public function mountMyTrait() {}
+    public function bootMyTrait() {}
+    public function hydratePropertyName() {}
+
+    public function saveData() {}
 }


### PR DESCRIPTION
# The Scenario

Livewire components can define lifecycle methods like `mount()`, `boot()`, `hydrate()`, and property hooks like `updatingFoo()` / `updatedFoo()`. These methods are intended to run automatically at specific points in the component lifecycle — they should never be callable from the frontend via `$wire.mount()` or similar.

# The Problem

Lifecycle methods defined on user subclasses pass the `getPublicMethodsDefinedBySubClass()` filter in `callMethods()`, since that filter only excludes methods from the base `Component` class. The existing `SupportLifecycleHooks::call()` hook blocked some lifecycle methods (`mount`, `exception`, `hydrate*`, `dehydrate*`, `updating*`, `updated*`) but was missing `boot`, `booted`, `rendering`, and `rendered`.

An attacker (or curious user) could call `$wire.boot()`, `$wire.rendering()`, or `$wire.rendered()` to execute these hooks out of sequence, potentially causing unexpected behaviour.

# The Solution

Extended the blocklist in `SupportLifecycleHooks::call()` to cover all lifecycle methods: `mount`, `boot`, `booted`, `rendering`, `rendered`, and `exception` (exact matches), plus `hydrate*`, `dehydrate*`, `updating*`, `updated*` (wildcard prefixes, unchanged from before).

For trait-suffixed lifecycle hooks (e.g. `mountWithFileUploads`, `bootMyTrait`), the blocklist is built dynamically by checking the component's actual traits via `class_uses_recursive()`. This ensures methods like `mountAction()` — legitimate user methods that happen to share a lifecycle prefix — are not falsely blocked.

Added a defense-in-depth check (`isLifecycleMethod()`) directly in `callMethods()` as a secondary guard, using the same trait-aware logic. It throws `MethodNotFoundException` — intentionally not revealing whether the method exists.