### PR TITLE
[4.x] Fix false positive multiple root element error on older libxml2 versions

### DIFF
--- a/src/Features/SupportMultipleRootElementDetection/SupportMultipleRootElementDetection.php
+++ b/src/Features/SupportMultipleRootElementDetection/SupportMultipleRootElementDetection.php
@@ -29,6 +29,12 @@ class SupportMultipleRootElementDetection extends ComponentHook
 
     function getRootElementCount($html)
     {
+        // Strip <script> and <style> tags before parsing to avoid inconsistent
+        // behavior across different libxml2 versions (older versions misparse
+        // these elements, producing incorrect DOM structures)...
+        $html = preg_replace('/<script\b[^>]*>.*?<\/script>/si', '', $html);
+        $html = preg_replace('/<style\b[^>]*>.*?<\/style>/si', '', $html);
+
         $dom = new \DOMDocument();
 
         @$dom->loadHTML($html);
@@ -39,8 +45,6 @@ class SupportMultipleRootElementDetection extends ComponentHook
 
         foreach ($body->childNodes as $child) {
             if ($child->nodeType == XML_ELEMENT_NODE) {
-                if ($child->tagName === 'script') continue;
-
                 $count++;
             }
         }

--- a/src/Features/SupportMultipleRootElementDetection/UnitTest.php
+++ b/src/Features/SupportMultipleRootElementDetection/UnitTest.php
@@ -57,6 +57,98 @@ class UnitTest extends TestCase
         })->assertSuccessful();
     }
 
+    function test_allow_script_tags_inside_root_element()
+    {
+        config()->set('app.debug', true);
+
+        Livewire::test(new class extends Component {
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <h1>Hello</h1>
+
+                    <script>
+                        alert('test')
+                    </script>
+                </div>
+                HTML;
+            }
+        })->assertSuccessful();
+    }
+
+    function test_allow_style_tags_as_second_element()
+    {
+        config()->set('app.debug', true);
+
+        Livewire::test(new class extends Component {
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    First element
+                </div>
+
+                <style>
+                    .foo { color: red; }
+                </style>
+                HTML;
+            }
+        })->assertSuccessful();
+    }
+
+    function test_two_root_elements_with_script_sibling_still_throws_error()
+    {
+        config()->set('app.debug', true);
+
+        $this->expectException(MultipleRootElementsDetectedException::class);
+
+        Livewire::test(new class extends Component {
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    First element
+                </div>
+
+                <script>
+                    let foo = 'bar'
+                </script>
+
+                <div>
+                    Second element
+                </div>
+                HTML;
+            }
+        });
+    }
+
+    function test_two_root_elements_with_style_sibling_still_throws_error()
+    {
+        config()->set('app.debug', true);
+
+        $this->expectException(MultipleRootElementsDetectedException::class);
+
+        Livewire::test(new class extends Component {
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    First element
+                </div>
+
+                <style>
+                    .foo { color: red; }
+                </style>
+
+                <div>
+                    Second element
+                </div>
+                HTML;
+            }
+        });
+    }
+
     function test_dont_throw_error_in_production_so_that_there_is_no_perf_penalty()
     {
         config()->set('app.debug', false);


### PR DESCRIPTION
# The Scenario

When a Livewire component contains a `<script>` tag inside the root element, deploying to an Ubuntu server with an older version of libxml2 (e.g., 2.9.x) throws a false positive error, while the same component works fine on macOS with a newer libxml2 (e.g., 2.15.x):

> Livewire only supports one HTML element per component. Multiple root elements detected for component: XXXX

This only occurs when `APP_DEBUG=true`, since the root element detection check is skipped in production.

```blade
<div>
    <h1>Hello</h1>

    <script>
        alert('test')
    </script>
</div>
```

# The Problem

`SupportMultipleRootElementDetection::getRootElementCount()` uses `DOMDocument::loadHTML()` to parse the component's HTML and count root elements. This method depends on the system's libxml2 C library, which is installed at the OS level.

Older libxml2 versions (pre-2.12) use a legacy HTML4 parser that handles `<script>` and `<style>` tag content inconsistently. When the older parser encounters these elements inside a `<div>`, it can produce a different DOM structure where elements get repositioned as direct children of `<body>`, causing the root element count to exceed 1.

Users on Ubuntu 22.04 LTS (which ships libxml2 2.9.x) are affected, while macOS users with Homebrew/Herd typically have a much newer libxml2.

The existing `<script>` skip on line 42 (`if ($child->tagName === 'script') continue`) only handled `<script>` as a sibling of the root element. It didn't account for the older parser mangling a `<script>` that's nested *inside* the root element.

# The Solution

Strip `<script>` and `<style>` tags from the HTML *before* passing it to `DOMDocument::loadHTML()`. Since these elements were already being skipped during the counting phase, removing them before parsing produces the same result while avoiding the cross-version parser inconsistency entirely.

Fixes #10017