### PR TITLE
[4.x] Prevent navigate crashes when head includes link tags without rel

### DIFF
--- a/js/plugins/navigate/page.js
+++ b/js/plugins/navigate/page.js
@@ -199,7 +199,7 @@ function extractUriAndQueryString(el) {
 }
 
 function isAsset(el) {
-    return (el.tagName.toLowerCase() === 'link' && el.getAttribute('rel').toLowerCase() === 'stylesheet')
+    return (el.tagName.toLowerCase() === 'link' && el.getAttribute('rel')?.toLowerCase() === 'stylesheet')
         || el.tagName.toLowerCase() === 'style'
         || el.tagName.toLowerCase() === 'script'
 }

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -31,6 +31,8 @@ class BrowserTest extends \Tests\BrowserTestCase
             Livewire::component('first-asset-page', FirstAssetPage::class);
             Livewire::component('second-asset-page', SecondAssetPage::class);
             Livewire::component('third-asset-page', ThirdAssetPage::class);
+            Livewire::component('first-head-link-without-rel-page', FirstHeadLinkWithoutRelPage::class);
+            Livewire::component('second-head-link-without-rel-page', SecondHeadLinkWithoutRelPage::class);
             Livewire::component('first-tracked-asset-page', FirstTrackedAssetPage::class);
             Livewire::component('second-tracked-asset-page', SecondTrackedAssetPage::class);
             Livewire::component('second-remote-asset', SecondRemoteAsset::class);
@@ -67,6 +69,8 @@ class BrowserTest extends \Tests\BrowserTestCase
             Route::get('/first-asset', FirstAssetPage::class)->middleware('web');
             Route::get('/second-asset', SecondAssetPage::class)->middleware('web');
             Route::get('/third-asset', ThirdAssetPage::class)->middleware('web');
+            Route::get('/first-head-link-without-rel', FirstHeadLinkWithoutRelPage::class)->middleware('web');
+            Route::get('/second-head-link-without-rel', SecondHeadLinkWithoutRelPage::class)->middleware('web');
             Route::get('/first-scroll', FirstScrollPage::class)->middleware('web');
             Route::get('/second-scroll', SecondScrollPage::class)->middleware('web');
             Route::get('/second-remote-asset', SecondRemoteAsset::class)->middleware('web');
@@ -470,6 +474,18 @@ class BrowserTest extends \Tests\BrowserTestCase
                 ->waitForNavigate()->click('@link.to.third')
                 ->waitForText('On third')
                 ->assertScript('return _lw_dusk_asset_count', 2);
+        });
+    }
+
+    public function test_can_navigate_when_head_contains_link_tag_without_rel_attribute()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/first-head-link-without-rel')
+                ->assertSee('On first page with head link without rel')
+                ->click('@link.to.second')
+                ->waitForText('On second page with head link without rel')
+                ->assertConsoleLogHasNoErrors();
         });
     }
 
@@ -1525,6 +1541,29 @@ class ThirdAssetPage extends Component
     public function render()
     {
         return '<div>On third asset page</div>';
+    }
+}
+
+class FirstHeadLinkWithoutRelPage extends Component
+{
+    #[\Livewire\Attributes\Layout('test-views::layout')]
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            On first page with head link without rel
+            <a href="/second-head-link-without-rel" wire:navigate dusk="link.to.second">Go to second page</a>
+        </div>
+        HTML;
+    }
+}
+
+class SecondHeadLinkWithoutRelPage extends Component
+{
+    #[\Livewire\Attributes\Layout('test-views::layout-with-head-link-without-rel')]
+    public function render()
+    {
+        return '<div>On second page with head link without rel</div>';
     }
 }
 

--- a/src/Features/SupportNavigate/test-views/layout-with-head-link-without-rel.blade.php
+++ b/src/Features/SupportNavigate/test-views/layout-with-head-link-without-rel.blade.php
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <link href="data:text/plain,noop">
+    <script src="/test-navigate-asset.js?v=789"></script>
+</head>
+<body>
+    {{ $slot }}
+
+    @stack('scripts')
+</body>
+</html>


### PR DESCRIPTION
## Summary

This change prevents navigate from failing when the destination page includes link tags in the head without a rel attribute.

Navigation now completes normally in this case, and a regression test keeps this behavior stable.