### PR TITLE
[4.x] Enforce payload max size using actual request size

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -145,10 +145,12 @@ class HandleRequests extends Mechanism
         $maxSize = config('livewire.payload.max_size');
 
         if ($maxSize !== null) {
-            $contentLength = request()->header('Content-Length', 0);
+            $actualPayloadSize = strlen(request()->getContent() ?? '');
+            $declaredPayloadSize = (int) request()->header('Content-Length', 0);
+            $payloadSize = max($actualPayloadSize, $declaredPayloadSize);
 
-            if ($contentLength > $maxSize) {
-                throw new PayloadTooLargeException($contentLength, $maxSize);
+            if ($payloadSize > $maxSize) {
+                throw new PayloadTooLargeException($payloadSize, $maxSize);
             }
         }
 

--- a/src/Mechanisms/HandleRequests/PayloadGuardsUnitTest.php
+++ b/src/Mechanisms/HandleRequests/PayloadGuardsUnitTest.php
@@ -37,6 +37,28 @@ class PayloadGuardsUnitTest extends TestCase
             ]);
     }
 
+    public function test_rejects_payload_exceeding_max_size_even_with_small_content_length_header()
+    {
+        config()->set('livewire.payload.max_size', 100);
+
+        $this->expectException(PayloadTooLargeException::class);
+        $this->expectExceptionMessage('payload.max_size');
+
+        $largeSnapshot = str_repeat('x', 1000);
+
+        $this->withoutExceptionHandling()
+            ->withHeaders(['Content-Length' => 1, 'X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), [
+                'components' => [
+                    [
+                        'snapshot' => $largeSnapshot,
+                        'updates' => [],
+                        'calls' => [],
+                    ],
+                ],
+            ]);
+    }
+
     public function test_allows_payload_within_max_size()
     {
         config()->set('livewire.payload.max_size', 1024 * 1024); // 1MB


### PR DESCRIPTION
## Problem
Some oversized Livewire update requests could slip past the configured payload size guard in edge request scenarios.

## Solution
The payload limit is now enforced using the true request size so requests above the configured threshold are consistently blocked.

## Outcome
Payload protection is now reliable across normal and edge request patterns, while keeping existing application behavior intact.
