### PR TITLE
[3.x] Fix click handlers on prefetched wire:navigate links

### DIFF
--- a/js/plugins/navigate/links.js
+++ b/js/plugins/navigate/links.js
@@ -31,7 +31,9 @@ export function whenThisLinkIsPressed(el, callback) {
             let handler = e => {
                 e.preventDefault()
 
-                whenReleased()
+                setTimeout(() => {
+                    whenReleased()
+                })
 
                 el.removeEventListener('mouseup', handler)
             }

--- a/js/plugins/navigate/links.js
+++ b/js/plugins/navigate/links.js
@@ -31,7 +31,7 @@ export function whenThisLinkIsPressed(el, callback) {
             let handler = e => {
                 e.preventDefault()
 
-                setTimeout(() => {
+                requestAnimationFrame(() => {
                     whenReleased()
                 })
 

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -36,6 +36,8 @@ class BrowserTest extends \Tests\BrowserTestCase
             Livewire::component('second-remote-asset', SecondRemoteAsset::class);
             Livewire::component('first-scroll-page', FirstScrollPage::class);
             Livewire::component('second-scroll-page', SecondScrollPage::class);
+            Livewire::component('first-click-handler-page', FirstClickHandlerPage::class);
+            Livewire::component('second-click-handler-page', SecondClickHandlerPage::class);
             Livewire::component('parent-component', ParentComponent::class);
             Livewire::component('child-component', ChildComponent::class);
             Livewire::component('script-component', ScriptComponent::class);
@@ -67,6 +69,8 @@ class BrowserTest extends \Tests\BrowserTestCase
             Route::get('/third-asset', ThirdAssetPage::class)->middleware('web');
             Route::get('/first-scroll', FirstScrollPage::class)->middleware('web');
             Route::get('/second-scroll', SecondScrollPage::class)->middleware('web');
+            Route::get('/first-click-handler', FirstClickHandlerPage::class)->middleware('web');
+            Route::get('/second-click-handler', SecondClickHandlerPage::class)->middleware('web');
             Route::get('/second-remote-asset', SecondRemoteAsset::class)->middleware('web');
 
             Route::get('/first-tracked-asset', FirstTrackedAssetPage::class)->middleware('web');
@@ -1187,6 +1191,20 @@ class BrowserTest extends \Tests\BrowserTestCase
         });
     }
 
+    public function test_click_handler_runs_on_prefetched_navigate_link()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first-click-handler')
+                ->assertSee('On first')
+                ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+                ->waitForNavigate()->click('@link.to.second')
+                ->assertSee('On second')
+                ->assertScript("window.foo_seen_on_second_page === 'baz'")
+            ;
+        });
+    }
+
     public function test_navigating_to_an_error_page_force_a_full_page_refresh_when_the_back_button_is_pressed()
     {
         $this->browse(function ($browser) {
@@ -1508,6 +1526,43 @@ class FirstScrollPage extends Component
             <a href="/second-scroll" x-on:click="$event.preventDefault(); Livewire.navigate($el.href, { preserveScroll: true })"  dusk="link.to.second.with.preserve.scroll.using.javascript">Go to second page with preserve scroll using javascript</a>
 
             <div style="height: 100vh;">spacer</div>
+        </div>
+        HTML;
+    }
+}
+
+class FirstClickHandlerPage extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <div>On first</div>
+
+            <script>window.foo = 'bar'</script>
+
+            <a
+                href="/second-click-handler"
+                wire:navigate.hover
+                x-on:click="window.foo = 'baz'"
+                dusk="link.to.second"
+            >
+                Go to second page
+            </a>
+        </div>
+        HTML;
+    }
+}
+
+class SecondClickHandlerPage extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <div>On second</div>
+
+            <script>window.foo_seen_on_second_page = window.foo;</script>
         </div>
         HTML;
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

  Yes, I believe this is a real bug in `wire:navigate`.

  There have been related discussions around `wire:navigate` timing and lifecycle behavior, but I did not find one covering this exact issue. I did not open a separate discussion
  first because this is a small, focused bug fix with a regression test.

  My reasoning is that if Livewire takes over link navigation, it should preserve native click behavior as closely as possible. In particular, a link's own `click` handler should
  still run before navigation occurs.

  2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

  Yes.

  3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

  No. This PR only contains a small timing fix for `wire:navigate` and its regression test.

  4️⃣ Does it include tests? (Required)

  Yes.

  This PR includes a browser regression test in `src/Features/SupportNavigate/BrowserTest.php` that verifies a same-element click handler still runs on a prefetched
  `wire:navigate` link.

  5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

  This PR fixes an event-ordering issue for prefetched `wire:navigate` links.

  Minimal example:

  ```html
  <a href="/second" wire:navigate.hover x-on:click="window.foo = 'baz'">
      Go to second page
  </a>
```

  Before this change, if the destination had already been prefetched, Livewire could begin navigation on mouseup before the browser dispatched the normal click event. In that
  case, the link's own click handler could be skipped entirely.

  I believe this is a bug because wire:navigate is taking over normal link navigation, and it should remain consistent with normal browser behavior: the link's click handlers
  should still run before navigation happens.

  This PR fixes that by delaying whenReleased() until the next task, allowing the browser to finish dispatching the click event first and then letting Livewire continue with
  navigation.

  Conceptually, the change is:

```js
  setTimeout(() => {
      whenReleased()
  })
```

  This keeps wire:navigate closer to native link behavior and fixes the regression covered by the browser test.