### PR TITLE
[4.x] Add View Transitions API support for wire:navigate

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -195,6 +195,7 @@ return [
     'navigate' => [
         'show_progress_bar' => true,
         'progress_bar_color' => '#2299dd',
+        'view_transitions' => false,
     ],
 
     /*

--- a/js/directives/wire-navigate.js
+++ b/js/directives/wire-navigate.js
@@ -7,19 +7,15 @@ export let wireNavigateSelectors = [
     '[wire\\:navigate\\.preserve-scroll]',
     '[wire\\:navigate\\.preserve-scroll\\.hover]',
     '[wire\\:navigate\\.hover\\.preserve-scroll]',
+    '[wire\\:navigate\\.transition]',
+    '[wire\\:navigate\\.hover\\.transition]',
+    '[wire\\:navigate\\.transition\\.hover]',
+    '[wire\\:navigate\\.preserve-scroll\\.transition]',
+    '[wire\\:navigate\\.transition\\.preserve-scroll]',
 ]
 
 // Combined selector for querying all wire:navigate elements
 export let wireNavigateSelector = wireNavigateSelectors.join(', ')
-
-// Attribute to Alpine directive mapping
-let attributeMap = {
-    'wire:navigate': 'x-navigate',
-    'wire:navigate.hover': 'x-navigate.hover',
-    'wire:navigate.preserve-scroll': 'x-navigate.preserve-scroll',
-    'wire:navigate.preserve-scroll.hover': 'x-navigate.preserve-scroll.hover',
-    'wire:navigate.hover.preserve-scroll': 'x-navigate.hover.preserve-scroll',
-}
 
 // Register all selectors with Alpine
 wireNavigateSelectors.forEach(selector => {
@@ -28,13 +24,11 @@ wireNavigateSelectors.forEach(selector => {
 
 Alpine.interceptInit(
     Alpine.skipDuringClone(el => {
-        // Find which wire:navigate attribute this element has
-        for (let [wireAttr, alpineDirective] of Object.entries(attributeMap)) {
-            if (el.hasAttribute(wireAttr)) {
-                Alpine.bind(el, { [alpineDirective]: true })
-                break
-            }
-        }
+        let attr = Array.from(el.getAttributeNames()).find(a => a.startsWith('wire:navigate'))
+
+        if (! attr) return
+
+        Alpine.bind(el, { [attr.replace('wire:', 'x-')]: true })
     })
 )
 

--- a/js/directives/wire-navigate.js
+++ b/js/directives/wire-navigate.js
@@ -12,6 +12,12 @@ export let wireNavigateSelectors = [
     '[wire\\:navigate\\.transition\\.hover]',
     '[wire\\:navigate\\.preserve-scroll\\.transition]',
     '[wire\\:navigate\\.transition\\.preserve-scroll]',
+    '[wire\\:navigate\\.hover\\.preserve-scroll\\.transition]',
+    '[wire\\:navigate\\.hover\\.transition\\.preserve-scroll]',
+    '[wire\\:navigate\\.preserve-scroll\\.hover\\.transition]',
+    '[wire\\:navigate\\.preserve-scroll\\.transition\\.hover]',
+    '[wire\\:navigate\\.transition\\.hover\\.preserve-scroll]',
+    '[wire\\:navigate\\.transition\\.preserve-scroll\\.hover]',
 ]
 
 // Combined selector for querying all wire:navigate elements

--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -22,70 +22,41 @@ function clearTransitionNames(root) {
     })
 }
 
-export async function transitionDomMutation(fromEl, toEl, callback, options = {}) {
-    // Skip transitions entirely if requested...
-    if (options.skip) return callback()
-
-    // Only transition if there is a [wire:transition] element within either the from or to elements...
-    if (! fromEl.querySelector('[wire\\:transition]') && ! toEl.querySelector('[wire\\:transition]')) return callback()
-
-    // Check if View Transitions API is supported...
-    if (typeof document.startViewTransition !== 'function') {
-        return callback()
+let viewTransitionStyles = `
+    @media (prefers-reduced-motion: reduce) {
+        ::view-transition-group(*), ::view-transition-old(*), ::view-transition-new(*) {
+            animation: none !important;
+        }
     }
 
-    // Skip entirely if a modal dialog is already open (transitions behind
-    // a dialog are invisible to the user and the ::view-transition pseudo-
-    // elements would paint above the dialog during animation)...
-    if (document.querySelector('dialog:modal')) return callback()
+    ::view-transition-old(root) {
+        animation: none !important;
+        opacity: 0 !important;
+    }
 
-    // Set transition names right before the transition starts (not permanently)...
-    setTransitionNames(fromEl)
+    ::view-transition-new(root) {
+        animation: none !important;
+        opacity: 1 !important;
+    }
+`
 
-    // Disable root transitions for the page...
+// Handles the view transition ceremony: CSS injection, try/catch for
+// Firefox compat, dialog skip observer, and cleanup...
+export function performViewTransition({ root, update, types }) {
+    setTransitionNames(root)
+
     let style = document.createElement('style')
-
-    style.textContent = `
-        @media (prefers-reduced-motion: reduce) {
-            ::view-transition-group(*), ::view-transition-old(*), ::view-transition-new(*) {
-                animation: none !important;
-            }
-        }
-
-        ::view-transition-old(root) {
-            animation: none !important;
-            opacity: 0 !important;
-        }
-
-        ::view-transition-new(root) {
-            animation: none !important;
-            opacity: 1 !important;
-        }
-    `
-
+    style.textContent = viewTransitionStyles
     document.head.appendChild(style)
 
-    let update = () => {
-        callback()
-
-        // After a morph, newly added wire:transition elements need their viewTransitionName
-        // set synchronously. Alpine's MutationObserver would normally handle this, but its
-        // internal queueMicrotask batching delays processing by one microtask hop — and the
-        // View Transitions API's "activate" step captures the new DOM state in between,
-        // before Alpine has a chance to initialize the directive...
-        setTransitionNames(fromEl)
-    }
-
-    let transitionConfig = { update }
-
-    // Add transition types if provided...
-    if (options.type) {
-        transitionConfig.types = [options.type]
+    let wrappedUpdate = () => {
+        update()
+        setTransitionNames(root)
     }
 
     let cleanup = () => {
         style.remove()
-        clearTransitionNames(fromEl)
+        clearTransitionNames(root)
     }
 
     // Watch for modal dialogs opening during the transition (e.g., via Alpine x-effect).
@@ -110,6 +81,12 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
         transition.finished.finally(() => observer.disconnect())
     }
 
+    let transitionConfig = { update: wrappedUpdate }
+
+    if (types) {
+        transitionConfig.types = types
+    }
+
     try {
         let transition = document.startViewTransition(transitionConfig)
 
@@ -117,15 +94,41 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
 
         transition.finished.finally(cleanup)
 
-        await transition.updateCallbackDone
+        return transition
     } catch (e) {
-        // Firefox 144+ supports View Transitions but only with a callback, not a config object (no transition types support)
-        let transition = document.startViewTransition(update)
+        // Firefox 144+ supports View Transitions but only with a callback, not a config object...
+        let transition = document.startViewTransition(wrappedUpdate)
 
         skipOnDialog(transition)
 
         transition.finished.finally(cleanup)
 
-        await transition.updateCallbackDone
+        return transition
     }
+}
+
+export async function transitionDomMutation(fromEl, toEl, callback, options = {}) {
+    // Skip transitions entirely if requested...
+    if (options.skip) return callback()
+
+    // Only transition if there is a [wire:transition] element within either the from or to elements...
+    if (! fromEl.querySelector('[wire\\:transition]') && ! toEl.querySelector('[wire\\:transition]')) return callback()
+
+    // Check if View Transitions API is supported...
+    if (typeof document.startViewTransition !== 'function') {
+        return callback()
+    }
+
+    // Skip entirely if a modal dialog is already open (transitions behind
+    // a dialog are invisible to the user and the ::view-transition pseudo-
+    // elements would paint above the dialog during animation)...
+    if (document.querySelector('dialog:modal')) return callback()
+
+    let transition = performViewTransition({
+        root: fromEl,
+        update: callback,
+        types: options.type ? [options.type] : undefined,
+    })
+
+    await transition.updateCallbackDone
 }

--- a/js/features/supportNavigate.js
+++ b/js/features/supportNavigate.js
@@ -1,5 +1,6 @@
 document.addEventListener('livewire:initialized', () => {
     shouldHideProgressBar() && Alpine.navigate.disableProgressBar()
+    shouldEnableViewTransitions() && Alpine.navigate.enableViewTransitions()
 })
 
 document.addEventListener('alpine:navigate', e => forwardEvent('livewire:navigate', e))
@@ -30,6 +31,14 @@ function shouldHideProgressBar() {
     if (!! document.querySelector('[data-no-progress-bar]')) return true
 
     if (window.livewireScriptConfig && window.livewireScriptConfig.progressBar === 'data-no-progress-bar') return true
+
+    return false
+}
+
+function shouldEnableViewTransitions() {
+    if (!! document.querySelector('[data-navigate-view-transitions]')) return true
+
+    if (window.livewireScriptConfig && window.livewireScriptConfig.viewTransitions) return true
 
     return false
 }

--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -8,11 +8,13 @@ import { finishAndHideProgressBar, removeAnyLeftOverStaleProgressBars, showAndSt
 import { packUpPersistedPopovers, unPackPersistedPopovers } from "./popover"
 import { swapCurrentPageWithNewHtml } from "./page"
 import { fetchHtml } from "./fetch"
+import { performViewTransition } from "@/directives/wire-transition"
 
 let enablePersist = true
 let showProgressBar = true
 let restoreScroll = true
 let autofocus = false
+let useViewTransitions = false
 
 export default function (Alpine) {
 
@@ -34,12 +36,18 @@ export default function (Alpine) {
         showProgressBar = false
     }
 
+    Alpine.navigate.enableViewTransitions = () => {
+        useViewTransitions = true
+    }
+
     Alpine.addInitSelector(() => `[${Alpine.prefixed('navigate')}]`)
 
     Alpine.directive('navigate', (el, { modifiers }) => {
         let shouldPrefetchOnHover = modifiers.includes('hover')
 
         let preserveScroll = modifiers.includes('preserve-scroll')
+
+        let transition = modifiers.includes('transition')
 
         shouldPrefetchOnHover && whenThisLinkIsHoveredFor(el, 60, () => {
             let destination = extractDestinationFromLink(el)
@@ -71,12 +79,12 @@ export default function (Alpine) {
 
                 if (prevented) return
 
-                navigateTo(destination, { preserveScroll })
+                navigateTo(destination, { preserveScroll, transition })
             })
         })
     })
 
-    function navigateTo(destination, { preserveScroll = false, shouldPushToHistoryState = true }) {
+    function navigateTo(destination, { preserveScroll = false, transition = false, shouldPushToHistoryState = true }) {
         showProgressBar && showAndStartProgressBar()
 
         fetchHtmlOrUsePrefetchedHtml(destination, (html, finalDestination) => {
@@ -108,29 +116,31 @@ export default function (Alpine) {
                     replaceUrl(finalDestination, html)
                 }
 
-                swapCurrentPageWithNewHtml(html, (afterNewScriptsAreDoneLoading) => {
-                    removeAnyLeftOverStaleTeleportTargets(document.body)
+                transitionPage(transition, () => {
+                    swapCurrentPageWithNewHtml(html, (afterNewScriptsAreDoneLoading) => {
+                        removeAnyLeftOverStaleTeleportTargets(document.body)
 
-                    enablePersist && putPersistantElementsBack((persistedEl, newStub) => {
-                        unPackPersistedTeleports(persistedEl)
-                        unPackPersistedPopovers(persistedEl)
-                    })
+                        enablePersist && putPersistantElementsBack((persistedEl, newStub) => {
+                            unPackPersistedTeleports(persistedEl)
+                            unPackPersistedPopovers(persistedEl)
+                        })
 
-                    !preserveScroll && restoreScrollPositionOrScrollToTop()
+                        !preserveScroll && restoreScrollPositionOrScrollToTop()
 
-                    // Invoke any callbacks registered via onSwap during the navigating event
-                    swapCallbacks.forEach(callback => callback())
+                        // Invoke any callbacks registered via onSwap during the navigating event
+                        swapCallbacks.forEach(callback => callback())
 
-                    afterNewScriptsAreDoneLoading(() => {
-                        andAfterAllThis(() => {
-                            setTimeout(() => {
-                                autofocus && autofocusElementsWithTheAutofocusAttribute()
+                        afterNewScriptsAreDoneLoading(() => {
+                            andAfterAllThis(() => {
+                                setTimeout(() => {
+                                    autofocus && autofocusElementsWithTheAutofocusAttribute()
+                                })
+
+                                nowInitializeAlpineOnTheNewPage(Alpine)
+
+                                fireEventForOtherLibrariesToHookInto('alpine:navigated')
+                                showProgressBar && finishAndHideProgressBar()
                             })
-
-                            nowInitializeAlpineOnTheNewPage(Alpine)
-
-                            fireEventForOtherLibrariesToHookInto('alpine:navigated')
-                            showProgressBar && finishAndHideProgressBar()
                         })
                     })
                 })
@@ -185,27 +195,30 @@ export default function (Alpine) {
                     packUpPersistedPopovers(persistedEl)
                 })
 
-                swapCurrentPageWithNewHtml(html, () => {
-                    removeAnyLeftOverStaleProgressBars()
+                // No per-link transition; global setting still applies via useViewTransitions...
+                transitionPage(false, () => {
+                    swapCurrentPageWithNewHtml(html, () => {
+                        removeAnyLeftOverStaleProgressBars()
 
-                    removeAnyLeftOverStaleTeleportTargets(document.body)
+                        removeAnyLeftOverStaleTeleportTargets(document.body)
 
-                    enablePersist && putPersistantElementsBack((persistedEl, newStub) => {
-                        unPackPersistedTeleports(persistedEl)
-                        unPackPersistedPopovers(persistedEl)
-                    })
+                        enablePersist && putPersistantElementsBack((persistedEl, newStub) => {
+                            unPackPersistedTeleports(persistedEl)
+                            unPackPersistedPopovers(persistedEl)
+                        })
 
-                    restoreScrollPositionOrScrollToTop()
+                        restoreScrollPositionOrScrollToTop()
 
-                    // Invoke any callbacks registered via onSwap during the navigating event
-                    swapCallbacks.forEach(callback => callback())
+                        // Invoke any callbacks registered via onSwap during the navigating event
+                        swapCallbacks.forEach(callback => callback())
 
-                    andAfterAllThis(() => {
-                        autofocus && autofocusElementsWithTheAutofocusAttribute()
+                        andAfterAllThis(() => {
+                            autofocus && autofocusElementsWithTheAutofocusAttribute()
 
-                        nowInitializeAlpineOnTheNewPage(Alpine)
+                            nowInitializeAlpineOnTheNewPage(Alpine)
 
-                        fireEventForOtherLibrariesToHookInto('alpine:navigated')
+                            fireEventForOtherLibrariesToHookInto('alpine:navigated')
+                        })
                     })
                 })
             })
@@ -216,6 +229,25 @@ export default function (Alpine) {
     // we should fire alpine:navigated as a replacement as well...
     setTimeout(() => {
         fireEventForOtherLibrariesToHookInto('alpine:navigated')
+    })
+}
+
+function transitionPage(perLinkTransition, callback) {
+    let shouldTransition = perLinkTransition || useViewTransitions
+
+    // If view transitions disabled or unsupported, call callback directly...
+    if (! shouldTransition || typeof document.startViewTransition !== 'function') {
+        return callback()
+    }
+
+    // Skip if a modal dialog is open (transitions paint above the dialog)...
+    if (document.querySelector('dialog:modal')) {
+        return callback()
+    }
+
+    performViewTransition({
+        root: document.body,
+        update: callback,
     })
 }
 

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -219,6 +219,8 @@ class FrontendAssets extends Mechanism
 
         $progressBar = config('livewire.navigate.show_progress_bar', true) ? '' : 'data-no-progress-bar';
 
+        $viewTransitions = config('livewire.navigate.view_transitions', false) ? 'data-navigate-view-transitions' : '';
+
         $moduleUrl = url(app('livewire')->getUriPrefix());
 
         $updateUri = url(app('livewire')->getUpdateUri());
@@ -228,7 +230,7 @@ class FrontendAssets extends Mechanism
         );
 
         return <<<HTML
-        {$assetWarning}<script src="{$url}" {$nonce} {$progressBar} data-csrf="{$token}" data-module-url="{$moduleUrl}" data-update-uri="{$updateUri}" {$extraAttributes}></script>
+        {$assetWarning}<script src="{$url}" {$nonce} {$progressBar} {$viewTransitions} data-csrf="{$token}" data-module-url="{$moduleUrl}" data-update-uri="{$updateUri}" {$extraAttributes}></script>
         HTML;
     }
 
@@ -240,12 +242,15 @@ class FrontendAssets extends Mechanism
 
         $progressBar = config('livewire.navigate.show_progress_bar', true) ? '' : 'data-no-progress-bar';
 
+        $viewTransitions = config('livewire.navigate.view_transitions', false);
+
         $attributes = json_encode([
             'csrf' => app()->has('session.store') ? csrf_token() : '',
             'uri' => url(app('livewire')->getUpdateUri()),
             'moduleUrl' => url(app('livewire')->getUriPrefix()),
             'progressBar' => $progressBar,
             'nonce' => isset($options['nonce']) ? $options['nonce'] : '',
+            'viewTransitions' => $viewTransitions,
         ]);
 
         return <<<HTML

--- a/src/Mechanisms/FrontendAssets/UnitTest.php
+++ b/src/Mechanisms/FrontendAssets/UnitTest.php
@@ -66,6 +66,24 @@ class UnitTest extends \Tests\TestCase
         $this->assertEmpty($assets->scripts());
     }
 
+    public function test_scripts_include_navigate_view_transitions_data_attribute_when_enabled()
+    {
+        config()->set('livewire.navigate.view_transitions', true);
+
+        $scripts = app(FrontendAssets::class)->scripts();
+
+        $this->assertStringContainsString('data-navigate-view-transitions', $scripts);
+    }
+
+    public function test_script_config_includes_view_transitions_flag()
+    {
+        config()->set('livewire.navigate.view_transitions', true);
+
+        $scriptConfig = FrontendAssets::scriptConfig();
+
+        $this->assertStringContainsString('"viewTransitions":true', $scriptConfig);
+    }
+
     public function test_use_normal_scripts_url_if_app_debug_is_true()
     {
         config()->set('app.debug', true);


### PR DESCRIPTION
Builds on the work started in #9696 by @joshhanley.

## Summary

- Wraps `wire:navigate` page swaps in `document.startViewTransition()` for smooth CSS-driven transitions between pages
- **Global opt-in** via `livewire.navigate.view_transitions` config (default `false`)
- **Per-link opt-in** via `wire:navigate.transition` modifier
- Elements with `wire:transition="name"` (already supported for component morphs) now animate across full-page navigations too
- Extracts shared `performViewTransition()` helper to eliminate duplication between morph and navigate transitions

## How it works

**Global (all wire:navigate links):**
```php
// config/livewire.php
'navigate' => [
    'view_transitions' => true,
],
```

**Per-link:**
```html
<a href="/dashboard" wire:navigate.transition>Dashboard</a>
```

**Named elements (existing wire:transition):**
```html
<img wire:transition="hero-image" src="...">
<h1 wire:transition="page-title">Title</h1>
```

**Custom CSS animations (user-land):**
```css
::view-transition-old(hero-image) { animation: fade-out 0.3s ease; }
::view-transition-new(hero-image) { animation: fade-in 0.3s ease; }
```

## Files changed

| File | Change |
|------|--------|
| `config/livewire.php` | Add `view_transitions` option to `navigate` config |
| `src/.../FrontendAssets.php` | Pass config to JS via `data-navigate-view-transitions` attribute and `scriptConfig` |
| `js/directives/wire-transition.js` | Extract shared `performViewTransition()` helper; refactor `transitionDomMutation()` to use it |
| `js/features/supportNavigate.js` | Add `shouldEnableViewTransitions()` config detection |
| `js/directives/wire-navigate.js` | Add `.transition` modifier selectors; replace static attribute map with dynamic parsing |
| `js/plugins/navigate/index.js` | Add `transitionPage()` wrapper; wrap forward nav and back/forward swaps |

## Design decisions

- **Follows existing patterns**: Config detection mirrors `shouldHideProgressBar()`, public API mirrors `Alpine.navigate.disableProgressBar()`
- **Shared ceremony**: CSS injection, Firefox try/catch fallback, `skipOnDialog` observer, and cleanup all live in one `performViewTransition()` helper used by both morph and navigate transitions
- **Respects `prefers-reduced-motion`**: Injects CSS that disables all view transition animations
- **Skips when dialog is open**: `::view-transition` pseudo-elements paint above the top layer, so transitions are skipped when a `<dialog:modal>` is present
- **Firefox compat**: Config-object API tried first, falls back to callback API (Firefox 144+ only supports callback)
- **Back/forward buttons**: Uses global `useViewTransitions` setting only (no per-link transition for popstate)

## Test plan

- [ ] Enable `view_transitions => true` in config — all `wire:navigate` links should animate
- [ ] Disable config — no transitions on any link
- [ ] Use `wire:navigate.transition` on a single link with config off — only that link animates
- [ ] Add `wire:transition="name"` to shared elements — they should morph smoothly across pages
- [ ] Test back/forward buttons — should animate when global config is on
- [ ] Test with `prefers-reduced-motion` enabled — animations should be disabled
- [ ] Test when a `<dialog>` modal is open — transitions should be skipped


🤖 Generated with [Claude Code](https://claude.com/claude-code)