### PR TITLE
[4.x] Fix client-side diff losing associative array key insertion order

### DIFF
--- a/js/diff.spec.js
+++ b/js/diff.spec.js
@@ -32,6 +32,33 @@ describe('diff (legacy)', () => {
             'items.3': '__rm__'
         })
     })
+
+    it('detects key order changes in objects', () => {
+        expect(diff(
+            { items: { a: 1, b: 2 } },
+            { items: { b: 2, a: 1 } }
+        )).toEqual({
+            items: { b: 2, a: 1 }
+        })
+    })
+
+    it('consolidates object when key is inserted in middle', () => {
+        expect(diff(
+            { items: { a: 1, b: 2, c: 3 } },
+            { items: { a: 1, new: 'NEW', b: 2, c: 3 } }
+        )).toEqual({
+            items: { a: 1, new: 'NEW', b: 2, c: 3 }
+        })
+    })
+
+    it('does not consolidate object when key is appended at end', () => {
+        expect(diff(
+            { items: { a: 1, b: 2 } },
+            { items: { a: 1, b: 2, c: 3 } }
+        )).toEqual({
+            'items.c': 3
+        })
+    })
 })
 
 describe('diffAndConsolidate', () => {
@@ -308,6 +335,15 @@ describe('diffAndConsolidate', () => {
             { data: { b: 3, a: 1 } }
         )).toEqual({
             data: { b: 3, a: 1 }
+        })
+    })
+
+    it('consolidates object when key is inserted in middle', () => {
+        expect(diffAndConsolidate(
+            { items: { a: 1, b: 2, c: 3 } },
+            { items: { a: 1, new: 'NEW', b: 2, c: 3 } }
+        )).toEqual({
+            items: { a: 1, new: 'NEW', b: 2, c: 3 }
         })
     })
 })

--- a/js/utils.js
+++ b/js/utils.js
@@ -181,8 +181,8 @@ export function diff(left, right, diffs = {}, path = '') {
     let leftKeys = Object.keys(left)
     let rightKeys = Object.keys(right)
 
-    // Did the key order change?
-    if (isObject(left) && leftKeys.length === rightKeys.length && leftKeys.some((key, i) => key !== rightKeys[i])) {
+    // Did the key order change? (includes insertions that shift existing keys)
+    if (isObject(left) && leftKeys.some((key, i) => key !== rightKeys[i])) {
         diffs[path] = right
         return diffs
     }

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -317,6 +317,38 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    function test_wire_data_reflects_key_insertion_order()
+    {
+        Livewire::visit(new class extends Component {
+            public $items = [
+                'a' => 'A',
+                'b' => 'B',
+                'c' => 'C',
+            ];
+
+            public function insertBetween()
+            {
+                $before = array_slice($this->items, 0, 1, true);
+                $after = array_slice($this->items, 1, null, true);
+                $this->items = $before + ['new' => 'NEW'] + $after;
+            }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <button wire:click="insertBetween" dusk="insert">Insert</button>
+                        <span dusk="keys" x-text="Object.keys($wire.items).join(',')"></span>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertSeeIn('@keys', 'a,b,c')
+            ->waitForLivewire()->click('@insert')
+            ->assertSeeIn('@keys', 'a,new,b,c')
+        ;
+    }
+
     public function test_multiple_wire_set_calls_to_empty_string_are_all_sent_to_server()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
# The Scenario

When inserting a new key into the middle of an associative array server-side, the key appears at the end of the client-side `$wire` state after the Livewire response is applied. The server renders the correct order, but the next round-trip sends the wrong key order back because the client-side state has drifted.

This works on v4.1.4 but breaks on v4.2.0.

```php
<?php

use Livewire\Volt\Component;
use Illuminate\Support\Str;

new class extends Component {
    public array $items = [];

    public function mount(): void
    {
        $this->items = [
            Str::uuid()->toString() => 'A',
            Str::uuid()->toString() => 'B',
            Str::uuid()->toString() => 'C',
        ];
    }

    public function insertBetween(): void
    {
        $before = array_slice($this->items, 0, 1, true);
        $after = array_slice($this->items, 1, null, true);
        $this->items = $before + [Str::uuid()->toString() => 'NEW'] + $after;
    }
}; ?>

<div>
    <ol>
        @foreach ($items as $item)
            <li>{{ $item }}</li>
        @endforeach
    </ol>

    <button wire:click="insertBetween">Insert between A and B</button>
</div>
```

# The Problem

The `diff()` function in `js/utils.js` has a key-order detection check that only fires when the key count is identical:

```js
if (isObject(left) && leftKeys.length === rightKeys.length && leftKeys.some((key, i) => key !== rightKeys[i])) {
```

When a new key is **inserted** (changing the count), the `leftKeys.length === rightKeys.length` guard is false, so the function falls through to granular per-key diffing. It returns something like `{ 'items.newUuid': 'NEW' }`, which is then applied via `dataSet()` in `mergeNewSnapshot()`. Since `dataSet()` appends new properties at the end of the existing object, the key ends up at the wrong position in the client-side state.

# The Solution

Remove the `leftKeys.length === rightKeys.length` guard from the condition. The remaining check (`leftKeys.some((key, i) => key !== rightKeys[i])`) compares each existing key's position against the new object. If any existing key has shifted (because something was inserted before it), the function consolidates to the parent level, replacing the entire object and preserving key order.

Appending to the end still produces efficient granular diffs because existing keys remain at their original positions, so the `some()` check returns false.

Fixes #10066