### PR TITLE
[4.x] Fix `<template x-if>` and `<template x-for>` content duplicating after morph

### DIFF
--- a/js/morph.js
+++ b/js/morph.js
@@ -146,6 +146,18 @@ function getMorphConfig(component) {
 
             if (isntElement(el)) return
 
+            // When an x-if template hasn't rendered its content yet (e.g. $wire.show just
+            // changed from false to true), prevent Alpine's cloneNode from evaluating x-if
+            // on the "to" element and injecting duplicate content into the "to" DOM. We strip
+            // the directive from "to" so cloneNode is inert, and use childrenOnly() to skip
+            // attribute patching so the "from" element keeps its original x-if directive...
+            if (el.tagName === 'TEMPLATE' && toEl.tagName === 'TEMPLATE'
+                && ! el._x_currentIfEl && toEl.hasAttribute('x-if')
+            ) {
+                toEl.removeAttribute('x-if')
+                childrenOnly()
+            }
+
             trigger('morph.updating', { el, toEl, component, skip, childrenOnly, skipChildren, skipUntil })
 
             // bypass DOM diffing for children by overwriting the content

--- a/js/morph.js
+++ b/js/morph.js
@@ -146,15 +146,24 @@ function getMorphConfig(component) {
 
             if (isntElement(el)) return
 
-            // When an x-if template hasn't rendered its content yet (e.g. $wire.show just
-            // changed from false to true), prevent Alpine's cloneNode from evaluating x-if
-            // on the "to" element and injecting duplicate content into the "to" DOM. We strip
-            // the directive from "to" so cloneNode is inert, and use childrenOnly() to skip
-            // attribute patching so the "from" element keeps its original x-if directive...
-            if (el.tagName === 'TEMPLATE' && toEl.tagName === 'TEMPLATE'
-                && ! el._x_currentIfEl && toEl.hasAttribute('x-if')
-            ) {
-                toEl.removeAttribute('x-if')
+            // Alpine directives like x-if and x-for insert sibling DOM nodes after
+            // <template> elements via el.after(). During morphing, Alpine.cloneNode
+            // evaluates these directives on the "to" element using already-updated
+            // reactive state, which can inject content into the "to" DOM that doesn't
+            // exist in "from" yet. The morph adds it, then Alpine's deferred effects
+            // add it again after the transaction commits — causing duplicates.
+            //
+            // When the "from" template hasn't rendered content yet, we stub .after()
+            // on the "to" element so cloneNode can't inject sibling nodes, and use
+            // childrenOnly() to preserve the "from" element's directives...
+            if (el.tagName === 'TEMPLATE' && toEl.tagName === 'TEMPLATE') {
+                let hasRenderedContent = el._x_currentIfEl
+                    || (el._x_prevKeys && el._x_prevKeys.length > 0)
+
+                if (! hasRenderedContent) {
+                    toEl.after = function () {}
+                }
+
                 childrenOnly()
             }
 

--- a/src/Tests/AlpineMorphingBrowserTest.php
+++ b/src/Tests/AlpineMorphingBrowserTest.php
@@ -443,6 +443,38 @@ class AlpineMorphingBrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_template_x_for_with_wire_click_does_not_duplicate_items()
+    {
+        // When a Livewire array property controls an x-for template and items are added
+        // via wire:click, each item should only render once - not be duplicated by the morph.
+        Livewire::visit(new class extends Component {
+            public array $items = [];
+
+            public function addItems(): void
+            {
+                $this->items = [
+                    ['id' => 1, 'name' => 'Item 1'],
+                    ['id' => 2, 'name' => 'Item 2'],
+                ];
+            }
+
+            function render() {
+                return <<<'HTML'
+                <div>
+                    <template x-for="item in $wire.items" :key="item.id">
+                        <p x-text="item.name" class="x-for-item"></p>
+                    </template>
+                    <button wire:click="addItems" dusk="add">Add Items</button>
+                </div>
+                HTML;
+            }
+        })
+            ->assertScript('document.querySelectorAll(".x-for-item").length', 0)
+            ->waitForLivewire()->click('@add')
+            ->assertScript('document.querySelectorAll(".x-for-item").length', 2)
+        ;
+    }
+
     public function test_nested_array_property_access_after_removal()
     {
         // This tests deeply nested property access that would fail if effects fire before cleanup

--- a/src/Tests/AlpineMorphingBrowserTest.php
+++ b/src/Tests/AlpineMorphingBrowserTest.php
@@ -413,6 +413,36 @@ class AlpineMorphingBrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_template_x_if_with_wire_click_does_not_duplicate_content()
+    {
+        // When a Livewire property controls an x-if template and is toggled via wire:click,
+        // the template content should only render once - not be duplicated by the morph.
+        Livewire::visit(new class extends Component {
+            public bool $show = false;
+
+            public function open(): void
+            {
+                $this->show = true;
+            }
+
+            function render() {
+                return <<<'HTML'
+                <div>
+                    <template x-if="$wire.show">
+                        <p dusk="message">Hello world!</p>
+                    </template>
+                    <button wire:click="open" dusk="open">Open</button>
+                </div>
+                HTML;
+            }
+        })
+            ->assertMissing('@message')
+            ->waitForLivewire()->click('@open')
+            ->assertVisible('@message')
+            ->assertScript('document.querySelectorAll("[dusk=message]").length', 1)
+        ;
+    }
+
     public function test_nested_array_property_access_after_removal()
     {
         // This tests deeply nested property access that would fail if effects fire before cleanup


### PR DESCRIPTION
# The Scenario

When using a `<template x-if>` or `<template x-for>` bound to a Livewire property and toggled via `wire:click`, the template content renders twice on the first interaction. Subsequent interactions render correctly.

The reporter confirmed this worked correctly on v4.1.0 and below.

```php
<?php

use Livewire\Component;

new class extends Component
{
    public bool $show = false;

    public function open(): void
    {
        $this->show = true;
    }
};
?>

<div>
    <template x-if="$wire.show">
        <p>Hello world!</p>
    </template>
    <button wire:click="open">Open</button>
</div>
```

# The Problem

During Livewire's morph, Alpine's `cloneNode` evaluates directives like `x-if` and `x-for` on the "to" element using already-updated reactive state. For `<template>` elements, these directives insert sibling DOM nodes via `el.after()`. This injects content into the "to" DOM that doesn't exist in the "from" yet. The morph algorithm adds this content, then Alpine's deferred effects add it again after the transaction commits, causing duplicates.

# The Solution

When both the "from" and "to" elements are `<template>` tags and the "from" template hasn't rendered content yet (checked via Alpine's internal `_x_currentIfEl` for `x-if` and `_x_prevKeys` for `x-for`), we stub `.after()` on the "to" element to a no-op. This prevents `cloneNode` from injecting sibling nodes during the morph. We also call `childrenOnly()` to preserve the "from" element's directives.

This approach handles both `x-if` and `x-for` templates, and avoids stripping directives from the "to" element.

Fixes https://github.com/livewire/livewire/discussions/10097