### PR TITLE
Fix wire:intersect inside @teleport

### DIFF
--- a/js/features/supportWireIntersect.js
+++ b/js/features/supportWireIntersect.js
@@ -1,6 +1,7 @@
 import Alpine from 'alpinejs'
 import { extractDirective } from '@/directives'
 import { evaluateActionExpression } from '@/evaluator'
+import { findComponentByEl } from '@/store'
 
 Alpine.interceptInit(el => {
     for (let i = 0; i < el.attributes.length; i++) {
@@ -17,8 +18,9 @@ Alpine.interceptInit(el => {
                 ['x-intersect' + modifierString](e) {
                     directive.eventContext = e
 
-                    // @todo: review if there is a better way to get the component...
-                    let component = el.closest('[wire\\:id]')?.__livewire
+                    let component = findComponentByEl(el, false)
+
+                    if (! component) return
 
                     component.addActionContext({
                         el,


### PR DESCRIPTION
## Summary
- `wire:intersect` failed inside `@teleport('body')` modals because `el.closest('[wire\\:id]')` can't traverse past a teleported element's new DOM position
- Replaced raw `el.closest()` with `findComponentByEl()` from the store, which uses `walkUpwards()` and follows Alpine's `_x_teleportBack` links to find the correct parent component
- Added a null guard so the handler silently returns if no component is found

Fixes https://github.com/livewire/livewire/discussions/10139

## Test plan
- [ ] Open a modal that uses `@teleport('body')` containing a `wire:intersect` element
- [ ] Verify the intersect callback fires when the element becomes visible
- [ ] Verify `wire:intersect` still works normally outside of `@teleport`

🤖 Generated with [Claude Code](https://claude.com/claude-code)