### PR TITLE
Add composer test scripts and default to headless browser tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,13 +40,12 @@ Most browser and unit tests live inside of feature directories for example:
 
 src/Features/SupportSlots/[UnitTest.php|BrowserTest.php]
 
-Unit: Run `phpunit --testsuite="Unit" [optional test file] [optional test name]`
-Browser: Run `phpunit --testsuite="Browser" [optional test file] [optional test name]`
-
-When running browser tests, use `DUSK_HEADLESS_DISABLED=false` to run Chrome in headless mode so the browser window doesn't pop up:
-
 ```bash
-DUSK_HEADLESS_DISABLED=false phpunit --testsuite="Browser" path/to/BrowserTest.php
+composer test                                        # all tests
+composer test:unit                                   # unit tests only
+composer test:browser                                # browser tests (headless)
+composer test:browser:headed                         # browser tests (opens Chrome)
+composer test:browser -- --filter="SupportCSP"       # specific browser tests
 ```
 
 **IMPORTANT:** Never run the full Livewire browser test suite — it takes too long. Always use `--filter` to run only the specific tests relevant to your changes. The full suite runs in CI.

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,12 @@
       }
     }
   },
+  "scripts": {
+    "test": "phpunit --configuration phpunit.xml.dist",
+    "test:unit": "phpunit --configuration phpunit.xml.dist --testsuite Unit",
+    "test:browser": "phpunit --configuration phpunit.xml.dist --testsuite Browser",
+    "test:browser:headed": "DUSK_HEADLESS_DISABLED=true phpunit --configuration phpunit.xml.dist --testsuite Browser"
+  },
   "minimum-stability": "dev",
   "prefer-stable": true
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,7 +17,7 @@ class TestCase extends \Orchestra\Testbench\Dusk\TestCase
         $this->afterApplicationCreated(function () {
             $this->makeACleanSlate();
 
-            if (env('DUSK_HEADLESS_DISABLED', true) == false) {
+            if (env('DUSK_HEADLESS_DISABLED', false) == false) {
                 DuskOptions::withoutUI();
             }
         });


### PR DESCRIPTION
## Summary

- Add `composer test`, `test:unit`, `test:browser`, and `test:browser:headed` scripts
- Default browser tests to headless (previously opened Chrome window by default)
- Update CLAUDE.md with the new commands

```bash
composer test                                        # all tests
composer test:unit                                   # unit tests only
composer test:browser                                # browser tests (headless)
composer test:browser:headed                         # browser tests (opens Chrome)
composer test:browser -- --filter="SupportCSP"       # specific browser tests
```

Generated with [Claude Code](https://claude.com/claude-code)