### PR TITLE
[4.x] Fix form object properties bypassing hydration and lifecycle hooks during consolidated updates

### DIFF
--- a/src/Features/SupportFormObjects/FormObjectSynth.php
+++ b/src/Features/SupportFormObjects/FormObjectSynth.php
@@ -3,10 +3,8 @@
 namespace Livewire\Features\SupportFormObjects;
 
 use Livewire\Drawer\Utils;
-use Livewire\Mechanisms\HandleComponents\HandleComponents;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Livewire\Features\SupportAttributes\AttributeCollection;
-use ReflectionUnionType;
 
 use function Livewire\wrap;
 
@@ -84,33 +82,9 @@ class FormObjectSynth extends Synth {
                 continue;
             }
 
-            $child = $hydrateChild($key, $child);
-
-            // During consolidated updates, the hydrateChild callback may return
-            // raw values (e.g. strings) without casting them to their proper types.
-            // Check the form property's type and cast through the synth system...
-            if (! is_object($child) && property_exists($form, $key) && Utils::propertyIsTyped($form, $key)) {
-                $child = $this->castValueByType($form, $key, $child);
-            }
-
-            $form->$key = $child;
+            $form->$key = $hydrateChild($key, $child);
         }
 
         return $form;
-    }
-
-    protected function castValueByType($form, $key, $value)
-    {
-        $type = Utils::getProperty($form, $key)->getType();
-
-        $types = $type instanceof ReflectionUnionType ? $type->getTypes() : [$type];
-
-        foreach ($types as $type) {
-            $synth = app(HandleComponents::class)->getSynthesizerByType($type->getName(), $this->context, "{$this->path}.{$key}");
-
-            if ($synth) return $synth->hydrateFromType($type->getName(), $value);
-        }
-
-        return $value;
     }
 }

--- a/src/Features/SupportFormObjects/FormObjectSynth.php
+++ b/src/Features/SupportFormObjects/FormObjectSynth.php
@@ -3,8 +3,10 @@
 namespace Livewire\Features\SupportFormObjects;
 
 use Livewire\Drawer\Utils;
+use Livewire\Mechanisms\HandleComponents\HandleComponents;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Livewire\Features\SupportAttributes\AttributeCollection;
+use ReflectionUnionType;
 
 use function Livewire\wrap;
 
@@ -82,9 +84,33 @@ class FormObjectSynth extends Synth {
                 continue;
             }
 
-            $form->$key = $hydrateChild($key, $child);
+            $child = $hydrateChild($key, $child);
+
+            // During consolidated updates, the hydrateChild callback may return
+            // raw values (e.g. strings) without casting them to their proper types.
+            // Check the form property's type and cast through the synth system...
+            if (! is_object($child) && property_exists($form, $key) && Utils::propertyIsTyped($form, $key)) {
+                $child = $this->castValueByType($form, $key, $child);
+            }
+
+            $form->$key = $child;
         }
 
         return $form;
+    }
+
+    protected function castValueByType($form, $key, $value)
+    {
+        $type = Utils::getProperty($form, $key)->getType();
+
+        $types = $type instanceof ReflectionUnionType ? $type->getTypes() : [$type];
+
+        foreach ($types as $type) {
+            $synth = app(HandleComponents::class)->getSynthesizerByType($type->getName(), $this->context, "{$this->path}.{$key}");
+
+            if ($synth) return $synth->hydrateFromType($type->getName(), $value);
+        }
+
+        return $value;
     }
 }

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -977,6 +977,22 @@ class UnitTest extends \Tests\TestCase
         ;
     }
 
+    function test_form_object_updated_lifecycle_hook_fires_during_consolidated_update()
+    {
+        // When ALL form fields change, JS consolidates individual field updates
+        // into a single "form" update. The updated() lifecycle hook on the form
+        // object must still fire for each changed property.
+        Livewire::test(new class extends TestComponent {
+            public FormWithUpdatedHookStub $form;
+        })
+        ->update(
+            updates: ['form' => ['title' => 'New Title', 'content' => 'New Content']],
+        )
+        ->assertSuccessful()
+        ->assertSetStrict('form.updated_properties', ['title', 'content'])
+        ;
+    }
+
     function test_form_object_synth_rejects_non_form_classes()
     {
         $this->expectException(\Exception::class);
@@ -1351,4 +1367,16 @@ class FormWithEnumPropertyStub extends Form
 {
     public string $title = '';
     public FormEnumStub $status = FormEnumStub::Draft;
+}
+
+class FormWithUpdatedHookStub extends Form
+{
+    public string $title = '';
+    public string $content = '';
+    public array $updated_properties = [];
+
+    public function updated(string $property)
+    {
+        $this->updated_properties[] = $property;
+    }
 }

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -952,6 +952,31 @@ class UnitTest extends \Tests\TestCase
         ->assertSet('form.bob', 'lob2');
     }
 
+    function test_form_object_with_enum_property_works_with_consolidated_update()
+    {
+        // When ALL form fields change, JS consolidates individual field updates
+        // into a single "form" update. Enum properties must still be properly
+        // cast from their string values during this consolidated hydration.
+        Livewire::test(new class extends TestComponent {
+            public FormWithEnumPropertyStub $form;
+
+            function save()
+            {
+                Assert::assertInstanceOf(FormEnumStub::class, $this->form->status);
+                Assert::assertEquals(FormEnumStub::Active, $this->form->status);
+                Assert::assertEquals('Some Title', $this->form->title);
+            }
+        })
+        // Simulate a consolidated update where all form fields are sent at once
+        // (this happens when JS detects all fields have changed from their initial values)
+        ->update(
+            calls: [['method' => 'save', 'params' => [], 'path' => '']],
+            updates: ['form' => ['title' => 'Some Title', 'status' => 'active']],
+        )
+        ->assertSuccessful() // Should not 419/500 due to TypeError
+        ;
+    }
+
     function test_form_object_synth_rejects_non_form_classes()
     {
         $this->expectException(\Exception::class);
@@ -1314,4 +1339,16 @@ class LifecycleHooksForm extends Form
 
         $this->lifecycles['updatedBarBaz'] = true;
     }
+}
+
+enum FormEnumStub: string
+{
+    case Draft = 'draft';
+    case Active = 'active';
+}
+
+class FormWithEnumPropertyStub extends Form
+{
+    public string $title = '';
+    public FormEnumStub $status = FormEnumStub::Draft;
 }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -719,7 +719,7 @@ class HandleComponents extends Mechanism
         return new $this->synthesizerTypeCache[$type]($context, $path);
     }
 
-    protected function getSynthesizerByType($type, $context, $path)
+    public function getSynthesizerByType($type, $context, $path)
     {
         foreach ($this->propertySynthesizers as $synth) {
             if ($synth::matchByType($type)) {

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -11,6 +11,7 @@ use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Exceptions\MaxNestingDepthExceededException;
 use Livewire\Exceptions\TooManyCallsException;
 use Livewire\Drawer\Utils;
+use Livewire\Features\SupportFormObjects\Form;
 use Illuminate\Support\Facades\View;
 
 class HandleComponents extends Mechanism
@@ -464,6 +465,13 @@ class HandleComponents extends Mechanism
 
     protected function updateProperties($component, $updates, $data, $context)
     {
+        // When the JS diff algorithm detects that all properties of a form object
+        // have changed, it consolidates them into a single update (e.g. {form: {title: '...', status: '...'}}).
+        // Form objects are special — they should never be fully replaced. Instead, decompose
+        // the consolidated update into individual property updates so each goes through
+        // the normal hydration path (which handles type casting for enums, etc.)...
+        $updates = $this->expandConsolidatedFormObjectUpdates($component, $updates);
+
         $finishes = [];
 
         foreach ($updates as $path => $value) {
@@ -478,6 +486,23 @@ class HandleComponents extends Mechanism
         foreach ($finishes as $finish) {
             $finish();
         }
+    }
+
+    protected function expandConsolidatedFormObjectUpdates($component, $updates)
+    {
+        $expanded = [];
+
+        foreach ($updates as $path => $value) {
+            if (is_array($value) && property_exists($component, $path) && $component->$path instanceof Form) {
+                foreach ($value as $key => $child) {
+                    $expanded["{$path}.{$key}"] = $child;
+                }
+            } else {
+                $expanded[$path] = $value;
+            }
+        }
+
+        return $expanded;
     }
 
     public function updateProperty($component, $path, $value, $context)
@@ -719,7 +744,7 @@ class HandleComponents extends Mechanism
         return new $this->synthesizerTypeCache[$type]($context, $path);
     }
 
-    public function getSynthesizerByType($type, $context, $path)
+    protected function getSynthesizerByType($type, $context, $path)
     {
         foreach ($this->propertySynthesizers as $synth) {
             if ($synth::matchByType($type)) {


### PR DESCRIPTION
# The Scenario

When all properties of a form object are changed simultaneously (e.g., filling out every field before submitting), two things break:

1. **Enum-typed properties throw a `TypeError`** because the raw string value is assigned directly without casting:

```
TypeError
Cannot assign string to property App\Livewire\Foo\Form::$enumfield of type App\Enums\SomeEnum
```

2. **The `updated()` lifecycle hook on the form object is never called**, even though every property has changed.

Both issues only occur when *all* form fields change from their initial values. If even one field remains unchanged, everything works correctly.

```php
<?php

use App\Enums\SomeEnum;
use Livewire\Form;
use Livewire\Component;

class MyForm extends Form
{
    public string $title = '';
    public SomeEnum $status = SomeEnum::Draft;

    public function updated(string $property)
    {
        // This is never called when ALL fields change at once
    }
}

class Page extends Component
{
    public MyForm $form;

    public function save(): void
    {
        // TypeError: Cannot assign string to property MyForm::$status of type SomeEnum
    }
}
?>

<form wire:submit="save">
    <input type="text" wire:model="form.title" />

    <select wire:model="form.status">
        @foreach (SomeEnum::cases() as $enum)
            <option :value="$enum">{{ $enum->value }}</option>
        @endforeach
    </select>

    <button type="submit">Save</button>
</form>
```

# The Problem

When only some form fields change, the JavaScript diff algorithm sends individual dot-notation updates (e.g., `form.title: '...'`, `form.status: 'active'`). Each goes through `hydrateForUpdate()` (which handles type casting via synthesizers) and `updateProperty()` (which fires lifecycle hooks).

When **all** form fields change, the JavaScript `diffAndConsolidate()` function consolidates them into a single form-level update (e.g., `form: {title: '...', status: 'active'}`). This consolidated update bypasses the normal per-property hydration path entirely: `hydratePropertyUpdate()` replaces the whole form object via `FormObjectSynth::hydrate()`, which assigns raw values directly to typed properties (causing `TypeError` for enums) and skips the `trigger('update', ...)` call that fires lifecycle hooks.

# The Solution

Form objects are special; they should never be fully replaced during a property update. In `HandleComponents::updateProperties()`, detect when a consolidated update targets a form object and decompose it back into individual dot-notation property updates. This ensures each property goes through the normal `hydrateForUpdate()` and `updateProperty()` path, which properly handles type casting (enums, Carbon, etc.) and fires lifecycle hooks (`updating`/`updated`).

Fixes #10086
Fixes #10102