### PR TITLE
[4.x] Fix stale Octane container on Route::view() routes breaking Livewire updates

### DIFF
--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -184,6 +184,7 @@ class PersistentMiddleware extends Mechanism
     {
         try {
             $route = app('router')->getRoutes()->match($request);
+            $route->setContainer(app());
             $request->setRouteResolver(fn() => $route);
         } catch (NotFoundHttpException $e){
             return null;

--- a/src/Mechanisms/PersistentMiddleware/UnitTest.php
+++ b/src/Mechanisms/PersistentMiddleware/UnitTest.php
@@ -2,8 +2,10 @@
 
 namespace Livewire\Mechanisms\PersistentMiddleware;
 
+use Illuminate\Http\Request;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Route;
 use Livewire\Component as BaseComponent;
 use Livewire\Livewire;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
@@ -35,6 +37,85 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             ...$base,
             'MyMiddleware',
         ], Livewire::getPersistentMiddleware());
+    }
+
+    public function test_get_route_from_request_sets_container_on_matched_route()
+    {
+        Route::get('/test-container-path', fn() => 'test');
+
+        $request = Request::create('/test-container-path', 'GET');
+
+        $mechanism = app(PersistentMiddleware::class);
+
+        $method = new \ReflectionMethod($mechanism, 'getRouteFromRequest');
+        $method->setAccessible(true);
+
+        $route = $method->invoke($mechanism, $request);
+
+        $this->assertNotNull($route);
+
+        $containerProp = new \ReflectionProperty($route, 'container');
+        $containerProp->setAccessible(true);
+
+        $this->assertSame(app(), $containerProp->getValue($route));
+    }
+
+    public function test_livewire_update_succeeds_when_view_route_has_stale_container()
+    {
+        $component = Livewire::test(EmptyComponent::class);
+        $snapshot = json_encode($component->snapshot);
+
+        // Replace the Livewire test route with a Route::view() route at the same
+        // URI. Route::view() uses ViewController which requires ResponseFactory
+        // from the route's container — the real-world trigger for this bug.
+        $existingRoutes = app('router')->getRoutes();
+        $newCollection = new RouteCollection;
+
+        foreach ($existingRoutes as $route) {
+            if (! str_contains($route->uri(), 'livewire-unit-test-endpoint')) {
+                $newCollection->add($route);
+                continue;
+            }
+
+            $viewRoute = new \Illuminate\Routing\Route(
+                ['GET', 'HEAD'],
+                $route->uri(),
+                [
+                    'uses'    => \Illuminate\Routing\ViewController::class.'@__invoke',
+                    'view'    => 'test',
+                    'data'    => [],
+                    'status'  => 200,
+                    'headers' => [],
+                ]
+            );
+
+            $newCollection->add($viewRoute);
+        }
+
+        // setRoutes() calls $route->setContainer($this->container) on every route,
+        // so we corrupt the container *after* to accurately simulate Octane's stale
+        // sandbox scenario — where a previous request's flushed container is still
+        // referenced by the route. Without the fix, ViewController cannot resolve
+        // ResponseFactory from this empty container and throws BindingResolutionException.
+        app('router')->setRoutes($newCollection);
+
+        foreach (app('router')->getRoutes() as $route) {
+            if (str_contains($route->uri(), 'livewire-unit-test-endpoint')) {
+                $route->setContainer(new \Illuminate\Container\Container);
+                break;
+            }
+        }
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), [
+                'components' => [[
+                    'calls'    => [],
+                    'updates'  => [],
+                    'snapshot' => $snapshot,
+                ]],
+            ]);
+
+        $response->assertStatus(200);
     }
 
     public function test_it_resolves_empty_middleware_list_for_non_matching_routes()


### PR DESCRIPTION
## Problem

On Laravel Octane (FrankenPHP / Swoole), Livewire AJAX updates throw a `BindingResolutionException` when the original page was served by a `Route::view()` route:

```
Illuminate\Contracts\Container\BindingResolutionException:
Target [Illuminate\Contracts\Routing\ResponseFactory] is not instantiable
while building [Illuminate\Routing\ViewController].
```

Reference: [laravel/octane#858](https://github.com/laravel/octane/issues/858), [livewire/livewire#6942](https://github.com/livewire/livewire/discussions/6942)

## Root Cause

Three things combine to produce this error:

1. **`Route::view()` uses `ViewController`**, which requires `ResponseFactory` injected from its container.

2. **`laravel/framework` v12.55.1** added `$this->computedMiddleware = null` to `Route::flushController()`. Octane calls `flushController()` after every request, which now also clears the middleware cache. This forces `PersistentMiddleware` to re-gather the route's middleware on every Livewire update — which calls `controllerMiddleware()` → `getController()` → `$this->container->make(ViewController::class)`.

3. **`PersistentMiddleware::getRouteFromRequest()`** uses `getRoutes()->match()` directly, bypassing `Router::findRoute()`, which is what normally calls `$route->setContainer($this->container)`. Under Octane, after the sandbox is flushed, the route still holds a reference to the **previous request's empty container** — so `ResponseFactory` cannot be resolved.

## Fix

Call `$route->setContainer(app())` immediately after matching the route, mirroring what `Router::findRoute()` does internally:

```php
protected function getRouteFromRequest($request)
{
    try {
        $route = app('router')->getRoutes()->match($request);
        $route->setContainer(app()); // ensures current container, not stale Octane sandbox
        $request->setRouteResolver(fn() => $route);
    } catch (NotFoundHttpException $e) {
        return null;
    }

    return $route;
}
```

## Tests

Two tests added to `src/Mechanisms/PersistentMiddleware/UnitTest.php`:

- **`test_get_route_from_request_sets_container_on_matched_route`** — unit test using reflection that directly asserts `setContainer(app())` was called on the matched route.
- **`test_livewire_update_succeeds_when_view_route_has_stale_container`** — integration test that replaces the test route with a `ViewController`-backed route, corrupts its container to simulate an Octane sandbox flush, then asserts the Livewire update returns 200. Without the fix this test fails with the exact `BindingResolutionException` from the production report.
