### PR TITLE
[4.x] Clean up upload cancel listeners on element teardown

### DIFF
--- a/js/features/supportFileUploads.js
+++ b/js/features/supportFileUploads.js
@@ -74,6 +74,7 @@ export function handleFileUpload(el, property, component, cleanup) {
     cleanup(() => {
         el.removeEventListener('change', eventHandler)
         el.removeEventListener('click', clearFileInputValue)
+        el.removeEventListener('livewire-upload-cancel', clearFileInputValue)
     })
 }
 

--- a/js/features/supportFileUploads.spec.js
+++ b/js/features/supportFileUploads.spec.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { handleFileUpload } from './supportFileUploads'
+
+function createComponentStub() {
+    return {
+        id: 'abc123',
+        $wire: {
+            $on: () => {},
+            $watch: () => {},
+            call: () => {},
+        },
+    }
+}
+
+describe('supportFileUploads cleanup', () => {
+    it('removes the cancel listener when cleanup runs', () => {
+        let component = createComponentStub()
+        let input = document.createElement('input')
+        let disposer = () => {}
+
+        handleFileUpload(input, 'photo', component, (cleanup) => {
+            disposer = cleanup
+        })
+
+        input.value = 'before-cancel'
+        input.dispatchEvent(new CustomEvent('livewire-upload-cancel'))
+        expect(input.value).toBe('')
+
+        input.value = 'after-cleanup'
+        disposer()
+        input.dispatchEvent(new CustomEvent('livewire-upload-cancel'))
+
+        expect(input.value).toBe('after-cleanup')
+    })
+})


### PR DESCRIPTION
## Summary

This change removes stale upload-cancel event listeners when file upload elements are cleaned up.

It prevents detached or reused elements from retaining old cancel behavior after teardown, and adds regression coverage for cleanup behavior.