### PR TITLE
[4.x] Fix EventBus listener leak causing memory growth under Octane

### DIFF
--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -3,8 +3,6 @@
 namespace Livewire\Features\SupportComputed;
 
 use function Livewire\invade;
-use function Livewire\on;
-use function Livewire\off;
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
@@ -22,15 +20,6 @@ class BaseComputed extends Attribute
         public $tags = null,
     ) {}
 
-    function boot()
-    {
-        off('__get', $this->handleMagicGet(...));
-        on('__get', $this->handleMagicGet(...));
-
-        off('__unset', $this->handleMagicUnset(...));
-        on('__unset', $this->handleMagicUnset(...));
-    }
-
     function call()
     {
         throw new CannotCallComputedDirectlyException(
@@ -39,11 +28,8 @@ class BaseComputed extends Attribute
         );
     }
 
-    protected function handleMagicGet($target, $property, $returnValue)
+    public function handleMagicGet($returnValue)
     {
-        if ($target !== $this->component) return;
-        if ($this->generatePropertyName($property) !== $this->getName()) return;
-
         if ($this->persist) {
             $returnValue($this->handlePersistedGet());
 
@@ -61,11 +47,8 @@ class BaseComputed extends Attribute
         );
     }
 
-    protected function handleMagicUnset($target, $property)
+    public function handleMagicUnset()
     {
-        if ($target !== $this->component) return;
-        if ($property !== $this->getName()) return;
-
         if ($this->persist) {
             $this->handlePersistedUnset();
 

--- a/src/Features/SupportMagicActions/SupportMagicActions.php
+++ b/src/Features/SupportMagicActions/SupportMagicActions.php
@@ -15,7 +15,7 @@ class SupportMagicActions extends ComponentHook
         '$commit',
     ];
 
-    public function boot()
+    public static function provide()
     {
         on('call', function ($component, $method, $params, $componentContext, $returnEarly, $context) {
             if (! in_array($method, self::$magicActions)) {


### PR DESCRIPTION
# The Scenario

When running Livewire under Laravel Octane, memory usage and EventBus listener count grow unboundedly with each request. After hundreds of requests, the application consumes significantly more memory than expected, eventually leading to out-of-memory errors.

A component with `#[Computed]` properties is enough to trigger the leak:

```php
<?php

use Livewire\Attributes\Computed;
use Livewire\Component;

new class extends Component {
    #[Computed]
    public function items(): array
    {
        return Item::all()->toArray();
    }
}; ?>

<div>
    @foreach ($this->items as $item)
        <p>{{ $item['name'] }}</p>
    @endforeach
</div>
```

# The Problem

Two `ComponentHook::boot()` methods register global EventBus listeners on every component instance, every request — but never successfully remove them:

1. **`SupportMagicActions::boot()`** registers an `on('call', ...)` listener per component per request. This listener only checks `self::$magicActions` (a static array) and doesn't need any instance state, so it should be a one-time registration in `provide()`.

2. **`BaseComputed::boot()`** registers `on('__get', ...)` and `on('__unset', ...)` listeners per `#[Computed]` attribute per component per request. It attempts cleanup with `off()`, but `off()` uses strict equality (`===`) to find the listener — and PHP first-class callables (`$this->handleMagicGet(...)`) create a **new closure instance** each time, so the `off()` call never matches and the listeners accumulate.

For a component with 3 `#[Computed]` properties, this adds 7 leaked listeners per request (1 from `SupportMagicActions` + 2 per computed property from `BaseComputed`). Simulating 200 Octane request cycles confirms the unbounded growth:

| Iteration | Memory (MB) | Delta (MB) | EventBus Listeners |
|---|---|---|---|
| 0 | 32.25 | +0.00 | 275 |
| 50 | 33.77 | +1.52 | 625 |
| 100 | 35.29 | +3.05 | 975 |
| 150 | 36.76 | +4.52 | 1,325 |
| 200 | 38.24 | +5.99 | 1,675 |

# The Solution

**`SupportMagicActions`**: Changed `boot()` to `provide()`. The `on('call', ...)` listener only references `self::$magicActions` and doesn't need per-component instance state, so it registers once at boot time instead of per-component per-request.

**`BaseComputed`**: Removed `boot()` entirely. The `__get` and `__unset` handling is now consolidated into `SupportLegacyComputedPropertySyntax::provide()`, which already registers global listeners for legacy computed properties (`getXxxProperty`). The existing listeners now also look up `#[Computed]` attributes on the component and delegate to `BaseComputed::handleMagicGet()` / `BaseComputed::handleMagicUnset()`.

This eliminates all per-request listener accumulation while preserving the same behaviour for computed property access and cache busting. The same benchmark now shows stable memory and listeners:

| Iteration | Memory (MB) | Delta (MB) | EventBus Listeners |
|---|---|---|---|
| 0 | 31.69 | +0.00 | 136 |
| 50 | 31.69 | +0.00 | 136 |
| 100 | 31.69 | +0.00 | 136 |
| 150 | 31.69 | +0.00 | 136 |
| 200 | 31.69 | +0.00 | 136 |

### Comparison

| | Listeners (start) | Listeners (end) | Memory delta |
|---|---|---|---|
| **Before** | 275 | 1,675 (+1,400) | +6.0 MB |
| **After** | 136 | 136 (+0) | +0.0 MB |

The test covers both leak sources independently — with only the `SupportMagicActions` fix, 4 listeners still leak per request from `BaseComputed` (2 per `#[Computed]` property). With only the `BaseComputed` fix, 1 listener still leaks per request from `SupportMagicActions`. `BaseComputed` is the larger contributor at 4x the leak rate.

| Fix applied | Leaked per request | Over 20 requests | Test result |
|---|---|---|---|
| Neither | +5 (1 + 4) | +100 | Fail |
| `SupportMagicActions` only | +4 | +80 | Fail |
| `BaseComputed` only | +1 | +20 | Fail |
| Both | +0 | +0 | Pass |

Fixes https://github.com/livewire/livewire/discussions/10009
Fixes https://github.com/livewire/livewire/discussions/8338

# Benchmark

<details>
<summary>Benchmark script</summary>

Create a component with `#[Computed]` properties and the following Artisan command, then run `php artisan benchmark:memory-leak`:

```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;
use Livewire\EventBus;
use Livewire\Livewire;

class BenchmarkMemoryLeak extends Command
{
    protected $signature = 'benchmark:memory-leak
        {--iterations=100 : Number of simulated requests}
        {--warmup=10 : Warm-up iterations before measuring}
        {--component=pages::benchmark : Component name to mount}
        {--sample-every=10 : Print memory every N iterations}';

    protected $description = 'Simulate Octane request cycles to detect Livewire memory leaks';

    public function handle(): int
    {
        $iterations = (int) $this->option('iterations');
        $warmup = (int) $this->option('warmup');
        $component = $this->option('component');
        $sampleEvery = (int) $this->option('sample-every');

        $this->info("Benchmarking memory leak: {$iterations} iterations of [{$component}]");

        // Warm-up phase: let one-time allocations settle (class loading, view compilation, etc.)
        $this->comment("Warming up ({$warmup} iterations)...");

        for ($i = 0; $i < $warmup; $i++) {
            $this->simulateRequest($component);
            Livewire::flushState();
        }

        gc_collect_cycles();

        $listenersAtStart = $this->countEventBusListeners();
        $baselineMemory = memory_get_usage();

        $this->newLine();
        $this->info("Baseline after warm-up: " . sprintf('%.2f MB', $baselineMemory / 1024 / 1024) . ", {$listenersAtStart} listeners");
        $this->newLine();

        // Measurement phase
        $rows = [];
        $rows[] = $this->sampleRow(0, $baselineMemory, $baselineMemory);

        for ($i = 1; $i <= $iterations; $i++) {
            $this->simulateRequest($component);
            Livewire::flushState();
            gc_collect_cycles();

            if ($i % $sampleEvery === 0 || $i === $iterations) {
                $rows[] = $this->sampleRow($i, memory_get_usage(), $baselineMemory);
            }
        }

        $this->table(
            ['Iteration', 'Memory (MB)', 'Delta (MB)', 'EventBus Listeners'],
            $rows,
        );

        // Final assessment
        gc_collect_cycles();
        $finalMemory = memory_get_usage();
        $leaked = ($finalMemory - $baselineMemory) / 1024 / 1024;
        $listenersAtEnd = $this->countEventBusListeners();
        $listenersGrew = $listenersAtEnd - $listenersAtStart;

        $this->newLine();

        $failed = false;

        if ($listenersGrew > 0) {
            $this->error("LISTENER LEAK: EventBus grew by {$listenersGrew} listeners ({$listenersAtStart} -> {$listenersAtEnd})");
            $failed = true;
        } else {
            $this->info("EventBus listeners stable: {$listenersAtEnd}");
        }

        if ($leaked > 1.0) {
            $this->error(sprintf('MEMORY LEAK: %.2f MB accumulated over %d iterations', $leaked, $iterations));
            $failed = true;
        } else {
            $this->info(sprintf('Memory stable: %.2f MB delta over %d iterations', $leaked, $iterations));
        }

        return $failed ? Command::FAILURE : Command::SUCCESS;
    }

    protected function simulateRequest(string $component): void
    {
        app('livewire')->mount($component);
    }

    protected function sampleRow(int $iteration, int $currentMemory, int $baselineMemory): array
    {
        return [
            $iteration,
            sprintf('%.2f', $currentMemory / 1024 / 1024),
            sprintf('%+.2f', ($currentMemory - $baselineMemory) / 1024 / 1024),
            $this->countEventBusListeners(),
        ];
    }

    protected function countEventBusListeners(): int
    {
        $eventBus = app(EventBus::class);
        $reflection = new \ReflectionClass($eventBus);
        $total = 0;

        foreach (['listeners', 'listenersAfter', 'listenersBefore'] as $prop) {
            $property = $reflection->getProperty($prop);
            $property->setAccessible(true);

            foreach ($property->getValue($eventBus) as $listeners) {
                $total += count($listeners);
            }
        }

        return $total;
    }
}
```

</details>