### PR TITLE
[4.x] Disable default update route when a custom route is registered

### DIFF
--- a/src/Mechanisms/HandleRequests/CustomUpdateRouteUnitTest.php
+++ b/src/Mechanisms/HandleRequests/CustomUpdateRouteUnitTest.php
@@ -18,6 +18,12 @@ class CustomUpdateRouteUnitTest extends TestCase
 
     public function test_custom_route_is_used_for_url_generation(): void
     {
+        // Both default and custom routes exist (with different names to avoid collision)
+        $livewireUpdateRoutes = collect(Route::getRoutes()->getRoutes())->filter(function ($route) {
+            return str($route->getName())->endsWith('livewire.update');
+        });
+
+        $this->assertCount(2, $livewireUpdateRoutes);
         $this->assertEquals('/custom/livewire/update', Livewire::getUpdateUri());
     }
 

--- a/src/Mechanisms/HandleRequests/CustomUpdateRouteUnitTest.php
+++ b/src/Mechanisms/HandleRequests/CustomUpdateRouteUnitTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Livewire\Livewire;
+use Livewire\Mechanisms\HandleRequests\EndpointResolver;
 use Tests\TestCase;
 
 class CustomUpdateRouteUnitTest extends TestCase
@@ -17,13 +18,24 @@ class CustomUpdateRouteUnitTest extends TestCase
 
     public function test_custom_route_is_used_for_url_generation(): void
     {
-        // Both default and custom routes exist (with different names to avoid collision)
-        $livewireUpdateRoutes = collect(Route::getRoutes()->getRoutes())->filter(function ($route) {
-            return str($route->getName())->endsWith('livewire.update');
-        });
-
-        $this->assertCount(2, $livewireUpdateRoutes);
         $this->assertEquals('/custom/livewire/update', Livewire::getUpdateUri());
+    }
+
+    public function test_default_route_returns_404_when_custom_route_registered(): void
+    {
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->post(EndpointResolver::updatePath(), ['components' => []]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_custom_route_accepts_requests_when_registered(): void
+    {
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->post('/custom/livewire/update', ['components' => []]);
+
+        $response->assertOk();
+        $this->assertArrayHasKey('components', $response->json());
     }
 }
 

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -17,6 +17,8 @@ class HandleRequests extends Mechanism
 {
     protected $updateRoute;
 
+    protected $defaultRouteDisabled = false;
+
     function boot()
     {
         // Register the default route immediately (before routes files load)
@@ -97,6 +99,13 @@ class HandleRequests extends Mechanism
         }
 
         $this->updateRoute = $route;
+
+        // When a custom route is registered, disable the default route so
+        // attackers cannot bypass middleware on the custom route by sending
+        // requests directly to the default hashed endpoint.
+        if ($route->getName() !== 'default-livewire.update') {
+            $this->defaultRouteDisabled = true;
+        }
     }
 
     function isLivewireRequest()
@@ -122,6 +131,13 @@ class HandleRequests extends Mechanism
 
     function handleUpdate()
     {
+        // When a custom update route is registered, reject requests that arrive
+        // via the default route. This prevents attackers from bypassing middleware
+        // (e.g. auth, tenant scoping) added to the custom route.
+        if ($this->defaultRouteDisabled && request()->route()?->getName() === 'default-livewire.update') {
+            abort(404);
+        }
+
         // Check payload size limit...
         $maxSize = config('livewire.payload.max_size');
 


### PR DESCRIPTION
# The Scenario

When a developer registers a custom update route with additional middleware (e.g. `auth`, tenant scoping), the default hashed route still accepts requests:

```php
// AppServiceProvider.php
Livewire::setUpdateRoute(function ($handle) {
    return Route::post('/tenant/{tenant}/livewire/update', $handle)
        ->middleware(['web', 'auth', 'tenant']);
});
```

An attacker can bypass the `auth` and `tenant` middleware by sending requests directly to the default `/livewire-{hash}/update` endpoint instead.

# The Problem

`HandleRequests::boot()` registers the default route before the user's service provider calls `setUpdateRoute()`. When the custom route is registered, both routes coexist in the router. While `findUpdateRoute()` already prioritises custom routes for URL generation, the default route remains active and continues processing requests — effectively making the custom route's middleware optional from an attacker's perspective.

# The Solution

At the top of `handleUpdate()`, the request's route name is checked against the actual route collection via `findUpdateRoute()`. If the request arrived via the default route (`default-livewire.update`) but a custom route exists, the request is rejected with a 404. This requires no additional state on the class and works correctly even with cached routes.