### PR TITLE
Fix $set/$get not routing to Livewire when Alpine plugins expose $-prefixed data stack keys

### DIFF
--- a/js/evaluator.js
+++ b/js/evaluator.js
@@ -9,7 +9,7 @@ function getAlpineScopeKeys(el) {
         if (currentEl._x_dataStack) {
             for (let scope of currentEl._x_dataStack) {
                 for (let key of Object.keys(scope)) {
-                    if (! keys.includes(key)) keys.push(key)
+                    if (! keys.includes(key) && ! key.startsWith('$')) keys.push(key)
                 }
             }
         }

--- a/js/evaluator.spec.js
+++ b/js/evaluator.spec.js
@@ -84,8 +84,27 @@ describe('Contextualize expressions', () => {
         expect(contextualizeExpression("$set('foo', 'bar')", mockEl)).toBe("$wire.$set('foo', 'bar')")
         // $get should also route to $wire.$get
         expect(contextualizeExpression("$get('foo')", mockEl)).toBe("$wire.$get('foo')")
+        // $toggle should also route to $wire.$toggle
+        expect(contextualizeExpression("$toggle('active')", mockEl)).toBe("$wire.$toggle('active')")
         // Regular Alpine keys should still be skipped (not prefixed)
         expect(contextualizeExpression('open', mockEl)).toBe('open')
+    })
+
+    it('$-prefixed keys on parent scope should not prevent $wire prefixing', () => {
+        let parentEl = {
+            _x_dataStack: [{ $set: () => {}, $get: () => {} }],
+            hasAttribute: () => false,
+            parentElement: null,
+        }
+
+        let childEl = {
+            _x_dataStack: [{ item: {} }],
+            hasAttribute: () => false,
+            parentElement: parentEl,
+        }
+
+        expect(contextualizeExpression("$set('foo', 'bar')", childEl)).toBe("$wire.$set('foo', 'bar')")
+        expect(contextualizeExpression('item', childEl)).toBe('item')
     })
 
     it('stops at livewire component root', () => {

--- a/js/evaluator.spec.js
+++ b/js/evaluator.spec.js
@@ -70,6 +70,24 @@ describe('Contextualize expressions', () => {
         expect(contextualizeExpression('other', childEl)).toBe('$wire.other')
     })
 
+    it('$-prefixed Alpine scope keys should not prevent $wire prefixing', () => {
+        // When Alpine plugins (e.g. Filament) expose $set/$get on the data stack,
+        // those $-prefixed keys should NOT be added to the SKIP list.
+        // Livewire's $set must still be contextualized to $wire.$set.
+        let mockEl = {
+            _x_dataStack: [{ open: true, $set: () => {}, $get: () => {} }],
+            hasAttribute: () => false,
+            parentElement: null,
+        }
+
+        // $set should route to $wire.$set, not Alpine's $set
+        expect(contextualizeExpression("$set('foo', 'bar')", mockEl)).toBe("$wire.$set('foo', 'bar')")
+        // $get should also route to $wire.$get
+        expect(contextualizeExpression("$get('foo')", mockEl)).toBe("$wire.$get('foo')")
+        // Regular Alpine keys should still be skipped (not prefixed)
+        expect(contextualizeExpression('open', mockEl)).toBe('open')
+    })
+
     it('stops at livewire component root', () => {
         let rootEl = {
             _x_dataStack: [{ outsideVar: {} }],


### PR DESCRIPTION
## The Reproduction

- You have a Livewire component with `wire:click="$set('value', 'updated')"` 
- The element sits inside an Alpine scope where a plugin (e.g. Filament) has put `$set` or `$get` on the `_x_dataStack`
- Expected: `$set(...)` calls Livewire's `$wire.$set(...)`
- Actual: `$set(...)` stays unrewritten and routes to Alpine's `$set` instead
- The Livewire action silently never fires

## The Problem

Livewire's `contextualizeExpression()` rewrites expressions like `$set('foo', 'bar')` into `$wire.$set('foo', 'bar')` — but it maintains a SKIP list of identifiers that should **not** be rewritten.

Before rewriting, it calls `getAlpineScopeKeys(el)` and adds those keys to the SKIP list. This is correct for regular Alpine data keys (e.g. `open`, `count`) — you don't want those prefixed with `$wire.`.

The bug: `getAlpineScopeKeys` collects **all** keys from Alpine's `_x_dataStack`, including `$`-prefixed ones like `$set`, `$get`, and `$toggle`. When Alpine plugins put these on the data stack, they land in the SKIP list, and Livewire's own `$set` never gets its `$wire.` prefix.

## Chosen Solution

Filter `$`-prefixed keys out of the Alpine scope collection — a single added condition on one line:

```js
// Before:
if (! keys.includes(key)) keys.push(key)

// After:
if (! keys.includes(key) && ! key.startsWith('$')) keys.push(key)
```

This is the right fix because `$`-prefixed keys on Alpine's `_x_dataStack` are **never** user-defined data — they're always framework magics or plugin-injected helpers. Alpine's own built-in magics (like `$el`, `$refs`) are non-enumerable and already invisible to `Object.keys()`. The only `$`-prefixed keys that show up are from plugins using an unconventional pattern, and Livewire should always own the `$` → `$wire.` rewriting for these.

## Other Solutions Explored

- **Hardcode known Livewire magics in a blocklist** — Explicitly un-skip `$set`, `$toggle`, `$refresh`, etc. after merging Alpine scope keys. Rejected because it creates a maintenance burden: every new Livewire magic would need adding to the list.
- **Register Livewire methods as Alpine magics with higher priority** — Livewire could use `Alpine.magic()` so `$set` always resolves to Livewire in `wire:` contexts. Correct in spirit but a major refactor of the evaluation pipeline — a v4-scale change.
- **Fix in individual Alpine plugins (e.g. Filament)** — Plugins could stop putting `$set`/`$get` on `_x_dataStack` and use `Alpine.magic()` instead. This would fix it for one plugin but not the root cause — any plugin using the same pattern would trigger the bug again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)