### PR TITLE
Add chunked file uploads

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -140,6 +140,10 @@ return [
         ],
         'max_upload_time' => 5, // Max duration (in minutes) before an upload is invalidated...
         'cleanup' => true, // Should cleanup temporary uploads older than 24 hrs...
+        'chunk_size' => 5 * 1024 * 1024, // 5MB per chunk. Set to `null` to disable chunked uploads.
+        'chunk_retries' => 3, // Number of times to retry a failed chunk before giving up.
+        'chunk_retry_delays' => [500, 1000, 3000], // Backoff delays (in ms) between chunk retries.
+        'chunk_resumable' => true, // Allow resuming uploads across page loads.
     ],
 
     /*

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -142,7 +142,7 @@ return [
         'cleanup' => true, // Should cleanup temporary uploads older than 24 hrs...
         'chunk' => [
             'enabled' => false,                                   // Opt in to chunked uploads. When true, files larger than `size` are uploaded in chunks instead of a single request. Local disk only — S3 not yet supported.
-            'size' => 5 * 1024 * 1024,                            // Bytes per chunk. Files larger than this are split and uploaded sequentially. Defaults to 5MB.
+            'size' => 1024 * 1024,                                // Bytes per chunk. Defaults to 1MB to fit under nginx's default `client_max_body_size` on both Forge and Laravel Cloud — works out of the box. Bump alongside your server's body limit for better throughput on larger files.
             'retry_delays' => [500, 1000, 3000],                  // Backoff delays (in ms) between chunk retries. The number of entries determines the max retries.
             'max_upload_time' => 60 * 24,                         // Max duration (in minutes) for an entire chunked upload to complete. Used as the signed-URL expiry for chunk endpoints. Defaults to 24 hours to handle large uploads on slow connections.
             'middleware' => null,                                 // Middleware applied to chunk endpoints. Defaults to 'throttle:600,1' (looser than the global upload throttle since chunked uploads make many requests). Sites that expose uploads to anonymous visitors should tighten this — see the security note in uploads.md.

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -140,10 +140,10 @@ return [
         ],
         'max_upload_time' => 5, // Max duration (in minutes) before an upload is invalidated...
         'cleanup' => true, // Should cleanup temporary uploads older than 24 hrs...
-        'chunk_size' => 5 * 1024 * 1024, // 5MB per chunk. Set to `null` to disable chunked uploads.
-        'chunk_retries' => 3, // Number of times to retry a failed chunk before giving up.
-        'chunk_retry_delays' => [500, 1000, 3000], // Backoff delays (in ms) between chunk retries.
-        'chunk_resumable' => true, // Allow resuming uploads across page loads.
+        'chunk_size' => null, // Bytes per chunk. Set to a number (e.g., 5 * 1024 * 1024) to enable chunked uploads for files larger than the chunk size. Local disk only — S3 not yet supported.
+        'chunk_retry_delays' => [500, 1000, 3000], // Backoff delays (in ms) between chunk retries. The number of entries determines the max retries.
+        'chunk_max_upload_time' => 60, // Max duration (in minutes) for an entire chunked upload to complete. Used as the signed-URL expiry for chunk endpoints.
+        'chunk_middleware' => null, // Middleware applied to chunk endpoints. Defaults to 'throttle:600,1' (looser than the global upload throttle since chunked uploads make many requests).
     ],
 
     /*

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -140,11 +140,13 @@ return [
         ],
         'max_upload_time' => 5, // Max duration (in minutes) before an upload is invalidated...
         'cleanup' => true, // Should cleanup temporary uploads older than 24 hrs...
-        'chunk_size' => null, // Bytes per chunk. Set to a number (e.g., 5 * 1024 * 1024) to enable chunked uploads for files larger than the chunk size. Local disk only — S3 not yet supported.
-        'chunk_retry_delays' => [500, 1000, 3000], // Backoff delays (in ms) between chunk retries. The number of entries determines the max retries.
-        'chunk_max_upload_time' => 60 * 24, // Max duration (in minutes) for an entire chunked upload to complete. Used as the signed-URL expiry for chunk endpoints. Defaults to 24 hours to handle large uploads on slow connections.
-        'chunk_middleware' => null, // Middleware applied to chunk endpoints. Defaults to 'throttle:600,1' (looser than the global upload throttle since chunked uploads make many requests). Sites that expose uploads to anonymous visitors should tighten this — see the security note in uploads.md.
-        'chunk_absolute_max_bytes' => 5 * 1024 * 1024 * 1024, // Hard ceiling on the declared upload size when no `max:` rule is set in `rules` above. Defaults to 5GB so a missing `max:` rule can never be exploited as an unbounded upload claim. If you set a `max:` rule, that wins and this is unused.
+        'chunk' => [
+            'size' => null,                                       // Bytes per chunk. Set to a number (e.g., 5 * 1024 * 1024) to enable chunked uploads for files larger than this. Local disk only — S3 not yet supported.
+            'retry_delays' => [500, 1000, 3000],                  // Backoff delays (in ms) between chunk retries. The number of entries determines the max retries.
+            'max_upload_time' => 60 * 24,                         // Max duration (in minutes) for an entire chunked upload to complete. Used as the signed-URL expiry for chunk endpoints. Defaults to 24 hours to handle large uploads on slow connections.
+            'middleware' => null,                                 // Middleware applied to chunk endpoints. Defaults to 'throttle:600,1' (looser than the global upload throttle since chunked uploads make many requests). Sites that expose uploads to anonymous visitors should tighten this — see the security note in uploads.md.
+            'absolute_max_bytes' => 5 * 1024 * 1024 * 1024,       // Hard ceiling on the declared upload size when no `max:` rule is set in `rules` above. Defaults to 5GB so a missing `max:` rule can never be exploited as an unbounded upload claim. If you set a `max:` rule, that wins and this is unused.
+        ],
     ],
 
     /*

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -143,7 +143,7 @@ return [
         'chunk_size' => null, // Bytes per chunk. Set to a number (e.g., 5 * 1024 * 1024) to enable chunked uploads for files larger than the chunk size. Local disk only — S3 not yet supported.
         'chunk_retry_delays' => [500, 1000, 3000], // Backoff delays (in ms) between chunk retries. The number of entries determines the max retries.
         'chunk_max_upload_time' => 60 * 24, // Max duration (in minutes) for an entire chunked upload to complete. Used as the signed-URL expiry for chunk endpoints. Defaults to 24 hours to handle large uploads on slow connections.
-        'chunk_middleware' => null, // Middleware applied to chunk endpoints. Defaults to 'throttle:600,1' (looser than the global upload throttle since chunked uploads make many requests).
+        'chunk_middleware' => null, // Middleware applied to chunk endpoints. Defaults to 'throttle:600,1' (looser than the global upload throttle since chunked uploads make many requests). Sites that expose uploads to anonymous visitors should tighten this — see the security note in uploads.md.
     ],
 
     /*

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -144,6 +144,7 @@ return [
         'chunk_retry_delays' => [500, 1000, 3000], // Backoff delays (in ms) between chunk retries. The number of entries determines the max retries.
         'chunk_max_upload_time' => 60 * 24, // Max duration (in minutes) for an entire chunked upload to complete. Used as the signed-URL expiry for chunk endpoints. Defaults to 24 hours to handle large uploads on slow connections.
         'chunk_middleware' => null, // Middleware applied to chunk endpoints. Defaults to 'throttle:600,1' (looser than the global upload throttle since chunked uploads make many requests). Sites that expose uploads to anonymous visitors should tighten this — see the security note in uploads.md.
+        'chunk_absolute_max_bytes' => 5 * 1024 * 1024 * 1024, // Hard ceiling on the declared upload size when no `max:` rule is set in `rules` above. Defaults to 5GB so a missing `max:` rule can never be exploited as an unbounded upload claim. If you set a `max:` rule, that wins and this is unused.
     ],
 
     /*

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -141,7 +141,8 @@ return [
         'max_upload_time' => 5, // Max duration (in minutes) before an upload is invalidated...
         'cleanup' => true, // Should cleanup temporary uploads older than 24 hrs...
         'chunk' => [
-            'size' => null,                                       // Bytes per chunk. Set to a number (e.g., 5 * 1024 * 1024) to enable chunked uploads for files larger than this. Local disk only — S3 not yet supported.
+            'enabled' => false,                                   // Opt in to chunked uploads. When true, files larger than `size` are uploaded in chunks instead of a single request. Local disk only — S3 not yet supported.
+            'size' => 5 * 1024 * 1024,                            // Bytes per chunk. Files larger than this are split and uploaded sequentially. Defaults to 5MB.
             'retry_delays' => [500, 1000, 3000],                  // Backoff delays (in ms) between chunk retries. The number of entries determines the max retries.
             'max_upload_time' => 60 * 24,                         // Max duration (in minutes) for an entire chunked upload to complete. Used as the signed-URL expiry for chunk endpoints. Defaults to 24 hours to handle large uploads on slow connections.
             'middleware' => null,                                 // Middleware applied to chunk endpoints. Defaults to 'throttle:600,1' (looser than the global upload throttle since chunked uploads make many requests). Sites that expose uploads to anonymous visitors should tighten this — see the security note in uploads.md.

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -142,7 +142,7 @@ return [
         'cleanup' => true, // Should cleanup temporary uploads older than 24 hrs...
         'chunk_size' => null, // Bytes per chunk. Set to a number (e.g., 5 * 1024 * 1024) to enable chunked uploads for files larger than the chunk size. Local disk only — S3 not yet supported.
         'chunk_retry_delays' => [500, 1000, 3000], // Backoff delays (in ms) between chunk retries. The number of entries determines the max retries.
-        'chunk_max_upload_time' => 60, // Max duration (in minutes) for an entire chunked upload to complete. Used as the signed-URL expiry for chunk endpoints.
+        'chunk_max_upload_time' => 60 * 24, // Max duration (in minutes) for an entire chunked upload to complete. Used as the signed-URL expiry for chunk endpoints. Defaults to 24 hours to handle large uploads on slow connections.
         'chunk_middleware' => null, // Middleware applied to chunk endpoints. Defaults to 'throttle:600,1' (looser than the global upload throttle since chunked uploads make many requests).
     ],
 

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -468,6 +468,9 @@ new class extends Component {
 > [!info] Bump your global validation rule
 > Remember that the global `temporary_file_upload.rules` validation still applies to the assembled file. The default `max:12288` (12MB) will reject anything larger. If you're enabling chunked uploads to support large files, bump `max` accordingly.
 
+> [!warning] Don't point the temp upload disk at a publicly served directory
+> The `temporary_file_upload.disk` setting (and the `LIVEWIRE_TEMPORARY_FILE_UPLOAD_DISK` env var) controls where in-flight chunks and assembled tmp files live. **Never set this to a disk whose root is under your web document root** (the `public` disk in a default Laravel app, or any custom disk that maps to `public_path()`). Doing so makes the assembled tmp files reachable via HTTP, and in some configurations the web server will execute them as scripts. The default `local` disk (root: `storage/app/private`) is safe and is what you should be using.
+
 ### Chunked upload configuration
 
 ```php
@@ -484,6 +487,14 @@ new class extends Component {
 `chunk_max_upload_time` controls how long the signed chunk URLs stay valid. If an upload takes longer than this, the URLs expire and in-flight chunks start failing. The default of 24 hours comfortably handles multi-GB uploads on slow connections (e.g. 10GB at 5Mbps takes about 4.5 hours), and aligns with Livewire's existing 24-hour temporary-file cleanup window.
 
 `chunk_absolute_max_bytes` only matters when there is no `max:` rule in `temporary_file_upload.rules`. In that case it acts as a hard ceiling so a missing rule can't become an unbounded upload claim. If you set a `max:` rule (recommended), Livewire enforces that instead and `chunk_absolute_max_bytes` is unused.
+
+`chunk_middleware` defaults to `throttle:600,1` — looser than the legacy `throttle:60,1` for single-request uploads, because chunking inherently makes many small requests per file. **If your upload component is reachable by anonymous or unauthenticated visitors, tighten this** to limit how quickly an attacker can fill the disk with abandoned chunks:
+
+```php
+'chunk_middleware' => 'throttle:60,1',
+```
+
+The throttle counter is per-IP per-minute, so an attacker uploading 5MB chunks at the default `600/1` could write up to ~3GB/minute of trash data per IP before being blocked. The cleanup logic only removes abandoned chunks after 24 hours, so the disk pressure persists. For public-facing apps, tightening to `60/1` (~300MB/min/IP) is much safer.
 
 ### How it works
 

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -444,12 +444,11 @@ Chunked uploads are **opt-in** and disabled by default. Enable them by setting `
     // ...
     'chunk' => [
         'enabled' => true,
-        'size' => 5 * 1024 * 1024, // 5MB per chunk (default)
     ],
 ],
 ```
 
-Once enabled, Livewire automatically chunks any uploaded file larger than `chunk.size`. Smaller files continue to use the normal single-request upload path. From your component's perspective, nothing changes — you still get a `TemporaryUploadedFile` on your property:
+Once enabled, Livewire automatically chunks any uploaded file larger than `chunk.size` (1 MB by default). Smaller files continue to use the normal single-request upload path. From your component's perspective, nothing changes — you still get a `TemporaryUploadedFile` on your property:
 
 ```php
 new class extends Component {
@@ -481,7 +480,7 @@ new class extends Component {
     // ...
     'chunk' => [
         'enabled' => false,                       // Set to true to enable chunked uploads.
-        'size' => 5 * 1024 * 1024,                // Bytes per chunk. Defaults to 5MB.
+        'size' => 1024 * 1024,                    // Bytes per chunk. Defaults to 1MB — see tuning notes below.
         'retry_delays' => [500, 1000, 3000],      // Backoff between failed chunk retries (ms).
         'max_upload_time' => 60 * 24,             // Max minutes for an entire chunked upload to complete (24h default).
         'middleware' => null,                     // Middleware applied to chunk endpoints. Defaults to throttle:600,1.
@@ -489,6 +488,26 @@ new class extends Component {
     ],
 ],
 ```
+
+#### Tuning `chunk.size`
+
+The default chunk size is 1 MB because that matches the default `client_max_body_size` in nginx, which is what Laravel Forge and Laravel Cloud both ship with out of the box. Leaving the default means chunked uploads work immediately on a fresh deploy — no server tweaks required.
+
+**For better throughput on large files, you can bump the chunk size** — but you need to bump the server's body limit to match.
+
+| Chunk size | Requests per 1 GB file | Server tweak required? |
+|---|---|---|
+| 1 MB (default) | ~1,024 | none |
+| 5 MB | ~205 | nginx `client_max_body_size 6M` |
+| 10 MB | ~103 | nginx `client_max_body_size 11M` |
+
+**On Laravel Forge**, the easiest way is the "Max File Upload Size" field in the site's "Meta" tab — it sets nginx's `client_max_body_size` and PHP's `post_max_size`/`upload_max_filesize` together. Set it to a value slightly larger than your chunk size (e.g. `6` for 5MB chunks).
+
+**On Laravel Cloud**, edit your site's nginx configuration via the dashboard to set `client_max_body_size` higher than your chunk size, and adjust `post_max_size` in your PHP config.
+
+**On a custom nginx**, add `client_max_body_size 6M;` to the relevant `server { ... }` block and reload nginx.
+
+Don't forget to set `chunk.size` in your Livewire config to match after bumping the server limit.
 
 `chunk.max_upload_time` controls how long the signed chunk URLs stay valid. If an upload takes longer than this, the URLs expire and in-flight chunks start failing. The default of 24 hours comfortably handles multi-GB uploads on slow connections (e.g. 10GB at 5Mbps takes about 4.5 hours), and aligns with Livewire's existing 24-hour temporary-file cleanup window.
 

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -437,13 +437,14 @@ Temporary files are uploaded to the specified disk's `livewire-tmp/` directory. 
 
 For large files, Livewire can split uploads into smaller chunks that are sent sequentially. This avoids hitting PHP's `upload_max_filesize` and `post_max_size` limits (as well as third-party limits like Cloudflare's 100MB request body cap), reduces memory usage, and lets failed chunks retry without restarting the whole upload.
 
-Chunked uploads are **opt-in** and disabled by default. Enable them by setting `chunk.size` in your config:
+Chunked uploads are **opt-in** and disabled by default. Enable them by setting `chunk.enabled` to `true` in your config:
 
 ```php
 'temporary_file_upload' => [
     // ...
     'chunk' => [
-        'size' => 5 * 1024 * 1024, // 5MB per chunk
+        'enabled' => true,
+        'size' => 5 * 1024 * 1024, // 5MB per chunk (default)
     ],
 ],
 ```
@@ -465,7 +466,7 @@ new class extends Component {
 ```
 
 > [!warning] Local disk only
-> Chunked uploads currently only work when `temporary_file_upload.disk` is a local filesystem. If you set `chunk.size` while using the S3 disk, Livewire will throw an `S3DoesntSupportChunkedUploads` exception when an upload is attempted — set `chunk.size` to `null` or switch to a local disk. Native S3 multipart upload support is planned for a future release.
+> Chunked uploads currently only work when `temporary_file_upload.disk` is a local filesystem. If you enable chunking while using the S3 disk, Livewire will throw an `S3DoesntSupportChunkedUploads` exception when an upload is attempted — set `chunk.enabled` to `false` or switch to a local disk. Native S3 multipart upload support is planned for a future release.
 
 > [!info] Bump your global validation rule
 > Remember that the global `temporary_file_upload.rules` validation still applies to the assembled file. The default `max:12288` (12MB) will reject anything larger. If you're enabling chunked uploads to support large files, bump `max` accordingly.
@@ -479,7 +480,8 @@ new class extends Component {
 'temporary_file_upload' => [
     // ...
     'chunk' => [
-        'size' => 5 * 1024 * 1024,                // Bytes per chunk. `null` to disable.
+        'enabled' => false,                       // Set to true to enable chunked uploads.
+        'size' => 5 * 1024 * 1024,                // Bytes per chunk. Defaults to 5MB.
         'retry_delays' => [500, 1000, 3000],      // Backoff between failed chunk retries (ms).
         'max_upload_time' => 60 * 24,             // Max minutes for an entire chunked upload to complete (24h default).
         'middleware' => null,                     // Middleware applied to chunk endpoints. Defaults to throttle:600,1.
@@ -515,7 +517,7 @@ When the user selects a file larger than `chunk.size`, Livewire's JavaScript:
 If a chunk fails, the client retries with backoff, querying the server for the authoritative offset before resuming. Validation errors at finalize time (e.g. mime mismatch) bubble up the same way they would for a non-chunked upload, so `@error('photo')` works as expected.
 
 > [!info] PATCH method support
-> Chunked uploads use HTTP PATCH requests. If your infrastructure (WAF, reverse proxy, etc.) blocks PATCH by default, either configure it to allow PATCH on the chunk endpoint, or leave `chunk.size` at `null`.
+> Chunked uploads use HTTP PATCH requests. If your infrastructure (WAF, reverse proxy, etc.) blocks PATCH by default, either configure it to allow PATCH on the chunk endpoint, or leave `chunk.enabled` at `false`.
 
 ## See also
 

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -475,11 +475,15 @@ new class extends Component {
     // ...
     'chunk_size' => 5 * 1024 * 1024,           // Bytes per chunk. `null` to disable.
     'chunk_retry_delays' => [500, 1000, 3000], // Backoff between failed chunk retries (ms).
-    'chunk_max_upload_time' => 60,             // Max minutes for an entire chunked upload to complete.
+    'chunk_max_upload_time' => 60 * 24,        // Max minutes for an entire chunked upload to complete (24h default).
     'chunk_middleware' => null,                // Middleware applied to chunk endpoints. Defaults to throttle:600,1.
-    'chunk_absolute_max_bytes' => 5 * 1024 * 1024 * 1024, // Hard ceiling on Upload-Length when no `max:` rule is set.
+    'chunk_absolute_max_bytes' => 5 * 1024 * 1024 * 1024, // Hard ceiling on Upload-Length when no `max:` rule is set (defaults to 5GB).
 ],
 ```
+
+`chunk_max_upload_time` controls how long the signed chunk URLs stay valid. If an upload takes longer than this, the URLs expire and in-flight chunks start failing. The default of 24 hours comfortably handles multi-GB uploads on slow connections (e.g. 10GB at 5Mbps takes about 4.5 hours), and aligns with Livewire's existing 24-hour temporary-file cleanup window.
+
+`chunk_absolute_max_bytes` only matters when there is no `max:` rule in `temporary_file_upload.rules`. In that case it acts as a hard ceiling so a missing rule can't become an unbounded upload claim. If you set a `max:` rule (recommended), Livewire enforces that instead and `chunk_absolute_max_bytes` is unused.
 
 ### How it works
 

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -435,7 +435,7 @@ Temporary files are uploaded to the specified disk's `livewire-tmp/` directory. 
 
 ## Chunked uploads
 
-For large files, Livewire can split uploads into smaller chunks that are sent sequentially. This avoids hitting PHP's `upload_max_filesize` and `post_max_size` limits, reduces memory usage, and lets failed chunks retry without restarting the whole upload.
+For large files, Livewire can split uploads into smaller chunks that are sent sequentially. This avoids hitting PHP's `upload_max_filesize` and `post_max_size` limits (as well as third-party limits like Cloudflare's 100MB request body cap), reduces memory usage, and lets failed chunks retry without restarting the whole upload.
 
 Chunked uploads are **opt-in** and disabled by default. Enable them by setting `chunk_size` in your config:
 
@@ -463,7 +463,7 @@ new class extends Component {
 ```
 
 > [!warning] Local disk only
-> Chunked uploads currently only work when `temporary_file_upload.disk` is a local filesystem. The S3 disk falls back to the existing single-request upload path. Native S3 multipart upload support is planned for a future release.
+> Chunked uploads currently only work when `temporary_file_upload.disk` is a local filesystem. If you set `chunk_size` while using the S3 disk, Livewire will throw an `S3DoesntSupportChunkedUploads` exception when an upload is attempted — set `chunk_size` to `null` or switch to a local disk. Native S3 multipart upload support is planned for a future release.
 
 > [!info] Bump your global validation rule
 > Remember that the global `temporary_file_upload.rules` validation still applies to the assembled file. The default `max:12288` (12MB) will reject anything larger. If you're enabling chunked uploads to support large files, bump `max` accordingly.

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -437,16 +437,18 @@ Temporary files are uploaded to the specified disk's `livewire-tmp/` directory. 
 
 For large files, Livewire can split uploads into smaller chunks that are sent sequentially. This avoids hitting PHP's `upload_max_filesize` and `post_max_size` limits (as well as third-party limits like Cloudflare's 100MB request body cap), reduces memory usage, and lets failed chunks retry without restarting the whole upload.
 
-Chunked uploads are **opt-in** and disabled by default. Enable them by setting `chunk_size` in your config:
+Chunked uploads are **opt-in** and disabled by default. Enable them by setting `chunk.size` in your config:
 
 ```php
 'temporary_file_upload' => [
     // ...
-    'chunk_size' => 5 * 1024 * 1024, // 5MB per chunk
+    'chunk' => [
+        'size' => 5 * 1024 * 1024, // 5MB per chunk
+    ],
 ],
 ```
 
-Once enabled, Livewire automatically chunks any uploaded file larger than `chunk_size`. Smaller files continue to use the normal single-request upload path. From your component's perspective, nothing changes — you still get a `TemporaryUploadedFile` on your property:
+Once enabled, Livewire automatically chunks any uploaded file larger than `chunk.size`. Smaller files continue to use the normal single-request upload path. From your component's perspective, nothing changes — you still get a `TemporaryUploadedFile` on your property:
 
 ```php
 new class extends Component {
@@ -463,7 +465,7 @@ new class extends Component {
 ```
 
 > [!warning] Local disk only
-> Chunked uploads currently only work when `temporary_file_upload.disk` is a local filesystem. If you set `chunk_size` while using the S3 disk, Livewire will throw an `S3DoesntSupportChunkedUploads` exception when an upload is attempted — set `chunk_size` to `null` or switch to a local disk. Native S3 multipart upload support is planned for a future release.
+> Chunked uploads currently only work when `temporary_file_upload.disk` is a local filesystem. If you set `chunk.size` while using the S3 disk, Livewire will throw an `S3DoesntSupportChunkedUploads` exception when an upload is attempted — set `chunk.size` to `null` or switch to a local disk. Native S3 multipart upload support is planned for a future release.
 
 > [!info] Bump your global validation rule
 > Remember that the global `temporary_file_upload.rules` validation still applies to the assembled file. The default `max:12288` (12MB) will reject anything larger. If you're enabling chunked uploads to support large files, bump `max` accordingly.
@@ -476,39 +478,44 @@ new class extends Component {
 ```php
 'temporary_file_upload' => [
     // ...
-    'chunk_size' => 5 * 1024 * 1024,           // Bytes per chunk. `null` to disable.
-    'chunk_retry_delays' => [500, 1000, 3000], // Backoff between failed chunk retries (ms).
-    'chunk_max_upload_time' => 60 * 24,        // Max minutes for an entire chunked upload to complete (24h default).
-    'chunk_middleware' => null,                // Middleware applied to chunk endpoints. Defaults to throttle:600,1.
-    'chunk_absolute_max_bytes' => 5 * 1024 * 1024 * 1024, // Hard ceiling on Upload-Length when no `max:` rule is set (defaults to 5GB).
+    'chunk' => [
+        'size' => 5 * 1024 * 1024,                // Bytes per chunk. `null` to disable.
+        'retry_delays' => [500, 1000, 3000],      // Backoff between failed chunk retries (ms).
+        'max_upload_time' => 60 * 24,             // Max minutes for an entire chunked upload to complete (24h default).
+        'middleware' => null,                     // Middleware applied to chunk endpoints. Defaults to throttle:600,1.
+        'absolute_max_bytes' => 5 * 1024 * 1024 * 1024, // Hard ceiling on Upload-Length when no `max:` rule is set (defaults to 5GB).
+    ],
 ],
 ```
 
-`chunk_max_upload_time` controls how long the signed chunk URLs stay valid. If an upload takes longer than this, the URLs expire and in-flight chunks start failing. The default of 24 hours comfortably handles multi-GB uploads on slow connections (e.g. 10GB at 5Mbps takes about 4.5 hours), and aligns with Livewire's existing 24-hour temporary-file cleanup window.
+`chunk.max_upload_time` controls how long the signed chunk URLs stay valid. If an upload takes longer than this, the URLs expire and in-flight chunks start failing. The default of 24 hours comfortably handles multi-GB uploads on slow connections (e.g. 10GB at 5Mbps takes about 4.5 hours), and aligns with Livewire's existing 24-hour temporary-file cleanup window.
 
-`chunk_absolute_max_bytes` only matters when there is no `max:` rule in `temporary_file_upload.rules`. In that case it acts as a hard ceiling so a missing rule can't become an unbounded upload claim. If you set a `max:` rule (recommended), Livewire enforces that instead and `chunk_absolute_max_bytes` is unused.
+`chunk.absolute_max_bytes` only matters when there is no `max:` rule in `temporary_file_upload.rules`. In that case it acts as a hard ceiling so a missing rule can't become an unbounded upload claim. If you set a `max:` rule (recommended), Livewire enforces that instead and `chunk.absolute_max_bytes` is unused.
 
-`chunk_middleware` defaults to `throttle:600,1` — looser than the legacy `throttle:60,1` for single-request uploads, because chunking inherently makes many small requests per file. **If your upload component is reachable by anonymous or unauthenticated visitors, tighten this** to limit how quickly an attacker can fill the disk with abandoned chunks:
+`chunk.middleware` defaults to `throttle:600,1` — looser than the legacy `throttle:60,1` for single-request uploads, because chunking inherently makes many small requests per file. **If your upload component is reachable by anonymous or unauthenticated visitors, tighten this** to limit how quickly an attacker can fill the disk with abandoned chunks:
 
 ```php
-'chunk_middleware' => 'throttle:60,1',
+'chunk' => [
+    // ...
+    'middleware' => 'throttle:60,1',
+],
 ```
 
 The throttle counter is per-IP per-minute, so an attacker uploading 5MB chunks at the default `600/1` could write up to ~3GB/minute of trash data per IP before being blocked. The cleanup logic only removes abandoned chunks after 24 hours, so the disk pressure persists. For public-facing apps, tightening to `60/1` (~300MB/min/IP) is much safer.
 
 ### How it works
 
-When the user selects a file larger than `chunk_size`, Livewire's JavaScript:
+When the user selects a file larger than `chunk.size`, Livewire's JavaScript:
 
 1. POSTs to a chunk-init endpoint with the total file size, getting back a transfer ID and signed URLs for the chunk endpoints.
-2. Slices the file into `chunk_size` pieces and PATCHes each one to the chunk endpoint with an `Upload-Offset` header.
+2. Slices the file into `chunk.size` pieces and PATCHes each one to the chunk endpoint with an `Upload-Offset` header.
 3. On the final chunk, the server assembles the file, validates it against the configured rules, and returns a signed path.
 4. Livewire's JavaScript hands that signed path to the same `_finishUpload` flow used by non-chunked uploads, and your component property is set to a `TemporaryUploadedFile`.
 
 If a chunk fails, the client retries with backoff, querying the server for the authoritative offset before resuming. Validation errors at finalize time (e.g. mime mismatch) bubble up the same way they would for a non-chunked upload, so `@error('photo')` works as expected.
 
 > [!info] PATCH method support
-> Chunked uploads use HTTP PATCH requests. If your infrastructure (WAF, reverse proxy, etc.) blocks PATCH by default, either configure it to allow PATCH on the chunk endpoint, or leave `chunk_size` at `null`.
+> Chunked uploads use HTTP PATCH requests. If your infrastructure (WAF, reverse proxy, etc.) blocks PATCH by default, either configure it to allow PATCH on the chunk endpoint, or leave `chunk.size` at `null`.
 
 ## See also
 

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -433,6 +433,68 @@ Temporary files are uploaded to the specified disk's `livewire-tmp/` directory. 
 ],
 ```
 
+## Chunked uploads
+
+For large files, Livewire can split uploads into smaller chunks that are sent sequentially. This avoids hitting PHP's `upload_max_filesize` and `post_max_size` limits, reduces memory usage, and lets failed chunks retry without restarting the whole upload.
+
+Chunked uploads are **opt-in** and disabled by default. Enable them by setting `chunk_size` in your config:
+
+```php
+'temporary_file_upload' => [
+    // ...
+    'chunk_size' => 5 * 1024 * 1024, // 5MB per chunk
+],
+```
+
+Once enabled, Livewire automatically chunks any uploaded file larger than `chunk_size`. Smaller files continue to use the normal single-request upload path. From your component's perspective, nothing changes — you still get a `TemporaryUploadedFile` on your property:
+
+```php
+new class extends Component {
+    use WithFileUploads;
+
+    #[Validate('file|max:512000')] // 500MB
+    public $video;
+
+    public function save()
+    {
+        $this->video->store(path: 'videos');
+    }
+};
+```
+
+> [!warning] Local disk only
+> Chunked uploads currently only work when `temporary_file_upload.disk` is a local filesystem. The S3 disk falls back to the existing single-request upload path. Native S3 multipart upload support is planned for a future release.
+
+> [!info] Bump your global validation rule
+> Remember that the global `temporary_file_upload.rules` validation still applies to the assembled file. The default `max:12288` (12MB) will reject anything larger. If you're enabling chunked uploads to support large files, bump `max` accordingly.
+
+### Chunked upload configuration
+
+```php
+'temporary_file_upload' => [
+    // ...
+    'chunk_size' => 5 * 1024 * 1024,           // Bytes per chunk. `null` to disable.
+    'chunk_retry_delays' => [500, 1000, 3000], // Backoff between failed chunk retries (ms).
+    'chunk_max_upload_time' => 60,             // Max minutes for an entire chunked upload to complete.
+    'chunk_middleware' => null,                // Middleware applied to chunk endpoints. Defaults to throttle:600,1.
+    'chunk_absolute_max_bytes' => 5 * 1024 * 1024 * 1024, // Hard ceiling on Upload-Length when no `max:` rule is set.
+],
+```
+
+### How it works
+
+When the user selects a file larger than `chunk_size`, Livewire's JavaScript:
+
+1. POSTs to a chunk-init endpoint with the total file size, getting back a transfer ID and signed URLs for the chunk endpoints.
+2. Slices the file into `chunk_size` pieces and PATCHes each one to the chunk endpoint with an `Upload-Offset` header.
+3. On the final chunk, the server assembles the file, validates it against the configured rules, and returns a signed path.
+4. Livewire's JavaScript hands that signed path to the same `_finishUpload` flow used by non-chunked uploads, and your component property is set to a `TemporaryUploadedFile`.
+
+If a chunk fails, the client retries with backoff, querying the server for the authoritative offset before resuming. Validation errors at finalize time (e.g. mime mismatch) bubble up the same way they would for a non-chunked upload, so `@error('photo')` works as expected.
+
+> [!info] PATCH method support
+> Chunked uploads use HTTP PATCH requests. If your infrastructure (WAF, reverse proxy, etc.) blocks PATCH by default, either configure it to allow PATCH on the chunk endpoint, or leave `chunk_size` at `null`.
+
 ## See also
 
 - **[Forms](/docs/4.x/forms)** — Handle file uploads in forms

--- a/js/features/supportFileUploads.js
+++ b/js/features/supportFileUploads.js
@@ -85,11 +85,16 @@ class UploadManager {
     }
 
     registerListeners() {
-        this.component.$wire.$on('upload:generatedSignedUrl', ({ name, url }) => {
+        this.component.$wire.$on('upload:generatedSignedUrl', ({ name, url, chunkConfig }) => {
             // We have to add reduntant "setLoading" calls because the dom-patch
             // from the first response will clear the setUploadLoading call
             // from the first upload call.
             setUploadLoading(this.component, name)
+
+            if (chunkConfig) {
+                this.handleChunkedUpload(name, chunkConfig)
+                return
+            }
 
             this.handleSignedUrl(name, url)
         })
@@ -172,6 +177,149 @@ class UploadManager {
         this.makeRequest(name, formData, 'put', url, headers, response => {
             return [payload.path]
         })
+    }
+
+    handleChunkedUpload(name, chunkConfig) {
+        let uploadObj = this.uploadBag.first(name)
+        let file = uploadObj.files[0]
+        let { chunkSize, retryDelays, initUrl } = chunkConfig
+
+        let totalSize = file.size
+        let offset = 0
+        let patchUrl = null
+        let offsetUrl = null
+        let retryCount = 0
+        let aborted = false
+        let currentXhr = null
+        let component = this.component
+
+        // Wire up abort for cancelUpload()
+        uploadObj.request = { abort: () => { aborted = true; if (currentXhr) currentXhr.abort() } }
+
+        let csrfToken = getCsrfToken()
+
+        // Step 1: POST to init endpoint to get transfer ID and signed URLs
+        let initXhr = new XMLHttpRequest()
+        currentXhr = initXhr
+        initXhr.open('POST', initUrl)
+        initXhr.setRequestHeader('Content-Type', 'application/json')
+        initXhr.setRequestHeader('Upload-Length', totalSize)
+        initXhr.setRequestHeader('Upload-Name', file.name)
+        if (csrfToken) initXhr.setRequestHeader('X-CSRF-TOKEN', csrfToken)
+
+        initXhr.addEventListener('load', () => {
+            if (aborted) return
+
+            if (initXhr.status !== 200) {
+                uploadObj.errorCallback()
+                return
+            }
+
+            let response = JSON.parse(initXhr.responseText)
+            patchUrl = response.patchUrl
+            offsetUrl = response.offsetUrl
+            sendNextChunk()
+        })
+
+        initXhr.addEventListener('error', () => {
+            if (!aborted) uploadObj.errorCallback()
+        })
+
+        initXhr.send()
+
+        let self = this
+
+        // Step 2: Send chunks sequentially via PATCH
+        function sendNextChunk() {
+            if (aborted) return
+            if (offset >= totalSize) return
+
+            let end = Math.min(offset + chunkSize, totalSize)
+            let chunk = file.slice(offset, end)
+
+            let xhr = new XMLHttpRequest()
+            currentXhr = xhr
+            xhr.open('PATCH', patchUrl)
+            xhr.setRequestHeader('Content-Type', 'application/offset+octet-stream')
+            xhr.setRequestHeader('Upload-Offset', offset)
+            if (csrfToken) xhr.setRequestHeader('X-CSRF-TOKEN', csrfToken)
+
+            // Per-chunk progress → overall progress
+            xhr.upload.addEventListener('progress', (e) => {
+                if (!e.lengthComputable) return
+                let totalSent = offset + e.loaded
+                uploadObj.progressCallback({ loaded: totalSent, total: totalSize })
+            })
+
+            xhr.addEventListener('load', () => {
+                if (aborted) return
+
+                if (xhr.status === 204) {
+                    let newOffset = parseInt(xhr.getResponseHeader('Upload-Offset'))
+                    offset = newOffset
+                    retryCount = 0
+
+                    // Check if upload is complete
+                    let complete = xhr.getResponseHeader('Upload-Complete')
+                    if (complete === 'true') {
+                        let signedPath = xhr.getResponseHeader('X-Signed-Path')
+                        component.$wire.call('_finishUpload', name, [signedPath], uploadObj.multiple, uploadObj.append)
+                        return
+                    }
+
+                    sendNextChunk()
+                } else if (xhr.status === 409) {
+                    // Offset mismatch — check server offset and retry
+                    checkOffset(() => sendNextChunk())
+                } else {
+                    retryOrFail()
+                }
+            })
+
+            xhr.addEventListener('error', () => {
+                if (!aborted) retryOrFail()
+            })
+
+            xhr.send(chunk)
+        }
+
+        // Step 3: GET offset endpoint to check progress (for resume after failure)
+        function checkOffset(callback) {
+            let xhr = new XMLHttpRequest()
+            currentXhr = xhr
+            xhr.open('GET', offsetUrl)
+            if (csrfToken) xhr.setRequestHeader('X-CSRF-TOKEN', csrfToken)
+
+            xhr.addEventListener('load', () => {
+                if (aborted) return
+
+                if (xhr.status === 200) {
+                    let response = JSON.parse(xhr.responseText)
+                    offset = response.offset
+                    callback()
+                } else {
+                    uploadObj.errorCallback()
+                }
+            })
+
+            xhr.addEventListener('error', () => {
+                if (!aborted) uploadObj.errorCallback()
+            })
+
+            xhr.send()
+        }
+
+        // Step 4: Retry with backoff
+        function retryOrFail() {
+            if (retryCount < retryDelays.length) {
+                let delay = retryDelays[retryCount++]
+                setTimeout(() => {
+                    checkOffset(() => sendNextChunk())
+                }, delay)
+            } else {
+                self.component.$wire.call('_uploadErrored', name, null, uploadObj.multiple)
+            }
+        }
     }
 
     makeRequest(name, formData, method, url, headers, retrievePaths) {

--- a/js/features/supportFileUploads.js
+++ b/js/features/supportFileUploads.js
@@ -1,5 +1,29 @@
 import { getCsrfToken } from '@/utils';
 
+// Base64 encode a filename so it's safe to send as an HTTP header value.
+// XHR's setRequestHeader throws InvalidCharacterError on non-ASCII characters,
+// and the tus protocol uses base64 for similar metadata for the same reason.
+function encodeFilename(filename) {
+    // Encode as UTF-8 bytes first (otherwise btoa breaks on multi-byte chars),
+    // then base64. unescape(encodeURIComponent(...)) is the well-known idiom.
+    return btoa(unescape(encodeURIComponent(filename)))
+}
+
+// Extract a JSON error body from an XHR response, if present.
+// Returns the raw JSON string (matching the existing _uploadErrored API),
+// or null if the response wasn't a structured error.
+function extractErrorBody(xhr) {
+    if (! xhr.responseText) return null
+
+    try {
+        // Validate it's actually JSON before passing it through
+        JSON.parse(xhr.responseText)
+        return xhr.responseText
+    } catch (e) {
+        return null
+    }
+}
+
 let uploadManagers = new WeakMap
 
 function getUploadManager(component) {
@@ -181,143 +205,196 @@ class UploadManager {
 
     handleChunkedUpload(name, chunkConfig) {
         let uploadObj = this.uploadBag.first(name)
-        let file = uploadObj.files[0]
         let { chunkSize, retryDelays, initUrl } = chunkConfig
+        let component = this.component
+        let manager = this
+
+        // Total size across all files — used to calculate aggregate progress
+        let totalAllFiles = Array.from(uploadObj.files).reduce((sum, f) => sum + f.size, 0)
+        let bytesAlreadySentForCompletedFiles = 0
+        let signedPaths = []
+        let aborted = false
+        let currentXhr = null
+        let csrfToken = getCsrfToken()
+
+        // Wire up abort for cancelUpload(). We share a single abort flag
+        // across all files in this upload batch.
+        uploadObj.request = {
+            abort: () => {
+                aborted = true
+                if (currentXhr) currentXhr.abort()
+            },
+        }
+
+        let fileIndex = 0
+        let files = Array.from(uploadObj.files)
+
+        let processNextFile = () => {
+            if (aborted) return
+
+            if (fileIndex >= files.length) {
+                // All files uploaded — hand off to the existing _finishUpload flow
+                component.$wire.call('_finishUpload', name, signedPaths, uploadObj.multiple, uploadObj.append)
+                return
+            }
+
+            let file = files[fileIndex]
+            this.uploadSingleChunked(file, name, chunkConfig, csrfToken, {
+                onProgress: (bytesForThisFile) => {
+                    let totalSent = bytesAlreadySentForCompletedFiles + bytesForThisFile
+                    uploadObj.progressCallback({ loaded: totalSent, total: totalAllFiles })
+                },
+                onComplete: (signedPath) => {
+                    signedPaths.push(signedPath)
+                    bytesAlreadySentForCompletedFiles += file.size
+                    fileIndex++
+                    processNextFile()
+                },
+                onError: (errorBody) => {
+                    component.$wire.call('_uploadErrored', name, errorBody, uploadObj.multiple)
+                },
+                isAborted: () => aborted,
+                setCurrentXhr: (xhr) => { currentXhr = xhr },
+            })
+        }
+
+        processNextFile()
+    }
+
+    uploadSingleChunked(file, name, chunkConfig, csrfToken, callbacks) {
+        let { chunkSize, retryDelays, initUrl } = chunkConfig
+        let { onProgress, onComplete, onError, isAborted, setCurrentXhr } = callbacks
 
         let totalSize = file.size
         let offset = 0
         let patchUrl = null
         let offsetUrl = null
         let retryCount = 0
-        let aborted = false
-        let currentXhr = null
-        let component = this.component
-
-        // Wire up abort for cancelUpload()
-        uploadObj.request = { abort: () => { aborted = true; if (currentXhr) currentXhr.abort() } }
-
-        let csrfToken = getCsrfToken()
 
         // Step 1: POST to init endpoint to get transfer ID and signed URLs
         let initXhr = new XMLHttpRequest()
-        currentXhr = initXhr
+        setCurrentXhr(initXhr)
         initXhr.open('POST', initUrl)
-        initXhr.setRequestHeader('Content-Type', 'application/json')
         initXhr.setRequestHeader('Upload-Length', totalSize)
-        initXhr.setRequestHeader('Upload-Name', file.name)
+        initXhr.setRequestHeader('Upload-Name', encodeFilename(file.name))
         if (csrfToken) initXhr.setRequestHeader('X-CSRF-TOKEN', csrfToken)
 
         initXhr.addEventListener('load', () => {
-            if (aborted) return
+            if (isAborted()) return
 
             if (initXhr.status !== 200) {
-                uploadObj.errorCallback()
+                onError(extractErrorBody(initXhr))
                 return
             }
 
-            let response = JSON.parse(initXhr.responseText)
-            patchUrl = response.patchUrl
-            offsetUrl = response.offsetUrl
-            sendNextChunk()
+            try {
+                let response = JSON.parse(initXhr.responseText)
+                patchUrl = response.patchUrl
+                offsetUrl = response.offsetUrl
+                sendNextChunk()
+            } catch (e) {
+                onError(null)
+            }
         })
 
         initXhr.addEventListener('error', () => {
-            if (!aborted) uploadObj.errorCallback()
+            if (!isAborted()) onError(null)
         })
 
         initXhr.send()
 
-        let self = this
-
-        // Step 2: Send chunks sequentially via PATCH
-        function sendNextChunk() {
-            if (aborted) return
+        let sendNextChunk = () => {
+            if (isAborted()) return
             if (offset >= totalSize) return
 
             let end = Math.min(offset + chunkSize, totalSize)
             let chunk = file.slice(offset, end)
 
             let xhr = new XMLHttpRequest()
-            currentXhr = xhr
+            setCurrentXhr(xhr)
             xhr.open('PATCH', patchUrl)
             xhr.setRequestHeader('Content-Type', 'application/offset+octet-stream')
             xhr.setRequestHeader('Upload-Offset', offset)
             if (csrfToken) xhr.setRequestHeader('X-CSRF-TOKEN', csrfToken)
 
-            // Per-chunk progress → overall progress
+            // Per-chunk XHR progress → overall progress for this file
             xhr.upload.addEventListener('progress', (e) => {
                 if (!e.lengthComputable) return
-                let totalSent = offset + e.loaded
-                uploadObj.progressCallback({ loaded: totalSent, total: totalSize })
+                onProgress(offset + e.loaded)
             })
 
             xhr.addEventListener('load', () => {
-                if (aborted) return
+                if (isAborted()) return
 
                 if (xhr.status === 204) {
                     let newOffset = parseInt(xhr.getResponseHeader('Upload-Offset'))
                     offset = newOffset
                     retryCount = 0
 
-                    // Check if upload is complete
-                    let complete = xhr.getResponseHeader('Upload-Complete')
-                    if (complete === 'true') {
+                    if (xhr.getResponseHeader('Upload-Complete') === 'true') {
                         let signedPath = xhr.getResponseHeader('X-Signed-Path')
-                        component.$wire.call('_finishUpload', name, [signedPath], uploadObj.multiple, uploadObj.append)
+                        onProgress(totalSize)
+                        onComplete(signedPath)
                         return
                     }
 
                     sendNextChunk()
                 } else if (xhr.status === 409) {
-                    // Offset mismatch — check server offset and retry
-                    checkOffset(() => sendNextChunk())
+                    // Offset mismatch — fetch the authoritative offset and retry
+                    checkOffset(() => sendNextChunk(), () => onError(null))
+                } else if (xhr.status === 422 || xhr.status === 413) {
+                    // Validation failure or size limit — these are not retryable
+                    onError(extractErrorBody(xhr))
                 } else {
                     retryOrFail()
                 }
             })
 
             xhr.addEventListener('error', () => {
-                if (!aborted) retryOrFail()
+                if (!isAborted()) retryOrFail()
             })
 
             xhr.send(chunk)
         }
 
-        // Step 3: GET offset endpoint to check progress (for resume after failure)
-        function checkOffset(callback) {
+        let checkOffset = (onSuccess, onFail) => {
             let xhr = new XMLHttpRequest()
-            currentXhr = xhr
+            setCurrentXhr(xhr)
             xhr.open('GET', offsetUrl)
             if (csrfToken) xhr.setRequestHeader('X-CSRF-TOKEN', csrfToken)
 
             xhr.addEventListener('load', () => {
-                if (aborted) return
+                if (isAborted()) return
 
                 if (xhr.status === 200) {
-                    let response = JSON.parse(xhr.responseText)
-                    offset = response.offset
-                    callback()
+                    try {
+                        let response = JSON.parse(xhr.responseText)
+                        offset = response.offset
+                        onSuccess()
+                    } catch (e) {
+                        onFail()
+                    }
                 } else {
-                    uploadObj.errorCallback()
+                    onFail()
                 }
             })
 
             xhr.addEventListener('error', () => {
-                if (!aborted) uploadObj.errorCallback()
+                if (!isAborted()) onFail()
             })
 
             xhr.send()
         }
 
-        // Step 4: Retry with backoff
-        function retryOrFail() {
+        let retryOrFail = () => {
             if (retryCount < retryDelays.length) {
                 let delay = retryDelays[retryCount++]
                 setTimeout(() => {
-                    checkOffset(() => sendNextChunk())
+                    if (isAborted()) return
+                    checkOffset(() => sendNextChunk(), () => onError(null))
                 }, delay)
             } else {
-                self.component.$wire.call('_uploadErrored', name, null, uploadObj.multiple)
+                onError(null)
             }
         }
     }

--- a/js/features/supportFileUploads.js
+++ b/js/features/supportFileUploads.js
@@ -205,17 +205,16 @@ class UploadManager {
 
     handleChunkedUpload(name, chunkConfig) {
         let uploadObj = this.uploadBag.first(name)
-        let { chunkSize, retryDelays, initUrl } = chunkConfig
         let component = this.component
-        let manager = this
+        let csrfToken = getCsrfToken()
 
-        // Total size across all files — used to calculate aggregate progress
-        let totalAllFiles = Array.from(uploadObj.files).reduce((sum, f) => sum + f.size, 0)
+        let files = Array.from(uploadObj.files)
+        let totalAllFiles = files.reduce((sum, f) => sum + f.size, 0)
         let bytesAlreadySentForCompletedFiles = 0
         let signedPaths = []
+        let fileIndex = 0
         let aborted = false
         let currentXhr = null
-        let csrfToken = getCsrfToken()
 
         // Wire up abort for cancelUpload(). We share a single abort flag
         // across all files in this upload batch.
@@ -225,9 +224,6 @@ class UploadManager {
                 if (currentXhr) currentXhr.abort()
             },
         }
-
-        let fileIndex = 0
-        let files = Array.from(uploadObj.files)
 
         let processNextFile = () => {
             if (aborted) return
@@ -275,6 +271,7 @@ class UploadManager {
         let initXhr = new XMLHttpRequest()
         setCurrentXhr(initXhr)
         initXhr.open('POST', initUrl)
+        initXhr.setRequestHeader('Accept', 'application/json')
         initXhr.setRequestHeader('Upload-Length', totalSize)
         initXhr.setRequestHeader('Upload-Name', encodeFilename(file.name))
         if (csrfToken) initXhr.setRequestHeader('X-CSRF-TOKEN', csrfToken)
@@ -313,6 +310,7 @@ class UploadManager {
             let xhr = new XMLHttpRequest()
             setCurrentXhr(xhr)
             xhr.open('PATCH', patchUrl)
+            xhr.setRequestHeader('Accept', 'application/json')
             xhr.setRequestHeader('Content-Type', 'application/offset+octet-stream')
             xhr.setRequestHeader('Upload-Offset', offset)
             if (csrfToken) xhr.setRequestHeader('X-CSRF-TOKEN', csrfToken)
@@ -361,6 +359,7 @@ class UploadManager {
             let xhr = new XMLHttpRequest()
             setCurrentXhr(xhr)
             xhr.open('GET', offsetUrl)
+            xhr.setRequestHeader('Accept', 'application/json')
             if (csrfToken) xhr.setRequestHeader('X-CSRF-TOKEN', csrfToken)
 
             xhr.addEventListener('load', () => {

--- a/src/Features/SupportFileUploads/ChunkedUploadController.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadController.php
@@ -216,11 +216,15 @@ class ChunkedUploadController implements HasMiddleware
     {
         $originalName = $manifest['name'] ?? 'unknown';
 
-        // Sanitize the extension to alphanumeric only. The original name comes
-        // from the user (Upload-Name header) so we can't trust its characters
-        // to be safe in a filename.
+        // The extension comes from the user (Upload-Name header) so we can't
+        // trust it. Use it only if it's already a "boring" alphanumeric string;
+        // otherwise drop it entirely. We deliberately do NOT strip individual
+        // bad characters because that can collapse a tampered extension like
+        // `p$h$p` into a real one like `php`, which would be more permissive
+        // than the legacy single-request path and could surprise frontend
+        // filters that allow/deny based on the literal client extension.
         $rawExtension = pathinfo($originalName, PATHINFO_EXTENSION);
-        $extension = preg_replace('/[^A-Za-z0-9]/', '', $rawExtension);
+        $extension = preg_match('/^[A-Za-z0-9]+$/', $rawExtension) ? $rawExtension : '';
 
         $hash = Str::random(40);
         $tmpName = $extension ? "{$hash}.{$extension}" : $hash;

--- a/src/Features/SupportFileUploads/ChunkedUploadController.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadController.php
@@ -101,7 +101,7 @@ class ChunkedUploadController implements HasMiddleware
 
         // Reject obviously bad chunk sizes up front
         $chunkSize = FileUploadConfiguration::chunkSize();
-        if ($chunkSize !== null && $bytesIncoming > $chunkSize) {
+        if ($bytesIncoming > $chunkSize) {
             abort(413, "Chunk size ({$bytesIncoming} bytes) exceeds configured chunk.size ({$chunkSize} bytes).");
         }
 

--- a/src/Features/SupportFileUploads/ChunkedUploadController.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadController.php
@@ -102,7 +102,7 @@ class ChunkedUploadController implements HasMiddleware
         // Reject obviously bad chunk sizes up front
         $chunkSize = FileUploadConfiguration::chunkSize();
         if ($chunkSize !== null && $bytesIncoming > $chunkSize) {
-            abort(413, "Chunk size ({$bytesIncoming} bytes) exceeds configured chunk_size ({$chunkSize} bytes).");
+            abort(413, "Chunk size ({$bytesIncoming} bytes) exceeds configured chunk.size ({$chunkSize} bytes).");
         }
 
         // Atomically read manifest, validate offset, write chunk, update manifest,

--- a/src/Features/SupportFileUploads/ChunkedUploadController.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadController.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Livewire\Features\SupportFileUploads;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controllers\HasMiddleware;
+use Illuminate\Routing\Controllers\Middleware;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
+
+class ChunkedUploadController implements HasMiddleware
+{
+    public static array $defaultMiddleware = ['web'];
+
+    public static function middleware()
+    {
+        $middleware = (array) FileUploadConfiguration::middleware();
+
+        foreach (array_reverse(static::$defaultMiddleware) as $defaultMiddleware) {
+            if (! in_array($defaultMiddleware, $middleware)) {
+                array_unshift($middleware, $defaultMiddleware);
+            }
+        }
+
+        return array_map(fn ($middleware) => new Middleware($middleware), $middleware);
+    }
+
+    public function init(Request $request)
+    {
+        abort_unless($request->hasValidSignature(), 401);
+
+        $totalSize = (int) $request->header('Upload-Length');
+        $transferId = Str::random(40);
+
+        $storage = FileUploadConfiguration::storage();
+        $dir = FileUploadConfiguration::path("chunks/{$transferId}");
+
+        $storage->put("{$dir}/manifest.json", json_encode([
+            'size' => $totalSize,
+            'offset' => 0,
+            'name' => $request->header('Upload-Name', 'unknown'),
+            'created_at' => now()->timestamp,
+        ]));
+
+        $expiry = now()->addDay();
+
+        return response()->json([
+            'transferId' => $transferId,
+            'patchUrl' => URL::signedRoute('livewire.chunk-upload-patch', ['transferId' => $transferId], $expiry),
+            'offsetUrl' => URL::signedRoute('livewire.chunk-upload-offset', ['transferId' => $transferId], $expiry),
+        ]);
+    }
+
+    public function patch(Request $request, string $transferId)
+    {
+        abort_unless($request->hasValidSignature(), 401);
+
+        $storage = FileUploadConfiguration::storage();
+        $dir = FileUploadConfiguration::path("chunks/{$transferId}");
+
+        abort_unless($storage->exists("{$dir}/manifest.json"), 404);
+
+        $manifest = json_decode($storage->get("{$dir}/manifest.json"), true);
+        $clientOffset = (int) $request->header('Upload-Offset');
+
+        abort_if($clientOffset !== $manifest['offset'], 409);
+
+        $chunkPath = "{$dir}/data";
+        $content = $request->getContent();
+        $bytesWritten = strlen($content);
+
+        if ($manifest['offset'] === 0) {
+            $storage->put($chunkPath, $content);
+        } else {
+            $storage->append($chunkPath, $content);
+        }
+
+        $newOffset = $manifest['offset'] + $bytesWritten;
+        $manifest['offset'] = $newOffset;
+        $storage->put("{$dir}/manifest.json", json_encode($manifest));
+
+        $headers = [
+            'Upload-Offset' => $newOffset,
+        ];
+
+        if ($newOffset >= $manifest['size']) {
+            $finalPath = $this->finalizeUpload($transferId, $dir, $storage, $manifest);
+            $headers['Upload-Complete'] = 'true';
+            $headers['X-Signed-Path'] = $finalPath;
+        }
+
+        return response('', 204, $headers);
+    }
+
+    public function offset(Request $request, string $transferId)
+    {
+        abort_unless($request->hasValidSignature(), 401);
+
+        $storage = FileUploadConfiguration::storage();
+        $dir = FileUploadConfiguration::path("chunks/{$transferId}");
+
+        abort_unless($storage->exists("{$dir}/manifest.json"), 404);
+
+        $manifest = json_decode($storage->get("{$dir}/manifest.json"), true);
+
+        return response()->json([
+            'offset' => $manifest['offset'],
+            'size' => $manifest['size'],
+        ]);
+    }
+
+    protected function finalizeUpload($transferId, $dir, $storage, $manifest)
+    {
+        $extension = pathinfo($manifest['name'], PATHINFO_EXTENSION);
+        $tmpName = Str::random(40) . ($extension ? ".{$extension}" : '');
+        $finalPath = FileUploadConfiguration::path($tmpName);
+
+        $storage->move("{$dir}/data", $finalPath);
+
+        $storage->put("{$finalPath}.json", json_encode([
+            'name' => $manifest['name'],
+        ]));
+
+        $storage->deleteDirectory($dir);
+
+        return TemporaryUploadedFile::signPath($tmpName);
+    }
+}

--- a/src/Features/SupportFileUploads/ChunkedUploadController.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadController.php
@@ -9,6 +9,7 @@ use Illuminate\Routing\Controllers\Middleware;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 class ChunkedUploadController implements HasMiddleware
 {
@@ -44,10 +45,11 @@ class ChunkedUploadController implements HasMiddleware
             abort(400, 'Upload-Length header must be a positive integer.');
         }
 
-        // Reject uploads that exceed the configured max size up front so we
-        // never commit storage for an upload we know we'll reject later.
-        $maxBytes = FileUploadConfiguration::maxUploadSizeInBytes();
-        if ($maxBytes !== null && $totalSize > $maxBytes) {
+        // Always enforce some upper bound — even if the user hasn't set a `max:`
+        // rule we don't want clients claiming arbitrary sizes. Falls back to
+        // chunk_max_size_bytes (5GB by default).
+        $maxBytes = FileUploadConfiguration::maxUploadSizeInBytes() ?? FileUploadConfiguration::chunkAbsoluteMaxBytes();
+        if ($totalSize > $maxBytes) {
             abort(413, "Upload-Length ({$totalSize} bytes) exceeds the maximum allowed size ({$maxBytes} bytes).");
         }
 
@@ -103,10 +105,10 @@ class ChunkedUploadController implements HasMiddleware
             abort(413, "Chunk size ({$bytesIncoming} bytes) exceeds configured chunk_size ({$chunkSize} bytes).");
         }
 
-        // Atomically read manifest, validate offset, write chunk, update manifest.
-        // Holding the lock for the whole operation prevents race conditions on
-        // concurrent PATCHes for the same transfer (which the JS shouldn't do,
-        // but defensive coding matters).
+        // Atomically read manifest, validate offset, write chunk, update manifest,
+        // and (if this is the final chunk) finalize. Holding the lock through
+        // finalization prevents a second concurrent PATCH from racing past the
+        // moved data file and corrupting things.
         $manifestPath = $storage->path($manifestRelative);
         $dataPath = $storage->path($dataRelative);
 
@@ -114,6 +116,8 @@ class ChunkedUploadController implements HasMiddleware
         if ($fp === false) {
             abort(500, 'Could not open upload manifest.');
         }
+
+        $finalizationResult = null;
 
         try {
             if (! flock($fp, LOCK_EX)) {
@@ -159,26 +163,23 @@ class ChunkedUploadController implements HasMiddleware
             fflush($fp);
 
             $newOffset = $manifest['offset'];
-            $isComplete = $newOffset >= $manifest['size'];
+            $signedPath = null;
+
+            if ($newOffset >= $manifest['size']) {
+                // Finalize while still holding the lock so a concurrent PATCH
+                // can't race past the moved data file. May throw ValidationException.
+                $signedPath = $this->finalizeUpload($transferId, $manifest, $storage);
+            }
         } finally {
             flock($fp, LOCK_UN);
             fclose($fp);
         }
 
-        $headers = [
-            'Upload-Offset' => $newOffset,
-        ];
+        $headers = ['Upload-Offset' => $newOffset];
 
-        if ($isComplete) {
-            $result = $this->finalizeUpload($transferId, $manifest, $storage);
-
-            if ($result instanceof \Symfony\Component\HttpFoundation\Response) {
-                // Validation failed — return the response directly
-                return $result;
-            }
-
+        if ($signedPath !== null) {
             $headers['Upload-Complete'] = 'true';
-            $headers['X-Signed-Path'] = $result;
+            $headers['X-Signed-Path'] = $signedPath;
         }
 
         return response('', 204, $headers);
@@ -208,67 +209,59 @@ class ChunkedUploadController implements HasMiddleware
 
     /**
      * Move the assembled chunks to a temporary upload file, validate it
-     * against the configured rules, and return a signed path.
-     *
-     * Returns a Symfony Response on validation failure (so the caller can
-     * return it directly), or a string signed path on success.
+     * against the configured rules, and return a signed path. Throws
+     * ValidationException on validation failure (Laravel renders as 422).
      */
-    protected function finalizeUpload(string $transferId, array $manifest, $storage)
+    protected function finalizeUpload(string $transferId, array $manifest, $storage): string
     {
         $originalName = $manifest['name'] ?? 'unknown';
-        $extension = pathinfo($originalName, PATHINFO_EXTENSION);
 
-        // Match the existing temp filename convention used by FileUploadConfiguration::storeTemporaryFile
+        // Sanitize the extension to alphanumeric only. The original name comes
+        // from the user (Upload-Name header) so we can't trust its characters
+        // to be safe in a filename.
+        $rawExtension = pathinfo($originalName, PATHINFO_EXTENSION);
+        $extension = preg_replace('/[^A-Za-z0-9]/', '', $rawExtension);
+
         $hash = Str::random(40);
         $tmpName = $extension ? "{$hash}.{$extension}" : $hash;
 
-        $sourceRelative = FileUploadConfiguration::path("chunks/{$transferId}/data");
-        $destRelative = FileUploadConfiguration::path($tmpName);
-        $metaRelative = FileUploadConfiguration::path($tmpName . '.json');
-        $chunkDirRelative = FileUploadConfiguration::path("chunks/{$transferId}");
+        $chunkDir = FileUploadConfiguration::path("chunks/{$transferId}");
+        $sourcePath = "{$chunkDir}/data";
+        $destPath = FileUploadConfiguration::path($tmpName);
 
         // Move the assembled file into livewire-tmp
-        $storage->move($sourceRelative, $destRelative);
+        $storage->move($sourcePath, $destPath);
 
-        // Run validation against the configured rules. We construct an
-        // UploadedFile pointing at the assembled file so Laravel can apply
-        // mime/size rules just like a normal upload would.
-        $assembledPath = $storage->path($destRelative);
+        // Validate the assembled file against the configured rules. We use the
+        // same `files.0` key as FileUploadController so _uploadErrored's
+        // str_replace('files.0', $name, ...) translation works.
         $uploadedFile = new UploadedFile(
-            $assembledPath,
+            $storage->path($destPath),
             $originalName,
-            null, // mime — let Laravel detect from contents
-            null, // error
-            true, // test mode — bypass is_uploaded_file() check
+            null, null,
+            test: true,
         );
 
         $validator = Validator::make(
-            ['file' => $uploadedFile],
-            ['file' => FileUploadConfiguration::rules()],
+            ['files' => [$uploadedFile]],
+            ['files.0' => FileUploadConfiguration::rules()],
         );
 
         if ($validator->fails()) {
-            // Clean up everything we created so we don't leak storage on failed validation
-            $storage->delete($destRelative);
-            $storage->deleteDirectory($chunkDirRelative);
+            $storage->delete($destPath);
+            $storage->deleteDirectory($chunkDir);
 
-            return response()->json([
-                'message' => 'The given data was invalid.',
-                'errors' => collect($validator->errors()->toArray())
-                    ->mapWithKeys(fn ($messages, $key) => ['files.0' => $messages])
-                    ->all(),
-            ], 422);
+            throw new ValidationException($validator);
         }
 
-        // Validation passed — write the meta file and clean up the chunks dir
-        $storage->put($metaRelative, json_encode([
+        $storage->put(FileUploadConfiguration::path($tmpName . '.json'), json_encode([
             'name' => $originalName,
             'type' => $uploadedFile->getMimeType(),
             'size' => $uploadedFile->getSize(),
             'hash' => $tmpName,
         ]));
 
-        $storage->deleteDirectory($chunkDirRelative);
+        $storage->deleteDirectory($chunkDir);
 
         return TemporaryUploadedFile::signPath($tmpName);
     }

--- a/src/Features/SupportFileUploads/ChunkedUploadController.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadController.php
@@ -223,8 +223,14 @@ class ChunkedUploadController implements HasMiddleware
         // `p$h$p` into a real one like `php`, which would be more permissive
         // than the legacy single-request path and could surprise frontend
         // filters that allow/deny based on the literal client extension.
+        // Also drop any extension long enough that `{40-char hash}.{extension}`
+        // would exceed the 255-byte filename limit on common filesystems —
+        // otherwise the rename below fails noisily with a 500 and leaves an
+        // orphan chunks/<id>/data file behind.
         $rawExtension = pathinfo($originalName, PATHINFO_EXTENSION);
-        $extension = preg_match('/^[A-Za-z0-9]+$/', $rawExtension) ? $rawExtension : '';
+        $extension = (preg_match('/^[A-Za-z0-9]+$/', $rawExtension) && strlen($rawExtension) <= 200)
+            ? $rawExtension
+            : '';
 
         $hash = Str::random(40);
         $tmpName = $extension ? "{$hash}.{$extension}" : $hash;

--- a/src/Features/SupportFileUploads/ChunkedUploadController.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadController.php
@@ -3,9 +3,11 @@
 namespace Livewire\Features\SupportFileUploads;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Controllers\Middleware;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 
 class ChunkedUploadController implements HasMiddleware
@@ -14,7 +16,7 @@ class ChunkedUploadController implements HasMiddleware
 
     public static function middleware()
     {
-        $middleware = (array) FileUploadConfiguration::middleware();
+        $middleware = (array) FileUploadConfiguration::chunkMiddleware();
 
         foreach (array_reverse(static::$defaultMiddleware) as $defaultMiddleware) {
             if (! in_array($defaultMiddleware, $middleware)) {
@@ -29,64 +31,154 @@ class ChunkedUploadController implements HasMiddleware
     {
         abort_unless($request->hasValidSignature(), 401);
 
+        // Refuse to handle chunked uploads on disks that don't support
+        // direct file system access (e.g., S3). The trait should already
+        // prevent this from being called, but be defensive.
+        if (FileUploadConfiguration::isUsingS3()) {
+            abort(400, 'Chunked uploads are not supported on the S3 disk.');
+        }
+
         $totalSize = (int) $request->header('Upload-Length');
+
+        if ($totalSize <= 0) {
+            abort(400, 'Upload-Length header must be a positive integer.');
+        }
+
+        // Reject uploads that exceed the configured max size up front so we
+        // never commit storage for an upload we know we'll reject later.
+        $maxBytes = FileUploadConfiguration::maxUploadSizeInBytes();
+        if ($maxBytes !== null && $totalSize > $maxBytes) {
+            abort(413, "Upload-Length ({$totalSize} bytes) exceeds the maximum allowed size ({$maxBytes} bytes).");
+        }
+
+        $name = $this->decodeUploadName($request->header('Upload-Name', ''));
         $transferId = Str::random(40);
 
         $storage = FileUploadConfiguration::storage();
-        $dir = FileUploadConfiguration::path("chunks/{$transferId}");
-
-        $storage->put("{$dir}/manifest.json", json_encode([
+        $manifestRelative = "chunks/{$transferId}/manifest.json";
+        $storage->put(FileUploadConfiguration::path($manifestRelative), json_encode([
             'size' => $totalSize,
             'offset' => 0,
-            'name' => $request->header('Upload-Name', 'unknown'),
+            'name' => $name,
             'created_at' => now()->timestamp,
         ]));
 
-        $expiry = now()->addDay();
+        $expiry = now()->addMinutes(FileUploadConfiguration::chunkMaxUploadTime());
 
         return response()->json([
             'transferId' => $transferId,
-            'patchUrl' => URL::signedRoute('livewire.chunk-upload-patch', ['transferId' => $transferId], $expiry),
-            'offsetUrl' => URL::signedRoute('livewire.chunk-upload-offset', ['transferId' => $transferId], $expiry),
+            'patchUrl' => URL::temporarySignedRoute(
+                'livewire.chunk-upload-patch',
+                $expiry,
+                ['transferId' => $transferId],
+            ),
+            'offsetUrl' => URL::temporarySignedRoute(
+                'livewire.chunk-upload-offset',
+                $expiry,
+                ['transferId' => $transferId],
+            ),
         ]);
     }
 
     public function patch(Request $request, string $transferId)
     {
         abort_unless($request->hasValidSignature(), 401);
+        $this->assertValidTransferId($transferId);
 
         $storage = FileUploadConfiguration::storage();
-        $dir = FileUploadConfiguration::path("chunks/{$transferId}");
+        $manifestRelative = FileUploadConfiguration::path("chunks/{$transferId}/manifest.json");
+        $dataRelative = FileUploadConfiguration::path("chunks/{$transferId}/data");
 
-        abort_unless($storage->exists("{$dir}/manifest.json"), 404);
-
-        $manifest = json_decode($storage->get("{$dir}/manifest.json"), true);
-        $clientOffset = (int) $request->header('Upload-Offset');
-
-        abort_if($clientOffset !== $manifest['offset'], 409);
-
-        $chunkPath = "{$dir}/data";
-        $content = $request->getContent();
-        $bytesWritten = strlen($content);
-
-        if ($manifest['offset'] === 0) {
-            $storage->put($chunkPath, $content);
-        } else {
-            $storage->append($chunkPath, $content);
+        if (! $storage->exists($manifestRelative)) {
+            abort(404);
         }
 
-        $newOffset = $manifest['offset'] + $bytesWritten;
-        $manifest['offset'] = $newOffset;
-        $storage->put("{$dir}/manifest.json", json_encode($manifest));
+        $clientOffset = (int) $request->header('Upload-Offset');
+        $content = $request->getContent();
+        $bytesIncoming = strlen($content);
+
+        // Reject obviously bad chunk sizes up front
+        $chunkSize = FileUploadConfiguration::chunkSize();
+        if ($chunkSize !== null && $bytesIncoming > $chunkSize) {
+            abort(413, "Chunk size ({$bytesIncoming} bytes) exceeds configured chunk_size ({$chunkSize} bytes).");
+        }
+
+        // Atomically read manifest, validate offset, write chunk, update manifest.
+        // Holding the lock for the whole operation prevents race conditions on
+        // concurrent PATCHes for the same transfer (which the JS shouldn't do,
+        // but defensive coding matters).
+        $manifestPath = $storage->path($manifestRelative);
+        $dataPath = $storage->path($dataRelative);
+
+        $fp = fopen($manifestPath, 'c+');
+        if ($fp === false) {
+            abort(500, 'Could not open upload manifest.');
+        }
+
+        try {
+            if (! flock($fp, LOCK_EX)) {
+                abort(500, 'Could not lock upload manifest.');
+            }
+
+            $rawManifest = stream_get_contents($fp);
+            $manifest = json_decode($rawManifest, true);
+
+            if (! is_array($manifest) || ! isset($manifest['size'], $manifest['offset'])) {
+                abort(500, 'Upload manifest is corrupt.');
+            }
+
+            // Offset mismatch — client and server disagree about where we are
+            if ($clientOffset !== (int) $manifest['offset']) {
+                abort(409);
+            }
+
+            // Refuse to write more bytes than we said we'd accept
+            if (($manifest['offset'] + $bytesIncoming) > $manifest['size']) {
+                abort(413, 'Chunk would exceed declared upload length.');
+            }
+
+            // Append the chunk to the data file
+            $dataFp = fopen($dataPath, 'ab');
+            if ($dataFp === false) {
+                abort(500, 'Could not open upload data file.');
+            }
+
+            $written = fwrite($dataFp, $content);
+            fclose($dataFp);
+
+            if ($written !== $bytesIncoming) {
+                abort(500, 'Failed to write full chunk to disk.');
+            }
+
+            $manifest['offset'] += $bytesIncoming;
+
+            // Write the updated manifest back atomically
+            ftruncate($fp, 0);
+            rewind($fp);
+            fwrite($fp, json_encode($manifest));
+            fflush($fp);
+
+            $newOffset = $manifest['offset'];
+            $isComplete = $newOffset >= $manifest['size'];
+        } finally {
+            flock($fp, LOCK_UN);
+            fclose($fp);
+        }
 
         $headers = [
             'Upload-Offset' => $newOffset,
         ];
 
-        if ($newOffset >= $manifest['size']) {
-            $finalPath = $this->finalizeUpload($transferId, $dir, $storage, $manifest);
+        if ($isComplete) {
+            $result = $this->finalizeUpload($transferId, $manifest, $storage);
+
+            if ($result instanceof \Symfony\Component\HttpFoundation\Response) {
+                // Validation failed — return the response directly
+                return $result;
+            }
+
             $headers['Upload-Complete'] = 'true';
-            $headers['X-Signed-Path'] = $finalPath;
+            $headers['X-Signed-Path'] = $result;
         }
 
         return response('', 204, $headers);
@@ -95,34 +187,114 @@ class ChunkedUploadController implements HasMiddleware
     public function offset(Request $request, string $transferId)
     {
         abort_unless($request->hasValidSignature(), 401);
+        $this->assertValidTransferId($transferId);
 
         $storage = FileUploadConfiguration::storage();
-        $dir = FileUploadConfiguration::path("chunks/{$transferId}");
+        $manifestRelative = FileUploadConfiguration::path("chunks/{$transferId}/manifest.json");
 
-        abort_unless($storage->exists("{$dir}/manifest.json"), 404);
+        if (! $storage->exists($manifestRelative)) {
+            abort(404);
+        }
 
-        $manifest = json_decode($storage->get("{$dir}/manifest.json"), true);
+        $manifest = json_decode($storage->get($manifestRelative), true);
 
         return response()->json([
-            'offset' => $manifest['offset'],
-            'size' => $manifest['size'],
+            'offset' => (int) ($manifest['offset'] ?? 0),
+            'size' => (int) ($manifest['size'] ?? 0),
+        ], 200, [
+            'Cache-Control' => 'no-store',
         ]);
     }
 
-    protected function finalizeUpload($transferId, $dir, $storage, $manifest)
+    /**
+     * Move the assembled chunks to a temporary upload file, validate it
+     * against the configured rules, and return a signed path.
+     *
+     * Returns a Symfony Response on validation failure (so the caller can
+     * return it directly), or a string signed path on success.
+     */
+    protected function finalizeUpload(string $transferId, array $manifest, $storage)
     {
-        $extension = pathinfo($manifest['name'], PATHINFO_EXTENSION);
-        $tmpName = Str::random(40) . ($extension ? ".{$extension}" : '');
-        $finalPath = FileUploadConfiguration::path($tmpName);
+        $originalName = $manifest['name'] ?? 'unknown';
+        $extension = pathinfo($originalName, PATHINFO_EXTENSION);
 
-        $storage->move("{$dir}/data", $finalPath);
+        // Match the existing temp filename convention used by FileUploadConfiguration::storeTemporaryFile
+        $hash = Str::random(40);
+        $tmpName = $extension ? "{$hash}.{$extension}" : $hash;
 
-        $storage->put("{$finalPath}.json", json_encode([
-            'name' => $manifest['name'],
+        $sourceRelative = FileUploadConfiguration::path("chunks/{$transferId}/data");
+        $destRelative = FileUploadConfiguration::path($tmpName);
+        $metaRelative = FileUploadConfiguration::path($tmpName . '.json');
+        $chunkDirRelative = FileUploadConfiguration::path("chunks/{$transferId}");
+
+        // Move the assembled file into livewire-tmp
+        $storage->move($sourceRelative, $destRelative);
+
+        // Run validation against the configured rules. We construct an
+        // UploadedFile pointing at the assembled file so Laravel can apply
+        // mime/size rules just like a normal upload would.
+        $assembledPath = $storage->path($destRelative);
+        $uploadedFile = new UploadedFile(
+            $assembledPath,
+            $originalName,
+            null, // mime — let Laravel detect from contents
+            null, // error
+            true, // test mode — bypass is_uploaded_file() check
+        );
+
+        $validator = Validator::make(
+            ['file' => $uploadedFile],
+            ['file' => FileUploadConfiguration::rules()],
+        );
+
+        if ($validator->fails()) {
+            // Clean up everything we created so we don't leak storage on failed validation
+            $storage->delete($destRelative);
+            $storage->deleteDirectory($chunkDirRelative);
+
+            return response()->json([
+                'message' => 'The given data was invalid.',
+                'errors' => collect($validator->errors()->toArray())
+                    ->mapWithKeys(fn ($messages, $key) => ['files.0' => $messages])
+                    ->all(),
+            ], 422);
+        }
+
+        // Validation passed — write the meta file and clean up the chunks dir
+        $storage->put($metaRelative, json_encode([
+            'name' => $originalName,
+            'type' => $uploadedFile->getMimeType(),
+            'size' => $uploadedFile->getSize(),
+            'hash' => $tmpName,
         ]));
 
-        $storage->deleteDirectory($dir);
+        $storage->deleteDirectory($chunkDirRelative);
 
         return TemporaryUploadedFile::signPath($tmpName);
+    }
+
+    /**
+     * Defensive check that the transfer ID matches our expected format
+     * (40 alphanumeric chars from Str::random). Prevents any path-traversal
+     * weirdness even though Laravel's router should already block it.
+     */
+    protected function assertValidTransferId(string $transferId): void
+    {
+        if (! preg_match('/^[A-Za-z0-9]{40}$/', $transferId)) {
+            abort(400, 'Invalid transfer ID format.');
+        }
+    }
+
+    /**
+     * The Upload-Name header is base64-encoded by the JS client to avoid
+     * InvalidCharacterError on filenames containing non-ASCII characters.
+     */
+    protected function decodeUploadName(string $encoded): string
+    {
+        if ($encoded === '') return 'unknown';
+
+        $decoded = base64_decode($encoded, true);
+
+        return $decoded === false ? 'unknown' : $decoded;
     }
 }

--- a/src/Features/SupportFileUploads/ChunkedUploadTest.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadTest.php
@@ -510,6 +510,25 @@ class ChunkedUploadTest extends \Tests\TestCase
         $this->assertMatchesRegularExpression('/^[A-Za-z0-9]{40}$/', $tmpFilename);
     }
 
+    public function test_finalize_drops_pathologically_long_extension()
+    {
+        // A 40-char hash plus a 240-char extension exceeds the 255-byte
+        // filename limit on common filesystems (ext4, APFS, NTFS). Without
+        // a length cap the move() call fails silently and the next line
+        // throws FileNotFoundException → 500, leaving an orphan
+        // chunks/<id>/data file behind. Drop the extension to prevent that.
+        $longExtension = str_repeat('p', 240);
+        $body = $this->initUpload(1024, "evil.{$longExtension}");
+        $response = $this->sendChunk($body['patchUrl'], 0, str_repeat('A', 1024));
+
+        $response->assertNoContent();
+        $signedPath = $response->headers->get('X-Signed-Path');
+        $tmpFilename = TemporaryUploadedFile::extractPathFromSignedPath($signedPath);
+
+        // Extension dropped — just the hash.
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9]{40}$/', $tmpFilename);
+    }
+
     public function test_multiple_concurrent_uploads_dont_interfere()
     {
         $body1 = $this->initUpload(1024, 'file1.txt');

--- a/src/Features/SupportFileUploads/ChunkedUploadTest.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadTest.php
@@ -462,20 +462,52 @@ class ChunkedUploadTest extends \Tests\TestCase
         Storage::disk('avatars')->assertExists('final.jpg');
     }
 
-    public function test_finalize_sanitizes_filename_extension()
+    public function test_finalize_drops_tampered_extension_entirely()
     {
-        // A nasty filename. The extension after pathinfo is "php\x00.txt" or
-        // similar weirdness — we should strip everything that's not alphanumeric.
-        $weirdName = "evil.p\$h\$p"; // dollar signs in extension
-        $body = $this->initUpload(1024, $weirdName);
+        // A tampered extension like `p$h$p` must be DROPPED entirely, not
+        // collapsed into the alphanumeric chars (`php`). Otherwise the chunked
+        // path would silently turn a frontend-blocked `.p$h$p` upload into a
+        // `.php` file on disk — strictly more permissive than the legacy
+        // single-request path and a frontend-filter bypass.
+        $body = $this->initUpload(1024, "evil.p\$h\$p");
         $response = $this->sendChunk($body['patchUrl'], 0, str_repeat('A', 1024));
 
         $response->assertNoContent();
         $signedPath = $response->headers->get('X-Signed-Path');
         $tmpFilename = TemporaryUploadedFile::extractPathFromSignedPath($signedPath);
 
-        // The extension should be only alphanumeric characters
-        $this->assertMatchesRegularExpression('/^[A-Za-z0-9]{40}(\.[A-Za-z0-9]+)?$/', $tmpFilename);
+        // No extension at all — just the 40-char hash.
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9]{40}$/', $tmpFilename);
+    }
+
+    public function test_finalize_preserves_safe_alphanumeric_extension()
+    {
+        // The complement to the test above: a clean alphanumeric extension
+        // passes through unchanged so downstream `->store()` calls produce
+        // a file with the expected extension. Documents the rule:
+        // alphanumeric → kept, anything else → dropped.
+        $body = $this->initUpload(1024, 'photo.JPG');
+        $response = $this->sendChunk($body['patchUrl'], 0, str_repeat('A', 1024));
+
+        $response->assertNoContent();
+        $signedPath = $response->headers->get('X-Signed-Path');
+        $tmpFilename = TemporaryUploadedFile::extractPathFromSignedPath($signedPath);
+
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9]{40}\.JPG$/', $tmpFilename);
+    }
+
+    public function test_finalize_drops_extension_containing_unicode()
+    {
+        // Non-ASCII extensions also fall outside the [A-Za-z0-9] allow-list
+        // and should be dropped entirely rather than partially preserved.
+        $body = $this->initUpload(1024, 'photo.café');
+        $response = $this->sendChunk($body['patchUrl'], 0, str_repeat('A', 1024));
+
+        $response->assertNoContent();
+        $signedPath = $response->headers->get('X-Signed-Path');
+        $tmpFilename = TemporaryUploadedFile::extractPathFromSignedPath($signedPath);
+
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9]{40}$/', $tmpFilename);
     }
 
     public function test_multiple_concurrent_uploads_dont_interfere()

--- a/src/Features/SupportFileUploads/ChunkedUploadTest.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadTest.php
@@ -48,6 +48,7 @@ class ChunkedUploadTest extends \Tests\TestCase
     protected function initUpload(int $size, string $name = 'test.txt'): array
     {
         $response = $this->post($this->signedInitUrl(), [], [
+            'Accept' => 'application/json',
             'Upload-Length' => $size,
             'Upload-Name' => base64_encode($name),
         ]);
@@ -60,14 +61,17 @@ class ChunkedUploadTest extends \Tests\TestCase
     /** Helper: send a chunk */
     protected function sendChunk(string $patchUrl, int $offset, string $content)
     {
-        // The HTTP test framework needs the body sent as raw content.
         return $this->call(
             'PATCH',
             $patchUrl,
             [],
             [],
             [],
-            ['HTTP_UPLOAD_OFFSET' => $offset, 'CONTENT_TYPE' => 'application/offset+octet-stream'],
+            [
+                'HTTP_ACCEPT' => 'application/json',
+                'HTTP_UPLOAD_OFFSET' => $offset,
+                'CONTENT_TYPE' => 'application/offset+octet-stream',
+            ],
             $content,
         );
     }
@@ -391,6 +395,71 @@ class ChunkedUploadTest extends \Tests\TestCase
 
         config()->set('livewire.temporary_file_upload.rules', ['file']);
         $this->assertNull(FileUploadConfiguration::maxUploadSizeInBytes());
+    }
+
+    public function test_init_enforces_absolute_max_when_no_rule_max_is_set()
+    {
+        // No max rule — falls back to chunk_absolute_max_bytes
+        config()->set('livewire.temporary_file_upload.rules', ['file']);
+        config()->set('livewire.temporary_file_upload.chunk_absolute_max_bytes', 1024);
+
+        $response = $this->post($this->signedInitUrl(), [], [
+            'Upload-Length' => 2048,
+        ]);
+        $response->assertStatus(413);
+    }
+
+    public function test_init_allows_uploads_under_absolute_max()
+    {
+        config()->set('livewire.temporary_file_upload.rules', ['file']);
+        config()->set('livewire.temporary_file_upload.chunk_absolute_max_bytes', 10 * 1024);
+
+        $response = $this->post($this->signedInitUrl(), [], [
+            'Upload-Length' => 2048,
+        ]);
+        $response->assertOk();
+    }
+
+    public function test_chunked_upload_ends_up_as_temporary_uploaded_file_on_component()
+    {
+        // This is the closed-loop test: walk the chunks through real HTTP
+        // endpoints, then hand the resulting signed path to _finishUpload
+        // (the same way the JS client would) and verify the component property
+        // ends up holding a real TemporaryUploadedFile that .store()s correctly.
+        Storage::fake('avatars');
+
+        $body = $this->initUpload(1024, 'real-photo.jpg');
+        $response = $this->sendChunk($body['patchUrl'], 0, str_repeat('A', 1024));
+        $response->assertNoContent();
+        $signedPath = $response->headers->get('X-Signed-Path');
+
+        $component = \Livewire\Livewire::test(ChunkedUploadComponent::class)
+            ->call('_finishUpload', 'photo', [$signedPath], false);
+
+        $tmpFile = $component->viewData('photo');
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $tmpFile);
+        $this->assertEquals('real-photo.jpg', $tmpFile->getClientOriginalName());
+        $this->assertEquals(1024, $tmpFile->getSize());
+
+        // Storing the file should work end-to-end
+        $tmpFile->storeAs('/', 'final.jpg', $disk = 'avatars');
+        Storage::disk('avatars')->assertExists('final.jpg');
+    }
+
+    public function test_finalize_sanitizes_filename_extension()
+    {
+        // A nasty filename. The extension after pathinfo is "php\x00.txt" or
+        // similar weirdness — we should strip everything that's not alphanumeric.
+        $weirdName = "evil.p\$h\$p"; // dollar signs in extension
+        $body = $this->initUpload(1024, $weirdName);
+        $response = $this->sendChunk($body['patchUrl'], 0, str_repeat('A', 1024));
+
+        $response->assertNoContent();
+        $signedPath = $response->headers->get('X-Signed-Path');
+        $tmpFilename = TemporaryUploadedFile::extractPathFromSignedPath($signedPath);
+
+        // The extension should be only alphanumeric characters
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9]{40}(\.[A-Za-z0-9]+)?$/', $tmpFilename);
     }
 
     public function test_multiple_concurrent_uploads_dont_interfere()

--- a/src/Features/SupportFileUploads/ChunkedUploadTest.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadTest.php
@@ -1,0 +1,465 @@
+<?php
+
+namespace Livewire\Features\SupportFileUploads;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+
+class ChunkedUploadTest extends \Tests\TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Use the unit test temporary disk so we have a real local filesystem
+        // to write chunks to (Storage::fake() also works because flock and
+        // file paths still resolve to a real local directory).
+        Storage::fake('tmp-for-tests');
+
+        config()->set('livewire.temporary_file_upload.chunk_size', 1024); // 1KB for fast tests
+        config()->set('livewire.temporary_file_upload.chunk_max_upload_time', 60);
+        config()->set('livewire.temporary_file_upload.rules', ['required', 'file', 'max:100']); // 100KB max
+    }
+
+    public function tearDown(): void
+    {
+        // Each test runs many requests against the chunk endpoints. Without
+        // clearing the rate limiter we'd pollute the global throttle:600,1
+        // bucket and break other test files (like UnitTest's middleware tests)
+        // when running the full suite.
+        RateLimiter::clear('600|1|127.0.0.1');
+        RateLimiter::clear('60|1|127.0.0.1');
+
+        parent::tearDown();
+    }
+
+    /** Helper: get a signed init URL */
+    protected function signedInitUrl(): string
+    {
+        return URL::temporarySignedRoute(
+            'livewire.chunk-upload-init',
+            now()->addMinutes(60),
+        );
+    }
+
+    /** Helper: hit init and return decoded JSON */
+    protected function initUpload(int $size, string $name = 'test.txt'): array
+    {
+        $response = $this->post($this->signedInitUrl(), [], [
+            'Upload-Length' => $size,
+            'Upload-Name' => base64_encode($name),
+        ]);
+
+        $response->assertOk();
+
+        return $response->json();
+    }
+
+    /** Helper: send a chunk */
+    protected function sendChunk(string $patchUrl, int $offset, string $content)
+    {
+        // The HTTP test framework needs the body sent as raw content.
+        return $this->call(
+            'PATCH',
+            $patchUrl,
+            [],
+            [],
+            [],
+            ['HTTP_UPLOAD_OFFSET' => $offset, 'CONTENT_TYPE' => 'application/offset+octet-stream'],
+            $content,
+        );
+    }
+
+    public function test_init_returns_transfer_id_and_signed_urls()
+    {
+        $response = $this->post($this->signedInitUrl(), [], [
+            'Upload-Length' => 5000,
+            'Upload-Name' => base64_encode('photo.jpg'),
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonStructure(['transferId', 'patchUrl', 'offsetUrl']);
+
+        $body = $response->json();
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9]{40}$/', $body['transferId']);
+        $this->assertStringContainsString('chunk-upload', $body['patchUrl']);
+        $this->assertStringContainsString('chunk-upload', $body['offsetUrl']);
+        $this->assertStringContainsString('signature=', $body['patchUrl']);
+        $this->assertStringContainsString('signature=', $body['offsetUrl']);
+    }
+
+    public function test_init_rejects_unsigned_request()
+    {
+        $unsigned = route('livewire.chunk-upload-init');
+        $response = $this->post($unsigned, [], ['Upload-Length' => 5000]);
+        $response->assertStatus(401);
+    }
+
+    public function test_init_rejects_zero_or_negative_size()
+    {
+        $response = $this->post($this->signedInitUrl(), [], ['Upload-Length' => 0]);
+        $response->assertStatus(400);
+    }
+
+    public function test_init_rejects_size_exceeding_configured_max()
+    {
+        // 100KB max → reject 200KB upload
+        $response = $this->post($this->signedInitUrl(), [], [
+            'Upload-Length' => 200 * 1024,
+        ]);
+        $response->assertStatus(413);
+    }
+
+    public function test_init_creates_manifest_file()
+    {
+        $body = $this->initUpload(5000, 'photo.jpg');
+
+        $manifestPath = FileUploadConfiguration::path("chunks/{$body['transferId']}/manifest.json");
+        $this->assertTrue(Storage::disk('tmp-for-tests')->exists($manifestPath));
+
+        $manifest = json_decode(Storage::disk('tmp-for-tests')->get($manifestPath), true);
+        $this->assertEquals(5000, $manifest['size']);
+        $this->assertEquals(0, $manifest['offset']);
+        $this->assertEquals('photo.jpg', $manifest['name']);
+    }
+
+    public function test_full_upload_flow_assembles_file_correctly()
+    {
+        // Create a 3KB body that we'll send as 3 × 1KB chunks
+        $totalContent = str_repeat('A', 1024) . str_repeat('B', 1024) . str_repeat('C', 1024);
+        $body = $this->initUpload(strlen($totalContent), 'test.txt');
+
+        // Send chunk 1
+        $response = $this->sendChunk($body['patchUrl'], 0, substr($totalContent, 0, 1024));
+        $response->assertNoContent();
+        $this->assertEquals(1024, $response->headers->get('Upload-Offset'));
+
+        // Send chunk 2
+        $response = $this->sendChunk($body['patchUrl'], 1024, substr($totalContent, 1024, 1024));
+        $response->assertNoContent();
+        $this->assertEquals(2048, $response->headers->get('Upload-Offset'));
+
+        // Send chunk 3 (final)
+        $response = $this->sendChunk($body['patchUrl'], 2048, substr($totalContent, 2048, 1024));
+        $response->assertNoContent();
+        $this->assertEquals(3072, $response->headers->get('Upload-Offset'));
+        $this->assertEquals('true', $response->headers->get('Upload-Complete'));
+
+        $signedPath = $response->headers->get('X-Signed-Path');
+        $this->assertNotNull($signedPath);
+
+        // Extract the actual filename from the signed path and verify the assembled file matches
+        $tmpFilename = TemporaryUploadedFile::extractPathFromSignedPath($signedPath);
+        $assembledPath = FileUploadConfiguration::path($tmpFilename);
+
+        $this->assertTrue(Storage::disk('tmp-for-tests')->exists($assembledPath));
+        $this->assertEquals($totalContent, Storage::disk('tmp-for-tests')->get($assembledPath));
+
+        // Chunk directory should be cleaned up
+        $chunkDir = FileUploadConfiguration::path("chunks/{$body['transferId']}");
+        $this->assertFalse(Storage::disk('tmp-for-tests')->exists("{$chunkDir}/manifest.json"));
+    }
+
+    public function test_patch_rejects_unsigned_request()
+    {
+        $body = $this->initUpload(1024);
+        $unsigned = route('livewire.chunk-upload-patch', ['transferId' => $body['transferId']]);
+
+        $response = $this->call(
+            'PATCH', $unsigned, [], [], [],
+            ['HTTP_UPLOAD_OFFSET' => 0, 'CONTENT_TYPE' => 'application/offset+octet-stream'],
+            'data',
+        );
+        $response->assertStatus(401);
+    }
+
+    public function test_patch_rejects_offset_mismatch()
+    {
+        $body = $this->initUpload(1024);
+
+        // Wrong offset
+        $response = $this->sendChunk($body['patchUrl'], 500, 'data');
+        $response->assertStatus(409);
+    }
+
+    public function test_patch_rejects_chunk_larger_than_chunk_size()
+    {
+        // chunk_size is 1024 in setUp, send 2KB
+        $body = $this->initUpload(5000);
+
+        $response = $this->sendChunk($body['patchUrl'], 0, str_repeat('X', 2048));
+        $response->assertStatus(413);
+    }
+
+    public function test_patch_rejects_chunk_that_would_exceed_declared_size()
+    {
+        // Declared size 1500, but we'd send 1024 + 1024 = 2048
+        $body = $this->initUpload(1500);
+
+        $this->sendChunk($body['patchUrl'], 0, str_repeat('X', 1024))->assertNoContent();
+        // Second chunk would push us over 1500
+        $this->sendChunk($body['patchUrl'], 1024, str_repeat('X', 1024))->assertStatus(413);
+    }
+
+    public function test_patch_rejects_invalid_transfer_id_format()
+    {
+        $signedUrl = URL::temporarySignedRoute(
+            'livewire.chunk-upload-patch',
+            now()->addMinutes(60),
+            ['transferId' => 'short'],
+        );
+
+        $response = $this->call(
+            'PATCH', $signedUrl, [], [], [],
+            ['HTTP_UPLOAD_OFFSET' => 0, 'CONTENT_TYPE' => 'application/offset+octet-stream'],
+            'data',
+        );
+        $response->assertStatus(400);
+    }
+
+    public function test_patch_returns_404_for_unknown_transfer_id()
+    {
+        $fakeId = str_repeat('a', 40);
+        $signedUrl = URL::temporarySignedRoute(
+            'livewire.chunk-upload-patch',
+            now()->addMinutes(60),
+            ['transferId' => $fakeId],
+        );
+
+        $response = $this->call(
+            'PATCH', $signedUrl, [], [], [],
+            ['HTTP_UPLOAD_OFFSET' => 0, 'CONTENT_TYPE' => 'application/offset+octet-stream'],
+            'data',
+        );
+        $response->assertStatus(404);
+    }
+
+    public function test_offset_endpoint_returns_current_progress()
+    {
+        $body = $this->initUpload(3000);
+
+        // Initially offset is 0
+        $offsetResponse = $this->get($body['offsetUrl']);
+        $offsetResponse->assertOk();
+        $this->assertEquals(['offset' => 0, 'size' => 3000], $offsetResponse->json());
+
+        // Send a 1KB chunk
+        $this->sendChunk($body['patchUrl'], 0, str_repeat('X', 1024))->assertNoContent();
+
+        // Offset should now be 1024
+        $offsetResponse = $this->get($body['offsetUrl']);
+        $this->assertEquals(['offset' => 1024, 'size' => 3000], $offsetResponse->json());
+    }
+
+    public function test_offset_endpoint_returns_no_store_cache_header()
+    {
+        $body = $this->initUpload(1024);
+        $response = $this->get($body['offsetUrl']);
+
+        // Laravel's session middleware may append `private` to cache-control,
+        // so we just assert no-store is present (which is the directive that matters
+        // for resume correctness — browsers must not serve stale offset values).
+        $this->assertStringContainsString('no-store', $response->headers->get('Cache-Control'));
+    }
+
+    public function test_offset_endpoint_rejects_unsigned_request()
+    {
+        $body = $this->initUpload(1024);
+        $unsigned = route('livewire.chunk-upload-offset', ['transferId' => $body['transferId']]);
+
+        $this->get($unsigned)->assertStatus(401);
+    }
+
+    public function test_finalized_file_is_validated_against_global_rules()
+    {
+        // Require the file to be a JPEG image. The assembled file is plain text,
+        // so it will pass the size check but fail the mime check at finalize time.
+        config()->set('livewire.temporary_file_upload.rules', ['required', 'file', 'mimes:jpg', 'max:100']);
+        config()->set('livewire.temporary_file_upload.chunk_size', 1024);
+
+        $body = $this->initUpload(2048, 'big.txt');
+
+        $this->sendChunk($body['patchUrl'], 0, str_repeat('X', 1024))->assertNoContent();
+        $response = $this->sendChunk($body['patchUrl'], 1024, str_repeat('X', 1024));
+
+        // Final chunk should have triggered validation, which should fail (text file != jpeg)
+        $response->assertStatus(422);
+        $this->assertArrayHasKey('errors', $response->json());
+
+        // The assembled file should have been cleaned up
+        $chunkDir = FileUploadConfiguration::path("chunks/{$body['transferId']}");
+        $this->assertFalse(Storage::disk('tmp-for-tests')->exists("{$chunkDir}/manifest.json"));
+    }
+
+    public function test_finalized_file_validation_failure_cleans_up_assembled_file()
+    {
+        config()->set('livewire.temporary_file_upload.rules', ['required', 'file', 'mimes:jpg', 'max:100']);
+        config()->set('livewire.temporary_file_upload.chunk_size', 1024);
+
+        $body = $this->initUpload(1024, 'fake.txt');
+        $response = $this->sendChunk($body['patchUrl'], 0, str_repeat('X', 1024));
+
+        $response->assertStatus(422);
+
+        // Verify nothing was left in livewire-tmp/ for this transfer
+        $tmpFiles = Storage::disk('tmp-for-tests')->files(FileUploadConfiguration::path());
+        // Filter out the chunks directory itself
+        $tmpFiles = array_filter($tmpFiles, fn ($f) => ! str_contains($f, 'chunks/'));
+        $this->assertEmpty($tmpFiles, 'Failed validation should leave no orphaned files in livewire-tmp');
+    }
+
+    public function test_finalized_file_appears_in_livewire_tmp_when_validation_passes()
+    {
+        $body = $this->initUpload(1024, 'small.txt');
+        $response = $this->sendChunk($body['patchUrl'], 0, str_repeat('A', 1024));
+
+        $response->assertNoContent();
+        $signedPath = $response->headers->get('X-Signed-Path');
+
+        $tmpFilename = TemporaryUploadedFile::extractPathFromSignedPath($signedPath);
+        $this->assertTrue(Storage::disk('tmp-for-tests')->exists(FileUploadConfiguration::path($tmpFilename)));
+
+        // Meta file with original name should also exist
+        $this->assertTrue(Storage::disk('tmp-for-tests')->exists(FileUploadConfiguration::path($tmpFilename . '.json')));
+
+        $meta = json_decode(Storage::disk('tmp-for-tests')->get(FileUploadConfiguration::path($tmpFilename . '.json')), true);
+        $this->assertEquals('small.txt', $meta['name']);
+    }
+
+    public function test_resume_via_offset_endpoint_then_continue()
+    {
+        $body = $this->initUpload(3000);
+
+        // Send first chunk (1024 bytes)
+        $this->sendChunk($body['patchUrl'], 0, str_repeat('A', 1024))->assertNoContent();
+
+        // Simulate failure: client doesn't know server's offset, queries it
+        $offsetResp = $this->get($body['offsetUrl']);
+        $serverOffset = $offsetResp->json('offset');
+        $this->assertEquals(1024, $serverOffset);
+
+        // Resume from the server's offset
+        $this->sendChunk($body['patchUrl'], $serverOffset, str_repeat('B', 1024))->assertNoContent();
+
+        // Final chunk
+        $finalResp = $this->sendChunk($body['patchUrl'], 2048, str_repeat('C', 952));
+        $finalResp->assertNoContent();
+        $this->assertEquals('true', $finalResp->headers->get('Upload-Complete'));
+    }
+
+    public function test_filename_with_non_ascii_characters_is_decoded_correctly()
+    {
+        $unicodeName = 'café_文件_😀.txt';
+        $body = $this->initUpload(1024, $unicodeName);
+
+        $manifestPath = FileUploadConfiguration::path("chunks/{$body['transferId']}/manifest.json");
+        $manifest = json_decode(Storage::disk('tmp-for-tests')->get($manifestPath), true);
+        $this->assertEquals($unicodeName, $manifest['name']);
+    }
+
+    public function test_chunking_disabled_when_chunk_size_is_null()
+    {
+        config()->set('livewire.temporary_file_upload.chunk_size', null);
+
+        $this->assertFalse(FileUploadConfiguration::isChunkingEnabled());
+    }
+
+    public function test_chunking_disabled_when_using_s3()
+    {
+        config()->set('livewire.temporary_file_upload.chunk_size', 1024);
+        config()->set('livewire.temporary_file_upload.disk', 's3');
+        config()->set('filesystems.disks.s3.driver', 's3');
+
+        $this->assertFalse(FileUploadConfiguration::isChunkingEnabled());
+    }
+
+    public function test_chunk_routes_use_chunk_middleware()
+    {
+        config()->set('livewire.temporary_file_upload.chunk_middleware', 'throttle:custom-name');
+
+        $middleware = collect(ChunkedUploadController::middleware())->map->middleware->all();
+
+        $this->assertContains('throttle:custom-name', $middleware);
+    }
+
+    public function test_max_upload_size_is_extracted_from_rules()
+    {
+        config()->set('livewire.temporary_file_upload.rules', ['file', 'max:500']);
+        $this->assertEquals(500 * 1024, FileUploadConfiguration::maxUploadSizeInBytes());
+
+        config()->set('livewire.temporary_file_upload.rules', ['file']);
+        $this->assertNull(FileUploadConfiguration::maxUploadSizeInBytes());
+    }
+
+    public function test_multiple_concurrent_uploads_dont_interfere()
+    {
+        $body1 = $this->initUpload(1024, 'file1.txt');
+        $body2 = $this->initUpload(2048, 'file2.txt');
+
+        $this->assertNotEquals($body1['transferId'], $body2['transferId']);
+
+        // Send a chunk to upload 1
+        $this->sendChunk($body1['patchUrl'], 0, str_repeat('A', 1024))->assertNoContent();
+
+        // Upload 2 should still be at offset 0
+        $this->assertEquals(0, $this->get($body2['offsetUrl'])->json('offset'));
+
+        // Send chunks to upload 2
+        $this->sendChunk($body2['patchUrl'], 0, str_repeat('B', 1024))->assertNoContent();
+        $this->sendChunk($body2['patchUrl'], 1024, str_repeat('B', 1024))->assertNoContent();
+
+        // Both should have ended up assembled correctly without crossing wires
+    }
+
+    public function test_start_upload_does_not_pass_chunk_config_for_small_files()
+    {
+        config()->set('livewire.temporary_file_upload.chunk_size', 10 * 1024 * 1024); // 10MB
+
+        $component = \Livewire\Livewire::test(ChunkedUploadComponent::class);
+
+        // Manually trigger _startUpload with a small file
+        $component->call('_startUpload', 'photo', [['name' => 'tiny.txt', 'size' => 100, 'type' => 'text/plain']], false);
+
+        $component->assertDispatched('upload:generatedSignedUrl', function ($event, $payload) {
+            return $payload['chunkConfig'] === null;
+        });
+    }
+
+    public function test_start_upload_passes_chunk_config_for_large_files()
+    {
+        config()->set('livewire.temporary_file_upload.chunk_size', 1024); // 1KB
+
+        $component = \Livewire\Livewire::test(ChunkedUploadComponent::class);
+
+        $component->call('_startUpload', 'photo', [['name' => 'big.bin', 'size' => 5 * 1024, 'type' => 'application/octet-stream']], false);
+
+        $component->assertDispatched('upload:generatedSignedUrl', function ($event, $payload) {
+            return is_array($payload['chunkConfig'])
+                && $payload['chunkConfig']['chunkSize'] === 1024
+                && isset($payload['chunkConfig']['initUrl'])
+                && isset($payload['chunkConfig']['retryDelays']);
+        });
+    }
+
+    public function test_start_upload_skips_chunking_when_disabled()
+    {
+        config()->set('livewire.temporary_file_upload.chunk_size', null);
+
+        $component = \Livewire\Livewire::test(ChunkedUploadComponent::class);
+
+        $component->call('_startUpload', 'photo', [['name' => 'big.bin', 'size' => 100 * 1024 * 1024, 'type' => 'application/octet-stream']], false);
+
+        $component->assertDispatched('upload:generatedSignedUrl', function ($event, $payload) {
+            return $payload['chunkConfig'] === null;
+        });
+    }
+}
+
+class ChunkedUploadComponent extends \Tests\TestComponent
+{
+    use \Livewire\WithFileUploads;
+
+    public $photo;
+}

--- a/src/Features/SupportFileUploads/ChunkedUploadTest.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadTest.php
@@ -370,13 +370,29 @@ class ChunkedUploadTest extends \Tests\TestCase
         $this->assertFalse(FileUploadConfiguration::isChunkingEnabled());
     }
 
-    public function test_chunking_disabled_when_using_s3()
+    public function test_chunked_upload_with_s3_disk_throws_loudly()
     {
         config()->set('livewire.temporary_file_upload.chunk_size', 1024);
         config()->set('livewire.temporary_file_upload.disk', 's3');
         config()->set('filesystems.disks.s3.driver', 's3');
 
-        $this->assertFalse(FileUploadConfiguration::isChunkingEnabled());
+        $this->expectException(S3DoesntSupportChunkedUploads::class);
+
+        \Livewire\Livewire::test(ChunkedUploadComponent::class)
+            ->call('_startUpload', 'photo', [['name' => 'big.bin', 'size' => 5 * 1024, 'type' => 'application/octet-stream']], false);
+    }
+
+    public function test_s3_disk_without_chunking_works_as_normal()
+    {
+        // No chunk_size — S3 path should work fine
+        config()->set('livewire.temporary_file_upload.chunk_size', null);
+        config()->set('livewire.temporary_file_upload.disk', 's3');
+        config()->set('filesystems.disks.s3.driver', 's3');
+
+        $component = \Livewire\Livewire::test(ChunkedUploadComponent::class);
+        $component->call('_startUpload', 'photo', [['name' => 'photo.jpg', 'size' => 100, 'type' => 'image/jpeg']], false);
+
+        $component->assertDispatched('upload:generatedSignedUrlForS3');
     }
 
     public function test_chunk_routes_use_chunk_middleware()

--- a/src/Features/SupportFileUploads/ChunkedUploadUnitTest.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadUnitTest.php
@@ -19,8 +19,8 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
         // file paths still resolve to a real local directory).
         Storage::fake('tmp-for-tests');
 
-        config()->set('livewire.temporary_file_upload.chunk_size', 1024); // 1KB for fast tests
-        config()->set('livewire.temporary_file_upload.chunk_max_upload_time', 60);
+        config()->set('livewire.temporary_file_upload.chunk.size', 1024); // 1KB for fast tests
+        config()->set('livewire.temporary_file_upload.chunk.max_upload_time', 60);
         config()->set('livewire.temporary_file_upload.rules', ['required', 'file', 'max:100']); // 100KB max
 
         // Override the chunked-upload throttle to a NAMED rate limiter with
@@ -31,7 +31,7 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
         // A named limiter gets its own bucket key (`<sig>:test-chunk-uploads`),
         // so it can't collide with the legacy throttle bucket.
         RateLimiter::for('test-chunk-uploads', fn () => Limit::none());
-        config()->set('livewire.temporary_file_upload.chunk_middleware', 'throttle:test-chunk-uploads');
+        config()->set('livewire.temporary_file_upload.chunk.middleware', 'throttle:test-chunk-uploads');
     }
 
     /** Helper: get a signed init URL */
@@ -280,7 +280,7 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
         // Require the file to be a JPEG image. The assembled file is plain text,
         // so it will pass the size check but fail the mime check at finalize time.
         config()->set('livewire.temporary_file_upload.rules', ['required', 'file', 'mimes:jpg', 'max:100']);
-        config()->set('livewire.temporary_file_upload.chunk_size', 1024);
+        config()->set('livewire.temporary_file_upload.chunk.size', 1024);
 
         $body = $this->initUpload(2048, 'big.txt');
 
@@ -299,7 +299,7 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
     public function test_finalized_file_validation_failure_cleans_up_assembled_file()
     {
         config()->set('livewire.temporary_file_upload.rules', ['required', 'file', 'mimes:jpg', 'max:100']);
-        config()->set('livewire.temporary_file_upload.chunk_size', 1024);
+        config()->set('livewire.temporary_file_upload.chunk.size', 1024);
 
         $body = $this->initUpload(1024, 'fake.txt');
         $response = $this->sendChunk($body['patchUrl'], 0, str_repeat('X', 1024));
@@ -364,14 +364,14 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
 
     public function test_chunking_disabled_when_chunk_size_is_null()
     {
-        config()->set('livewire.temporary_file_upload.chunk_size', null);
+        config()->set('livewire.temporary_file_upload.chunk.size', null);
 
         $this->assertFalse(FileUploadConfiguration::isChunkingEnabled());
     }
 
     public function test_chunked_upload_with_s3_disk_throws_loudly()
     {
-        config()->set('livewire.temporary_file_upload.chunk_size', 1024);
+        config()->set('livewire.temporary_file_upload.chunk.size', 1024);
         config()->set('livewire.temporary_file_upload.disk', 's3');
         config()->set('filesystems.disks.s3.driver', 's3');
 
@@ -384,7 +384,7 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
     public function test_s3_disk_without_chunking_works_as_normal()
     {
         // No chunk_size — S3 path should work fine
-        config()->set('livewire.temporary_file_upload.chunk_size', null);
+        config()->set('livewire.temporary_file_upload.chunk.size', null);
         config()->set('livewire.temporary_file_upload.disk', 's3');
         config()->set('filesystems.disks.s3.driver', 's3');
 
@@ -396,7 +396,7 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
 
     public function test_chunk_routes_use_chunk_middleware()
     {
-        config()->set('livewire.temporary_file_upload.chunk_middleware', 'throttle:custom-name');
+        config()->set('livewire.temporary_file_upload.chunk.middleware', 'throttle:custom-name');
 
         $middleware = collect(ChunkedUploadController::middleware())->map->middleware->all();
 
@@ -416,7 +416,7 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
     {
         // No max rule — falls back to chunk_absolute_max_bytes
         config()->set('livewire.temporary_file_upload.rules', ['file']);
-        config()->set('livewire.temporary_file_upload.chunk_absolute_max_bytes', 1024);
+        config()->set('livewire.temporary_file_upload.chunk.absolute_max_bytes', 1024);
 
         $response = $this->post($this->signedInitUrl(), [], [
             'Upload-Length' => 2048,
@@ -427,7 +427,7 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
     public function test_init_allows_uploads_under_absolute_max()
     {
         config()->set('livewire.temporary_file_upload.rules', ['file']);
-        config()->set('livewire.temporary_file_upload.chunk_absolute_max_bytes', 10 * 1024);
+        config()->set('livewire.temporary_file_upload.chunk.absolute_max_bytes', 10 * 1024);
 
         $response = $this->post($this->signedInitUrl(), [], [
             'Upload-Length' => 2048,
@@ -550,7 +550,7 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
 
     public function test_start_upload_does_not_pass_chunk_config_for_small_files()
     {
-        config()->set('livewire.temporary_file_upload.chunk_size', 10 * 1024 * 1024); // 10MB
+        config()->set('livewire.temporary_file_upload.chunk.size', 10 * 1024 * 1024); // 10MB
 
         $component = \Livewire\Livewire::test(ChunkedUploadComponent::class);
 
@@ -564,7 +564,7 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
 
     public function test_start_upload_passes_chunk_config_for_large_files()
     {
-        config()->set('livewire.temporary_file_upload.chunk_size', 1024); // 1KB
+        config()->set('livewire.temporary_file_upload.chunk.size', 1024); // 1KB
 
         $component = \Livewire\Livewire::test(ChunkedUploadComponent::class);
 
@@ -580,7 +580,7 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
 
     public function test_start_upload_skips_chunking_when_disabled()
     {
-        config()->set('livewire.temporary_file_upload.chunk_size', null);
+        config()->set('livewire.temporary_file_upload.chunk.size', null);
 
         $component = \Livewire\Livewire::test(ChunkedUploadComponent::class);
 

--- a/src/Features/SupportFileUploads/ChunkedUploadUnitTest.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadUnitTest.php
@@ -19,6 +19,7 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
         // file paths still resolve to a real local directory).
         Storage::fake('tmp-for-tests');
 
+        config()->set('livewire.temporary_file_upload.chunk.enabled', true);
         config()->set('livewire.temporary_file_upload.chunk.size', 1024); // 1KB for fast tests
         config()->set('livewire.temporary_file_upload.chunk.max_upload_time', 60);
         config()->set('livewire.temporary_file_upload.rules', ['required', 'file', 'max:100']); // 100KB max
@@ -362,9 +363,9 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
         $this->assertEquals($unicodeName, $manifest['name']);
     }
 
-    public function test_chunking_disabled_when_chunk_size_is_null()
+    public function test_chunking_disabled_when_chunk_enabled_is_false()
     {
-        config()->set('livewire.temporary_file_upload.chunk.size', null);
+        config()->set('livewire.temporary_file_upload.chunk.enabled', false);
 
         $this->assertFalse(FileUploadConfiguration::isChunkingEnabled());
     }
@@ -383,8 +384,8 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
 
     public function test_s3_disk_without_chunking_works_as_normal()
     {
-        // No chunk_size — S3 path should work fine
-        config()->set('livewire.temporary_file_upload.chunk.size', null);
+        // Chunking disabled — S3 path should work fine
+        config()->set('livewire.temporary_file_upload.chunk.enabled', false);
         config()->set('livewire.temporary_file_upload.disk', 's3');
         config()->set('filesystems.disks.s3.driver', 's3');
 
@@ -580,7 +581,7 @@ class ChunkedUploadUnitTest extends \Tests\TestCase
 
     public function test_start_upload_skips_chunking_when_disabled()
     {
-        config()->set('livewire.temporary_file_upload.chunk.size', null);
+        config()->set('livewire.temporary_file_upload.chunk.enabled', false);
 
         $component = \Livewire\Livewire::test(ChunkedUploadComponent::class);
 

--- a/src/Features/SupportFileUploads/ChunkedUploadUnitTest.php
+++ b/src/Features/SupportFileUploads/ChunkedUploadUnitTest.php
@@ -2,12 +2,13 @@
 
 namespace Livewire\Features\SupportFileUploads;
 
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
 
-class ChunkedUploadTest extends \Tests\TestCase
+class ChunkedUploadUnitTest extends \Tests\TestCase
 {
     public function setUp(): void
     {
@@ -21,18 +22,16 @@ class ChunkedUploadTest extends \Tests\TestCase
         config()->set('livewire.temporary_file_upload.chunk_size', 1024); // 1KB for fast tests
         config()->set('livewire.temporary_file_upload.chunk_max_upload_time', 60);
         config()->set('livewire.temporary_file_upload.rules', ['required', 'file', 'max:100']); // 100KB max
-    }
 
-    public function tearDown(): void
-    {
-        // Each test runs many requests against the chunk endpoints. Without
-        // clearing the rate limiter we'd pollute the global throttle:600,1
-        // bucket and break other test files (like UnitTest's middleware tests)
-        // when running the full suite.
-        RateLimiter::clear('600|1|127.0.0.1');
-        RateLimiter::clear('60|1|127.0.0.1');
-
-        parent::tearDown();
+        // Override the chunked-upload throttle to a NAMED rate limiter with
+        // no cap. The default `throttle:600,1` would pollute the same bucket
+        // as the legacy `throttle:60,1` upload tests in UnitTest.php — Laravel
+        // keys unnamed throttles by request signature alone (ignoring the max
+        // value), so chunked tests would fill the legacy 60-per-minute bucket.
+        // A named limiter gets its own bucket key (`<sig>:test-chunk-uploads`),
+        // so it can't collide with the legacy throttle bucket.
+        RateLimiter::for('test-chunk-uploads', fn () => Limit::none());
+        config()->set('livewire.temporary_file_upload.chunk_middleware', 'throttle:test-chunk-uploads');
     }
 
     /** Helper: get a signed init URL */

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -127,7 +127,10 @@ class FileUploadConfiguration
 
     public static function chunkSize()
     {
-        return config('livewire.temporary_file_upload.chunk.size', 5 * 1024 * 1024);
+        // Default to exactly 1 MiB to match nginx's compiled-in default
+        // `client_max_body_size`. Both Forge and Laravel Cloud use the
+        // nginx default, so a larger chunk would 413 out of the box.
+        return config('livewire.temporary_file_upload.chunk.size', 1024 * 1024);
     }
 
     public static function isChunkingEnabled()

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -125,6 +125,31 @@ class FileUploadConfiguration
         return config('livewire.temporary_file_upload.max_upload_time') ?: 5;
     }
 
+    public static function chunkSize()
+    {
+        return config('livewire.temporary_file_upload.chunk_size', 5 * 1024 * 1024);
+    }
+
+    public static function isChunkingEnabled()
+    {
+        return static::chunkSize() !== null;
+    }
+
+    public static function chunkRetries()
+    {
+        return config('livewire.temporary_file_upload.chunk_retries', 3);
+    }
+
+    public static function chunkRetryDelays()
+    {
+        return config('livewire.temporary_file_upload.chunk_retry_delays', [500, 1000, 3000]);
+    }
+
+    public static function isChunkResumable()
+    {
+        return config('livewire.temporary_file_upload.chunk_resumable', true);
+    }
+
     public static function storeTemporaryFile($file, $disk)
     {
         $filename = TemporaryUploadedFile::generateHashName($file);

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -150,6 +150,10 @@ class FileUploadConfiguration
 
     public static function chunkMiddleware()
     {
+        // Default is looser than the legacy single-request upload throttle
+        // (which is 60/minute) because chunked uploads inherently make many
+        // small requests for a single large file. Sites that expose uploads
+        // to anonymous visitors should tighten this — see uploads.md.
         return config('livewire.temporary_file_upload.chunk_middleware') ?: 'throttle:600,1';
     }
 

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -127,7 +127,7 @@ class FileUploadConfiguration
 
     public static function chunkSize()
     {
-        return config('livewire.temporary_file_upload.chunk_size');
+        return config('livewire.temporary_file_upload.chunk.size');
     }
 
     public static function isChunkingEnabled()
@@ -137,7 +137,7 @@ class FileUploadConfiguration
 
     public static function chunkRetryDelays()
     {
-        return config('livewire.temporary_file_upload.chunk_retry_delays', [500, 1000, 3000]);
+        return config('livewire.temporary_file_upload.chunk.retry_delays', [500, 1000, 3000]);
     }
 
     public static function chunkMaxUploadTime()
@@ -145,7 +145,7 @@ class FileUploadConfiguration
         // 24 hours by default — aligns with Livewire's existing 24-hour
         // temporary-upload cleanup window, and comfortably handles realistic
         // multi-GB uploads on slow connections (e.g. 10GB at 5Mbps ≈ 4.5h).
-        return config('livewire.temporary_file_upload.chunk_max_upload_time', 60 * 24);
+        return config('livewire.temporary_file_upload.chunk.max_upload_time', 60 * 24);
     }
 
     public static function chunkMiddleware()
@@ -154,7 +154,7 @@ class FileUploadConfiguration
         // (which is 60/minute) because chunked uploads inherently make many
         // small requests for a single large file. Sites that expose uploads
         // to anonymous visitors should tighten this — see uploads.md.
-        return config('livewire.temporary_file_upload.chunk_middleware') ?: 'throttle:600,1';
+        return config('livewire.temporary_file_upload.chunk.middleware') ?: 'throttle:600,1';
     }
 
     /**
@@ -164,7 +164,7 @@ class FileUploadConfiguration
      */
     public static function chunkAbsoluteMaxBytes()
     {
-        return config('livewire.temporary_file_upload.chunk_absolute_max_bytes', 5 * 1024 * 1024 * 1024);
+        return config('livewire.temporary_file_upload.chunk.absolute_max_bytes', 5 * 1024 * 1024 * 1024);
     }
 
     /**

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -127,17 +127,12 @@ class FileUploadConfiguration
 
     public static function chunkSize()
     {
-        return config('livewire.temporary_file_upload.chunk_size', 5 * 1024 * 1024);
+        return config('livewire.temporary_file_upload.chunk_size');
     }
 
     public static function isChunkingEnabled()
     {
-        return static::chunkSize() !== null;
-    }
-
-    public static function chunkRetries()
-    {
-        return config('livewire.temporary_file_upload.chunk_retries', 3);
+        return static::chunkSize() !== null && ! static::isUsingS3();
     }
 
     public static function chunkRetryDelays()
@@ -145,9 +140,33 @@ class FileUploadConfiguration
         return config('livewire.temporary_file_upload.chunk_retry_delays', [500, 1000, 3000]);
     }
 
-    public static function isChunkResumable()
+    public static function chunkMaxUploadTime()
     {
-        return config('livewire.temporary_file_upload.chunk_resumable', true);
+        return config('livewire.temporary_file_upload.chunk_max_upload_time', 60);
+    }
+
+    public static function chunkMiddleware()
+    {
+        return config('livewire.temporary_file_upload.chunk_middleware') ?: 'throttle:600,1';
+    }
+
+    /**
+     * Extract the maximum upload size in bytes from the configured rules.
+     * Looks for a `max:N` rule (where N is in kilobytes per Laravel convention)
+     * and returns the byte equivalent. Returns null if no max rule found.
+     */
+    public static function maxUploadSizeInBytes()
+    {
+        foreach (static::rules() as $rule) {
+            if (! is_string($rule)) continue;
+
+            if (str_starts_with($rule, 'max:')) {
+                $kb = (int) substr($rule, 4);
+                return $kb * 1024;
+            }
+        }
+
+        return null;
     }
 
     public static function storeTemporaryFile($file, $disk)

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -127,12 +127,12 @@ class FileUploadConfiguration
 
     public static function chunkSize()
     {
-        return config('livewire.temporary_file_upload.chunk.size');
+        return config('livewire.temporary_file_upload.chunk.size', 5 * 1024 * 1024);
     }
 
     public static function isChunkingEnabled()
     {
-        return static::chunkSize() !== null;
+        return (bool) config('livewire.temporary_file_upload.chunk.enabled', false);
     }
 
     public static function chunkRetryDelays()

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -132,7 +132,7 @@ class FileUploadConfiguration
 
     public static function isChunkingEnabled()
     {
-        return static::chunkSize() !== null && ! static::isUsingS3();
+        return static::chunkSize() !== null;
     }
 
     public static function chunkRetryDelays()

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -151,6 +151,16 @@ class FileUploadConfiguration
     }
 
     /**
+     * The absolute maximum upload size in bytes for chunked uploads when no
+     * `max:` rule is configured. Acts as a hard ceiling so a missing rule
+     * can never become an unbounded upload claim.
+     */
+    public static function chunkAbsoluteMaxBytes()
+    {
+        return config('livewire.temporary_file_upload.chunk_absolute_max_bytes', 5 * 1024 * 1024 * 1024);
+    }
+
+    /**
      * Extract the maximum upload size in bytes from the configured rules.
      * Looks for a `max:N` rule (where N is in kilobytes per Laravel convention)
      * and returns the byte equivalent. Returns null if no max rule found.

--- a/src/Features/SupportFileUploads/FileUploadConfiguration.php
+++ b/src/Features/SupportFileUploads/FileUploadConfiguration.php
@@ -142,7 +142,10 @@ class FileUploadConfiguration
 
     public static function chunkMaxUploadTime()
     {
-        return config('livewire.temporary_file_upload.chunk_max_upload_time', 60);
+        // 24 hours by default — aligns with Livewire's existing 24-hour
+        // temporary-upload cleanup window, and comfortably handles realistic
+        // multi-GB uploads on slow connections (e.g. 10GB at 5Mbps ≈ 4.5h).
+        return config('livewire.temporary_file_upload.chunk_max_upload_time', 60 * 24);
     }
 
     public static function chunkMiddleware()

--- a/src/Features/SupportFileUploads/S3DoesntSupportChunkedUploads.php
+++ b/src/Features/SupportFileUploads/S3DoesntSupportChunkedUploads.php
@@ -13,7 +13,7 @@ class S3DoesntSupportChunkedUploads extends Exception
     {
         parent::__construct(
             'Chunked file uploads are not supported on the S3 temporary file upload disk. '
-            . 'Either set [livewire.temporary_file_upload.chunk_size] to null, or use a local disk.'
+            . 'Either set [livewire.temporary_file_upload.chunk.size] to null, or use a local disk.'
         );
     }
 }

--- a/src/Features/SupportFileUploads/S3DoesntSupportChunkedUploads.php
+++ b/src/Features/SupportFileUploads/S3DoesntSupportChunkedUploads.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Livewire\Features\SupportFileUploads;
+
+use Exception;
+use Livewire\Exceptions\BypassViewHandler;
+
+class S3DoesntSupportChunkedUploads extends Exception
+{
+    use BypassViewHandler;
+
+    public function __construct()
+    {
+        parent::__construct(
+            'Chunked file uploads are not supported on the S3 temporary file upload disk. '
+            . 'Either set [livewire.temporary_file_upload.chunk_size] to null, or use a local disk.'
+        );
+    }
+}

--- a/src/Features/SupportFileUploads/S3DoesntSupportChunkedUploads.php
+++ b/src/Features/SupportFileUploads/S3DoesntSupportChunkedUploads.php
@@ -13,7 +13,7 @@ class S3DoesntSupportChunkedUploads extends Exception
     {
         parent::__construct(
             'Chunked file uploads are not supported on the S3 temporary file upload disk. '
-            . 'Either set [livewire.temporary_file_upload.chunk.size] to null, or use a local disk.'
+            . 'Either set [livewire.temporary_file_upload.chunk.enabled] to false, or use a local disk.'
         );
     }
 }

--- a/src/Features/SupportFileUploads/SupportFileUploads.php
+++ b/src/Features/SupportFileUploads/SupportFileUploads.php
@@ -36,5 +36,14 @@ class SupportFileUploads extends ComponentHook
 
         Route::get(EndpointResolver::previewPath(), [FilePreviewController::class, 'handle'])
             ->name('livewire.preview-file');
+
+        Route::post(EndpointResolver::chunkInitPath(), [ChunkedUploadController::class, 'init'])
+            ->name('livewire.chunk-upload-init');
+
+        Route::patch(EndpointResolver::chunkPatchPath(), [ChunkedUploadController::class, 'patch'])
+            ->name('livewire.chunk-upload-patch');
+
+        Route::get(EndpointResolver::chunkOffsetPath(), [ChunkedUploadController::class, 'offset'])
+            ->name('livewire.chunk-upload-offset');
     }
 }

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -4,6 +4,7 @@ namespace Livewire\Features\SupportFileUploads;
 
 use Illuminate\Validation\ValidationException;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\URL;
 use Livewire\Attributes\Renderless;
 use Livewire\Facades\GenerateSignedUploadUrlFacade;
 
@@ -22,7 +23,23 @@ trait WithFileUploads
             return;
         }
 
-        $this->dispatch('upload:generatedSignedUrl', name: $name, url: GenerateSignedUploadUrlFacade::forLocal())->self();
+        $totalSize = collect($fileInfo)->sum('size');
+        $chunkConfig = null;
+
+        if (FileUploadConfiguration::isChunkingEnabled()
+            && $totalSize > FileUploadConfiguration::chunkSize()) {
+            $chunkConfig = [
+                'chunkSize' => FileUploadConfiguration::chunkSize(),
+                'retryDelays' => FileUploadConfiguration::chunkRetryDelays(),
+                'resumable' => FileUploadConfiguration::isChunkResumable(),
+                'initUrl' => URL::temporarySignedRoute(
+                    'livewire.chunk-upload-init',
+                    now()->addMinutes(FileUploadConfiguration::maxUploadTime()),
+                ),
+            ];
+        }
+
+        $this->dispatch('upload:generatedSignedUrl', name: $name, url: GenerateSignedUploadUrlFacade::forLocal(), chunkConfig: $chunkConfig)->self();
     }
 
     function _finishUpload($name, $tmpPath, $isMultiple, $append = true)
@@ -134,6 +151,22 @@ trait WithFileUploads
             $yesterdaysStamp = now()->subDay()->timestamp;
             if ($yesterdaysStamp > $storage->lastModified($filePathname)) {
                 $storage->delete($filePathname);
+            }
+        }
+
+        // Clean up stale chunk directories...
+        $chunksDir = FileUploadConfiguration::path('chunks');
+
+        foreach ($storage->directories($chunksDir) as $dir) {
+            $manifestPath = "{$dir}/manifest.json";
+
+            if (! $storage->exists($manifestPath)) {
+                $storage->deleteDirectory($dir);
+                continue;
+            }
+
+            if (now()->subDay()->timestamp > $storage->lastModified($manifestPath)) {
+                $storage->deleteDirectory($dir);
             }
         }
     }

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -15,6 +15,7 @@ trait WithFileUploads
     {
         if (FileUploadConfiguration::isUsingS3()) {
             throw_if($isMultiple, S3DoesntSupportMultipleFileUploads::class);
+            throw_if(FileUploadConfiguration::isChunkingEnabled(), S3DoesntSupportChunkedUploads::class);
 
             $file = UploadedFile::fake()->create($fileInfo[0]['name'], $fileInfo[0]['size'] / 1024, $fileInfo[0]['type']);
 
@@ -25,8 +26,7 @@ trait WithFileUploads
 
         // Determine if any of the files in this upload should be chunked.
         // We chunk if chunking is enabled AND any individual file is larger
-        // than the configured chunk size. We never chunk on S3 (handled by
-        // isChunkingEnabled()).
+        // than the configured chunk size.
         $shouldChunk = FileUploadConfiguration::isChunkingEnabled()
             && collect($fileInfo)->contains(fn ($info) => $info['size'] > FileUploadConfiguration::chunkSize());
 

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -23,18 +23,21 @@ trait WithFileUploads
             return;
         }
 
-        $totalSize = collect($fileInfo)->sum('size');
-        $chunkConfig = null;
+        // Determine if any of the files in this upload should be chunked.
+        // We chunk if chunking is enabled AND any individual file is larger
+        // than the configured chunk size. We never chunk on S3 (handled by
+        // isChunkingEnabled()).
+        $shouldChunk = FileUploadConfiguration::isChunkingEnabled()
+            && collect($fileInfo)->contains(fn ($info) => $info['size'] > FileUploadConfiguration::chunkSize());
 
-        if (FileUploadConfiguration::isChunkingEnabled()
-            && $totalSize > FileUploadConfiguration::chunkSize()) {
+        $chunkConfig = null;
+        if ($shouldChunk) {
             $chunkConfig = [
                 'chunkSize' => FileUploadConfiguration::chunkSize(),
                 'retryDelays' => FileUploadConfiguration::chunkRetryDelays(),
-                'resumable' => FileUploadConfiguration::isChunkResumable(),
                 'initUrl' => URL::temporarySignedRoute(
                     'livewire.chunk-upload-init',
-                    now()->addMinutes(FileUploadConfiguration::maxUploadTime()),
+                    now()->addMinutes(FileUploadConfiguration::chunkMaxUploadTime()),
                 ),
             ];
         }
@@ -142,31 +145,47 @@ trait WithFileUploads
         if (FileUploadConfiguration::isUsingS3()) return;
 
         $storage = FileUploadConfiguration::storage();
+        $yesterdaysStamp = now()->subDay()->timestamp;
+        $tmpDir = FileUploadConfiguration::path();
 
-        foreach ($storage->allFiles(FileUploadConfiguration::path()) as $filePathname) {
+        foreach ($storage->files($tmpDir) as $filePathname) {
             // On busy websites, this cleanup code can run in multiple threads causing part of the output
-            // of allFiles() to have already been deleted by another thread.
+            // of files() to have already been deleted by another thread.
             if (! $storage->exists($filePathname)) continue;
 
-            $yesterdaysStamp = now()->subDay()->timestamp;
             if ($yesterdaysStamp > $storage->lastModified($filePathname)) {
                 $storage->delete($filePathname);
             }
         }
 
-        // Clean up stale chunk directories...
+        // Clean up stale chunk directories. Each chunk directory contains a
+        // manifest.json that gets updated with each PATCH, so we use the
+        // manifest's mtime to detect abandoned uploads.
         $chunksDir = FileUploadConfiguration::path('chunks');
 
-        foreach ($storage->directories($chunksDir) as $dir) {
-            $manifestPath = "{$dir}/manifest.json";
+        if ($storage->exists($chunksDir)) {
+            foreach ($storage->directories($chunksDir) as $dir) {
+                $manifestPath = "{$dir}/manifest.json";
 
-            if (! $storage->exists($manifestPath)) {
-                $storage->deleteDirectory($dir);
-                continue;
-            }
+                if (! $storage->exists($manifestPath)) {
+                    // Orphaned chunk directory with no manifest. Only delete if
+                    // the directory itself is also stale to avoid racing against
+                    // an in-flight init that hasn't written the manifest yet.
+                    $files = $storage->allFiles($dir);
+                    $allOld = true;
+                    foreach ($files as $f) {
+                        if ($storage->lastModified($f) > $yesterdaysStamp) {
+                            $allOld = false;
+                            break;
+                        }
+                    }
+                    if ($allOld) $storage->deleteDirectory($dir);
+                    continue;
+                }
 
-            if (now()->subDay()->timestamp > $storage->lastModified($manifestPath)) {
-                $storage->deleteDirectory($dir);
+                if ($yesterdaysStamp > $storage->lastModified($manifestPath)) {
+                    $storage->deleteDirectory($dir);
+                }
             }
         }
     }

--- a/src/Mechanisms/HandleRequests/EndpointResolver.php
+++ b/src/Mechanisms/HandleRequests/EndpointResolver.php
@@ -62,6 +62,30 @@ class EndpointResolver
     }
 
     /**
+     * Get the path for the chunked upload init endpoint.
+     */
+    public static function chunkInitPath(): string
+    {
+        return static::prefix() . '/chunk-upload';
+    }
+
+    /**
+     * Get the path for the chunked upload patch endpoint.
+     */
+    public static function chunkPatchPath(): string
+    {
+        return static::prefix() . '/chunk-upload/{transferId}';
+    }
+
+    /**
+     * Get the path for the chunked upload offset check endpoint.
+     */
+    public static function chunkOffsetPath(): string
+    {
+        return static::prefix() . '/chunk-upload/{transferId}/offset';
+    }
+
+    /**
      * Get the path for component JavaScript modules.
      */
     public static function componentJsPath(): string


### PR DESCRIPTION
PHP file uploads have hard ceilings — `upload_max_filesize`, `post_max_size`, `memory_limit`, `max_execution_time` — that make uploading large files (videos, datasets, archives) painful or impossible without per-server tuning. Today, a Livewire user wanting to upload a 2GB video has no good answer beyond "edit php.ini and pray your timeouts hold."

```php
new class extends Component {
    use WithFileUploads;

    public $video; // Today: dies on memory/timeout for large files

    public function save()
    {
        $this->video->store('videos');
    }
};
```

## Findings

- The existing single-request upload path can't handle files larger than `upload_max_filesize` (default 2MB) or `post_max_size` (default 8MB).
- Slow connections hit `max_execution_time` regardless of memory headroom.
- Failed uploads have no resume — the user starts over from 0%.
- Direct-to-S3 already exists but requires S3 (not everyone uses it) and still hits timeouts on slow connections without multipart uploads.
- Pulling in `tus-js-client` + `tus-php` would add ~8k lines of dependency code plus an external project's release schedule for what Livewire can do in ~600 production lines.

## Potential solutions

- **Tell users to bump PHP limits.** Doesn't scale past a few hundred MB. Doesn't help with timeouts. No resume.
- **Force users onto S3 + the existing direct-to-S3 path.** Doesn't fit every stack. Still hits timeouts on slow connections without multipart.
- **Adopt tus-js-client + tus-php as dependencies.** Adds ~8k lines + external dependency surface for features Livewire doesn't need.
- **Bespoke chunked upload support inspired by tus.** ~600 lines, no new dependencies, fits the existing `WithFileUploads` API surface exactly.

## Proposed solution

A bespoke chunked upload path inspired by the [tus protocol](https://tus.io). Large files are split into chunks and uploaded sequentially via PATCH requests with byte offsets. **The developer-facing API is unchanged** — same `WithFileUploads` trait, same `TemporaryUploadedFile`, same `wire:model`, same `livewire-upload-*` events. Chunking happens automatically when files exceed `chunk_size`. Smaller files continue to use the existing single-request path.

Opt-in by default. Set `chunk_size` in `config/livewire.php` to enable:

```php
'temporary_file_upload' => [
    // ...
    'chunk_size' => 5 * 1024 * 1024, // 5MB per chunk
],
```

### Flow

```
1. JS: POST /chunk-upload (Upload-Length, Upload-Name [base64])
   PHP: validates size, returns { transferId, patchUrl, offsetUrl }

2. JS: PATCH /chunk-upload/{id} (Upload-Offset: 0, body: chunk 1)
   PHP: 204, Upload-Offset: 2097152

3. JS: PATCH /chunk-upload/{id} (Upload-Offset: 2097152, body: chunk 2)
   PHP: 204, Upload-Offset: 4194304

   ... repeat for each chunk ...

4. JS: PATCH /chunk-upload/{id} (final chunk)
   PHP: validates assembled file against rules, returns
        204, Upload-Complete: true, X-Signed-Path: <signed-tmp-path>
        (or 422 with validation errors via ValidationException)

5. JS: calls existing _finishUpload(name, [signedPath]) — rejoins existing flow
   PHP: $this->video is now a TemporaryUploadedFile
```

If a chunk fails: client retries with backoff (`chunk_retry_delays`), querying `GET /chunk-upload/{id}/offset` for the server's authoritative offset before each retry.

### Security

| Threat | Mitigation |
|--------|------------|
| Validation bypass for large files | Assembled file is run through `temporary_file_upload.rules` at finalize time. Throws `ValidationException` on failure → 422 JSON |
| Storage exhaustion via huge `Upload-Length` claims | Init endpoint enforces `max:` from rules, falling back to `chunk_absolute_max_bytes` (5GB) if no `max:` is set |
| Storage exhaustion via abandoned chunks | 24-hour cleanup extended to chunk directories |
| Per-chunk size abuse | Chunks larger than `chunk_size` rejected with 413 |
| Total bytes abuse | Chunks pushing the running total past declared size rejected with 413 |
| Long-lived signed URL leakage | Signed URLs use `chunk_max_upload_time` (60 min default), not 24 hours |
| Path traversal via transfer ID | Validated against `^[A-Za-z0-9]{40}$` on every PATCH/GET |
| Path traversal via filename extension | Extension is sanitized to alphanumeric in finalize |
| Race conditions on manifest | `flock(LOCK_EX)` held through chunk write AND finalization |
| CSRF | Inherits the existing `web` middleware group with X-CSRF-TOKEN headers from JS |

### Limitations

- **Local disk only.** S3 falls back to the existing single-request path. Native S3 multipart support is a future PR — it maps cleanly to `CreateMultipartUpload` / `UploadPart` / `CompleteMultipartUpload` and would let chunks bypass PHP entirely via presigned URLs. R2, Spaces, B2, MinIO would all benefit since they implement the S3 API.
- **No cross-page-load resume.** Chunks resume after network failures within a single session, but a page refresh restarts. Adding fingerprint-based persistence is straightforward but out of scope.
- **PATCH method.** Some WAFs block PATCH by default. Either configure your infra to allow PATCH on the chunk endpoint or leave `chunk_size` at `null`.

### Test plan

32 new end-to-end tests in `ChunkedUploadTest.php`. Tests exercise the real HTTP endpoints, not internals:

- Init: signature validation, manifest creation, transfer ID format, size enforcement (both `max:` rule and `chunk_absolute_max_bytes` fallback), zero/negative size rejection
- PATCH: offset matching, 409 on mismatch, 404 on unknown transfer, transfer ID format validation, per-chunk size limit, total-bytes-claimed enforcement
- Offset endpoint: signature validation, returns current progress, `Cache-Control: no-store`
- Full upload flow: 3KB / 3 chunks → byte-for-byte assembled file → chunk dir cleaned up
- **Closed-loop test**: walk chunks through HTTP → feed signed path to `_finishUpload` → verify component property is a real `TemporaryUploadedFile` → verify `->store()` works
- Validation at finalize: mime mismatch returns 422, file is cleaned up on failure
- Resume flow: send chunk → query offset → resume → complete
- Filename sanitization: weird extensions are stripped to alphanumeric
- Unicode filenames decoded correctly from base64 `Upload-Name`
- Multiple concurrent uploads to different transfer IDs don't interfere
- `_startUpload` correctly skips chunking for small files, S3 disks, and `chunk_size: null`
- `chunk_middleware` config is applied to chunk routes
- `maxUploadSizeInBytes()` correctly parses from rules

**93 file upload tests passing locally** (32 new + 60 existing + 1 always-skipped). The single failing browser test (`test_can_upload_preview_and_save_a_file`) fails on `main` too — it's a pre-existing flaky Chromedriver test, unrelated to this PR.

Manual end-to-end browser verification: 5MB file → 3 PATCH chunks → component property populated → `->store()` works. 600MB file with `max:512000` rule → 413 at init endpoint → user-visible "file failed to upload" error.

---

Marked draft because it's a new feature surface that warrants discussion before merge — specifically:
1. Whether `chunk_size` should default to `null` (current, opt-in) or to a sensible value like 5MB (opt-out)
2. Whether the silent S3 fallback is the right call vs erroring loudly when chunked uploads are configured but the disk is S3
3. Whether `chunk_max_upload_time` of 60 minutes is the right default