### PR TITLE
[4.x] Fix island tokens changing across zero-downtime deployments

### DIFF
--- a/src/Compiler/CacheManager.php
+++ b/src/Compiler/CacheManager.php
@@ -3,6 +3,7 @@
 namespace Livewire\Compiler;
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 
 class CacheManager
 {
@@ -62,7 +63,7 @@ class CacheManager
 
     public function getHash(string $sourcePath): string
     {
-        return substr(md5($sourcePath), 0, 8);
+        return substr(md5(Str::after($sourcePath, base_path())), 0, 8);
     }
 
     public function getClassPath(string $sourcePath): string

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -452,4 +452,21 @@ class UnitTest extends TestCase
 
         $this->assertCount(1, $fragments, 'Expected only one island fragment but got ' . count($fragments));
     }
+
+    public function test_island_tokens_are_stable_across_different_base_paths()
+    {
+        $path = '/resources/views/components/foo.blade.php';
+
+        $content = '@island @endisland';
+
+        $islandA = IslandCompiler::compile(base_path($path), $content);
+
+        // Simulate Forge's zero-downtime deployments where each release has its own folder...
+        app()->setBasePath('/home/forge/domain/releases/22222');
+
+        $islandB = IslandCompiler::compile(base_path($path), $content);
+
+        $this->assertSame($islandA, $islandB);
+    }
+
 }


### PR DESCRIPTION
## The scenario

Islands break after deploying to Forge with zero-downtime deployments — the island cache files can't be found because their tokens change between releases.

## The problem

Island tokens are derived from the full absolute path of the view being compiled. On zero-downtime deployments, each release has its own directory, so the same view produces a different token per release:

1. First release deploys — island cache files are written with token `b437fa2f-1`
2. User loads a page — the component memo stores that token
3. Second release deploys — island cache files are rewritten with a new token `e0266c0a-1` because the release directory changed
4. User's browser makes a Livewire request — the memo still references the old token, which no longer exists

```
File does not exist at path .../storage/framework/views/livewire/islands/b437fa2f-1.blade.php
```

## The solution

Strip `base_path()` before hashing, matching how Laravel's own blade compiler uses `Str::after($path, $this->basePath)`:

```php
- return substr(md5($sourcePath), 0, 8);
+ return substr(md5(Str::after($sourcePath, base_path())), 0, 8);
```

Fixes livewire/livewire#10162