### PR TITLE
[4.x] Fix sessioned pagination not restoring query string on revisit

### DIFF
--- a/src/Features/SupportPagination/BrowserTest.php
+++ b/src/Features/SupportPagination/BrowserTest.php
@@ -1155,6 +1155,43 @@ class BrowserTest extends BrowserTestCase
             ;
         });
     }
+
+    public function test_sessioned_cursor_pagination_query_string_is_restored_on_revisit()
+    {
+        $this->beforeServingApplication(function () {
+            app('livewire')->component('session-cursor-pagination', SessionCursorPaginationComponent::class);
+
+            Route::get('/session-cursor-pagination', function () {
+                return app('livewire')->new('session-cursor-pagination')();
+            })->middleware('web');
+        });
+
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/session-cursor-pagination')
+                ->waitForLivewireToLoad()
+                ->assertSee('Post #1')
+                ->assertSee('Post #3')
+                ->assertDontSee('Post #4')
+                ->assertQueryStringMissing('page')
+
+                // Navigate to page 2 — stores cursor in session...
+                ->waitForLivewire()->click('@nextPage')
+                ->assertSee('Post #4')
+                ->assertSee('Post #6')
+                ->assertDontSee('Post #1')
+
+                // Revisit with a clean URL — session should restore
+                // the cursor AND the query string should reflect it...
+                ->visit('/session-cursor-pagination')
+                ->waitForLivewireToLoad()
+                ->assertSee('Post #4')
+                ->assertSee('Post #6')
+                ->assertDontSee('Post #1')
+                ->assertScript("return new URL(window.location.href).searchParams.has('page')", true)
+            ;
+        });
+    }
 }
 
 class SessionPaginationComponent extends Component
@@ -1187,6 +1224,41 @@ class SessionPaginationComponent extends Component
             HTML,
             [
                 'posts' => Post::paginate(3),
+            ]
+        );
+    }
+}
+
+class SessionCursorPaginationComponent extends Component
+{
+    use WithPagination;
+
+    public function mount()
+    {
+        if ($cursor = session('test_cursor_pagination')) {
+            $this->setPage($cursor);
+        }
+    }
+
+    public function updatedPaginators($page, $pageName)
+    {
+        session(['test_cursor_pagination' => $page]);
+    }
+
+    public function render()
+    {
+        return Blade::render(
+            <<< 'HTML'
+            <div>
+                @foreach ($posts as $post)
+                    <h1 wire:key="post-{{ $post->id }}">{{ $post->title }}</h1>
+                @endforeach
+
+                {{ $posts->links() }}
+            </div>
+            HTML,
+            [
+                'posts' => Post::cursorPaginate(3, '*', 'page'),
             ]
         );
     }

--- a/src/Features/SupportPagination/BrowserTest.php
+++ b/src/Features/SupportPagination/BrowserTest.php
@@ -9,6 +9,7 @@ use Livewire\WithPagination;
 use Livewire\Livewire;
 use Livewire\Component;
 use Livewire\Attributes\Computed;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Database\Eloquent\Model;
 
@@ -1115,6 +1116,79 @@ class BrowserTest extends BrowserTestCase
             ->assertSee('Post #6')
             ->assertQueryStringMissing('page')
         ;
+    }
+
+    public function test_sessioned_pagination_query_string_is_restored_on_revisit()
+    {
+        $this->beforeServingApplication(function () {
+            app('livewire')->component('session-pagination', SessionPaginationComponent::class);
+
+            Route::get('/session-pagination', function () {
+                return app('livewire')->new('session-pagination')();
+            })->middleware('web');
+        });
+
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/session-pagination')
+                ->waitForLivewireToLoad()
+                ->assertSee('Post #1')
+                ->assertSee('Post #3')
+                ->assertDontSee('Post #4')
+                ->assertQueryStringMissing('page')
+
+                // Navigate to page 2 — stores page in session...
+                ->waitForLivewire()->click('@nextPage.before')
+                ->assertSee('Post #4')
+                ->assertSee('Post #6')
+                ->assertDontSee('Post #1')
+                ->assertQueryStringHas('page', '2')
+
+                // Revisit with a clean URL — session should restore
+                // the page AND the query string should reflect it...
+                ->visit('/session-pagination')
+                ->waitForLivewireToLoad()
+                ->assertSee('Post #4')
+                ->assertSee('Post #6')
+                ->assertDontSee('Post #1')
+                ->assertQueryStringHas('page', '2')
+            ;
+        });
+    }
+}
+
+class SessionPaginationComponent extends Component
+{
+    use WithPagination;
+
+    public function mount()
+    {
+        if ($page = session('test_pagination_page')) {
+            $this->setPage($page);
+        }
+    }
+
+    public function updatedPaginators($page, $pageName)
+    {
+        session(['test_pagination_page' => $page]);
+    }
+
+    public function render()
+    {
+        return Blade::render(
+            <<< 'HTML'
+            <div>
+                @foreach ($posts as $post)
+                    <h1 wire:key="post-{{ $post->id }}">{{ $post->title }}</h1>
+                @endforeach
+
+                {{ $posts->links() }}
+            </div>
+            HTML,
+            [
+                'posts' => Post::paginate(3),
+            ]
+        );
     }
 }
 

--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -27,7 +27,6 @@ class SupportPagination extends ComponentHook
     }
 
     protected $restoreOverriddenPaginationViews;
-    protected $urlHooksAdded = [];
 
     function skip()
     {
@@ -88,16 +87,14 @@ class SupportPagination extends ComponentHook
     protected function ensurePaginatorIsInitialized($pageName, $defaultPage = 1)
     {
         if (isset($this->component->paginators[$pageName])) {
-            // On subsequent Livewire requests, the value came from hydration.
-            // The URL hook was set up on the initial page load — nothing to do.
+            // On subsequent requests, the value came from hydration
+            // and JS already has URL tracking from the initial load...
             if (app('livewire')->isLivewireRequest()) return;
         } else {
             $queryStringDetails = $this->getQueryStringDetails($pageName);
 
             $this->component->paginators[$pageName] = $this->resolvePage($queryStringDetails['as'], $defaultPage);
         }
-
-        if (isset($this->urlHooksAdded[$pageName])) return;
 
         $shouldSkipUrlTracking = in_array(
             WithoutUrlPagination::class, class_uses_recursive($this->component)
@@ -108,7 +105,6 @@ class SupportPagination extends ComponentHook
         $queryStringDetails ??= $this->getQueryStringDetails($pageName);
 
         $this->addUrlHook($pageName, $queryStringDetails, $defaultPage);
-        $this->urlHooksAdded[$pageName] = true;
     }
 
     protected function getQueryStringDetails($pageName)

--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportPagination;
 use function Livewire\invade;
 use Livewire\WithPagination;
 use Livewire\Features\SupportQueryString\SupportQueryString;
+use Livewire\Features\SupportQueryString\BaseUrl;
 use Livewire\ComponentHookRegistry;
 use Livewire\ComponentHook;
 use Livewire\Livewire;
@@ -86,15 +87,23 @@ class SupportPagination extends ComponentHook
 
     protected function ensurePaginatorIsInitialized($pageName, $defaultPage = 1)
     {
-        if (isset($this->component->paginators[$pageName])) {
+        $alreadyInitialized = isset($this->component->paginators[$pageName]);
+
+        if ($alreadyInitialized) {
             // On subsequent requests, the value came from hydration
             // and JS already has URL tracking from the initial load...
             if (app('livewire')->isLivewireRequest()) return;
+
+            // If SupportQueryString already registered a URL attribute
+            // for this paginator, it's handling URL tracking...
+            $key = 'paginators.' . $pageName;
+
+            if ($this->component->getAttributes()->contains(fn ($attr) => $attr instanceof BaseUrl && $attr->getName() === $key)) return;
         }
 
         $queryStringDetails = $this->getQueryStringDetails($pageName);
 
-        if (! isset($this->component->paginators[$pageName])) {
+        if (! $alreadyInitialized) {
             $this->component->paginators[$pageName] = $this->resolvePage($queryStringDetails['as'], $defaultPage);
         }
 
@@ -104,7 +113,7 @@ class SupportPagination extends ComponentHook
 
         if ($shouldSkipUrlTracking) return;
 
-        $this->addUrlHook($pageName, $queryStringDetails, $defaultPage);
+        $this->addUrlHook($pageName, $queryStringDetails, $alreadyInitialized ? $defaultPage : null);
     }
 
     protected function getQueryStringDetails($pageName)

--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -86,13 +86,15 @@ class SupportPagination extends ComponentHook
 
     protected function ensurePaginatorIsInitialized($pageName, $defaultPage = 1)
     {
-        $queryStringDetails = $this->getQueryStringDetails($pageName);
-
         if (isset($this->component->paginators[$pageName])) {
             // On subsequent requests, the value came from hydration
             // and JS already has URL tracking from the initial load...
             if (app('livewire')->isLivewireRequest()) return;
-        } else {
+        }
+
+        $queryStringDetails = $this->getQueryStringDetails($pageName);
+
+        if (! isset($this->component->paginators[$pageName])) {
             $this->component->paginators[$pageName] = $this->resolvePage($queryStringDetails['as'], $defaultPage);
         }
 

--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -86,13 +86,13 @@ class SupportPagination extends ComponentHook
 
     protected function ensurePaginatorIsInitialized($pageName, $defaultPage = 1)
     {
+        $queryStringDetails = $this->getQueryStringDetails($pageName);
+
         if (isset($this->component->paginators[$pageName])) {
             // On subsequent requests, the value came from hydration
             // and JS already has URL tracking from the initial load...
             if (app('livewire')->isLivewireRequest()) return;
         } else {
-            $queryStringDetails = $this->getQueryStringDetails($pageName);
-
             $this->component->paginators[$pageName] = $this->resolvePage($queryStringDetails['as'], $defaultPage);
         }
 
@@ -101,8 +101,6 @@ class SupportPagination extends ComponentHook
         );
 
         if ($shouldSkipUrlTracking) return;
-
-        $queryStringDetails ??= $this->getQueryStringDetails($pageName);
 
         $this->addUrlHook($pageName, $queryStringDetails, $defaultPage);
     }

--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -27,6 +27,7 @@ class SupportPagination extends ComponentHook
     }
 
     protected $restoreOverriddenPaginationViews;
+    protected $urlHooksAdded = [];
 
     function skip()
     {
@@ -86,11 +87,17 @@ class SupportPagination extends ComponentHook
 
     protected function ensurePaginatorIsInitialized($pageName, $defaultPage = 1)
     {
-        if (isset($this->component->paginators[$pageName])) return;
+        if (isset($this->component->paginators[$pageName])) {
+            // On subsequent Livewire requests, the value came from hydration.
+            // The URL hook was set up on the initial page load — nothing to do.
+            if (app('livewire')->isLivewireRequest()) return;
+        } else {
+            $queryStringDetails = $this->getQueryStringDetails($pageName);
 
-        $queryStringDetails = $this->getQueryStringDetails($pageName);
+            $this->component->paginators[$pageName] = $this->resolvePage($queryStringDetails['as'], $defaultPage);
+        }
 
-        $this->component->paginators[$pageName] = $this->resolvePage($queryStringDetails['as'], $defaultPage);
+        if (isset($this->urlHooksAdded[$pageName])) return;
 
         $shouldSkipUrlTracking = in_array(
             WithoutUrlPagination::class, class_uses_recursive($this->component)
@@ -98,7 +105,10 @@ class SupportPagination extends ComponentHook
 
         if ($shouldSkipUrlTracking) return;
 
-        $this->addUrlHook($pageName, $queryStringDetails);
+        $queryStringDetails ??= $this->getQueryStringDetails($pageName);
+
+        $this->addUrlHook($pageName, $queryStringDetails, $defaultPage);
+        $this->urlHooksAdded[$pageName] = true;
     }
 
     protected function getQueryStringDetails($pageName)
@@ -117,14 +127,14 @@ class SupportPagination extends ComponentHook
         return request()->query($alias, $default);
     }
 
-    protected function addUrlHook($pageName, $queryStringDetails)
+    protected function addUrlHook($pageName, $queryStringDetails, $defaultPage = 1)
     {
         $key = 'paginators.' . $pageName;
         $alias = $queryStringDetails['as'];
         $history = $queryStringDetails['history'];
         $keep = $queryStringDetails['keep'];
 
-        $attribute = new PaginationUrl(as: $alias, history: $history, keep: $keep);
+        $attribute = new PaginationUrl(as: $alias, history: $history, keep: $keep, except: $defaultPage);
 
         $this->component->setPropertyAttribute($key, $attribute);
 


### PR DESCRIPTION
# The Scenario

When persisting the current page to session and restoring it on revisit, the page content is correctly restored but the URL stays clean — the query string is not synced to reflect the restored page. This affects both standard and cursor pagination.

```php
<?php

use Livewire\Volt\Component;
use Livewire\WithPagination;
use Livewire\Attributes\Computed;
use App\Models\Post;

new class extends Component {
    use WithPagination;

    public function mount()
    {
        if ($page = session('pagination_page')) {
            $this->setPage($page);
        }
    }

    public function updatedPaginators($page, $pageName)
    {
        session(['pagination_page' => $page]);
    }

    #[Computed]
    public function posts()
    {
        return Post::paginate(10);
    }
}

?>

<div>
    @foreach ($this->posts as $post)
        <h1 wire:key="post-{{ $post->id }}">{{ $post->title }}</h1>
    @endforeach

    {{ $this->posts->links() }}
</div>
```

1. User navigates to page 2 — URL updates to `?page=2`, page stored in session
2. User navigates away
3. User revisits with a clean URL — page 2 content is shown (session restored) but the URL stays as `/posts` instead of `/posts?page=2`

# The Problem

Two issues in `SupportPagination::ensurePaginatorIsInitialized()` prevent the query string from syncing:

1. **URL hook skipped when paginator value is pre-set.** The method has an early return when `$this->component->paginators[$pageName]` is already set. This guards both value resolution and URL hook setup. When user code sets the paginator from session during `mount()` (before the paginator resolver runs), the `PaginationUrl` attribute is never created and no URL effect is sent to the frontend.

2. **Missing `except` value on `PaginationUrl`.** The `addUrlHook()` method creates a `PaginationUrl` without an `except` value (defaults to `null`). The push-mode sync logic added in #10028 compares the current value against `except` to detect session-restored values — when `except` is `null`, the comparison falls back to comparing the ephemeral value against itself, which is always equal, so the URL is never synced.

# The Solution

In `ensurePaginatorIsInitialized()`, the early return when the paginator is already set now only applies to subsequent Livewire AJAX requests (where the value came from hydration and JS already has URL tracking from the initial load), or when `SupportQueryString` has already registered a `BaseUrl` attribute for the paginator (e.g. via the legacy `$queryString` property). On the initial page load, when no existing URL tracking exists, the URL hook is added even when the paginator value was pre-set by user code (e.g. session restoration in `mount()`).

In `addUrlHook()`, when the paginator was pre-set, the `$defaultPage` is passed as `except` to `PaginationUrl`. This tells JS that `1` is the default page value (or `''` for cursor pagination), enabling the push-mode sync logic from #10028 to detect when the session-restored value differs from the default and sync the URL via `replaceState`.

Fixes https://github.com/livewire/livewire/discussions/10064