### PR TITLE
[3.x] Fix `smart_wire_keys` breaking `@while` and `@for` loops

### DIFF
--- a/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
@@ -318,6 +318,9 @@ class SupportMorphAwareBladeCompilation extends ComponentHook
         $loopDirectives = [
             'foreach',
             'forelse',
+            // temp disabling because of "missing $loop" error
+            // 'for',
+            // 'while',
         ];
 
         $pattern = '/@(' . implode('|', $loopDirectives) . ')(?![a-zA-Z])/i';
@@ -331,6 +334,8 @@ class SupportMorphAwareBladeCompilation extends ComponentHook
             'endforeach',
             // This `endforelse` should NOT be included here, but it is left here for documentation purposes. The close of a `@forelse` loop is handled by the `@empty` directive...
             // 'endforelse',
+            // 'endfor',
+            // 'endwhile',
         ];
 
         $pattern = '/@(' . implode('|', $loopDirectives) . ')(?![a-zA-Z])/i';

--- a/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
@@ -318,8 +318,6 @@ class SupportMorphAwareBladeCompilation extends ComponentHook
         $loopDirectives = [
             'foreach',
             'forelse',
-            'for',
-            'while',
         ];
 
         $pattern = '/@(' . implode('|', $loopDirectives) . ')(?![a-zA-Z])/i';
@@ -333,8 +331,6 @@ class SupportMorphAwareBladeCompilation extends ComponentHook
             'endforeach',
             // This `endforelse` should NOT be included here, but it is left here for documentation purposes. The close of a `@forelse` loop is handled by the `@empty` directive...
             // 'endforelse',
-            'endfor',
-            'endwhile',
         ];
 
         $pattern = '/@(' . implode('|', $loopDirectives) . ')(?![a-zA-Z])/i';

--- a/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
@@ -812,7 +812,14 @@ class UnitTest extends \Tests\TestCase
                         <span> {{ $i }} </span>
                     @endfor
                 </div>
-                HTML
+                HTML,
+                <<<'HTML'
+                <div>
+                    <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if BLOCK]><![endif]--><?php endif; ?><?php for($i = 0; $i < 3; $i++): ?>
+                        <span> <?php echo e($i); ?> </span>
+                    <?php endfor; ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if ENDBLOCK]><![endif]--><?php endif; ?>
+                </div>
+                HTML,
             ],
             // @while loops should not inject $loop variable references...
             46 => [
@@ -824,7 +831,15 @@ class UnitTest extends \Tests\TestCase
                         @break
                     @endwhile
                 </div>
-                HTML
+                HTML,
+                <<<'HTML'
+                <div>
+                    <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if BLOCK]><![endif]--><?php endif; ?><?php while(true): ?>
+                        <span>Looping</span>
+                        <?php break; ?>
+                    <?php endwhile; ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if ENDBLOCK]><![endif]--><?php endif; ?>
+                </div>
+                HTML,
             ],
         ];
     }

--- a/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
@@ -573,9 +573,9 @@ class UnitTest extends \Tests\TestCase
                 <<<'HTML'
                 <div>
                     @forelse([1, 2] as $post)
-                        @for($i=0; $i < 10; $i++)
+                        @foreach(range(0, 10) as $i)
                             <span> {{ $i }} </span>
-                        @endfor
+                        @endforeach
                     @empty
                         <span> {{ $someProperty }} </span>
                     @endforelse
@@ -584,9 +584,9 @@ class UnitTest extends \Tests\TestCase
                 <<<'HTML'
                 <div>
                     <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if BLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::openLoop(); ?><?php endif; ?><?php $__empty_1 = true; $__currentLoopData = [1, 2]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $post): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoop($loop->index); ?><?php endif; ?>
-                        <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if BLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::openLoop(); ?><?php endif; ?><?php for($i=0; $i < 10; $i++): ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoop($loop->index); ?><?php endif; ?>
+                        <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if BLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::openLoop(); ?><?php endif; ?><?php $__currentLoopData = range(0, 10); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $i): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoop($loop->index); ?><?php endif; ?>
                             <span> <?php echo e($i); ?> </span>
-                        <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::endLoop(); ?><?php endif; ?><?php endfor; ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if ENDBLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::closeLoop(); ?><?php endif; ?>
+                        <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::endLoop(); ?><?php endif; ?><?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if ENDBLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::closeLoop(); ?><?php endif; ?>
                     <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::endLoop(); ?><?php endif; ?><?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_1): ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::closeLoop(); ?><?php endif; ?>
                         <span> <?php echo e($someProperty); ?> </span>
                     <?php endif; ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if ENDBLOCK]><![endif]--><?php endif; ?>
@@ -800,6 +800,29 @@ class UnitTest extends \Tests\TestCase
                             <div></div>
                         @endforeach
                     </div>
+                </div>
+                HTML
+            ],
+            // @for loops should not inject $loop variable references...
+            45 => [
+                1,
+                <<<'HTML'
+                <div>
+                    @for ($i = 0; $i < 3; $i++)
+                        <span> {{ $i }} </span>
+                    @endfor
+                </div>
+                HTML
+            ],
+            // @while loops should not inject $loop variable references...
+            46 => [
+                1,
+                <<<'HTML'
+                <div>
+                    @while (true)
+                        <span>Looping</span>
+                        @break
+                    @endwhile
                 </div>
                 HTML
             ],


### PR DESCRIPTION
# The Scenario

When `smart_wire_keys` is enabled (the default), using `@while` or `@for` loops in a Livewire component throws an `Undefined variable $loop` error, preventing the page from rendering.

```php
<?php

use Livewire\Component;

new class extends Component
{
    //
};
?>

<div>
    @while (true)
        <p>I'm looping forever.</p>
        @break
    @endwhile
</div>
```

# The Problem

In `SupportMorphAwareBladeCompilation`, the `isLoop()` method treats `@while` and `@for` as loop directives. When a loop directive is detected, the precompiler injects code that references `$loop->index`:

```php
$suffix .= '<?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoop($loop->index); ?>';
```

The `$loop` variable is only available in `@foreach` and `@forelse` loops (provided by Laravel's Blade compiler). It does not exist for `@while` or `@for` loops, so the injected code throws an `Undefined variable $loop` error at runtime.

# The Solution

Remove `@while` and `@for` (and their closing counterparts `@endwhile` and `@endfor`) from the `isLoop()` and `isEndLoop()` methods. These directives still get conditional morph markers (`<!--[if BLOCK]><![endif]-->`) but no longer have loop tracking markers injected.

Fixes https://github.com/livewire/livewire/discussions/10078