### PR TITLE
Document wire:model bracket notation support

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -312,6 +312,20 @@ This change adds support for passing slots when mounting components and generall
 
 These changes only affect applications using advanced features or customization.
 
+### `wire:model` now supports bracket notation
+
+`wire:model` expressions now support bracket notation for accessing nested properties:
+
+```blade
+<input type="text" wire:model="foo['bar']['baz']">
+
+<input type="text" wire:model="items[0].name">
+```
+
+This means square brackets (`[` and `]`) in `wire:model` values are now interpreted as property accessors. In v3, they were treated as literal characters. If your property keys contain square brackets, rename them to avoid conflicts.
+
+[Learn more about wire:model →](/docs/4.x/wire-model#accessing-nested-properties)
+
 ### Livewire Asset and Endpoint URL Changes
 
 All Livewire URLs now include a unique hash derived from your `APP_KEY`. The prefix changed from `/livewire/` to `/livewire-{hash}/`:

--- a/docs/wire-model.md
+++ b/docs/wire-model.md
@@ -282,6 +282,28 @@ In rare cases where you want `wire:model` to also respond to events bubbling up 
 > [!warning] Use `.deep` sparingly
 > Most use cases don't require listening to child events. Only use `.deep` when you specifically need to capture events from descendant elements.
 
+## Accessing nested properties
+
+`wire:model` supports dot notation for binding to nested properties, array elements, and form object fields:
+
+```blade
+<input type="text" wire:model="address.city">
+
+<input type="text" wire:model="items.0.name">
+
+<input type="text" wire:model="form.title">
+```
+
+Bracket notation is also supported as an alternative:
+
+```blade
+<input type="text" wire:model="address['city']">
+
+<input type="text" wire:model="items[0].name">
+```
+
+Both notations are equivalent — `address['city']` resolves the same path as `address.city`. Bracket and dot notation can be mixed freely within a single expression.
+
 ## Going deeper
 
 For a more complete documentation on using `wire:model` in the context of HTML forms, visit the [Livewire forms documentation page](/docs/4.x/forms).
@@ -297,6 +319,9 @@ For a more complete documentation on using `wire:model` in the context of HTML f
 
 ```blade
 wire:model="propertyName"
+wire:model="property.nested"
+wire:model="property['nested']"
+wire:model="property[0]"
 ```
 
 ### Modifiers


### PR DESCRIPTION
## The scenario

`wire:model` in v4 supports bracket notation (`foo['bar']`, `items[0]`) for accessing nested properties, but this isn't documented anywhere. 

## The problem

Users upgrading from v3 who happen to have square brackets in their property key names hit unexpected behavior because `[]` is now parsed as an accessor.

## The solution

**`docs/wire-model.md`** — Added an "Accessing nested properties" section documenting both dot notation and bracket notation:

```blade
<input type="text" wire:model="address.city">
<input type="text" wire:model="address['city']">
<input type="text" wire:model="items[0].name">
```

Also expanded the Reference section to show all supported expression syntaxes.

**`docs/upgrading.md`** — Added a note under "Low-impact changes" explaining that `wire:model` now interprets square brackets as property accessors (breaking change from v3 where they were literal characters).

Fixes #10170