### PR TITLE
Validate #[Modelable] root element doesn't have wire:model

### DIFF
--- a/docs/attribute-modelable.md
+++ b/docs/attribute-modelable.md
@@ -92,6 +92,8 @@ new class extends Component {
 <livewire:date-picker wire:model="endDate" />
 ```
 
+Be sure to wrap your input elements in a `<div>` rather than using them as the root element. Livewire needs the root element to wire up the parent binding.
+
 ## Modifiers
 
 The parent can use wire:model modifiers, and they'll work as expected:

--- a/docs/attribute-modelable.md
+++ b/docs/attribute-modelable.md
@@ -92,7 +92,8 @@ new class extends Component {
 <livewire:date-picker wire:model="endDate" />
 ```
 
-Be sure to wrap your input elements in a `<div>` rather than using them as the root element. Livewire needs the root element to wire up the parent binding.
+> [!warning]
+> Your component's root element must be a wrapper element (like `<div>`), not the input element itself. Livewire injects attributes on the root element to wire up the parent binding, which conflicts with an existing `wire:model`.
 
 ## Modifiers
 

--- a/docs/attribute-modelable.md
+++ b/docs/attribute-modelable.md
@@ -93,7 +93,7 @@ new class extends Component {
 ```
 
 > [!warning]
-> Your component's root element must be a wrapper element (like `<div>`), not the input element itself. Livewire injects attributes on the root element to wire up the parent binding, which conflicts with an existing `wire:model`.
+> Your component's root element cannot be a form control with `wire:model`. Wrap your input in a wrapper element like `<div>`. Livewire injects `wire:model` and `x-modelable` on the root element to wire up the parent binding — a second `wire:model` on the same element creates a conflict.
 
 ## Modifiers
 

--- a/src/Exceptions/ModelableRootHasWireModelException.php
+++ b/src/Exceptions/ModelableRootHasWireModelException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Livewire\Exceptions;
+
+class ModelableRootHasWireModelException extends \Exception
+{
+    use BypassViewHandler;
+
+    public function __construct()
+    {
+        parent::__construct(
+            "A #[Modelable] component's root element cannot have wire:model. " .
+            "Wrap your input element in a <div> so Livewire can inject the parent binding on the root element."
+        );
+    }
+}

--- a/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
+++ b/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
@@ -4,6 +4,7 @@ namespace Livewire\Features\SupportWireModelingNestedComponents;
 
 use Livewire\ComponentHook;
 use Livewire\Drawer\Utils;
+use Livewire\Exceptions\ModelableRootHasWireModelException;
 use function Livewire\on;
 use function Livewire\store;
 
@@ -69,6 +70,14 @@ class SupportWireModelingNestedComponents extends ComponentHook
             $outer = array_keys($bindings)[0];
             $inner = array_values($bindings)[0];
             $directive = array_values($directives)[0];
+
+            // Throw if the root element already has wire:model, since HTML
+            // doesn't allow duplicate attributes and the parent binding
+            // would silently break.
+            throw_if(
+                preg_match('/^<[^>]*\bwire:model[=.\s>]/', ltrim($html)),
+                new ModelableRootHasWireModelException
+            );
 
             // Attach the necessary Alpine directives so that the child and
             // parent's JS, ephemeral, values are bound.

--- a/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
+++ b/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
@@ -73,9 +73,13 @@ class SupportWireModelingNestedComponents extends ComponentHook
 
             // Throw if the root element already has wire:model, since HTML
             // doesn't allow duplicate attributes and the parent binding
-            // would silently break.
+            // would silently break. We extract just the opening tag first
+            // to avoid regex backtracking on long attribute lists.
+            $trimmed = ltrim($html);
+            $tagEnd = strpos($trimmed, '>');
+
             throw_if(
-                preg_match('/^<[^>]*\bwire:model[=.\s>]/', ltrim($html)),
+                $tagEnd !== false && preg_match('/\bwire:model[=.\s>]/', substr($trimmed, 0, $tagEnd)),
                 new ModelableRootHasWireModelException
             );
 

--- a/src/Features/SupportWireModelingNestedComponents/UnitTest.php
+++ b/src/Features/SupportWireModelingNestedComponents/UnitTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Livewire\Features\SupportWireModelingNestedComponents;
+
+use Livewire\Component;
+use Livewire\Exceptions\ModelableRootHasWireModelException;
+use Livewire\Livewire;
+
+class UnitTest extends \Tests\TestCase
+{
+    public function test_modelable_throws_when_root_element_has_wire_model()
+    {
+        $this->expectException(ModelableRootHasWireModelException::class);
+
+        Livewire::test([
+            new class extends Component {
+                public $foo = '';
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <livewire:child wire:model="foo" />
+                </div>
+                HTML; }
+            },
+            'child' => new class extends Component {
+                #[BaseModelable]
+                public $value = '';
+
+                public function render() { return <<<'HTML'
+                <select wire:model="value">
+                    <option value="a">A</option>
+                    <option value="b">B</option>
+                </select>
+                HTML; }
+            },
+        ]);
+    }
+
+    public function test_modelable_works_when_input_is_wrapped_in_div()
+    {
+        Livewire::test([
+            new class extends Component {
+                public $foo = '';
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <livewire:child wire:model="foo" />
+                </div>
+                HTML; }
+            },
+            'child' => new class extends Component {
+                #[BaseModelable]
+                public $value = '';
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <select wire:model="value">
+                        <option value="a">A</option>
+                        <option value="b">B</option>
+                    </select>
+                </div>
+                HTML; }
+            },
+        ])->assertSee('A');
+    }
+}


### PR DESCRIPTION
## Summary

Instead of just documenting that `#[Modelable]` components can't use form controls as root elements with `wire:model`, this PR **detects the issue at runtime and throws a clear exception**.

Fixes #9984
Closes #9991

## Problem

When building reusable input components with `#[Modelable]`, if the root element already has `wire:model`, it creates an HTML attribute conflict:

```blade
<!-- ❌ Broken: root element has wire:model -->
<select wire:model="value">
    <option value="a">A</option>
</select>
```

Livewire injects its own `wire:model="$parent.foo"` and `x-modelable="$wire.value"` on the root element to wire up the parent binding. HTML doesn't allow duplicate attributes — the browser silently drops one, breaking the parent binding.

## Solution

This PR adds:

1. **Runtime validation** in `SupportWireModelingNestedComponents::render()` (lines 77-80)
   - Detects if root element already has `wire:model` 
   - Throws `ModelableRootHasWireModelException` with helpful message

2. **Clear exception message**:
   ```
   A #[Modelable] component's root element cannot have wire:model.
   Wrap your input element in a <div> so Livewire can inject the parent binding on the root element.
   ```

3. **Unit tests** to verify:
   - Exception thrown when root has `wire:model`
   - Works correctly when input is wrapped

4. **Improved docs warning** with technical explanation

## Technical Details

The check uses a regex pattern `/^<[^>]*\bwire:model[=.\s>]/` to detect `wire:model` attributes on the root element only (not nested elements). This catches all variants: `wire:model`, `wire:model.live`, `wire:model.blur`, etc.

## Test Plan

```bash
phpunit --testsuite="Unit" src/Features/SupportWireModelingNestedComponents/UnitTest.php
```

Both new tests pass:
- ✅ `test_modelable_throws_when_root_element_has_wire_model`
- ✅ `test_modelable_works_when_input_is_wrapped_in_div`

🤖 Generated with [Claude Code](https://claude.com/claude-code)