### PR TITLE
[3.x] Fix reactive children re-rendering when props haven't changed

### DIFF
--- a/src/Features/SupportReactiveProps/BaseReactive.php
+++ b/src/Features/SupportReactiveProps/BaseReactive.php
@@ -28,7 +28,14 @@ class BaseReactive extends LivewireAttribute
                 $this->component->getId(), $this->getName()
             );
 
-            $this->setValue($updatedValue);
+            $currentHash = crc32(json_encode($this->getValue()));
+            $updatedHash = crc32(json_encode($updatedValue));
+
+            if ($currentHash !== $updatedHash) {
+                $this->setValue($updatedValue);
+
+                store($this->component)->set('reactivePropsChanged', true);
+            }
         }
 
         $this->originalValueHash = crc32(json_encode($this->getValue()));

--- a/src/Features/SupportReactiveProps/BrowserTest.php
+++ b/src/Features/SupportReactiveProps/BrowserTest.php
@@ -175,6 +175,61 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertSeeIn('@child.count', 1);
     }
 
+    public function test_reactive_child_skips_render_when_prop_is_unchanged()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public $count = 0;
+
+                public $other = 'foo';
+
+                public function changeOther() { $this->other = $this->other . '!'; }
+
+                public function inc() { $this->count++; }
+
+                public function render() { return <<<'HTML'
+                    <div>
+                        <span dusk="parent.other">{{ $other }}</span>
+
+                        <button wire:click="changeOther" dusk="parent.changeOther">Change Other</button>
+                        <button wire:click="inc" dusk="parent.inc">Inc</button>
+
+                        <livewire:child :$count />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                #[BaseReactive]
+                public $count;
+
+                public $renderCount = 0;
+
+                public function render() {
+                    $this->renderCount++;
+
+                    return <<<'HTML'
+                        <div>
+                            <span dusk="child.count">{{ $count }}</span>
+                            <span dusk="child.renderCount">{{ $renderCount }}</span>
+                        </div>
+                        HTML;
+                }
+            }
+        ])
+            ->assertSeeIn('@child.count', 0)
+            ->assertSeeIn('@child.renderCount', 1)
+
+            ->waitForLivewire()->click('@parent.changeOther')
+            ->assertSeeIn('@parent.other', 'foo!')
+            ->assertSeeIn('@child.count', 0)
+            ->assertSeeIn('@child.renderCount', 1)
+
+            ->waitForLivewire()->click('@parent.inc')
+            ->assertSeeIn('@child.count', 1)
+            ->assertSeeIn('@child.renderCount', 2);
+    }
+
     public function test_can_pass_a_reactive_property_from_parent_to_lazy_child()
     {
         Livewire::visit([

--- a/src/Features/SupportReactiveProps/SupportReactiveProps.php
+++ b/src/Features/SupportReactiveProps/SupportReactiveProps.php
@@ -34,6 +34,9 @@ class SupportReactiveProps extends ComponentHook
 
             if (store($component)->get('reactivePropsChanged', false)) return;
 
+            if (! empty(store($component)->get('pendingUpdates', []))) return;
+            if (! empty(store($component)->get('pendingCalls', []))) return;
+
             $pooled = store()->get('pooledChildIds', []);
 
             if (! isset($pooled[$component->getId()])) return;

--- a/src/Features/SupportReactiveProps/SupportReactiveProps.php
+++ b/src/Features/SupportReactiveProps/SupportReactiveProps.php
@@ -3,6 +3,8 @@
 namespace Livewire\Features\SupportReactiveProps;
 
 use function Livewire\on;
+use function Livewire\after;
+use function Livewire\store;
 use Livewire\ComponentHook;
 
 class SupportReactiveProps extends ComponentHook
@@ -15,6 +17,28 @@ class SupportReactiveProps extends ComponentHook
 
         on('mount.stub', function ($tag, $id, $params, $parent, $key) {
             static::$pendingChildParams[$id] = $params;
+        });
+
+        on('hydrate', function ($component, $memo) {
+            $pooled = store()->get('pooledChildIds', []);
+
+            foreach ($memo['children'] ?? [] as [$tag, $childId]) {
+                $pooled[$childId] = true;
+            }
+
+            store()->set('pooledChildIds', $pooled);
+        });
+
+        after('hydrate', function ($component, $memo) {
+            if (empty($memo['props'] ?? [])) return;
+
+            if (store($component)->get('reactivePropsChanged', false)) return;
+
+            $pooled = store()->get('pooledChildIds', []);
+
+            if (! isset($pooled[$component->getId()])) return;
+
+            $component->skipRender();
         });
     }
 

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -93,8 +93,11 @@ class HandleComponents extends Mechanism
 
         $this->pushOntoComponentStack($component);
 
+        // Store updates and calls before hydration so reactive prop hooks
+        // can check whether this component has its own work to do.
         store($component)->set('pendingUpdates', $updates);
         store($component)->set('pendingCalls', $calls);
+
         trigger('hydrate', $component, $memo, $context);
 
         $this->updateProperties($component, $updates, $data, $context);

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -93,6 +93,8 @@ class HandleComponents extends Mechanism
 
         $this->pushOntoComponentStack($component);
 
+        store($component)->set('pendingUpdates', $updates);
+        store($component)->set('pendingCalls', $calls);
         trigger('hydrate', $component, $memo, $context);
 
         $this->updateProperties($component, $updates, $data, $context);


### PR DESCRIPTION

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Related to https://github.com/filamentphp/filament/issues/18535.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

4️⃣ Does it include tests? (Required)

Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

When a parent component commits, all child components with `#[Reactive]` props are pooled into the request and re-rendered, even when their prop values haven't changed. This causes unnecessary work in `render()`, like expensive database queries, on every parent interaction.

This PR adds a hash comparison in `BaseReactive::hydrate()` to detect whether reactive prop values actually changed, and calls `skipRender()` when they haven't — as long as the component has no pending updates or method calls of its own.

The hash comparison approach is consistent with how v4 (`main` branch) already handles this in `BaseReactive::hydrate()`, but v4 currently only skips the `setValue()` call — it doesn't skip the `render()`. This PR extends that idea to also call `skipRender()` when no reactive props have changed.

Before:

// BaseReactive::hydrate() — always sets the value
```php
$this->setValue($updatedValue);
```

After:
```php
$currentHash = crc32(json_encode($this->getValue()));
$updatedHash = crc32(json_encode($updatedValue));

if ($currentHash !== $updatedHash) {
    $this->setValue($updatedValue);

    store($this->component)->set('reactivePropsChanged', true);
}
```