### PR TITLE
[4.x] Fix asset URL handling for non-standard protocol schemes

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -198,7 +198,10 @@ class FrontendAssets extends Mechanism
 
         $url = rtrim($url, '/');
 
-        $url = (string) str($url)->when(! str($url)->isUrl(), fn($url) => $url->start('/'));
+        $url = (string) str($url)->when(
+            ! str($url)->isUrl() && ! preg_match('#^[a-zA-Z][a-zA-Z0-9+\-.]*://#', $url),
+            fn ($url) => $url->start('/')
+        );
 
         // Add the build manifest hash to it...
         $manifest = json_decode(file_get_contents(__DIR__.'/../../../dist/manifest.json'), true);


### PR DESCRIPTION
## Summary
- `FrontendAssets::js()` uses `isUrl()` to decide whether to prefix an asset URL with `/`
- `isUrl()` validates against a whitelist of known protocols (`http`, `https`, `ftp`, etc.)
- Custom schemes like `php://` (used by NativePHP Mobile on iOS) are not in that whitelist
- This causes Livewire to prepend `/`, producing `/php://127.0.0.1/livewire/livewire.js` which 404s in the browser
- Added a fallback check for any valid URI scheme per RFC 3986 so non-standard protocols are preserved as-is

## Reproduction

1. Set `APP_URL=php://127.0.0.1` (NativePHP Mobile sets this for iOS)
2. Load any page with a Livewire component
3. The script tag `src` becomes `/php://127.0.0.1/livewire-xxxxx/livewire.js`
4. Browser requests this as a root-relative path → 404
5. No Livewire JS loads, no Alpine, no interactivity

## Fix

```php
// Before
$url = (string) str($url)->when(! str($url)->isUrl(), fn($url) => $url->start('/'));

// After
$url = (string) str($url)->when(
    ! str($url)->isUrl() && ! preg_match('#^[a-zA-Z][a-zA-Z0-9+\-.]*://#', $url),
    fn ($url) => $url->start('/')
);
```