### PR TITLE
[4.x] Fix namespace prefix missing in generateNameFromClass

### DIFF
--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -336,7 +336,7 @@ class Finder
             ->merge($this->classLocations)
             ->toArray();
 
-        foreach ($classNamespaces as $classNamespace) {
+        foreach ($classNamespaces as $key => $classNamespace) {
             $namespace = str_replace(
                 ['/', '\\'],
                 '.',
@@ -348,7 +348,9 @@ class Finder
                 ->implode('.');
 
             if ($fullName->startsWith($namespace)) {
-                return (string) $fullName->substr(strlen($namespace) + 1);
+                $name = (string) $fullName->substr(strlen($namespace) + 1);
+
+                return is_string($key) ? $key . '::' . $name : $name;
             }
         }
 

--- a/src/Finder/UnitTest.php
+++ b/src/Finder/UnitTest.php
@@ -634,6 +634,36 @@ class UnitTest extends \Tests\TestCase
         Livewire::test(IndexViewComponent::class)
             ->assertSee('Index view component rendered');
     }
+
+    public function test_can_normalize_namespace_class_component()
+    {
+        $finder = new Finder();
+
+        $finder->addNamespace('admin', classNamespace: 'Livewire\Finder\Fixtures');
+
+        $name = $finder->normalizeName(FinderTestClassComponent::class);
+
+        $this->assertEquals('admin::finder-test-class-component', $name);
+
+        $class = $finder->resolveClassComponentClassName($name);
+
+        $this->assertEquals('Livewire\Finder\Fixtures\FinderTestClassComponent', $class);
+    }
+
+    public function test_can_normalize_namespace_class_nested_component()
+    {
+        $finder = new Finder();
+
+        $finder->addNamespace('admin', classNamespace: 'Livewire\Finder\Fixtures');
+
+        $name = $finder->normalizeName(NestedComponent::class);
+
+        $this->assertEquals('admin::nested.nested-component', $name);
+
+        $class = $finder->resolveClassComponentClassName($name);
+
+        $this->assertEquals('Livewire\Finder\Fixtures\Nested\NestedComponent', $class);
+    }
 }
 
 class SingleSegmentComponent extends Component


### PR DESCRIPTION
I ran into this while working on a modular Laravel package that uses `addNamespace()` to register Livewire components per module.

**The problem:**

When you register a component via `addNamespace()` and then reference it by class in `Route::livewire()`, it throws `ComponentNotFoundException`.

```php
// Register namespace in a service provider
Livewire::addNamespace('admin', classNamespace: 'App\\Admin\\Livewire');

// This works fine
Route::livewire('/dashboard', 'admin::dashboard');

// This throws ComponentNotFoundException
Route::livewire('/dashboard', Dashboard::class);
```

I traced it down to `Finder::generateNameFromClass()` when it matches a class against a registered namespace, it strips the `classNamespace` prefix but doesn't prepend the namespace key back. So `App\Admin\Livewire\Dashboard` becomes `'dashboard'` instead of `'admin::dashboard'`.

The issue is that the `foreach` loop iterates over a merged array of `classNamespaces` (string-keyed) and `classLocations` (numerically-keyed), but never uses the key:

```php
foreach ($classNamespaces as $classNamespace) { // key is ignored
    // ...
    return (string) $fullName->substr(strlen($namespace) + 1); // returns bare name
}
```

**The fix:**

Use the key in the loop. If it's a string key (from `classNamespaces`), prepend it. If it's numeric (from `classLocations`), return the bare name as before.

1. Yes - this breaks `Route::livewire()` with class references for any component registered via `addNamespace()`.
2. Yes - separate branch.
3. No - single focused fix.
4. Yes - two unit tests added to `src/Finder/UnitTest.php` covering both flat and nested namespace class normalization.
5. See above