### PR TITLE
[4.x] Fix diffRecursive() not detecting key order changes

### DIFF
--- a/js/diff.spec.js
+++ b/js/diff.spec.js
@@ -285,4 +285,29 @@ describe('diffAndConsolidate', () => {
             data: { b: 2, a: 1 }
         })
     })
+
+    it('ignores key order changes at root level', () => {
+        expect(diffAndConsolidate(
+            { a: 1, b: 2 },
+            { b: 2, a: 1 }
+        )).toEqual({})
+    })
+
+    it('detects key order changes in deeply nested objects', () => {
+        expect(diffAndConsolidate(
+            { a: { b: { c: 1, d: 2 } } },
+            { a: { b: { d: 2, c: 1 } } }
+        )).toEqual({
+            'a.b': { d: 2, c: 1 }
+        })
+    })
+
+    it('detects key order changes with simultaneous value changes', () => {
+        expect(diffAndConsolidate(
+            { data: { a: 1, b: 2 } },
+            { data: { b: 3, a: 1 } }
+        )).toEqual({
+            data: { b: 3, a: 1 }
+        })
+    })
 })

--- a/js/diff.spec.js
+++ b/js/diff.spec.js
@@ -276,4 +276,13 @@ describe('diffAndConsolidate', () => {
             'form.text': 'Text'
         })
     })
+
+    it('detects key order changes in objects', () => {
+        expect(diffAndConsolidate(
+            { data: { a: 1, b: 2 } },
+            { data: { b: 2, a: 1 } }
+        )).toEqual({
+            data: { b: 2, a: 1 }
+        })
+    })
 })

--- a/js/utils.js
+++ b/js/utils.js
@@ -282,6 +282,14 @@ function diffRecursive(left, right, path, diffs, rootLeft, rootRight) {
         return { changed: true, consolidated: true }
     }
 
+    // Did the key order change?
+    if (isObject(left) && leftKeys.length === rightKeys.length && leftKeys.some((key, i) => key !== rightKeys[i])) {
+        if (path !== '') {
+            diffs[path] = dataGet(rootRight, path)
+            return { changed: true, consolidated: true }
+        }
+    }
+
     // Check if all keys are the same (no additions/removals)
     let keysMatch = leftKeys.every(k => rightKeys.includes(k))
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Companion fix for #10001 (3.x). The same key-order issue exists in `diffRecursive()`.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

4️⃣ Does it include tests? (Required)

Yes. Added a vitest case in `diff.spec.js`.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

`diffRecursive()` checks key presence (`leftKeys.every(k => rightKeys.includes(k))`) but not key order. So `{a: 1, b: 2}` → `{b: 2, a: 1}` produces no diff.

`diff()` was fixed in #10001 but is `@deprecated`. Once it gets replaced by `diffAndConsolidate()`, the bug would come back without this fix.

```js

if (isObject(left) && leftKeys.length === rightKeys.length && leftKeys.some((key, i) => key !== rightKeys[i])) {
        if (path !== '') {
            diffs[path] = dataGet(rootRight, path)
            return { changed: true, consolidated: true }
        }
}
```