### PR TITLE
[4.x] Fix asset URL handling for non-standard protocol schemes

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -198,7 +198,10 @@ class FrontendAssets extends Mechanism
 
         $url = rtrim($url, '/');
 
-        $url = (string) str($url)->when(! str($url)->isUrl(), fn($url) => $url->start('/'));
+        $url = (string) str($url)->when(
+            ! str($url)->isUrl() && ! preg_match('#^[a-zA-Z][a-zA-Z0-9+\-.]*://#', $url),
+            fn ($url) => $url->start('/')
+        );
 
         // Add the build manifest hash to it...
         $manifest = json_decode(file_get_contents(__DIR__.'/../../../dist/manifest.json'), true);

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -199,7 +199,7 @@ class FrontendAssets extends Mechanism
         $url = rtrim($url, '/');
 
         $url = (string) str($url)->when(
-            ! str($url)->isUrl() && ! preg_match('#^[a-zA-Z][a-zA-Z0-9+\-.]*://#', $url),
+            ! str_contains($url, '://'),
             fn ($url) => $url->start('/')
         );
 

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -198,6 +198,7 @@ class FrontendAssets extends Mechanism
 
         $url = rtrim($url, '/');
 
+        // Ensure relative URLs start with "/", but don't touch URLs with protocol schemes (e.g. "php://")...
         $url = (string) str($url)->when(
             ! str_contains($url, '://'),
             fn ($url) => $url->start('/')

--- a/src/Mechanisms/FrontendAssets/UnitTest.php
+++ b/src/Mechanisms/FrontendAssets/UnitTest.php
@@ -170,6 +170,12 @@ class UnitTest extends \Tests\TestCase
         $this->assertStringStartsWith('<script src="/'.$url, FrontendAssets::js(['url' => $url]));
     }
 
+    public function test_js_does_not_prepend_slash_for_non_standard_protocol_scheme()
+    {
+        $url = 'php://127.0.0.1/livewire/livewire.js';
+        $this->assertStringStartsWith('<script src="'.$url, FrontendAssets::js(['url' => $url]));
+    }
+
     public function test_js_appends_version_with_correct_query_separator()
     {
         // URL without query params should use ?


### PR DESCRIPTION
Closes #9996

Cherry-picked from #9996 by @shanerbaner82 with review fixes applied.

## Original description
- `FrontendAssets::js()` uses `isUrl()` to decide whether to prefix an asset URL with `/`
- `isUrl()` validates against a whitelist of known protocols (`http`, `https`, `ftp`, etc.)
- Custom schemes like `php://` (used by NativePHP Mobile on iOS) are not in that whitelist
- This causes Livewire to prepend `/`, producing `/php://127.0.0.1/livewire/livewire.js` which 404s in the browser

## Review fixes applied
- Simplified the URL check: replaced `isUrl()` + RFC 3986 regex fallback with `str_contains($url, '://')`. We're not validating URLs here, just deciding whether to prepend a slash. If the URL has a scheme separator, it's absolute.
- Added unit test (`test_js_does_not_prepend_slash_for_non_standard_protocol_scheme`) — verified it fails on `main` and passes with the fix.