### PR TITLE
[4.x] Fix `#[Json]` methods not handling non-validation exceptions via Promise rejection

### DIFF
--- a/js/request/message.js
+++ b/js/request/message.js
@@ -233,10 +233,17 @@ export default class Message {
 
             if (! action) return;
 
-            // Check for validation errors in returnsMeta
+            // Check for errors in returnsMeta
             let meta = returnsMeta[index]
             if (meta?.errors) {
                 action.rejectPromise({ status: 422, body: null, json: null, errors: meta.errors })
+                action.invokeOnFinish()
+                resolvedActions.add(action)
+                return
+            }
+
+            if (meta?.status) {
+                action.rejectPromise({ status: meta.status, body: null, json: null, errors: null })
                 action.invokeOnFinish()
                 resolvedActions.add(action)
                 return

--- a/src/Features/SupportJson/BrowserTest.php
+++ b/src/Features/SupportJson/BrowserTest.php
@@ -186,6 +186,39 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_json_method_rejects_promise_on_non_validation_exception()
+    {
+        Livewire::visit(new class extends Component {
+            public $status = '';
+            public $body = '';
+
+            #[Json]
+            public function forbidden()
+            {
+                abort(403);
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button dusk="call" @click="$wire.forbidden().catch(e => { $wire.status = String(e.status); $wire.body = 'rejected' })">Call</button>
+
+                    <span dusk="status" wire:text="status"></span>
+                    <span dusk="body" wire:text="body"></span>
+                </div>
+                HTML;
+            }
+        })
+        ->waitForLivewireToLoad()
+        ->click('@call')
+        ->waitForTextIn('@body', 'rejected')
+        ->assertSeeIn('@status', '403')
+        ->assertSeeIn('@body', 'rejected')
+        ->assertMissing('#livewire-error')
+        ;
+    }
+
     public function test_json_method_with_try_catch_pattern()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportJson/SupportJson.php
+++ b/src/Features/SupportJson/SupportJson.php
@@ -6,6 +6,7 @@ use function Livewire\on;
 use Livewire\ComponentHook;
 
 use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class SupportJson extends ComponentHook
 {
@@ -27,6 +28,14 @@ class SupportJson extends ComponentHook
                 $context->addEffect('returnsMeta', $existingMeta);
 
                 // Return null so the returns array stays aligned
+                $returnEarly(null);
+            } catch (\Throwable $e) {
+                $status = $e instanceof HttpExceptionInterface ? $e->getStatusCode() : 500;
+
+                $existingMeta = $context->effects['returnsMeta'] ?? [];
+                $existingMeta[$index] = ['status' => $status];
+                $context->addEffect('returnsMeta', $existingMeta);
+
                 $returnEarly(null);
             }
         });


### PR DESCRIPTION
# The Scenario

The `#[Json]` attribute [documents](https://livewire.laravel.com/docs/4.x/attribute-json#error-rejection-shape) that when a Promise is rejected, the error object has this shape:

```js
{
    status: 500,
    body: '<html>...</html>',
    json: null,
    errors: null
}
```

This works correctly for validation exceptions (status 422 with `errors`), but for any other exception (e.g., `abort(403)`), Livewire shows the error modal instead of rejecting the Promise.

```php
<?php // resources/views/components/⚡search.blade.php

use Livewire\Attributes\Json;
use Livewire\Component;
use App\Models\Post;

new class extends Component {
    #[Json]
    public function search($query)
    {
        abort(403);

        return Post::where('title', 'like', "%{$query}%")
            ->limit(10)
            ->get();
    }
};
```

```blade
<div x-data="{ query: '', posts: [] }">
    <input
        type="text"
        x-model="query"
        x-on:input.debounce="$wire.search(query)
            .then(data => posts = data)
            .catch(e => console.log(e.status))"
    >
</div>
```

# The Problem

The `try/catch` block in `SupportJson::provide()` only catches `ValidationException`. When any other exception is thrown (e.g., `abort(403)` which throws an `HttpException`), it escapes the catch block and propagates up to Laravel's exception handler, which returns an HTTP error response. On the JavaScript side, this triggers both a Promise rejection (via `message.invokeOnError()`) and the error modal (`showHtmlModal()`).

```php
// src/Features/SupportJson/SupportJson.php
try {
    $result = $component->{$method}(...$params);
    $returnEarly($result);
} catch (ValidationException $e) {
    // Only ValidationException is caught...
}
// All other exceptions escape to Laravel's error handler
```

# The Solution

Catch `\Throwable` after `ValidationException` in `SupportJson::provide()`. The HTTP status code is extracted from the exception (using `HttpExceptionInterface::getStatusCode()` for HTTP exceptions, defaulting to 500 otherwise) and stored in `returnsMeta` under a `status` key. This keeps the Livewire response intact so the error is communicated through the normal response flow.

On the JavaScript side, `resolveActionPromises()` now checks for `meta?.status` (in addition to the existing `meta?.errors` check) and rejects the Promise with the [documented error rejection shape](https://livewire.laravel.com/docs/4.x/attribute-json#error-rejection-shape).

Fixes https://github.com/livewire/livewire/discussions/10043