### PR TITLE
[4.x] Fix $-prefixed expressions not routing to Livewire inside Alpine scope

### DIFF
--- a/js/evaluator.js
+++ b/js/evaluator.js
@@ -9,7 +9,7 @@ function getAlpineScopeKeys(el) {
         if (currentEl._x_dataStack) {
             for (let scope of currentEl._x_dataStack) {
                 for (let key of Object.keys(scope)) {
-                    if (! keys.includes(key)) keys.push(key)
+                    if (! keys.includes(key) && ! key.startsWith('$')) keys.push(key)
                 }
             }
         }

--- a/js/evaluator.spec.js
+++ b/js/evaluator.spec.js
@@ -70,6 +70,16 @@ describe('Contextualize expressions', () => {
         expect(contextualizeExpression('other', childEl)).toBe('$wire.other')
     })
 
+    it('$-prefixed alpine scope keys are not skipped', () => {
+        let mockEl = {
+            _x_dataStack: [{ $set: () => {} }],
+            hasAttribute: () => false,
+            parentElement: null,
+        }
+
+        expect(contextualizeExpression("$set('foo', 'bar')", mockEl)).toBe('$wire.$set(\'foo\', \'bar\')')
+    })
+
     it('stops at livewire component root', () => {
         let rootEl = {
             _x_dataStack: [{ outsideVar: {} }],

--- a/src/Features/SupportJsEvaluation/BrowserTest.php
+++ b/src/Features/SupportJsEvaluation/BrowserTest.php
@@ -317,4 +317,28 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertScript('JSON.parse(window.selectedUser).name === "Bob"')
         ;
     }
+
+    public function test_dollar_prefixed_wire_methods_work_inside_alpine_scope()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $value = 'initial';
+
+                public function render() {
+                    return <<<'HTML'
+                        <div>
+                            <div x-data="{ $set: () => {}, $get: () => {} }">
+                                <button wire:click="$set('value', 'updated')" dusk="button">Click</button>
+                            </div>
+                            <span dusk="output" x-text="$wire.value"></span>
+                        </div>
+                    HTML;
+                }
+            }
+        )
+        ->assertSeeIn('@output', 'initial')
+        ->waitForLivewire()->click('@button')
+        ->assertSeeIn('@output', 'updated')
+        ;
+    }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes. This fixes a regression in 4.2 where $-prefixed expressions (like $set, $toggle) inside Alpine scope get intercepted instead of routing to Livewire. Reported in            
  filamentphp/filament#19354.       

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No


4️⃣ Does it include tests? (Required)

Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

                                                                                                                                                                                   
  getAlpineScopeKeys() in the evaluator was collecting $-prefixed keys (like $set, $get) from Alpine's data stack. This caused expressions like $set('foo', 'bar') to be treated as
   Alpine scope calls instead of being contextualized to $wire.$set('foo', 'bar').                                                                                                 
                                                                                                                                                                                   
  Fix: skip keys starting with $ when collecting Alpine scope keys.

```js
  // before
  if (! keys.includes(key)) keys.push(key)

  // after
  if (! keys.includes(key) && ! key.startsWith('$')) keys.push(key)
```