### PR TITLE
[4.x] Add payload schema validation and tiered response handling

### DIFF
--- a/src/Features/SupportLockedProperties/CannotUpdateLockedPropertyException.php
+++ b/src/Features/SupportLockedProperties/CannotUpdateLockedPropertyException.php
@@ -10,4 +10,13 @@ class CannotUpdateLockedPropertyException extends \Exception
             'Cannot update locked property: ['.$this->property.']'
         );
     }
+
+    // In debug mode, let Laravel render the full error page.
+    // In production, return a generic 419 to avoid leaking details.
+    public function render($request)
+    {
+        if (config('app.debug')) return false;
+
+        return response('', 419);
+    }
 }

--- a/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
+++ b/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
@@ -16,14 +16,6 @@ class CorruptComponentPayloadException extends \Exception
         );
     }
 
-    /**
-     * Render the exception as an HTTP response.
-     *
-     * Returns 419 ("Page Expired") — the JS client already handles this status
-     * with a "page expired, refresh?" prompt, which is the correct UX for stale
-     * snapshots (expired session, rotated key, stale tab). A generic body avoids
-     * leaking any internal details to attackers.
-     */
     public function render($request)
     {
         if (config('app.debug')) return false;

--- a/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
+++ b/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
@@ -16,6 +16,8 @@ class CorruptComponentPayloadException extends \Exception
         );
     }
 
+    // In debug mode, let Laravel render the full error page.
+    // In production, return a generic 419 to avoid leaking details.
     public function render($request)
     {
         if (config('app.debug')) return false;

--- a/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
+++ b/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
@@ -26,6 +26,8 @@ class CorruptComponentPayloadException extends \Exception
      */
     public function render($request)
     {
+        if (config('app.debug')) return false;
+
         return response('', 419);
     }
 }

--- a/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
+++ b/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
@@ -15,4 +15,17 @@ class CorruptComponentPayloadException extends \Exception
             "Ensure that the [name, id, data] of the Livewire component wasn't tampered with between requests."
         );
     }
+
+    /**
+     * Render the exception as an HTTP response.
+     *
+     * Returns 419 ("Page Expired") — the JS client already handles this status
+     * with a "page expired, refresh?" prompt, which is the correct UX for stale
+     * snapshots (expired session, rotated key, stale tab). A generic body avoids
+     * leaking any internal details to attackers.
+     */
+    public function render($request)
+    {
+        return response('', 419);
+    }
 }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -199,8 +199,27 @@ class HandleComponents extends Mechanism
 
     public function update($snapshot, $updates, $calls)
     {
-        if (! is_array($snapshot) || ! isset($snapshot['data'], $snapshot['memo'])) {
-            throw new \InvalidArgumentException('Invalid Livewire snapshot');
+        if (! is_array($snapshot)
+            || ! is_array($snapshot['data'] ?? null)
+            || ! is_array($snapshot['memo'] ?? null)
+            || ! is_string($snapshot['checksum'] ?? null)
+            || ! is_string($snapshot['memo']['id'] ?? null)
+            || ! is_string($snapshot['memo']['name'] ?? null)
+        ) {
+            if (config('app.debug')) throw new \InvalidArgumentException('Invalid Livewire snapshot structure: expected [data], [memo], [checksum], [memo.id], and [memo.name].');
+
+            abort(404);
+        }
+
+        foreach ($calls as $call) {
+            if (! is_array($call)
+                || ! is_string($call['method'] ?? null)
+                || ! is_array($call['params'] ?? null)
+            ) {
+                if (config('app.debug')) throw new \InvalidArgumentException('Invalid Livewire call structure: each call must contain [method] (string) and [params] (array).');
+
+                abort(404);
+            }
         }
 
         $data = $snapshot['data'];

--- a/src/Mechanisms/HandleRequests/CustomUpdateRouteUnitTest.php
+++ b/src/Mechanisms/HandleRequests/CustomUpdateRouteUnitTest.php
@@ -5,6 +5,7 @@ use Illuminate\Support\ServiceProvider;
 use Livewire\Livewire;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
 use Tests\TestCase;
+use Tests\TestComponent;
 
 class CustomUpdateRouteUnitTest extends TestCase
 {
@@ -37,8 +38,13 @@ class CustomUpdateRouteUnitTest extends TestCase
 
     public function test_custom_route_accepts_requests_when_registered(): void
     {
+        $testable = Livewire::test(new class extends TestComponent {});
+        $snapshotJson = json_encode($testable->snapshot);
+
         $response = $this->withHeaders(['X-Livewire' => 'true'])
-            ->post('/custom/livewire/update', ['components' => []]);
+            ->postJson('/custom/livewire/update', ['components' => [
+                ['snapshot' => $snapshotJson, 'updates' => [], 'calls' => []],
+            ]]);
 
         $response->assertOk();
         $this->assertArrayHasKey('components', $response->json());

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -167,7 +167,13 @@ class HandleRequests extends Mechanism
             $updates = $componentPayload['updates'];
             $calls = $componentPayload['calls'];
 
-            [ $snapshot, $effects ] = app('livewire')->update($snapshot, $updates, $calls);
+            try {
+                [ $snapshot, $effects ] = app('livewire')->update($snapshot, $updates, $calls);
+            } catch (\TypeError|\ErrorException $e) {
+                if (config('app.debug')) throw $e;
+
+                abort(419);
+            }
 
             $componentResponses[] = [
                 'snapshot' => json_encode($snapshot),

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -169,7 +169,7 @@ class HandleRequests extends Mechanism
 
             try {
                 [ $snapshot, $effects ] = app('livewire')->update($snapshot, $updates, $calls);
-            } catch (\TypeError|\ErrorException $e) {
+            } catch (\TypeError $e) {
                 if (config('app.debug')) throw $e;
 
                 abort(419);

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -110,6 +110,26 @@ class UnitTest extends TestCase
         $response->assertStatus(419);
     }
 
+    public function test_type_mismatched_update_value_returns_419(): void
+    {
+        // Disable debug mode to test production HTTP responses (404/419)...
+        config()->set('app.debug', false);
+
+        $testable = Livewire::test(new class extends TestComponent {
+            public array $items = [];
+        });
+
+        $snapshotJson = json_encode($testable->snapshot);
+
+        // Send a string where an array property is expected...
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $snapshotJson, 'updates' => ['items' => 'not_an_array'], 'calls' => []],
+            ]]);
+
+        $response->assertStatus(419);
+    }
+
     public function test_valid_request_returns_200(): void
     {
         // Disable debug mode to test production HTTP responses (404/419)...

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -13,6 +13,9 @@ class UnitTest extends TestCase
     #[DataProvider('malformedRequestPayloads')]
     public function test_malformed_request_payload_returns_404($payload): void
     {
+        // Disable debug mode to test production HTTP responses (404/419)...
+        config()->set('app.debug', false);
+
         $response = $this->withHeaders(['X-Livewire' => 'true'])
             ->postJson(EndpointResolver::updatePath(), $payload);
 
@@ -37,6 +40,9 @@ class UnitTest extends TestCase
     #[DataProvider('malformedSnapshots')]
     public function test_malformed_snapshot_returns_404($snapshot): void
     {
+        // Disable debug mode to test production HTTP responses (404/419)...
+        config()->set('app.debug', false);
+
         $response = $this->withHeaders(['X-Livewire' => 'true'])
             ->postJson(EndpointResolver::updatePath(), ['components' => [
                 ['snapshot' => $snapshot, 'updates' => [], 'calls' => []],
@@ -60,6 +66,9 @@ class UnitTest extends TestCase
     #[DataProvider('malformedCalls')]
     public function test_malformed_calls_returns_404($calls): void
     {
+        // Disable debug mode to test production HTTP responses (404/419)...
+        config()->set('app.debug', false);
+
         $snapshot = json_encode(['data' => [], 'memo' => ['id' => 'abc', 'name' => 'foo'], 'checksum' => 'hash']);
 
         $response = $this->withHeaders(['X-Livewire' => 'true'])
@@ -82,6 +91,9 @@ class UnitTest extends TestCase
 
     public function test_bad_checksum_returns_419(): void
     {
+        // Disable debug mode to test production HTTP responses (404/419)...
+        config()->set('app.debug', false);
+
         $testable = Livewire::test(new class extends TestComponent {});
 
         $snapshot = json_encode([
@@ -100,6 +112,9 @@ class UnitTest extends TestCase
 
     public function test_valid_request_returns_200(): void
     {
+        // Disable debug mode to test production HTTP responses (404/419)...
+        config()->set('app.debug', false);
+
         $testable = Livewire::test(new class extends TestComponent {});
         $snapshotJson = json_encode($testable->snapshot);
 

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -147,15 +147,17 @@ class UnitTest extends TestCase
 
     public function test_catch_all_route_does_not_intercept_livewire_update_requests(): void
     {
-        Livewire::component('schema-test', SchemaValidationTestComponent::class);
-
+        // Register a catch-all route (simulating what happens in routes files)
         Route::any('{all?}', function () {
             return 'catch-all';
         })->where('all', '.*');
 
+        Livewire::component('schema-test', SchemaValidationTestComponent::class);
+
         $testable = Livewire::test(SchemaValidationTestComponent::class);
         $snapshotJson = json_encode($testable->snapshot);
 
+        // Livewire's update route should still be matched, not the catch-all
         $response = $this->withHeaders(['X-Livewire' => 'true'])
             ->postJson(EndpointResolver::updatePath(), ['components' => [
                 ['snapshot' => $snapshotJson, 'updates' => [], 'calls' => []],

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -1,12 +1,12 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use Livewire\Component;
 use Livewire\Livewire;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
+use Tests\TestComponent;
 
 class UnitTest extends TestCase
 {
@@ -82,11 +82,11 @@ class UnitTest extends TestCase
 
     public function test_bad_checksum_returns_419(): void
     {
-        Livewire::component('schema-test', SchemaValidationTestComponent::class);
+        $testable = Livewire::test(new class extends TestComponent {});
 
         $snapshot = json_encode([
             'data' => [],
-            'memo' => ['id' => 'abc', 'name' => 'schema-test'],
+            'memo' => ['id' => 'abc', 'name' => $testable->snapshot['memo']['name']],
             'checksum' => 'invalid-checksum-value',
         ]);
 
@@ -100,9 +100,7 @@ class UnitTest extends TestCase
 
     public function test_valid_request_returns_200(): void
     {
-        Livewire::component('schema-test', SchemaValidationTestComponent::class);
-
-        $testable = Livewire::test(SchemaValidationTestComponent::class);
+        $testable = Livewire::test(new class extends TestComponent {});
         $snapshotJson = json_encode($testable->snapshot);
 
         $response = $this->withHeaders(['X-Livewire' => 'true'])
@@ -152,9 +150,7 @@ class UnitTest extends TestCase
             return 'catch-all';
         })->where('all', '.*');
 
-        Livewire::component('schema-test', SchemaValidationTestComponent::class);
-
-        $testable = Livewire::test(SchemaValidationTestComponent::class);
+        $testable = Livewire::test(new class extends TestComponent {});
         $snapshotJson = json_encode($testable->snapshot);
 
         // Livewire's update route should still be matched, not the catch-all
@@ -208,13 +204,5 @@ class UnitTest extends TestCase
         $uri = $handleRequests->getUpdateUri();
 
         $this->assertEquals(EndpointResolver::updatePath(), $uri);
-    }
-}
-
-class SchemaValidationTestComponent extends Component
-{
-    public function render()
-    {
-        return '<div></div>';
     }
 }

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -98,7 +98,11 @@ class UnitTest extends TestCase
 
         $snapshot = json_encode([
             'data' => [],
-            'memo' => ['id' => 'abc', 'name' => $testable->snapshot['memo']['name']],
+            'memo' => [
+                'id' => 'abc',
+                'name' => $testable->snapshot['memo']['name'],
+                'release' => $testable->snapshot['memo']['release'],
+            ],
             'checksum' => 'invalid-checksum-value',
         ]);
 

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -149,21 +149,6 @@ class UnitTest extends TestCase
 
         $response->assertOk();
         $this->assertArrayHasKey('components', $response->json());
-        $handleRequestsInstance = new HandleRequests();
-
-        // Set the required headers on the container's request instance...
-        request()->headers->set('X-Livewire', '1');
-        request()->headers->set('Content-Type', 'application/json');
-
-        $result = $handleRequestsInstance->handleUpdate();
-
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('components', $result);
-        $this->assertArrayHasKey('assets', $result);
-        $this->assertIsArray($result['components']);
-        $this->assertEmpty($result['components']);
-        $this->assertIsArray($result['assets']);
-        $this->assertEmpty($result['assets']);
     }
 
     public function test_default_livewire_update_route_is_registered(): void
@@ -212,7 +197,6 @@ class UnitTest extends TestCase
             ->postJson(EndpointResolver::updatePath(), ['components' => [
                 ['snapshot' => $snapshotJson, 'updates' => [], 'calls' => []],
             ]]);
-            ->postJson(EndpointResolver::updatePath(), ['components' => []]);
 
         $response->assertOk();
         $this->assertArrayHasKey('components', $response->json());
@@ -242,8 +226,13 @@ class UnitTest extends TestCase
 
     public function test_update_endpoint_succeeds_with_required_headers(): void
     {
+        $testable = Livewire::test(new class extends TestComponent {});
+        $snapshotJson = json_encode($testable->snapshot);
+
         $response = $this->withHeaders(['X-Livewire' => 'true'])
-            ->postJson(EndpointResolver::updatePath(), ['components' => []]);
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $snapshotJson, 'updates' => [], 'calls' => []],
+            ]]);
 
         $response->assertOk();
         $this->assertArrayHasKey('components', $response->json());

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -164,6 +164,7 @@ class UnitTest extends TestCase
             ]]);
 
         $response->assertOk();
+        $this->assertArrayHasKey('components', $response->json());
     }
 
     public function test_get_update_uri_works_when_update_route_property_is_null(): void

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -2,26 +2,257 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Livewire\Component;
+use Livewire\Livewire;
+use Livewire\Mechanisms\HandleComponents\Checksum;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
 use Tests\TestCase;
 
 class UnitTest extends TestCase
 {
-    public function test_livewire_can_run_handle_request_without_components_on_payload(): void
+    public function test_missing_components_returns_404(): void
     {
-        $handleRequestsInstance = new HandleRequests();
-        $request = new Request();
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), []);
 
-        $result = $handleRequestsInstance->handleUpdate($request);
+        $response->assertNotFound();
+    }
 
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('components', $result);
-        $this->assertArrayHasKey('assets', $result);
-        $this->assertIsArray($result['components']);
-        $this->assertEmpty($result['components']);
-        $this->assertIsArray($result['assets']);
-        $this->assertEmpty($result['assets']);
+    public function test_empty_components_array_returns_404(): void
+    {
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => []]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_non_array_components_returns_404(): void
+    {
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => 'not-an-array']);
+
+        $response->assertNotFound();
+    }
+
+    public function test_component_missing_snapshot_returns_404(): void
+    {
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_component_with_non_string_snapshot_returns_404(): void
+    {
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => 123, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_component_missing_updates_returns_404(): void
+    {
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => '{}', 'calls' => []],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_component_missing_calls_returns_404(): void
+    {
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => '{}', 'updates' => []],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_component_with_non_array_updates_returns_404(): void
+    {
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => '{}', 'updates' => 'bad', 'calls' => []],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_component_with_non_array_calls_returns_404(): void
+    {
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => '{}', 'updates' => [], 'calls' => 'bad'],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_snapshot_decoding_to_null_returns_404(): void
+    {
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => 'not-valid-json', 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_decoded_snapshot_missing_data_returns_404(): void
+    {
+        $snapshot = json_encode(['memo' => ['id' => 'abc', 'name' => 'foo'], 'checksum' => 'hash']);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_decoded_snapshot_missing_memo_returns_404(): void
+    {
+        $snapshot = json_encode(['data' => [], 'checksum' => 'hash']);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_decoded_snapshot_missing_checksum_returns_404(): void
+    {
+        $snapshot = json_encode(['data' => [], 'memo' => ['id' => 'abc', 'name' => 'foo']]);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_decoded_snapshot_memo_missing_id_returns_404(): void
+    {
+        $snapshot = json_encode(['data' => [], 'memo' => ['name' => 'foo'], 'checksum' => 'hash']);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_decoded_snapshot_memo_missing_name_returns_404(): void
+    {
+        $snapshot = json_encode(['data' => [], 'memo' => ['id' => 'abc'], 'checksum' => 'hash']);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_call_missing_method_returns_404(): void
+    {
+        $snapshot = json_encode(['data' => [], 'memo' => ['id' => 'abc', 'name' => 'foo'], 'checksum' => 'hash']);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => [
+                    ['params' => []],
+                ]],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_call_missing_params_returns_404(): void
+    {
+        $snapshot = json_encode(['data' => [], 'memo' => ['id' => 'abc', 'name' => 'foo'], 'checksum' => 'hash']);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => [
+                    ['method' => 'doSomething'],
+                ]],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_call_with_non_string_method_returns_404(): void
+    {
+        $snapshot = json_encode(['data' => [], 'memo' => ['id' => 'abc', 'name' => 'foo'], 'checksum' => 'hash']);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => [
+                    ['method' => 123, 'params' => []],
+                ]],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_call_with_non_array_params_returns_404(): void
+    {
+        $snapshot = json_encode(['data' => [], 'memo' => ['id' => 'abc', 'name' => 'foo'], 'checksum' => 'hash']);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => [
+                    ['method' => 'doSomething', 'params' => 'bad'],
+                ]],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_bad_checksum_returns_419(): void
+    {
+        Livewire::component('schema-test', SchemaValidationTestComponent::class);
+
+        $snapshot = json_encode([
+            'data' => [],
+            'memo' => ['id' => 'abc', 'name' => 'schema-test'],
+            'checksum' => 'invalid-checksum-value',
+        ]);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertStatus(419);
+    }
+
+    public function test_valid_request_returns_200(): void
+    {
+        Livewire::component('schema-test', SchemaValidationTestComponent::class);
+
+        $testable = Livewire::test(SchemaValidationTestComponent::class);
+        $snapshotJson = json_encode($testable->snapshot);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $snapshotJson, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertOk();
+        $this->assertArrayHasKey('components', $response->json());
     }
 
     public function test_default_livewire_update_route_is_registered(): void
@@ -62,12 +293,12 @@ class UnitTest extends TestCase
             return 'catch-all';
         })->where('all', '.*');
 
-        // Livewire's update route should still be matched
+        // Livewire's update route should still be matched (returns 404 from
+        // schema validation, not 200 "catch-all" from the catch-all route)
         $response = $this->withHeaders(['X-Livewire' => 'true'])
-            ->post(EndpointResolver::updatePath(), ['components' => []]);
+            ->postJson(EndpointResolver::updatePath(), ['components' => []]);
 
-        $response->assertOk();
-        $this->assertArrayHasKey('components', $response->json());
+        $response->assertNotFound();
     }
 
     public function test_get_update_uri_works_when_update_route_property_is_null(): void
@@ -111,5 +342,13 @@ class UnitTest extends TestCase
         $uri = $handleRequests->getUpdateUri();
 
         $this->assertEquals(EndpointResolver::updatePath(), $uri);
+    }
+}
+
+class SchemaValidationTestComponent extends Component
+{
+    public function render()
+    {
+        return '<div></div>';
     }
 }


### PR DESCRIPTION
# The Scenario

When Livewire's update endpoint receives malformed or malicious requests, the responses leak information about the endpoint's existence and internal structure:

- A request with no `components` key returns `200` with empty JSON — confirming the endpoint exists to scanners
- A request with missing `snapshot`/`updates`/`calls` fields triggers a PHP warning and returns `500` with a stack trace (in debug mode)
- A request with invalid JSON in `snapshot` returns `500` with a type error
- A request with a bad checksum returns `500` with a `CorruptComponentPayloadException` message
- A request with type-mismatched update values (e.g., a string where an array property is expected) passes all structural validation but crashes during hydration with an unhandled `TypeError` → `500`
- A request that attempts to update a `#[Locked]` property returns `500` with a `CannotUpdateLockedPropertyException` message

The variety of distinct error responses also helps attackers fingerprint the endpoint and understand its internal structure.

# The Problem

`handleUpdate()` performs minimal validation of the incoming request structure. It defaults `components` to an empty array and iterates directly over whatever is provided, trusting that each element contains `snapshot`, `updates`, and `calls` with the correct types. There is no structural validation before data reaches the checksum verification or component hydration logic.

Additionally, `CorruptComponentPayloadException` (thrown on checksum failure) and `CannotUpdateLockedPropertyException` (thrown when a `#[Locked]` property is modified) both render as generic `500` errors. The JS client already has code to handle `419` responses with a "page expired, refresh?" prompt — which is exactly the right UX for stale snapshots — but it never receives that status code.

Even with structural validation in place, type-mismatched update values (e.g., sending `"not_an_array"` for an `array` property) pass validation because the request envelope is well-formed — `updates` is a valid array of key-value pairs. The type mismatch only surfaces when PHP attempts to hydrate the property, throwing a `TypeError` that results in a `500`.

# The Solution

Two layers of schema validation were added to `handleUpdate()`:

**Request-level** (before the processing loop):
- `components` must be a non-empty array
- Each element must be an array containing `snapshot` (string), `updates` (array), `calls` (array)

**Component-level** (after `json_decode`, before checksum verification):
- Decoded snapshot must contain `data` (array), `memo` (array), `checksum` (string)
- `memo` must contain `id` (string) and `name` (string)
- Each call entry must have `method` (string) and `params` (array)

The JS client always sends well-formed payloads — there are no code paths where any of these could be missing or have unexpected types — so these checks are safe to enforce.

**Type mismatch handling:**

The `app('livewire')->update()` call is wrapped in a try/catch for `\TypeError` — the exception PHP 8+ throws for type mismatches like assigning a string to an `array`-typed property. In production, this returns `419`. In debug mode, the exception propagates so developers see the real error. Only `\TypeError` is caught — `\ErrorException` (Laravel's wrapper for PHP warnings/notices) is intentionally excluded to avoid masking unrelated warnings as 419s.

**Tiered response handling:**

| Scenario | Response | Rationale |
|---|---|---|
| Missing/malformed structure | **404** | Request didn't come from the JS client. Avoids confirming endpoint exists. |
| Valid structure, bad checksum | **419** | JS handles 419 with "page expired, refresh?" prompt — correct UX for stale pages. |
| Valid structure, type-mismatched values | **419** | Same recovery action as checksum failure (see below). |
| Valid structure, locked property update | **419** | Same recovery action — only legitimate cause is a stale page after deployment. |
| Rate limited | **429** (unchanged) | Correct HTTP status. |
| Valid request | **200** (unchanged) | Normal operation. |

**Why 419 for type mismatches and locked property updates (not 400 or 422)?**

While `400` or `422` would be more semantically precise from an HTTP perspective, the user experience is the deciding factor. The only legitimate scenario where a real user triggers a type mismatch or locked property violation is after a deployment changes a property's type or adds `#[Locked]` — the user has a stale page with the old schema. The correct recovery action is the same as a checksum failure: refresh the page. Since the JS client already handles `419` with a "page expired, refresh?" prompt, using a different status code would require adding a second client-side handler that does exactly the same thing. Using `419` consistently for all "structurally valid but unprocessable" payloads also avoids giving attackers a way to distinguish how their payload failed.

The 419 for checksum failures and locked property updates is implemented via a `render()` method on `CorruptComponentPayloadException` and `CannotUpdateLockedPropertyException` respectively. The type mismatch 419 is handled by a try/catch in `handleUpdate()`. All three gate on `app.debug` so developers see full errors during development. All response bodies are generic to avoid leaking schema information.

Fixes #9997