### PR TITLE
[4.x] Add a warning to the docs about when using `$js` inside alpine loop

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -550,6 +550,23 @@ You can call JavaScript actions directly from Alpine using the `$wire` object. F
 <button x-on:click="$wire.$js.bookmark()">Bookmark</button>
 ```
 
+> [!warning] Calling JavaScript actions inside Alpine for-loop
+> When using a JavaScript action inside Alpine for-loop, make sure to call it from alpine
+> ```blade
+> <template x-for="user in $wire.users" :key="user.id">
+>   <div>
+>     /.../
+>     <button x-on:click="$wire.$js.addUser(user)"></button>
+>   </div>
+> </template>
+> <script>
+>     this.$js.addUser = (user) => { /* ... */ }
+> </script>
+> ```
+> This will make sure the User is avalible as an object in `$js` function
+
+
+
 ### Calling from PHP
 
 JavaScript actions can also be called using the `js()` method from PHP:

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -550,23 +550,6 @@ You can call JavaScript actions directly from Alpine using the `$wire` object. F
 <button x-on:click="$wire.$js.bookmark()">Bookmark</button>
 ```
 
-> [!warning] Calling JavaScript actions inside Alpine for-loop
-> When using a JavaScript action inside Alpine for-loop, make sure to call it from alpine
-> ```blade
-> <template x-for="user in $wire.users" :key="user.id">
->   <div>
->     /.../
->     <button x-on:click="$wire.$js.addUser(user)"></button>
->   </div>
-> </template>
-> <script>
->     this.$js.addUser = (user) => { /* ... */ }
-> </script>
-> ```
-> This will make sure the User is avalible as an object in `$js` function
-
-
-
 ### Calling from PHP
 
 JavaScript actions can also be called using the `js()` method from PHP:

--- a/js/evaluator.js
+++ b/js/evaluator.js
@@ -1,27 +1,26 @@
 import Alpine from 'alpinejs'
 
-function parseForExpression(expression) {
-    let forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?$/
-    let stripParensRE = /^\s*\(|\)\s*$/g
-    let forAliasRE = /([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/
-    let inMatch = expression.match(forAliasRE)
-    if (!inMatch) return null
+function getAlpineScopeKeys(el) {
+    let keys = []
 
-    let res = {}
-    res.items = inMatch[2].trim()
-    let item = inMatch[1].replace(stripParensRE, '').trim()
-    let iteratorMatch = item.match(forIteratorRE)
+    let currentEl = el
 
-    if (iteratorMatch) {
-        res.item = item.replace(forIteratorRE, '').trim()
-        res.index = iteratorMatch[1].trim()
-        if (iteratorMatch[2]) {
-            res.collection = iteratorMatch[2].trim()
+    while (currentEl) {
+        if (currentEl._x_dataStack) {
+            for (let scope of currentEl._x_dataStack) {
+                for (let key of Object.keys(scope)) {
+                    if (! keys.includes(key)) keys.push(key)
+                }
+            }
         }
-    } else {
-        res.item = item
+
+        // Stop at the Livewire component root element...
+        if (currentEl.hasAttribute && currentEl.hasAttribute('wire:id')) break
+
+        currentEl = currentEl.parentElement
     }
-    return res
+
+    return keys
 }
 
 export function evaluateExpression(el, expression, options = {}) {
@@ -61,33 +60,11 @@ export function evaluateActionExpression(el, expression, options = {}) {
 export function contextualizeExpression(expression, el) {
     let SKIP = ['JSON', 'true', 'false', 'null', 'undefined', 'this', '$wire', '$event']
 
-    // If an element is provided, collect x-for loop variables (item, index, collection)
-    // so they don't get incorrectly prefixed with $wire.
-    //
-    // Key insight: We ONLY skip loop variables from x-for, not all Alpine scope.
-    // This allows Livewire properties to intentionally shadow Alpine x-data variables.
-    //
-    // Example: If Alpine has x-data="{ user: 'alpine' }" and Livewire has $user,
-    // expressions like wire:click="doSomething(user)" should reference $wire.user,
-    // not the Alpine variable. Only loop variables like x-for="user in users"
-    // need to be skipped.
-    //
-    // Performance: We walk the DOM tree once per expression evaluation, only checking
-    // for x-for attributes. This is O(depth) where depth is typically small (< 10).
+    // If an element is provided, collect Alpine scope keys between
+    // this element and the Livewire component root so they don't
+    // get incorrectly prefixed with $wire.
     if (el) {
-        let currentEl = el
-        while (currentEl && currentEl.nodeType === 1) {
-            let xForAttr = currentEl.getAttribute('x-for')
-            if (xForAttr) {
-                let loopVars = parseForExpression(xForAttr)
-                if (loopVars) {
-                    if (loopVars.item && !SKIP.includes(loopVars.item)) SKIP.push(loopVars.item)
-                    if (loopVars.index && !SKIP.includes(loopVars.index)) SKIP.push(loopVars.index)
-                    if (loopVars.collection && !SKIP.includes(loopVars.collection)) SKIP.push(loopVars.collection)
-                }
-            }
-            currentEl = currentEl.parentElement
-        }
+        SKIP.push(...getAlpineScopeKeys(el))
     }
     let strings = []
 

--- a/js/evaluator.js
+++ b/js/evaluator.js
@@ -1,5 +1,29 @@
 import Alpine from 'alpinejs'
 
+function parseForExpression(expression) {
+    let forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?$/
+    let stripParensRE = /^\s*\(|\)\s*$/g
+    let forAliasRE = /([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/
+    let inMatch = expression.match(forAliasRE)
+    if (!inMatch) return null
+
+    let res = {}
+    res.items = inMatch[2].trim()
+    let item = inMatch[1].replace(stripParensRE, '').trim()
+    let iteratorMatch = item.match(forIteratorRE)
+
+    if (iteratorMatch) {
+        res.item = item.replace(forIteratorRE, '').trim()
+        res.index = iteratorMatch[1].trim()
+        if (iteratorMatch[2]) {
+            res.collection = iteratorMatch[2].trim()
+        }
+    } else {
+        res.item = item
+    }
+    return res
+}
+
 export function evaluateExpression(el, expression, options = {}) {
     if (! expression || expression.trim() === '') return
 
@@ -37,16 +61,32 @@ export function evaluateActionExpression(el, expression, options = {}) {
 export function contextualizeExpression(expression, el) {
     let SKIP = ['JSON', 'true', 'false', 'null', 'undefined', 'this', '$wire', '$event']
 
-    // If an element is provided, collect Alpine scope keys (e.g. x-for loop variables)
+    // If an element is provided, collect x-for loop variables (item, index, collection)
     // so they don't get incorrectly prefixed with $wire.
+    //
+    // Key insight: We ONLY skip loop variables from x-for, not all Alpine scope.
+    // This allows Livewire properties to intentionally shadow Alpine x-data variables.
+    //
+    // Example: If Alpine has x-data="{ user: 'alpine' }" and Livewire has $user,
+    // expressions like wire:click="doSomething(user)" should reference $wire.user,
+    // not the Alpine variable. Only loop variables like x-for="user in users"
+    // need to be skipped.
+    //
+    // Performance: We walk the DOM tree once per expression evaluation, only checking
+    // for x-for attributes. This is O(depth) where depth is typically small (< 10).
     if (el) {
-        let dataStack = Alpine.closestDataStack(el)
-        if (dataStack) {
-            dataStack.forEach(scope => {
-                Object.keys(Alpine.raw(scope)).forEach(key => {
-                    if (! SKIP.includes(key)) SKIP.push(key)
-                })
-            })
+        let currentEl = el
+        while (currentEl && currentEl.nodeType === 1) {
+            let xForAttr = currentEl.getAttribute('x-for')
+            if (xForAttr) {
+                let loopVars = parseForExpression(xForAttr)
+                if (loopVars) {
+                    if (loopVars.item && !SKIP.includes(loopVars.item)) SKIP.push(loopVars.item)
+                    if (loopVars.index && !SKIP.includes(loopVars.index)) SKIP.push(loopVars.index)
+                    if (loopVars.collection && !SKIP.includes(loopVars.collection)) SKIP.push(loopVars.collection)
+                }
+            }
+            currentEl = currentEl.parentElement
         }
     }
     let strings = []

--- a/js/evaluator.spec.js
+++ b/js/evaluator.spec.js
@@ -38,4 +38,76 @@ describe('Contextualize expressions', () => {
         expect(contextualizeExpression("{ foo: foo }")).toBe('{ foo: $wire.foo }')
         expect(contextualizeExpression("{ fooBar: foo }")).toBe('{ fooBar: $wire.foo }')
     })
+
+    it('x-for loop variables are skipped', () => {
+        // Create a mock element with x-for attribute
+        let mockEl = {
+            nodeType: 1,
+            getAttribute: (attr) => attr === 'x-for' ? 'user in users' : null,
+            parentElement: null
+        }
+
+        expect(contextualizeExpression('user', mockEl)).toBe('user')
+        expect(contextualizeExpression('user.name', mockEl)).toBe('user.name')
+        expect(contextualizeExpression('doSomething(user)', mockEl)).toBe('$wire.doSomething(user)')
+    })
+
+    it('x-for with index variable', () => {
+        let mockEl = {
+            nodeType: 1,
+            getAttribute: (attr) => attr === 'x-for' ? '(user, index) in users' : null,
+            parentElement: null
+        }
+
+        expect(contextualizeExpression('user', mockEl)).toBe('user')
+        expect(contextualizeExpression('index', mockEl)).toBe('index')
+        expect(contextualizeExpression('users', mockEl)).toBe('$wire.users')
+    })
+
+    it('x-for with all variables (item, index, collection)', () => {
+        let mockEl = {
+            nodeType: 1,
+            getAttribute: (attr) => attr === 'x-for' ? '(value, key, collection) in items' : null,
+            parentElement: null
+        }
+
+        expect(contextualizeExpression('value', mockEl)).toBe('value')
+        expect(contextualizeExpression('key', mockEl)).toBe('key')
+        expect(contextualizeExpression('collection', mockEl)).toBe('collection')
+        expect(contextualizeExpression('items', mockEl)).toBe('$wire.items')
+    })
+
+    it('nested x-for loops', () => {
+        let childEl = {
+            nodeType: 1,
+            getAttribute: (attr) => attr === 'x-for' ? 'item in items' : null,
+            parentElement: {
+                nodeType: 1,
+                getAttribute: (attr) => attr === 'x-for' ? 'user in users' : null,
+                parentElement: null
+            }
+        }
+
+        expect(contextualizeExpression('item', childEl)).toBe('item')
+        expect(contextualizeExpression('user', childEl)).toBe('user')
+        expect(contextualizeExpression('items', childEl)).toBe('$wire.items')
+        expect(contextualizeExpression('users', childEl)).toBe('$wire.users')
+    })
+
+    it('only loop variables are skipped, not Alpine x-data scope', () => {
+        // This is the key test: Alpine scope variables that aren't loop variables
+        // should still get prefixed with $wire, allowing intentional shadowing
+        let mockEl = {
+            nodeType: 1,
+            getAttribute: (attr) => attr === 'x-for' ? 'item in items' : null,
+            parentElement: null
+        }
+
+        // 'item' is a loop variable, so it's skipped
+        expect(contextualizeExpression('item', mockEl)).toBe('item')
+
+        // But other identifiers (even if they exist in Alpine x-data scope)
+        // should be prefixed, allowing Livewire properties to shadow them
+        expect(contextualizeExpression('someProperty', mockEl)).toBe('$wire.someProperty')
+    })
 })


### PR DESCRIPTION
Discussion: [9881](https://github.com/livewire/livewire/discussions/9881)

hi this is a very simple docs change in action.md to use `@click` when calling `$js` for inside the Alpine JS for-loop