### PR TITLE
[3.x] Fix child component `:key` expression overwriting foreach `$key` variable

### DIFF
--- a/src/Features/SupportNestingComponents/BrowserTest.php
+++ b/src/Features/SupportNestingComponents/BrowserTest.php
@@ -394,6 +394,38 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->waitForLivewire()->click('@refresh-parent')
         ->assertConsoleLogHasNoErrors();
     }
+
+    public function test_concatenated_child_key_does_not_overwrite_foreach_variable()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public $items = ['foo', 'bar'];
+
+                public function render()
+                {
+                    return <<<'BLADE'
+                    <div>
+                        @foreach ($items as $key => $item)
+                            <div wire:key="item-{{ $key }}">
+                                <livewire:child :key="$key . '-child'" />
+                                <span dusk="key-{{ $key }}">{{ $key }}</span>
+                            </div>
+                        @endforeach
+                    </div>
+                    BLADE;
+                }
+            },
+            'child' => new class extends Component {
+                public function render()
+                {
+                    return '<div>child</div>';
+                }
+            },
+        ])
+            ->assertSeeIn('[dusk="key-0"]', '0')
+            ->assertSeeIn('[dusk="key-1"]', '1')
+        ;
+    }
 }
 
 class Page extends Component

--- a/src/Mechanisms/RenderComponent.php
+++ b/src/Mechanisms/RenderComponent.php
@@ -36,15 +36,16 @@ class RenderComponent extends Mechanism
 };
 [\$__name, \$__params] = \$__split($expression);
 
-\$key = $key;
+\$__key = $key;
 
-\$key ??= \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::generateKey($deterministicBladeKey, $key);
+\$__key ??= \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::generateKey($deterministicBladeKey, \$__key);
 
-\$__html = app('livewire')->mount(\$__name, \$__params, \$key);
+\$__html = app('livewire')->mount(\$__name, \$__params, \$__key);
 
 echo \$__html;
 
 unset(\$__html);
+unset(\$__key);
 unset(\$__name);
 unset(\$__params);
 unset(\$__split);


### PR DESCRIPTION
# The Scenario

When rendering a child Livewire component inside a `@foreach` loop with a concatenated `:key` expression, the foreach `$key` variable gets silently overwritten. This causes any template expressions after the child component (`{{ $key }}`, `wire:model="items.{{ $key }}.quantity"`, etc.) to use the wrong value.

For example, with `$key` equal to `abc-123`, expressions after the child component incorrectly resolve to `abc-123-child-dropdown` instead of `abc-123`:

```php
<?php

use Livewire\Component;

new class extends Component {
    public $items = [];

    public function mount()
    {
        $this->items['abc-123'] = [
            'quantity' => null,
            'cost' => null,
        ];
    }
}; ?>

<div>
    @foreach ($items as $key => $item)
        <div wire:key="item-{{ $key }}">
            <livewire:child-dropdown
                :key="$key . '-child-dropdown'"
                :item-key="$key"
            />

            {{-- $key is now 'abc-123-child-dropdown' instead of 'abc-123' --}}
            <input wire:model="items.{{ $key }}.quantity" />
            <input wire:model="items.{{ $key }}.cost" />
        </div>
    @endforeach
</div>
```

# The Problem

The `@livewire` Blade directive in `RenderComponent.php` compiles the `:key` expression into a PHP assignment using the variable name `$key`:

```php
$key = $key . '-child-dropdown';
```

This overwrites any `$key` variable that exists in the surrounding Blade scope — most commonly the iteration variable from a `@foreach ($items as $key => $item)` loop. All subsequent `{{ $key }}` references in the template then use the modified value.

# The Solution

Renamed the internal variable from `$key` to `$__key` in the compiled PHP output, following the existing double-underscore convention already used by other internal variables in the same block (`$__split`, `$__name`, `$__params`, `$__html`). The variable is also properly `unset()` after use.

Fixes https://github.com/livewire/livewire/discussions/10020