### PR TITLE
Add memo parameter to #[Computed] for in-request memoization

### DIFF
--- a/docs/attribute-computed.md
+++ b/docs/attribute-computed.md
@@ -135,6 +135,20 @@ You can optionally set a custom cache key:
 #[Computed(cache: true, key: 'homepage-posts')] // [tl! highlight]
 ```
 
+## Memoizing cached values within a request
+
+With distributed cache stores like Redis, Memcached, or DynamoDB, each access to a cached computed property is a network round-trip. The `memo` parameter stores the result in memory after the first access, so subsequent accesses within the same request skip the cache store entirely:
+
+```php
+#[Computed(cache: true, memo: true)] // [tl! highlight]
+public function posts()
+{
+    return Post::all();
+}
+```
+
+For more details, see [Memoizing cached values](/docs/4.x/computed-properties#memoizing-cached-values-within-a-request).
+
 ## When to use
 
 Computed properties are especially useful when:
@@ -162,6 +176,7 @@ For detailed information about computed properties, caching strategies, and adva
     bool $cache = false,
     ?string $key = null,
     mixed $tags = null,
+    bool $memo = false,
 )]
 ```
 
@@ -172,3 +187,4 @@ For detailed information about computed properties, caching strategies, and adva
 | `$cache` | `bool` | `false` | Cache the value across all component instances |
 | `$key` | `?string` | `null` | Custom cache key (auto-generated if not provided) |
 | `$tags` | `mixed` | `null` | Cache tags (requires a cache driver that supports tags) |
+| `$memo` | `bool` | `false` | Memoize the cached value in memory within the request to avoid redundant cache lookups |

--- a/docs/attribute-computed.md
+++ b/docs/attribute-computed.md
@@ -137,7 +137,7 @@ You can optionally set a custom cache key:
 
 ## Memoizing cached values within a request
 
-When using `cache` or `persist` with a distributed store like Redis, each access is a network round-trip. The `memo` parameter keeps the resolved value in memory for the duration of the request:
+Cached and persisted computed properties hit the cache store on every access, even within the same request. If your application uses a distributed cache like Redis, the `memo` parameter can help by keeping the resolved value in memory for the duration of the request:
 
 ```php
 #[Computed(cache: true, memo: true)] // [tl! highlight]

--- a/docs/attribute-computed.md
+++ b/docs/attribute-computed.md
@@ -137,7 +137,7 @@ You can optionally set a custom cache key:
 
 ## Memoizing cached values within a request
 
-With distributed cache stores like Redis, Memcached, or DynamoDB, each access to a cached computed property is a network round-trip. The `memo` parameter stores the result in memory after the first access, so subsequent accesses within the same request skip the cache store entirely:
+When using `cache` or `persist` with a distributed store like Redis, each access is a network round-trip. The `memo` parameter keeps the resolved value in memory for the duration of the request:
 
 ```php
 #[Computed(cache: true, memo: true)] // [tl! highlight]
@@ -187,4 +187,4 @@ For detailed information about computed properties, caching strategies, and adva
 | `$cache` | `bool` | `false` | Cache the value across all component instances |
 | `$key` | `?string` | `null` | Custom cache key (auto-generated if not provided) |
 | `$tags` | `mixed` | `null` | Cache tags (requires a cache driver that supports tags) |
-| `$memo` | `bool` | `false` | Memoize the cached value in memory within the request to avoid redundant cache lookups |
+| `$memo` | `bool` | `false` | Keep the resolved value in memory for the duration of the request |

--- a/docs/computed-properties.md
+++ b/docs/computed-properties.md
@@ -197,6 +197,59 @@ public function posts()
 }
 ```
 
+## Memoizing cached values within a request
+
+When using `cache: true` or `persist: true`, Livewire queries the cache store on every access within a request. For in-process cache drivers like `array`, this is negligible. However, with distributed cache stores like Redis, Memcached, or DynamoDB, each access is a network round-trip — accessing a cached property 5 times in a template means 5 round-trips to the cache service.
+
+The `memo` parameter stores the cache result in memory after the first access, so subsequent accesses within the same request skip the cache store entirely:
+
+```php
+use Livewire\Attributes\Computed;
+use App\Models\Post;
+
+#[Computed(cache: true, memo: true)]
+public function posts()
+{
+    return Post::all();
+}
+```
+
+```blade
+<div>
+    @if ($this->posts->count())              {{-- Hits the cache store --}}
+        @foreach ($this->posts as $post)     {{-- Returns from memory --}}
+            <div wire:key="{{ $post->id }}">
+                {{ $post->title }}
+            </div>
+        @endforeach
+    @endif
+</div>
+```
+
+The `memo` parameter works the same way with `persist: true`:
+
+```php
+#[Computed(persist: true, memo: true)]
+public function user()
+{
+    return User::find($this->userId);
+}
+```
+
+Calling `unset()` on a memoized cached property clears both the in-memory value and the underlying cache entry:
+
+```php
+public function createPost()
+{
+    Auth::user()->posts()->create(...);
+
+    unset($this->posts); // Clears both memo and cache store
+}
+```
+
+> [!tip] When to use `memo`
+> The `memo` parameter is most beneficial when using distributed cache stores (Redis, Memcached, DynamoDB) and accessing the cached property multiple times within a single request. For the `array` cache driver, the performance difference is negligible.
+
 ## When to use computed properties?
 
 In addition to offering performance advantages, there are a few other scenarios where computed properties are helpful.

--- a/docs/computed-properties.md
+++ b/docs/computed-properties.md
@@ -199,14 +199,9 @@ public function posts()
 
 ## Memoizing cached values within a request
 
-When using `cache: true` or `persist: true`, Livewire queries the cache store on every access within a request. For in-process cache drivers like `array`, this is negligible. However, with distributed cache stores like Redis, Memcached, or DynamoDB, each access is a network round-trip — accessing a cached property 5 times in a template means 5 round-trips to the cache service.
-
-The `memo` parameter stores the cache result in memory after the first access, so subsequent accesses within the same request skip the cache store entirely:
+When using `cache` or `persist`, Livewire queries the cache store on every access within a request. With distributed stores like Redis or Memcached, each access is a network round-trip. The `memo` parameter keeps the resolved value in memory for the duration of the request:
 
 ```php
-use Livewire\Attributes\Computed;
-use App\Models\Post;
-
 #[Computed(cache: true, memo: true)]
 public function posts()
 {
@@ -214,41 +209,22 @@ public function posts()
 }
 ```
 
-```blade
-<div>
-    @if ($this->posts->count())              {{-- Hits the cache store --}}
-        @foreach ($this->posts as $post)     {{-- Returns from memory --}}
-            <div wire:key="{{ $post->id }}">
-                {{ $post->title }}
-            </div>
-        @endforeach
-    @endif
-</div>
-```
-
-The `memo` parameter works the same way with `persist: true`:
+The first access hits the cache store, but subsequent accesses return the in-memory value:
 
 ```php
-#[Computed(persist: true, memo: true)]
-public function user()
-{
-    return User::find($this->userId);
-}
+$this->posts; // Hits the cache store...
+$this->posts; // Returns from memory...
+$this->posts; // Returns from memory...
 ```
 
-Calling `unset()` on a memoized cached property clears both the in-memory value and the underlying cache entry:
+Calling `unset()` clears both the in-memory value and the underlying cache entry:
 
 ```php
-public function createPost()
-{
-    Auth::user()->posts()->create(...);
-
-    unset($this->posts); // Clears both memo and cache store
-}
+unset($this->posts); // Clears memo and cache store...
+$this->posts;        // Hits the cache store again...
 ```
 
-> [!tip] When to use `memo`
-> The `memo` parameter is most beneficial when using distributed cache stores (Redis, Memcached, DynamoDB) and accessing the cached property multiple times within a single request. For the `array` cache driver, the performance difference is negligible.
+The `memo` parameter works with both `cache` and `persist`.
 
 ## When to use computed properties?
 

--- a/docs/computed-properties.md
+++ b/docs/computed-properties.md
@@ -199,7 +199,7 @@ public function posts()
 
 ## Memoizing cached values within a request
 
-When using `cache` or `persist`, Livewire queries the cache store on every access within a request. With distributed stores like Redis or Memcached, each access is a network round-trip. The `memo` parameter keeps the resolved value in memory for the duration of the request:
+Cached and persisted computed properties hit the cache store every time they are accessed, even within the same request. If your application uses a distributed cache like Redis or Memcached, the `memo` parameter can help by keeping the resolved value in memory for the duration of the request:
 
 ```php
 #[Computed(cache: true, memo: true)]

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -32,13 +32,19 @@ class BaseComputed extends Attribute
     public function handleMagicGet($returnValue)
     {
         if ($this->persist) {
-            $returnValue($this->handlePersistedGet());
+            $returnValue($this->memo
+                ? $this->requestCachedValue ??= $this->handlePersistedGet()
+                : $this->handlePersistedGet()
+            );
 
             return;
         }
 
         if ($this->cache) {
-            $returnValue($this->handleCachedGet());
+            $returnValue($this->memo
+                ? $this->requestCachedValue ??= $this->handleCachedGet()
+                : $this->handleCachedGet()
+            );
 
             return;
         }
@@ -52,8 +58,16 @@ class BaseComputed extends Attribute
     {
         if ($this->persist) {
             $this->handlePersistedUnset();
-        } elseif ($this->cache) {
+            unset($this->requestCachedValue);
+
+            return;
+        }
+
+        if ($this->cache) {
             $this->handleCachedUnset();
+            unset($this->requestCachedValue);
+
+            return;
         }
 
         unset($this->requestCachedValue);
@@ -61,46 +75,26 @@ class BaseComputed extends Attribute
 
     protected function handlePersistedGet()
     {
-        if ($this->memo && isset($this->requestCachedValue)) {
-            return $this->requestCachedValue;
-        }
-
         $key = $this->generatePersistedKey();
 
         $closure = fn () => $this->evaluateComputed();
 
-        $value = match(Cache::supportsTags() && !empty($this->tags)) {
+        return match(Cache::supportsTags() && !empty($this->tags)) {
             true => Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
             default => Cache::remember($key, $this->seconds, $closure)
         };
-
-        if ($this->memo) {
-            $this->requestCachedValue = $value;
-        }
-
-        return $value;
     }
 
     protected function handleCachedGet()
     {
-        if ($this->memo && isset($this->requestCachedValue)) {
-            return $this->requestCachedValue;
-        }
-
         $key = $this->generateCachedKey();
 
         $closure = fn () => $this->evaluateComputed();
 
-        $value = match(Cache::supportsTags() && !empty($this->tags)) {
+        return match(Cache::supportsTags() && !empty($this->tags)) {
             true => Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
             default => Cache::remember($key, $this->seconds, $closure)
         };
-
-        if ($this->memo) {
-            $this->requestCachedValue = $value;
-        }
-
-        return $value;
     }
 
     protected function handlePersistedUnset()

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -18,6 +18,7 @@ class BaseComputed extends Attribute
         public $cache = false,
         public $key = null,
         public $tags = null,
+        public $memo = false,
     ) {}
 
     function call()
@@ -51,14 +52,8 @@ class BaseComputed extends Attribute
     {
         if ($this->persist) {
             $this->handlePersistedUnset();
-
-            return;
-        }
-
-        if ($this->cache) {
+        } elseif ($this->cache) {
             $this->handleCachedUnset();
-
-            return;
         }
 
         unset($this->requestCachedValue);
@@ -66,26 +61,46 @@ class BaseComputed extends Attribute
 
     protected function handlePersistedGet()
     {
+        if ($this->memo && isset($this->requestCachedValue)) {
+            return $this->requestCachedValue;
+        }
+
         $key = $this->generatePersistedKey();
 
         $closure = fn () => $this->evaluateComputed();
 
-        return match(Cache::supportsTags() && !empty($this->tags)) {
+        $value = match(Cache::supportsTags() && !empty($this->tags)) {
             true => Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
             default => Cache::remember($key, $this->seconds, $closure)
         };
+
+        if ($this->memo) {
+            $this->requestCachedValue = $value;
+        }
+
+        return $value;
     }
 
     protected function handleCachedGet()
     {
+        if ($this->memo && isset($this->requestCachedValue)) {
+            return $this->requestCachedValue;
+        }
+
         $key = $this->generateCachedKey();
 
         $closure = fn () => $this->evaluateComputed();
 
-        return match(Cache::supportsTags() && !empty($this->tags)) {
+        $value = match(Cache::supportsTags() && !empty($this->tags)) {
             true => Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
             default => Cache::remember($key, $this->seconds, $closure)
         };
+
+        if ($this->memo) {
+            $this->requestCachedValue = $value;
+        }
+
+        return $value;
     }
 
     protected function handlePersistedUnset()

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -253,6 +253,64 @@ class UnitTest extends TestCase
             ->assertSetStrict('count', 2);
     }
 
+    function test_can_memoize_persisted_computed_property_within_request()
+    {
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
+            #[Computed(persist: true, memo: true)]
+            function foo() {
+                $this->count++;
+
+                return 'bar';
+            }
+
+            function render() {
+                $noop = $this->foo;
+                $noop = $this->foo;
+                $noop = $this->foo;
+
+                return <<<'HTML'
+                    <div>foo{{ $this->foo }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobar')
+            ->assertSetStrict('count', 1)
+            ->call('$refresh')
+            ->assertSetStrict('count', 1);
+    }
+
+    function test_can_bust_memoized_persisted_computed_using_unset()
+    {
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
+            #[Computed(persist: true, memo: true)]
+            function foo() {
+                $this->count++;
+
+                return 'bar';
+            }
+
+            function render() {
+                $noop = $this->foo;
+                unset($this->foo);
+                $noop = $this->foo;
+
+                return <<<'HTML'
+                    <div>foo{{ $this->foo }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobar')
+            ->assertSetStrict('count', 2);
+    }
+
     function test_cant_call_a_computed_directly()
     {
         $this->expectException(CannotCallComputedDirectlyException::class);

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -195,6 +195,64 @@ class UnitTest extends TestCase
         $this->assertTrue(Cache::has('baz'));
     }
 
+    function test_can_memoize_cached_computed_property_within_request()
+    {
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
+            #[Computed(cache: true, memo: true)]
+            function foo() {
+                $this->count++;
+
+                return 'bar';
+            }
+
+            function render() {
+                $noop = $this->foo;
+                $noop = $this->foo;
+                $noop = $this->foo;
+
+                return <<<'HTML'
+                    <div>foo{{ $this->foo }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobar')
+            ->assertSetStrict('count', 1)
+            ->call('$refresh')
+            ->assertSetStrict('count', 1);
+    }
+
+    function test_can_bust_memoized_cached_computed_using_unset()
+    {
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
+            #[Computed(cache: true, memo: true)]
+            function foo() {
+                $this->count++;
+
+                return 'bar';
+            }
+
+            function render() {
+                $noop = $this->foo;
+                unset($this->foo);
+                $noop = $this->foo;
+
+                return <<<'HTML'
+                    <div>foo{{ $this->foo }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobar')
+            ->assertSetStrict('count', 2);
+    }
+
     function test_cant_call_a_computed_directly()
     {
         $this->expectException(CannotCallComputedDirectlyException::class);


### PR DESCRIPTION
# The scenario

`#[Computed(cache: true)]` and `#[Computed(persist: true)]` query the cache store on every access within a request — with distributed cache stores like Redis or Memcached, accessing `$this->posts` 5 times in a template means 5 network round-trips to the cache service.

```blade
@if ($this->posts->count())           {{-- round-trip 1 --}}
    @foreach ($this->posts as $post)  {{-- round-trip 2 --}}
        {{ $post->title }}
    @endforeach
@endif
```

# The problem

There is currently no way to memoize cached or persisted computed properties within a request in Livewire.

# The solution

Add a `memo` parameter to `#[Computed]`, following Laravel's `Cache::memo()`, which achieves the same thing at the cache driver level.

```php
#[Computed(cache: true, memo: true)]
public function posts()
{
    return Post::all();
}
```

Works with both `cache` and `persist`:

```php
#[Computed(persist: true, memo: true)]
public function user()
{
    return User::find($this->userId);
}
```

`unset($this->posts)` clears both the in-memory value and the cache store.

Discussion: https://github.com/livewire/livewire/discussions/10168