### PR TITLE
[3.x] Fix dynamic property deprecation on TestResponse when using withoutDeprecationHandling()

### DIFF
--- a/src/Features/SupportTesting/InitialRender.php
+++ b/src/Features/SupportTesting/InitialRender.php
@@ -39,7 +39,7 @@ class InitialRender extends Render
         $html = $response->getContent();
 
         // Set "original" to Blade view for assertions like "assertViewIs()"...
-        $response->original = $componentView;
+        $response->baseResponse->original = $componentView;
 
         $snapshot = Utils::extractAttributeDataFromHtml($html, 'wire:snapshot');
         $effects = Utils::extractAttributeDataFromHtml($html, 'wire:effects');

--- a/src/Features/SupportTesting/SubsequentRender.php
+++ b/src/Features/SupportTesting/SubsequentRender.php
@@ -53,7 +53,7 @@ class SubsequentRender extends Render
         $json = $response->json();
 
         // Set "original" to Blade view for assertions like "assertViewIs()"...
-        $response->original = $componentView;
+        $response->baseResponse->original = $componentView;
 
         $componentResponsePayload = $json['components'][0];
 

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -615,6 +615,16 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             ->assertSetStrict('colourCookie', 'blue')
             ->assertSetStrict('nameCookie', 'Taylor');
     }
+
+    function test_testing_does_not_create_dynamic_properties_on_test_response()
+    {
+        $this->withoutDeprecationHandling();
+
+        Livewire::test(HasMountArguments::class, ['name' => 'foo'])
+            ->assertSee('foo')
+            ->set('name', 'bar')
+            ->assertSee('bar');
+    }
 }
 
 class HasMountArguments extends Component


### PR DESCRIPTION
# The Scenario

When testing Livewire components with `withoutDeprecationHandling()` enabled (which promotes PHP deprecation notices to exceptions), tests fail with an `ErrorException`:

> Creation of dynamic property Illuminate\Testing\TestResponse::$original is deprecated

This affects any project using PHP 8.2+, where dynamic properties were deprecated. The test passes with default deprecation handling, but many projects enable `withoutDeprecationHandling()` globally to catch deprecated code usage.

```php
class CounterTest extends TestCase
{
    public function test_counter_renders(): void
    {
        $this->withoutDeprecationHandling();

        // Throws ErrorException: Creation of dynamic property TestResponse::$original is deprecated
        Livewire::test('counter')->assertSet('count', 0);
    }
}
```

# The Problem

`TestResponse` wraps an underlying `Response` object (`baseResponse`) which has `$original` as a declared property. `TestResponse` proxies property reads to `baseResponse` via `__get()`, but has no `__set()`. So when Livewire sets `$response->original = $componentView`, it creates a dynamic property on `TestResponse` instead of writing to the underlying `Response`.

# The Solution

Changed `$response->original` to `$response->baseResponse->original` in both `InitialRender.php` and `SubsequentRender.php`. This sets the property on the underlying `Response` where it's properly declared, avoiding the dynamic property creation.

Fixes #9426