### PR TITLE
[4.x] Ensure Livewire route with scoped bindings works regardless of order of properties in livewire component

### DIFF
--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -69,6 +69,9 @@ class ImplicitRouteBinding
     {
         return $this->getPublicPropertyTypes($component)
             ->intersectByKeys($route->parametersWithoutNulls())
+            ->sortBy(function ($className, $propName) use ($route) {
+                return array_search($propName, array_keys($route->parametersWithoutNulls()));
+            })
             ->map(function ($className, $propName) use ($route) {
                 // If typed public property, resolve the class
                 if ($className) {

--- a/src/Drawer/Tests/ImplicitRouteBindingUnitTest.php
+++ b/src/Drawer/Tests/ImplicitRouteBindingUnitTest.php
@@ -46,6 +46,22 @@ class ImplicitRouteBindingUnitTest extends \Tests\TestCase
             ->assertSeeText('Book ID: 2');
     }
 
+    public function test_props_are_set_via_scope_binding_when_props_declared_in_reverse_order()
+    {
+        Route::get('/scope-binding-reversed/{store}/{book}', ComponentWithScopeBindingsReversedProps::class)->scopeBindings();
+
+        $this->get('/scope-binding-reversed/1/1')
+            ->assertSeeText('Store ID: 1')
+            ->assertSeeText('Book ID: 1');
+
+        $this->get('/scope-binding-reversed/2/2')
+            ->assertSeeText('Store ID: 2')
+            ->assertSeeText('Book ID: 2');
+
+        $this->get('/scope-binding-reversed/1/2')
+            ->assertNotFound();
+    }
+
     public function test_dependent_props_are_set_via_mount()
     {
         Route::get('/foo/{parent:custom}/bar/{child:custom}', ComponentWithDependentMountBindings::class);
@@ -316,4 +332,20 @@ class Book extends Model
             'name' => 'Foo',
         ],
     ];
+}
+
+class ComponentWithScopeBindingsReversedProps extends Component
+{
+    public Book $book;
+    public Store $store;
+
+    public function render()
+    {
+        return <<<'BLADE'
+            <div>
+                Store ID: {{ $store->id }}
+                Book ID: {{ $book->id }}
+            </div>
+        BLADE;
+    }
 }


### PR DESCRIPTION
I was trying to use scoped bindings on a Livewire route in my project, but the route did not return a 404 when the child model did not belong to the provided parent.

```php
Route::livewire('scoped-bindings/{store}/{book}', 'pages::scoped-bindings')->scopeBindings();
```

After some debugging, I found out that the scoped bindings did not work because the child property was defined before the parent property in the Livewire component.

```php
// $book property is defined before $store property
// so scoped bindings currently do not work.

new class extends Component {
    public Book $book;

    public Store $store;
}
```

This PR fixes that.

```php
// $store property can be defined before or after $book property,
// scope bindings will work in both scenarios.

new class extends Component {
    public Book $book;

    public Store $store;
}

new class extends Component {
    public Store $store;

    public Book $book;
}
```