### PR TITLE
[4.x] Add type validation in `CollectionSynth` to prevent arbitrary class instantiation

### DIFF
--- a/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
@@ -25,7 +25,7 @@ class CollectionSynth extends ArraySynth {
     }
 
     function hydrate($value, $meta, $hydrateChild) {
-        if (! is_a($meta['class'], Collection::class, true)) {
+        if (! isset($meta['class']) || ! is_a($meta['class'], Collection::class, true)) {
             throw new \Exception("Livewire: Class [{$meta['class']}] is not a valid Collection type.");
         }
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
@@ -25,6 +25,10 @@ class CollectionSynth extends ArraySynth {
     }
 
     function hydrate($value, $meta, $hydrateChild) {
+        if (! is_a($meta['class'], Collection::class, true)) {
+            throw new \Exception("Livewire: Class [{$meta['class']}] is not a valid Collection type.");
+        }
+
         foreach ($value as $key => $child) {
             $value[$key] = $hydrateChild($key, $child);
         }

--- a/src/Mechanisms/HandleComponents/Synthesizers/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/UnitTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
+
+use Illuminate\Support\Collection;
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\TestComponent;
+
+class UnitTest extends \Tests\TestCase
+{
+    public function test_collection_synth_hydrates_a_collection()
+    {
+        Livewire::test(ComponentWithCollectionProperty::class)
+            ->assertSet('items', collect(['foo', 'bar']))
+            ->call('$refresh')
+            ->assertSet('items', collect(['foo', 'bar']));
+    }
+
+    public function test_collection_synth_hydrates_a_custom_collection_subclass()
+    {
+        Livewire::test(ComponentWithCustomCollectionProperty::class)
+            ->call('$refresh')
+            ->assertSet('items', new CustomCollection(['foo', 'bar']));
+    }
+
+    public function test_collection_synth_rejects_non_collection_class()
+    {
+        $synth = new CollectionSynth(
+            new \Livewire\Mechanisms\HandleComponents\ComponentContext(
+                new ComponentWithCollectionProperty,
+                mounting: false,
+            ),
+            'items',
+        );
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Livewire: Class [stdClass] is not a valid Collection type.');
+
+        $synth->hydrate([], ['class' => 'stdClass'], fn ($key, $child) => $child);
+    }
+
+    public function test_collection_synth_rejects_arbitrary_class_with_array_constructor()
+    {
+        $synth = new CollectionSynth(
+            new \Livewire\Mechanisms\HandleComponents\ComponentContext(
+                new ComponentWithCollectionProperty,
+                mounting: false,
+            ),
+            'items',
+        );
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not a valid Collection type');
+
+        $synth->hydrate([], ['class' => \ArrayObject::class], fn ($key, $child) => $child);
+    }
+
+    public function test_collection_synth_allows_collection_subclass()
+    {
+        $synth = new CollectionSynth(
+            new \Livewire\Mechanisms\HandleComponents\ComponentContext(
+                new ComponentWithCustomCollectionProperty,
+                mounting: false,
+            ),
+            'items',
+        );
+
+        $result = $synth->hydrate(['foo', 'bar'], ['class' => CustomCollection::class], fn ($key, $child) => $child);
+
+        $this->assertInstanceOf(CustomCollection::class, $result);
+        $this->assertEquals(['foo', 'bar'], $result->all());
+    }
+}
+
+class ComponentWithCollectionProperty extends TestComponent
+{
+    public Collection $items;
+
+    public function mount()
+    {
+        $this->items = collect(['foo', 'bar']);
+    }
+}
+
+class ComponentWithCustomCollectionProperty extends TestComponent
+{
+    public CustomCollection $items;
+
+    public function mount()
+    {
+        $this->items = new CustomCollection(['foo', 'bar']);
+    }
+}
+
+class CustomCollection extends Collection
+{
+    //
+}


### PR DESCRIPTION
# The Scenario

When `APP_KEY` is compromised, an attacker can forge valid HMAC checksums for Livewire component snapshots. With a forged snapshot, they can manipulate the `CollectionSynth` metadata to specify an arbitrary class name, which gets instantiated via `new $meta['class']($value)` during hydration.

This was the primary gadget chain entry point described in [Synacktiv's disclosure of CVE-2025-54068](https://www.synacktiv.com/en/publications/livewire-remote-command-execution-through-unmarshaling) — classes like `GuzzleHttp\Psr7\FnStream` could be instantiated through `CollectionSynth` to achieve remote code execution.

# The Problem

`CollectionSynth::hydrate()` performs `new $meta['class']($value)` where `$meta['class']` comes from the signed snapshot. The only guards are the HMAC checksum (requires `APP_KEY` to forge) and the `SecurityPolicy` denylist. If the checksum is valid and the class isn't on the denylist, any class whose constructor accepts an array can be instantiated.

`FormObjectSynth` already validates that the class extends `Form` before instantiation:

```php
if (\! isset($meta['class']) || \! is_a($meta['class'], Form::class, true)) {
    throw new \Exception('Livewire: Invalid form object class.');
}
```

`CollectionSynth` had no equivalent check.

# The Solution

Added a type validation in `CollectionSynth::hydrate()` that ensures `$meta['class']` is `Illuminate\Support\Collection` or a subclass of it before instantiation — mirroring the same pattern `FormObjectSynth` already uses for `Form`:

```php
if (\! is_a($meta['class'], Collection::class, true)) {
    throw new \Exception("Livewire: Class [{$meta['class']}] is not a valid Collection type.");
}
```

This closes the primary gadget chain entry point even if the `APP_KEY` is compromised, as only legitimate Collection types can be instantiated through this synthesiser. The `is_a()` check with `true` as the third argument allows string class names to be validated without instantiation, and supports custom Collection subclasses that applications may use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)