### PR TITLE
Fix --test flag for class-based components

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -134,6 +134,14 @@ class MakeCommand extends Command
         $this->files->put($paths['class'], $classContent);
         $this->files->put($paths['view'], $viewContent);
 
+        // Create test file if --test flag is present or configured in make_command.with.test
+        if ($this->option('test') || config('livewire.make_command.with.test')) {
+            $testPath = $this->getClassBasedComponentTestPath($name);
+            $this->ensureDirectoryExists(dirname($testPath));
+            $testContent = $this->buildClassBasedComponentTest($name);
+            $this->files->put($testPath, $testContent);
+        }
+
         $this->components->info(sprintf('Livewire component [%s] created successfully.', $paths['class']));
 
         return 0;

--- a/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
+++ b/src/Features/SupportConsoleCommands/Tests/MakeCommandUnitTest.php
@@ -477,6 +477,30 @@ class MakeCommandUnitTest extends \Tests\TestCase
         $this->assertTrue(File::exists($this->livewireComponentsPath('admin/⚡users.test.php')));
     }
 
+    public function test_class_based_component_with_test_flag_creates_test_file()
+    {
+        Artisan::call('make:livewire', ['name' => 'foo', '--class' => true, '--test' => true]);
+
+        $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
+        $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('FooTest.php')));
+
+        $testContent = File::get($this->livewireTestsPath('FooTest.php'));
+        $this->assertStringContainsString("it('renders successfully'", $testContent);
+        $this->assertStringContainsString('foo', $testContent);
+    }
+
+    public function test_class_based_component_with_test_when_configured_in_make_command_with()
+    {
+        $this->app['config']->set('livewire.make_command.with.test', true);
+
+        Artisan::call('make:livewire', ['name' => 'foo', '--class' => true]);
+
+        $this->assertTrue(File::exists($this->livewireClassesPath('Foo.php')));
+        $this->assertTrue(File::exists($this->livewireViewsPath('foo.blade.php')));
+        $this->assertTrue(File::exists($this->livewireTestsPath('FooTest.php')));
+    }
+
     public function test_multi_file_component_with_test_when_configured_in_make_command_with()
     {
         $this->app['config']->set('livewire.make_command.with.test', true);


### PR DESCRIPTION
## Description
- Running `php artisan make:livewire SomeComponent --class --test` does not create a test file. The `--test` flag works correctly for SFC and MFC components, but the test creation logic was missing from `createClassBasedComponent`.

## Diagnosis
- The `createClassBasedComponent` method was missing the conditional block to create the test file. The helper methods `getClassBasedComponentTestPath` and `buildClassBasedComponentTest` already existed and worked correctly — they just were never called during component creation.

## Exploration
- The fix mirrors the exact pattern used in `createSingleFileComponent` (line 198) and `createMultiFileComponent` (line 269) — a simple conditional check for `$this->option('test') || config('livewire.make_command.with.test')`.

## Proposal
- Added the missing test file creation block to `createClassBasedComponent`, matching the pattern in the other two creation methods. Added two tests: one for the `--test` flag and one for the `make_command.with.test` config option.

Fixes #10132

🤖 Generated with [Claude Code](https://claude.com/claude-code)