### PR TITLE
[4.x] Fix route model binding bug

### DIFF
--- a/src/Mechanisms/PersistentMiddleware/BrowserTest.php
+++ b/src/Mechanisms/PersistentMiddleware/BrowserTest.php
@@ -28,6 +28,14 @@ class BrowserTest extends BrowserTestCase
         $app['config']->set('auth.providers.users.model', User::class);
     }
 
+    public function tearDown(): void
+    {
+        User::deleteSushiCache();
+        Post::deleteSushiCache();
+
+        parent::tearDown();
+    }
+
     protected function resolveApplicationHttpKernel($app)
     {
         $app->singleton(\Illuminate\Contracts\Http\Kernel::class, HttpKernel::class);
@@ -525,9 +533,24 @@ class BlockListedMiddleware
     }
 }
 
+trait DeletesSushiCache
+{
+    public static function deleteSushiCache(): void
+    {
+        $cachePath = (new self)->sushiCachePath();
+
+        if (!file_exists($cachePath)) {
+            return;
+        }
+
+        unlink($cachePath);
+    }
+}
+
 class User extends AuthUser
 {
     use Sushi;
+    use DeletesSushiCache;
 
     protected $fillable = ['banned'];
 
@@ -557,6 +580,7 @@ class User extends AuthUser
 class Post extends Model
 {
     use Sushi;
+    use DeletesSushiCache;
 
     public function user()
     {

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -156,7 +156,7 @@ class PersistentMiddleware extends Mechanism
         // run are available for subsequent child components on the same route,
         // preventing re-resolution of deleted models (which would 404).
         if (isset($this->cachedRoutes[$cacheKey])) {
-            $route = clone $this->cachedRoutes[$cacheKey];
+            $route = $this->cachedRoutes[$cacheKey];
             $request->setRouteResolver(fn() => $route);
 
             return $route;
@@ -169,7 +169,7 @@ class PersistentMiddleware extends Mechanism
             return null;
         }
 
-        $this->cachedRoutes[$cacheKey] = clone $route;
+        $this->cachedRoutes[$cacheKey] = $route;
 
         return $route;
     }

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -156,7 +156,7 @@ class PersistentMiddleware extends Mechanism
         // run are available for subsequent child components on the same route,
         // preventing re-resolution of deleted models (which would 404).
         if (isset($this->cachedRoutes[$cacheKey])) {
-            $route = $this->cachedRoutes[$cacheKey];
+            $route = clone $this->cachedRoutes[$cacheKey];
             $request->setRouteResolver(fn() => $route);
 
             return $route;
@@ -169,7 +169,7 @@ class PersistentMiddleware extends Mechanism
             return null;
         }
 
-        $this->cachedRoutes[$cacheKey] = $route;
+        $this->cachedRoutes[$cacheKey] = clone $route;
 
         return $route;
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

As per the discussion here: https://github.com/livewire/livewire/discussions/9973

This PR fixes an edge case bug where having custom route model binding gives you a 404 due to the caching on persistent middleware which was recently implemented.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes, new fix branch.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

1 commit for the failing test, another for the fix, that's all.

4️⃣ Does it include tests? (Required)

Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

It seems as though the `\Illuminate\Routing\Route` which is generated below and then saved in the cache gets mutated after it's saved to the cache and then when it's reused in future it's using that mutated version.

https://github.com/livewire/livewire/blob/4697085e02a1f5f11410a1b5962400e3539f8843/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php#L186 

Specifically in my experience the route parameters went from `['slug' => 'title-123'] ` to `['slug' => Model]` when pulled back out of the cache.

The simple fix was just to clone the object to prevent the mutations after it's been saved to/pulled from the cache.