### PR TITLE
[4.x] Improve event testing assertions DX

### DIFF
--- a/src/Features/SupportEvents/UnitTest.php
+++ b/src/Features/SupportEvents/UnitTest.php
@@ -79,6 +79,34 @@ class UnitTest extends \Tests\TestCase
         ;
     }
 
+    public function test_dispatched_event_callback_assertion_checks_all_matching_events()
+    {
+        Livewire::test(new class extends TestComponent {
+            public function dispatchFooTwice()
+            {
+                $this->dispatch('foo', id: 1);
+                $this->dispatch('foo', id: 2);
+            }
+        })
+            ->call('dispatchFooTwice')
+            ->assertDispatched('foo', fn ($name, $params) => $params['id'] === 2)
+            ->assertNotDispatched('foo', fn ($name, $params) => $params['id'] === 3);
+    }
+
+    public function test_can_assert_dispatched_event_times()
+    {
+        Livewire::test(new class extends TestComponent {
+            public function dispatchFooTwice()
+            {
+                $this->dispatch('foo');
+                $this->dispatch('foo');
+            }
+        })
+            ->call('dispatchFooTwice')
+            ->assertDispatchedTimes('foo', 2)
+            ->assertDispatchedTimes('bar', 0);
+    }
+
     public function test_it_can_register_multiple_listeners_via_attribute(): void
     {
         Livewire::test(new class extends TestComponent {


### PR DESCRIPTION
## Summary
This improves Livewire test ergonomics for dispatched events.

## What this solves
- Event callback assertions now evaluate all matching dispatched events, avoiding false negatives when the same event is dispatched multiple times.
- Adds an explicit event count assertion so tests can clearly verify how many times an event was dispatched.