### PR TITLE
[4.x] Fix `->lazy()` and `->defer()` route macros not working for components without `mount()`

### DIFF
--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -195,6 +195,46 @@ class BrowserTest extends BrowserTestCase
         });
     }
 
+    public function test_can_lazy_load_component_without_mount_using_route()
+    {
+        $this->beforeServingApplication(function() {
+            Livewire::component('page-without-mount', PageWithoutMount::class);
+            Route::get('/', PageWithoutMount::class)->lazy()->middleware('web');
+        });
+
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/')
+                ->tap(fn ($b) => $b->script('window._lw_dusk_test = true'))
+                ->assertScript('return window._lw_dusk_test')
+                ->assertSee('Loading...')
+                ->assertDontSee('Hello World')
+                ->waitFor('#page')
+                ->assertDontSee('Loading...')
+                ->assertSee('Hello World');
+        });
+    }
+
+    public function test_can_defer_lazy_load_component_without_mount_using_route()
+    {
+        $this->beforeServingApplication(function() {
+            Livewire::component('page-without-mount', PageWithoutMount::class);
+            Route::get('/', PageWithoutMount::class)->defer()->middleware('web');
+        });
+
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/')
+                ->tap(fn ($b) => $b->script('window._lw_dusk_test = true'))
+                ->assertScript('return window._lw_dusk_test')
+                ->assertSee('Loading...')
+                ->assertDontSee('Hello World')
+                ->waitFor('#page')
+                ->assertDontSee('Loading...')
+                ->assertSee('Hello World');
+        });
+    }
+
     public function test_can_lazy_load_a_component_with_a_placeholder()
     {
         Livewire::visit([new class extends Component {
@@ -541,6 +581,20 @@ class Page extends Component {
         sleep(1);
     }
 
+    public function placeholder() { return <<<HTML
+            <div id="loading">
+                Loading...
+            </div>
+            HTML; }
+
+    public function render() { return <<<HTML
+            <div id="page">
+                Hello World
+            </div>
+            HTML; }
+}
+
+class PageWithoutMount extends Component {
     public function placeholder() { return <<<HTML
             <div id="loading">
                 Loading...

--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -595,6 +595,10 @@ class Page extends Component {
 }
 
 class PageWithoutMount extends Component {
+    public function boot() {
+        usleep(200_000);
+    }
+
     public function placeholder() { return <<<HTML
             <div id="loading">
                 Loading...

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -144,6 +144,14 @@ class SupportPageComponents extends ComponentHook
             throw $exception;
         }
 
+        // Merge lazy/defer route defaults so that ->lazy() and ->defer()
+        // route macros work even when the component has no mount() method...
+        foreach (['lazy', 'defer'] as $key) {
+            if (array_key_exists($key, $route->defaults) && ! array_key_exists($key, $params)) {
+                $params[$key] = $route->defaults[$key];
+            }
+        }
+
         return $params;
     }
 


### PR DESCRIPTION
# The Scenario

When using `->defer()` or `->lazy()` on a route for a full-page single-file component, the component renders immediately instead of being deferred/lazy loaded. The only workaround is adding the `#[Defer]` or `#[Lazy]` attribute directly to the component class, which defeats the purpose of the route macro.

```php
// routes/web.php
Route::get('/dashboard', DashboardPage::class)->defer();
```

```php
<?php

use Livewire\Attributes\Computed;
use Livewire\Component;

new class extends Component {
    #[Computed]
    public function computedProp()
    {
        sleep(10);

        return "OK";
    }
};
?>

@placeholder
<div>
    This is the placeholder
</div>
@endplaceholder
<div>
    This is not the placeholder: {{ $this->computedProp }}
</div>
```

# The Problem

The `->defer()` and `->lazy()` route macros store their flags in route defaults (`$route->defaults['defer']` / `$route->defaults['lazy']`). Laravel merges these defaults into `$route->parameters()` when the route is matched.

In `SupportPageComponents::gatherMountMethodParamsFromRouteParameters()`, the parameters are resolved via `ImplicitRouteBinding::resolveMountParameters()`, which calls `$route->resolveMethodDependencies($route->parameters(), ...)` against the component's `mount()` method. When `mount()` exists (even with no parameters), `resolveMethodDependencies` passes through all route parameters including defaults, so the `defer`/`lazy` keys reach `SupportLazyLoading::mount($params)`.

However, when the component has no `mount()` method, `resolveMountParameters()` returns an empty collection. The `resolveComponentProps()` fallback only includes parameters matching public properties. Since there's no `$defer` or `$lazy` public property, the flags are silently dropped and lazy/deferred loading never activates.

# The Solution

After resolving route parameters in `gatherMountMethodParamsFromRouteParameters()`, explicitly merge `lazy` and `defer` route defaults into the params array (if they're not already present). This ensures the flags always reach component hooks regardless of whether the component has a `mount()` method.

Fixes #10093