### PR TITLE
[4.x] Add `both` to animation shorthands in `wire:transition` docs

### DIFF
--- a/docs/attribute-transition.md
+++ b/docs/attribute-transition.md
@@ -44,19 +44,19 @@ The transition type can be targeted in CSS using the `:active-view-transition-ty
 ```css
 html:active-view-transition-type(forward) {
     &::view-transition-old(content) {
-        animation: 300ms ease-out slide-out-left;
+        animation: 300ms ease-out both slide-out-left;
     }
     &::view-transition-new(content) {
-        animation: 300ms ease-in slide-in-right;
+        animation: 300ms ease-in both slide-in-right;
     }
 }
 
 html:active-view-transition-type(backward) {
     &::view-transition-old(content) {
-        animation: 300ms ease-out slide-out-right;
+        animation: 300ms ease-out both slide-out-right;
     }
     &::view-transition-new(content) {
-        animation: 300ms ease-in slide-in-left;
+        animation: 300ms ease-in both slide-in-left;
     }
 }
 

--- a/docs/wire-transition.md
+++ b/docs/wire-transition.md
@@ -49,11 +49,11 @@ View Transitions are controlled entirely through CSS. You can customize the anim
 ```css
 /* Customize the transition for a specific element */
 ::view-transition-old(sidebar) {
-    animation: 300ms ease-out slide-out;
+    animation: 300ms ease-out both slide-out;
 }
 
 ::view-transition-new(sidebar) {
-    animation: 300ms ease-in slide-in;
+    animation: 300ms ease-in both slide-in;
 }
 
 @keyframes slide-out {
@@ -95,19 +95,19 @@ Then target the type in your CSS using the `:active-view-transition-type()` sele
 ```css
 html:active-view-transition-type(forward) {
     &::view-transition-old(content) {
-        animation: 300ms ease-out slide-out-left;
+        animation: 300ms ease-out both slide-out-left;
     }
     &::view-transition-new(content) {
-        animation: 300ms ease-in slide-in-right;
+        animation: 300ms ease-in both slide-in-right;
     }
 }
 
 html:active-view-transition-type(backward) {
     &::view-transition-old(content) {
-        animation: 300ms ease-out slide-out-right;
+        animation: 300ms ease-out both slide-out-right;
     }
     &::view-transition-new(content) {
-        animation: 300ms ease-in slide-in-left;
+        animation: 300ms ease-in both slide-in-left;
     }
 }
 


### PR DESCRIPTION
# The Scenario

When using `wire:transition` with custom CSS animations following the documented examples, the old content flashes back to its original position for a single frame at the end of the transition before disappearing.

![Screenshot 2026-02-11 at 02 31 34PM](https://github.com/user-attachments/assets/42d08028-7af2-40c4-8720-66f9979e1b1e)

# The Problem

The CSS animation examples in the `wire:transition` and `#[Transition]` docs use the `animation` shorthand without specifying `animation-fill-mode`:

```css
::view-transition-old(sidebar) {
    animation: 300ms ease-out slide-out;
}
```

The `animation` shorthand resets `animation-fill-mode` to `none` by default. When a CSS animation runs, `animation-fill-mode` controls what styles the element has before and after the animation plays:

- **`none`** (default): The element only has the animation styles during the animation. Before and after, it snaps back to its original styles. So if your animation ends at `opacity: 0; translateX(-100%)`, the moment the animation finishes the element jumps back to `opacity: 1; translateX(0)` — that's the flash.
- **`forwards`**: After the animation ends, the element keeps the styles from the last keyframe. So it stays at `opacity: 0; translateX(-100%)`.
- **`backwards`**: Before the animation starts (during `animation-delay`), the element applies the styles from the first keyframe.
- **`both`**: Combines `forwards` and `backwards` — applies the first keyframe before the animation, and holds the last keyframe after.

In this case, the `::view-transition-old` pseudo-element animates to `translateX(-100%); opacity: 0`. With `fill-mode: none`, it snaps back to full opacity at its original position for a frame before the browser cleans up the pseudo-element.

# The Solution

Updated all CSS examples in the `wire:transition` and `#[Transition]` docs to include `both` in the animation shorthand (e.g., `animation: 300ms ease-out both slide-out-left`). With `both`, the old snapshot stays invisible and off-screen until the browser cleans up the transition — no more blip.

A framework-level fix was considered (injecting `animation-fill-mode: both !important` on `::view-transition-old(*)` / `::view-transition-new(*)`), but since the `animation` shorthand on a named selector always overrides a `*` rule, `!important` would be required — which isn't appropriate for a framework default. Documenting the correct shorthand is the cleaner approach.

![Screenshot 2026-02-11 at 02 29 11PM](https://github.com/user-attachments/assets/35ab5f9e-ab55-4a25-a45b-513b01c822e4)

Fixes https://github.com/livewire/livewire/discussions/9931