### PR TITLE
[3.x] Enable smart wire keys for @for and @while loops

### DIFF
--- a/src/Features/SupportCompiledWireKeys/SupportCompiledWireKeys.php
+++ b/src/Features/SupportCompiledWireKeys/SupportCompiledWireKeys.php
@@ -84,6 +84,21 @@ class SupportCompiledWireKeys extends ComponentHook
         ];
     }
     
+    // Increment the loop index for the current iteration. This mirrors how
+    // Laravel's Blade `$__env->incrementLoopIndices()` works for `@foreach`,
+    // but without depending on the `$loop` variable (which doesn't exist
+    // for `@for` and `@while` loops)...
+    public static function startLoopIteration() {
+        if (static::$currentLoop['index'] === null) {
+            static::$currentLoop['index'] = 0;
+        } else {
+            static::$currentLoop['index']++;
+        }
+    }
+
+    /**
+     * @deprecated Use startLoopIteration() instead. Kept for cached compiled views.
+     */
     public static function startLoop($index) {
         static::$currentLoop['index'] = $index;
     }
@@ -91,7 +106,7 @@ class SupportCompiledWireKeys extends ComponentHook
     public static function endLoop() {
         static::$currentLoop = [
             'count' => null,
-            'index' => null,
+            'index' => static::$currentLoop['index'] ?? null,
             'key' => null,
         ];
     }

--- a/src/Features/SupportCompiledWireKeys/UnitTest.php
+++ b/src/Features/SupportCompiledWireKeys/UnitTest.php
@@ -884,6 +884,169 @@ class UnitTest extends \Tests\TestCase
         );
     }
 
+    public function test_nested_loop_iterations_generate_unique_keys()
+    {
+        $keys = [];
+
+        // Simulate: @for ($i = 0; $i < 3; $i++) -> @for ($j = 0; $j < 2; $j++)
+        SupportCompiledWireKeys::openLoop();
+
+        for ($i = 0; $i < 3; $i++) {
+            SupportCompiledWireKeys::startLoopIteration();
+
+            SupportCompiledWireKeys::openLoop();
+
+            for ($j = 0; $j < 2; $j++) {
+                SupportCompiledWireKeys::startLoopIteration();
+                $keys[] = SupportCompiledWireKeys::generateKey('test');
+                SupportCompiledWireKeys::endLoop();
+            }
+
+            SupportCompiledWireKeys::closeLoop();
+            SupportCompiledWireKeys::endLoop();
+        }
+
+        SupportCompiledWireKeys::closeLoop();
+
+        // All 6 keys should be unique, and the outer loop index should
+        // increment across iterations (not be reset by the inner loop)...
+        $this->assertEquals([
+            'test-0-0-0-0', // outer=0, inner=0
+            'test-0-0-0-1', // outer=0, inner=1
+            'test-0-1-0-0', // outer=1, inner=0
+            'test-0-1-0-1', // outer=1, inner=1
+            'test-0-2-0-0', // outer=2, inner=0
+            'test-0-2-0-1', // outer=2, inner=1
+        ], $keys);
+    }
+
+    public function test_break_in_loop_does_not_corrupt_key_generation()
+    {
+        $keys = [];
+
+        // Simulate: @for with break on iteration 1 (endLoop is skipped)
+        // followed by a second loop that should generate correct keys...
+        SupportCompiledWireKeys::openLoop();
+
+        // Iteration 0: normal...
+        SupportCompiledWireKeys::startLoopIteration();
+        $keys[] = SupportCompiledWireKeys::generateKey('test');
+        SupportCompiledWireKeys::endLoop();
+
+        // Iteration 1: break (endLoop is skipped)...
+        SupportCompiledWireKeys::startLoopIteration();
+        $keys[] = SupportCompiledWireKeys::generateKey('test');
+        // No endLoop() — @break skips it...
+
+        SupportCompiledWireKeys::closeLoop();
+
+        // A second loop after the broken one should work correctly...
+        SupportCompiledWireKeys::openLoop();
+
+        SupportCompiledWireKeys::startLoopIteration();
+        $keys[] = SupportCompiledWireKeys::generateKey('test');
+        SupportCompiledWireKeys::endLoop();
+
+        SupportCompiledWireKeys::startLoopIteration();
+        $keys[] = SupportCompiledWireKeys::generateKey('test');
+        SupportCompiledWireKeys::endLoop();
+
+        SupportCompiledWireKeys::closeLoop();
+
+        $this->assertEquals(4, count(array_unique($keys)));
+    }
+
+    public function test_continue_in_loop_does_not_corrupt_key_generation()
+    {
+        $keys = [];
+
+        // Simulate: @for with continue on iteration 1 (endLoop is skipped)...
+        SupportCompiledWireKeys::openLoop();
+
+        // Iteration 0: normal...
+        SupportCompiledWireKeys::startLoopIteration();
+        $keys[] = SupportCompiledWireKeys::generateKey('test');
+        SupportCompiledWireKeys::endLoop();
+
+        // Iteration 1: continue (endLoop is skipped)...
+        SupportCompiledWireKeys::startLoopIteration();
+        // No generateKey or endLoop — @continue skips them...
+
+        // Iteration 2: should still get the correct index...
+        SupportCompiledWireKeys::startLoopIteration();
+        $keys[] = SupportCompiledWireKeys::generateKey('test');
+        SupportCompiledWireKeys::endLoop();
+
+        SupportCompiledWireKeys::closeLoop();
+
+        $this->assertEquals([
+            'test-0-0',  // iteration 0
+            'test-0-2',  // iteration 2 (1 was skipped by continue)
+        ], $keys);
+    }
+
+    public function test_break_in_nested_loop_does_not_corrupt_outer_loop_keys()
+    {
+        $keys = [];
+
+        // Simulate: outer @for (3 iterations) -> inner @for (break on iteration 1)...
+        SupportCompiledWireKeys::openLoop();
+
+        for ($i = 0; $i < 3; $i++) {
+            SupportCompiledWireKeys::startLoopIteration();
+
+            SupportCompiledWireKeys::openLoop();
+
+            // Inner iteration 0: normal...
+            SupportCompiledWireKeys::startLoopIteration();
+            $keys[] = SupportCompiledWireKeys::generateKey('test');
+
+            // Break — endLoop is skipped, closeLoop still runs...
+            SupportCompiledWireKeys::closeLoop();
+            SupportCompiledWireKeys::endLoop();
+        }
+
+        SupportCompiledWireKeys::closeLoop();
+
+        // Each outer iteration should have a different key, proving the
+        // inner break didn't corrupt the outer loop's index...
+        $this->assertEquals(3, count(array_unique($keys)));
+    }
+
+    public function test_continue_in_nested_loop_does_not_corrupt_outer_loop_keys()
+    {
+        $keys = [];
+
+        // Simulate: outer @for (3 iterations) -> inner @for (continue on iteration 0)...
+        SupportCompiledWireKeys::openLoop();
+
+        for ($i = 0; $i < 3; $i++) {
+            SupportCompiledWireKeys::startLoopIteration();
+
+            SupportCompiledWireKeys::openLoop();
+
+            // Inner iteration 0: continue (endLoop is skipped)...
+            SupportCompiledWireKeys::startLoopIteration();
+
+            // Inner iteration 1: normal...
+            SupportCompiledWireKeys::startLoopIteration();
+            $keys[] = SupportCompiledWireKeys::generateKey('test');
+            SupportCompiledWireKeys::endLoop();
+
+            SupportCompiledWireKeys::closeLoop();
+            SupportCompiledWireKeys::endLoop();
+        }
+
+        SupportCompiledWireKeys::closeLoop();
+
+        // The outer loop index should still increment correctly...
+        $this->assertEquals([
+            'test-0-0-0-1', // outer=0, inner=1
+            'test-0-1-0-1', // outer=1, inner=1
+            'test-0-2-0-1', // outer=2, inner=1
+        ], $keys);
+    }
+
     #[DataProvider('elementsTestProvider')]
     public function test_we_can_correctly_find_wire_keys_on_elements_only_but_not_blade_or_livewire_components($occurrences, $template)
     {
@@ -1091,169 +1254,6 @@ class UnitTest extends \Tests\TestCase
     protected function assertOccurrences($expected, $needle, $haystack)
     {
         $this->assertEquals($expected, count(explode($needle, $haystack)) - 1);
-    }
-
-    public function test_nested_loop_iterations_generate_unique_keys()
-    {
-        $keys = [];
-
-        // Simulate: @for ($i = 0; $i < 3; $i++) -> @for ($j = 0; $j < 2; $j++)
-        SupportCompiledWireKeys::openLoop();
-
-        for ($i = 0; $i < 3; $i++) {
-            SupportCompiledWireKeys::startLoopIteration();
-
-            SupportCompiledWireKeys::openLoop();
-
-            for ($j = 0; $j < 2; $j++) {
-                SupportCompiledWireKeys::startLoopIteration();
-                $keys[] = SupportCompiledWireKeys::generateKey('test');
-                SupportCompiledWireKeys::endLoop();
-            }
-
-            SupportCompiledWireKeys::closeLoop();
-            SupportCompiledWireKeys::endLoop();
-        }
-
-        SupportCompiledWireKeys::closeLoop();
-
-        // All 6 keys should be unique, and the outer loop index should
-        // increment across iterations (not be reset by the inner loop)...
-        $this->assertEquals([
-            'test-0-0-0-0', // outer=0, inner=0
-            'test-0-0-0-1', // outer=0, inner=1
-            'test-0-1-0-0', // outer=1, inner=0
-            'test-0-1-0-1', // outer=1, inner=1
-            'test-0-2-0-0', // outer=2, inner=0
-            'test-0-2-0-1', // outer=2, inner=1
-        ], $keys);
-    }
-
-    public function test_break_in_loop_does_not_corrupt_key_generation()
-    {
-        $keys = [];
-
-        // Simulate: @for with break on iteration 1 (endLoop is skipped)
-        // followed by a second loop that should generate correct keys...
-        SupportCompiledWireKeys::openLoop();
-
-        // Iteration 0: normal...
-        SupportCompiledWireKeys::startLoopIteration();
-        $keys[] = SupportCompiledWireKeys::generateKey('test');
-        SupportCompiledWireKeys::endLoop();
-
-        // Iteration 1: break (endLoop is skipped)...
-        SupportCompiledWireKeys::startLoopIteration();
-        $keys[] = SupportCompiledWireKeys::generateKey('test');
-        // No endLoop() — @break skips it...
-
-        SupportCompiledWireKeys::closeLoop();
-
-        // A second loop after the broken one should work correctly...
-        SupportCompiledWireKeys::openLoop();
-
-        SupportCompiledWireKeys::startLoopIteration();
-        $keys[] = SupportCompiledWireKeys::generateKey('test');
-        SupportCompiledWireKeys::endLoop();
-
-        SupportCompiledWireKeys::startLoopIteration();
-        $keys[] = SupportCompiledWireKeys::generateKey('test');
-        SupportCompiledWireKeys::endLoop();
-
-        SupportCompiledWireKeys::closeLoop();
-
-        $this->assertEquals(4, count(array_unique($keys)));
-    }
-
-    public function test_continue_in_loop_does_not_corrupt_key_generation()
-    {
-        $keys = [];
-
-        // Simulate: @for with continue on iteration 1 (endLoop is skipped)...
-        SupportCompiledWireKeys::openLoop();
-
-        // Iteration 0: normal...
-        SupportCompiledWireKeys::startLoopIteration();
-        $keys[] = SupportCompiledWireKeys::generateKey('test');
-        SupportCompiledWireKeys::endLoop();
-
-        // Iteration 1: continue (endLoop is skipped)...
-        SupportCompiledWireKeys::startLoopIteration();
-        // No generateKey or endLoop — @continue skips them...
-
-        // Iteration 2: should still get the correct index...
-        SupportCompiledWireKeys::startLoopIteration();
-        $keys[] = SupportCompiledWireKeys::generateKey('test');
-        SupportCompiledWireKeys::endLoop();
-
-        SupportCompiledWireKeys::closeLoop();
-
-        $this->assertEquals([
-            'test-0-0',  // iteration 0
-            'test-0-2',  // iteration 2 (1 was skipped by continue)
-        ], $keys);
-    }
-
-    public function test_break_in_nested_loop_does_not_corrupt_outer_loop_keys()
-    {
-        $keys = [];
-
-        // Simulate: outer @for (3 iterations) -> inner @for (break on iteration 1)...
-        SupportCompiledWireKeys::openLoop();
-
-        for ($i = 0; $i < 3; $i++) {
-            SupportCompiledWireKeys::startLoopIteration();
-
-            SupportCompiledWireKeys::openLoop();
-
-            // Inner iteration 0: normal...
-            SupportCompiledWireKeys::startLoopIteration();
-            $keys[] = SupportCompiledWireKeys::generateKey('test');
-
-            // Break — endLoop is skipped, closeLoop still runs...
-            SupportCompiledWireKeys::closeLoop();
-            SupportCompiledWireKeys::endLoop();
-        }
-
-        SupportCompiledWireKeys::closeLoop();
-
-        // Each outer iteration should have a different key, proving the
-        // inner break didn't corrupt the outer loop's index...
-        $this->assertEquals(3, count(array_unique($keys)));
-    }
-
-    public function test_continue_in_nested_loop_does_not_corrupt_outer_loop_keys()
-    {
-        $keys = [];
-
-        // Simulate: outer @for (3 iterations) -> inner @for (continue on iteration 0)...
-        SupportCompiledWireKeys::openLoop();
-
-        for ($i = 0; $i < 3; $i++) {
-            SupportCompiledWireKeys::startLoopIteration();
-
-            SupportCompiledWireKeys::openLoop();
-
-            // Inner iteration 0: continue (endLoop is skipped)...
-            SupportCompiledWireKeys::startLoopIteration();
-
-            // Inner iteration 1: normal...
-            SupportCompiledWireKeys::startLoopIteration();
-            $keys[] = SupportCompiledWireKeys::generateKey('test');
-            SupportCompiledWireKeys::endLoop();
-
-            SupportCompiledWireKeys::closeLoop();
-            SupportCompiledWireKeys::endLoop();
-        }
-
-        SupportCompiledWireKeys::closeLoop();
-
-        // The outer loop index should still increment correctly...
-        $this->assertEquals([
-            'test-0-0-0-1', // outer=0, inner=1
-            'test-0-1-0-1', // outer=1, inner=1
-            'test-0-2-0-1', // outer=2, inner=1
-        ], $keys);
     }
 
     protected function assertKeysMatchPattern($expected, $keys)

--- a/src/Features/SupportCompiledWireKeys/UnitTest.php
+++ b/src/Features/SupportCompiledWireKeys/UnitTest.php
@@ -1129,6 +1129,133 @@ class UnitTest extends \Tests\TestCase
         ], $keys);
     }
 
+    public function test_break_in_loop_does_not_corrupt_key_generation()
+    {
+        $keys = [];
+
+        // Simulate: @for with break on iteration 1 (endLoop is skipped)
+        // followed by a second loop that should generate correct keys...
+        SupportCompiledWireKeys::openLoop();
+
+        // Iteration 0: normal...
+        SupportCompiledWireKeys::startLoopIteration();
+        $keys[] = SupportCompiledWireKeys::generateKey('test');
+        SupportCompiledWireKeys::endLoop();
+
+        // Iteration 1: break (endLoop is skipped)...
+        SupportCompiledWireKeys::startLoopIteration();
+        $keys[] = SupportCompiledWireKeys::generateKey('test');
+        // No endLoop() — @break skips it...
+
+        SupportCompiledWireKeys::closeLoop();
+
+        // A second loop after the broken one should work correctly...
+        SupportCompiledWireKeys::openLoop();
+
+        SupportCompiledWireKeys::startLoopIteration();
+        $keys[] = SupportCompiledWireKeys::generateKey('test');
+        SupportCompiledWireKeys::endLoop();
+
+        SupportCompiledWireKeys::startLoopIteration();
+        $keys[] = SupportCompiledWireKeys::generateKey('test');
+        SupportCompiledWireKeys::endLoop();
+
+        SupportCompiledWireKeys::closeLoop();
+
+        $this->assertEquals(4, count(array_unique($keys)));
+    }
+
+    public function test_continue_in_loop_does_not_corrupt_key_generation()
+    {
+        $keys = [];
+
+        // Simulate: @for with continue on iteration 1 (endLoop is skipped)...
+        SupportCompiledWireKeys::openLoop();
+
+        // Iteration 0: normal...
+        SupportCompiledWireKeys::startLoopIteration();
+        $keys[] = SupportCompiledWireKeys::generateKey('test');
+        SupportCompiledWireKeys::endLoop();
+
+        // Iteration 1: continue (endLoop is skipped)...
+        SupportCompiledWireKeys::startLoopIteration();
+        // No generateKey or endLoop — @continue skips them...
+
+        // Iteration 2: should still get the correct index...
+        SupportCompiledWireKeys::startLoopIteration();
+        $keys[] = SupportCompiledWireKeys::generateKey('test');
+        SupportCompiledWireKeys::endLoop();
+
+        SupportCompiledWireKeys::closeLoop();
+
+        $this->assertEquals([
+            'test-0-0',  // iteration 0
+            'test-0-2',  // iteration 2 (1 was skipped by continue)
+        ], $keys);
+    }
+
+    public function test_break_in_nested_loop_does_not_corrupt_outer_loop_keys()
+    {
+        $keys = [];
+
+        // Simulate: outer @for (3 iterations) -> inner @for (break on iteration 1)...
+        SupportCompiledWireKeys::openLoop();
+
+        for ($i = 0; $i < 3; $i++) {
+            SupportCompiledWireKeys::startLoopIteration();
+
+            SupportCompiledWireKeys::openLoop();
+
+            // Inner iteration 0: normal...
+            SupportCompiledWireKeys::startLoopIteration();
+            $keys[] = SupportCompiledWireKeys::generateKey('test');
+
+            // Break — endLoop is skipped, closeLoop still runs...
+            SupportCompiledWireKeys::closeLoop();
+            SupportCompiledWireKeys::endLoop();
+        }
+
+        SupportCompiledWireKeys::closeLoop();
+
+        // Each outer iteration should have a different key, proving the
+        // inner break didn't corrupt the outer loop's index...
+        $this->assertEquals(3, count(array_unique($keys)));
+    }
+
+    public function test_continue_in_nested_loop_does_not_corrupt_outer_loop_keys()
+    {
+        $keys = [];
+
+        // Simulate: outer @for (3 iterations) -> inner @for (continue on iteration 0)...
+        SupportCompiledWireKeys::openLoop();
+
+        for ($i = 0; $i < 3; $i++) {
+            SupportCompiledWireKeys::startLoopIteration();
+
+            SupportCompiledWireKeys::openLoop();
+
+            // Inner iteration 0: continue (endLoop is skipped)...
+            SupportCompiledWireKeys::startLoopIteration();
+
+            // Inner iteration 1: normal...
+            SupportCompiledWireKeys::startLoopIteration();
+            $keys[] = SupportCompiledWireKeys::generateKey('test');
+            SupportCompiledWireKeys::endLoop();
+
+            SupportCompiledWireKeys::closeLoop();
+            SupportCompiledWireKeys::endLoop();
+        }
+
+        SupportCompiledWireKeys::closeLoop();
+
+        // The outer loop index should still increment correctly...
+        $this->assertEquals([
+            'test-0-0-0-1', // outer=0, inner=1
+            'test-0-1-0-1', // outer=1, inner=1
+            'test-0-2-0-1', // outer=2, inner=1
+        ], $keys);
+    }
+
     protected function assertKeysMatchPattern($expected, $keys)
     {
         for ($i = 0; $i < count($expected); $i++) {

--- a/src/Features/SupportCompiledWireKeys/UnitTest.php
+++ b/src/Features/SupportCompiledWireKeys/UnitTest.php
@@ -1093,6 +1093,42 @@ class UnitTest extends \Tests\TestCase
         $this->assertEquals($expected, count(explode($needle, $haystack)) - 1);
     }
 
+    public function test_nested_loop_iterations_generate_unique_keys()
+    {
+        $keys = [];
+
+        // Simulate: @for ($i = 0; $i < 3; $i++) -> @for ($j = 0; $j < 2; $j++)
+        SupportCompiledWireKeys::openLoop();
+
+        for ($i = 0; $i < 3; $i++) {
+            SupportCompiledWireKeys::startLoopIteration();
+
+            SupportCompiledWireKeys::openLoop();
+
+            for ($j = 0; $j < 2; $j++) {
+                SupportCompiledWireKeys::startLoopIteration();
+                $keys[] = SupportCompiledWireKeys::generateKey('test');
+                SupportCompiledWireKeys::endLoop();
+            }
+
+            SupportCompiledWireKeys::closeLoop();
+            SupportCompiledWireKeys::endLoop();
+        }
+
+        SupportCompiledWireKeys::closeLoop();
+
+        // All 6 keys should be unique, and the outer loop index should
+        // increment across iterations (not be reset by the inner loop)...
+        $this->assertEquals([
+            'test-0-0-0-0', // outer=0, inner=0
+            'test-0-0-0-1', // outer=0, inner=1
+            'test-0-1-0-0', // outer=1, inner=0
+            'test-0-1-0-1', // outer=1, inner=1
+            'test-0-2-0-0', // outer=2, inner=0
+            'test-0-2-0-1', // outer=2, inner=1
+        ], $keys);
+    }
+
     protected function assertKeysMatchPattern($expected, $keys)
     {
         for ($i = 0; $i < count($expected); $i++) {

--- a/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
@@ -180,7 +180,7 @@ class SupportMorphAwareBladeCompilation extends ComponentHook
         if (static::$shouldInjectLoopMarkers && static::isLoop($found)) {
             $prefix .= '<?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::openLoop(); ?>';
 
-            $suffix .= '<?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoop($loop->index); ?>';
+            $suffix .= '<?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoopIteration(); ?>';
         }
 
         if ($prefix === '' && $suffix === '') {

--- a/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
@@ -42,7 +42,7 @@ class UnitTest extends \Tests\TestCase
         HTML);
 
         $this->assertStringNotContainsString('SupportCompiledWireKeys::openLoop(', $compiled);
-        $this->assertStringNotContainsString('SupportCompiledWireKeys::startLoop(', $compiled);
+        $this->assertStringNotContainsString('SupportCompiledWireKeys::startLoopIteration(', $compiled);
         $this->assertStringNotContainsString('SupportCompiledWireKeys::endLoop(', $compiled);
         $this->assertStringNotContainsString('SupportCompiledWireKeys::closeLoop(', $compiled);
     }
@@ -107,7 +107,7 @@ class UnitTest extends \Tests\TestCase
         HTML);
 
         $this->assertStringContainsString('SupportCompiledWireKeys::openLoop(', $compiled);
-        $this->assertStringContainsString('SupportCompiledWireKeys::startLoop(', $compiled);
+        $this->assertStringContainsString('SupportCompiledWireKeys::startLoopIteration(', $compiled);
         $this->assertStringContainsString('SupportCompiledWireKeys::endLoop(', $compiled);
         $this->assertStringContainsString('SupportCompiledWireKeys::closeLoop(', $compiled);
     }
@@ -238,6 +238,54 @@ class UnitTest extends \Tests\TestCase
         $this->assertStringContainsString('Test', $output);
 
         // When the template is rendered, there should be 1 loop in the stack, which will be a count of 0 so we don't have an offset compared to the loop indexes...
+        $this->assertEquals(0, SupportCompiledWireKeys::$currentLoop['count']);
+    }
+
+    public function test_for_loop_trackers_are_used_when_used_within_a_livewire_context()
+    {
+        Livewire::component('foo', new class extends \Livewire\Component
+        {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @for ($i = 0; $i < 3; $i++)
+                        <span>Test</span>
+                    @endfor
+                </div>
+                HTML;
+            }
+        });
+
+        $output = $this->render('<livewire:foo />');
+
+        $this->assertStringContainsString('Test', $output);
+
+        $this->assertEquals(0, SupportCompiledWireKeys::$currentLoop['count']);
+    }
+
+    public function test_while_loop_trackers_are_used_when_used_within_a_livewire_context()
+    {
+        Livewire::component('foo', new class extends \Livewire\Component
+        {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <?php $i = 0; ?>
+                    @while ($i < 3)
+                        <span>Test</span>
+                        <?php $i++; ?>
+                    @endwhile
+                </div>
+                HTML;
+            }
+        });
+
+        $output = $this->render('<livewire:foo />');
+
+        $this->assertStringContainsString('Test', $output);
+
         $this->assertEquals(0, SupportCompiledWireKeys::$currentLoop['count']);
     }
 
@@ -583,8 +631,8 @@ class UnitTest extends \Tests\TestCase
                 HTML,
                 <<<'HTML'
                 <div>
-                    <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if BLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::openLoop(); ?><?php endif; ?><?php $__empty_1 = true; $__currentLoopData = [1, 2]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $post): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoop($loop->index); ?><?php endif; ?>
-                        <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if BLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::openLoop(); ?><?php endif; ?><?php for($i=0; $i < 10; $i++): ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoop($loop->index); ?><?php endif; ?>
+                    <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if BLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::openLoop(); ?><?php endif; ?><?php $__empty_1 = true; $__currentLoopData = [1, 2]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $post): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); $__empty_1 = false; ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoopIteration(); ?><?php endif; ?>
+                        <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if BLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::openLoop(); ?><?php endif; ?><?php for($i=0; $i < 10; $i++): ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoopIteration(); ?><?php endif; ?>
                             <span> <?php echo e($i); ?> </span>
                         <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::endLoop(); ?><?php endif; ?><?php endfor; ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if ENDBLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::closeLoop(); ?><?php endif; ?>
                     <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::endLoop(); ?><?php endif; ?><?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); if ($__empty_1): ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::closeLoop(); ?><?php endif; ?>
@@ -802,6 +850,44 @@ class UnitTest extends \Tests\TestCase
                     </div>
                 </div>
                 HTML
+            ],
+            // @for loops should have loop tracking markers...
+            45 => [
+                1,
+                <<<'HTML'
+                <div>
+                    @for ($i = 0; $i < 3; $i++)
+                        <span> {{ $i }} </span>
+                    @endfor
+                </div>
+                HTML,
+                <<<'HTML'
+                <div>
+                    <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if BLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::openLoop(); ?><?php endif; ?><?php for($i = 0; $i < 3; $i++): ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoopIteration(); ?><?php endif; ?>
+                        <span> <?php echo e($i); ?> </span>
+                    <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::endLoop(); ?><?php endif; ?><?php endfor; ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if ENDBLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::closeLoop(); ?><?php endif; ?>
+                </div>
+                HTML,
+            ],
+            // @while loops should have loop tracking markers...
+            46 => [
+                1,
+                <<<'HTML'
+                <div>
+                    @while (true)
+                        <span>Looping</span>
+                        @break
+                    @endwhile
+                </div>
+                HTML,
+                <<<'HTML'
+                <div>
+                    <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if BLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::openLoop(); ?><?php endif; ?><?php while(true): ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::startLoopIteration(); ?><?php endif; ?>
+                        <span>Looping</span>
+                        <?php break; ?>
+                    <?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::endLoop(); ?><?php endif; ?><?php endwhile; ?><?php if(\Livewire\Mechanisms\ExtendBlade\ExtendBlade::isRenderingLivewireComponent()): ?><!--[if ENDBLOCK]><![endif]--><?php \Livewire\Features\SupportCompiledWireKeys\SupportCompiledWireKeys::closeLoop(); ?><?php endif; ?>
+                </div>
+                HTML,
             ],
         ];
     }

--- a/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/UnitTest.php
@@ -259,8 +259,9 @@ class UnitTest extends \Tests\TestCase
 
         $output = $this->render('<livewire:foo />');
 
-        $this->assertStringContainsString('Test', $output);
+        preg_match_all('/<span>(.*?)<\/span>/', $output, $matches);
 
+        $this->assertEquals(['Test', 'Test', 'Test'], $matches[1]);
         $this->assertEquals(0, SupportCompiledWireKeys::$currentLoop['count']);
     }
 
@@ -284,10 +285,12 @@ class UnitTest extends \Tests\TestCase
 
         $output = $this->render('<livewire:foo />');
 
-        $this->assertStringContainsString('Test', $output);
+        preg_match_all('/<span>(.*?)<\/span>/', $output, $matches);
 
+        $this->assertEquals(['Test', 'Test', 'Test'], $matches[1]);
         $this->assertEquals(0, SupportCompiledWireKeys::$currentLoop['count']);
     }
+
 
     #[DataProvider('templatesProvider')]
     public function test_foo($occurrences, $template, $expectedCompiled = null)


### PR DESCRIPTION
# The Scenario

When using `@for` or `@while` loops inside a Livewire component, the smart wire keys feature (`smart_wire_keys`) crashes with an "Undefined variable $loop" error. This is because `$loop` is a Blade variable that only exists for `@foreach` and `@forelse` loops. PR #10082 worked around this by disabling smart key tracking for `@for` and `@while` entirely, but ideally these loops should participate in key generation too.

```php
<?php

use Livewire\Volt\Component;

new class extends Component {
    public int $count = 3;
}

?>

<div>
    @for ($i = 0; $i < $count; $i++)
        <livewire:some-child :item="$i" />
    @endfor
</div>
```

# The Problem

The compiled Blade output injected `startLoop($loop->index)` at the start of every loop iteration to track the current index. This works for `@foreach` and `@forelse` because Laravel provides the `$loop` variable via `$__env->addLoop()` and `$__env->incrementLoopIndices()`. However, `@for` and `@while` loops don't have this variable, so the injected code throws an error.

# The Solution

Replace `startLoop($loop->index)` with a new `startLoopIteration()` method that auto-increments the loop index internally, mirroring how Laravel's `$__env->incrementLoopIndices()` works but without depending on the `$loop` variable. This is used for all loop types (`@foreach`, `@forelse`, `@for`, `@while`), not just the previously broken ones.

The `endLoop()` method was also updated to preserve the current index between iterations (only resetting `count` and `key`), so that nested loops don't wipe out the outer loop's counter.

The original `startLoop($index)` method is kept as deprecated for backwards compatibility with cached compiled views.

Fixes #10078