### PR TITLE
[4.x] Fix child component `:key` expression overwriting foreach `$key` variable

### DIFF
--- a/src/Mechanisms/RenderComponent.php
+++ b/src/Mechanisms/RenderComponent.php
@@ -48,16 +48,17 @@ class RenderComponent extends Mechanism
 };
 [\$__name, \$__params] = \$__split($expression);
 
-\$key = $key;
+\$__key = $key;
 \$__componentSlots = $slots;
 
-\$key ??= \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::generateKey($deterministicBladeKey, \$key);
+\$__key ??= \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::generateKey($deterministicBladeKey, \$__key);
 
-\$__html = app('livewire')->mount(\$__name, \$__params, \$key, \$__componentSlots);
+\$__html = app('livewire')->mount(\$__name, \$__params, \$__key, \$__componentSlots);
 
 echo \$__html;
 
 unset(\$__html);
+unset(\$__key);
 unset(\$__name);
 unset(\$__params);
 unset(\$__componentSlots);


### PR DESCRIPTION
# The Scenario

When rendering a child Livewire component inside a `@foreach` loop with a concatenated `:key` expression, the foreach `$key` variable gets silently overwritten. This causes `wire:model` bindings and other template expressions after the child component to reference the wrong key, creating "ghost entries" in the parent's array properties.

For example, with `$key` equal to `abc-123`, the `wire:model` paths after the child component incorrectly become `items.abc-123-child-dropdown.quantity` instead of `items.abc-123.quantity`:

```php
<?php

use Livewire\Component;

new class extends Component {
    public $items = [];

    public function mount()
    {
        $this->items['abc-123'] = [
            'quantity' => null,
            'cost' => null,
        ];
    }
}; ?>

<div>
    @foreach ($items as $key => $item)
        <div wire:key="item-{{ $key }}">
            <livewire:child-dropdown
                :key="$key . '-child-dropdown'"
                :item-key="$key"
            />

            {{-- These inputs bind to the WRONG key after the child component --}}
            <input wire:model="items.{{ $key }}.quantity" />
            <input wire:model="items.{{ $key }}.cost" />
        </div>
    @endforeach
</div>
```

# The Problem

The `@livewire` Blade directive in `RenderComponent.php` compiles the `:key` expression into a PHP assignment using the variable name `$key`:

```php
$key = $key . '-child-dropdown';
```

This overwrites any `$key` variable that exists in the surrounding Blade scope — most commonly the iteration variable from a `@foreach ($items as $key => $item)` loop. All subsequent `{{ $key }}` references in the template then use the modified value.

# The Solution

Renamed the internal variable from `$key` to `$__key` in the compiled PHP output, following the existing double-underscore convention already used by other internal variables in the same block (`$__split`, `$__name`, `$__params`, `$__html`, `$__componentSlots`). The variable is also properly `unset()` after use.

Fixes https://github.com/livewire/livewire/discussions/10020