### PR TITLE
[4.x] Optimize smart keys

### DIFF
--- a/src/Features/SupportCompiledWireKeys/SupportCompiledWireKeys.php
+++ b/src/Features/SupportCompiledWireKeys/SupportCompiledWireKeys.php
@@ -53,8 +53,8 @@ class SupportCompiledWireKeys extends ComponentHook
         preg_match_all('/(?<=\s)wire:key\s*=\s*(?:"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"|\'([^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\')/', $cleanedContents, $keys);
 
         foreach ($keys[0] as $index => $key) {
-            $escapedKey = str_replace("'", "\'", $keys[1][$index]);
-            $prefix = "<?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::processElementKey('{$escapedKey}', get_defined_vars()); ?>";
+            $keyExpression = static::compileKeyExpression($keys[1][$index]);
+            $prefix = "<?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::\$currentLoop['key'] = {$keyExpression}; ?>";
             $contents = str_replace($key, $prefix . $key, $contents);
         }
 
@@ -100,18 +100,18 @@ class SupportCompiledWireKeys extends ComponentHook
         static::$currentLoop = array_pop(static::$loopStack);
     }
 
-    public static function processElementKey($keyString, $data)
+    public static function compileKeyExpression($keyString)
     {
-        // If the key string matches an existing view name, return it as-is.
-        // This prevents Blade::render() from incorrectly rendering a view
-        // when the user just wants a literal string key like "account".
-        if (view()->exists($keyString)) {
-            $key = $keyString;
-        } else {
-            $key = Blade::render($keyString, $data);
-        }
+        $value = str_replace("'", "\\'", $keyString);
 
-        static::$currentLoop['key'] = $key;
+        // Compile Blade echo statements into PHP string concatenation
+        // This mirrors Laravel's ComponentTagCompiler::compileAttributeEchos approach...
+        $value = Blade::compileEchos($value);
+
+        $value = str_replace('<'.'?php echo ', "'.", $value);
+        $value = str_replace('; ?'.'>', ".'", $value);
+
+        return "'".$value."'";
     }
 
     public static function processComponentKey($component)

--- a/src/Features/SupportCompiledWireKeys/UnitTest.php
+++ b/src/Features/SupportCompiledWireKeys/UnitTest.php
@@ -40,6 +40,23 @@ class UnitTest extends \Tests\TestCase
         $this->assertStringNotContainsString('SupportCompiledWireKeys::$currentLoop[\'key\']', $compiled);
     }
 
+    public function test_child_keys_are_correctly_generated_with_array_access_wire_key()
+    {
+        app('livewire')->component('keys-parent-with-array-access', KeysParentWithArrayAccess::class);
+        app('livewire')->component('keys-child', KeysChild::class);
+
+        $component = Livewire::test(KeysParentWithArrayAccess::class);
+
+        $childKeys = array_keys(invade($component)->lastState->getSnapshot()['memo']['children']);
+
+        $this->assertEquals(2, count($childKeys));
+
+        $this->assertKeysMatchPattern([
+            'lw-XXXXXXXX-0-0-B',
+            'lw-XXXXXXXX-0-0-D'
+        ], $childKeys);
+    }
+
     public function test_child_keys_are_correctly_generated()
     {
         app('livewire')->component('keys-parent', KeysParent::class);
@@ -1290,6 +1307,24 @@ class KeysParentWithForElse extends Component
                     <livewire:keys-child item="empty" />
                 </div>
             @endforelse
+        </div>
+        HTML;
+    }
+}
+
+class KeysParentWithArrayAccess extends Component
+{
+    public $items = [['id' => 'B'], ['id' => 'D']];
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            @foreach ($items as $item)
+                <div wire:key="{{ $item['id'] }}">
+                    <livewire:keys-child :item="$item['id']" />
+                </div>
+            @endforeach
         </div>
         HTML;
     }

--- a/src/Features/SupportCompiledWireKeys/UnitTest.php
+++ b/src/Features/SupportCompiledWireKeys/UnitTest.php
@@ -37,7 +37,7 @@ class UnitTest extends \Tests\TestCase
 
         $compiled = $this->compile('<div wire:key="foo">');
 
-        $this->assertStringNotContainsString('<?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::processElementKey', $compiled);
+        $this->assertStringNotContainsString('SupportCompiledWireKeys::$currentLoop[\'key\']', $compiled);
     }
 
     public function test_child_keys_are_correctly_generated()
@@ -648,15 +648,6 @@ class UnitTest extends \Tests\TestCase
         );
     }
 
-    public function test_plain_string_key_matching_view_name_is_not_rendered_as_view()
-    {
-        // "show-name" is an existing test view in tests/views/show-name.blade.php
-        // Using it as a wire:key should return the literal string, not render the view
-        SupportCompiledWireKeys::processElementKey('show-name', []);
-
-        $this->assertEquals('show-name', SupportCompiledWireKeys::$currentLoop['key']);
-    }
-
     public function test_we_can_open_a_loop()
     {
         SupportCompiledWireKeys::openLoop();
@@ -898,7 +889,7 @@ class UnitTest extends \Tests\TestCase
     {
         $compiled = $this->compile($template);
 
-        $this->assertOccurrences($occurrences, '<?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::processElementKey', $compiled);
+        $this->assertOccurrences($occurrences, 'SupportCompiledWireKeys::$currentLoop[\'key\']', $compiled);
     }
 
     #[DataProvider('bladeComponentsTestProvider')]


### PR DESCRIPTION
## The scenario

Using `wire:key` in a loop with many items becomes slow:

```blade
@foreach (range(1, 5000) as $item)
    <div wire:key="item-{{ $item }}">
        ...
    </div>
@endforeach
```

| Scenario | Render time |
|---|---|
| Smart keys disabled | ~8ms |
| Smart keys enabled | ~165ms |

## The problem

`SupportCompiledWireKeys` calls `Blade::render()` at runtime to evaluate every `wire:key` expression:

```php
public static function processElementKey($keyString, $data)
{
    if (view()->exists($keyString)) {
        $key = $keyString;
    } else {
        $key = Blade::render($keyString, $data);
    }

    static::$currentLoop['key'] = $key;
}
```

`Blade::render()` is slow — it compiles a template string, writes it to disk, and evaluates it. In a loop with 5000 items, that's 5000 calls per page load.

## The solution

Compile the key expression at build-time instead of evaluating it at runtime.

```blade
wire:key="item-{{ $item }}"
```

compiles directly to:

```php
<?php SupportCompiledWireKeys::$currentLoop['key'] = 'item-'.e($item).''; ?>
```

No runtime overhead, no method call. The assignment is baked directly into the compiled template.

| Scenario | Render time |
|---|---|
| Before | ~165ms |
| After | **~6ms** (~27x faster) |

This uses `Blade::compileEchos()` to turn echo statements into string concatenation — the same approach [Laravel uses in `ComponentTagCompiler::compileAttributeEchos`](https://github.com/laravel/framework/blob/391d5401826dfa1825f382c25149f89c09133bf0/src/Illuminate/View/Compilers/ComponentTagCompiler.php#L752-L762):

## Note

Because we changed from `Blade::render()` to `Blade::compileEchos()`, the stored key value could differ if someone uses Blade directives inside `wire:key`. For example with:

```blade
wire:key="@if($item > 1) big-{{ $item }} @else small-{{ $item }} @endif"
```

**Before:**
```php
<!--[if BLOCK]><!--[endif]--> small-1 <!--[if ENDBLOCK]><!--[endif]-->
<!--[if BLOCK]><!--[endif]--> big-2 <!--[if ENDBLOCK]><!--[endif]-->
```

**After:**
```blade
@if($item > 1) big-1 @else small-1 @endif
@if($item > 1) big-2 @else small-2 @endif
```

I believe using directives inside `wire:key` is a pretty unusual pattern, so I decided not to address it and only focus on compiling echo statements. Open to discussion.