### PR TITLE
[4.x] Fix positional-after-named arg crash in callTraitHook

### DIFF
--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -62,7 +62,12 @@ class ImplicitRouteBinding
             throw $e;
         }
 
-        return new Collection($parameters);
+        // resolveMethodDependencies() adds default values for optional
+        // parameters with integer keys. Strip them so the array only
+        // contains named route-matched parameters and can be safely
+        // unpacked with `...` downstream (PHP forbids positional args
+        // after named args).
+        return new Collection(array_filter($parameters, 'is_string', ARRAY_FILTER_USE_KEY));
     }
 
     public function resolveComponentProps(Route $route, Component $component)

--- a/src/Features/SupportLifecycleHooks/SupportLifecycleHooks.php
+++ b/src/Features/SupportLifecycleHooks/SupportLifecycleHooks.php
@@ -197,11 +197,7 @@ class SupportLifecycleHooks extends ComponentHook
             }
 
             if (static::$methodCache[$cacheKey]) {
-                $keys = array_keys($params);
-                $paramsToSpread = array_filter($keys, 'is_string') && array_filter($keys, 'is_int')
-                    ? array_filter($params, fn ($key) => is_string($key), ARRAY_FILTER_USE_KEY)
-                    : $params;
-                wrap($this->component)->$method(...$paramsToSpread);
+                wrap($this->component)->$method(...$params);
             }
         }
     }

--- a/src/Features/SupportLifecycleHooks/SupportLifecycleHooks.php
+++ b/src/Features/SupportLifecycleHooks/SupportLifecycleHooks.php
@@ -197,7 +197,11 @@ class SupportLifecycleHooks extends ComponentHook
             }
 
             if (static::$methodCache[$cacheKey]) {
-                wrap($this->component)->$method(...$params);
+                $keys = array_keys($params);
+                $paramsToSpread = array_filter($keys, 'is_string') && array_filter($keys, 'is_int')
+                    ? array_filter($params, fn ($key) => is_string($key), ARRAY_FILTER_USE_KEY)
+                    : $params;
+                wrap($this->component)->$method(...$paramsToSpread);
             }
         }
     }

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -443,6 +443,16 @@ class UnitTest extends \Tests\TestCase
 
         $this->get('/route-with-params/123')->assertSeeText('123');
     }
+
+    public function test_full_page_component_with_optional_mount_params_and_trait_hook_does_not_crash()
+    {
+        Route::get('/posts/{postId}', ComponentWithOptionalMountParamAndTrait::class);
+
+        $this->withoutExceptionHandling()
+            ->get('/posts/123')
+            ->assertSeeText('123')
+            ->assertSeeText('overview');
+    }
 }
 
 class ComponentForRouteWithoutMountParametersTest extends Component
@@ -771,6 +781,35 @@ class ComponentWithStacks extends Component
                     @endpush
                 @endonce
             @endforeach
+        HTML;
+    }
+}
+
+trait WithOptionalMountParamTrait
+{
+    public function mountWithOptionalMountParamTrait()
+    {
+        // trait mount hook — its presence triggers the bug
+    }
+}
+
+class ComponentWithOptionalMountParamAndTrait extends Component
+{
+    use WithOptionalMountParamTrait;
+
+    public $postId;
+    public $tab;
+
+    public function mount($postId, $tab = null)
+    {
+        $this->postId = $postId;
+        $this->tab = $tab ?? 'overview';
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>{{ $postId }} {{ $tab }}</div>
         HTML;
     }
 }


### PR DESCRIPTION
`resolveMethodDependencies()` returns integer keys for optional parameters that have no matching route segment. When these mixed-key arrays are later unpacked with `...` in `callTraitHook()`, PHP throws `Cannot use positional argument after named argument during unpacking`.

Filter out integer-keyed entries in resolveMountParameters() before returning so only named (route-matched) parameters are passed downstream.

Fixes: https://github.com/livewire/livewire/discussions/10146


