### PR TITLE
Add composer setup script for one-command dev environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,15 @@ tests/         → A smattering of PHP tests however, most tests are inside thei
 
 # Development Workflow
 
+## Setup
+
+Run `composer setup` to install all dependencies (PHP, JS, ChromeDriver).
+
 ## Build JS assets
 
 Run `npm run build` to bundle the JS
+
+**IMPORTANT:** Do not commit `dist/` files. They are built in CI.
 
 # Code Patterns
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ Livewire is a full-stack framework for Laravel that allows you to build dynamic 
 
 You can read the official documentation on the [Livewire website](https://livewire.laravel.com/docs).
 
+## Local Development
+
+```bash
+git clone git@github.com:livewire/livewire.git && cd livewire
+composer setup
+```
+
+This installs PHP and JS dependencies and sets up ChromeDriver for browser tests.
+
+```bash
+composer test:unit                                   # unit tests
+composer test:browser                                # browser tests (headless)
+composer test:browser:headed                         # browser tests (opens Chrome)
+composer test:browser -- --filter="SupportCSP"       # specific tests
+```
+
+To build the JS assets after making changes: `npm run build`
+
 ## Contributing
 <a name="contributing"></a>
 

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,11 @@
     }
   },
   "scripts": {
+    "setup": [
+      "@composer install",
+      "npm install",
+      "@php vendor/bin/dusk-updater detect --auto-update --no-interaction"
+    ],
     "test": "phpunit --configuration phpunit.xml.dist",
     "test:unit": "phpunit --configuration phpunit.xml.dist --testsuite Unit",
     "test:browser": "phpunit --configuration phpunit.xml.dist --testsuite Browser",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
     "setup": [
       "@composer install",
       "npm install",
-      "@php vendor/bin/dusk-updater detect --auto-update --no-interaction"
+      "@php vendor/bin/dusk-updater detect --auto-update --no-interaction",
+      "npm run build"
     ],
     "test": "phpunit --configuration phpunit.xml.dist",
     "test:unit": "phpunit --configuration phpunit.xml.dist --testsuite Unit",


### PR DESCRIPTION
## Summary

Adds `composer setup` — a single command to go from fresh clone to running tests:

```bash
git clone livewire/livewire && cd livewire
composer setup
composer test:browser -- --filter="SupportCSP"  # ready to go
```

The script runs:
1. `composer install`
2. `npm install`
3. `dusk-updater detect --auto-update` (installs correct ChromeDriver)

Also adds a "Local Development" section to the README and updates CLAUDE.md.

Generated with [Claude Code](https://claude.com/claude-code)