### PR TITLE
Fix $refs access in JS actions called from PHP

### DIFF
--- a/js/$wire.js
+++ b/js/$wire.js
@@ -157,7 +157,7 @@ wireProperty('$js', (component) => {
     let jsActions = component.getJsActions()
 
     Object.keys(jsActions).forEach((name) => {
-        fn[name] = component.getJsAction(name)
+        fn[name] = jsActions[name]
     })
 
     return new Proxy(fn, {

--- a/js/component.js
+++ b/js/component.js
@@ -295,7 +295,11 @@ export class Component {
     }
 
     getJsActions() {
-        return this.jsActions
+        let actions = {}
+        for (let key of Object.keys(this.jsActions)) {
+            actions[key] = this.getJsAction(key)
+        }
+        return actions
     }
 
     // Called by JSON.stringify() on both $wire (via the Proxy) and the

--- a/js/features/supportJsEvaluation.js
+++ b/js/features/supportJsEvaluation.js
@@ -26,7 +26,7 @@ on('effect', ({ component, effects }) => {
         xjs.forEach(({ expression, params }) => {
             params = Object.values(params)
 
-            evaluateExpression(component.el, expression, { scope: component.jsActions, params })
+            evaluateExpression(component.el, expression, { scope: component.getJsActions(), params })
         })
     }
 })

--- a/src/Features/SupportJsEvaluation/BrowserTest.php
+++ b/src/Features/SupportJsEvaluation/BrowserTest.php
@@ -342,25 +342,22 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
-    public function test_js_action_called_from_php_can_access_refs()
+    public function test_js_action_called_from_wire_click_has_this_bound_to_wire()
     {
         Livewire::visit(
             new class extends \Livewire\Component {
-                public function findRef() {
-                    $this->js('findRef');
-                }
+                public $value = 'from wire';
 
                 public function render() {
                     return <<<'HTML'
                         <div>
-                            <button wire:click="findRef" dusk="find">Find ref</button>
-                            <div wire:ref="target">Target</div>
+                            <button wire:click="$js.test" dusk="test">Test</button>
                         </div>
 
                         @script
                         <script>
-                            $js('findRef', function () {
-                                window.refFound = this.$refs.target ? this.$refs.target.textContent : 'not found'
+                            this.$js('test', function () {
+                                window.test = this.$get('value')
                             })
                         </script>
                         @endscript
@@ -368,8 +365,40 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             }
         )
-        ->waitForLivewire()->click('@find')
-        ->assertScript('window.refFound === "Target"')
+        ->click('@test')
+        ->assertScript('window.test === "from wire"')
+        ;
+    }
+
+    public function test_js_action_called_from_php_has_this_bound_to_wire()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $value = 'from wire';
+
+                public function save() {
+                    $this->js('test');
+                }
+
+                public function render() {
+                    return <<<'HTML'
+                        <div>
+                            <button wire:click="save" dusk="save">Save</button>
+                        </div>
+
+                        @script
+                        <script>
+                            this.$js('test', function () {
+                                window.test = this.$get('value')
+                            })
+                        </script>
+                        @endscript
+                    HTML;
+                }
+            }
+        )
+        ->waitForLivewire()->click('@save')
+        ->assertScript('window.test === "from wire"')
         ;
     }
 

--- a/src/Features/SupportJsEvaluation/BrowserTest.php
+++ b/src/Features/SupportJsEvaluation/BrowserTest.php
@@ -342,6 +342,37 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_js_action_called_from_php_can_access_refs()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public function findRef() {
+                    $this->js('findRef');
+                }
+
+                public function render() {
+                    return <<<'HTML'
+                        <div>
+                            <button wire:click="findRef" dusk="find">Find ref</button>
+                            <div wire:ref="target">Target</div>
+                        </div>
+
+                        @script
+                        <script>
+                            $js('findRef', function () {
+                                window.refFound = this.$refs.target ? this.$refs.target.textContent : 'not found'
+                            })
+                        </script>
+                        @endscript
+                    HTML;
+                }
+            }
+        )
+        ->waitForLivewire()->click('@find')
+        ->assertScript('window.refFound === "Target"')
+        ;
+    }
+
     public function test_parent_alpine_scope_does_not_leak_into_child_wire_click()
     {
         Livewire::visit([


### PR DESCRIPTION
## The scenario

JS actions defined with `$js()` can't access `this.$refs` when called from PHP via `$this->js('actionName')`, even though the same action works fine when called directly from Blade via `wire:click="$js.actionName"`.

```blade
<script>
    $js("logRef", function () {
        console.log(this.$refs.myRef); // undefined when called from PHP
    });
</script>
```

## The problem

There are two paths for calling a JS action, and they handle `this` binding differently:

1. **From Blade** — the action is retrieved through `getJsAction()`, which binds `this` to `$wire`
2. **From PHP** — the action is retrieved through `getJsActions()`, which returned raw unbound functions

## The solution

Changed `getJsActions()` to return bound actions using `getJsAction()` internally, making both paths consistent.

Fixes livewire/livewire#10179

## Considerations

- **Breaking change risk**: the previous `this` binding was an Alpine internal proxy with no useful Livewire magics — no one could have relied on it intentionally
- **Extraction**: the binding logic lives in `getJsAction()` as the single source of truth; `getJsActions()` delegates to it rather than duplicating
- **`getJsActions()` behavior change**: only two source-level callers exist, both already wanted bound actions
- **`getJsAction()` still used**: the async script loading path in `$wire.js` needs lazy per-action binding, so the singular method is still needed