### PR TITLE
[4.x] Require `X-Livewire` and JSON content type on update requests

### DIFF
--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -273,15 +273,16 @@ class UnitTest extends \Tests\TestCase
         Article::resolveConnection()->flushQueryLog();
 
         // POST to the update endpoint to trigger an update request
-        $this->post(app('livewire')->getUpdateUri(), [
-            'components' => [
-                [
-                    'snapshot' => $encodedSnapshot,
-                    'calls' => [['method' => '$refresh', 'params' => [], 'path' => '']],
-                    'updates' => [],
+        $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(app('livewire')->getUpdateUri(), [
+                'components' => [
+                    [
+                        'snapshot' => $encodedSnapshot,
+                        'calls' => [['method' => '$refresh', 'params' => [], 'path' => '']],
+                        'updates' => [],
+                    ],
                 ],
-            ],
-        ])->assertOk();
+            ])->assertOk();
 
         // Count queries to the articles table — should only be one, not two
         $queryLog = Article::resolveConnection()->getQueryLog();

--- a/src/Features/SupportTesting/SubsequentRender.php
+++ b/src/Features/SupportTesting/SubsequentRender.php
@@ -33,7 +33,7 @@ class SubsequentRender extends Render
 
         [$response, $componentInstance, $componentView] = $this->extractComponentAndBladeView(function () use ($uri, $payload, $cookies) {
             return $this->requestBroker->temporarilyDisableExceptionHandlingAndMiddleware(function ($requestBroker) use ($uri, $payload, $cookies) {
-                return $requestBroker->addHeaders(['X-Livewire' => true])->call('POST', $uri, $payload, $cookies);
+                return $requestBroker->addHeaders(['X-Livewire' => true, 'Content-Type' => 'application/json'])->call('POST', $uri, [], $cookies, [], [], json_encode($payload));
             });
         });
 

--- a/src/Features/SupportTesting/SubsequentRender.php
+++ b/src/Features/SupportTesting/SubsequentRender.php
@@ -33,7 +33,7 @@ class SubsequentRender extends Render
 
         [$response, $componentInstance, $componentView] = $this->extractComponentAndBladeView(function () use ($uri, $payload, $cookies) {
             return $this->requestBroker->temporarilyDisableExceptionHandlingAndMiddleware(function ($requestBroker) use ($uri, $payload, $cookies) {
-                return $requestBroker->addHeaders(['X-Livewire' => true, 'Content-Type' => 'application/json'])->call('POST', $uri, [], $cookies, [], [], json_encode($payload));
+                return $requestBroker->addHeaders(['X-Livewire' => true])->call('POST', $uri, $payload, $cookies);
             });
         });
 

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -122,6 +122,14 @@ class HandleRequests extends Mechanism
 
     function handleUpdate()
     {
+        // Reject requests missing required headers. The legitimate Livewire
+        // JS client always sends both X-Livewire and Content-Type: application/json.
+        // Their absence indicates the request did not come from Livewire.
+        // Return 404 to avoid confirming the endpoint exists to scanners.
+        if (! request()->hasHeader('X-Livewire') || ! request()->isJson()) {
+            abort(404);
+        }
+
         // Check payload size limit...
         $maxSize = config('livewire.payload.max_size');
 

--- a/src/Mechanisms/HandleRequests/PayloadGuardsUnitTest.php
+++ b/src/Mechanisms/HandleRequests/PayloadGuardsUnitTest.php
@@ -22,7 +22,7 @@ class PayloadGuardsUnitTest extends TestCase
         // Simulate a request with a large Content-Length header
         $this->withoutExceptionHandling()
             ->withHeaders(['Content-Length' => 1000, 'X-Livewire' => 'true'])
-            ->post(EndpointResolver::updatePath(), [
+            ->postJson(EndpointResolver::updatePath(), [
                 'components' => [
                     [
                         'snapshot' => json_encode([
@@ -71,7 +71,7 @@ class PayloadGuardsUnitTest extends TestCase
         // Create a request with 3 components (exceeds limit of 2)
         $this->withoutExceptionHandling()
             ->withHeaders(['X-Livewire' => 'true'])
-            ->post(EndpointResolver::updatePath(), [
+            ->postJson(EndpointResolver::updatePath(), [
                 'components' => [
                     ['snapshot' => '{}', 'updates' => [], 'calls' => []],
                     ['snapshot' => '{}', 'updates' => [], 'calls' => []],
@@ -118,7 +118,7 @@ class PayloadGuardsUnitTest extends TestCase
         // Send a request with 4 calls (exceeds limit of 3)
         $this->withoutExceptionHandling()
             ->withHeaders(['X-Livewire' => 'true'])
-            ->post(EndpointResolver::updatePath(), [
+            ->postJson(EndpointResolver::updatePath(), [
                 'components' => [
                     [
                         'snapshot' => json_encode($snapshot),

--- a/src/Mechanisms/HandleRequests/RequireLivewireHeaders.php
+++ b/src/Mechanisms/HandleRequests/RequireLivewireHeaders.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleRequests;
+
+use Closure;
+
+class RequireLivewireHeaders
+{
+    function handle($request, Closure $next)
+    {
+        // Reject requests missing required headers. The legitimate Livewire
+        // JS client always sends both X-Livewire and Content-Type: application/json.
+        // Their absence indicates the request did not come from Livewire.
+        // Return 404 to avoid confirming the endpoint exists to scanners.
+        if (! $request->hasHeader('X-Livewire') || ! $request->isJson()) {
+            abort(404);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Mechanisms/PersistentMiddleware/UnitTest.php
+++ b/src/Mechanisms/PersistentMiddleware/UnitTest.php
@@ -55,15 +55,16 @@ class UnitTest extends \LegacyTests\Unit\TestCase
         app('router')->setRoutes($runningCollection);
 
         // Hit update endpoint, including PersistentMiddleware
-        $response = $this->post(EndpointResolver::updatePath(), [
-            'components' => [
-                [
-                    'calls' => [],
-                    'updates' => [],
-                    'snapshot' => $snapshot
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), [
+                'components' => [
+                    [
+                        'calls' => [],
+                        'updates' => [],
+                        'snapshot' => $snapshot
+                    ]
                 ]
-            ]
-        ]);
+            ]);
         $response->assertStatus(200);
         $response->assertJsonPath('components.0.snapshot', $snapshot);
     }


### PR DESCRIPTION
# The Scenario

The Livewire update endpoint processes any POST request regardless of its headers. The legitimate Livewire JS client always sends both `X-Livewire: 1` and `Content-Type: application/json` on every update request, but the server never validates their presence.

# The Problem

Without header validation, the update endpoint is more exposed than necessary to non-client requests. Browsers can send cross-origin `application/x-www-form-urlencoded` POST requests without a CORS preflight check, which means a malicious page could potentially submit form-encoded POST requests to the Livewire endpoint. While Laravel's CSRF middleware provides the primary defence, requiring JSON content type adds defence-in-depth — browsers will trigger a CORS preflight for cross-origin `application/json` requests, providing an additional layer of protection.

Additionally, any POST request (from scanners, bots, or manual probing) reaches the handler logic regardless of whether it originated from the Livewire JS client.

# The Solution

Added a `RequireLivewireHeaders` middleware that rejects requests missing either the `X-Livewire` header or a JSON `Content-Type` header, returning a 404 response to avoid confirming the endpoint exists to scanners.

The middleware is registered on the default update route and is also automatically applied to custom routes defined via `setUpdateRoute()`.

The check uses Laravel's `$request->isJson()` method which matches any content type containing `/json` or `+json`, so it handles standard `application/json` as well as variants like `application/json; charset=utf-8`.

Since the legitimate JS client always sends both headers, this change will never affect real users.