### PR TITLE
[4.x] Fix ES import statements in multi-file component JS files

### DIFF
--- a/src/Compiler/Fixtures/mfc-component-with-imports/mfc-component-with-imports.blade.php
+++ b/src/Compiler/Fixtures/mfc-component-with-imports/mfc-component-with-imports.blade.php
@@ -1,0 +1,1 @@
+<div>{{ $message }}</div>

--- a/src/Compiler/Fixtures/mfc-component-with-imports/mfc-component-with-imports.js
+++ b/src/Compiler/Fixtures/mfc-component-with-imports/mfc-component-with-imports.js
@@ -1,0 +1,9 @@
+import { Alpine } from 'alpinejs'
+import { debounce } from './utils'
+
+console.log('Component initialized');
+Alpine.data('myComponent', () => ({
+    init() {
+        debounce(() => console.log('Debounced'), 100);
+    }
+}));

--- a/src/Compiler/Fixtures/mfc-component-with-imports/mfc-component-with-imports.php
+++ b/src/Compiler/Fixtures/mfc-component-with-imports/mfc-component-with-imports.php
@@ -1,0 +1,9 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component
+{
+    public $message = 'Hello World';
+};
+?>

--- a/src/Compiler/Parser/MultiFileParser.php
+++ b/src/Compiler/Parser/MultiFileParser.php
@@ -101,7 +101,25 @@ class MultiFileParser extends Parser
 
         $scriptContents = trim($this->scriptPortion);
 
+        // Hoist imports to the top
+        $imports = [];
+        $scriptContents = preg_replace_callback(
+            '/^import\s+.+?;?\s*$/m',
+            function ($matches) use (&$imports) {
+                $imports[] = trim($matches[0]);
+                return '';
+            },
+            $scriptContents
+        );
+
+        // Clean up any extra whitespace left by removed imports
+        $scriptContents = trim($scriptContents);
+
+        // Build the final script with hoisted imports and export function
+        $hoistedImports = empty($imports) ? '' : implode("\n", $imports) . "\n";
+
         return <<<JS
+        {$hoistedImports}
         export function run(\$wire, \$js) {
             {$scriptContents}
         }

--- a/src/Compiler/UnitTest.php
+++ b/src/Compiler/UnitTest.php
@@ -290,6 +290,50 @@ class UnitTest extends \Tests\TestCase
         $this->assertStringNotContainsString('<div>{{ $message }}</div>', $scriptContents);
     }
 
+    public function test_mfc_script_wraps_in_export_function_even_without_imports()
+    {
+        $compiler = new Compiler(new CacheManager($this->cacheDir));
+
+        $parser = MultiFileParser::parse($compiler, __DIR__ . '/Fixtures/mfc-component');
+
+        $scriptContents = $parser->generateScriptContents();
+
+        // Check that the script is wrapped in export function run() even without imports
+        $this->assertMatchesRegularExpression('/export function run\([^)]*\) \{/', $scriptContents);
+        $this->assertStringContainsString("console.log('Hello from script');", $scriptContents);
+
+        // Ensure no import statements are present
+        $this->assertStringNotContainsString('import', $scriptContents);
+    }
+
+    public function test_mfc_script_hoists_imports_and_wraps_in_export_function()
+    {
+        $compiler = new Compiler(new CacheManager($this->cacheDir));
+
+        $parser = MultiFileParser::parse($compiler, __DIR__ . '/Fixtures/mfc-component-with-imports');
+
+        $scriptContents = $parser->generateScriptContents();
+
+        // Check that imports are hoisted to the top
+        $this->assertStringContainsString("import { Alpine } from 'alpinejs'", $scriptContents);
+        $this->assertStringContainsString("import { debounce } from './utils'", $scriptContents);
+
+        // Check that the script is wrapped in export function run()
+        $this->assertMatchesRegularExpression('/export function run\([^)]*\) \{/', $scriptContents);
+        $this->assertStringContainsString("console.log('Component initialized');", $scriptContents);
+
+        // Ensure imports appear before the export function
+        $importPos = strpos($scriptContents, 'import');
+        $exportPos = strpos($scriptContents, 'export function run');
+        $this->assertLessThan($exportPos, $importPos, 'Imports should appear before export function');
+
+        // Ensure the function body contains the actual logic (not the imports)
+        preg_match('/export function run\([^)]*\) \{(.+)\}/s', $scriptContents, $matches);
+        $functionBody = $matches[1] ?? '';
+        $this->assertStringNotContainsString('import', $functionBody, 'Import statements should not be in function body');
+        $this->assertStringContainsString("console.log('Component initialized');", $functionBody);
+    }
+
     public function test_can_parse_placeholder_directive()
     {
         $compiler = new Compiler($cacheManager = new CacheManager($this->cacheDir));

--- a/src/Features/SupportJsModules/BrowserTest.php
+++ b/src/Features/SupportJsModules/BrowserTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportJsModules;
 
+use Illuminate\Support\Facades\Route;
 use Livewire\Livewire;
 
 class BrowserTest extends \Tests\BrowserTestCase
@@ -10,6 +11,12 @@ class BrowserTest extends \Tests\BrowserTestCase
     {
         return function () {
             app('livewire.finder')->addNamespace('testns', viewPath: __DIR__ . '/fixtures');
+
+            Route::get('/test-module.js', function () {
+                return response("export let greeting = 'js-import-loaded'", 200, [
+                    'Content-Type' => 'application/javascript',
+                ]);
+            });
         };
     }
 
@@ -24,5 +31,28 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->pause(100)
             // If the JS loaded correctly, it will have set the text to 'js-loaded'
             ->assertSeeIn('@target', 'js-loaded');
+    }
+
+    public function test_single_file_component_js_supports_es_imports()
+    {
+        // This tests that ES module import statements work in single-file
+        // component <script> blocks. The imports should be hoisted above the
+        // export function run() wrapper so they remain at the module top level.
+        Livewire::visit('testns::sfc-with-imports')
+            ->waitForLivewireToLoad()
+            ->pause(100)
+            ->assertSeeIn('@target', 'js-import-loaded');
+    }
+
+    public function test_multi_file_component_js_supports_es_imports()
+    {
+        // This tests that ES module import statements work in multi-file
+        // component .js files. The imports should be hoisted above the
+        // export function run() wrapper so they remain at the module top level.
+        // Regression test for: https://github.com/livewire/livewire/discussions/10163
+        Livewire::visit('testns::mfc-with-imports')
+            ->waitForLivewireToLoad()
+            ->pause(100)
+            ->assertSeeIn('@target', 'js-import-loaded');
     }
 }

--- a/src/Features/SupportJsModules/fixtures/mfc-with-imports/mfc-with-imports.blade.php
+++ b/src/Features/SupportJsModules/fixtures/mfc-with-imports/mfc-with-imports.blade.php
@@ -1,0 +1,3 @@
+<div>
+    <div dusk="target">waiting</div>
+</div>

--- a/src/Features/SupportJsModules/fixtures/mfc-with-imports/mfc-with-imports.js
+++ b/src/Features/SupportJsModules/fixtures/mfc-with-imports/mfc-with-imports.js
@@ -1,0 +1,3 @@
+import { greeting } from '/test-module.js'
+
+this.$el.querySelector('[dusk="target"]').textContent = greeting

--- a/src/Features/SupportJsModules/fixtures/mfc-with-imports/mfc-with-imports.php
+++ b/src/Features/SupportJsModules/fixtures/mfc-with-imports/mfc-with-imports.php
@@ -1,0 +1,7 @@
+<?php
+
+new class extends \Livewire\Component
+{
+    //
+};
+?>

--- a/src/Features/SupportJsModules/fixtures/sfc-with-imports.blade.php
+++ b/src/Features/SupportJsModules/fixtures/sfc-with-imports.blade.php
@@ -1,0 +1,16 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <div dusk="target">waiting</div>
+</div>
+
+<script>
+import { greeting } from '/test-module.js'
+
+this.$el.querySelector('[dusk="target"]').textContent = greeting
+</script>


### PR DESCRIPTION
# The Scenario

When using ES `import` statements in a multi-file component's `.js` file, the browser throws a syntax error:

```
Uncaught (in promise) SyntaxError: Unexpected token '{'
```

For example, a multi-file component with a `.js` file like this fails:

```js
import { OBJLoader } from "three/examples/jsm/Addons.js"

// Use OBJLoader...
```

Single-file components with `<script>` blocks handle imports correctly, but multi-file components do not.

# The Problem

When Livewire compiles a multi-file component's `.js` file, `MultiFileParser::generateScriptContents()` wraps the entire file contents inside an `export function run()` wrapper:

```js
export function run($wire, $js) {
    import { OBJLoader } from "three/examples/jsm/Addons.js"
    // ...
}
```

ES `import` statements are only valid at the top level of a module, not inside function bodies. This causes the browser to throw a `SyntaxError` when parsing the module.

The `SingleFileParser` already handles this correctly by hoisting `import` statements above the wrapper, but this logic was missing from the `MultiFileParser`.

# The Solution

The same import-hoisting logic has been applied to `MultiFileParser::generateScriptContents()`. Import statements are now extracted from the user's code and placed at the top of the module, with only the remaining code wrapped inside the `export function run()` body:

```js
import { OBJLoader } from "three/examples/jsm/Addons.js"

export function run($wire, $js) {
    // ...
}
```

### Tests

**Unit tests** (`src/Compiler/UnitTest.php`):

| Test | SFC/MFC |
|---|---|
| `test_script_hoists_imports_and_wraps_in_export_function` | SFC (existing) |
| `test_script_wraps_in_export_function_even_without_imports` | SFC (existing) |
| `test_mfc_script_wraps_in_export_function_even_without_imports` | MFC (new) |
| `test_mfc_script_hoists_imports_and_wraps_in_export_function` | MFC (new) |

**Browser tests** (`src/Features/SupportJsModules/BrowserTest.php`):

| Test | SFC/MFC |
|---|---|
| `test_nested_namespaced_component_loads_js_module` | SFC (existing) |
| `test_single_file_component_js_supports_es_imports` | SFC (new) |
| `test_multi_file_component_js_supports_es_imports` | MFC (new) |

Fixes https://github.com/livewire/livewire/discussions/10163