### PR TITLE
Fix optional route binding regression from #10147

### DIFF
--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -62,12 +62,7 @@ class ImplicitRouteBinding
             throw $e;
         }
 
-        // resolveMethodDependencies() adds default values for optional
-        // parameters with integer keys. Strip them so the array only
-        // contains named route-matched parameters and can be safely
-        // unpacked with `...` downstream (PHP forbids positional args
-        // after named args).
-        return new Collection(array_filter($parameters, 'is_string', ARRAY_FILTER_USE_KEY));
+        return new Collection($parameters);
     }
 
     public function resolveComponentProps(Route $route, Component $component)

--- a/src/Features/SupportLifecycleHooks/SupportLifecycleHooks.php
+++ b/src/Features/SupportLifecycleHooks/SupportLifecycleHooks.php
@@ -197,7 +197,21 @@ class SupportLifecycleHooks extends ComponentHook
             }
 
             if (static::$methodCache[$cacheKey]) {
-                wrap($this->component)->$method(...$params);
+                // resolveMethodDependencies() can produce arrays with both
+                // string and integer keys (e.g. ['postId' => '123', 0 => null]).
+                // PHP forbids positional args after named args when spreading,
+                // so strip the integer-keyed entries in that case. When all keys
+                // are the same type (e.g. updating/updated hooks pass only
+                // integer-keyed [$name, $value]), leave them as-is.
+                $keys = array_keys($params);
+                $hasStringKeys = array_filter($keys, 'is_string');
+                $hasIntKeys = array_filter($keys, 'is_int');
+
+                $paramsToSpread = ($hasStringKeys && $hasIntKeys)
+                    ? array_filter($params, 'is_string', ARRAY_FILTER_USE_KEY)
+                    : $params;
+
+                wrap($this->component)->$method(...$paramsToSpread);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Reverts the `array_filter` in `ImplicitRouteBinding::resolveMountParameters()` that stripped integer-keyed defaults — this was removing null values for optional params (like `?Model $model = null`), causing `ImplicitlyBoundMethod` to resolve the type from the container instead of using `null`
- Moves the mixed-key spreading fix to `callTraitHook()` where the actual crash occurs — only strips integer keys when both string and integer keys are present, preserving pure integer-keyed params used by `updating`/`updated`/`rendered` hooks

## Test plan

- [x] `ComponentMethodBindingsUnitTest` — all 14 tests pass (was 2 failures)
- [x] `SupportPageComponents/UnitTest` — all 39 tests pass
- [x] `SupportLifecycleHooks/TraitsUnitTest` — all 4 tests pass
- [x] Full unit suite — all 1224 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)