### PR TITLE
[4.x] Fix model dehydration for models with overridden getMorphClass

### DIFF
--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -7,7 +7,6 @@ use Livewire\Mechanisms\HandleComponents\ComponentContext;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Database\ClassMorphViolationException;
 
 class EloquentCollectionSynth extends Synth {
     use SerializesAndRestoresModelIdentifiers, IsLazy;
@@ -33,20 +32,12 @@ class EloquentCollectionSynth extends Synth {
         $class = $target::class;
         $modelClass = $target->getQueueableClass();
 
-        /**
-         * `getQueueableClass` above checks all models are the same and
-         * then returns the class. We then instantiate a model object
-         * so we can call `getMorphClass()` on it.
-         *
-         * If no alias is found, this just returns the class name
-         */
         if ($modelClass) {
-            try {
-                $modelAlias = (new $modelClass)->getMorphClass();
-            } catch (ClassMorphViolationException $e) {
-                // If the model is not using morph classes, this exception is thrown
-                $modelAlias = $modelClass;
-            }
+            $morphMap = Relation::morphMap();
+
+            $modelAlias = in_array($modelClass, $morphMap)
+                ? array_search($modelClass, $morphMap, true)
+                : $modelClass;
         } else {
             $modelAlias = null;
         }

--- a/src/Features/SupportModels/ModelSynth.php
+++ b/src/Features/SupportModels/ModelSynth.php
@@ -8,7 +8,6 @@ use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\ClassMorphViolationException;
 
 class ModelSynth extends Synth {
     use SerializesAndRestoresModelIdentifiers, IsLazy;
@@ -31,13 +30,11 @@ class ModelSynth extends Synth {
 
         $class = $target::class;
 
-        try {
-            // If no alias is found, this just returns the class name
-            $alias = $target->getMorphClass();
-        } catch (ClassMorphViolationException $e) {
-            // If the model is not using morph classes, this exception is thrown
-            $alias = $class;
-        }
+        $morphMap = Relation::morphMap();
+
+        $alias = in_array($class, $morphMap)
+            ? array_search($class, $morphMap, true)
+            : $class;
 
         $serializedModel = $target->exists
             ? (array) $this->getSerializedPropertyValue($target)

--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -233,6 +233,40 @@ class UnitTest extends \Tests\TestCase
         Relation::requireMorphMap(false);
     }
 
+    public function test_it_dehydrates_models_with_overridden_getMorphClass_using_actual_class()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public $article;
+
+            public function mount() {
+                $this->article = ExtendedArticle::first();
+            }
+
+            public function render() { return <<<'HTML'
+                <div>{{ $article->title }}</div>
+            HTML; }
+        });
+
+        $this->assertEquals(ExtendedArticle::class, $component->snapshot['data']['article'][1]['class']);
+    }
+
+    public function test_it_hydrates_models_with_overridden_getMorphClass_using_actual_class()
+    {
+        Livewire::test(new class extends \Livewire\Component {
+            public $article;
+
+            public function mount() {
+                $this->article = ExtendedArticle::first();
+            }
+
+            public function render() { return <<<'HTML'
+                <div>{{ $article->title }}</div>
+            HTML; }
+        })
+        ->call('$refresh')
+        ->assertSet('article', ExtendedArticle::first());
+    }
+
     public function test_model_synth_rejects_non_model_classes()
     {
         $this->expectException(\Exception::class);
@@ -320,6 +354,19 @@ class Article extends Model
         ['title' => 'First'],
         ['title' => 'Second'],
     ];
+}
+
+// Simulates tightenco/parental's HasParent trait, which overrides
+// getTable() and getMorphClass() to return the parent's values so
+// that polymorphic relations use the parent's table.
+class ExtendedArticle extends Article
+{
+    protected $table = 'articles';
+
+    public function getMorphClass()
+    {
+        return (new Article)->getMorphClass();
+    }
 }
 
 class RouteModelBindingComponent extends \Livewire\Component


### PR DESCRIPTION
# The scenario

Models using `tightenco/parental` fail to hydrate on PHP 8.4.

A child model (e.g. `Box extends Shape`) works on the first request but throws a type error on subsequent ones.

# The problem

We use `getMorphClass()` during dehydration to avoid exposing FQCN if someone has defined a morph map alias.

However, `tightenco/parental` also overrides `getMorphClass()` to make child models appear as their parent.

This causes us to store the wrong class, and on PHP 8.4 the lazy proxy fails because it's created for `Shape` but the database returns a `Box`.

# The solution

`Relation::morphMap()` is a more reliable source for the alias — it only contains explicitly registered morph map entries and isn't affected by model-level overrides:

```php
$morphMap = Relation::morphMap();

$alias = in_array($class, $morphMap)
    ? array_search($class, $morphMap, true)
    : $class;
```

Applied the same fix to `EloquentCollectionSynth`.

Discussion: https://github.com/livewire/livewire/discussions/10127