### PR TITLE
[4.x] Allow browser back-forward cache on Livewire pages

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -183,6 +183,19 @@ return [
 
     /*
     |---------------------------------------------------------------------------
+    | Back-Button Cache
+    |---------------------------------------------------------------------------
+    |
+    | By default, Livewire sends cache headers that prevent browsers from using
+    | back-forward cache (bfcache) on pages containing Livewire components.
+    | Set this to true to allow bfcache, improving back/forward navigation.
+    |
+    */
+
+    'back_button_cache' => false,
+
+    /*
+    |---------------------------------------------------------------------------
     | Navigate (SPA mode)
     |---------------------------------------------------------------------------
     |

--- a/src/Features/SupportDisablingBackButtonCache/SupportDisablingBackButtonCache.php
+++ b/src/Features/SupportDisablingBackButtonCache/SupportDisablingBackButtonCache.php
@@ -27,6 +27,6 @@ class SupportDisablingBackButtonCache extends ComponentHook
 
     public function boot()
     {
-        static::$disableBackButtonCache = true;
+        //
     }
 }

--- a/src/Features/SupportDisablingBackButtonCache/SupportDisablingBackButtonCache.php
+++ b/src/Features/SupportDisablingBackButtonCache/SupportDisablingBackButtonCache.php
@@ -27,6 +27,8 @@ class SupportDisablingBackButtonCache extends ComponentHook
 
     public function boot()
     {
-        //
+        if (! config('livewire.back_button_cache', false)) {
+            static::$disableBackButtonCache = true;
+        }
     }
 }

--- a/src/Features/SupportDisablingBackButtonCache/UnitTest.php
+++ b/src/Features/SupportDisablingBackButtonCache/UnitTest.php
@@ -18,6 +18,15 @@ class UnitTest extends \Tests\TestCase
         $this->assertFalse($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
     }
 
+    public function test_back_button_cache_is_allowed_by_default_for_livewire_components()
+    {
+        Route::get('test-route-containing-livewire-component', DefaultBrowserCache::class);
+
+        $response = $this->get('test-route-containing-livewire-component')->assertSuccessful();
+
+        $this->assertFalse($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
+    }
+
     public function test_ensure_browser_cache_middleware_is_applied_to_a_route_that_contains_a_component_with_disable_set_to_true()
     {
         Route::get('test-route-containing-livewire-component', DisableBrowserCache::class);
@@ -46,6 +55,11 @@ class UnitTest extends \Tests\TestCase
         // so just testing for one that isn't normally in a Laravel request
         $this->assertFalse($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
     }
+}
+
+class DefaultBrowserCache extends TestComponent
+{
+    //
 }
 
 class DisableBrowserCache extends TestComponent

--- a/src/Features/SupportDisablingBackButtonCache/UnitTest.php
+++ b/src/Features/SupportDisablingBackButtonCache/UnitTest.php
@@ -18,13 +18,35 @@ class UnitTest extends \Tests\TestCase
         $this->assertFalse($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
     }
 
-    public function test_back_button_cache_is_allowed_by_default_for_livewire_components()
+    public function test_back_button_cache_is_disabled_by_default_for_livewire_components()
     {
         Route::get('test-route-containing-livewire-component', DefaultBrowserCache::class);
 
         $response = $this->get('test-route-containing-livewire-component')->assertSuccessful();
 
+        $this->assertTrue($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
+    }
+
+    public function test_back_button_cache_is_allowed_when_config_is_true()
+    {
+        config()->set('livewire.back_button_cache', true);
+
+        Route::get('test-route-containing-livewire-component', DefaultBrowserCache::class);
+
+        $response = $this->get('test-route-containing-livewire-component')->assertSuccessful();
+
         $this->assertFalse($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
+    }
+
+    public function test_per_component_disable_overrides_config()
+    {
+        config()->set('livewire.back_button_cache', true);
+
+        Route::get('test-route-containing-livewire-component', DisableBrowserCache::class);
+
+        $response = $this->get('test-route-containing-livewire-component')->assertSuccessful();
+
+        $this->assertTrue($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
     }
 
     public function test_ensure_browser_cache_middleware_is_applied_to_a_route_that_contains_a_component_with_disable_set_to_true()


### PR DESCRIPTION
# The scenario

Livewire disables the back-forward cache (bfcache), causing full page reloads on every Back/Forward navigation. 

Despite that, Chrome restores native form values after navigating back, even when bfcache is disabled.

This desyncs the state between the browser and Livewire:

https://github.com/user-attachments/assets/0cd0b857-b1e2-4a55-aa54-79b2571d3113

> Chrome can reload a page on back navigation _and still restore native form values_, because it stores and reapplies them from session history—not from bfcache—so the DOM is rebuilt but inputs are repopulated afterward.
> 
> This behavior is defined by the [HTML Living Standard (persisted user state in history traversal)]( https://html.spec.whatwg.org/multipage/browsing-the-web.html) and is also observed in real-world issues (e.g. Next.js/Turbo reporting restored inputs with reset app state), which strongly indicates it is intentional browser behavior rather than a Chrome bug.

# The problem

In v2, pressing the browser Back button on a cached Livewire page would cause various issues:

- Restoring stale HTML — component IDs no longer matched server-side state
- `wire:loading` attributes were stuck as `readonly`/`disabled`
- interactions silently failed

The fix (#2747) was to send `Cache-Control: no-store` on every Livewire page, forcing browsers to do a full reload instead of using bfcache.

In v3/v4, none of these problems exist anymore:

- Components are self-contained via `wire:snapshot` — no server-side session dependency for component state. The snapshot in the DOM is updated after every request, so a cached page always has current state.
- Form disabling during requests uses cleanup functions tied to the response lifecycle, not dangling DOM attributes.
- Server-side checksum validation rejects stale snapshots before any code executes.
- CSRF tokens are read fresh on every request, with a 419 → refresh prompt if the session expired.
- In-flight requests clean up properly — `fetch()` promises reject when bfcache aborts connections, clearing `activeMessages` and resolving loading states.

The `no-store` header is now unnecessary and actively harmful — it forces Chrome into a full reload path where its separate form restoration feature creates a new class of desync bugs between DOM state and Livewire state.

# The solution

Add a new `back_button_cache` config option (default: `false`) that users can opt into.

This is because existing apps may rely on the current behavior where pressing Back triggers a full page reload (re-running `mount()`, resetting form state, etc.) but could potentially become enabled by default in the next major version. 

```php
// config/livewire.php
'back_button_cache' => true,
```

When set to `true`, Livewire pages no longer send `no-store` cache headers, allowing browsers to use bfcache for instant back/forward navigation.

`$this->disableBackButtonCache()` and `$this->enableBackButtonCache()` remain available for per-component overrides regardless of the config value.

Fixes #10142