### PR TITLE
[4.x] Add `wire:navigate.dirty-confirm` with custom dialog support

### DIFF
--- a/docs/navigate.md
+++ b/docs/navigate.md
@@ -197,6 +197,31 @@ To do this, you must add `wire:navigate:scroll` to the element containing a scro
 @endpersist
 ```
 
+### Confirming before leaving dirty state
+
+When users have unsaved Livewire changes, you can require confirmation before navigating away:
+
+```blade
+<a href="/settings" wire:navigate.dirty-confirm>Settings</a>
+```
+
+Livewire will prompt only when a component on the current page is dirty. If everything is in sync, it navigates immediately.
+
+You can also provide an expression for custom modal flows:
+
+```blade
+<a
+    href="/settings"
+    wire:navigate.dirty-confirm="isOpenDialog = true; pendingUrl = $url"
+>
+    Settings
+</a>
+```
+
+With an expression, Livewire pauses the current navigation and lets your expression decide the UX. You can resume manually (for example from a Tailwind modal) with `Livewire.navigate(pendingUrl)`.
+
+For browser-confirm fallback inside custom flows, call `$fallbackConfirm()`.
+
 ## JavaScript hooks
 
 Each page navigation triggers three lifecycle hooks:

--- a/docs/wire-navigate.md
+++ b/docs/wire-navigate.md
@@ -37,6 +37,42 @@ By adding the `.hover` modifier, Livewire will pre-fetch a page when a user hove
 <a href="/" wire:navigate.hover>Dashboard</a>
 ```
 
+## Confirming when there are unsaved changes
+
+Use `.dirty-confirm` to show a confirmation dialog before navigating away if any Livewire component on the page has unsaved state:
+
+```blade
+<a href="/posts" wire:navigate.dirty-confirm>Posts</a>
+```
+
+If the page is clean, navigation proceeds normally without showing a dialog.
+
+### Using a custom dialog flow
+
+You can provide an expression to `.dirty-confirm` and open your own modal/dialog instead of using the browser confirm:
+
+```blade
+<a
+    href="/posts"
+    wire:navigate.dirty-confirm="isOpenDialog = true; pendingUrl = $url"
+>
+    Posts
+</a>
+```
+
+When an expression is present, Livewire evaluates it and pauses the current navigation. You can then continue later from your custom dialog by calling `Livewire.navigate(pendingUrl)`.
+
+If you still want browser fallback inside your expression, use `$fallbackConfirm()`:
+
+```blade
+<a
+    href="/posts"
+    wire:navigate.dirty-confirm="if ($fallbackConfirm()) Livewire.navigate($url)"
+>
+    Posts
+</a>
+```
+
 ## Going deeper
 
 For more complete documentation on this feature, visit [Livewire's navigate documentation page](/docs/4.x/navigate).
@@ -58,3 +94,4 @@ wire:navigate
 | Modifier | Description |
 |----------|-------------|
 | `.hover` | Prefetches the page when user hovers over the link |
+| `.dirty-confirm` | Prompts before navigating away when Livewire state is dirty |

--- a/js/directives/wire-navigate.js
+++ b/js/directives/wire-navigate.js
@@ -1,25 +1,14 @@
 import Alpine from 'alpinejs'
 
+let supportedNavigateModifiers = ['hover', 'preserve-scroll', 'dirty-confirm']
+
+let wireNavigateAttributes = generateNavigateAttributes()
+
 // Export all wire:navigate variations for use in other files
-export let wireNavigateSelectors = [
-    '[wire\\:navigate]',
-    '[wire\\:navigate\\.hover]',
-    '[wire\\:navigate\\.preserve-scroll]',
-    '[wire\\:navigate\\.preserve-scroll\\.hover]',
-    '[wire\\:navigate\\.hover\\.preserve-scroll]',
-]
+export let wireNavigateSelectors = wireNavigateAttributes.map(attribute => `[${escapeSelectorAttribute(attribute)}]`)
 
 // Combined selector for querying all wire:navigate elements
 export let wireNavigateSelector = wireNavigateSelectors.join(', ')
-
-// Attribute to Alpine directive mapping
-let attributeMap = {
-    'wire:navigate': 'x-navigate',
-    'wire:navigate.hover': 'x-navigate.hover',
-    'wire:navigate.preserve-scroll': 'x-navigate.preserve-scroll',
-    'wire:navigate.preserve-scroll.hover': 'x-navigate.preserve-scroll.hover',
-    'wire:navigate.hover.preserve-scroll': 'x-navigate.hover.preserve-scroll',
-}
 
 // Register all selectors with Alpine
 wireNavigateSelectors.forEach(selector => {
@@ -28,13 +17,15 @@ wireNavigateSelectors.forEach(selector => {
 
 Alpine.interceptInit(
     Alpine.skipDuringClone(el => {
-        // Find which wire:navigate attribute this element has
-        for (let [wireAttr, alpineDirective] of Object.entries(attributeMap)) {
-            if (el.hasAttribute(wireAttr)) {
-                Alpine.bind(el, { [alpineDirective]: true })
-                break
-            }
-        }
+        let wireNavigateAttribute = findNavigateAttribute(el)
+
+        if (! wireNavigateAttribute) return
+
+        let alpineDirective = wireNavigateAttribute.replace('wire:', 'x-')
+        let expression = el.getAttribute(wireNavigateAttribute)
+        let directiveValue = expression === '' ? true : expression
+
+        Alpine.bind(el, { [alpineDirective]: directiveValue })
     })
 )
 
@@ -45,3 +36,51 @@ document.addEventListener('alpine:navigating', () => {
         component.inscribeSnapshotAndEffectsOnElement()
     })
 })
+
+function findNavigateAttribute(el) {
+    return Array
+        .from(el.attributes)
+        .map(attribute => attribute.name)
+        .find(name => name === 'wire:navigate' || name.startsWith('wire:navigate.'))
+}
+
+function generateNavigateAttributes() {
+    let attributes = ['wire:navigate']
+
+    let subsetCount = 2 ** supportedNavigateModifiers.length
+
+    for (let mask = 1; mask < subsetCount; mask++) {
+        let selectedModifiers = supportedNavigateModifiers.filter((_, index) => {
+            return (mask & (1 << index)) !== 0
+        })
+
+        generateModifierPermutations(selectedModifiers).forEach(permutation => {
+            attributes.push(`wire:navigate.${permutation.join('.')}`)
+        })
+    }
+
+    return attributes
+}
+
+function generateModifierPermutations(modifiers) {
+    if (modifiers.length <= 1) return [modifiers]
+
+    let permutations = []
+
+    modifiers.forEach((modifier, index) => {
+        let remainingModifiers = modifiers.filter((_, remainingIndex) => remainingIndex !== index)
+        let subPermutations = generateModifierPermutations(remainingModifiers)
+
+        subPermutations.forEach(subPermutation => {
+            permutations.push([modifier, ...subPermutation])
+        })
+    })
+
+    return permutations
+}
+
+function escapeSelectorAttribute(attribute) {
+    return attribute
+        .replaceAll(':', '\\:')
+        .replaceAll('.', '\\.')
+}

--- a/js/plugins/navigate/index.spec.js
+++ b/js/plugins/navigate/index.spec.js
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { hasDirtyLivewireComponents, shouldProceedWithDirtyNavigationConfirmation } from './index'
+
+let originalLivewire = window.Livewire
+let originalConfirm = window.confirm
+
+afterEach(() => {
+    window.Livewire = originalLivewire
+    window.confirm = originalConfirm
+})
+
+describe('Navigate dirty confirmation', () => {
+    it('does not trigger confirmation when no component is dirty', () => {
+        window.Livewire = {
+            all: () => [{ canonical: { title: 'A' }, reactive: { title: 'A' } }],
+        }
+        window.confirm = vi.fn(() => false)
+
+        expect(hasDirtyLivewireComponents()).toBe(false)
+        expect(shouldProceedWithDirtyNavigationConfirmation()).toBe(true)
+        expect(window.confirm).not.toHaveBeenCalled()
+    })
+
+    it('triggers confirmation when at least one component is dirty', () => {
+        window.Livewire = {
+            all: () => [
+                { canonical: { title: 'A' }, reactive: { title: 'A' } },
+                { canonical: { title: 'A' }, reactive: { title: 'B' } },
+            ],
+        }
+        window.confirm = vi.fn(() => false)
+
+        expect(hasDirtyLivewireComponents()).toBe(true)
+        expect(shouldProceedWithDirtyNavigationConfirmation()).toBe(false)
+        expect(window.confirm).toHaveBeenCalledOnce()
+    })
+
+    it('runs custom expression and cancels by default when dirty', () => {
+        let evaluate = vi.fn()
+
+        window.Livewire = {
+            all: () => [{ canonical: { title: 'A' }, reactive: { title: 'B' } }],
+        }
+        window.confirm = vi.fn(() => true)
+
+        let result = shouldProceedWithDirtyNavigationConfirmation({
+            expression: 'isOpenDialog = true',
+            evaluate,
+            destination: new URL('https://example.com/posts'),
+        })
+
+        expect(result).toBe(false)
+        expect(evaluate).toHaveBeenCalledOnce()
+        expect(window.confirm).not.toHaveBeenCalled()
+    })
+
+    it('allows browser fallback confirmation inside custom expression', () => {
+        let evaluate = vi.fn((expression, { scope }) => {
+            scope.$fallbackConfirm()
+        })
+
+        window.Livewire = {
+            all: () => [{ canonical: { title: 'A' }, reactive: { title: 'B' } }],
+        }
+        window.confirm = vi.fn(() => true)
+
+        let result = shouldProceedWithDirtyNavigationConfirmation({
+            expression: 'if (needsFallback) $fallbackConfirm()',
+            evaluate,
+            destination: new URL('https://example.com/posts'),
+        })
+
+        expect(result).toBe(true)
+        expect(window.confirm).toHaveBeenCalledOnce()
+    })
+})


### PR DESCRIPTION
## Summary
- adds `wire:navigate.dirty-confirm` to protect users from accidentally leaving pages with unsaved changes
- supports custom modal flows by allowing an inline expression (for example opening a Tailwind dialog)
- keeps browser confirm as the default behavior and provides a fallback helper for custom flows

## Why this helps
- prevents accidental data loss in forms and editing screens
- lets teams use their own dialog UX while keeping navigation safety built in
- reduces repetitive hand-rolled unsaved-change handling across applications

## Validation
- JS tests for dirty detection, custom-expression behavior, and browser fallback behavior
- browser tests for both default confirm flow and custom dialog flow
- dist assets rebuilt
