### PR TITLE
[3.x] Add Laravel 13 support

### DIFF
--- a/.github/workflows/test-3.x.yml
+++ b/.github/workflows/test-3.x.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         exclude:
           - php: 8.5
             laravel: 10.*
@@ -84,6 +84,10 @@ jobs:
             laravel: 11.*
           - php: 8.1
             laravel: 12.*
+          - php: 8.1
+            laravel: 13.*
+          - php: 8.2
+            laravel: 13.*
 
     name: 1. Unit - L${{ matrix.laravel }} - PHP ${{ matrix.php }}
 
@@ -130,7 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         shard: [1, 2, 3]
         exclude:
           - php: 8.5
@@ -141,6 +145,10 @@ jobs:
             laravel: 11.*
           - php: 8.1
             laravel: 12.*
+          - php: 8.1
+            laravel: 13.*
+          - php: 8.2
+            laravel: 13.*
 
     name: 2. Browser ${{ matrix.shard }} - L${{ matrix.laravel }} - PHP ${{ matrix.php }}
 
@@ -204,7 +212,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         exclude:
           - php: 8.5
             laravel: 10.*
@@ -214,6 +222,10 @@ jobs:
             laravel: 11.*
           - php: 8.1
             laravel: 12.*
+          - php: 8.1
+            laravel: 13.*
+          - php: 8.2
+            laravel: 13.*
 
     name: 3. Legacy - L${{ matrix.laravel }} - PHP ${{ matrix.php }}
 

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.4, 8.5]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
 
     name: 1. Unit - L${{ matrix.laravel }} - PHP ${{ matrix.php }}
 
@@ -120,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.4, 8.5]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
         shard: [1, 2, 3]
 
     name: 2. Browser ${{ matrix.shard }} - L${{ matrix.laravel }} - PHP ${{ matrix.php }}
@@ -185,7 +185,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.4, 8.5]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
 
     name: 3. Legacy - L${{ matrix.laravel }} - PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require-dev": {
     "psy/psysh": "^0.11.22|^0.12",
     "mockery/mockery": "^1.3.1",
-    "phpunit/phpunit": "^10.4|^11.5",
+    "phpunit/phpunit": "^10.4|^11.5|^12.5",
     "laravel/framework": "^10.15.0|^11.0|^12.0|^13.0",
     "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0",
     "orchestra/testbench-dusk": "^8.24|^9.1|^10.0|^11.0",

--- a/composer.json
+++ b/composer.json
@@ -10,22 +10,22 @@
   ],
   "require": {
     "php": "^8.1",
-    "illuminate/database": "^10.0|^11.0|^12.0",
-    "illuminate/routing": "^10.0|^11.0|^12.0",
-    "illuminate/support": "^10.0|^11.0|^12.0",
-    "illuminate/validation": "^10.0|^11.0|^12.0",
+    "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
     "league/mime-type-detection": "^1.9",
-    "symfony/console": "^6.0|^7.0",
-    "symfony/http-kernel": "^6.2|^7.0",
+    "symfony/console": "^6.0|^7.0|^8.0",
+    "symfony/http-kernel": "^6.2|^7.0|^8.0",
     "laravel/prompts": "^0.1.24|^0.2|^0.3"
   },
   "require-dev": {
     "psy/psysh": "^0.11.22|^0.12",
     "mockery/mockery": "^1.3.1",
     "phpunit/phpunit": "^10.4|^11.5",
-    "laravel/framework": "^10.15.0|^11.0|^12.0",
-    "orchestra/testbench": "^8.21.0|^9.0|^10.0",
-    "orchestra/testbench-dusk": "^8.24|^9.1|^10.0",
+    "laravel/framework": "^10.15.0|^11.0|^12.0|^13.0",
+    "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0",
+    "orchestra/testbench-dusk": "^8.24|^9.1|^10.0|^11.0",
     "calebporzio/sushi": "^2.1"
   },
   "autoload": {

--- a/src/Features/SupportConsoleCommands/Commands/CpCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/CpCommand.php
@@ -6,7 +6,7 @@ class CpCommand extends CopyCommand
 {
     protected $signature = 'livewire:cp {name} {new-name} {--inline} {--force} {--test}';
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setHidden(true);
     }

--- a/src/Features/SupportConsoleCommands/Commands/MvCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MvCommand.php
@@ -6,7 +6,7 @@ class MvCommand extends MoveCommand
 {
     protected $signature = 'livewire:mv {name} {new-name} {--inline} {--force}';
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setHidden(true);
     }

--- a/src/Features/SupportConsoleCommands/Commands/RmCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/RmCommand.php
@@ -6,7 +6,7 @@ class RmCommand extends DeleteCommand
 {
     protected $signature = 'livewire:rm {name} {--inline} {--force} {--test}';
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setHidden(true);
     }

--- a/src/Features/SupportConsoleCommands/Commands/TouchCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/TouchCommand.php
@@ -6,7 +6,7 @@ class TouchCommand extends MakeCommand
 {
     protected $signature = 'livewire:touch {name} {--force} {--inline} {--test} {--pest} {--stub=default}';
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setHidden(true);
     }

--- a/src/Features/SupportErrorResponses/BrowserTest.php
+++ b/src/Features/SupportErrorResponses/BrowserTest.php
@@ -9,7 +9,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 {
     public function test_it_shows_page_expired_dialog_when_session_has_expired()
     {
-        if (version_compare(app()->version(), '13.0.0', '>=')) {
+        if (app()->version() >= '13') {
             $this->markTestSkipped(
                 'Laravel 13+ uses Sec-Fetch-Site origin verification which bypasses CSRF token checks for same-origin requests.'
             );
@@ -29,7 +29,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_it_shows_custom_hook_dialog_using_on_error_response_hook_when_session_has_expired()
     {
-        if (version_compare(app()->version(), '13.0.0', '>=')) {
+        if (app()->version() >= '13') {
             $this->markTestSkipped(
                 'Laravel 13+ uses Sec-Fetch-Site origin verification which bypasses CSRF token checks for same-origin requests.'
             );

--- a/src/Features/SupportErrorResponses/BrowserTest.php
+++ b/src/Features/SupportErrorResponses/BrowserTest.php
@@ -9,6 +9,12 @@ class BrowserTest extends \Tests\BrowserTestCase
 {
     public function test_it_shows_page_expired_dialog_when_session_has_expired()
     {
+        if (version_compare(app()->version(), '13.0.0', '>=')) {
+            $this->markTestSkipped(
+                'Laravel 13+ uses Sec-Fetch-Site origin verification which bypasses CSRF token checks for same-origin requests.'
+            );
+        }
+
         Livewire::visit(Component::class)
             ->waitForLivewire()->click('@regenerateSession')
             ->click('@refresh')
@@ -23,6 +29,12 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_it_shows_custom_hook_dialog_using_on_error_response_hook_when_session_has_expired()
     {
+        if (version_compare(app()->version(), '13.0.0', '>=')) {
+            $this->markTestSkipped(
+                'Laravel 13+ uses Sec-Fetch-Site origin verification which bypasses CSRF token checks for same-origin requests.'
+            );
+        }
+
         Livewire::withQueryParams(['useCustomErrorResponseHook' => true])
             ->visit(Component::class)
             ->waitForLivewire()->click('@regenerateSession')


### PR DESCRIPTION
# The Scenario

Laravel 13 is releasing next month and Livewire 3.x doesn't yet declare compatibility with it.

# The Solution

- Added `|^13.0` to `illuminate/*` package constraints
- Added `|^8.0` to `symfony/console` and `symfony/http-kernel` (Laravel 13 uses Symfony 8)
- Added `|^13.0` to `laravel/framework`, `|^11.0` to `orchestra/testbench` and `orchestra/testbench-dusk`
- Added `|^12.5` to `phpunit/phpunit` (required by `orchestra/testbench-core` 11.x)
- Added `13.*` to the CI matrices with PHP 8.1/8.2 exclusions (Laravel 13 requires PHP 8.3+)
- Added `void` return type to `configure()` on `TouchCommand`, `MvCommand`, `RmCommand`, and `CpCommand` for Symfony 8 compatibility