### PR TITLE
Fix flaky browser tests and add CI retry [3.x]

### DIFF
--- a/.github/workflows/test-3.x.yml
+++ b/.github/workflows/test-3.x.yml
@@ -200,13 +200,13 @@ jobs:
         run: echo "files=$(php .github/scripts/get-browser-test-shard.php $(( ${{ matrix.shard }} - 1 )) 3)" >> $GITHUB_OUTPUT
 
       - name: Run Browser tests (Shard ${{ matrix.shard }})
-        run: vendor/bin/phpunit ${{ steps.shard.outputs.files }}
+        run: vendor/bin/phpunit ${{ steps.shard.outputs.files }} || vendor/bin/phpunit ${{ steps.shard.outputs.files }} --order-by=defects --stop-on-failure
         env:
           RUNNING_IN_CI: true
 
       - name: Run Cancel Upload test
         if: matrix.shard == 1
-        run: FORCE_RUN=1 vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload"
+        run: FORCE_RUN=1 vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload" || FORCE_RUN=1 vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload"
         env:
           RUNNING_IN_CI: true
           FORCE_RUN: 1
@@ -273,6 +273,6 @@ jobs:
         run: vendor/bin/dusk-updater detect --no-interaction
 
       - name: Run Legacy Browser tests
-        run: vendor/bin/phpunit --testsuite LegacyBrowser
+        run: vendor/bin/phpunit --testsuite LegacyBrowser || vendor/bin/phpunit --testsuite LegacyBrowser --order-by=defects --stop-on-failure
         env:
           RUNNING_IN_CI: true

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -173,13 +173,13 @@ jobs:
         run: echo "files=$(php .github/scripts/get-browser-test-shard.php $(( ${{ matrix.shard }} - 1 )) 3)" >> $GITHUB_OUTPUT
 
       - name: Run Browser tests (Shard ${{ matrix.shard }})
-        run: vendor/bin/phpunit ${{ steps.shard.outputs.files }}
+        run: vendor/bin/phpunit ${{ steps.shard.outputs.files }} || vendor/bin/phpunit ${{ steps.shard.outputs.files }} --order-by=defects --stop-on-failure
         env:
           RUNNING_IN_CI: true
 
       - name: Run Cancel Upload test
         if: matrix.shard == 1
-        run: FORCE_RUN=1 vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload"
+        run: FORCE_RUN=1 vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload" || FORCE_RUN=1 vendor/bin/phpunit --testsuite Browser --filter "test_can_cancel_an_upload"
         env:
           RUNNING_IN_CI: true
           FORCE_RUN: 1
@@ -233,6 +233,6 @@ jobs:
         run: vendor/bin/dusk-updater detect --no-interaction
 
       - name: Run Legacy Browser tests
-        run: vendor/bin/phpunit --testsuite LegacyBrowser
+        run: vendor/bin/phpunit --testsuite LegacyBrowser || vendor/bin/phpunit --testsuite LegacyBrowser --order-by=defects --stop-on-failure
         env:
           RUNNING_IN_CI: true

--- a/legacy_tests/Browser/Actions/Test.php
+++ b/legacy_tests/Browser/Actions/Test.php
@@ -100,7 +100,10 @@ class Test extends TestCase
                 ->waitForLivewire(function ($b) {
                     $b->press('@blog.button');
 
-                    $this->assertEquals('true', $b->attribute('@blog.button', 'disabled'));
+                    $b->waitUsing(6, 25, function () use ($b) {
+                        return $b->attribute('@blog.button', 'disabled') === 'true';
+                    }, 'Button was never disabled after press');
+
                     $this->assertEquals('true', $b->attribute('@blog.input', 'readonly'));
                     $this->assertNull($b->attribute('@blog.input.ignored', 'readonly'));
                 })
@@ -114,7 +117,9 @@ class Test extends TestCase
                  */
                 ->press('@boo.button')
                 ->tap(function ($b) {
-                    $this->assertEquals('true', $b->attribute('@boo.button', 'disabled'));
+                    $b->waitUsing(6, 25, function () use ($b) {
+                        return $b->attribute('@boo.button', 'disabled') === 'true';
+                    }, 'Boo button was never disabled after press');
                 })
                 ->tap(function ($b) {
                     $this->assertNull($b->attribute('@blog.button', 'disabled'));

--- a/legacy_tests/Browser/Loading/Test.php
+++ b/legacy_tests/Browser/Loading/Test.php
@@ -48,9 +48,7 @@ class Test extends TestCase
                 ->waitForLivewire(function (Browser $browser) {
                     $browser->click('@button');
 
-                    $browser->pause(225);
-
-                    $browser->assertVisible('@show-w-delay');
+                    $browser->waitFor('@show-w-delay');
                 })
                 ->tap($this->assertInitialState())
                 ->waitForLivewire(function (Browser $browser) {

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -41,9 +41,8 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertInputValue('@filter_2', '')
         ->assertInputValue('@filter_3', '')
         ->assertQueryStringMissing('tableFilters')
-        ->type('@filter_1', 'test')
-        ->waitForLivewire()
-        ->assertScript(
+        ->waitForLivewire()->type('@filter_1', 'test')
+        ->waitForScript(
             '(new URLSearchParams(window.location.search)).toString()',
             'tableFilters%5Bfilter_1%5D%5Bvalue%5D=test'
         )
@@ -79,7 +78,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
         ])
-            ->assertScript('return window.location.search', '?filters[startDate]=2024-01-01&filters[endDate]=2024-09-05');
+            ->waitForScript('window.location.search', '?filters[startDate]=2024-01-01&filters[endDate]=2024-09-05');
     }
 
     public function test_does_not_duplicate_url_query_string_for_array_parameters_on_page_load()
@@ -109,7 +108,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
         ])
-            ->assertScript('return window.location.search', '?filters[startDate]=2024-01-01&filters[endDate]=2024-09-05');
+            ->waitForScript('window.location.search', '?filters[startDate]=2024-01-01&filters[endDate]=2024-09-05');
     }
 
     public function test_keep_option_does_not_duplicate_url_query_string_for_string_parameter_on_page_load()
@@ -132,7 +131,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
         ])
-            ->assertScript('return window.location.search', '?date=2024-01-01');
+            ->waitForScript('window.location.search', '?date=2024-01-01');
     }
 
 
@@ -228,7 +227,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
         ])
-            ->assertQueryStringHas('search', 'foo')
+            ->waitForQueryString('search', 'foo')
             ->waitForLivewire()->type('@input', 'bar')
             ->assertQueryStringHas('search', 'bar')
             ->waitForLivewire()->type('@input', ' ')
@@ -338,7 +337,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             },
         ])
             ->waitForLivewireToLoad()
-            ->assertQueryStringHas('perPage', '25')
+            ->waitForQueryString('perPage', '25')
             ->assertInputValue('@input', '25')
         ;
     }
@@ -372,7 +371,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
         ])
-            ->assertQueryStringHas('search', 'foo')
+            ->waitForQueryString('search', 'foo')
             ->waitForLivewire()->type('@input', 'bar')
             ->assertQueryStringHas('search', 'bar')
             ->waitForLivewire()->type('@input', ' ')

--- a/src/Features/SupportTesting/DuskBrowserMacros.php
+++ b/src/Features/SupportTesting/DuskBrowserMacros.php
@@ -149,6 +149,40 @@ class DuskBrowserMacros
         };
     }
 
+    public function waitForQueryString()
+    {
+        return function ($key, $expected) {
+            /** @var \Laravel\Dusk\Browser $this */
+            $this->waitUsing(6, 25, function () use ($key, $expected) {
+                $search = $this->driver->executeScript('return window.location.search');
+
+                parse_str(ltrim($search, '?'), $params);
+
+                return ($params[$key] ?? null) === $expected;
+            }, "Query string [{$key}] never had expected value [{$expected}].");
+
+            PHPUnit::assertTrue(true);
+
+            return $this;
+        };
+    }
+
+    public function waitForScript()
+    {
+        return function ($js, $expected = true) {
+            /** @var \Laravel\Dusk\Browser $this */
+            $this->waitUsing(6, 25, function () use ($js, $expected) {
+                return head($this->script(
+                    str($js)->start('return ')
+                )) === $expected;
+            }, "Script [{$js}] never returned expected value.");
+
+            PHPUnit::assertTrue(true);
+
+            return $this;
+        };
+    }
+
     public function waitForLivewireToLoad()
     {
         return function () {


### PR DESCRIPTION
## Summary

Backport of #10191 to the `3.x` branch.

CI has a ~46% failure rate from flaky browser tests. This PR fixes the root causes and adds a safety-net retry mechanism.

### Root cause fixes

- **SupportQueryString (5 tests)** — Tests asserted URL state immediately after `visit()` before Livewire's JS had pushed `history.pushState`. Added `waitForQueryString` and `waitForScript` polling macros to `DuskBrowserMacros` and replaced one-shot assertions with polling waits.
- **Actions/Test (6 CI failures)** — After `press()`, the test immediately asserted `disabled` attribute before JS form-submission handler had run. Replaced with `waitUsing` to poll for the attribute.
- **Loading/Test** — Used `pause(225)` to test a 200ms delay threshold (only 25ms margin). Replaced with `waitFor()`.

### Safety net

Added `|| retry` to all browser test steps in CI workflows. If a test fails, the full shard re-runs with `--order-by=defects --stop-on-failure`.

### New test utilities

Two new macros in `DuskBrowserMacros`:
- `waitForQueryString($key, $value)` — polls `window.location.search` until the query param matches
- `waitForScript($js, $expected)` — polling version of `assertScript`

## Test plan

- [x] Main branch PR (#10191) passed CI 3/3 times
- [ ] Full CI matrix passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)