### PR TITLE
[4.x] Fix `reset()` and `pull()` on nested array properties

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -3,6 +3,7 @@
 namespace Livewire\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Livewire\Drawer\Utils;
 use Livewire\Form;
 
@@ -70,6 +71,8 @@ trait InteractsWithProperties
 
                 if (is_object($object)) {
                     $isInitialized = (new \ReflectionProperty($object, (string) $propertyName))->isInitialized($object);
+                } elseif (is_array($object)) {
+                    $isInitialized = Arr::has($freshInstance->{$objectName}, Utils::afterFirstDot((string) $property));
                 } else {
                     $isInitialized = false;
                 }

--- a/src/Concerns/Tests/ResetPropertiesUnitTest.php
+++ b/src/Concerns/Tests/ResetPropertiesUnitTest.php
@@ -113,9 +113,37 @@ class ResetPropertiesUnitTest extends \Tests\TestCase
         $component = Livewire::test(ResetPropertiesComponent::class)
             ->set('nestedArrayProp.foo', 'bar')
             ->assertSetStrict('nestedArrayProp.foo', 'bar')
-            ->call('resetKeys', 'nestedArrayProp.foo');
+            ->call('resetKeys', 'nestedArrayProp.foo')
+            ->assertSetStrict('nestedArrayProp.foo', '');
+    }
 
-        $this->assertTrue(!array_key_exists('foo', $component->nestedArrayProp));
+    public function test_can_reset_dynamically_added_nested_array_key()
+    {
+        $component = Livewire::test(ResetPropertiesComponent::class)
+            ->set('nestedArrayProp.newKey', 'dynamic')
+            ->assertSetStrict('nestedArrayProp.newKey', 'dynamic')
+            ->call('resetKeys', 'nestedArrayProp.newKey');
+
+        $this->assertFalse(array_key_exists('newKey', $component->nestedArrayProp));
+    }
+
+    public function test_can_reset_nested_array_property_with_null_default()
+    {
+        Livewire::test(ResetPropertiesComponent::class)
+            ->set('nestedArrayProp.nullValue', 'changed')
+            ->assertSetStrict('nestedArrayProp.nullValue', 'changed')
+            ->call('resetKeys', 'nestedArrayProp.nullValue')
+            ->assertSetStrict('nestedArrayProp.nullValue', null);
+    }
+
+    public function test_can_pull_nested_array_property()
+    {
+        Livewire::test(ResetPropertiesComponent::class)
+            ->set('nestedArrayProp.foo', 'bar')
+            ->assertSetStrict('nestedArrayProp.foo', 'bar')
+            ->call('proxyPull', 'nestedArrayProp.foo')
+            ->assertSetStrict('pullResult', 'bar')
+            ->assertSetStrict('nestedArrayProp.foo', '');
     }
 
     public function test_can_reset_and_return_property_with_pull_method()
@@ -175,6 +203,7 @@ class ResetPropertiesComponent extends TestComponent
 
     public array $nestedArrayProp = [
         'foo' => '',
+        'nullValue' => null,
     ];
 
     public function resetAll()


### PR DESCRIPTION
# The scenario

Calling `$this->reset('filters.status')` removes `status` key entirely instead of resetting it to the default value:

```php
public array $filters = [
    'status' => 'active',
];

$this->reset('filters.status');

// ...

{{ $this->filters['status'] }}
```

throws

```
ErrorException: Undefined array key "search"
```

Same applies to `$this->pull()` which calls `$this->reset()` under the hood.

# The problem

When handling keys with dot-notation in `reset()`, we don't account for arrays:

```php
// InteractsWithProperties.php — reset()

if (str($property)->contains('.')) {
    if (is_object($object)) {
        // ...
    } else {
        $isInitialized = false; // <--- 1 . arrays land here
    }
    
    if (! $isInitialized) {
        data_forget($this, (string) $property); // <--- 2. key is removed
        continue;
    }
}

data_set($this, $property, data_get($freshInstance, $property)); // <--- 3. never reached
```

# The solution

Determine whether the array key exists in the default value:

```php
if (is_object($object)) {
    // ...
} elseif (is_array($object)) {
    $isInitialized = Arr::has($freshInstance->{$objectName}, Utils::afterFirstDot((string) $property));
} else {
    // ...
}
```

## The origin

This was introduced in #6729. Before that, nested array keys were reset to their default value.

## Breaking changes

Only if users rely on the incorrect behavior of `->reset()` removing keys instead of resetting them.

The change passes Filament's test suite.

Fixes livewire/livewire#10123