### PR TITLE
[4.x] Reactive props during boot hooks

### DIFF
--- a/src/Features/SupportReactiveProps/UnitTest.php
+++ b/src/Features/SupportReactiveProps/UnitTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Livewire\Features\SupportReactiveProps;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class UnitTest extends \Tests\TestCase
+{
+    public function test_reactive_prop_value_is_available_during_boot_hydrate_and_booted_hooks()
+    {
+        Livewire::component('child-with-lifecycle-hooks', ChildWithLifecycleHooks::class);
+
+        $child = Livewire::test(ChildWithLifecycleHooks::class, ['count' => 0]);
+        $this->assertEquals(0, $child->get('count'));
+
+        // Simulate parent passing count=5 on next request
+        SupportReactiveProps::$pendingChildParams[$child->id()] = ['count' => 5];
+        $child->call('$refresh');
+
+        $this->assertEquals(5, $child->get('count'));
+        $this->assertEquals(5, $child->get('bootValue'), 'boot() should see the new reactive prop value');
+        $this->assertEquals(5, $child->get('hydrateValue'), 'hydrate() should see the new reactive prop value');
+        $this->assertEquals(5, $child->get('bootedValue'), 'booted() should see the new reactive prop value');
+    }
+
+    public function test_updating_hook_sees_old_value_and_updated_hook_sees_new_value_for_reactive_props()
+    {
+        Livewire::component('child-with-update-hooks', ChildWithUpdateHooks::class);
+
+        $child = Livewire::test(ChildWithUpdateHooks::class, ['count' => 0]);
+
+        // Simulate parent passing count=5 on next request
+        SupportReactiveProps::$pendingChildParams[$child->id()] = ['count' => 5];
+        $child->call('$refresh');
+
+        $this->assertEquals(5, $child->get('count'));
+        $this->assertEquals(0, $child->get('oldValueDuringUpdating'), 'updatingCount() should see the old value via $this->count');
+        $this->assertEquals(5, $child->get('newValueDuringUpdated'), 'updatedCount() should see the new value via $this->count');
+    }
+}
+
+class ChildWithLifecycleHooks extends Component
+{
+    #[BaseReactive]
+    public $count;
+
+    public $bootValue = 0;
+    public $hydrateValue = 0;
+    public $bootedValue = 0;
+
+    public function boot()
+    {
+        $this->bootValue = $this->count;
+    }
+
+    public function hydrate()
+    {
+        $this->hydrateValue = $this->count;
+    }
+
+    public function booted()
+    {
+        $this->bootedValue = $this->count;
+    }
+
+    public function render()
+    {
+        return '<div>{{ $count }}</div>';
+    }
+}
+
+class ChildWithUpdateHooks extends Component
+{
+    #[BaseReactive]
+    public $count;
+
+    public $oldValueDuringUpdating = null;
+    public $newValueDuringUpdated = null;
+
+    public function updatingCount($value)
+    {
+        // $this->count should still be the OLD value at this point
+        $this->oldValueDuringUpdating = $this->count;
+    }
+
+    public function updatedCount($value)
+    {
+        // $this->count should be the NEW value at this point
+        $this->newValueDuringUpdated = $this->count;
+    }
+
+    public function render()
+    {
+        return '<div>{{ $count }}</div>';
+    }
+}


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

This is a bug fix from PR #9643.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

PR #9643 added `updating*` / `updated*` lifecycle hook support for `#[Reactive]` props. To make that work, `SupportLifecycleHooks` had to be initialized before firing `trigger('update')`. The solution at the time was to defer the entire update, including setting the value, to an `after('hydrate')` callback.

`SupportLifecycleHooks::hydrate()` runs `boot()`, `hydrate()`, and `booted()` during the regular `on('hydrate')` phase, before any `after('hydrate')` callbacks fire. That means all of those hooks run with stale prop values. The new value does not actually land on the component until after all lifecycle hooks have already executed.

Before #9643 (beta.6 and earlier), `BaseReactive::hydrate()` called `$this->setValue()` immediately. Since `SupportAttributes` runs before `SupportLifecycleHooks` in the hook registration order, the value was already set by the time `boot()`, `hydrate()`, and `booted()` ran, so everything worked as expected.

This restores the pre-#9643 behavior by setting the value immediately again, but still queues `trigger('update')` for `after('hydrate')` so that `updating*` / `updated*` hooks continue to fire correctly.

During the deferred `trigger('update')`, the old value is temporarily swapped back in so `updating*` hooks still see the previous state via `$this->property`, then the new value is restored before `updated*` hooks run.

This affects anyone reading `#[Reactive]` prop values inside `boot()`, `hydrate()`, or `booted()`.