### PR TITLE
[4.x] Fix prevent error when invalidating opcache if `opcache.restrict_api` directive is set

### DIFF
--- a/src/Compiler/CacheManager.php
+++ b/src/Compiler/CacheManager.php
@@ -189,7 +189,8 @@ class CacheManager
 
     public function invalidateOpCache(string $sourcePath): void
     {
-        if (function_exists('opcache_invalidate')) {
+        // Prevent error in case if `opcache.restrict_api` directive is set
+        if (function_exists('opcache_invalidate') && strlen(ini_get('opcache.restrict_api')) < 1) {
             opcache_invalidate($sourcePath, true);
         }
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

- While working on a client server that has the `opcache.restrict_api` directive set, I discovered that the Livewire component throws an error when invalidating opcache.

```
[previous exception] [object] (ErrorException(code: 0): 
Zend OPcache API is restricted by \"restrict_api\" configuration directive at
/vendor/livewire/livewire/src/Compiler/CacheManager.php:193)
```

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

- Yes, I created a dedicated branch for this fix.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

- No, the PR only includes changes relevant to this issue.

4️⃣ Does it include tests? (Required)

- No, sorry for not providing test, but the fix itself is minimal. `opcache.restrict_api`, as part of INI_SYSTEM, cannot be changed at runtime. The test coverage for `opcache.restrict_api=1` would require an integration test running under a specific php.ini, which is overkill. I could provide test for happy path if needed.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

The change is minimal and only checks if `opcache.restrict_api` is set ("" means no restrictions). This is a common solution for checking if restrictions are in place:

```php
public function invalidateOpCache(string $sourcePath): void
    {
        if (function_exists('opcache_invalidate') && strlen(ini_get('opcache.restrict_api')) < 1) {
            opcache_invalidate($sourcePath, true);
        }
    }
```

A tempting solution would be adding @ to suppress the error, but this may hide other important issues.