### PR TITLE
[4.x] Strengthen checksum failure rate limiting with lower per-IP threshold and global limiter

### DIFF
--- a/src/Mechanisms/HandleComponents/ChecksumRateLimitUnitTest.php
+++ b/src/Mechanisms/HandleComponents/ChecksumRateLimitUnitTest.php
@@ -19,6 +19,7 @@ class ChecksumRateLimitUnitTest extends TestCase
 
         // Clear any existing rate limits before each test
         RateLimiter::clear('livewire-checksum-failures:127.0.0.1');
+        RateLimiter::clear('livewire-checksum-failures:global');
 
         // Register a test component for use in snapshots
         Livewire::component('test-component', ChecksumRateLimitTestComponent::class);
@@ -72,8 +73,8 @@ class ChecksumRateLimitUnitTest extends TestCase
             'checksum' => 'invalid-checksum',
         ];
 
-        // Hit the rate limit (10 failures across 10 "requests")
-        for ($i = 0; $i < 10; $i++) {
+        // Hit the rate limit (5 failures across 5 "requests")
+        for ($i = 0; $i < 5; $i++) {
             // Clear the flag to simulate a new request
             request()->attributes->remove('livewire_rate_limit_checked');
 
@@ -119,7 +120,7 @@ class ChecksumRateLimitUnitTest extends TestCase
             'checksum' => 'invalid-checksum',
         ];
 
-        for ($i = 0; $i < 10; $i++) {
+        for ($i = 0; $i < 5; $i++) {
             // Clear the flag to simulate a new request
             request()->attributes->remove('livewire_rate_limit_checked');
 
@@ -157,8 +158,9 @@ class ChecksumRateLimitUnitTest extends TestCase
         Checksum::verify($snapshot);
         Checksum::verify($snapshot);
 
-        // tooManyAttempts should only be called once, not three times
-        RateLimiter::shouldHaveReceived('tooManyAttempts')->once();
+        // tooManyAttempts should only be called twice (global + per-IP),
+        // not six times — the once-per-request flag prevents re-checking.
+        RateLimiter::shouldHaveReceived('tooManyAttempts')->twice();
     }
 
     public function test_rate_limit_is_checked_again_on_new_request()
@@ -178,8 +180,106 @@ class ChecksumRateLimitUnitTest extends TestCase
         // Second "request" - verify again
         Checksum::verify($snapshot);
 
-        // tooManyAttempts should be called twice (once per request)
-        RateLimiter::shouldHaveReceived('tooManyAttempts')->twice();
+        // tooManyAttempts should be called 4 times (global + per-IP, twice each for 2 requests)
+        RateLimiter::shouldHaveReceived('tooManyAttempts')->times(4);
+    }
+
+    public function test_failure_is_recorded_to_global_rate_limiter()
+    {
+        $snapshot = [
+            'memo' => ['name' => 'test-component', 'release' => ReleaseToken::generate(ChecksumRateLimitTestComponent::class)],
+            'data' => ['foo' => 'bar'],
+            'checksum' => 'invalid-checksum',
+        ];
+
+        try {
+            Checksum::verify($snapshot);
+        } catch (CorruptComponentPayloadException $e) {
+            // Expected
+        }
+
+        // Verify a hit was recorded against both the per-IP and global keys
+        $this->assertEquals(1, RateLimiter::attempts('livewire-checksum-failures:127.0.0.1'));
+        $this->assertEquals(1, RateLimiter::attempts('livewire-checksum-failures:global'));
+    }
+
+    public function test_global_rate_limit_blocks_when_threshold_exceeded()
+    {
+        $snapshot = [
+            'memo' => ['name' => 'test-component', 'release' => ReleaseToken::generate(ChecksumRateLimitTestComponent::class)],
+            'data' => ['foo' => 'bar'],
+            'checksum' => 'invalid-checksum',
+        ];
+
+        // Simulate 50 failures hitting the global limit by pre-filling
+        // the global rate limiter (as if from many different IPs).
+        for ($i = 0; $i < 50; $i++) {
+            RateLimiter::hit('livewire-checksum-failures:global', 60);
+        }
+
+        // Clear per-IP limiter so the global limit is what triggers
+        RateLimiter::clear('livewire-checksum-failures:127.0.0.1');
+
+        request()->attributes->remove('livewire_rate_limit_checked');
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        $this->expectExceptionMessage('Too many invalid Livewire requests');
+
+        Checksum::verify($snapshot);
+    }
+
+    public function test_global_rate_limit_blocks_even_valid_requests()
+    {
+        // Pre-fill the global rate limiter past its threshold
+        for ($i = 0; $i < 50; $i++) {
+            RateLimiter::hit('livewire-checksum-failures:global', 60);
+        }
+
+        // Clear per-IP limiter so only global triggers
+        RateLimiter::clear('livewire-checksum-failures:127.0.0.1');
+
+        request()->attributes->remove('livewire_rate_limit_checked');
+
+        $validSnapshot = [
+            'memo' => ['name' => 'test-component', 'release' => ReleaseToken::generate(ChecksumRateLimitTestComponent::class)],
+            'data' => ['foo' => 'bar'],
+        ];
+        $validSnapshot['checksum'] = Checksum::generate($validSnapshot);
+
+        $this->expectException(TooManyRequestsHttpException::class);
+
+        Checksum::verify($validSnapshot);
+    }
+
+    public function test_per_ip_limit_triggers_before_global_limit()
+    {
+        $snapshot = [
+            'memo' => ['name' => 'test-component', 'release' => ReleaseToken::generate(ChecksumRateLimitTestComponent::class)],
+            'data' => ['foo' => 'bar'],
+            'checksum' => 'invalid-checksum',
+        ];
+
+        // Hit the per-IP limit (5 failures)
+        for ($i = 0; $i < 5; $i++) {
+            request()->attributes->remove('livewire_rate_limit_checked');
+
+            try {
+                Checksum::verify($snapshot);
+            } catch (CorruptComponentPayloadException $e) {
+                // Expected
+            }
+        }
+
+        // Per-IP should be at 5, global should be at 5 (well under 50)
+        $this->assertEquals(5, RateLimiter::attempts('livewire-checksum-failures:127.0.0.1'));
+        $this->assertEquals(5, RateLimiter::attempts('livewire-checksum-failures:global'));
+
+        // Next attempt should be blocked by per-IP limit
+        request()->attributes->remove('livewire_rate_limit_checked');
+
+        $this->expectException(TooManyRequestsHttpException::class);
+
+        Checksum::verify($snapshot);
     }
 }
 


### PR DESCRIPTION
# The Scenario

An attacker is attempting to brute-force or probe the Livewire update endpoint by sending requests with invalid checksums. With the previous rate limit of 10 failures per IP per 10 minutes, an attacker could make a significant number of probing requests before being blocked. Worse, by rotating across multiple IP addresses, they could bypass the per-IP limit entirely and sustain a high volume of invalid requests indefinitely.

# The Problem

The rate limiting in `Checksum.php` only tracked failures per individual IP address, with a threshold of 10 failures per 10 minutes. This had two weaknesses:

1. **The per-IP threshold was too generous** — 10 failures is more than a legitimate user would ever trigger (a real user might cause 1-2 checksum failures from a stale tab, never 10).

2. **No global limit existed** — an attacker using IP rotation (botnets, proxy pools, cloud functions) could distribute requests across many IPs, with each IP staying under the per-IP limit while the total attack volume remained high. There was no mechanism to detect or block this pattern.

Additionally, `request()->ip()` relies on correct trusted proxy configuration — applications behind reverse proxies or load balancers that haven't configured `TrustProxies` middleware would see all requests as coming from the same proxy IP, causing legitimate users to be incorrectly rate-limited.

# The Solution

- **Reduced per-IP threshold from 10 to 5** failures per 10 minutes — still generous enough for legitimate edge cases (stale tabs, key rotation) but significantly reduces the window for probing.

- **Added global rate limiting** — 50 failures per minute across all IPs. This catches distributed attacks where no single IP exceeds its individual limit. The global check runs first in `enforceRateLimit()` so it short-circuits before the per-IP check when the system is under distributed attack. Both `recordFailure()` and `enforceRateLimit()` now operate on both keys.

- **Documented trusted proxy requirements** — added an inline comment explaining that applications behind reverse proxies must configure `TrustProxies` middleware (or `TRUSTED_PROXIES` env var) for `request()->ip()` to return real client IPs, with a link to the Laravel documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)