### PR TITLE
[4.x] Fix compiler matching `new` inside comments when adding `return` statement

### DIFF
--- a/src/Compiler/Parser/Parser.php
+++ b/src/Compiler/Parser/Parser.php
@@ -54,12 +54,15 @@ class Parser
 
     protected function ensureAnonymousClassHasReturn(string $contents): string
     {
-        // Find the position of the first "new"...
-        if (preg_match('/\bnew\b/', $contents, $newMatch, PREG_OFFSET_CAPTURE)) {
+        // Use (*SKIP)(*FAIL) to ignore "new" inside comments...
+        $skipComments = '(?:\/\/[^\n]*|\/\*.*?\*\/)(*SKIP)(*FAIL)';
+
+        // Find the position of the first "new" outside of comments...
+        if (preg_match('/' . $skipComments . '|\bnew\b/s', $contents, $newMatch, PREG_OFFSET_CAPTURE)) {
             $newPosition = $newMatch[0][1];
 
-            // Check if "return new" exists and find where "new" starts in that match...
-            $hasReturnNew = preg_match('/\breturn\s+(new\b)/', $contents, $returnNewMatch, PREG_OFFSET_CAPTURE);
+            // Check if "return new" exists outside of comments and find where "new" starts in that match...
+            $hasReturnNew = preg_match('/' . $skipComments . '|\breturn\s+(new\b)/s', $contents, $returnNewMatch, PREG_OFFSET_CAPTURE);
 
             // If "return new" does not exist or "new" is not at the same position as "return new", add "return"...
             if (!$hasReturnNew || $returnNewMatch[1][1] !== $newPosition) {
@@ -72,7 +75,10 @@ class Parser
 
     protected function ensureAnonymousClassHasTrailingSemicolon(string $contents): string
     {
-        if (!preg_match('/\bnew\b/', $contents)) {
+        // Use (*SKIP)(*FAIL) to ignore "new" inside comments...
+        $skipComments = '(?:\/\/[^\n]*|\/\*.*?\*\/)(*SKIP)(*FAIL)';
+
+        if (!preg_match('/' . $skipComments . '|\bnew\b/s', $contents)) {
             return $contents;
         }
 

--- a/src/Compiler/UnitTest.php
+++ b/src/Compiler/UnitTest.php
@@ -658,6 +658,106 @@ class UnitTest extends \Tests\TestCase
 
                 EOT,
             ],
+            'single line comment with new' => [
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                // new
+                new class extends Component {
+                    //
+                };
+                ?>
+                EOT,
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                // new
+                return new class extends Component {
+                    //
+                };
+
+                EOT,
+            ],
+            'multi line comment with new' => [
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                /* new */
+                new class extends Component {
+                    //
+                };
+                ?>
+                EOT,
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                /* new */
+                return new class extends Component {
+                    //
+                };
+
+                EOT,
+            ],
+            'docblock comment with new' => [
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                /**
+                 * new
+                 */
+                new class extends Component {
+                    //
+                };
+                ?>
+                EOT,
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                /**
+                 * new
+                 */
+                return new class extends Component {
+                    //
+                };
+
+                EOT,
+            ],
+            'todo comment with new keyword' => [
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                // TODO: new feature coming soon
+                new class extends Component {
+                    //
+                };
+                ?>
+                EOT,
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                // TODO: new feature coming soon
+                return new class extends Component {
+                    //
+                };
+
+                EOT,
+            ],
         ];
     }
 }


### PR DESCRIPTION
# The Scenario

When a single-file component has a comment containing the word `new` above the class definition, the component fails with a `TypeError`. This can happen with any comment style: single-line, multi-line, or docblock.

The error reported is that `$instance` holds `1` instead of a class instance in `CacheManager::getClassName()`.

```php
<?php

use Livewire\Component;

// new
new class extends Component {
    //
};
```

```php
<?php

use Livewire\Component;

// TODO: new feature coming soon
new class extends Component {
    //
};
```

# The Problem

The `ensureAnonymousClassHasReturn` method in `Parser.php` uses `/\bnew\b/` to find the first `new` keyword and insert `return` before it. When a comment like `// new` appears before the anonymous class declaration, the regex matches the commented `new` first, producing:

```php
// return new
new class extends Component {
```

The `return` is inside the comment (a no-op), so the `new class` expression is never returned. `require` then returns `1` by default, and `$instance::class` triggers a `TypeError`.

The same issue also affected `ensureAnonymousClassHasTrailingSemicolon`, which used the same unguarded `/\bnew\b/` pattern.

# The Solution

Both methods now use a `(*SKIP)(*FAIL)` regex pattern to skip over single-line (`// ...`) and multi-line (`/* ... */`) comments before matching `new`. This ensures only `new` in actual code is matched, regardless of what appears in comments.

Fixes https://github.com/livewire/livewire/discussions/10099