### PR TITLE
[4.x] Fire ChecksumFailure event on checksum verification failure

### DIFF
--- a/src/Events/ChecksumFailure.php
+++ b/src/Events/ChecksumFailure.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Livewire\Events;
+
+class ChecksumFailure
+{
+    public function __construct(
+        public string $ipAddress,
+        public string $userAgent,
+        public ?string $componentName = null,
+    ) {}
+}

--- a/src/Mechanisms/HandleComponents/ChecksumFailureEventUnitTest.php
+++ b/src/Mechanisms/HandleComponents/ChecksumFailureEventUnitTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents;
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\RateLimiter;
+use Livewire\Component;
+use Livewire\Events\ChecksumFailure;
+use Livewire\Features\SupportReleaseTokens\ReleaseToken;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ChecksumFailureEventUnitTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        RateLimiter::clear('livewire-checksum-failures:127.0.0.1');
+
+        Livewire::component('test-component', ChecksumFailureEventTestComponent::class);
+    }
+
+    public function test_checksum_failure_fires_event()
+    {
+        Event::fake([ChecksumFailure::class]);
+
+        $snapshot = [
+            'memo' => ['name' => 'test-component', 'release' => ReleaseToken::generate(ChecksumFailureEventTestComponent::class)],
+            'data' => ['foo' => 'bar'],
+            'checksum' => 'invalid-checksum',
+        ];
+
+        try {
+            Checksum::verify($snapshot);
+        } catch (CorruptComponentPayloadException $e) {
+            // Expected
+        }
+
+        Event::assertDispatched(ChecksumFailure::class, function ($event) {
+            return $event->ipAddress === '127.0.0.1'
+                && $event->componentName === 'test-component';
+        });
+    }
+
+    public function test_checksum_failure_event_includes_user_agent()
+    {
+        Event::fake([ChecksumFailure::class]);
+
+        request()->headers->set('User-Agent', 'TestBrowser/1.0');
+
+        $snapshot = [
+            'memo' => ['name' => 'test-component', 'release' => ReleaseToken::generate(ChecksumFailureEventTestComponent::class)],
+            'data' => ['foo' => 'bar'],
+            'checksum' => 'invalid-checksum',
+        ];
+
+        try {
+            Checksum::verify($snapshot);
+        } catch (CorruptComponentPayloadException $e) {
+            // Expected
+        }
+
+        Event::assertDispatched(ChecksumFailure::class, function ($event) {
+            return $event->userAgent === 'TestBrowser/1.0';
+        });
+    }
+
+    public function test_checksum_failure_event_fires_on_each_failure()
+    {
+        Event::fake([ChecksumFailure::class]);
+
+        $snapshot = [
+            'memo' => ['name' => 'test-component', 'release' => ReleaseToken::generate(ChecksumFailureEventTestComponent::class)],
+            'data' => ['foo' => 'bar'],
+            'checksum' => 'invalid-checksum',
+        ];
+
+        for ($i = 0; $i < 3; $i++) {
+            request()->attributes->remove('livewire_rate_limit_checked');
+
+            try {
+                Checksum::verify($snapshot);
+            } catch (CorruptComponentPayloadException $e) {
+                // Expected
+            }
+        }
+
+        Event::assertDispatchedTimes(ChecksumFailure::class, 3);
+    }
+
+    public function test_valid_checksum_does_not_fire_event()
+    {
+        Event::fake([ChecksumFailure::class]);
+
+        $snapshot = [
+            'memo' => ['name' => 'test-component', 'release' => ReleaseToken::generate(ChecksumFailureEventTestComponent::class)],
+            'data' => ['foo' => 'bar'],
+        ];
+
+        $snapshot['checksum'] = Checksum::generate($snapshot);
+
+        Checksum::verify($snapshot);
+
+        Event::assertNotDispatched(ChecksumFailure::class);
+    }
+}
+
+class ChecksumFailureEventTestComponent extends Component
+{
+    public function render()
+    {
+        return '<div></div>';
+    }
+}


### PR DESCRIPTION
# The Scenario

When an attacker sends requests with tampered component payloads to the Livewire update endpoint, the checksum verification rejects them and rate-limits the IP. However, there's no way for applications to detect these attempts — the failures are silent beyond the rate limiter and the exception.

# The Problem

`Checksum::verify()` throws a `CorruptComponentPayloadException` and records a rate limit hit, but doesn't fire any Laravel event. Applications that want to monitor for potential attacks (e.g. to alert, log to a security dashboard, or trigger IP bans) have no hook to listen for.

# The Solution

A new `Livewire\Events\ChecksumFailure` event is now fired whenever a checksum mismatch is detected. The event includes:

- `ipAddress` — the request IP
- `userAgent` — the request user agent
- `componentName` — the component name from the snapshot (if available)

Applications can listen for this event using standard Laravel event listeners:

```php
Event::listen(ChecksumFailure::class, function (ChecksumFailure $event) {
    Log::warning('Livewire checksum failure', [
        'ip' => $event->ipAddress,
        'user_agent' => $event->userAgent,
        'component' => $event->componentName,
    ]);
});
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)