### PR TITLE
[4.x] Disable checksum rate limiting during tests

### DIFF
--- a/src/Mechanisms/HandleComponents/Checksum.php
+++ b/src/Mechanisms/HandleComponents/Checksum.php
@@ -10,6 +10,7 @@ use function Livewire\trigger;
 class Checksum {
     protected static $maxFailures = 10;
     protected static $decaySeconds = 600; // 10 minutes
+    protected static $rateLimitingEnabledForTesting = false;
 
     static function verify($snapshot) {
         // Check if this IP is already blocked due to too many failures
@@ -30,8 +31,20 @@ class Checksum {
         }
     }
 
+    static function enableRateLimitingForTesting()
+    {
+        static::$rateLimitingEnabledForTesting = true;
+    }
+
+    static function disableRateLimitingForTesting()
+    {
+        static::$rateLimitingEnabledForTesting = false;
+    }
+
     protected static function enforceRateLimit()
     {
+        if (app()->runningUnitTests() && ! static::$rateLimitingEnabledForTesting) return;
+
         $request = request();
 
         // Only check the rate limit once per request (not once per component)
@@ -55,6 +68,8 @@ class Checksum {
 
     protected static function recordFailure()
     {
+        if (app()->runningUnitTests() && ! static::$rateLimitingEnabledForTesting) return;
+
         RateLimiter::hit(static::rateLimitKey(), static::$decaySeconds);
     }
 

--- a/src/Mechanisms/HandleComponents/ChecksumRateLimitUnitTest.php
+++ b/src/Mechanisms/HandleComponents/ChecksumRateLimitUnitTest.php
@@ -17,11 +17,21 @@ class ChecksumRateLimitUnitTest extends TestCase
     {
         parent::setUp();
 
+        // Enable rate limiting for these tests (disabled by default in tests)
+        Checksum::enableRateLimitingForTesting();
+
         // Clear any existing rate limits before each test
         RateLimiter::clear('livewire-checksum-failures:127.0.0.1');
 
         // Register a test component for use in snapshots
         Livewire::component('test-component', ChecksumRateLimitTestComponent::class);
+    }
+
+    public function tearDown(): void
+    {
+        Checksum::disableRateLimitingForTesting();
+
+        parent::tearDown();
     }
 
     public function test_checksum_failure_is_recorded()


### PR DESCRIPTION
# The Scenario

When using ParaTest (parallel testing) with Livewire 4 and the `database` cache driver, all Livewire component tests fail with `TypeError` or `abort(419)` errors. This worked fine in Livewire 3.

The issue manifests when ParaTest calls `DB::purge()` to switch between test databases. Every subsequent Livewire request triggers a checksum rate limit check that queries through a stale database connection, destroying the test transaction and causing model hydration to fail.

This only appears when three conditions align:

1. Livewire 4's `Checksum::enforceRateLimit()` is called (new in v4)
2. The `RateLimiter` singleton holds a `DatabaseStore` with a direct DB connection reference
3. ParaTest calls `DB::purge()`, invalidating that connection while the singleton retains the stale reference

# The Problem

`Checksum::enforceRateLimit()` calls `RateLimiter::tooManyAttempts()` on every Livewire request. Laravel's `RateLimiter` is registered as a singleton in the container, and when using the `database` cache driver, it holds a `DatabaseStore` that references a specific DB connection object.

When ParaTest calls `DB::purge()` to swap databases, it removes the connection from the `DatabaseManager` and creates a new one wrapped in a test transaction. But the `DatabaseStore` inside the `RateLimiter` singleton still references the old (now dead) connection.

When the rate limit check runs, it queries through the dead connection, which triggers a reconnect. That reconnect disconnects the new connection (destroying the test transaction), creates a fresh connection with no transaction, and model hydration can't find test data.

# The Solution

Checksum rate limiting is now automatically skipped when `app()->runningUnitTests()` returns true. This is a production security feature that provides no value in test environments, and its reliance on a singleton cache store is fundamentally incompatible with ParaTest's connection swapping.

For Livewire's own rate limit tests, `Checksum::enableRateLimitingForTesting()` and `Checksum::disableRateLimitingForTesting()` allow opting back in on a per-test basis.