### PR TITLE
[4.x] Fix repeated expired dialog on pages with multiple polling components

### DIFF
--- a/js/directives/wire-poll.js
+++ b/js/directives/wire-poll.js
@@ -1,5 +1,5 @@
 import { directive, getDirectives } from "@/directives"
-import { setNextActionMetadata, setNextActionOrigin } from '@/request'
+import { setNextActionMetadata, setNextActionOrigin, isSessionExpired } from '@/request'
 import { evaluateActionExpression } from '../evaluator'
 
 directive('poll', ({ el, directive, component }) => {
@@ -15,6 +15,7 @@ directive('poll', ({ el, directive, component }) => {
     pauseWhile(() => theDirectiveHasVisible(directive) && theElementIsNotInTheViewport(el))
     pauseWhile(() => theDirectiveIsOffTheElement(el))
     pauseWhile(() => livewireIsOffline())
+    pauseWhile(() => isSessionExpired())
     stopWhen(() => theElementIsDisconnected(el))
 })
 

--- a/js/directives/wire-poll.js
+++ b/js/directives/wire-poll.js
@@ -1,5 +1,5 @@
 import { directive, getDirectives } from "@/directives"
-import { setNextActionMetadata, setNextActionOrigin, isSessionExpired } from '@/request'
+import { setNextActionMetadata, setNextActionOrigin, sessionIsExpired } from '@/request'
 import { evaluateActionExpression } from '../evaluator'
 
 directive('poll', ({ el, directive, component }) => {
@@ -15,7 +15,7 @@ directive('poll', ({ el, directive, component }) => {
     pauseWhile(() => theDirectiveHasVisible(directive) && theElementIsNotInTheViewport(el))
     pauseWhile(() => theDirectiveIsOffTheElement(el))
     pauseWhile(() => livewireIsOffline())
-    pauseWhile(() => isSessionExpired())
+    pauseWhile(() => sessionIsExpired())
     stopWhen(() => theElementIsDisconnected(el))
 })
 

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -15,6 +15,11 @@ let interceptors = new InterceptorRegistry
 let messageBus = new MessageBus()
 let actionInterceptors = []
 let partitionInterceptors = []
+let sessionExpired = false
+
+export function isSessionExpired() {
+    return sessionExpired
+}
 
 export function setNextActionOrigin(origin) {
     outstandingActionOrigin = origin
@@ -372,6 +377,10 @@ function sendMessages() {
                 if (preventDefault) return
 
                 if (response.status === 419) {
+                    if (sessionExpired) return
+
+                    sessionExpired = true
+
                     confirm(
                         'This page has expired.\nWould you like to refresh the page?'
                     ) && window.location.reload()

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -17,7 +17,7 @@ let actionInterceptors = []
 let partitionInterceptors = []
 let sessionExpired = false
 
-export function isSessionExpired() {
+export function sessionIsExpired() {
     return sessionExpired
 }
 

--- a/src/Features/SupportReleaseTokens/BrowserTest.php
+++ b/src/Features/SupportReleaseTokens/BrowserTest.php
@@ -40,4 +40,60 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->dismissDialog()
         ;
     }
+
+    public function test_only_one_expired_dialog_is_shown_when_multiple_requests_fail()
+    {
+        Livewire::visit(new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click.async="$refresh" dusk="first">First</button>
+                    <button wire:click.async="$refresh" dusk="second">Second</button>
+
+                    @script
+                    <script>
+                        window.__confirmCount = 0
+                        window.confirm = () => { window.__confirmCount++; return false }
+                    </script>
+                    @endscript
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->waitForLivewire()->click('@first')
+            ->waitForLivewire()->click('@second')
+            ->assertScript('window.__confirmCount', 1)
+        ;
+    }
+
+    public function test_polling_stops_after_session_expired()
+    {
+        Livewire::visit(new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <div wire:poll.50ms>A</div>
+
+                    @script
+                    <script>
+                        window.__requestCount = 0
+                        window.confirm = () => false
+
+                        this.interceptMessage(() => {
+                            window.__requestCount++
+                        })
+                    </script>
+                    @endscript
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->pause(300)
+            ->assertScript('window.__requestCount', 1)
+        ;
+    }
 }


### PR DESCRIPTION
# The scenario

When a `release_token` mismatch causes a 419 response, the "This page has expired" confirm dialog appears repeatedly — once per failed request — and polling components continue sending requests indefinitely.

# The problem

Every request that gets a 419 independently calls `confirm()`:

```js
if (response.status === 419) {
    confirm('This page has expired.\nWould you like to refresh the page?') && window.location.reload()
}
```

1. Multiple requests fail with 419 (concurrent async actions, or polls at different intervals).
2. Each 419 triggers its own blocking `confirm()` dialog.
3. While `confirm()` blocks, `setInterval` callbacks queue up behind it.
4. Dismissing the dialog fires the queued poll callbacks, which send new requests, which get new 419s — endlessly.

# The solution

Track a `sessionExpired` flag in the request module. On the first 419, set the flag before showing the dialog. Subsequent 419s silently return. Polls check the flag via `pauseWhile` to stop all outgoing traffic:

```js
// js/request/index.js
if (sessionExpired) return
sessionExpired = true

confirm(...) && window.location.reload()
```

```js
// js/directives/wire-poll.js
pauseWhile(() => isSessionExpired())
```

Fixes livewire/livewire#10161