### PR TITLE
Fix wire:navigate error when inline scripts use let/const

### DIFF
--- a/js/plugins/navigate/page.js
+++ b/js/plugins/navigate/page.js
@@ -56,7 +56,15 @@ function prepNewBodyScriptTagsToRun(newBody, oldBodyScriptTagHashes) {
             if (oldBodyScriptTagHashes.includes(hash)) return
         }
 
-        i.replaceWith(cloneScriptTag(i))
+        let cloned = cloneScriptTag(i)
+
+        // Wrap inline scripts in an IIFE to prevent "Identifier has already
+        // been declared" errors when re-executing scripts that use let/const...
+        if (! cloned.src && cloned.textContent) {
+            cloned.textContent = `(() => {${cloned.textContent}})()`
+        }
+
+        i.replaceWith(cloned)
     })
 }
 

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -1295,6 +1295,38 @@ class BrowserTest extends \Tests\BrowserTestCase
         });
     }
 
+    public function test_inline_scripts_with_let_or_const_dont_error_on_navigate()
+    {
+        $this->registerComponentTestRoutes([
+            '/page-b' => new class extends Component {
+                #[Layout('test-views::layout')]
+                public function render() {
+                    return <<<'HTML'
+                    <div>
+                        <a href="/page-b" wire:navigate dusk="link.to.self">Self</a>
+                        <script>let foo = 'bar'</script>
+                    </div>
+                    HTML;
+                }
+            },
+        ]);
+
+        Livewire::visit(new class extends Component {
+            #[Layout('test-views::layout')]
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    <a href="/page-b" wire:navigate dusk="link">Go</a>
+                </div>
+                HTML;
+            }
+        })
+        ->waitForNavigate()->click('@link')
+        ->waitForNavigate()->click('@link.to.self')
+        ->assertConsoleLogHasNoErrors()
+        ;
+    }
+
     protected function registerComponentTestRoutes($routes)
     {
         $registered = 0;


### PR DESCRIPTION
# The scenario

Clicking a `wire:navigate` link that leads to a page with an inline `<script>` using `let` or `const` throws a JavaScript error when the same script was already executed on the previous page (most commonly when navigating to the same page).

```html
<a href="/client/1/profile" wire:navigate>Profile</a>

<script>
    let currentTabId = Math.random().toString(36)
</script>
```

# The problem

When `wire:navigate` swaps the page body, `prepNewBodyScriptTagsToRun` clones every inline `<script>` tag (that doesn't have `data-navigate-once`) so the browser will re-execute it. The cloned script runs in the global scope — but `let` and `const` bindings from the previous execution still exist in the global lexical environment (they persist even after the DOM element is removed). Since `let`/`const` can't be redeclared in the same scope, the browser throws:

```
Uncaught SyntaxError: Failed to execute 'replaceWith' on 'Element':
Identifier 'currentTabId' has already been declared
```

# The solution

Wrap inline body scripts in an IIFE before re-executing them during navigation. This scopes `let`/`const` declarations so they don't conflict with previous global bindings.

```js
let cloned = cloneScriptTag(i)

if (! cloned.src && cloned.textContent) {
    cloned.textContent = `(() => {${cloned.textContent}})()`
}

i.replaceWith(cloned)
```

Only inline scripts (no `src` attribute) are wrapped. External scripts are unaffected.

Fixes livewire/livewire#9979