### PR TITLE
[4.x] Add `Authorize` attribute

### DIFF
--- a/docs/attribute-authorize.md
+++ b/docs/attribute-authorize.md
@@ -1,8 +1,8 @@
-The `#[Authorize]` attribute integrates Laravel’s Gate system directly into your Livewire actions. It ensures that an action is only executed if the user has the necessary permissions, throwing a `403 Forbidden` response otherwise.
+The `#[Authorize]` attribute integrates Laravel's Gate system directly into your Livewire actions. It ensures that an action is only executed if the user has the necessary permissions, throwing a `403 Forbidden` response otherwise.
 
 ## Basic usage
 
-Apply the `#[Authorize]` attribute to any action method. You can pass the ability name and an optional argument:
+Apply the `#[Authorize]` attribute to any action method. Pass the ability name and an optional argument:
 
 ```php
 <?php // resources/views/components/post/⚡edit.blade.php
@@ -26,62 +26,22 @@ new class extends Component {
 <button wire:click="save">
     Update Post
 </button>
-```
-
-When `save()` is called, Livewire automatically checks if the current user is authorized to `update` the `$post` model stored on the component.
-
-Certainly! Adding that clarification is important because the underlying logic relies on reflection to identify the class for model resolution.
-
-Here is the updated documentation with a specific section on type-hinting requirements.
-
----
-
-The `#[Authorize]` attribute integrates Laravel’s Gate system directly into your Livewire actions. It ensures that an action is only executed if the user has the necessary permissions, throwing a `403 Forbidden` response otherwise.
-
-## Basic usage
-
-Apply the `#[Authorize]` attribute to any action method. You can pass the ability name and an optional argument:
-
-```php
-<?php // resources/views/components/post/⚡edit.blade.php
-
-use Livewire\Attributes\Authorize;
-use Livewire\Component;
-use App\Models\Post;
-
-new class extends Component {
-    public Post $post;
-
-    #[Authorize('update', 'post')] // [tl! highlight]
-    public function save()
-    {
-        $this->post->save();
-    }
-};
-
-```
-
-```blade
-<button wire:click="save">
-    Update Post
-</button>
-
 ```
 
 When `save()` is called, Livewire automatically checks if the current user is authorized to `update` the `$post` model stored on the component.
 
 ## Argument resolution
 
-The attribute is intelligent about how it resolves the object you want to authorize. It checks for arguments in the following order:
+The attribute resolves the object to authorize against in the following order:
 
-* **No argument** - Checks a simple gate that doesn't require a model (e.g., `#[Authorize('view-dashboard')]`).
-* **Class strings** - Useful for 'create' permissions where no instance exists yet (e.g., `#[Authorize('create', Post::class)]`).
-* **Method parameters** - It resolves the argument from the method's own parameters.
-* **Component properties** - It looks for a property on the component matching the argument name (e.g., `public $post`).
+* **No argument** — Checks a simple gate that doesn't require a model (e.g., `#[Authorize('view-dashboard')]`).
+* **Class string** — Useful for `create` permissions where no instance exists yet (e.g., `#[Authorize('create', Post::class)]`).
+* **Method parameter** — Resolves the argument from the method's own parameters.
+* **Component property** — Looks for a property on the component matching the argument name (e.g., `public Post $post`).
 
 ### Resolving from method parameters
 
-When authorizing based on a method parameter, **you must type-hint the parameter**. Livewire uses the type-hint to determine which model class to use when resolving the record from the database.
+When authorizing based on a method parameter, you must type-hint the parameter so Livewire knows which model to resolve:
 
 ```php
 <?php // resources/views/components/⚡comment-manager.blade.php
@@ -92,28 +52,37 @@ use App\Models\Comment;
 
 new class extends Component {
     #[Authorize('delete', 'comment')] // [tl! highlight]
-    public function deleteComment(Comment $comment) // Type-hint is required! [tl! highlight]
+    public function deleteComment(Comment $comment) // [tl! highlight]
     {
         $comment->delete();
     }
 };
-
 ```
 
-> [!important] Type-hints are mandatory for method resolution
-> If you resolve a model via a method parameter, the attribute requires a valid type-hint (e.g., `Comment $comment`). Without the type-hint, Livewire won't know which model to resolve, and the authorization check will fail.
+> [!important]
+> If you resolve a model via a method parameter, a type-hint (e.g., `Comment $comment`) is required. Without it, Livewire cannot determine which model to resolve and the authorization check will fail.
 
----
+## Stacking multiple checks
+
+The attribute is repeatable, so you can stack multiple authorization checks on a single method:
+
+```php
+#[Authorize('create', Post::class)]
+#[Authorize('update', 'post')]
+public function save()
+{
+    // Both checks must pass...
+}
+```
 
 ## When NOT to use
 
-> [!warning] Authorization is not UI masking
-> **The `#[Authorize]` attribute only protects the server-side execution of an action.** It does not automatically hide UI elements in your Blade template.
+> [!warning]
+> The `#[Authorize]` attribute only protects server-side execution of an action. It does not hide UI elements in your Blade template.
 
-Even if an action is protected, you should still use Blade's `@can` directives to prevent users from seeing buttons they aren't allowed to use:
+You should still use Blade's `@can` directives to hide buttons the user isn't allowed to use:
 
 ```blade
-{{-- The action is secure, but the button should still be hidden for UX --}}
 @can('update', $post)
     <button wire:click="save">Save</button>
 @endcan

--- a/docs/attribute-authorize.md
+++ b/docs/attribute-authorize.md
@@ -1,0 +1,99 @@
+The `#[Authorize]` attribute integrates Laravel’s Gate system directly into your Livewire actions. It ensures that an action is only executed if the user has the necessary permissions, throwing a `403 Forbidden` response otherwise.
+
+## Basic usage
+
+Apply the `#[Authorize]` attribute to any action method. You can pass the ability name and an optional argument:
+
+```php
+<?php // resources/views/components/post/⚡edit.blade.php
+
+use Livewire\Attributes\Authorize;
+use Livewire\Component;
+use App\Models\Post;
+
+new class extends Component {
+    public Post $post;
+
+    #[Authorize('update', 'post')] // [tl! highlight]
+    public function save()
+    {
+        $this->post->save();
+    }
+};
+```
+
+```blade
+<button wire:click="save">
+    Update Post
+</button>
+```
+
+When `save()` is called, Livewire automatically checks if the current user is authorized to `update` the `$post` model stored on the component.
+
+## Argument resolution
+
+The attribute is intelligent about how it resolves the object you want to authorize. It checks for arguments in the following order:
+
+* **No argument** - Checks a simple gate that doesn't require a model (e.g., `#[Authorize('view-dashboard')]`).
+* **Class strings** - Useful for 'create' permissions where no instance exists yet (e.g., `#[Authorize('create', Post::class)]`).
+* **Component properties** - It looks for a property on the component matching the argument name (e.g., `public $post`).
+* **Method parameters** - If not found on the component, it resolves the argument from the method's own parameters (including Route Model Binding resolution).
+
+### Example: Resolving from method parameters
+
+```php
+<?php // resources/views/components/⚡comment-manager.blade.php
+
+use Livewire\Attributes\Authorize;
+use Livewire\Component;
+use App\Models\Comment;
+
+new class extends Component {
+    #[Authorize('delete', 'comment')] // [tl! highlight]
+    public function deleteComment(Comment $comment)
+    {
+        $comment->delete();
+    }
+};
+```
+
+---
+
+## When to use
+
+Use `#[Authorize]` to centralize your security logic and keep your action methods focused on their primary task:
+
+* **Resource protection** - Ensuring a user can only modify or delete records they own.
+* **Action-specific restrictions** - Restricting sensitive operations like exporting data or changing site settings.
+* **Cleaner code** - Removing boilerplate `Gate::authorize()` or `$this->authorize()` calls from the beginning of every method.
+
+---
+
+## When NOT to use
+
+> [!warning] Authorization is not UI masking
+> **The `#[Authorize]` attribute only protects the server-side execution of an action.** It does not automatically hide UI elements in your Blade template.
+
+Even if an action is protected, you should still use Blade's `@can` directives to prevent users from seeing buttons they aren't allowed to use:
+
+```blade
+{{-- The action is secure, but the button should still be hidden for UX --}}
+@can('update', $post)
+    <button wire:click="save">Save</button>
+@endcan
+```
+
+## Advanced: Dynamic resolution
+
+If you pass a string as the second argument, Livewire first checks if a property with that name exists on your component. if not, it inspects the method's parameters:
+
+```php
+#[Authorize('update', 'item')]
+public function update(Item $item) { ... }
+```
+
+In this scenario, the attribute identifies the `$item` parameter, resolves the model from the incoming request data, and passes it to the Gate.
+
+## Learn more
+
+For more information on defining abilities and policies, see the [Laravel Authorization documentation](https://laravel.com/docs/authorization).

--- a/docs/attribute-authorize.md
+++ b/docs/attribute-authorize.md
@@ -30,6 +30,46 @@ new class extends Component {
 
 When `save()` is called, Livewire automatically checks if the current user is authorized to `update` the `$post` model stored on the component.
 
+Certainly! Adding that clarification is important because the underlying logic relies on reflection to identify the class for model resolution.
+
+Here is the updated documentation with a specific section on type-hinting requirements.
+
+---
+
+The `#[Authorize]` attribute integrates Laravel’s Gate system directly into your Livewire actions. It ensures that an action is only executed if the user has the necessary permissions, throwing a `403 Forbidden` response otherwise.
+
+## Basic usage
+
+Apply the `#[Authorize]` attribute to any action method. You can pass the ability name and an optional argument:
+
+```php
+<?php // resources/views/components/post/⚡edit.blade.php
+
+use Livewire\Attributes\Authorize;
+use Livewire\Component;
+use App\Models\Post;
+
+new class extends Component {
+    public Post $post;
+
+    #[Authorize('update', 'post')] // [tl! highlight]
+    public function save()
+    {
+        $this->post->save();
+    }
+};
+
+```
+
+```blade
+<button wire:click="save">
+    Update Post
+</button>
+
+```
+
+When `save()` is called, Livewire automatically checks if the current user is authorized to `update` the `$post` model stored on the component.
+
 ## Argument resolution
 
 The attribute is intelligent about how it resolves the object you want to authorize. It checks for arguments in the following order:
@@ -37,9 +77,11 @@ The attribute is intelligent about how it resolves the object you want to author
 * **No argument** - Checks a simple gate that doesn't require a model (e.g., `#[Authorize('view-dashboard')]`).
 * **Class strings** - Useful for 'create' permissions where no instance exists yet (e.g., `#[Authorize('create', Post::class)]`).
 * **Component properties** - It looks for a property on the component matching the argument name (e.g., `public $post`).
-* **Method parameters** - If not found on the component, it resolves the argument from the method's own parameters (including Route Model Binding resolution).
+* **Method parameters** - It resolves the argument from the method's own parameters.
 
-### Example: Resolving from method parameters
+### Resolving from method parameters
+
+When authorizing based on a method parameter, **you must type-hint the parameter**. Livewire uses the type-hint to determine which model class to use when resolving the record from the database.
 
 ```php
 <?php // resources/views/components/⚡comment-manager.blade.php
@@ -50,22 +92,16 @@ use App\Models\Comment;
 
 new class extends Component {
     #[Authorize('delete', 'comment')] // [tl! highlight]
-    public function deleteComment(Comment $comment)
+    public function deleteComment(Comment $comment) // Type-hint is required! [tl! highlight]
     {
         $comment->delete();
     }
 };
+
 ```
 
----
-
-## When to use
-
-Use `#[Authorize]` to centralize your security logic and keep your action methods focused on their primary task:
-
-* **Resource protection** - Ensuring a user can only modify or delete records they own.
-* **Action-specific restrictions** - Restricting sensitive operations like exporting data or changing site settings.
-* **Cleaner code** - Removing boilerplate `Gate::authorize()` or `$this->authorize()` calls from the beginning of every method.
+> [!important] Type-hints are mandatory for method resolution
+> If you resolve a model via a method parameter, the attribute requires a valid type-hint (e.g., `Comment $comment`). Without the type-hint, Livewire won't know which model to resolve, and the authorization check will fail.
 
 ---
 
@@ -82,17 +118,6 @@ Even if an action is protected, you should still use Blade's `@can` directives t
     <button wire:click="save">Save</button>
 @endcan
 ```
-
-## Advanced: Dynamic resolution
-
-If you pass a string as the second argument, Livewire first checks if a property with that name exists on your component. if not, it inspects the method's parameters:
-
-```php
-#[Authorize('update', 'item')]
-public function update(Item $item) { ... }
-```
-
-In this scenario, the attribute identifies the `$item` parameter, resolves the model from the incoming request data, and passes it to the Gate.
 
 ## Learn more
 

--- a/docs/attribute-authorize.md
+++ b/docs/attribute-authorize.md
@@ -76,8 +76,8 @@ The attribute is intelligent about how it resolves the object you want to author
 
 * **No argument** - Checks a simple gate that doesn't require a model (e.g., `#[Authorize('view-dashboard')]`).
 * **Class strings** - Useful for 'create' permissions where no instance exists yet (e.g., `#[Authorize('create', Post::class)]`).
-* **Component properties** - It looks for a property on the component matching the argument name (e.g., `public $post`).
 * **Method parameters** - It resolves the argument from the method's own parameters.
+* **Component properties** - It looks for a property on the component matching the argument name (e.g., `public $post`).
 
 ### Resolving from method parameters
 

--- a/src/Attributes/Authorize.php
+++ b/src/Attributes/Authorize.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Attribute;
+use Livewire\Features\SupportAuthorization\BaseAuthorize;
+
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
+class Authorize extends BaseAuthorize
+{
+    //
+}

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -19,16 +19,14 @@ class BaseAuthorize extends LivewireAttribute
     public function call(array $parameters) : void
     {
         // Action that does not require a model or class...
-        if (is_null($this->argument))
-        {
+        if (is_null($this->argument)) {
             Gate::authorize($this->ability);
 
             return;
         }
 
         // Action that does not require a model, for example a 'create' action...
-        if (is_string($this->argument) && class_exists($this->argument))
-        {
+        if (is_string($this->argument) && class_exists($this->argument)) {
             Gate::authorize($this->ability, $this->argument);
 
             return;
@@ -40,9 +38,14 @@ class BaseAuthorize extends LivewireAttribute
         );
 
         // Action that requires a model, extracted from the called method...
-        if (is_string($this->argument) && $methodArgument instanceof \ReflectionParameter && isset($parameters[$this->argument]))
-        {
-            Gate::authorize($this->ability, app($methodArgument->getType()->getName())->resolveRouteBinding($parameters[$this->argument]));
+        if ($methodArgument instanceof \ReflectionParameter && isset($parameters[$this->argument])) {
+            $model = app($methodArgument->getType()->getName())->resolveRouteBinding($parameters[$this->argument]);
+
+            if (! $model) {
+                throw (new \Illuminate\Database\Eloquent\ModelNotFoundException)->setModel($methodArgument->getType()->getName());
+            }
+
+            Gate::authorize($this->ability, $model);
 
             return;
         }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Livewire\Features\SupportAuthorization;
+
+use Attribute;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+use UnitEnum;
+
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
+class BaseAuthorize extends LivewireAttribute
+{
+    public function __construct(
+        public UnitEnum|string $ability,
+        public string|null $argument = null,
+    ) {}
+
+    public function call(array $parameters) : void
+    {
+        // Action that does not require a model or class...
+        if (is_null($this->argument))
+        {
+            Gate::authorize($this->ability);
+
+            return;
+        }
+
+        // Action that does not require a model, for example a 'create' action...
+        if (is_string($this->argument) && class_exists($this->argument))
+        {
+            Gate::authorize($this->ability, $this->argument);
+
+            return;
+        }
+
+        // Action that requires a model, extracted from the component...
+        if (is_string($this->argument) && $model = data_get($this->component, $this->argument))
+        {
+            Gate::authorize($this->ability, $model);
+
+            return;
+        }
+
+        $methodArgument = Arr::first(
+            (new \ReflectionObject($this->component))->getMethod($this->getName())->getParameters(),
+            fn (\ReflectionParameter $parameter) : bool => $parameter->getName() === $this->argument,
+        );
+
+        // Action that requires a model, extracted from the called method...
+        Gate::authorize($this->ability, app($methodArgument->getType()->getName())->resolveRouteBinding($parameters[$this->argument]));
+    }
+}

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -34,20 +34,20 @@ class BaseAuthorize extends LivewireAttribute
             return;
         }
 
-        // Action that requires a model, extracted from the component...
-        if (is_string($this->argument) && $model = data_get($this->component, $this->argument))
-        {
-            Gate::authorize($this->ability, $model);
-
-            return;
-        }
-
         $methodArgument = Arr::first(
             (new \ReflectionObject($this->component))->getMethod($this->getName())->getParameters(),
             fn (\ReflectionParameter $parameter) : bool => $parameter->getName() === $this->argument,
         );
 
         // Action that requires a model, extracted from the called method...
-        Gate::authorize($this->ability, app($methodArgument->getType()->getName())->resolveRouteBinding($parameters[$this->argument]));
+        if (is_string($this->argument) && $methodArgument instanceof \ReflectionParameter && isset($parameters[$this->argument]))
+        {
+            Gate::authorize($this->ability, app($methodArgument->getType()->getName())->resolveRouteBinding($parameters[$this->argument]));
+
+            return;
+        }
+
+        // Action that requires a model, extracted from the component...
+        Gate::authorize($this->ability, data_get($this->component, $this->argument));
     }
 }

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -208,6 +208,47 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_prioritizes_arguments_over_properties()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                #[Authorize('edit', 'post')]
+                public function editPost(AuthorizationPost $post) : bool
+                {
+                    return true;
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('edit', 'post')]
+                public function editPost(AuthorizationPost $post) : bool
+                {
+                    return true;
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_multiple_policies()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace Livewire\Features\SupportAuthorization;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User as AuthUser;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Session;
+use Livewire\Attributes\Authorize;
+use Livewire\Livewire;
+use Sushi\Sushi;
+use Tests\TestCase;
+use Tests\TestComponent;
+
+class UnitTest extends TestCase
+{
+    public function test_can_authorize_defined_basic_gates()
+    {
+        Gate::define('can-open-post', fn () : bool => true);
+        Gate::define('cannot-open-post', fn () : bool => false);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize('can-open-post')]
+                public function canOpenPost() : bool
+                {
+                    return true;
+                }
+
+                #[Authorize('cannot-open-post')]
+                public function cannotOpenPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('canOpenPost')
+            ->assertOk()
+            ->call('cannotOpenPost')
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_defined_gates_without_arguments()
+    {
+        Gate::define('can-open-post', function (AuthorizationUser $user) : bool
+        {
+            return (int) $user->id === 1;
+        });
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize('can-open-post')]
+                public function canOpenPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('canOpenPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[Authorize('can-open-post')]
+                public function canOpenPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('canOpenPost')
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_defined_gates_with_model_argument()
+    {
+        Gate::define('can-open-post', function (AuthorizationUser $user, AuthorizationPost $post) : bool
+        {
+            return (int) $post->user_id === (int) $user->id;
+        });
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('can-open-post', 'post')]
+                public function canOpenPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('canOpenPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('can-open-post', 'post')]
+                public function canOpenPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('canOpenPost')
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_policy_with_class()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize('create', AuthorizationPost::class)]
+                public function createPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('createPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[Authorize('create', AuthorizationPost::class)]
+                public function createPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('createPost')
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_policy_with_model_argument()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('edit', 'post')]
+                public function editPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('editPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('edit', 'post')]
+                public function editPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('editPost')
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_policy_with_model_id_argument()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize('edit', 'post')]
+                public function editPost(AuthorizationPost $post) : bool
+                {
+                    return true;
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[Authorize('edit', 'post')]
+                public function editPost(AuthorizationPost $post) : bool
+                {
+                    return true;
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_multiple_policies()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('create', AuthorizationPost::class)]
+                #[Authorize('edit', 'post')]
+                public function createPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('createPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                #[Authorize('create', AuthorizationPost::class)]
+                #[Authorize('edit', 'post')]
+                public function createPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('createPost')
+            ->assertForbidden();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                #[Authorize('create', AuthorizationPost::class)]
+                #[Authorize('edit', 'post')]
+                public function createPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('createPost')
+            ->assertForbidden();
+    }
+
+    public function test_it_does_not_perform_any_action_when_denied()
+    {
+        Gate::define('cannot-open-post', fn () => false);
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize('cannot-open-post')]
+                public function cannotOpenPost() : void
+                {
+                    Session::put('should-never-be-set', true);
+                }
+            })
+            ->call('cannotOpenPost')
+            ->assertForbidden();
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+}
+
+class AuthorizationUser extends AuthUser
+{
+    use Sushi;
+
+    protected $rows = [
+        ['id' => 1, 'name' => 'First User', 'email' => 'first@example.com', 'password' => ''],
+        ['id' => 2, 'name' => 'Second User', 'email' => 'second@example.com', 'password' => ''],
+    ];
+}
+
+class AuthorizationPost extends Model
+{
+    use Sushi;
+
+    protected $rows = [
+        ['id' => 1, 'title' => 'First', 'user_id' => 1],
+        ['id' => 2, 'title' => 'Second', 'user_id' => 2],
+    ];
+}
+
+class AuthorizationPostPolicy
+{
+    public function create(AuthorizationUser $user) : bool
+    {
+        return (int) $user->id === 1;
+    }
+
+    public function edit(AuthorizationUser $user, AuthorizationPost $post) : bool
+    {
+        return (int) $post->user_id === (int) $user->id;
+    }
+}

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -330,6 +330,44 @@ class UnitTest extends TestCase
 
         $this->assertFalse(Session::has('should-never-be-set'));
     }
+
+    public function test_authorize_is_enforced_on_event_listeners()
+    {
+        Gate::define('cannot-open-post', fn () => false);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[\Livewire\Attributes\On('some-event')]
+                #[Authorize('cannot-open-post')]
+                public function handleEvent() : void
+                {
+                    Session::put('should-never-be-set', true);
+                }
+            })
+            ->dispatch('some-event')
+            ->assertForbidden();
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
+    public function test_authorize_allows_authorized_event_listeners()
+    {
+        Gate::define('can-open-post', fn () => true);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[\Livewire\Attributes\On('some-event')]
+                #[Authorize('can-open-post')]
+                public function handleEvent() : void
+                {
+                    Session::put('event-was-handled', true);
+                }
+            })
+            ->dispatch('some-event')
+            ->assertOk();
+
+        $this->assertTrue(Session::has('event-was-handled'));
+    }
 }
 
 class AuthorizationUser extends AuthUser

--- a/src/Features/SupportEvents/SupportEvents.php
+++ b/src/Features/SupportEvents/SupportEvents.php
@@ -8,6 +8,7 @@ use function Livewire\invade;
 use Livewire\Features\SupportAttributes\AttributeLevel;
 use Livewire\ComponentHook;
 use Livewire\Exceptions\EventHandlerDoesNotExist;
+use Livewire\Features\SupportAuthorization\BaseAuthorize;
 use Livewire\Mechanisms\HandleComponents\BaseRenderless;
 
 class SupportEvents extends ComponentHook
@@ -24,6 +25,15 @@ class SupportEvents extends ComponentHook
             }
 
             $method = static::getListenerMethodName($this->component, $name);
+
+            // Run any authorization checks on the listener method since
+            // its normal "call" hook doesn't get run when the method
+            // is called as an event listener...
+            $this->component->getAttributes()
+                ->filter(fn ($i) => is_subclass_of($i, BaseAuthorize::class))
+                ->filter(fn ($i) => $i->getName() === $method)
+                ->filter(fn ($i) => $i->getLevel() === AttributeLevel::METHOD)
+                ->each(fn ($i) => $i->call($params));
 
             $returnEarly(
                 wrap($this->component)->$method(...$params)


### PR DESCRIPTION
This PR introduces a declarative `#[Authorize]` attribute for Livewire actions, bringing the same elegant authorization DX recently introduced in the Laravel framework https://github.com/laravel/framework/pull/59048 directly into Livewire components.

Currently, authorizing actions in Livewire requires manual calls to `Gate::authorize()` or `$this->authorize()` inside the method body. This attribute allows you to lift that logic into the method signature, making the intent of your code clearer and more concise.

## Examples

### Basic Gate Check

For simple permissions that don't require a model instance:

```php
#[Authorize('view-dashboard')]
public function showStats() { ... }
```

### Class-based Gate Check

Useful for 'create' permissions where no instance exists yet:

```php
#[Authorize('create', Post::class)]
public function create() { ... }
```

### Authorizing via Component Property

The attribute can automatically pull models from the component's state:

```php
public Post $post;

#[Authorize('update', 'post')]
public function save() { ... }
```

### Authorizing via Method Parameter

It also supports resolving models passed directly to the action, including support for route-model-binding resolution:

```php
#[Authorize('delete', 'comment')]
public function delete(Comment $comment) { ... }
```
