### PR TITLE
Remove misleading event-based modifier examples from modelable docs

### DIFF
--- a/docs/attribute-modelable.md
+++ b/docs/attribute-modelable.md
@@ -94,18 +94,29 @@ new class extends Component {
 
 ## Modifiers
 
-The parent can use wire:model modifiers, and they'll work as expected:
+The parent can use `wire:model` modifiers for timing and network control:
 
 ```blade
 {{-- Live updates on every keystroke --}}
 <livewire:todo-input wire:model.live="todo" />
 
-{{-- Update on blur --}}
-<livewire:todo-input wire:model.live.blur="todo" />
-
 {{-- Debounce updates --}}
 <livewire:todo-input wire:model.live.debounce.500ms="todo" />
+
+{{-- Throttle updates --}}
+<livewire:todo-input wire:model.live.throttle.500ms="todo" />
 ```
+
+> [!note] Event-based modifiers on components
+> Event-based modifiers like `.blur`, `.change`, and `.enter` control DOM events on specific elements, not reactive component bindings. To control sync timing for modelable components, place these modifiers on the actual input element inside the child component:
+>
+> ```blade
+> {{-- Parent --}}
+> <livewire:todo-input wire:model="todo" />
+>
+> {{-- Child component --}}
+> <input wire:model.blur="value" />
+> ```
 
 ## Example: Custom rich text editor
 


### PR DESCRIPTION
## Summary

Removes the misleading `wire:model.live.blur` example from the `#[Modelable]` documentation. Event-based modifiers (`.blur`, `.change`, `.enter`) don't actually work on modelable components.

## Background

PR #9832 (Jan 2026) introduced event-based modifiers for `wire:model` to control client-side sync timing. The docs were updated to show these working on modelable components, but the implementation never supported them.

**Why they don't work:**
- Event-based modifiers control DOM events on specific elements
- Modelable components use reactive bindings via Alpine's `x-modelable`
- `blur` events don't bubble from inner inputs to component wrapper divs
- Reactive bindings bypass DOM events entirely

## Changes

- ❌ Removed `wire:model.live.blur` example (doesn't work)
- ✅ Added `wire:model.live.throttle` example (does work)
- 📝 Added note explaining the limitation
- 📚 Documented the correct pattern: place modifiers on the child's input element

## Correct Pattern

```blade
{{-- Parent --}}
<livewire:todo-input wire:model="todo" />

{{-- Child component --}}
<input wire:model.blur="value" />
```

The modifier belongs on the actual `<input>` inside the child, not on the component tag.

## Related

- Discussion: #9952
- PR attempting to implement this: #9993 (analysis posted showing why this shouldn't be implemented)

## Testing

Docs-only change. Verified:
- Markdown renders correctly
- Code examples are valid syntax
- Note callout displays properly