### PR TITLE
[4.x] Failing test for nested `<script>` extracted as component script module

### DIFF
--- a/src/Compiler/Fixtures/sfc-component-with-only-nested-script.blade.php
+++ b/src/Compiler/Fixtures/sfc-component-with-only-nested-script.blade.php
@@ -1,0 +1,19 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component
+{
+    public $message = 'Hello World';
+};
+?>
+
+<div>
+    {{ $message }}
+
+    <div>
+        <script>
+            console.log('This should NOT be extracted - it is nested inside div');
+        </script>
+    </div>
+</div>

--- a/src/Compiler/UnitTest.php
+++ b/src/Compiler/UnitTest.php
@@ -119,6 +119,27 @@ class UnitTest extends \Tests\TestCase
         $this->assertStringContainsString('{{ $message }}', $viewContents);
     }
 
+    public function test_wont_parse_nested_script_when_no_root_level_script_exists()
+    {
+        $compiler = new Compiler(new CacheManager($this->cacheDir));
+
+        $parser = SingleFileParser::parse($compiler, __DIR__ . '/Fixtures/sfc-component-with-only-nested-script.blade.php');
+
+        $classContents = $parser->generateClassContents('view-path.blade.php');
+        $scriptContents = $parser->generateScriptContents();
+        $viewContents = $parser->generateViewContents();
+
+        $this->assertStringContainsString('new class extends Component', $classContents);
+
+        // No script should be extracted — the only script tag is nested inside the root element
+        $this->assertNull($scriptContents);
+
+        // The nested script should remain in the view portion
+        $this->assertStringContainsString("console.log('This should NOT be extracted - it is nested inside div');", $viewContents);
+        $this->assertStringContainsString('<div>', $viewContents);
+        $this->assertStringContainsString('{{ $message }}', $viewContents);
+    }
+
     public function test_wont_parse_scripts_inside_assets_or_script_directives()
     {
         $compiler = new Compiler(new CacheManager($this->cacheDir));


### PR DESCRIPTION
Livewire's single file component compiler is wrongly identifying a script tag in the view portion of the template as a script tag intended for the script portion of the template.