### PR TITLE
Add default value for layout title

### DIFF
--- a/src/Features/SupportConsoleCommands/Commands/livewire.layout.stub
+++ b/src/Features/SupportConsoleCommands/Commands/livewire.layout.stub
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-        <title>{{ $title ?? config('app.name') }}</title>
+        <title>{{ $title ?? config('app.name', 'Livewire') }}</title>
 
         @vite(['resources/css/app.css', 'resources/js/app.js'])
 


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Its for defensive only

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

4️⃣ Does it include tests? (Required)

No

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Users may change the `config/app.php` by removing `env('APP_NAME', 'Laravel')` or the `name` key entirely. This PR align Livewire default layout with Laravel default layout.

Related PR: https://github.com/laravel/laravel/pull/6655

References:
- https://laravel.com/docs/12.x/helpers#method-config
- https://laravel.com/docs/12.x/helpers#method-env

Thanks for contributing! 🙌
