### PR TITLE
[4.x] Fix #[Url(history: true)] breaking browser forward button

### DIFF
--- a/js/features/supportQueryString.js
+++ b/js/features/supportQueryString.js
@@ -24,6 +24,8 @@ on('effect', ({ component, effects, cleanup }) => {
 
             cleanup(() => Alpine.release(effectReference))
         } else if (use === 'push') {
+            let popNavigating = false
+
             let forgetCommitHandler = on('commit', ({ component: commitComponent, succeed }) => {
                 if (component !== commitComponent) return
 
@@ -34,17 +36,30 @@ on('effect', ({ component, effects, cleanup }) => {
 
                     if (JSON.stringify(beforeValue) === JSON.stringify(afterValue)) return
 
-                    push(afterValue)
+                    // If we're handling a popstate (back/forward navigation), use
+                    // replaceState instead of pushState so we don't wipe out the
+                    // forward history entries...
+                    if (popNavigating) {
+                        replace(afterValue)
+                    } else {
+                        push(afterValue)
+                    }
                 })
             })
 
             let forgetPopHandler = pop(async newValue => {
+                popNavigating = true
+
                 await component.$wire.set(name, newValue)
 
                 // @todo: this is the absolute worst thing ever I'm so sorry this needs to be refactored stat:
                 document.querySelectorAll('input').forEach(el => {
                     el._x_forceModelUpdate && el._x_forceModelUpdate(el._x_model.get())
                 })
+
+                // Use requestAnimationFrame to ensure the flag stays true through
+                // the succeed callback which fires in a requestAnimationFrame...
+                requestAnimationFrame(() => popNavigating = false)
             })
 
             // If the current property value differs from the initial value

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -1262,6 +1262,123 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertScript('return window.location.hash', '#default-tab')
         ;
     }
+
+    public function test_url_history_push_mode_forward_button_works_after_back()
+    {
+        Livewire::visit([
+            new class extends Component {
+                #[BaseUrl(history: true)]
+                public $search = '';
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <input type="text" dusk="search" wire:model.live="search" />
+                    <span dusk="output">{{ $search }}</span>
+                </div>
+                HTML; }
+            },
+        ])
+        ->waitForLivewireToLoad()
+        ->assertQueryStringMissing('search')
+
+        // Type "a" — should push a new history entry...
+        ->waitForLivewire()->type('@search', 'a')
+        ->pause(50)
+        ->assertQueryStringHas('search', 'a')
+        ->assertSeeIn('@output', 'a')
+
+        // Type "ab" — should push another history entry...
+        ->waitForLivewire()->type('@search', 'ab')
+        ->pause(50)
+        ->assertQueryStringHas('search', 'ab')
+        ->assertSeeIn('@output', 'ab')
+
+        // Click Back — should go to "a"...
+        ->waitForLivewire()->back()
+        ->pause(50)
+        ->assertQueryStringHas('search', 'a')
+        ->assertSeeIn('@output', 'a')
+
+        // Click Forward — should go back to "ab" (this was the bug)...
+        ->waitForLivewire()->forward()
+        ->pause(50)
+        ->assertQueryStringHas('search', 'ab')
+        ->assertSeeIn('@output', 'ab')
+        ;
+    }
+
+    public function test_url_history_push_mode_multiple_back_forward_navigations()
+    {
+        Livewire::visit([
+            new class extends Component {
+                #[BaseUrl(history: true)]
+                public $page = '1';
+
+                public function setPage($value) {
+                    $this->page = $value;
+                }
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <button dusk="page2" wire:click="setPage('2')">Page 2</button>
+                    <button dusk="page3" wire:click="setPage('3')">Page 3</button>
+                    <button dusk="page4" wire:click="setPage('4')">Page 4</button>
+                    <span dusk="output">{{ $page }}</span>
+                </div>
+                HTML; }
+            },
+        ])
+        ->waitForLivewireToLoad()
+        ->assertSeeIn('@output', '1')
+        ->assertQueryStringMissing('page')
+
+        // Navigate through several pages...
+        ->waitForLivewire()->click('@page2')
+        ->pause(50)
+        ->assertSeeIn('@output', '2')
+        ->assertQueryStringHas('page', '2')
+
+        ->waitForLivewire()->click('@page3')
+        ->pause(50)
+        ->assertSeeIn('@output', '3')
+        ->assertQueryStringHas('page', '3')
+
+        ->waitForLivewire()->click('@page4')
+        ->pause(50)
+        ->assertSeeIn('@output', '4')
+        ->assertQueryStringHas('page', '4')
+
+        // Back to page 3...
+        ->waitForLivewire()->back()
+        ->pause(50)
+        ->assertSeeIn('@output', '3')
+        ->assertQueryStringHas('page', '3')
+
+        // Back to page 2...
+        ->waitForLivewire()->back()
+        ->pause(50)
+        ->assertSeeIn('@output', '2')
+        ->assertQueryStringHas('page', '2')
+
+        // Forward to page 3...
+        ->waitForLivewire()->forward()
+        ->pause(50)
+        ->assertSeeIn('@output', '3')
+        ->assertQueryStringHas('page', '3')
+
+        // Forward to page 4...
+        ->waitForLivewire()->forward()
+        ->pause(50)
+        ->assertSeeIn('@output', '4')
+        ->assertQueryStringHas('page', '4')
+
+        // Back again to page 3 (ensure back still works after forward)...
+        ->waitForLivewire()->back()
+        ->pause(50)
+        ->assertSeeIn('@output', '3')
+        ->assertQueryStringHas('page', '3')
+        ;
+    }
 }
 
 class FormObject extends \Livewire\Form


### PR DESCRIPTION
## Summary

- Fixes `#[Url(history: true)]` destroying the browser forward history stack when clicking Back
- Root cause: during popstate navigation, the `succeed` callback fires after the `lock` mechanism releases (timing gap between Promise microtask and requestAnimationFrame), causing `pushState` to be called when it shouldn't be
- Adds a `popNavigating` flag that spans the full back/forward navigation cycle (including rAF-deferred `succeed`), using `replaceState` instead of `pushState` during that window

Fixes #10122

## Test plan

- [ ] Create a Livewire component with `#[Url(history: true)]` on a property
- [ ] Change the property value multiple times (creating history entries)
- [ ] Click the browser Back button — the URL and component state should revert
- [ ] Click the browser Forward button — it should navigate forward (previously broken: forward button was disabled)
- [ ] Verify normal (non-back/forward) navigation still uses `pushState` and creates proper history entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)