### PR TITLE
[4.x] Decode non-array query keys in history URL parsing

### DIFF
--- a/js/plugins/history/index.js
+++ b/js/plugins/history/index.js
@@ -266,7 +266,10 @@ function fromQueryString(search, queryKey) {
         let shouldBeHandledAsArray = decodedKey.includes('[') && decodedKey.startsWith(queryKey)
 
         if (!shouldBeHandledAsArray) {
-            data[decodedKey] = value
+            // Decode only the key being tracked. Preserve unrelated encoded keys.
+            let nonArrayKey = decodedKey === queryKey ? decodedKey : key
+
+            data[nonArrayKey] = value
         } else {
             // Convert to dot notation because it's easier...
             let dotNotatedKey = decodedKey.replaceAll('[', '.').replaceAll(']', '')

--- a/js/plugins/history/index.js
+++ b/js/plugins/history/index.js
@@ -266,7 +266,7 @@ function fromQueryString(search, queryKey) {
         let shouldBeHandledAsArray = decodedKey.includes('[') && decodedKey.startsWith(queryKey)
 
         if (!shouldBeHandledAsArray) {
-            data[key] = value
+            data[decodedKey] = value
         } else {
             // Convert to dot notation because it's easier...
             let dotNotatedKey = decodedKey.replaceAll('[', '.').replaceAll(']', '')

--- a/js/plugins/history/query-key-decoding.spec.js
+++ b/js/plugins/history/query-key-decoding.spec.js
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { track } from './index'
+
+describe('History query key decoding', () => {
+    beforeEach(() => {
+        window.history.replaceState({}, '', '/livewire-test')
+    })
+
+    it('reads encoded non-array query keys as their decoded key names', async () => {
+        window.history.replaceState({}, '', '/livewire-test?foo%20bar=baz')
+
+        let tracked = track('foo bar', 'seed')
+
+        await new Promise(queueMicrotask)
+
+        expect(tracked.initial).toBe('baz')
+    })
+
+    it('updates an encoded key without creating duplicate query params', async () => {
+        window.history.replaceState({}, '', '/livewire-test?foo%20bar=baz')
+
+        let tracked = track('foo bar', '')
+        tracked.replace('qux')
+
+        await new Promise(queueMicrotask)
+
+        expect(window.location.search).toBe('?foo%20bar=qux')
+    })
+})


### PR DESCRIPTION
## Summary

This change ensures history URL parsing decodes non-array query parameter keys before tracking and updates.

It prevents missed initial values and duplicate query parameters when a tracked key contains encoded characters (for example spaces). A regression test is included.