### PR TITLE
[4.x] Clarify `rendering()` and `rendered()` lifecycle hook descriptions

### DIFF
--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -9,8 +9,8 @@ Here's a list of all the available component lifecycle hooks:
 | `boot()`         | Called at the beginning of every request. Both initial, and subsequent          |
 | `updating()`     | Called before updating a component property                                     |
 | `updated()`      | Called after updating a property                                                |
-| `rendering()`    | Called before `render()` is called                                              |
-| `rendered()`     | Called after `render()` is called                                               |
+| `rendering()`    | Called before the component's view is rendered                                  |
+| `rendered()`     | Called after the component's view is rendered                                   |
 | `dehydrate()`    | Called at the end of every component request                                    |
 | `exception($e, $stopPropagation)` | Called when an exception is thrown                     |                    |
 


### PR DESCRIPTION
# The Scenario

The lifecycle hooks documentation table describes `rendering()` as "Called before `render()` is called", which implies it fires before the component's `render()` method is invoked. A user reasonably expected that state set in `rendering()` would be available inside `render()`, but found it was not:

```php
<?php

use Livewire\Component;

new class extends Component {
    public int $x;

    public function render()
    {
        $this->x = 1;
        return $this->view();
    }

    public function rendering()
    {
        $this->x ??= 2;
    }
};
```

```blade
<div>
    {{ $x }}
</div>
```

# The Problem

The table descriptions for `rendering()` and `rendered()` reference the `render()` method, which is misleading. In reality, `rendering()` fires after `render()` returns a view but before that view is compiled to HTML. The code comment in the Render section on the same page ("Runs BEFORE the provided view is rendered") is accurate, but the table contradicts it.

# The Solution

Updated the table descriptions to say "Called before the component's view is rendered" and "Called after the component's view is rendered", which accurately reflects the behaviour and is consistent with the code comments further down the page.

Fixes https://github.com/livewire/livewire/discussions/10056