### PR TITLE
[4.x] Use `hash_equals()` for checksum comparison

### DIFF
--- a/src/Mechanisms/HandleComponents/Checksum.php
+++ b/src/Mechanisms/HandleComponents/Checksum.php
@@ -21,7 +21,7 @@ class Checksum {
 
         trigger('checksum.verify', $checksum, $snapshot);
 
-        if ($checksum !== $comparitor = self::generate($snapshot)) {
+        if (! hash_equals($comparitor = self::generate($snapshot), $checksum)) {
             trigger('checksum.fail', $checksum, $comparitor, $snapshot);
 
             static::recordFailure();


### PR DESCRIPTION
# The Scenario

Livewire's `Checksum::verify()` method compares the client-submitted HMAC against the server-generated HMAC using PHP's `!==` operator:

```php
if ($checksum !== $comparitor = self::generate($snapshot)) {
```

# The Problem

PHP's `!==` operator short-circuits on the first differing byte rather than comparing the full string. `hash_equals()` is the standard constant-time function for comparing secrets and HMACs, ensuring the comparison takes the same amount of time regardless of where mismatches occur.

# The Solution

Replace `!==` with `hash_equals()`:

```php
if (! hash_equals($comparitor = self::generate($snapshot), $checksum)) {
```