### PR TITLE
[4.x] Fix `--emoji` flag being ignored on `make:livewire`

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -141,7 +141,7 @@ class MakeCommand extends Command
 
     protected function createSingleFileComponent(string $name): int
     {
-        $path = $this->finder->resolveSingleFileComponentPathForCreation($name);
+        $path = $this->finder->resolveSingleFileComponentPathForCreation($name, $this->shouldUseEmoji());
 
         if ($path === null) {
             [$namespace] = $this->finder->parseNamespaceAndName($name);
@@ -208,7 +208,7 @@ class MakeCommand extends Command
 
     protected function createMultiFileComponent(string $name): int
     {
-        $directory = $this->finder->resolveMultiFileComponentPathForCreation($name);
+        $directory = $this->finder->resolveMultiFileComponentPathForCreation($name, $this->shouldUseEmoji());
 
         if ($directory === null) {
             [$namespace] = $this->finder->parseNamespaceAndName($name);
@@ -233,7 +233,7 @@ class MakeCommand extends Command
         $cssPath = $directory . '/' . $componentName . '.css';
 
         // Check if we're upgrading from a single-file component
-        $sfcPath = $this->finder->resolveSingleFileComponentPathForCreation($name);
+        $sfcPath = $this->finder->resolveSingleFileComponentPathForCreation($name, $this->shouldUseEmoji());
         if ($this->files->exists($sfcPath)) {
             // Skip interactive prompts in testing environment
             if (app()->runningUnitTests()) {
@@ -490,7 +490,7 @@ class MakeCommand extends Command
         }
 
         // Check for single-file component
-        $sfcPath = $finder->resolveSingleFileComponentPathForCreation($name);
+        $sfcPath = $finder->resolveSingleFileComponentPathForCreation($name, $this->shouldUseEmoji());
         if ($sfcPath !== null && $this->files->exists($sfcPath)) {
             return true;
         }
@@ -532,7 +532,7 @@ class MakeCommand extends Command
         }
 
         // Check for single-file component
-        $sfcPath = $finder->resolveSingleFileComponentPathForCreation($name);
+        $sfcPath = $finder->resolveSingleFileComponentPathForCreation($name, $this->shouldUseEmoji());
         if ($sfcPath !== null && $this->files->exists($sfcPath)) {
             $testPath = $this->getSingleFileComponentTestPath($sfcPath);
 

--- a/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
@@ -36,6 +36,26 @@ class MakeCommandUnitTest extends \Tests\TestCase
         $this->assertFalse(File::exists($this->livewireComponentsPath('⚡foo.blade.php')));
     }
 
+    public function test_emoji_flag_false_overrides_config_emoji_enabled()
+    {
+        $this->app['config']->set('livewire.make_command.emoji', true);
+
+        Artisan::call('make:livewire', ['name' => 'foo', '--emoji' => 'false']);
+
+        $this->assertTrue(File::exists($this->livewireComponentsPath('foo.blade.php')));
+        $this->assertFalse(File::exists($this->livewireComponentsPath('⚡foo.blade.php')));
+    }
+
+    public function test_emoji_flag_true_overrides_config_emoji_disabled()
+    {
+        $this->app['config']->set('livewire.make_command.emoji', false);
+
+        Artisan::call('make:livewire', ['name' => 'foo', '--emoji' => 'true']);
+
+        $this->assertTrue(File::exists($this->livewireComponentsPath('⚡foo.blade.php')));
+        $this->assertFalse(File::exists($this->livewireComponentsPath('foo.blade.php')));
+    }
+
     public function test_single_file_component_with_sfc_flag()
     {
         Artisan::call('make:livewire', ['name' => 'foo', '--sfc' => true]);

--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -396,7 +396,7 @@ class Finder
             && file_exists($dir . '/' . $fileBaseName . '.blade.php');
     }
 
-    public function resolveSingleFileComponentPathForCreation(string $name): ?string
+    public function resolveSingleFileComponentPathForCreation(string $name, ?bool $useEmoji = null): ?string
     {
         [$namespace, $componentName] = $this->parseNamespaceAndName($name);
 
@@ -420,15 +420,15 @@ class Finder
         $lastSegment = array_pop($segments);
         $leadingPath = !empty($segments) ? implode('/', $segments) . '/' : '';
 
-        // Determine if emoji should be used (get from config)
-        $useEmoji = config('livewire.make_command.emoji', true);
+        // Determine if emoji should be used (prefer explicit parameter, then config)
+        $useEmoji = $useEmoji ?? config('livewire.make_command.emoji', true);
         $prefix = $useEmoji ? self::ZAP : '';
 
         // Build the file path
         return $location . '/' . $leadingPath . $prefix . $lastSegment . '.blade.php';
     }
 
-    public function resolveMultiFileComponentPathForCreation(string $name): ?string
+    public function resolveMultiFileComponentPathForCreation(string $name, ?bool $useEmoji = null): ?string
     {
         [$namespace, $componentName] = $this->parseNamespaceAndName($name);
 
@@ -452,8 +452,8 @@ class Finder
         $lastSegment = array_pop($segments);
         $leadingPath = !empty($segments) ? implode('/', $segments) . '/' : '';
 
-        // Determine if emoji should be used (get from config)
-        $useEmoji = config('livewire.make_command.emoji', true);
+        // Determine if emoji should be used (prefer explicit parameter, then config)
+        $useEmoji = $useEmoji ?? config('livewire.make_command.emoji', true);
         $prefix = $useEmoji ? self::ZAP : '';
 
         // Build the directory path


### PR DESCRIPTION
# The Scenario

When creating a Livewire component with the `--emoji=false` flag, the emoji prefix is still applied to the filename:

```shell
php artisan make:livewire post.create --emoji=false
# Expected: resources/views/components/post/create.blade.php
# Actual:   resources/views/components/post/⚡create.blade.php
```

The only way to disable the emoji was to publish the config file and set `make_command.emoji` to `false`, even though the `--emoji` flag exists on the command.

# The Problem

The `MakeCommand` has a `shouldUseEmoji()` method that correctly checks the `--emoji` CLI flag before falling back to config:

```php
protected function shouldUseEmoji(): bool
{
    if ($this->option('emoji') !== null) {
        return filter_var($this->option('emoji'), FILTER_VALIDATE_BOOLEAN);
    }

    return config('livewire.make_command.emoji', true);
}
```

However, the `Finder` methods that actually build the file paths (`resolveSingleFileComponentPathForCreation` and `resolveMultiFileComponentPathForCreation`) read directly from config, completely bypassing the CLI flag:

```php
$useEmoji = config('livewire.make_command.emoji', true);
```

# The Solution

Added an optional `?bool $useEmoji = null` parameter to both Finder creation methods. When provided, it takes precedence over config. When `null` (the default), it falls back to config for backwards compatibility.

Updated all call sites in `MakeCommand` to pass `$this->shouldUseEmoji()` through to the Finder.

Fixes #10085