### PR TITLE
[4.x] Fix lazy components loading when reactive prop changes

### DIFF
--- a/js/component.js
+++ b/js/component.js
@@ -237,6 +237,8 @@ export class Component {
 
     getDeepChildrenWithBindings(callback) {
         this.getDeepChildren(child => {
+            if (child.isLazy && ! child.hasBeenLazyLoaded) return
+
             if (child.hasReactiveProps() || child.hasWireModelableBindings()) {
                 callback(child)
             }

--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -303,6 +303,39 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_lazy_component_outside_viewport_is_not_loaded_when_reactive_prop_changes()
+    {
+        Livewire::visit([new class extends Component {
+            public $count = 1;
+            public function inc() { $this->count++; }
+            public function render() { return <<<'HTML'
+            <div>
+                <button wire:click="inc" dusk="button">+</button>
+                <div dusk="parent-count">Parent: {{ $count }}</div>
+                <div style="height: 200vh"></div>
+                <livewire:child :$count lazy />
+            </div>
+            HTML; }
+        }, 'child' => new class extends Component {
+            #[Reactive]
+            public $count;
+            public $config = [];
+            public function mount() { $this->config = ['label' => 'Count']; }
+            public function render() { return <<<'HTML'
+            <div id="child">
+                <div x-data="{ state: $wire.$entangle('config.label') }">
+                    <span dusk="child-label" x-text="state"></span>
+                </div>
+            </div>
+            HTML; }
+        }])
+        ->assertMissing('#child')
+        ->waitForLivewire()->click('@button')
+        ->waitForTextIn('@parent-count', 'Parent: 2')
+        ->assertMissing('#child')
+        ;
+    }
+
     public function test_can_access_component_parameters_in_placeholder_view()
     {
         Livewire::visit([new class extends Component {


### PR DESCRIPTION
# The Scenario

A lazy child component placed outside the viewport gets loaded when the parent updates a reactive prop, even though the user never scrolled to it. This also triggers `$wire.$entangle()` errors if the child accesses properties that depend on `mount()` (which was skipped by lazy loading).

```php
<?php

use Livewire\Component;
use Livewire\Attributes\Reactive;

class Parent extends Component
{
    public $count = 1;

    public function inc()
    {
        $this->count++;
    }
}
?>

<div>
    <button wire:click="inc">+</button>
    <div>Parent: {{ $count }}</div>

    {{-- Spacer to push child below the viewport --}}
    <div style="height: 200vh"></div>

    <livewire:child :$count lazy />
</div>
```

```php
<?php

use Livewire\Component;
use Livewire\Attributes\Reactive;

class Child extends Component
{
    #[Reactive]
    public $count;

    public $config = [];

    public function mount()
    {
        $this->config = ['label' => 'Count'];
    }
}
?>

<div>
    <div x-data="{ state: $wire.$entangle('config.label') }">
        <span x-text="state"></span>
    </div>
</div>
```

# The Problem

When a parent component commits, the JavaScript in `js/request/interactions.js` calls `getDeepChildrenWithBindings()` to find all child components with reactive props or `wire:model` bindings and bundles them into the same request. This method does not check whether those children are lazy and haven't been loaded yet.

The `isLazy` and `hasBeenLazyLoaded` getters already exist on the `Component` class but are never checked in this code path, so an unloaded lazy child with `props` in its memo gets bundled into the request, forcing it to hydrate prematurely.

# The Solution

Added a guard in `getDeepChildrenWithBindings()` to skip any lazy child that hasn't been loaded yet:

```js
if (child.isLazy && ! child.hasBeenLazyLoaded) return
```

This matches the pattern already used for isolated lazy components at the top of `interactions.js`. Once the lazy component loads (when the user scrolls to it), it will receive the current reactive prop value through normal rendering.

Fixes #8186