### PR TITLE
[4.x] Fix `DOMDocument::loadHTML()` warnings when parsing HTML with SVG elements

### DIFF
--- a/src/Features/SupportMultipleRootElementDetection/SupportMultipleRootElementDetection.php
+++ b/src/Features/SupportMultipleRootElementDetection/SupportMultipleRootElementDetection.php
@@ -37,7 +37,7 @@ class SupportMultipleRootElementDetection extends ComponentHook
 
         $dom = new \DOMDocument();
 
-        @$dom->loadHTML($html);
+        $dom->loadHTML($html, LIBXML_NOERROR);
 
         $body = $dom->getElementsByTagName('body')->item(0);
 

--- a/src/Features/SupportMultipleRootElementDetection/UnitTest.php
+++ b/src/Features/SupportMultipleRootElementDetection/UnitTest.php
@@ -149,6 +149,28 @@ class UnitTest extends TestCase
         });
     }
 
+    function test_parsing_html_does_not_trigger_warnings()
+    {
+        config()->set('app.debug', true);
+
+        // HTML that triggers libxml errors (e.g. block elements nested inside
+        // inline elements, or SVG tags on older libxml2 versions)...
+        $html = '<div><p><div>nested</div></p></div>';
+
+        // Convert warnings to exceptions so the test fails if any are emitted...
+        set_error_handler(function ($severity, $message) {
+            throw new \ErrorException($message, 0, $severity);
+        }, E_WARNING);
+
+        try {
+            (new SupportMultipleRootElementDetection)->getRootElementCount($html);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertTrue(true);
+    }
+
     function test_dont_throw_error_in_production_so_that_there_is_no_perf_penalty()
     {
         config()->set('app.debug', false);


### PR DESCRIPTION
# The Scenario

When using SVG icons (e.g. via `blade-ui-kit/blade-heroicons`) inside a Livewire component, PHP warnings are emitted:

```
DOMDocument::loadHTML(): Tag svg invalid in Entity, line: 15
DOMDocument::loadHTML(): Tag circle invalid in Entity, line: 16
DOMDocument::loadHTML(): Tag path invalid in Entity, line: 17
```

```php
<?php

use Livewire\Component;

class Demo extends Component
{
    public function render()
    {
        return <<<'BLADE'
            <div>
              <x-heroicon-s-heart class="h-6 w-6 text-red-600" />
            </div>
            BLADE;
    }
}
```

# The Problem

The `SupportMultipleRootElementDetection` feature uses `@$dom->loadHTML($html)` to parse rendered HTML and count root elements. The `@` operator suppresses warnings at the PHP level by temporarily setting `error_reporting` to `0`, but custom error handlers (like Laravel's) are still invoked. If the handler doesn't check `error_reporting()`, the warnings come through.

On older `libxml2` versions, SVG elements like `<svg>`, `<path>`, and `<circle>` are not recognised as valid HTML tags, causing `DOMDocument::loadHTML()` to emit warnings for each one.

# The Solution

Replace `@$dom->loadHTML($html)` with `$dom->loadHTML($html, LIBXML_NOERROR)`. The `LIBXML_NOERROR` flag suppresses error reporting at the `libxml` level itself, so warnings are never emitted to PHP regardless of error handler configuration. The DOM is still parsed identically — only the error reporting is affected, so root element detection continues to work correctly.

Fixes #10094