### PR TITLE
[4.x] Fix file uploads failing with 403 when persistent middleware changes session ID

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -263,13 +263,9 @@ class TemporaryUploadedFile extends UploadedFile
         return new static($filePath, FileUploadConfiguration::disk());
     }
 
-    /**
-     * Generate a short token for a given path using the app key and session ID.
-     * This ensures tokens are unique per session and cannot be forged without the app key.
-     */
     protected static function generateToken(string $path): string
     {
-        return substr(hash_hmac('sha256', $path, app('encrypter')->getKey() . session()->getId()), 0, 8);
+        return substr(hash_hmac('sha256', $path, app('encrypter')->getKey()), 0, 8);
     }
 
     public static function signPath(string $path): string


### PR DESCRIPTION
## The scenario

File uploads use two separate requests: one to the **upload endpoint** and one to the **update endpoint**. If the session ID changes between them, the upload signature doesn't match and Livewire returns a 403.

The most documented case is **apps running inside an iframe** (e.g. Shopify embedded apps). Browsers block third-party cookies in iframes, so the session cookie never reaches the server. On each request, Laravel generates a fresh random session ID:

```php
// Illuminate\Session\Middleware\StartSession
public function getSession(Request $request)
{
    return tap($this->manager->driver(), function ($session) use ($request) {
        $session->setId($request->cookies->get($session->getName()));
    });
}

// Illuminate\Session\Store
public function setId($id)
{
    $this->id = $this->isValidId($id) ? $id : $this->generateSessionId();
}
```

When the cookie is `null`, `setId()` fails validation and generates a new ID — so each request gets a different session ID and the signatures never match.

[Discussion #9847](https://github.com/livewire/livewire/discussions/9847) also reports this in multi-tenant apps with custom middleware configurations. We investigated these cases but couldn't identify a specific middleware that would legitimately change the session ID without also breaking other session-dependent features. These may stem from incorrect middleware setup (e.g., a custom update route missing the `web` group, which Livewire now auto-adds).

## The problem

The upload path signature includes the session ID in the HMAC:

```php
hash_hmac('sha256', $path, app('encrypter')->getKey() . session()->getId())
```

1. The file is uploaded to the **upload endpoint**, which signs the temp path using session ID **A**.
2. The upload is finalized on the **update endpoint** — session ID is now **B**.
3. The signature is recomputed with session ID **B** — it doesn't match — Livewire aborts with 403.

## The solution

Remove the session ID from the upload path signature. The app key alone prevents forgery — this is the same approach used by Livewire's snapshot checksums.

The session ID was meant to scope tokens per user, but this is unnecessary:

- Temp file paths are 40-character random strings — unguessable across users.
- Finalizing an upload already requires a valid CSRF token and snapshot checksum.
- If an attacker can intercept signed paths, they already have the victim's session.

Fixes #9847