### PR TITLE
[4.x] Keep query string model values in sync on back/forward

### DIFF
--- a/js/features/supportQueryString.js
+++ b/js/features/supportQueryString.js
@@ -41,10 +41,8 @@ on('effect', ({ component, effects, cleanup }) => {
             let forgetPopHandler = pop(async newValue => {
                 await component.$wire.set(name, newValue)
 
-                // @todo: this is the absolute worst thing ever I'm so sorry this needs to be refactored stat:
-                document.querySelectorAll('input').forEach(el => {
-                    el._x_forceModelUpdate && el._x_forceModelUpdate(el._x_model.get())
-                })
+                // Ensure model-bound elements reflect popstate-restored values.
+                refreshComponentModelElements(component)
             })
 
             // If the current property value differs from the initial value
@@ -73,4 +71,20 @@ function normalizeQueryStringEntry(key, value) {
 
         return {...fullerDefaults, ...value }
     }
+}
+
+function refreshComponentModelElements(component) {
+    let root = component?.el
+
+    if (! root) return
+
+    let refresh = (el) => {
+        if (! el?._x_forceModelUpdate || ! el?._x_model?.get) return
+
+        el._x_forceModelUpdate(el._x_model.get())
+    }
+
+    refresh(root)
+
+    root.querySelectorAll('*').forEach(refresh)
 }


### PR DESCRIPTION
## Problem
When navigating browser history, some query-string-bound fields could display stale UI values even though the URL/state had already changed.

## Solution
History restores now consistently keep model-bound field values in sync with the restored state across field types.

## Outcome
Back/forward navigation now behaves predictably for query-string state and avoids UI mismatches.
