### PR TITLE
Fix in-request memoization for cached and persisted computed properties

### DIFF
--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -31,13 +31,17 @@ class BaseComputed extends Attribute
     public function handleMagicGet($returnValue)
     {
         if ($this->persist) {
-            $returnValue($this->handlePersistedGet());
+            $returnValue(
+                $this->requestCachedValue ??= $this->handlePersistedGet()
+            );
 
             return;
         }
 
         if ($this->cache) {
-            $returnValue($this->handleCachedGet());
+            $returnValue(
+                $this->requestCachedValue ??= $this->handleCachedGet()
+            );
 
             return;
         }
@@ -51,12 +55,14 @@ class BaseComputed extends Attribute
     {
         if ($this->persist) {
             $this->handlePersistedUnset();
+            unset($this->requestCachedValue);
 
             return;
         }
 
         if ($this->cache) {
             $this->handleCachedUnset();
+            unset($this->requestCachedValue);
 
             return;
         }

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -96,6 +96,118 @@ class UnitTest extends TestCase
             ->assertSetStrict('count', 4);
     }
 
+    function test_cached_computed_property_is_memoized_within_a_single_request()
+    {
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
+            #[Computed(cache: true)]
+            function foo() {
+                $this->count++;
+
+                return 'bar';
+            }
+
+            function render() {
+                $noop = $this->foo;
+                $noop = $this->foo;
+                $noop = $this->foo;
+
+                return <<<'HTML'
+                    <div>foo{{ $this->foo }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobar')
+            ->assertSetStrict('count', 1);
+    }
+
+    function test_persisted_computed_property_is_memoized_within_a_single_request()
+    {
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
+            #[Computed(persist: true)]
+            function foo() {
+                $this->count++;
+
+                return 'bar';
+            }
+
+            function render() {
+                $noop = $this->foo;
+                $noop = $this->foo;
+                $noop = $this->foo;
+
+                return <<<'HTML'
+                    <div>foo{{ $this->foo }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobar')
+            ->assertSetStrict('count', 1);
+    }
+
+    function test_can_bust_cached_computed_cache_using_unset()
+    {
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
+            #[Computed(cache: true)]
+            function foo() {
+                $this->count++;
+
+                return 'bar';
+            }
+
+            function render() {
+                $noop = $this->foo;
+                unset($this->foo);
+                $noop = $this->foo;
+
+                return <<<'HTML'
+                    <div>foo{{ $this->foo }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobar')
+            ->assertSetStrict('count', 2);
+    }
+
+    function test_can_bust_persisted_computed_cache_using_unset()
+    {
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
+            #[Computed(persist: true)]
+            function foo() {
+                $this->count++;
+
+                return 'bar';
+            }
+
+            function render() {
+                $noop = $this->foo;
+                unset($this->foo);
+                $noop = $this->foo;
+
+                return <<<'HTML'
+                    <div>foo{{ $this->foo }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobar')
+            ->assertSetStrict('count', 2);
+    }
+
     function test_can_tag_cached_computed_property()
     {
         // need to set a cache driver, which can handle tags


### PR DESCRIPTION
## Summary
- `#[Computed(cache: true)]` and `#[Computed(persist: true)]` were bypassing the `requestCachedValue` memoization, causing a full round-trip to the cache store on every access within the same request
- Wrapped the `persist` and `cache` branches in `handleMagicGet()` with `requestCachedValue ??=` so the cache store is only hit once per request
- Updated `handleMagicUnset()` to clear `requestCachedValue` in the cache and persist branches so `unset()` properly busts the in-memory memo

## Test plan
- [x] Added `test_cached_computed_property_is_memoized_within_a_single_request` — verifies the computed closure only runs once despite 4 accesses
- [x] Added `test_persisted_computed_property_is_memoized_within_a_single_request` — same for persist
- [x] Added `test_can_bust_cached_computed_cache_using_unset` — verifies unset clears both external cache and in-memory memo
- [x] Added `test_can_bust_persisted_computed_cache_using_unset` — same for persist
- [x] All 25 SupportComputed unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)