### PR TITLE
[4.x] Add backward-compatibility shim for removed `processElementKey()` method

### DIFF
--- a/src/Features/SupportCompiledWireKeys/SupportCompiledWireKeys.php
+++ b/src/Features/SupportCompiledWireKeys/SupportCompiledWireKeys.php
@@ -125,6 +125,23 @@ class SupportCompiledWireKeys extends ComponentHook
         return "'".$value."'";
     }
 
+    /**
+     * Backward-compatibility shim for cached compiled Blade views that still
+     * reference this method from before the smart keys optimisation in v4.2.
+     *
+     * TODO: Remove in v5.
+     */
+    public static function processElementKey($keyString, $data)
+    {
+        if (view()->exists($keyString)) {
+            $key = $keyString;
+        } else {
+            $key = Blade::render($keyString, $data);
+        }
+
+        static::$currentLoop['key'] = $key;
+    }
+
     public static function processComponentKey($component)
     {
         if ($component->attributes->has('wire:key')) {

--- a/src/Features/SupportCompiledWireKeys/UnitTest.php
+++ b/src/Features/SupportCompiledWireKeys/UnitTest.php
@@ -901,6 +901,19 @@ class UnitTest extends \Tests\TestCase
         );
     }
 
+    public function test_deprecated_process_element_key_shim_still_sets_current_loop_key()
+    {
+        SupportCompiledWireKeys::$currentLoop = [
+            'count' => null,
+            'index' => null,
+            'key' => null,
+        ];
+
+        SupportCompiledWireKeys::processElementKey('{{ $foo }}', ['foo' => 'bar']);
+
+        $this->assertEquals('bar', SupportCompiledWireKeys::$currentLoop['key']);
+    }
+
     #[DataProvider('elementsTestProvider')]
     public function test_we_can_correctly_find_wire_keys_on_elements_only_but_not_blade_or_livewire_components($occurrences, $template)
     {


### PR DESCRIPTION
# The Scenario

After upgrading Livewire to v4.2, applications get a 500 error if they have cached compiled Blade views from before the upgrade:

```
Call to undefined method Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::processElementKey()
```

# The Problem

The smart keys optimisation in #9987 changed how `wire:key` expressions on elements are compiled. Before, the compiled Blade output called `processElementKey()` at runtime:

```php
<?php \Livewire\...\SupportCompiledWireKeys::processElementKey('{$escapedKey}', get_defined_vars()); ?>
```

After, it directly assigns the key expression (compiled at Blade compile-time):

```php
<?php \Livewire\...\SupportCompiledWireKeys::$currentLoop['key'] = {$keyExpression}; ?>
```

The optimisation is valid, but the `processElementKey()` method was removed entirely. Since `composer update` doesn't clear the view cache, cached compiled views from before the upgrade will call a method that no longer exists.

# The Solution

Restore `processElementKey()` as a backward-compatibility shim. The method is functionally identical to the original, so cached views continue to work. Newly compiled views use the optimised direct assignment. Once the view cache is cleared (on deployment, `php artisan view:clear`, etc.), the old references are gone.

The shim is marked with a `TODO: Remove in v5.` comment.

Fixes #10065