### PR TITLE
[4.x] Fix streaming of falsy values

### DIFF
--- a/src/Features/SupportStreaming/BrowserTest.php
+++ b/src/Features/SupportStreaming/BrowserTest.php
@@ -8,6 +8,33 @@ use Livewire\Component;
 
 class BrowserTest extends BrowserTestCase
 {
+    public function test_can_stream_falsy_values()
+    {
+        Livewire::visit([new class extends Component {
+            public function begin()
+            {
+                for ($i = 0; $i < 5; $i++) {
+                    $this->stream(to: 'stream', content: $i);
+                }
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="begin" dusk="button">Start</button>
+                    <div wire:ignore>
+                        <span wire:stream="stream" dusk="output"></span>
+                    </div>
+                </div>
+                HTML;
+            }
+        }])
+        ->waitForLivewire()->click('@button')
+        ->assertSeeIn('@output', '01234')
+        ;
+    }
+
     public function test_can_stream()
     {
         Livewire::visit([new class extends Component {

--- a/src/Features/SupportStreaming/HandlesStreaming.php
+++ b/src/Features/SupportStreaming/HandlesStreaming.php
@@ -15,7 +15,7 @@ trait HandlesStreaming
 
         $stream = new StreamManager($this, $hook);
 
-        if (! $content) {
+        if (is_null($content)) {
             return $stream;
         }
 


### PR DESCRIPTION
# The Scenario

When streaming content that includes falsy values like `0`, `'0'`, or an empty string, those values are silently skipped. For example, streaming integers 0 through 4 produces "1234" instead of "01234":

```php
<?php

use Livewire\Component;

new class extends Component {
    public function start(): void
    {
        for ($i = 0; $i < 5; $i++) {
            $this->stream(
                content: $i,
                name: 'stream',
            );
            sleep(1);
        }
    }
};
?>

<div>
    <div wire:stream="stream"></div>

    <form wire:submit="start">
        <button type="submit">Start</button>
    </form>
</div>
```

# The Problem

The `stream()` method in `HandlesStreaming` uses a loose truthiness check to determine whether content was provided:

```php
if (! $content) {
    return $stream;
}
```

In PHP, `0`, `'0'`, and `''` are all falsy, so this check incorrectly treats them as "no content provided" and returns the `StreamManager` for the fluent API instead of actually streaming the value.

# The Solution

Changed the check from `! $content` to `is_null($content)`. This preserves the fluent API behaviour (calling `$this->stream()` with no arguments returns a `StreamManager` for chaining), while allowing any non-null value — including falsy ones like `0`, `'0'`, and `''` — to be streamed.

Fixes #10008