### PR TITLE
Fix SFC parser extracting style/script tags from inside @verbatim blocks

### DIFF
--- a/src/Compiler/Fixtures/sfc-component-with-style-in-verbatim.blade.php
+++ b/src/Compiler/Fixtures/sfc-component-with-style-in-verbatim.blade.php
@@ -1,0 +1,19 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component
+{
+    public $message = 'Hello World';
+};
+?>
+
+<div>{{ $message }}</div>
+
+@verbatim
+```html
+<style>
+    .example { color: red; }
+</style>
+```
+@endverbatim

--- a/src/Compiler/Parser/SingleFileParser.php
+++ b/src/Compiler/Parser/SingleFileParser.php
@@ -67,6 +67,9 @@ class SingleFileParser extends Parser
         // Remove @assets/@endassets blocks (let Livewire handle these normally)
         $viewContents = preg_replace('/@assets\s*.*?@endassets/s', '', $viewContents);
 
+        // Remove @verbatim/@endverbatim blocks (content inside is literal, not extractable)
+        $viewContents = preg_replace('/@verbatim\s*.*?@endverbatim/s', '', $viewContents);
+
         // Only match script tags at column 0 (root-level). Nested scripts are indented and should stay in the view.
         $pattern = '/(?:^|\n)(<script\b[^>]*>.*?<\/script>)/s';
         preg_match_all($pattern, $viewContents, $matches);
@@ -89,6 +92,9 @@ class SingleFileParser extends Parser
         // Get the view portion (everything after the PHP class)
         $viewContents = static::getViewPortion($contents);
 
+        // Remove @verbatim/@endverbatim blocks (content inside is literal, not extractable)
+        $viewContents = preg_replace('/@verbatim\s*.*?@endverbatim/s', '', $viewContents);
+
         // Only match style tags at column 0 (root-level), excluding <style global>
         $pattern = '/(?:^|\n)(<style\b(?![^>]*\bglobal\b)[^>]*>.*?<\/style>)/s';
         preg_match_all($pattern, $viewContents, $matches);
@@ -110,6 +116,9 @@ class SingleFileParser extends Parser
     {
         // Get the view portion (everything after the PHP class)
         $viewContents = static::getViewPortion($contents);
+
+        // Remove @verbatim/@endverbatim blocks (content inside is literal, not extractable)
+        $viewContents = preg_replace('/@verbatim\s*.*?@endverbatim/s', '', $viewContents);
 
         // Only match style tags with "global" attribute at column 0 (root-level)
         $pattern = '/(?:^|\n)(<style\b[^>]*\bglobal\b[^>]*>.*?<\/style>)/s';

--- a/src/Compiler/UnitTest.php
+++ b/src/Compiler/UnitTest.php
@@ -156,6 +156,22 @@ class UnitTest extends \Tests\TestCase
         $this->assertStringContainsString('.nested { color: red; }', $viewContents);
     }
 
+    public function test_wont_extract_style_inside_verbatim()
+    {
+        $compiler = new Compiler(new CacheManager($this->cacheDir));
+
+        $parser = SingleFileParser::parse($compiler, __DIR__ . '/Fixtures/sfc-component-with-style-in-verbatim.blade.php');
+
+        $styleContents = $parser->generateStyleContents();
+        $viewContents = $parser->generateViewContents();
+
+        // No style should be extracted — the only style tag is inside a @verbatim block
+        $this->assertNull($styleContents);
+
+        // The style tag should remain in the view portion
+        $this->assertStringContainsString('.example { color: red; }', $viewContents);
+    }
+
     public function test_wont_parse_scripts_inside_assets_or_script_directives()
     {
         $compiler = new Compiler(new CacheManager($this->cacheDir));


### PR DESCRIPTION
# The scenario

A single-file component with a `<style>` or `<script>` tag inside a `@verbatim`/`@endverbatim` block has the tag incorrectly extracted and stripped from the view.

````blade
@verbatim
```html
<style>
    .example { color: red; }
</style>
```
@endverbatim
````

# The problem

We use a regex to find root-level `<style>` tags in the view portion, but it has no awareness of `@verbatim` blocks.

# The solution

Before running the tag-matching regex, strip `@verbatim`/`@endverbatim` blocks from the local copy of the view content used for matching.

```php
// Remove @verbatim/@endverbatim blocks (content inside is literal, not extractable)
$viewContents = preg_replace('/@verbatim\s*.*?@endverbatim/s', '', $viewContents);
```

This is the same pattern already used in `extractScriptPortion()` for `@script` and `@assets` directives.