### PR TITLE
Use npm ci in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build assets
         run: npm run build


### PR DESCRIPTION
Matches the test workflows which already use `npm ci` for deterministic installs.