### PR TITLE
Bump Alpine.js packages to v3.15.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,18 @@
             "name": "laravel-livewire",
             "license": "MIT",
             "dependencies": {
-                "@alpinejs/anchor": "^3.15.8",
-                "@alpinejs/collapse": "^3.15.8",
-                "@alpinejs/csp": "^3.15.8",
-                "@alpinejs/focus": "^3.15.8",
-                "@alpinejs/intersect": "^3.15.8",
-                "@alpinejs/mask": "^3.15.8",
-                "@alpinejs/morph": "^3.15.8",
-                "@alpinejs/persist": "^3.15.8",
-                "@alpinejs/resize": "^3.15.8",
-                "@alpinejs/sort": "^3.15.8",
+                "@alpinejs/anchor": "^3.15.9",
+                "@alpinejs/collapse": "^3.15.9",
+                "@alpinejs/csp": "^3.15.9",
+                "@alpinejs/focus": "^3.15.9",
+                "@alpinejs/intersect": "^3.15.9",
+                "@alpinejs/mask": "^3.15.9",
+                "@alpinejs/morph": "^3.15.9",
+                "@alpinejs/persist": "^3.15.9",
+                "@alpinejs/resize": "^3.15.9",
+                "@alpinejs/sort": "^3.15.9",
                 "@vue/reactivity": "^3.2.45",
-                "alpinejs": "^3.15.8",
+                "alpinejs": "^3.15.9",
                 "nprogress": "^0.2.0"
             },
             "devDependencies": {
@@ -29,21 +29,24 @@
             }
         },
         "node_modules/@alpinejs/anchor": {
-            "version": "3.15.8",
-            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.15.8.tgz",
-            "integrity": "sha512-TLQD9htRlcIPX+bGp1Tfkc5aWac7lC6jfCHZurkxdVLMbJxJ0ZVDBjgCG+B++uknCwBnIDHZ8w6nZPQ+7MILSw==",
-            "license": "MIT"
+            "version": "3.15.9",
+            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.15.9.tgz",
+            "integrity": "sha512-b/B/TjZH/7BMtltWSV1lbVokDTwF+yQszJUYM4qZ3Moj0hZkan1KVZCpy2OvwHaCnB/4Pq8VpvuXYIlMoQT3Lw==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/dom": "^1.5.3"
+            }
         },
         "node_modules/@alpinejs/collapse": {
-            "version": "3.15.8",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.15.8.tgz",
-            "integrity": "sha512-zZhD8DHdHuzGFe8+cHNH99K//oFutzKwcy6vagydb3KFlTzmqxTnHZo5sSV81lAazhV7qKsYCKtNV14tR9QkJw==",
+            "version": "3.15.9",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.15.9.tgz",
+            "integrity": "sha512-8u3So/YaCRpa6K/JNG5fIkTe7bbdz5AhQ9CuCMy/xreIHYiZoLnDhlZWYnhRvzMhgxGiO6PIIR4SaF3ALJV9Zw==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/csp": {
-            "version": "3.15.8",
-            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.15.8.tgz",
-            "integrity": "sha512-rQAHFPpxyaicATEjSLeg2Ofedwy82Ft7qK3kRmg+vffe9dOHatR45oCBJ7VZ6Q+WzpEwVvPvx8QLJfchfPxmeA==",
+            "version": "3.15.9",
+            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.15.9.tgz",
+            "integrity": "sha512-yIZWdYUwS/Pv3pl6mHnptPWl9zV2Ut91KuNVSF2nFHD3Vns9uG9LqXydoz3e1UflqFXx2XVlrQk4SqLBZxEBQQ==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -65,50 +68,53 @@
             "license": "MIT"
         },
         "node_modules/@alpinejs/focus": {
-            "version": "3.15.8",
-            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.15.8.tgz",
-            "integrity": "sha512-YPF7jtaMFqrWI7xLjathWe/Hi/dXLReGoeZZxJZCW6pgmbFaVKqUFhl3DA+kUPSYsEhh9xk2wr9yoTZ2aB8xew==",
+            "version": "3.15.9",
+            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.15.9.tgz",
+            "integrity": "sha512-7GU2vDmpqa3hs5HhYveUBnF8HWC58yg3vVZySIA2f7AOn4ylcN0DXPND2X2xqo7VuX2ctBnKOtPhXcXGh5/V7w==",
             "license": "MIT",
             "dependencies": {
-                "focus-trap": "^6.9.4",
-                "tabbable": "^5.3.3"
+                "focus-trap": "^8.0.0",
+                "tabbable": "^6.4.0"
             }
         },
         "node_modules/@alpinejs/intersect": {
-            "version": "3.15.8",
-            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.15.8.tgz",
-            "integrity": "sha512-iDrv7rFLp48lXcQkpsojLXrDDWhYKF3NAaem0piiwRs7xBOix5UAOCd/Uj8+PLhV/fuv+itqU1qKxKal9Z0Jaw==",
+            "version": "3.15.9",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.15.9.tgz",
+            "integrity": "sha512-psjb9fvsZEdvBP0Kr6XbLEBz2mNK9M2gEBU2T8VTW9CknTc/qwdW6/wHBHj9uqV1C2ZqoAA4sivon7avgEKlng==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/mask": {
-            "version": "3.15.8",
-            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.15.8.tgz",
-            "integrity": "sha512-u0VjGOMgz42Fx5g4FxvKR6hcevgTegfVXOY6VO4aHYCaND1ISEu1yzlmWp7K8UUinYKO5KqJ+wbFiW0FGOvLqA==",
+            "version": "3.15.9",
+            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.15.9.tgz",
+            "integrity": "sha512-cj6aJ+MzYq6if41npK9/Rdo2ugZQaKhRRdh9yHOvKByQRarDkhMkg9V5NlO0p4PjtCVQdSPZ3pXvm90fWM3xCQ==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/morph": {
-            "version": "3.15.8",
-            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.15.8.tgz",
-            "integrity": "sha512-6m1UD0IwYQj5BVFCeUGy5G1eYW9H/YcVWDskX4VaJc6HTIT+eKbDge4BjcD291WENbbjdFSf6isbcZYAOm6Orw==",
+            "version": "3.15.9",
+            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.15.9.tgz",
+            "integrity": "sha512-Ej20tICmzqAZhr6yd04d8jxxniVepNWu9ZfjlhVH/CQpavn3YvD8SmvdTEHj6J967506DTuPnhLzCuG2PiAZrQ==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/persist": {
-            "version": "3.15.8",
-            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.15.8.tgz",
-            "integrity": "sha512-xKJk0aa5p0QAquP9ivEuLnpzuBC2MyoWmiMRVzWiTR9/VLnbVgFM+6dE/D+NvfKOzhTSeht6FkYqOi/C27LBTg==",
+            "version": "3.15.9",
+            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.15.9.tgz",
+            "integrity": "sha512-Ed/kdLxGjwxl77p6F/Bt6WUW+uUuE9xYSKkxSzgKDpx2sWxOAHjlISxyafhRiRarzUyH616AW98qxvmFzd0n/Q==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/resize": {
-            "version": "3.15.8",
-            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.15.8.tgz",
-            "integrity": "sha512-3XGZz/OIBDsGacHtK0vyTBOmd7JqL6IuQZmKSPcJDoF+Kh5aUX5n4DCqnqw+R17niK0UKGyYtVLdgmBOh4GvOA==",
+            "version": "3.15.9",
+            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.15.9.tgz",
+            "integrity": "sha512-SlgTZsAPBC1kU/PWDgflcPz48Rzt2a7V7vofApppOxykhR0ug2uFDt9in4mbjTO66NCC8GW7E6on2ney//+DcA==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/sort": {
-            "version": "3.15.8",
-            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.15.8.tgz",
-            "integrity": "sha512-m+bfzlSgC8u9Q8kDjVb+0DnFWxERYLGC4MarlRMdz5KpSp5OZwx42o0j87ceRfD6PBIwsrA/uGOfN3oj1J/JmQ==",
-            "license": "MIT"
+            "version": "3.15.9",
+            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.15.9.tgz",
+            "integrity": "sha512-quDvOqHveWtvuTquOqFIQm4f1cEi5GzAFuifFOB59R85lZk/Gzs6V9uR4AvbapsYf1xBOuKVrXQKi3dAdEPSvA==",
+            "license": "MIT",
+            "dependencies": {
+                "sortablejs": "^1.15.2"
+            }
         },
         "node_modules/@asamuzakjp/css-color": {
             "version": "4.1.1",
@@ -719,6 +725,31 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@floating-ui/core": {
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+            "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/utils": "^0.2.11"
+            }
+        },
+        "node_modules/@floating-ui/dom": {
+            "version": "1.7.6",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+            "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/core": "^1.7.5",
+                "@floating-ui/utils": "^0.2.11"
+            }
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+            "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+            "license": "MIT"
+        },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1242,9 +1273,9 @@
             }
         },
         "node_modules/alpinejs": {
-            "version": "3.15.8",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.8.tgz",
-            "integrity": "sha512-zxIfCRTBGvF1CCLIOMQOxAyBuqibxSEwS6Jm1a3HGA9rgrJVcjEWlwLcQTVGAWGS8YhAsTRLVrtQ5a5QT9bSSQ==",
+            "version": "3.15.9",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.9.tgz",
+            "integrity": "sha512-O30m8Tw/aARbLXmeTnISAFgrNm0K71PT7bZy/1NgRqFD36QGb34VJ4a6WBL1iIO/bofN+LkIkKLikUTkfPL2wQ==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -1866,12 +1897,12 @@
             }
         },
         "node_modules/focus-trap": {
-            "version": "6.9.4",
-            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
-            "integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.0.1.tgz",
+            "integrity": "sha512-9ptSG6z51YQOstI/oN4XuVGP/03u2nh0g//qz7L6zX0i6PZiPnkcf3GenXq7N2hZnASXaMxTPpbKwdI+PFvxlw==",
             "license": "MIT",
             "dependencies": {
-                "tabbable": "^5.3.3"
+                "tabbable": "^6.4.0"
             }
         },
         "node_modules/fsevents": {
@@ -2241,6 +2272,12 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/sortablejs": {
+            "version": "1.15.7",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+            "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
+            "license": "MIT"
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2286,9 +2323,9 @@
             "license": "MIT"
         },
         "node_modules/tabbable": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-            "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+            "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
             "license": "MIT"
         },
         "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
         "vitest": "^3.2.4"
     },
     "dependencies": {
-        "@alpinejs/anchor": "^3.15.8",
-        "@alpinejs/collapse": "^3.15.8",
-        "@alpinejs/csp": "^3.15.8",
-        "@alpinejs/focus": "^3.15.8",
-        "@alpinejs/intersect": "^3.15.8",
-        "@alpinejs/mask": "^3.15.8",
-        "@alpinejs/morph": "^3.15.8",
-        "@alpinejs/persist": "^3.15.8",
-        "@alpinejs/resize": "^3.15.8",
-        "@alpinejs/sort": "^3.15.8",
+        "@alpinejs/anchor": "^3.15.9",
+        "@alpinejs/collapse": "^3.15.9",
+        "@alpinejs/csp": "^3.15.9",
+        "@alpinejs/focus": "^3.15.9",
+        "@alpinejs/intersect": "^3.15.9",
+        "@alpinejs/mask": "^3.15.9",
+        "@alpinejs/morph": "^3.15.9",
+        "@alpinejs/persist": "^3.15.9",
+        "@alpinejs/resize": "^3.15.9",
+        "@alpinejs/sort": "^3.15.9",
         "@vue/reactivity": "^3.2.45",
-        "alpinejs": "^3.15.8",
+        "alpinejs": "^3.15.9",
         "nprogress": "^0.2.0"
     }
 }


### PR DESCRIPTION
Upgrade alpinejs and related @alpinejs/* dependencies from 3.15.8 to 3.15.9 in package.json and regenerate package-lock.json to capture updated transitive deps and integrity hashes.

Fix x-model.blur crash when input is removed from a form
https://github.com/alpinejs/alpine/pull/4783

Because of the ISO audit i'm running on Windows today so I'm unable to run te tests.