### PR TITLE
[4.x] Improve component docs: naming clarity, command options, and v3 opt-out

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -37,13 +37,29 @@ new class extends Component {
 > [!info] Why the ⚡ emoji?
 > You might be wondering about the lightning bolt in the filename. This small touch serves a practical purpose: it makes Livewire components instantly recognizable in your editor's file tree and search results. Since it's a Unicode character, it works seamlessly across all platforms — Windows, macOS, Linux, Git, and your production servers.
 >
-> The emoji is completely optional and if you find it outside your comfort zone you can disable it entirely in your `config/livewire.php` file:
+> The emoji is completely optional. You can disable it per-command with the `--emoji` flag or globally in your `config/livewire.php` file:
+>
+> ```shell
+> php artisan make:livewire post.create --emoji=false
+> ```
 >
 > ```php
 > 'make_command' => [
 >     'emoji' => false,
 > ],
 > ```
+
+> [!tip] Prefer v3 conventions?
+> If you prefer the class-based component style from Livewire v2/v3, you can restore the previous defaults with two config lines in `config/livewire.php`:
+>
+> ```php
+> 'make_command' => [
+>     'type' => 'class',
+>     'emoji' => false,
+> ],
+> ```
+>
+> This makes `make:livewire` generate class-based components without the emoji prefix, just like v3. You can also override these per-command with the `--class`, `--sfc`, `--mfc`, and `--emoji` flags.
 
 ### Creating page components
 
@@ -78,6 +94,21 @@ resources/views/components/post/⚡create/
 ├── create.global.css   # Global styles (optional)
 └── create.test.php     # Pest test (optional, with --test flag)
 ```
+
+### Command options
+
+The `make:livewire` command accepts the following options:
+
+| Option | Description |
+|--------|-------------|
+| `--sfc` | Create a single-file component (default) |
+| `--mfc` | Create a multi-file component |
+| `--class` | Create a class-based component |
+| `--type=sfc\|mfc\|class` | Set the component type explicitly |
+| `--emoji=true\|false` | Override the config emoji setting for this command |
+| `--test` | Create a Pest test file alongside the component |
+| `--js` | Create a JavaScript file (multi-file components only) |
+| `--css` | Create CSS files (multi-file components only) |
 
 ### Converting between formats
 
@@ -148,6 +179,20 @@ For namespaced components—like `pages::`—use the namespace prefix:
 ```blade
 <livewire:pages::post.create />
 ```
+
+### How file paths map to component names
+
+Regardless of which format you use (single-file, multi-file, or class-based), the component name you use in Blade tags and routes is always the same. The ⚡ emoji prefix and file structure are stripped away automatically:
+
+| Format | File path | Component name |
+|--------|-----------|---------------|
+| Single-file | `resources/views/components/post/⚡create.blade.php` | `post.create` |
+| Multi-file | `resources/views/components/post/⚡create/create.php` | `post.create` |
+| Class-based | `app/Livewire/Post/Create.php` | `post.create` |
+| Single-file (namespaced) | `resources/views/pages/post/⚡create.blade.php` | `pages::post.create` |
+| Multi-file (namespaced) | `resources/views/pages/post/⚡create/create.php` | `pages::post.create` |
+
+This means you can switch between formats without changing any of your Blade templates or routes.
 
 ### Passing props
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -37,11 +37,7 @@ new class extends Component {
 > [!info] Why the ⚡ emoji?
 > You might be wondering about the lightning bolt in the filename. This small touch serves a practical purpose: it makes Livewire components instantly recognizable in your editor's file tree and search results. Since it's a Unicode character, it works seamlessly across all platforms — Windows, macOS, Linux, Git, and your production servers.
 >
-> The emoji is completely optional. You can disable it per-command with the `--emoji` flag or globally in your `config/livewire.php` file:
->
-> ```shell
-> php artisan make:livewire post.create --emoji=false
-> ```
+> The emoji is completely optional and if you find it outside your comfort zone you can disable it entirely in your `config/livewire.php` file:
 >
 > ```php
 > 'make_command' => [

--- a/docs/components.md
+++ b/docs/components.md
@@ -46,7 +46,7 @@ new class extends Component {
 > ```
 
 > [!tip] Prefer v3 conventions?
-> If you prefer the class-based component style from Livewire v2/v3, you can restore the previous defaults with two config lines in `config/livewire.php`:
+> If you prefer class-based components from v3, you can restore the previous defaults with two config lines in `config/livewire.php`:
 >
 > ```php
 > 'make_command' => [
@@ -54,8 +54,6 @@ new class extends Component {
 >     'emoji' => false,
 > ],
 > ```
->
-> This makes `make:livewire` generate class-based components without the emoji prefix, just like v3. You can also override these per-command with the `--class`, `--sfc`, `--mfc`, and `--emoji` flags.
 
 ### Creating page components
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -100,9 +100,9 @@ The `make:livewire` command accepts the following options:
 | `--class` | Create a class-based component |
 | `--type=sfc\|mfc\|class` | Set the component type explicitly |
 | `--emoji=true\|false` | Override the config emoji setting for this command |
-| `--test` | Create a Pest test file alongside the component |
-| `--js` | Create a JavaScript file (multi-file components only) |
-| `--css` | Create CSS files (multi-file components only) |
+| `--test` | Include a Pest test file |
+| `--js` | Include a JavaScript file (multi-file components only) |
+| `--css` | Include CSS files (multi-file components only) |
 
 ### Converting between formats
 


### PR DESCRIPTION
# The Scenario

Users new to Livewire v4 have questions about how component naming works across the different formats (SFC, MFC, class-based), how to disable the emoji prefix, and what CLI flags are available on `make:livewire`.

# The Problem

The information exists across the docs but isn't easy to discover:

- The emoji info box only showed the config approach, not the `--emoji=false` CLI flag
- The `--sfc`, `--emoji`, `--type`, `--js`, and `--css` flags were undocumented
- There was no single reference showing how file paths map to component names across all three formats
- The config options to restore v3 conventions (`type => 'class'` and `emoji => false`) were scattered across different doc pages

# The Solution

Four improvements to `components.md`:

1. **Updated emoji info box** to show the `--emoji=false` CLI flag alongside the config approach
2. **Added "Prefer v3 conventions?" callout** consolidating both config lines (`type` and `emoji`) in one place
3. **Added command options reference table** documenting all `make:livewire` flags
4. **Added file path to component name mapping table** showing how SFC, MFC, and class-based paths all resolve to the same component name, making it clear that the format doesn't affect how you reference components