### PR TITLE
[4.x] Clarify that `#[Modelable]` components need a wrapper root element

### DIFF
--- a/docs/attribute-modelable.md
+++ b/docs/attribute-modelable.md
@@ -92,6 +92,8 @@ new class extends Component {
 <livewire:date-picker wire:model="endDate" />
 ```
 
+Be sure to wrap your input elements in a `<div>` rather than using them as the root element. Livewire needs the root element to wire up the parent binding.
+
 ## Modifiers
 
 The parent can use wire:model modifiers, and they'll work as expected:

--- a/docs/attribute-modelable.md
+++ b/docs/attribute-modelable.md
@@ -92,7 +92,8 @@ new class extends Component {
 <livewire:date-picker wire:model="endDate" />
 ```
 
-Be sure to wrap your input elements in a `<div>` rather than using them as the root element. Livewire needs the root element to wire up the parent binding.
+> [!warning]
+> Your component's root element must be a wrapper element (like `<div>`), not the input element itself. Livewire injects attributes on the root element to wire up the parent binding, which conflicts with an existing `wire:model`.
 
 ## Modifiers
 

--- a/src/Exceptions/ModelableRootHasWireModelException.php
+++ b/src/Exceptions/ModelableRootHasWireModelException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Livewire\Exceptions;
+
+class ModelableRootHasWireModelException extends \Exception
+{
+    use BypassViewHandler;
+
+    public function __construct()
+    {
+        parent::__construct(
+            "A #[Modelable] component's root element cannot have wire:model. " .
+            "Wrap your input element in a <div> so Livewire can inject the parent binding on the root element."
+        );
+    }
+}

--- a/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
+++ b/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
@@ -4,6 +4,7 @@ namespace Livewire\Features\SupportWireModelingNestedComponents;
 
 use Livewire\ComponentHook;
 use Livewire\Drawer\Utils;
+use Livewire\Exceptions\ModelableRootHasWireModelException;
 use function Livewire\on;
 use function Livewire\store;
 
@@ -69,6 +70,14 @@ class SupportWireModelingNestedComponents extends ComponentHook
             $outer = array_keys($bindings)[0];
             $inner = array_values($bindings)[0];
             $directive = array_values($directives)[0];
+
+            // Throw if the root element already has wire:model, since HTML
+            // doesn't allow duplicate attributes and the parent binding
+            // would silently break.
+            throw_if(
+                preg_match('/^<[^>]*\bwire:model[=.\s>]/', ltrim($html)),
+                new ModelableRootHasWireModelException
+            );
 
             // Attach the necessary Alpine directives so that the child and
             // parent's JS, ephemeral, values are bound.

--- a/src/Features/SupportWireModelingNestedComponents/UnitTest.php
+++ b/src/Features/SupportWireModelingNestedComponents/UnitTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Livewire\Features\SupportWireModelingNestedComponents;
+
+use Livewire\Component;
+use Livewire\Exceptions\ModelableRootHasWireModelException;
+use Livewire\Livewire;
+
+class UnitTest extends \Tests\TestCase
+{
+    public function test_modelable_throws_when_root_element_has_wire_model()
+    {
+        $this->expectException(ModelableRootHasWireModelException::class);
+
+        Livewire::test([
+            new class extends Component {
+                public $foo = '';
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <livewire:child wire:model="foo" />
+                </div>
+                HTML; }
+            },
+            'child' => new class extends Component {
+                #[BaseModelable]
+                public $value = '';
+
+                public function render() { return <<<'HTML'
+                <select wire:model="value">
+                    <option value="a">A</option>
+                    <option value="b">B</option>
+                </select>
+                HTML; }
+            },
+        ]);
+    }
+
+    public function test_modelable_works_when_input_is_wrapped_in_div()
+    {
+        Livewire::test([
+            new class extends Component {
+                public $foo = '';
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <livewire:child wire:model="foo" />
+                </div>
+                HTML; }
+            },
+            'child' => new class extends Component {
+                #[BaseModelable]
+                public $value = '';
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <select wire:model="value">
+                        <option value="a">A</option>
+                        <option value="b">B</option>
+                    </select>
+                </div>
+                HTML; }
+            },
+        ])->assertSee('A');
+    }
+}


### PR DESCRIPTION
# The Scenario

When building reusable input components with `#[Modelable]`, using a form control as the root element with `wire:model` causes the parent binding to silently break:

```php
<?php

use Livewire\Attributes\Modelable;
use Livewire\Component;

new class extends Component {
    #[Modelable]
    public ?string $value = null;
};
?>

<select wire:model="value">
    <option value="UTC">UTC</option>
    <option value="Europe/Oslo">Europe/Oslo</option>
</select>
```

# The Problem

Livewire injects its own `wire:model` and `x-modelable` attributes on the child component's root element to wire up the parent binding. When the root element already has `wire:model` (e.g., `wire:model="value"`), the HTML ends up with two `wire:model` attributes on the same element. HTML doesn't allow duplicate attributes — the browser silently drops the second one, breaking the binding chain between child and parent.

# The Solution

Updated the `#[Modelable]` docs in the "Building reusable input components" section to clarify that input elements should be wrapped in a `<div>` rather than used as the root element directly, since Livewire needs the root element for the parent binding.

Fixes #9984