### PR TITLE
[3.x] Fix 'Route not defined' error for update route when route name index is stale

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -40,7 +40,7 @@ class HandleRequests extends Mechanism
         // In this case, find the route from the router.
         $route = $this->updateRoute ?? $this->findUpdateRoute();
 
-        return (string) str($route->uri())->start('/');
+        return (string) str(app('url')->toRoute($route, [], false))->start('/');
     }
 
     protected function findUpdateRoute()

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -40,9 +40,7 @@ class HandleRequests extends Mechanism
         // In this case, find the route from the router.
         $route = $this->updateRoute ?? $this->findUpdateRoute();
 
-        return (string) str(
-            route($route->getName(), [], false)
-        )->start('/');
+        return (string) str($route->uri())->start('/');
     }
 
     protected function findUpdateRoute()

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -83,4 +83,32 @@ class UnitTest extends TestCase
 
         $this->assertEquals('/livewire/update', $uri);
     }
+
+    public function test_get_update_uri_works_when_route_name_is_not_indexed(): void
+    {
+        // Resolve URL generator first to prevent its initial resolution
+        // from rebuilding the nameList via refreshNameLookups().
+        app('url');
+
+        // Remove the route from nameList while keeping it in allRoutes.
+        // This simulates Octane worker resets where ->name() runs after
+        // RouteCollection::add() and nameList isn't refreshed.
+        $routes = Route::getRoutes();
+        $nameListProperty = new \ReflectionProperty($routes, 'nameList');
+        $nameList = $nameListProperty->getValue($routes);
+        unset($nameList['default.livewire.update']);
+        $nameListProperty->setValue($routes, $nameList);
+
+        // Route findable by iteration but not by name lookup...
+        $found = collect($routes->getRoutes())
+            ->first(fn ($route) => str($route->getName())->endsWith('livewire.update'));
+        $this->assertNotNull($found);
+        $this->assertNull($routes->getByName('default.livewire.update'));
+
+        // getUpdateUri() should still work...
+        $handleRequests = app(HandleRequests::class);
+        $uri = $handleRequests->getUpdateUri();
+
+        $this->assertEquals('/livewire/update', $uri);
+    }
 }


### PR DESCRIPTION
## Summary

Backport of #9918 from 4.x.

- `getUpdateUri()` now uses `$route->uri()` directly instead of re-looking up the route by name via the `route()` helper
- Fixes edge case (primarily under Octane) where the route object exists in `allRoutes` but its name isn't indexed in `nameList`, causing `route('default.livewire.update')` to throw `RouteNotFoundException`
- Adds a test that simulates the out-of-sync `nameList` state via reflection

## Test plan

- [x] All 6 existing `HandleRequests` unit tests pass
- [x] New `test_get_update_uri_works_when_route_name_is_not_indexed` test passes
- [x] Verified the new test fails without the fix (throws `Route [default.livewire.update] not defined`)