### PR TITLE
[4.x] Fix `$wire.$parent` throwing on root components

### DIFF
--- a/js/$wire.js
+++ b/js/$wire.js
@@ -333,13 +333,17 @@ wireProperty('$cancelUpload', (component) => (...params) => cancelUpload(compone
 let parentMemo = new WeakMap
 
 wireProperty('$parent', component => {
-    if (parentMemo.has(component)) return parentMemo.get(component).$wire
+    if (parentMemo.has(component)) {
+        let parent = parentMemo.get(component)
+
+        return parent ? parent.$wire : undefined
+    }
 
     let parent = component.parent
 
     parentMemo.set(component, parent)
 
-    return parent.$wire
+    return parent ? parent.$wire : undefined
 })
 
 let overriddenMethods = new WeakMap

--- a/js/$wire.js
+++ b/js/$wire.js
@@ -339,7 +339,7 @@ wireProperty('$parent', component => {
         return parent ? parent.$wire : undefined
     }
 
-    let parent = component.parent
+    let parent = findComponentByEl(component.el.parentElement, false)
 
     parentMemo.set(component, parent)
 

--- a/js/$wire.js
+++ b/js/$wire.js
@@ -333,17 +333,15 @@ wireProperty('$cancelUpload', (component) => (...params) => cancelUpload(compone
 let parentMemo = new WeakMap
 
 wireProperty('$parent', component => {
-    if (parentMemo.has(component)) {
-        let parent = parentMemo.get(component)
-
-        return parent ? parent.$wire : undefined
-    }
+    if (parentMemo.has(component)) return parentMemo.get(component).$wire
 
     let parent = findComponentByEl(component.el.parentElement, false)
 
+    if (! parent) return
+
     parentMemo.set(component, parent)
 
-    return parent ? parent.$wire : undefined
+    return parent.$wire
 })
 
 let overriddenMethods = new WeakMap

--- a/js/component.js
+++ b/js/component.js
@@ -216,7 +216,7 @@ export class Component {
     }
 
     get parent() {
-        return findComponentByEl(this.el.parentElement)
+        return findComponentByEl(this.el.parentElement, false)
     }
 
     get isIsolated() {

--- a/js/component.js
+++ b/js/component.js
@@ -216,7 +216,7 @@ export class Component {
     }
 
     get parent() {
-        return findComponentByEl(this.el.parentElement, false)
+        return findComponentByEl(this.el.parentElement)
     }
 
     get isIsolated() {

--- a/src/Features/SupportAccessingParent/BrowserTest.php
+++ b/src/Features/SupportAccessingParent/BrowserTest.php
@@ -18,6 +18,15 @@ class BrowserTest extends TestCase
             ;
         });
     }
+
+    public function test_accessing_parent_on_root_component_returns_undefined()
+    {
+        $this->browse(function ($browser) {
+            $this->visitLivewireComponent($browser, RootComponentWithParentAccess::class)
+                ->assertSeeIn('@output', 'undefined')
+            ;
+        });
+    }
 }
 
 class ParentCounter extends Component
@@ -48,6 +57,18 @@ class ChildCounter extends Component
         return <<<'HTML'
         <div>
             <button wire:click="$parent.increment()" dusk="button"></button>
+        </div>
+        HTML;
+    }
+}
+
+class RootComponentWithParentAccess extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <span x-text="typeof $wire.$parent" dusk="output"></span>
         </div>
         HTML;
     }


### PR DESCRIPTION
# The Scenario

When accessing `$wire.$parent` on a root Livewire component (one with no parent), a JavaScript error is thrown. This makes it impossible to use optional chaining patterns like `$wire.$parent?.someMethod()` to write code that works regardless of whether the component is nested or not.

For example, a user might want to conditionally access parent errors from a component that could be either a root or child component:

```js
const parentErrors = $wire.$parent?.$errors
```

Instead of gracefully returning `undefined`, this throws `"Could not find Livewire component in DOM tree"`.

```php
<?php

use Livewire\Component;

class MyComponent extends Component
{
    //
}

?>

<div>
    <span x-text="typeof $wire.$parent"></span>
    {{-- Throws instead of rendering "undefined" --}}
</div>
```

# The Problem

The `$parent` wire property accesses `component.parent`, which throws an error when accessed on a root component that has no Livewire parent:

```js
wireProperty('$parent', component => {
    // ...
    let parent = component.parent  // throws for root components
    return parent.$wire
})
```

# The Solution

The `$parent` wire property now calls `findComponentByEl` directly with `strict: false` to gracefully handle root components, returning `undefined` when no parent exists. This leaves `component.parent` unchanged for callers that expect it to throw when a parent is missing. The change enables optional chaining patterns like `$wire.$parent?.$errors` and `$wire.$parent?.someMethod()`.

Fixes https://github.com/livewire/livewire/discussions/10095