### PR TITLE
[3.x] Fix x-mask recreating deleted wire:model array entries

### DIFF
--- a/js/request/commit.js
+++ b/js/request/commit.js
@@ -1,5 +1,6 @@
 import { diff } from '@/utils'
 import { on, trigger } from '@/hooks'
+import Alpine from 'alpinejs'
 
 /**
  * A commit represents an individual component updating itself server-side...
@@ -105,11 +106,18 @@ export class Commit {
 
             respond()
 
-            // Take the new snapshot and merge it into the existing one...
-            this.component.mergeNewSnapshot(snapshot, effects, updates)
+            // Wrap in Alpine.transaction() to defer reactive effects until
+            // after the morph completes. Without this, Alpine plugins like
+            // x-mask can fire synthetic input events during the reactive
+            // update, which trigger x-model setters that recreate deleted
+            // array entries via dataSet() before the morph removes them...
+            Alpine.transaction(() => {
+                // Take the new snapshot and merge it into the existing one...
+                this.component.mergeNewSnapshot(snapshot, effects, updates)
 
-            // Trigger any side effects from the payload like "morph" and "dispatch event"...
-            this.component.processEffects(this.component.effects)
+                // Trigger any side effects from the payload like "morph" and "dispatch event"...
+                this.component.processEffects(this.component.effects)
+            })
 
             if (effects['returns']) {
                 let returns = effects['returns']

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -232,4 +232,48 @@ class BrowserTest extends BrowserTestCase
             ->assertSeeIn('@values', '3,1')
         ;
     }
+
+    public function test_x_mask_does_not_recreate_deleted_array_entries()
+    {
+        Livewire::visit(new class extends Component {
+            public int $count = 2;
+            public array $items = [
+                ['phone' => ''],
+                ['phone' => ''],
+            ];
+
+            public function updatedCount(): void
+            {
+                $this->items = array_slice($this->items, 0, $this->count);
+            }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <select wire:model.live="count" dusk="count">
+                            <option value="1">1</option>
+                            <option value="2">2</option>
+                        </select>
+
+                        <div dusk="item-count">{{ count($items) }}</div>
+
+                        @foreach ($items as $index => $item)
+                            <div wire:key="item-{{ $index }}">
+                                <input wire:model="items.{{ $index }}.phone" x-mask="9999999999" dusk="phone-{{ $index }}" />
+                            </div>
+                        @endforeach
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertSeeIn('@item-count', '2')
+            ->type('@phone-1', '1234567890')
+            ->waitForLivewire()->select('@count', '1')
+            ->assertSeeIn('@item-count', '1')
+            ->assertMissing('@phone-1')
+            ->waitForLivewire()->select('@count', '2')
+            ->assertSeeIn('@item-count', '1')
+        ;
+    }
 }


### PR DESCRIPTION
# The Scenario

When a component uses a `wire:model.live` select to control the number of items in an array (by slicing it down in `updatedCount`), reducing the count correctly removes items. However, when `x-mask` is present on the array inputs, the deleted entries are silently recreated in the frontend state. On the next server round-trip, the corrupted state is sent back, causing the removed items to reappear.

Steps to reproduce:

1. Type a phone number into the second input
2. Change count to 1 — the second input is correctly removed
3. Change count to 2 — the second input reappears with its old value, even though `updatedCount` only slices and never adds entries

```php
class MyComponent extends Component
{
    public int $count = 2;
    public array $items = [
        ['phone' => ''],
        ['phone' => ''],
    ];

    public function updatedCount(): void
    {
        $this->items = array_slice($this->items, 0, $this->count);
    }
}
```

```blade
<div>
    <select wire:model.live="count">
        <option value="1">1</option>
        <option value="2">2</option>
    </select>

    @foreach ($items as $index => $item)
        <div wire:key="item-{{ $index }}">
            <input wire:model="items.{{ $index }}.phone" x-mask="9999999999" />
        </div>
    @endforeach
</div>
```

# The Problem

When a server response is processed, `mergeNewSnapshot()` updates the Alpine reactive proxy immediately without deferring effects. This causes Alpine plugins like `x-mask` to fire synthetic input events in response to the reactive data change, which trigger `x-model` setters that call `dataSet()` on the component state. `dataSet()` recreates array entries that were just removed by the server (e.g., `items.1.phone`), corrupting the reactive state. On the next commit, the stale entry is sent back to the server.

# The Solution

Wrap the `mergeNewSnapshot()` and `processEffects()` calls in `Alpine.transaction()`, which defers all reactive effects until after the morph completes. By the time effects fire, the removed DOM elements are gone and `x-mask` has no element to act on. This matches the approach already used in v4's request handling.

Fixes https://github.com/livewire/livewire/discussions/10184