### PR TITLE
[4.x] Fix `wire:model` not setting values when string array key doesn't exist

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -320,7 +320,9 @@ function diffRecursive(left, right, path, diffs, rootLeft, rootRight) {
     Object.assign(diffs, childDiffs)
 
     // If any child was consolidated, bubble that up to prevent further consolidation
-    return { changed: changedCount > 0, consolidated: consolidatedCount > 0 }
+    // Also bubble up convertedToObject to prevent parent consolidation from
+    // JSON-serializing arrays with non-numeric keys (which JSON.stringify ignores)
+    return { changed: changedCount > 0, consolidated: consolidatedCount > 0 || convertedToObject }
 }
 
 /**

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -740,6 +740,50 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    function test_wire_model_sets_value_when_string_array_key_does_not_exist()
+    {
+        Livewire::visit(new class extends Component {
+            public array $items = [
+                [],
+                [],
+                ['name' => ''],
+                ['name' => ''],
+            ];
+
+            public function check()
+            {
+                //
+            }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        @foreach($items as $index => $item)
+                            <div wire:key="{{ $index }}">
+                                <input dusk="input-{{ $index }}" type="text" wire:model="items.{{ $index }}.name">
+                            </div>
+                        @endforeach
+
+                        <button dusk="check" wire:click="check">Check</button>
+
+                        <span dusk="output">{{ json_encode($items) }}</span>
+                    </div>
+                BLADE;
+            }
+        })
+            ->type('@input-0', 'Alice')
+            ->type('@input-1', 'Bob')
+            ->type('@input-2', 'Charlie')
+            ->type('@input-3', 'Dave')
+            ->waitForLivewire()->click('@check')
+            ->assertSeeIn('@output', '"Alice"')
+            ->assertSeeIn('@output', '"Bob"')
+            ->assertSeeIn('@output', '"Charlie"')
+            ->assertSeeIn('@output', '"Dave"')
+        ;
+    }
+
     function test_wire_model_with_large_numeric_key_on_non_empty_array_preserves_data()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
# The Scenario

When binding `wire:model` to a nested string array key that doesn't yet exist on an inner array, the value is silently lost. Numeric keys and pre-initialised string keys work fine — only uninitialised string keys on empty inner arrays are affected.

For example, the first two items below lose their values when the form is submitted, while the last two (which have `name` pre-initialised) work correctly:

```php
<?php

use Livewire\Component;

new class extends Component
{
    public $items = [
        // Broken — name key doesn't exist yet
        [],
        [],
        // Working — name key is pre-initialised
        ['name' => ''],
        ['name' => ''],
    ];

    public function check()
    {
        dd($this->items);
    }
?>

<div>
    @foreach($items as $index => $item)
        <div wire:key="{{ $index }}">
            <input type="text" wire:model="items.{{ $index }}.name">
        </div>
    @endforeach
    <button wire:click="check()">Check</button>
</div>
```

# The Problem

Livewire's JavaScript diff system detects what changed between the original and current state, then sends those changes to the server. When many things change at once, it optimises by consolidating individual changes (like `items.0.name`, `items.1.name`) into a single parent-level update (`items = [entire array]`).

The problem is that `JSON.stringify` silently drops string-keyed properties from JavaScript arrays. When `items[0]` is `[]` and you set `.name = "Alice"` on it, the property exists in memory but vanishes during JSON serialisation — `[]` with `.name = "Alice"` becomes just `[]`.

The granular diffs (`"items.0.name": "Alice"`) don't have this problem because the value is a plain string, not an array. But the consolidation replaces them with the parent array, which loses the data.

# The Solution

The diff system already detects arrays with string keys and avoids consolidation at that level — but it doesn't tell the parent. So the parent consolidates anyway, undoing the work.

The fix bubbles up a `consolidated` flag from these special cases so that parent levels know to preserve the granular diffs instead of rolling them up into a single value.

Fixes #9955