### PR TITLE
Fix wire:navigate CSP nonce mismatch violations

### DIFF
--- a/js/plugins/navigate/page.js
+++ b/js/plugins/navigate/page.js
@@ -6,7 +6,18 @@ let attributesExemptFromScriptTagHashing = [
     'aria-hidden',
 ]
 
+// Capture the current page's CSP nonce on first load, before the browser
+// clears it from the DOM. This nonce must be used for all subsequent
+// wire:navigate page swaps since the browser keeps enforcing the original
+// page's CSP header throughout SPA navigation.
+let currentPageNonce = captureInitialNonce()
+
 export function swapCurrentPageWithNewHtml(html, andThen) {
+    // Replace nonces in the raw HTML string before parsing so that
+    // DOMParser.parseFromString() doesn't trigger CSP violations.
+    // The browser enforces CSP even on inert parsed documents.
+    html = replaceNoncesInHtml(html)
+
     let newDocument = (new DOMParser()).parseFromString(html, "text/html")
     let newHtml = newDocument.documentElement
     let newBody = document.adoptNode(newDocument.body)
@@ -78,7 +89,12 @@ function replaceHtmlAttributes(newHtmlElement) {
 
 function mergeNewHead(newHead) {
     let children = Array.from(document.head.children)
-    let headChildrenHtmlLookup = children.map(i => i.outerHTML)
+
+    // Use nonce-stripped outerHTML for comparisons so that assets with
+    // different CSP nonces (which change on every request) are still
+    // recognised as already-loaded and not re-injected. Re-injecting
+    // them with the wrong nonce triggers CSP violations.
+    let headChildrenHtmlLookup = children.map(i => ignoreAttributes(i.outerHTML, attributesExemptFromScriptTagHashing))
 
     // Only add scripts and styles that aren't already loaded on the page.
     let garbageCollector = document.createDocumentFragment()
@@ -89,7 +105,7 @@ function mergeNewHead(newHead) {
 
     for (let child of Array.from(newHead.children)) {
         if (isAsset(child)) {
-            if (! headChildrenHtmlLookup.includes(child.outerHTML)) {
+            if (! headChildrenHtmlLookup.includes(ignoreAttributes(child.outerHTML, attributesExemptFromScriptTagHashing))) {
                 if (isTracked(child)) {
                     if (ifTheQueryStringChangedSinceLastRequest(child, children)) {
                         setTimeout(() => window.location.reload())
@@ -169,7 +185,13 @@ function cloneScriptTag(el) {
     script.async = el.async
 
     for (let attr of el.attributes) {
-        script.setAttribute(attr.name, attr.value)
+        if (attr.name === 'nonce') {
+            // Use the .nonce IDL property so dynamically inserted scripts
+            // pass CSP nonce checks (setAttribute won't work)...
+            script.nonce = currentPageNonce || el.nonce
+        } else {
+            script.setAttribute(attr.name, attr.value)
+        }
     }
 
     return script
@@ -231,4 +253,37 @@ function ignoreAttributes(subject, attributesToRemove) {
     result = result.replaceAll(' ', '')
 
     return result.trim()
+}
+
+function replaceNoncesInHtml(html) {
+    if (! currentPageNonce) return html
+
+    // Extract the nonce from the fetched HTML (the new page's nonce)...
+    let match = html.match(/nonce="([^"]+)"/)
+
+    if (! match) return html
+
+    let newNonce = match[1]
+
+    // Already the same nonce (shouldn't happen, but guard against it)...
+    if (newNonce === currentPageNonce) return html
+
+    // Replace all occurrences of the new nonce with the current page's nonce
+    // so that DOMParser and subsequent DOM insertion pass CSP checks...
+    return html.replaceAll(newNonce, currentPageNonce)
+}
+
+function captureInitialNonce() {
+    // Capture the CSP nonce on first load while it's still available.
+    // Browsers clear the nonce content attribute after rendering, but the
+    // .nonce IDL property preserves the value...
+    if (window.livewireScriptConfig && window.livewireScriptConfig.nonce) {
+        return window.livewireScriptConfig.nonce
+    }
+
+    let el = document.head.querySelector('script[nonce], style[nonce]')
+
+    if (el) return el.nonce || el.getAttribute('nonce')
+
+    return null
 }

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -81,8 +81,15 @@ class BrowserTest extends \Tests\BrowserTestCase
             Route::get('/parent', ParentComponent::class)->middleware('web');
             Route::get('/page-with-link-to-page-without-livewire', PageWithLinkAway::class);
 
-            Route::get('/nonce', fn () => self::renderNoncePage('First Nonce Page', 'ABCD1234'));
-            Route::get('/nonce2', fn () => self::renderNoncePage('Second Nonce Page', 'EFGH5678'));
+            Route::get('/nonce', fn () => self::renderNoncePage('First Nonce Page', 'ABCD1234'))
+                ->middleware('web');
+            Route::get('/nonce2', fn () => self::renderNoncePage('Second Nonce Page', 'EFGH5678'))
+                ->middleware('web');
+
+            Route::get('/csp-nonce', fn () => self::renderCspNoncePage('First CSP Page', 'NonceAAA111'))
+                ->middleware('web');
+            Route::get('/csp-nonce2', fn () => self::renderCspNoncePage('Second CSP Page', 'NonceBBB222', '/csp-nonce'))
+                ->middleware('web');
             Route::get('/page-without-livewire-component', fn () => Blade::render(<<<'HTML'
                 <html>
                     <head>
@@ -125,6 +132,30 @@ class BrowserTest extends \Tests\BrowserTestCase
                     </body>
                 </html>
             HTML, ['name' => $name, 'nonce' => $nonce]);
+    }
+
+    public static function renderCspNoncePage(string $name, string $nonce, string $linkTo = '/csp-nonce2'): string
+    {
+        $html = Blade::render(<<<'HTML'
+                <html>
+                    <head>
+                        <meta name="empty-layout" content>
+                        <style nonce="{{ $nonce }}">body { margin: 0 }</style>
+                    </head>
+                    <body>
+                        <div dusk="csp-page">{{ $name }}</div>
+                        <a href="{{ $linkTo }}" wire:navigate dusk="csp-link">navigate</a>
+                        @livewireScripts(['nonce' => $nonce])
+                    </body>
+                </html>
+            HTML, ['name' => $name, 'nonce' => $nonce, 'linkTo' => $linkTo]);
+
+        // Add a real CSP header enforcing the nonce. This is the key: each page
+        // has a different nonce, but the browser enforces the first page's CSP
+        // throughout wire:navigate SPA navigation.
+        return response($html)->withHeaders([
+            'Content-Security-Policy' => "script-src 'nonce-{$nonce}' 'unsafe-inline'; style-src 'nonce-{$nonce}' 'unsafe-inline'",
+        ]);
     }
 
     public function test_back_button_works_with_teleports()
@@ -415,6 +446,19 @@ class BrowserTest extends \Tests\BrowserTestCase
                 ->waitForText('Second Nonce Page')
                 ->assertConsoleLogMissingWarning('Detected multiple instances of Livewire')
                 ->assertConsoleLogMissingWarning('Detected multiple instances of Alpine');
+        });
+    }
+
+    public function test_navigate_does_not_trigger_csp_violations_with_different_nonces(): void
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/csp-nonce')
+                ->assertSee('First CSP Page')
+                ->click('@csp-link')
+                ->waitForText('Second CSP Page')
+                ->assertConsoleLogHasNoErrors()
+                ->assertConsoleLogMissingWarning('Content Security Policy');
         });
     }
 


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

This is a bugfix. I couldn't find any existing discussions, so attempted to fix.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes, own branch.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

Single change to fix the issue.

4️⃣ Does it include tests? (Required)

Yes, although they were written by Claude - and won't run locally because I don't have Chrome set up in my dev env.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌

_Note, the fix and tests were implemented using Claude, because my JS skills are limited. I have full tested the fix in my own app, but it might need some wider testing, and as noted above, I haven't been able to run the tests._

## Problem

  When using `wire:navigate` with a strict nonce-based Content Security Policy, every SPA navigation triggers CSP violations.
  Each server response includes a unique CSP nonce, but during SPA navigation the browser continues enforcing the **original
  page's** CSP header. When Livewire fetches a new page and swaps the HTML, the new page's nonce-bearing `<script>`, `<style>`,  and `<link>` elements are rejected because their nonces don't match.

  This causes three distinct violations:
  1. **`DOMParser.parseFromString()`** reports violations when parsing HTML containing nonce'd elements — the browser enforces
  CSP even on inert parsed documents
  2. **`mergeNewHead()`** re-injects already-loaded assets because `outerHTML` comparison includes the nonce (which differs per
   request), making identical assets look "new"
  3. **`cloneScriptTag()`** copies nonces via `setAttribute()` which browsers ignore for CSP — the `.nonce` IDL property is
  required for dynamically inserted elements

  ## Solution

  Four changes to `js/plugins/navigate/page.js`:

  1. **Capture the initial CSP nonce** on first page load (via `livewireScriptConfig.nonce` or the `.nonce` IDL property) and
  store it for the SPA session lifetime
  2. **Replace nonces in raw HTML before parsing** — `replaceNoncesInHtml()` extracts the new page's nonce from the fetched
  HTML string and replaces all occurrences with the captured nonce *before* `DOMParser.parseFromString()` sees it
  3. **Compare head assets ignoring nonces** — `mergeNewHead()` uses the existing `ignoreAttributes()` function (already used
  for body script deduplication) to strip nonces before comparing
  4. **Use `.nonce` IDL property in `cloneScriptTag()`** — dynamically created scripts use `script.nonce = value` instead of
  `setAttribute('nonce', value)`

  ## Test

  Added `test_navigate_does_not_trigger_csp_violations_with_different_nonces` browser test that:
  - Renders two pages with different CSP nonces and enforcing `Content-Security-Policy` headers
  - Navigates between them via `wire:navigate`
  - Asserts no console errors and no CSP violation warnings
