### PR TITLE
[4.x] Add optimistic actions with automatic rollback

### DIFF
--- a/docs/__nav.md
+++ b/docs/__nav.md
@@ -63,6 +63,7 @@ PHP Attributes:
     Locked: { uri: /docs/4.x/attribute-locked, file: /attribute-locked.md }
     Modelable: { uri: /docs/4.x/attribute-modelable, file: /attribute-modelable.md }
     On: { uri: /docs/4.x/attribute-on, file: /attribute-on.md }
+    Optimistic: { uri: /docs/4.x/attribute-optimistic, file: /attribute-optimistic.md }
     Reactive: { uri: /docs/4.x/attribute-reactive, file: /attribute-reactive.md }
     Renderless: { uri: /docs/4.x/attribute-renderless, file: /attribute-renderless.md }
     Session: { uri: /docs/4.x/attribute-session, file: /attribute-session.md }

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -732,6 +732,40 @@ You can also skip render from an element directly using the `.renderless` modifi
 <button type="button" wire:click.renderless="incrementViewCount">
 ```
 
+## Optimistic actions
+
+Sometimes you want the UI to update instantly, then let the server catch up.  
+Use `#[Optimistic]` or `.optimistic` for this behavior.
+
+When an optimistic action sends local Livewire updates and the request fails, Livewire rolls those updates back automatically.
+
+### Using the optimistic modifier
+
+```blade
+<button wire:click.optimistic="$set('likes', likes + 1)">
+    👍 <span wire:text="likes"></span>
+</button>
+```
+
+### Using the Optimistic attribute
+
+```php
+<?php
+
+use Livewire\Attributes\Optimistic;
+use Livewire\Component;
+
+new class extends Component {
+    #[Optimistic]
+    public function saveLike()
+    {
+        // Persist like...
+    }
+};
+```
+
+Use optimistic actions for small, reversible UI interactions such as reactions, toggles, and lightweight counters.
+
 ## Parallel execution with async
 
 By default, Livewire serializes actions within the same component to ensure predictable state updates. If one action is in-flight, subsequent actions are queued and wait for it to finish. While this prevents race conditions and keeps your component's state consistent, there are times when you want actions to run immediately without waiting—in parallel rather than sequentially.

--- a/docs/attribute-optimistic.md
+++ b/docs/attribute-optimistic.md
@@ -1,0 +1,62 @@
+The `#[Optimistic]` attribute marks an action as optimistic. If that action sends local Livewire updates and the request fails, Livewire automatically rolls those optimistic updates back to the last known server state.
+
+## Basic usage
+
+Apply `#[Optimistic]` to actions where users should see immediate UI feedback:
+
+```php
+<?php // resources/views/components/post/⚡likes.blade.php
+
+use Livewire\Attributes\Optimistic;
+use Livewire\Component;
+
+new class extends Component {
+    public int $likes = 0;
+
+    #[Optimistic] // [tl! highlight]
+    public function saveLike()
+    {
+        // Persist likes...
+    }
+};
+```
+
+```blade
+<button
+    type="button"
+    wire:click.optimistic="$set('likes', likes + 1)"
+>
+    👍 <span wire:text="likes"></span>
+</button>
+```
+
+If the request succeeds, the optimistic value stays.  
+If it fails, Livewire restores the previous value.
+
+## Modifier alternative
+
+Instead of an attribute, you can mark a specific call optimistic with `.optimistic`:
+
+```blade
+<button wire:click.optimistic="saveLike">Like</button>
+```
+
+You can also opt in when using JavaScript `$set`:
+
+```js
+$wire.$set('likes', $wire.$get('likes') + 1, true, { optimistic: true })
+```
+
+## When to use
+
+Use optimistic actions when latency is noticeable and users benefit from instant feedback:
+
+* **Counters and reactions** - likes, votes, favorites
+* **Toggle state** - enable/disable flags, pin/unpin
+* **Reordering and small edits** - quick interactions where rollback is acceptable
+
+## See also
+
+- **[Actions](/docs/4.x/actions)** — Action lifecycle and modifiers
+- **[wire:click](/docs/4.x/wire-click)** — Event-driven actions
+- **[Async Attribute](/docs/4.x/attribute-async)** — Parallel execution (different tradeoff)

--- a/docs/wire-click.md
+++ b/docs/wire-click.md
@@ -77,6 +77,18 @@ By default, Livewire queues actions within the same component. Use `.async` to a
 <button wire:click.async="process">Process</button>
 ```
 
+## Optimistic actions
+
+Use `.optimistic` when you want instant UI feedback with automatic rollback on request failure:
+
+```blade
+<button wire:click.optimistic="$set('likes', likes + 1)">
+    Like
+</button>
+```
+
+If the request succeeds, the new value is kept. If it fails, Livewire restores the previous value.
+
 ## Going deeper
 
 The `wire:click` directive is just one of many different available event listeners in Livewire. For full documentation on its (and other event listeners) capabilities, visit [the Livewire actions documentation page](/docs/4.x/actions).
@@ -114,3 +126,4 @@ wire:click="methodName(param1, param2)"
 | `.renderless` | Skips re-rendering after action completes |
 | `.preserve-scroll` | Maintains scroll position during updates |
 | `.async` | Executes action in parallel instead of queued |
+| `.optimistic` | Enables optimistic updates with automatic rollback on failure |

--- a/js/$wire.js
+++ b/js/$wire.js
@@ -193,13 +193,21 @@ wireProperty('$js', (component) => {
     })
 })
 
-wireProperty('$set', (component) => async (property, value, live = true) => {
+wireProperty('$set', (component) => async (property, value, live = true, options = {}) => {
     dataSet(component.reactive, property, value)
 
     // If "live", send a request, queueing the property update to happen first
     // on the server, then trickle back down to the client and get merged...
     if (live) {
+        let optimistic = typeof options === 'boolean'
+            ? options
+            : !! options?.optimistic
+
         component.queueUpdate(property, value)
+
+        if (optimistic) {
+            setNextActionMetadata({ optimistic: true })
+        }
 
         return fireAction(component, '$set')
     }

--- a/js/directives/wire-wildcard.js
+++ b/js/directives/wire-wildcard.js
@@ -21,6 +21,11 @@ on('directive.init', ({ el, directive, cleanup, component }) => {
         attribute = attribute.replace('.async', '')
     }
 
+    // Strip .optimistic from Alpine expression because it only concerns Livewire and trips up Alpine...
+    if (directive.modifiers.includes('optimistic')) {
+        attribute = attribute.replace('.optimistic', '')
+    }
+
     // Strip .renderless from Alpine expression because it only concerns Livewire and trips up Alpine...
     if (directive.modifiers.includes('renderless')) {
         attribute = attribute.replace('.renderless', '')

--- a/js/features/supportWireSort.js
+++ b/js/features/supportWireSort.js
@@ -33,6 +33,11 @@ Alpine.interceptInit(el => {
                 attribute = attribute.replace('.async', '')
             }
 
+            // Strip .optimistic from Alpine expression because it only concerns Livewire and trips up Alpine...
+            if (directive.modifiers.includes('optimistic')) {
+                attribute = attribute.replace('.optimistic', '')
+            }
+
             // Strip .renderless from Alpine expression because it only concerns Livewire and trips up Alpine...
             if (directive.modifiers.includes('renderless')) {
                 attribute = attribute.replace('.renderless', '')

--- a/js/request/action.js
+++ b/js/request/action.js
@@ -99,6 +99,16 @@ export default class Action {
         return methodIsMarkedAsync || actionIsAsync
     }
 
+    isOptimistic() {
+        let optimisticMethods = this.component.snapshot.memo?.optimistic || []
+
+        let methodIsMarkedOptimistic = optimisticMethods.includes(this.name)
+
+        let actionIsOptimistic = this.origin?.directive?.modifiers.includes('optimistic') || (!! this.metadata.optimistic)
+
+        return methodIsMarkedOptimistic || actionIsOptimistic
+    }
+
     isJson() {
         let jsonMethods = this.component.snapshot.memo?.json || []
 

--- a/js/request/action.spec.js
+++ b/js/request/action.spec.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import Action from './action'
+
+function createComponent(memo = {}) {
+    return {
+        id: 'component-id',
+        snapshot: {
+            memo,
+        },
+    }
+}
+
+describe('Action optimism detection', () => {
+    it('detects optimistic methods from component memo', () => {
+        let action = new Action(createComponent({ optimistic: ['save'] }), 'save')
+
+        expect(action.isOptimistic()).toBe(true)
+    })
+
+    it('detects optimistic modifier on directive origin', () => {
+        let action = new Action(
+            createComponent(),
+            'save',
+            [],
+            {},
+            { directive: { modifiers: ['optimistic'] } }
+        )
+
+        expect(action.isOptimistic()).toBe(true)
+    })
+
+    it('detects optimistic metadata on action', () => {
+        let action = new Action(createComponent(), 'save', [], { optimistic: true })
+
+        expect(action.isOptimistic()).toBe(true)
+    })
+})

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -262,6 +262,9 @@ function sendMessages() {
         request.messages.forEach(message => {
             message.snapshot = message.component.getEncodedSnapshotWithLatestChildrenMergedIn()
             message.updates = message.component.getUpdates()
+            message.optimisticRollback = message.hasOptimisticAction()
+                ? message.component.captureRollbackStateForUpdates(message.updates)
+                : null
             message.calls = Array.from(message.actions).map(i => ({
                 method: i.name,
                 params: i.params,

--- a/js/request/message.spec.js
+++ b/js/request/message.spec.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest'
+import Message from './message'
+
+function createAction({ optimistic = false, fingerprint = 'action' } = {}) {
+    return {
+        fingerprint,
+        message: null,
+        addSquashedAction: () => {},
+        isOptimistic: () => optimistic,
+        invokeOnError: () => {},
+        invokeOnFailure: () => {},
+        invokeOnFinish: () => {},
+        rejectPromise: () => {},
+    }
+}
+
+describe('Optimistic rollback', () => {
+    it('rolls back optimistic updates when a message errors', () => {
+        let rollbackOptimisticUpdates = vi.fn()
+        let message = new Message({ rollbackOptimisticUpdates })
+
+        message.optimisticRollback = {
+            count: { exists: true, value: 1 },
+        }
+
+        message.addAction(createAction({ optimistic: true }))
+
+        message.invokeOnError({
+            response: { status: 500 },
+            body: '',
+            preventDefault: () => {},
+        })
+
+        expect(rollbackOptimisticUpdates).toHaveBeenCalledOnce()
+        expect(rollbackOptimisticUpdates).toHaveBeenCalledWith({
+            count: { exists: true, value: 1 },
+        })
+    })
+
+    it('does not roll back when no optimistic action is present', () => {
+        let rollbackOptimisticUpdates = vi.fn()
+        let message = new Message({ rollbackOptimisticUpdates })
+
+        message.optimisticRollback = {
+            count: { exists: true, value: 1 },
+        }
+
+        message.addAction(createAction({ optimistic: false }))
+
+        message.invokeOnError({
+            response: { status: 500 },
+            body: '',
+            preventDefault: () => {},
+        })
+
+        expect(rollbackOptimisticUpdates).not.toHaveBeenCalled()
+    })
+})

--- a/src/Attributes/Optimistic.php
+++ b/src/Attributes/Optimistic.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Livewire\Features\SupportOptimistic\BaseOptimistic;
+
+#[\Attribute]
+class Optimistic extends BaseOptimistic
+{
+    //
+}

--- a/src/Features/SupportOptimistic/BaseOptimistic.php
+++ b/src/Features/SupportOptimistic/BaseOptimistic.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Livewire\Features\SupportOptimistic;
+
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
+#[\Attribute]
+class BaseOptimistic extends LivewireAttribute
+{
+    public function dehydrate($context)
+    {
+        $methodName = $this->getName();
+
+        $context->pushMemo('optimistic', $methodName);
+    }
+}

--- a/src/Features/SupportOptimistic/UnitTest.php
+++ b/src/Features/SupportOptimistic/UnitTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Livewire\Features\SupportOptimistic;
+
+use Livewire\Attributes\Optimistic;
+use Livewire\Livewire;
+use Tests\TestComponent;
+
+class UnitTest extends \Tests\TestCase
+{
+    public function test_optimistic_attribute_adds_method_to_snapshot_memo()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[Optimistic]
+            public function save()
+            {
+                //
+            }
+        });
+
+        $this->assertContains('save', data_get($component->snapshot, 'memo.optimistic', []));
+    }
+}


### PR DESCRIPTION
## Summary
This introduces optimistic action support so Livewire UIs can respond instantly while still staying safe when requests fail.

Actions can now be marked optimistic using either:
- `wire:click.optimistic`
- `#[Optimistic]`
- `$wire.$set(..., { optimistic: true })`

If an optimistic request fails, Livewire rolls those optimistic client updates back to the last known server state.

## Real-world example
A common case is a "Like" button (or quick cart quantity toggle) on slower networks:

- User clicks and sees the count update immediately.
- Request succeeds: value stays.
- Request fails: value is automatically restored.

This gives the speed users expect without leaving the UI in a broken state.

## What changed
- Added optimistic action detection in the request/action pipeline.
- Added rollback capture/replay for optimistic updates on error/failure/cancel.
- Added new `#[Optimistic]` attribute that marks methods in snapshot memo.
- Added docs for optimistic usage and updated action/click docs.
- Added JS and PHP tests for optimistic detection, rollback behavior, and attribute memoing.

## Safety/compatibility
- Fully opt-in behavior.
- No changes for existing actions unless optimistic mode is explicitly used.
