### PR TITLE
Fix deprecation warnings for dynamic original property in tests

### DIFF
--- a/src/Features/SupportTesting/InitialRender.php
+++ b/src/Features/SupportTesting/InitialRender.php
@@ -39,7 +39,7 @@ class InitialRender extends Render
         $html = $response->getContent();
 
         // Set "original" to Blade view for assertions like "assertViewIs()"...
-        $response->original = $componentView;
+        $response->baseResponse->original = $componentView;
 
         $snapshot = Utils::extractAttributeDataFromHtml($html, 'wire:snapshot');
         $effects = Utils::extractAttributeDataFromHtml($html, 'wire:effects');

--- a/src/Features/SupportTesting/SubsequentRender.php
+++ b/src/Features/SupportTesting/SubsequentRender.php
@@ -53,7 +53,7 @@ class SubsequentRender extends Render
         $json = $response->json();
 
         // Set "original" to Blade view for assertions like "assertViewIs()"...
-        $response->original = $componentView;
+        $response->baseResponse->original = $componentView;
 
         $componentResponsePayload = $json['components'][0];
 

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -560,6 +560,51 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             ->assertReturned(fn ($data) => $data === 'bar');
     }
 
+    function test_livewire_test_does_not_emit_dynamic_original_deprecation_on_initial_render()
+    {
+        $messages = $this->captureDynamicOriginalDeprecations(function () {
+            Livewire::test(new class extends TestComponent {});
+        });
+
+        $this->assertCount(0, $messages, implode("\n", $messages));
+    }
+
+    function test_livewire_test_does_not_emit_dynamic_original_deprecation_on_subsequent_render()
+    {
+        $messages = $this->captureDynamicOriginalDeprecations(function () {
+            Livewire::test(new class extends TestComponent {})
+                ->call('$refresh');
+        });
+
+        $this->assertCount(0, $messages, implode("\n", $messages));
+    }
+
+    protected function captureDynamicOriginalDeprecations(callable $callback): array
+    {
+        $messages = [];
+
+        set_error_handler(function ($severity, $message, $file, $line) use (&$messages) {
+            if ($severity !== E_DEPRECATED) return false;
+
+            if (! str_contains($message, 'Creation of dynamic property Illuminate\\Testing\\TestResponse::$original is deprecated')) {
+                return false;
+            }
+
+            $messages[] = $message.' at '.$file.':'.$line;
+
+            // Consume this known deprecation so the test can assert on it explicitly.
+            return true;
+        });
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $messages;
+    }
+
     public function test_can_set_cookies_for_use_with_testing()
     {
         // Test both the `withCookies` and `withCookie` methods that Laravel normally provides


### PR DESCRIPTION
## Summary
This PR fixes a PHP 8.2+ deprecation triggered during Livewire component testing and adds regression coverage to prevent it from returning.

When calling Livewire::test(), Livewire previously assigned the rendered view to original on the Laravel TestResponse wrapper. On PHP 8.2+, that write creates a dynamic property on TestResponse, which emits a deprecation notice. On newer PHP versions, this path becomes increasingly strict.

## Problem
Running component tests with deprecations enabled produced:

Creation of dynamic property Illuminate\Testing\TestResponse::$original is deprecated

This happened once per Livewire::test() call.

## Root Cause
TestResponse reads unknown properties through __get() by proxying to its underlying base response, but it does not define original and does not implement __set() for forwarding writes.

So writing to response.original creates a dynamic property on the wrapper object, even though the underlying base response already has a declared original property.

## What Changed
The assignment now targets the underlying base response directly, where original is declared.

Before:
response.original = componentView

After:
response.baseResponse.original = componentView

This was applied to both the initial render path and the subsequent render path.

## Why This Is Safe
Behavior remains unchanged for consumers:

- Assertions that read response.original still work, because TestResponse read access continues to proxy to the base response.
- The only change is where the write happens.
- No protocol, payload, or rendering behavior changed.

## Tests Added
Two regression tests were added to focus specifically on this deprecation path:

- test_livewire_test_does_not_emit_dynamic_original_deprecation_on_initial_render
- test_livewire_test_does_not_emit_dynamic_original_deprecation_on_subsequent_render

These tests install a temporary error handler, capture E_DEPRECATED messages, and assert that the specific dynamic-property warning for TestResponse.original is not emitted.

## Validation
Targeted test execution:

./vendor/bin/phpunit --testsuite="Unit" UnitTest.php --filter="dynamic_original_deprecation"

Result:
2 tests passed.

## Impact
- Removes one deprecation per Livewire::test() call on PHP 8.2+.
- Improves forward compatibility for newer PHP versions, including PHP 8.4 environments.
- Preserves existing testing behavior and assertion semantics.