### PR TITLE
[4.x] Improve checksum mismatch debugging experience

### DIFF
--- a/src/Mechanisms/HandleComponents/Checksum.php
+++ b/src/Mechanisms/HandleComponents/Checksum.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Mechanisms\HandleComponents;
 
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\RateLimiter;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
@@ -10,6 +11,7 @@ use function Livewire\trigger;
 class Checksum {
     protected static $maxFailures = 10;
     protected static $decaySeconds = 600; // 10 minutes
+    protected static $debugSnapshotTtl = 600; // 10 minutes
 
     static function verify($snapshot) {
         // Check if this IP is already blocked due to too many failures
@@ -21,12 +23,14 @@ class Checksum {
 
         trigger('checksum.verify', $checksum, $snapshot);
 
-        if (! hash_equals($comparitor = self::generate($snapshot), $checksum)) {
+        if (! hash_equals($comparitor = self::generate($snapshot, false), $checksum)) {
             trigger('checksum.fail', $checksum, $comparitor, $snapshot);
 
             static::recordFailure();
 
-            throw new CorruptComponentPayloadException;
+            throw new CorruptComponentPayloadException(
+                static::debugChecksumFailureContext($checksum, $comparitor, $snapshot)
+            );
         }
     }
 
@@ -63,18 +67,105 @@ class Checksum {
         return 'livewire-checksum-failures:' . request()->ip();
     }
 
-    static function generate($snapshot) {
+    static function generate($snapshot, bool $storeForDebugging = true) {
         $hashKey = app('encrypter')->getKey();
 
         // Remove the children from the memo in the snapshot, as it is actually Ok
         // if the "children" tracking is tampered with. This way JavaScript can
         // modify children as it needs to for dom-diffing purposes...
         unset($snapshot['memo']['children']);
-        
+
         $checksum = hash_hmac('sha256', json_encode($snapshot), $hashKey);
+
+        if ($storeForDebugging) {
+            static::storeSnapshotForDebugging($checksum, $snapshot);
+        }
 
         trigger('checksum.generate', $checksum, $snapshot);
 
         return $checksum;
+    }
+
+    protected static function storeSnapshotForDebugging(string $checksum, array $snapshot): void
+    {
+        if (! config('app.debug')) return;
+
+        Cache::put(
+            static::debugSnapshotCacheKey($checksum),
+            $snapshot,
+            now()->addSeconds(static::$debugSnapshotTtl)
+        );
+    }
+
+    protected static function debugChecksumFailureContext(string $checksum, string $comparitor, array $tamperedSnapshot): ?string
+    {
+        if (! config('app.debug')) return null;
+
+        $canonicalSnapshot = Cache::get(static::debugSnapshotCacheKey($checksum));
+
+        if (! is_array($canonicalSnapshot)) {
+            return "Checksum mismatch details: received [{$checksum}] but computed [{$comparitor}]. No baseline snapshot was found for this checksum.";
+        }
+
+        [ $path, $expected, $actual ] = static::firstDiff($canonicalSnapshot, $tamperedSnapshot);
+
+        if ($path === null) {
+            return "Checksum mismatch details: received [{$checksum}] but computed [{$comparitor}]. No specific payload diff could be determined.";
+        }
+
+        return "Checksum mismatch details: received [{$checksum}] but computed [{$comparitor}]. "
+            ."First differing path [{$path}] expected ".static::stringifyDebugValue($expected)
+            ." and received ".static::stringifyDebugValue($actual).".";
+    }
+
+    protected static function debugSnapshotCacheKey(string $checksum): string
+    {
+        return "livewire:checksum-snapshot:{$checksum}";
+    }
+
+    protected static function firstDiff(array $expected, array $actual, string $path = ''): array
+    {
+        $keys = array_values(array_unique(array_merge(array_keys($expected), array_keys($actual))));
+
+        foreach ($keys as $key) {
+            $hasExpected = array_key_exists($key, $expected);
+            $hasActual = array_key_exists($key, $actual);
+            $currentPath = $path === '' ? (string) $key : $path.'.'.$key;
+
+            if (! $hasExpected) return [$currentPath, null, $actual[$key]];
+            if (! $hasActual) return [$currentPath, $expected[$key], null];
+
+            $expectedValue = $expected[$key];
+            $actualValue = $actual[$key];
+
+            if (is_array($expectedValue) && is_array($actualValue)) {
+                [ $diffPath, $diffExpected, $diffActual ] = static::firstDiff($expectedValue, $actualValue, $currentPath);
+
+                if ($diffPath !== null) {
+                    return [ $diffPath, $diffExpected, $diffActual ];
+                }
+
+                continue;
+            }
+
+            if ($expectedValue !== $actualValue) {
+                return [ $currentPath, $expectedValue, $actualValue ];
+            }
+        }
+
+        return [null, null, null];
+    }
+
+    protected static function stringifyDebugValue($value): string
+    {
+        $encoded = json_encode($value);
+
+        if ($encoded === false) return '"[unserializable]"';
+
+        if (strlen($encoded) > 120) {
+            return substr($encoded, 0, 117).'...';
+        }
+
+        return $encoded;
     }
 }

--- a/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
+++ b/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
@@ -8,11 +8,18 @@ class CorruptComponentPayloadException extends \Exception
 {
     use BypassViewHandler;
 
-    public function __construct()
+    public function __construct(?string $debugContext = null)
     {
-        parent::__construct(
+        $message =
             "Livewire encountered corrupt data when trying to hydrate a component. \n".
-            "Ensure that the [name, id, data] of the Livewire component wasn't tampered with between requests."
+            "Ensure that the [name, id, data] of the Livewire component wasn't tampered with between requests.";
+
+        if ($debugContext) {
+            $message .= "\n\n".$debugContext;
+        }
+
+        parent::__construct(
+            $message
         );
     }
 


### PR DESCRIPTION
### Why
Checksum mismatch issues are painful to troubleshoot because the failure gives very little context about what changed between requests.

### Solution
In local/debug workflows, checksum failures now provide actionable context by showing the first mismatched payload path and the expected vs received value.
Production behavior is unchanged.

### Developer impact
This removes guesswork during debugging and makes it much faster to identify the exact state difference causing the failure.

### Safety
This is scoped to developer debugging behavior and does not change production error handling.