### PR TITLE
[4.x] Enforce web middleware on custom update routes

### DIFF
--- a/src/Mechanisms/HandleRequests/EnforceWebMiddlewareUnitTest.php
+++ b/src/Mechanisms/HandleRequests/EnforceWebMiddlewareUnitTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class EnforceWebMiddlewareUnitTest extends TestCase
+{
+    public function test_web_middleware_is_automatically_added_to_custom_route_when_missing(): void
+    {
+        Livewire::setUpdateRoute(function ($handle) {
+            return Route::post('/custom/livewire/update', $handle);
+        });
+
+        $route = $this->findCustomUpdateRoute();
+
+        $this->assertNotNull($route, 'Custom livewire.update route should exist');
+        $this->assertContains('web', $route->middleware());
+    }
+
+    public function test_web_middleware_is_not_duplicated_when_already_present(): void
+    {
+        Livewire::setUpdateRoute(function ($handle) {
+            return Route::post('/custom/livewire/update', $handle)->middleware('web');
+        });
+
+        $route = $this->findCustomUpdateRoute();
+
+        $middlewareCount = count(array_filter($route->middleware(), fn ($m) => $m === 'web'));
+
+        $this->assertEquals(1, $middlewareCount);
+    }
+
+    public function test_web_middleware_is_detected_from_route_group(): void
+    {
+        Route::middleware('web')->group(function () {
+            Livewire::setUpdateRoute(function ($handle) {
+                return Route::post('/custom/livewire/update', $handle);
+            });
+        });
+
+        $route = $this->findCustomUpdateRoute();
+
+        $middlewareCount = count(array_filter($route->middleware(), fn ($m) => $m === 'web'));
+
+        $this->assertEquals(1, $middlewareCount);
+    }
+
+    public function test_additional_middleware_is_preserved_when_web_is_auto_added(): void
+    {
+        Livewire::setUpdateRoute(function ($handle) {
+            return Route::post('/custom/livewire/update', $handle)->middleware('auth');
+        });
+
+        $route = $this->findCustomUpdateRoute();
+
+        $this->assertNotNull($route, 'Custom livewire.update route should exist');
+
+        $middleware = $route->middleware();
+
+        $this->assertContains('web', $middleware);
+        $this->assertContains('auth', $middleware);
+    }
+
+    protected function findCustomUpdateRoute()
+    {
+        return collect(Route::getRoutes()->getRoutes())->first(function ($route) {
+            return str($route->getName())->endsWith('livewire.update')
+                && $route->getName() !== 'default-livewire.update';
+        });
+    }
+}

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -91,6 +91,14 @@ class HandleRequests extends Mechanism
     {
         $route = $callback([self::class, 'handleUpdate']);
 
+        // Ensure the route includes the `web` middleware group.
+        // Without it, CSRF protection is lost entirely on the update endpoint.
+        // Note: we use middleware() (not gatherMiddleware()) to avoid polluting
+        // the route's computed middleware cache before it's fully configured.
+        if (! in_array('web', $route->middleware())) {
+            $route->middleware('web');
+        }
+
         // Append `livewire.update` to the existing name, if any.
         if (! str($route->getName())->endsWith('livewire.update')) {
             $route->name('livewire.update');

--- a/src/Mechanisms/Tests/CustomUpdateRouteBrowserTest.php
+++ b/src/Mechanisms/Tests/CustomUpdateRouteBrowserTest.php
@@ -22,7 +22,7 @@ class CustomUpdateRouteBrowserTest extends \Tests\BrowserTestCase
             // Doesn't seem to be needed in real applications, but is needed in tests
             app('router')->getRoutes()->refreshNameLookups();
 
-            Route::prefix('/{tenant}')->group(function () {
+            Route::middleware('web')->prefix('/{tenant}')->group(function () {
                 Route::get('/page', function ($tenant) {
                     return (app('livewire')->new('test'))();
                 })->name('tenant.page');


### PR DESCRIPTION
# The Scenario

When customising the Livewire update endpoint, a developer might forget to include the `web` middleware group:

```php
Livewire::setUpdateRoute(function ($handle) {
    return Route::post('/custom/livewire/update', $handle)
        ->middleware('auth');
    // Forgot ->middleware('web')!
});
```

Without `web` middleware, Laravel's CSRF protection (`VerifyCsrfToken`) is not applied, leaving the update endpoint vulnerable to cross-site request forgery attacks.

# The Problem

`setUpdateRoute()` accepts a callback that returns a route, but performs no validation on the returned route's middleware. The default Livewire route always includes `web` middleware, but custom routes rely entirely on the developer to include it. A single omission silently removes CSRF protection from the most security-sensitive endpoint in the application.

# The Solution

`setUpdateRoute()` now automatically ensures the `web` middleware group is present on custom routes. After the user's callback returns the route, Livewire checks the route's middleware list and adds `web` if it's missing. This is transparent — routes that already include `web` (either directly or via a route group) are unaffected.

The check uses `$route->middleware()` rather than `$route->gatherMiddleware()` to avoid polluting Laravel's computed middleware cache before the route is fully configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)