### PR TITLE
[4.x] Fix explicit route model bindings broken by cached route middleware

### DIFF
--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -26,7 +26,6 @@ class PersistentMiddleware extends Mechanism
 
     protected $path;
     protected $method;
-    protected $cachedRoutes = [];
     protected $middlewareAppliedFor = [];
     protected $resolvedRouteModels = [];
 
@@ -52,7 +51,6 @@ class PersistentMiddleware extends Mechanism
             // Only flush these at the end of a full request, so that child components have access to this data.
             $this->path = null;
             $this->method = null;
-            $this->cachedRoutes = [];
             $this->middlewareAppliedFor = [];
             $this->resolvedRouteModels = [];
         });
@@ -184,27 +182,12 @@ class PersistentMiddleware extends Mechanism
 
     protected function getRouteFromRequest($request)
     {
-        $cacheKey = $request->method() . '|' . $request->path();
-
-        // Reuse cached route if available for this method and path. This ensures
-        // that route bindings resolved during the first component's middleware
-        // run are available for subsequent child components on the same route,
-        // preventing re-resolution of deleted models (which would 404).
-        if (isset($this->cachedRoutes[$cacheKey])) {
-            $route = $this->cachedRoutes[$cacheKey];
-            $request->setRouteResolver(fn() => $route);
-
-            return $route;
-        }
-
         try {
             $route = app('router')->getRoutes()->match($request);
             $request->setRouteResolver(fn() => $route);
         } catch (NotFoundHttpException $e){
             return null;
         }
-
-        $this->cachedRoutes[$cacheKey] = $route;
 
         return $route;
     }


### PR DESCRIPTION
# The Scenario

When using `Route::model()` (explicit route model binding) on a route that renders a Livewire page component with lazy or reactive child components, Livewire update requests return 404s or resolve the wrong model. The model's `__toString()` value ends up being used as the route key instead of the original URL slug.

```php
// routes/web.php
Route::model('team', Team::class);
Route::livewire('/{team}/dashboard', 'dashboard');
```

```php
<?php

use Livewire\Component;

new class extends Component {
    //
};
?>

<div>
    Dashboard

    <livewire:sidebar lazy />
</div>
```

# The Problem

PR #9813 introduced route caching in `PersistentMiddleware` to prevent child components from 404ing when a parent deletes a route-bound model. When a route is first matched, it's cached by method and path. `SubstituteBindings` middleware then runs and mutates the cached route's parameters in-place — replacing raw strings (e.g., `'valid-slug'`) with resolved model instances.

When a subsequent component snapshot (e.g., a lazy child loading) hits the same route, the cached route is reused. `SubstituteBindings` runs again. For **implicit** bindings, Laravel's `ImplicitRouteBinding::resolveForRoute()` checks `$parameterValue instanceof UrlRoutable` and skips already-resolved models. But for **explicit** bindings registered via `Route::model()`, Laravel's `Router::substituteBindings()` does no such check — it unconditionally calls the binder closure with whatever value is in the parameter.

The binder receives a model instance instead of a string, passes it to `resolveRouteBinding()`, which either uses the model's `__toString()` as the lookup value (producing wrong queries like `WHERE slug = 'Personal'`) or fails entirely with a 404.

# The Solution

Replace the route caching with a simpler approach: track which method+path combinations have already had persistent middleware applied in the current request cycle. When a subsequent component snapshot shares the same route, skip re-applying middleware entirely.

Persistent middleware only needs to run once per route per request. When a Livewire update request contains multiple component snapshots (e.g., a parent and its lazy or reactive children), they all share the same original page route. The authentication state, route bindings, and authorisation checks are all properties of the route and the request — they don't change between components in the same request cycle. Running `SubstituteBindings`, `Authenticate`, or `Authorize` a second time for the same route in the same request is redundant at best and harmful at worst (as this bug demonstrates).

This also lets us remove the route caching that PR #9813 introduced in `getRouteFromRequest()`. That caching was needed because `SubstituteBindings` mutates the route's parameters in-place, and the cached route (with already-resolved models) was reused so implicit bindings would skip re-resolution. By preventing middleware from running more than once, there's no re-resolution to worry about, so the caching becomes unnecessary.

Fixes #9973