### PR TITLE
[4.x] Fix `make:livewire` crash when using `--class` with a view-only namespace

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -116,7 +116,7 @@ class MakeCommand extends Command
             $classNamespaceDetails = $this->finder->getClassNamespace($namespace);
 
             if ($classNamespaceDetails === null) {
-                $this->components->error('Namespace not found.');
+                $this->components->error(sprintf('Class namespace [%s] not found.', $namespace));
                 return 1;
             }
         } else {

--- a/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
@@ -866,6 +866,19 @@ class MakeCommandUnitTest extends \Tests\TestCase
         $this->assertStringContainsString('height: 100%', $finalContent);
     }
 
+    public function test_view_only_namespace_shows_error_for_class_based_component()
+    {
+        // The "pages" namespace is registered as a view namespace only (via component_namespaces config),
+        // not a class namespace. Creating a class-based component with it should show an error, not crash.
+        $exitCode = Artisan::call('make:livewire', ['name' => 'pages::create-post', '--class' => true]);
+
+        $this->assertEquals(1, $exitCode);
+        $this->assertStringContainsString('Class namespace [pages] not found', Artisan::output());
+
+        // Ensure no files were created
+        $this->assertFalse(File::exists($this->livewireClassesPath('CreatePost.php')));
+    }
+
     public function test_unregistered_namespace_shows_error_for_sfc()
     {
         // Try to create a component with an unregistered namespace

--- a/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
@@ -870,13 +870,13 @@ class MakeCommandUnitTest extends \Tests\TestCase
     {
         // The "pages" namespace is registered as a view namespace only (via component_namespaces config),
         // not a class namespace. Creating a class-based component with it should show an error, not crash.
-        $exitCode = Artisan::call('make:livewire', ['name' => 'pages::create-post', '--class' => true]);
+        $exitCode = Artisan::call('make:livewire', ['name' => 'pages::edit-post', '--class' => true]);
 
         $this->assertEquals(1, $exitCode);
         $this->assertStringContainsString('Class namespace [pages] not found', Artisan::output());
 
         // Ensure no files were created
-        $this->assertFalse(File::exists($this->livewireClassesPath('CreatePost.php')));
+        $this->assertFalse(File::exists($this->livewireClassesPath('EditPost.php')));
     }
 
     public function test_unregistered_namespace_shows_error_for_sfc()

--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -68,9 +68,9 @@ class Finder
         if ($viewPath !== null) $this->viewNamespaces[$namespace] = $viewPath;
     }
 
-    public function getClassNamespace(string $namespace): array
+    public function getClassNamespace(string $namespace): ?array
     {
-        return $this->classNamespaces[$namespace];
+        return $this->classNamespaces[$namespace] ?? null;
     }
 
     public function normalizeName($nameComponentOrClass): ?string


### PR DESCRIPTION
# The Scenario

When using `make:livewire` with the `--class` flag and a view-only namespace like `pages`, the command crashes with an `ErrorException` instead of showing a helpful error message.

```
php artisan make:livewire pages::posts.create --class

ErrorException: Undefined array key "pages"
at vendor/livewire/livewire/src/Finder/Finder.php:73
```

This also happens when `make_command.type` is set to `'class'` in `config/livewire.php`:

```php
// config/livewire.php
'make_command' => [
    'type' => 'class',
],

'component_namespaces' => [
    'pages' => resource_path('views/pages'),
],
```

```
php artisan make:livewire pages::posts.create

ErrorException: Undefined array key "pages"
```

# The Problem

`Finder::getClassNamespace()` directly accesses `$this->classNamespaces[$namespace]` without checking if the key exists:

```php
public function getClassNamespace(string $namespace): array
{
    return $this->classNamespaces[$namespace];
}
```

Namespaces registered via `component_namespaces` config are only added as **view namespaces** (via `addNamespace($namespace, viewPath: $location)`), not class namespaces. So when `MakeCommand::createClassBasedComponent()` calls `getClassNamespace('pages')`, the array access throws an undefined key error.

The calling code in `MakeCommand` already had a null check for this case, but the method crashed before it could return.

# The Solution

Changed `Finder::getClassNamespace()` to return `null` instead of crashing when the namespace isn't registered as a class namespace:

```php
public function getClassNamespace(string $namespace): ?array
{
    return $this->classNamespaces[$namespace] ?? null;
}
```

Also improved the error message from the generic `"Namespace not found."` to `"Class namespace [pages] not found."` to clarify what's missing.

Fixes #9986