### PR TITLE
[4.x] Add offline action queueing for Livewire actions

### DIFF
--- a/docs/__nav.md
+++ b/docs/__nav.md
@@ -63,6 +63,7 @@ PHP Attributes:
     Locked: { uri: /docs/4.x/attribute-locked, file: /attribute-locked.md }
     Modelable: { uri: /docs/4.x/attribute-modelable, file: /attribute-modelable.md }
     On: { uri: /docs/4.x/attribute-on, file: /attribute-on.md }
+    QueueOffline: { uri: /docs/4.x/attribute-queue-offline, file: /attribute-queue-offline.md }
     Reactive: { uri: /docs/4.x/attribute-reactive, file: /attribute-reactive.md }
     Renderless: { uri: /docs/4.x/attribute-renderless, file: /attribute-renderless.md }
     Session: { uri: /docs/4.x/attribute-session, file: /attribute-session.md }

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -889,6 +889,54 @@ new class extends Component {
 
 Because the suggestions are stored purely in Alpine's `suggestions` data and never in Livewire's component state, it's safe to fetch them asynchronously.
 
+## Queueing actions while offline
+
+For actions that should wait until connectivity is restored, use `#[QueueOffline]` or `.offline.queue`.
+
+### Using the offline queue modifier
+
+Add `.offline.queue` to any action listener:
+
+```blade
+<button wire:click.offline.queue="saveDraft">Save Draft</button>
+```
+
+If the browser is offline, Livewire defers this action and replays it automatically when the browser comes back online.
+
+### Using the QueueOffline attribute
+
+Mark a method with `#[QueueOffline]` to make all calls to that action offline-queue aware:
+
+```php
+<?php
+
+use Livewire\Attributes\QueueOffline;
+use Livewire\Component;
+
+new class extends Component {
+    #[QueueOffline]
+    public function saveDraft()
+    {
+        // Persist draft...
+    }
+};
+```
+
+```blade
+<button wire:click="saveDraft">Save Draft</button>
+```
+
+### When to use offline queueing
+
+- Draft-saving or progress-saving actions users expect not to lose
+- Low-risk write operations that can be replayed safely after reconnect
+
+### Important behavior notes
+
+- Offline queued actions are kept in browser memory and replayed when the page is still open
+- If the page is refreshed or closed before reconnecting, queued actions are lost
+- Prefer idempotent server handlers for replayed actions
+
 ## Preserving scroll position
 
 When updating content, the browser may jump to a different scroll position. The `.preserve-scroll` modifier maintains the current scroll position during updates:

--- a/docs/attribute-queue-offline.md
+++ b/docs/attribute-queue-offline.md
@@ -1,0 +1,54 @@
+The `#[QueueOffline]` attribute marks an action so Livewire queues it when the browser is offline, then replays it automatically once the connection returns.
+
+## Basic usage
+
+Apply `#[QueueOffline]` to any action that should wait for reconnection instead of failing immediately:
+
+```php
+<?php // resources/views/components/post/⚡editor.blade.php
+
+use Livewire\Attributes\QueueOffline;
+use Livewire\Component;
+
+new class extends Component {
+    #[QueueOffline]
+    public function saveDraft()
+    {
+        // Persist draft...
+    }
+};
+```
+
+```blade
+<button wire:click="saveDraft">Save Draft</button>
+```
+
+When the user clicks this while offline, Livewire defers the request and sends it automatically after reconnecting.
+
+## Modifier alternative
+
+Instead of annotating the method, you can apply offline queueing at call-site with `.offline.queue`:
+
+```blade
+<button wire:click.offline.queue="saveDraft">Save Draft</button>
+```
+
+Use this when you want some calls to be offline-queued and others to run normally.
+
+## When to use
+
+Use `#[QueueOffline]` for actions where delayed execution is better than immediate failure:
+
+- Draft autosave and form-progress saves
+- Non-destructive preference updates
+- User-intent actions that should survive brief connectivity drops
+
+## Important notes
+
+- Queued actions are held in browser memory and replayed when the page is still open
+- Refreshing or closing the page before reconnecting clears queued actions
+- Keep handlers idempotent so replayed actions are safe
+
+## Learn more
+
+See [Actions](/docs/4.x/actions#queueing-actions-while-offline) and [wire:offline](/docs/4.x/wire-offline).

--- a/docs/wire-click.md
+++ b/docs/wire-click.md
@@ -77,6 +77,16 @@ By default, Livewire queues actions within the same component. Use `.async` to a
 <button wire:click.async="process">Process</button>
 ```
 
+## Queueing while offline
+
+Use `.offline.queue` to hold an action while the browser has no network connection, then send it automatically when the connection returns:
+
+```blade
+<button wire:click.offline.queue="saveDraft">Save Draft</button>
+```
+
+This is useful for actions users expect to "stick" even when they temporarily lose connectivity.
+
 ## Going deeper
 
 The `wire:click` directive is just one of many different available event listeners in Livewire. For full documentation on its (and other event listeners) capabilities, visit [the Livewire actions documentation page](/docs/4.x/actions).
@@ -114,3 +124,4 @@ wire:click="methodName(param1, param2)"
 | `.renderless` | Skips re-rendering after action completes |
 | `.preserve-scroll` | Maintains scroll position during updates |
 | `.async` | Executes action in parallel instead of queued |
+| `.offline.queue` | Queues the action while offline and replays it when back online |

--- a/docs/wire-offline.md
+++ b/docs/wire-offline.md
@@ -34,6 +34,16 @@ The `.attr` modifier allows you to add an attribute to an element when the user 
 <button wire:offline.attr="disabled">Save</button>
 ```
 
+## Queueing actions while offline
+
+If you want an action click to be preserved while offline, use the `.offline.queue` action modifier:
+
+```blade
+<button wire:click.offline.queue="saveDraft">Save Draft</button>
+```
+
+Livewire will defer the action while offline and automatically send it when the browser reconnects.
+
 ## Reference
 
 ```blade

--- a/js/directives/wire-wildcard.js
+++ b/js/directives/wire-wildcard.js
@@ -21,6 +21,15 @@ on('directive.init', ({ el, directive, cleanup, component }) => {
         attribute = attribute.replace('.async', '')
     }
 
+    // Strip .offline from Alpine expression because it only concerns Livewire and trips up Alpine...
+    if (directive.modifiers.includes('offline')) {
+        attribute = attribute.replace('.offline', '')
+    }
+
+    // Strip .queue from Alpine expression because it only concerns Livewire and trips up Alpine...
+    if (directive.modifiers.includes('queue')) {
+        attribute = attribute.replace('.queue', '')
+    }
     // Strip .renderless from Alpine expression because it only concerns Livewire and trips up Alpine...
     if (directive.modifiers.includes('renderless')) {
         attribute = attribute.replace('.renderless', '')

--- a/js/features/supportWireSort.js
+++ b/js/features/supportWireSort.js
@@ -33,6 +33,15 @@ Alpine.interceptInit(el => {
                 attribute = attribute.replace('.async', '')
             }
 
+            // Strip .offline from Alpine expression because it only concerns Livewire and trips up Alpine...
+            if (directive.modifiers.includes('offline')) {
+                attribute = attribute.replace('.offline', '')
+            }
+
+            // Strip .queue from Alpine expression because it only concerns Livewire and trips up Alpine...
+            if (directive.modifiers.includes('queue')) {
+                attribute = attribute.replace('.queue', '')
+            }
             // Strip .renderless from Alpine expression because it only concerns Livewire and trips up Alpine...
             if (directive.modifiers.includes('renderless')) {
                 attribute = attribute.replace('.renderless', '')

--- a/js/request/action.js
+++ b/js/request/action.js
@@ -99,6 +99,17 @@ export default class Action {
         return methodIsMarkedAsync || actionIsAsync
     }
 
+    isOfflineQueued() {
+        let offlineQueueMethods = this.component.snapshot.memo?.offlineQueue || []
+
+        let methodIsMarkedOfflineQueue = offlineQueueMethods.includes(this.name)
+
+        let hasOfflineModifier = this.origin?.directive?.modifiers.includes('offline')
+        let hasQueueModifier = this.origin?.directive?.modifiers.includes('queue')
+        let actionIsMarkedOfflineQueue = (hasOfflineModifier && hasQueueModifier) || (!! this.metadata.offlineQueue)
+
+        return methodIsMarkedOfflineQueue || actionIsMarkedOfflineQueue
+    }
     isJson() {
         let jsonMethods = this.component.snapshot.memo?.json || []
 

--- a/js/request/interactions.js
+++ b/js/request/interactions.js
@@ -1,4 +1,5 @@
 import { constructAction, createOrAddToOutstandingMessage, interceptAction, interceptPartition } from '@/request'
+import { queueActionForOffline } from './offlineQueue.js'
 
 export function coordinateNetworkInteractions(messageBus) {
     // Handle isolated components...
@@ -39,6 +40,12 @@ export function coordinateNetworkInteractions(messageBus) {
 
     // If a request is in-flight, queue up the action to fire after the in-flight request has finished...
     interceptAction(({ action }) => {
+        if (action.isOfflineQueued() && ! window.navigator.onLine) {
+            queueActionForOffline(action)
+
+            return
+        }
+
         // Wire:click.renderless
         let isRenderless = action?.origin?.directive?.modifiers.includes('renderless')
         if (isRenderless) {

--- a/js/request/interactions.spec.js
+++ b/js/request/interactions.spec.js
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushOfflineActionQueue, getOfflineActionQueueSize, queueActionForOffline, resetOfflineActionQueue } from './offlineQueue'
+
+function createAction({ cancelled = false } = {}) {
+    return {
+        defer: vi.fn(),
+        fire: vi.fn(),
+        isCancelled: () => cancelled,
+    }
+}
+
+describe('Offline action queue', () => {
+    beforeEach(() => {
+        resetOfflineActionQueue()
+    })
+
+    it('queues actions and marks them deferred', () => {
+        let action = createAction()
+
+        queueActionForOffline(action)
+
+        expect(action.defer).toHaveBeenCalledOnce()
+        expect(getOfflineActionQueueSize()).toBe(1)
+    })
+
+    it('flushes queued actions when back online', () => {
+        let action = createAction()
+
+        queueActionForOffline(action)
+        flushOfflineActionQueue()
+
+        expect(action.fire).toHaveBeenCalledOnce()
+        expect(getOfflineActionQueueSize()).toBe(0)
+    })
+
+    it('skips cancelled actions while flushing', () => {
+        let cancelledAction = createAction({ cancelled: true })
+
+        queueActionForOffline(cancelledAction)
+        flushOfflineActionQueue()
+
+        expect(cancelledAction.fire).not.toHaveBeenCalled()
+    })
+})

--- a/js/request/offlineAction.spec.js
+++ b/js/request/offlineAction.spec.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import Action from './action'
+
+function createComponent(memo = {}) {
+    return {
+        id: 'component-id',
+        snapshot: {
+            memo,
+        },
+    }
+}
+
+describe('Action offline queue detection', () => {
+    it('detects offline queue methods from component memo', () => {
+        let action = new Action(createComponent({ offlineQueue: ['save'] }), 'save')
+
+        expect(action.isOfflineQueued()).toBe(true)
+    })
+
+    it('detects offline.queue modifiers on directive origin', () => {
+        let action = new Action(
+            createComponent(),
+            'save',
+            [],
+            {},
+            { directive: { modifiers: ['offline', 'queue'] } }
+        )
+
+        expect(action.isOfflineQueued()).toBe(true)
+    })
+
+    it('detects offline queue metadata on action', () => {
+        let action = new Action(createComponent(), 'save', [], { offlineQueue: true })
+
+        expect(action.isOfflineQueued()).toBe(true)
+    })
+})

--- a/js/request/offlineQueue.js
+++ b/js/request/offlineQueue.js
@@ -1,0 +1,40 @@
+let offlineActionQueue = []
+let hasRegisteredOfflineListener = false
+
+export function queueActionForOffline(action) {
+    registerOfflineListener()
+
+    action.defer()
+
+    offlineActionQueue.push(action)
+}
+
+export function flushOfflineActionQueue() {
+    let queued = offlineActionQueue
+
+    offlineActionQueue = []
+
+    queued.forEach(action => {
+        if (action.isCancelled()) return
+
+        action.fire()
+    })
+}
+
+export function getOfflineActionQueueSize() {
+    return offlineActionQueue.length
+}
+
+export function resetOfflineActionQueue() {
+    offlineActionQueue = []
+}
+
+function registerOfflineListener() {
+    if (hasRegisteredOfflineListener) return
+
+    hasRegisteredOfflineListener = true
+
+    window.addEventListener('online', () => {
+        flushOfflineActionQueue()
+    })
+}

--- a/src/Attributes/QueueOffline.php
+++ b/src/Attributes/QueueOffline.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Livewire\Features\SupportOfflineQueue\BaseQueueOffline;
+
+#[\Attribute]
+class QueueOffline extends BaseQueueOffline
+{
+    //
+}

--- a/src/Features/SupportOfflineQueue/BaseQueueOffline.php
+++ b/src/Features/SupportOfflineQueue/BaseQueueOffline.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Livewire\Features\SupportOfflineQueue;
+
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
+#[\Attribute]
+class BaseQueueOffline extends LivewireAttribute
+{
+    public function dehydrate($context)
+    {
+        $methodName = $this->getName();
+
+        $context->pushMemo('offlineQueue', $methodName);
+    }
+}

--- a/src/Features/SupportOfflineQueue/UnitTest.php
+++ b/src/Features/SupportOfflineQueue/UnitTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Livewire\Features\SupportOfflineQueue;
+
+use Livewire\Attributes\QueueOffline;
+use Livewire\Livewire;
+use Tests\TestComponent;
+
+class UnitTest extends \Tests\TestCase
+{
+    public function test_queue_offline_attribute_adds_method_to_snapshot_memo()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[QueueOffline]
+            public function save()
+            {
+                //
+            }
+        });
+
+        $this->assertContains('save', data_get($component->snapshot, 'memo.offlineQueue', []));
+    }
+}


### PR DESCRIPTION
## Summary
- adds offline action queueing for component actions
- introduces wire:click.offline.queue so user intent is preserved during brief connectivity loss
- introduces #[QueueOffline] for method-level offline queue behavior
- replays queued actions automatically when the browser reconnects

## Why this helps
- protects draft/progress save flows when users temporarily go offline
- keeps interaction flow predictable without forcing users to retry manually

## Validation
- JS tests for offline queue detection and replay behavior
- PHP test for snapshot memo hydration of #[QueueOffline]
- docs updated for actions, wire:click, wire:offline, and new attribute reference
