### PR TITLE
[4.x] Restore query string from session-stored values in push mode

### DIFF
--- a/js/features/supportQueryString.js
+++ b/js/features/supportQueryString.js
@@ -47,6 +47,13 @@ on('effect', ({ component, effects, cleanup }) => {
                 })
             })
 
+            // If the component already has a value that differs from the seed
+            // (e.g. restored from session), update the URL immediately...
+            let currentValue = dataGet(component.ephemeral, name)
+            if (JSON.stringify(currentValue) !== JSON.stringify(initialValue)) {
+                replace(currentValue)
+            }
+
             cleanup(() => {
                 forgetCommitHandler()
                 forgetPopHandler()


### PR DESCRIPTION
# The Scenario

When a Livewire component has a property with both `#[Session]` and `#[Url(history: true)]`, the session value is correctly restored on page revisit, but the query string is not updated to reflect it.

For example, a user has a search input that persists across visits and is reflected in the URL. They type "hello", the URL updates to `?search=hello`, and the value is stored in the session. They navigate away and come back — the input shows "hello" (restored from session), but the URL stays clean with no query string:

```php
<?php

use Livewire\Attributes\Session;
use Livewire\Attributes\Url;
use Livewire\Component;

class SearchPage extends Component
{
    #[Session]
    #[Url(history: true, except: '')]
    public string $search = '';
}
```

```blade
<div>
    <input type="text" wire:model.live="search" />
</div>
```

# The Problem

When `#[Url]` is configured with `history: true`, it uses `pushState` mode on the JavaScript side. In this mode, query string updates are only triggered by a commit handler that listens for Livewire round-trips — there is no initial URL update on page load.

Compare this with the default `replaceState` mode, which creates an Alpine reactive effect that fires immediately and would correctly push the session-restored value to the URL.

The relevant code in `js/features/supportQueryString.js`:

```js
// Replace mode — Alpine effect fires immediately on page load ✓
if (use === 'replace') {
    let effectReference = Alpine.effect(() => {
        replace(dataGet(component.reactive, name))
    })
// Push mode — only registers a commit handler, never fires on load ✗
} else if (use === 'push') {
    let forgetCommitHandler = on('commit', ({ component: commitComponent, succeed }) => {
        // ...only fires on subsequent Livewire requests...
    })
}
```

When `#[Session]` restores a value during PHP mount, the component's snapshot includes the restored value. The JavaScript receives this value but never pushes it to the URL because no Livewire commit occurs during the initial page load.

# The Solution

After setting up the push mode handlers, the URL is now immediately updated via `replaceState` (not `pushState`, to avoid creating an extra browser history entry) if the component's current value differs from the initial seed value:

```js
let currentValue = dataGet(component.ephemeral, name)
if (JSON.stringify(currentValue) !== JSON.stringify(initialValue)) {
    replace(currentValue)
}
```

This handles any case where the component's value has been set to something other than the `except` value before the JavaScript initialises — whether from `#[Session]`, `mount()`, or any other mechanism.

Fixes https://github.com/livewire/livewire/discussions/10000