### PR TITLE
Add configurable Livewire back button cache

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -19,6 +19,19 @@ return [
     ],
 
     /*
+    |--------------------------------------------------------------------------
+    | Back Button Cache
+    |--------------------------------------------------------------------------
+    |
+    | Livewire normally disables the browser back/forward cache on pages with
+    | components so the browser always performs a full reload. Set this to true
+    | to opt into bfcache by default while still allowing per-component overrides.
+    |
+    */
+
+    'back_button_cache' => false,
+
+    /*
     |---------------------------------------------------------------------------
     | Component Namespaces
     |---------------------------------------------------------------------------

--- a/docs/navigate.md
+++ b/docs/navigate.md
@@ -424,6 +424,18 @@ If you have a `<script>` tag in the body that you only want to be run once, you 
 </script>
 ```
 
+### Browser back-forward cache
+
+Livewire disables the browser back-forward cache on pages that contain Livewire components so users always get a fresh page load when using the browser back and forward buttons.
+
+If you want to opt into the browser's cache instead, set `back_button_cache` to `true` in your Livewire config:
+
+```php
+'back_button_cache' => true,
+```
+
+You can still disable the cache per component with `$this->disableBackButtonCache()`.
+
 ## Customizing the progress bar
 
 When a page takes longer than 150ms to load, Livewire will show a progress bar at the top of the page.

--- a/src/Features/SupportDisablingBackButtonCache/DisableBackButtonCacheMiddleware.php
+++ b/src/Features/SupportDisablingBackButtonCache/DisableBackButtonCacheMiddleware.php
@@ -27,7 +27,7 @@ class DisableBackButtonCacheMiddleware
 
             // We do flush this in the `SupportDisablingBackButtonCache` hook, but we 
             // need to do it here as well to ensure that unit tests still work...
-            SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+            SupportDisablingBackButtonCache::$disableBackButtonCache = null;
         }
 
         return $response;

--- a/src/Features/SupportDisablingBackButtonCache/SupportDisablingBackButtonCache.php
+++ b/src/Features/SupportDisablingBackButtonCache/SupportDisablingBackButtonCache.php
@@ -27,6 +27,6 @@ class SupportDisablingBackButtonCache extends ComponentHook
 
     public function boot()
     {
-        static::$disableBackButtonCache = true;
+        static::$disableBackButtonCache = ! config('livewire.back_button_cache', false);
     }
 }

--- a/src/Features/SupportDisablingBackButtonCache/SupportDisablingBackButtonCache.php
+++ b/src/Features/SupportDisablingBackButtonCache/SupportDisablingBackButtonCache.php
@@ -8,12 +8,12 @@ use function Livewire\on;
 
 class SupportDisablingBackButtonCache extends ComponentHook
 {
-    public static $disableBackButtonCache = false;
+    public static $disableBackButtonCache = null;
 
     public static function provide()
     {
         on('flush-state', function () {
-            static::$disableBackButtonCache = false;
+            static::$disableBackButtonCache = null;
         });
 
         $kernel = app()->make(\Illuminate\Contracts\Http\Kernel::class);
@@ -27,6 +27,10 @@ class SupportDisablingBackButtonCache extends ComponentHook
 
     public function boot()
     {
+        if (! is_null(static::$disableBackButtonCache)) {
+            return;
+        }
+
         static::$disableBackButtonCache = ! config('livewire.back_button_cache', false);
     }
 }

--- a/src/Features/SupportDisablingBackButtonCache/UnitTest.php
+++ b/src/Features/SupportDisablingBackButtonCache/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportDisablingBackButtonCache;
 
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
 use Tests\TestComponent;
 
@@ -10,7 +11,7 @@ class UnitTest extends \Tests\TestCase
     protected function tearDown(): void
     {
         config()->set('livewire.back_button_cache', false);
-        SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+        SupportDisablingBackButtonCache::$disableBackButtonCache = null;
 
         parent::tearDown();
     }
@@ -58,7 +59,7 @@ class UnitTest extends \Tests\TestCase
     public function test_back_button_cache_can_be_enabled_by_config_for_standard_components()
     {
         config()->set('livewire.back_button_cache', true);
-        SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+        SupportDisablingBackButtonCache::$disableBackButtonCache = null;
 
         Route::get('test-route-containing-livewire-component', DefaultBrowserCache::class);
 
@@ -70,13 +71,47 @@ class UnitTest extends \Tests\TestCase
     public function test_back_button_cache_can_still_be_disabled_per_component_when_config_enables_it()
     {
         config()->set('livewire.back_button_cache', true);
-        SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+        SupportDisablingBackButtonCache::$disableBackButtonCache = null;
 
         Route::get('test-route-containing-livewire-component', DisableBrowserCache::class);
 
         $response = $this->get('test-route-containing-livewire-component')->assertSuccessful();
 
         $this->assertTrue($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
+    }
+
+    public function test_back_button_cache_stays_disabled_when_a_later_component_does_not_opt_in()
+    {
+        config()->set('livewire.back_button_cache', true);
+        SupportDisablingBackButtonCache::$disableBackButtonCache = null;
+
+        Route::get('test-route-containing-livewire-components', function () {
+            return Blade::render(<<<'BLADE'
+                @livewire(\Livewire\Features\SupportDisablingBackButtonCache\DisableBrowserCache::class)
+                @livewire(\Livewire\Features\SupportDisablingBackButtonCache\DefaultBrowserCache::class)
+                BLADE);
+        });
+
+        $response = $this->get('test-route-containing-livewire-components')->assertSuccessful();
+
+        $this->assertTrue($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
+    }
+
+    public function test_back_button_cache_stays_enabled_when_a_later_component_does_not_opt_out()
+    {
+        config()->set('livewire.back_button_cache', false);
+        SupportDisablingBackButtonCache::$disableBackButtonCache = null;
+
+        Route::get('test-route-containing-livewire-components', function () {
+            return Blade::render(<<<'BLADE'
+                @livewire(\Livewire\Features\SupportDisablingBackButtonCache\EnableBrowserCache::class)
+                @livewire(\Livewire\Features\SupportDisablingBackButtonCache\DefaultBrowserCache::class)
+                BLADE);
+        });
+
+        $response = $this->get('test-route-containing-livewire-components')->assertSuccessful();
+
+        $this->assertFalse($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
     }
 }
 
@@ -90,4 +125,12 @@ class DisableBrowserCache extends TestComponent
 
 class DefaultBrowserCache extends TestComponent
 {
+}
+
+class EnableBrowserCache extends TestComponent
+{
+    public function mount()
+    {
+        $this->enableBackButtonCache();
+    }
 }

--- a/src/Features/SupportDisablingBackButtonCache/UnitTest.php
+++ b/src/Features/SupportDisablingBackButtonCache/UnitTest.php
@@ -7,6 +7,14 @@ use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
+    protected function tearDown(): void
+    {
+        config()->set('livewire.back_button_cache', false);
+        SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+
+        parent::tearDown();
+    }
+
     public function test_ensure_disable_browser_cache_middleware_is_not_applied_to_a_route_that_does_not_contain_a_component()
     {
         Route::get('test-route-without-livewire-component', function () { return 'ok'; });
@@ -46,6 +54,30 @@ class UnitTest extends \Tests\TestCase
         // so just testing for one that isn't normally in a Laravel request
         $this->assertFalse($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
     }
+
+    public function test_back_button_cache_can_be_enabled_by_config_for_standard_components()
+    {
+        config()->set('livewire.back_button_cache', true);
+        SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+
+        Route::get('test-route-containing-livewire-component', DefaultBrowserCache::class);
+
+        $response = $this->get('test-route-containing-livewire-component')->assertSuccessful();
+
+        $this->assertFalse($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
+    }
+
+    public function test_back_button_cache_can_still_be_disabled_per_component_when_config_enables_it()
+    {
+        config()->set('livewire.back_button_cache', true);
+        SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+
+        Route::get('test-route-containing-livewire-component', DisableBrowserCache::class);
+
+        $response = $this->get('test-route-containing-livewire-component')->assertSuccessful();
+
+        $this->assertTrue($response->baseResponse->headers->hasCacheControlDirective('must-revalidate'));
+    }
 }
 
 class DisableBrowserCache extends TestComponent
@@ -56,3 +88,6 @@ class DisableBrowserCache extends TestComponent
     }
 }
 
+class DefaultBrowserCache extends TestComponent
+{
+}


### PR DESCRIPTION
I’m adding a `back_button_cache` config option to Livewire.

Livewire currently disables the browser back-forward cache on pages with Livewire components. I want an opt-in way to change that behavior for apps that still want normal browser caching on back and forward navigation.

Why I think this is useful:
- I can enable bfcache without writing custom code in every component
- I still keep the existing per-component `disableBackButtonCache()` override when I need it
- it gives apps that are not fully using `wire:navigate` a simple config-based option

What I changed:
- added `back_button_cache` to `config/livewire.php` with a default of `false`
- updated `SupportDisablingBackButtonCache` to read that config value
- kept per-component overrides working
- added unit tests for the config default, the override, and the multi-component case
- documented the option in the navigate docs

I also fixed the request lifecycle behavior so one component cannot accidentally undo another component’s cache choice on the same page.

Tests:
- `./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite Unit --filter SupportDisablingBackButtonCache`