### PR TITLE
[4.x] Fix blade compiler path resolution during optimize with Sentry

### DIFF
--- a/src/Features/SupportIslands/SupportIslands.php
+++ b/src/Features/SupportIslands/SupportIslands.php
@@ -23,11 +23,13 @@ class SupportIslands extends ComponentHook
 
     public static function registerInlineIslandPrecompiler()
     {
-        Blade::prepareStringsForCompilationUsing(function ($content) {
+        $compiler = app('blade.compiler');
+
+        $compiler->prepareStringsForCompilationUsing(function ($content) use ($compiler) {
             // Shortcut out if there are no islands in the content...
             if (! str_contains($content, '@endisland')) return $content;
 
-            $pathSignature = Blade::getPath() ?: crc32($content);
+            $pathSignature = $compiler->getPath() ?: crc32($content);
 
             return IslandCompiler::compile($pathSignature, $content);
         });

--- a/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
@@ -3,7 +3,6 @@
 namespace Livewire\Features\SupportMorphAwareBladeCompilation;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Blade;
 use Livewire\ComponentHook;
 use Livewire\Livewire;
 
@@ -33,6 +32,8 @@ class SupportMorphAwareBladeCompilation extends ComponentHook
 
     public static function registerPrecompilers()
     {
+        $compiler = app('blade.compiler');
+
         $directives = [
             '@if' => '@endif',
             '@unless' => '@endunless',
@@ -48,8 +49,8 @@ class SupportMorphAwareBladeCompilation extends ComponentHook
             '@for' => '@endfor',
         ];
 
-        Blade::precompiler(function ($entire) use ($directives) {
-            $conditions = \Livewire\invade(app('blade.compiler'))->conditions;
+        $compiler->precompiler(function ($entire) use ($compiler, $directives) {
+            $conditions = \Livewire\invade($compiler)->conditions;
 
             foreach (array_keys($conditions) as $conditionalDirective) {
                 $directives['@'.$conditionalDirective] = '@end'.$conditionalDirective;

--- a/src/Features/SupportScriptsAndAssets/SupportScriptsAndAssets.php
+++ b/src/Features/SupportScriptsAndAssets/SupportScriptsAndAssets.php
@@ -2,7 +2,6 @@
 
 namespace Livewire\Features\SupportScriptsAndAssets;
 
-use Illuminate\Support\Facades\Blade;
 use function Livewire\store;
 use Livewire\ComponentHook;
 
@@ -42,14 +41,14 @@ class SupportScriptsAndAssets extends ComponentHook
         }
     }
 
-    public static function getUniqueBladeCompileTimeKey()
+    public static function getUniqueBladeCompileTimeKey($compiler)
     {
         // Rather than using random strings as compile-time keys for blade directives,
         // we want something more detereminstic to protect against problems that arise
         // from using load-balancers and such.
         // Therefore, we create a key based on the currently compiling view path and
         // number of already compiled directives here...
-        $viewPath = crc32(app('blade.compiler')->getPath() ?? '');
+        $viewPath = crc32($compiler->getPath() ?? '');
 
         if (! isset(static::$countersByViewPath[$viewPath])) static::$countersByViewPath[$viewPath] = 0;
 
@@ -62,6 +61,8 @@ class SupportScriptsAndAssets extends ComponentHook
 
     static function provide()
     {
+        $compiler = app('blade.compiler');
+
         on('flush-state', function () {
             static::$alreadyRunAssetKeys = [];
             static::$countersByViewPath = [];
@@ -69,8 +70,8 @@ class SupportScriptsAndAssets extends ComponentHook
             static::$nonLivewireAssets = [];
         });
 
-        Blade::directive('script', function () {
-            $key = static::getUniqueBladeCompileTimeKey();
+        $compiler->directive('script', function () use ($compiler) {
+            $key = static::getUniqueBladeCompileTimeKey($compiler);
 
             return <<<PHP
                 <?php
@@ -80,7 +81,7 @@ class SupportScriptsAndAssets extends ComponentHook
             PHP;
         });
 
-        Blade::directive('endscript', function () {
+        $compiler->directive('endscript', function () {
             return <<<PHP
                 <?php
                     \$__output = ob_get_clean();
@@ -90,8 +91,8 @@ class SupportScriptsAndAssets extends ComponentHook
             PHP;
         });
 
-        Blade::directive('assets', function () {
-            $key = static::getUniqueBladeCompileTimeKey();
+        $compiler->directive('assets', function () use ($compiler) {
+            $key = static::getUniqueBladeCompileTimeKey($compiler);
 
             return <<<PHP
                 <?php
@@ -102,7 +103,7 @@ class SupportScriptsAndAssets extends ComponentHook
             PHP;
         });
 
-        Blade::directive('endassets', function () {
+        $compiler->directive('endassets', function () {
             return <<<PHP
                 <?php
                     \$__output = ob_get_clean();

--- a/src/Mechanisms/ExtendBlade/ExtendBlade.php
+++ b/src/Mechanisms/ExtendBlade/ExtendBlade.php
@@ -77,8 +77,10 @@ class ExtendBlade extends Mechanism
 
         // We're using "precompiler" as a hook for the point in time when
         // Laravel compiles a Blade view...
-        app('blade.compiler')->precompiler(function ($value) {
-            app(DeterministicBladeKeys::class)->hookIntoCompile(app('blade.compiler'), $value);
+        $compiler = app('blade.compiler');
+
+        $compiler->precompiler(function ($value) use ($compiler) {
+            app(DeterministicBladeKeys::class)->hookIntoCompile($compiler, $value);
 
             return $value;
         });

--- a/src/Mechanisms/ExtendBlade/UnitTest.php
+++ b/src/Mechanisms/ExtendBlade/UnitTest.php
@@ -6,6 +6,7 @@ use ErrorException;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\View;
 use Livewire\Component;
 use Livewire\Exceptions\BypassViewHandler;
@@ -16,6 +17,31 @@ use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
+    public function test_compilation_callbacks_dont_resolve_blade_compiler_from_container()
+    {
+        // Get the compiler that has all Livewire hooks registered on it...
+        $compiler = app('blade.compiler');
+
+        // Forget the blade compiler from the container and clear the facade cache.
+        // This simulates the scenario where `php artisan optimize` swaps the app
+        // instance (during config:cache), causing the container to return a different
+        // blade compiler than the one actually doing compilation...
+        app()->forgetInstance('blade.compiler');
+        Facade::clearResolvedInstance('blade.compiler');
+
+        $resolved = false;
+
+        app()->resolving('blade.compiler', function () use (&$resolved) {
+            $resolved = true;
+        });
+
+        // This fixture exercises all Livewire compilation hooks: islands
+        // precompiler, deterministic keys precompiler, and @script/@assets directives...
+        $compiler->compile(view('compiler-instance-test')->getPath());
+
+        $this->assertFalse($resolved, 'Blade compiler was resolved from the container during compilation. Compilation callbacks should use the captured compiler instance.');
+    }
+
     public function test_livewire_only_directives_apply_to_livewire_components_and_not_normal_blade()
     {
         Livewire::directive('foo', function ($expression) {

--- a/tests/views/compiler-instance-test.blade.php
+++ b/tests/views/compiler-instance-test.blade.php
@@ -1,0 +1,13 @@
+<div>
+    @island
+        <span>island</span>
+    @endisland
+
+    @script
+        <script></script>
+    @endscript
+
+    @assets
+        <link>
+    @endassets
+</div>


### PR DESCRIPTION
[Merged into 3.x](https://github.com/livewire/livewire/pull/10160)

## The scenario

Running `php artisan optimize` with Sentry installed produces broken compiled templates — island paths collide and deterministic keys are wrong.

## The problem

Sentry forces early resolution of the blade engine during boot via `app('view')->getEngineResolver()->resolve('blade')`, which captures the current blade compiler instance. When `php artisan optimize` runs:

1. **`config:cache`** — swaps the application instance in the container.
2. **`view:cache`** — compiles views using the original compiler captured by the engine in step 0.

Inside compilation callbacks, `Blade::getPath()` and `app('blade.compiler')->getPath()` resolve a *new* compiler from the swapped container — one that was never given a path. The original compiler (the one actually compiling) has the path set, but nobody asks it.

## The solution

Capture the blade compiler reference once at registration time and thread it into compilation callbacks:

```php
$compiler = app('blade.compiler');

$compiler->prepareStringsForCompilationUsing(function ($content) use ($compiler) {
    $pathSignature = $compiler->getPath() ?: crc32($content);
    // ...
});
```

Applied to four files:
- `SupportIslands` — `Blade::getPath()` in `prepareStringsForCompilationUsing` callback
- `ExtendBlade` — `app('blade.compiler')` in `precompiler` callback
- `SupportScriptsAndAssets` — `app('blade.compiler')->getPath()` in directive callbacks
- `SupportMorphAwareBladeCompilation` — `app('blade.compiler')` in `precompiler` callback

Includes a regression test that forgets the compiler from the container before compilation and asserts it's never re-resolved.

Same fix as livewire/blaze#88.

Fixes livewire/blaze#169