### PR TITLE
[3.x] Add payload schema validation and tiered response handling

### DIFF
--- a/src/Features/SupportLockedProperties/CannotUpdateLockedPropertyException.php
+++ b/src/Features/SupportLockedProperties/CannotUpdateLockedPropertyException.php
@@ -10,4 +10,13 @@ class CannotUpdateLockedPropertyException extends \Exception
             'Cannot update locked property: ['.$this->property.']'
         );
     }
+
+    // In debug mode, let Laravel render the full error page.
+    // In production, return a generic 419 to avoid leaking details.
+    public function render($request)
+    {
+        if (config('app.debug')) return false;
+
+        return response('', 419);
+    }
 }

--- a/src/Features/SupportLockedProperties/UnitTest.php
+++ b/src/Features/SupportLockedProperties/UnitTest.php
@@ -61,6 +61,25 @@ class UnitTest extends \Tests\TestCase
             ->assertSetStrict('form.foo', 'bar')
             ->assertOk();
     }
+
+    function test_updating_locked_property_returns_419_in_production()
+    {
+        config()->set('app.debug', false);
+
+        $testable = Livewire::test(new class extends TestComponent {
+            #[BaseLocked]
+            public $count = 1;
+        });
+
+        $snapshotJson = json_encode($testable->snapshot);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson('/livewire/update', ['components' => [
+                ['snapshot' => $snapshotJson, 'updates' => ['count' => 2], 'calls' => []],
+            ]]);
+
+        $response->assertStatus(419);
+    }
 }
 
 class SomeForm extends Form {

--- a/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
+++ b/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
@@ -15,4 +15,13 @@ class CorruptComponentPayloadException extends \Exception
             "Ensure that the [name, id, data] of the Livewire component wasn't tampered with between requests."
         );
     }
+
+    // In debug mode, let Laravel render the full error page.
+    // In production, return a generic 419 to avoid leaking details.
+    public function render($request)
+    {
+        if (config('app.debug')) return false;
+
+        return response('', 419);
+    }
 }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -85,6 +85,29 @@ class HandleComponents extends Mechanism
 
     public function update($snapshot, $updates, $calls)
     {
+        if (! is_array($snapshot)
+            || ! is_array($snapshot['data'] ?? null)
+            || ! is_array($snapshot['memo'] ?? null)
+            || ! is_string($snapshot['checksum'] ?? null)
+            || ! is_string($snapshot['memo']['id'] ?? null)
+            || ! is_scalar($snapshot['memo']['name'] ?? null)
+        ) {
+            if (config('app.debug')) throw new \InvalidArgumentException('Invalid Livewire snapshot structure: expected [data], [memo], [checksum], [memo.id], and [memo.name].');
+
+            abort(404);
+        }
+
+        foreach ($calls as $call) {
+            if (! is_array($call)
+                || ! is_string($call['method'] ?? null)
+                || ! is_array($call['params'] ?? null)
+            ) {
+                if (config('app.debug')) throw new \InvalidArgumentException('Invalid Livewire call structure: each call must contain [method] (string) and [params] (array).');
+
+                abort(404);
+            }
+        }
+
         $data = $snapshot['data'];
         $memo = $snapshot['memo'];
 

--- a/src/Mechanisms/HandleRequests/CustomUpdateRouteUnitTest.php
+++ b/src/Mechanisms/HandleRequests/CustomUpdateRouteUnitTest.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Livewire\Livewire;
 use Tests\TestCase;
+use Tests\TestComponent;
 
 class CustomUpdateRouteUnitTest extends TestCase
 {
@@ -24,6 +25,20 @@ class CustomUpdateRouteUnitTest extends TestCase
 
         $this->assertCount(2, $livewireUpdateRoutes);
         $this->assertEquals('/custom/livewire/update', Livewire::getUpdateUri());
+    }
+
+    public function test_custom_route_accepts_requests_when_registered(): void
+    {
+        $testable = Livewire::test(new class extends TestComponent {});
+        $snapshotJson = json_encode($testable->snapshot);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson('/custom/livewire/update', ['components' => [
+                ['snapshot' => $snapshotJson, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertOk();
+        $this->assertArrayHasKey('components', $response->json());
     }
 }
 

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -113,7 +113,21 @@ class HandleRequests extends Mechanism
 
     function handleUpdate()
     {
-        $requestPayload = request(key: 'components', default: []);
+        $requestPayload = request('components');
+
+        if (! is_array($requestPayload) || empty($requestPayload)) {
+            abort(404);
+        }
+
+        foreach ($requestPayload as $component) {
+            if (! is_array($component)
+                || ! is_string($component['snapshot'] ?? null)
+                || ! is_array($component['updates'] ?? null)
+                || ! is_array($component['calls'] ?? null)
+            ) {
+                abort(404);
+            }
+        }
 
         $finish = trigger('request', $requestPayload);
 
@@ -126,7 +140,13 @@ class HandleRequests extends Mechanism
             $updates = $componentPayload['updates'];
             $calls = $componentPayload['calls'];
 
-            [ $snapshot, $effects ] = app('livewire')->update($snapshot, $updates, $calls);
+            try {
+                [ $snapshot, $effects ] = app('livewire')->update($snapshot, $updates, $calls);
+            } catch (\TypeError $e) {
+                if (config('app.debug')) throw $e;
+
+                abort(419);
+            }
 
             $componentResponses[] = [
                 'snapshot' => json_encode($snapshot),

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -1,26 +1,152 @@
 <?php
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Livewire\Livewire;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
+use Tests\TestComponent;
 
 class UnitTest extends TestCase
 {
-    public function test_livewire_can_run_handle_request_without_components_on_payload(): void
+    #[DataProvider('malformedRequestPayloads')]
+    public function test_malformed_request_payload_returns_404($payload): void
     {
-        $handleRequestsInstance = new HandleRequests();
-        $request = new Request();
+        // Disable debug mode to test production HTTP responses (404/419)...
+        config()->set('app.debug', false);
 
-        $result = $handleRequestsInstance->handleUpdate($request);
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson('/livewire/update', $payload);
 
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('components', $result);
-        $this->assertArrayHasKey('assets', $result);
-        $this->assertIsArray($result['components']);
-        $this->assertEmpty($result['components']);
-        $this->assertIsArray($result['assets']);
-        $this->assertEmpty($result['assets']);
+        $response->assertNotFound();
+    }
+
+    public static function malformedRequestPayloads()
+    {
+        return [
+            'missing components' => [[]],
+            'empty components' => [['components' => []]],
+            'non-array components' => [['components' => 'not-an-array']],
+            'missing snapshot' => [['components' => [['updates' => [], 'calls' => []]]]],
+            'non-string snapshot' => [['components' => [['snapshot' => 123, 'updates' => [], 'calls' => []]]]],
+            'missing updates' => [['components' => [['snapshot' => '{}', 'calls' => []]]]],
+            'missing calls' => [['components' => [['snapshot' => '{}', 'updates' => []]]]],
+            'non-array updates' => [['components' => [['snapshot' => '{}', 'updates' => 'bad', 'calls' => []]]]],
+            'non-array calls' => [['components' => [['snapshot' => '{}', 'updates' => [], 'calls' => 'bad']]]],
+        ];
+    }
+
+    #[DataProvider('malformedSnapshots')]
+    public function test_malformed_snapshot_returns_404($snapshot): void
+    {
+        // Disable debug mode to test production HTTP responses (404/419)...
+        config()->set('app.debug', false);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson('/livewire/update', ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public static function malformedSnapshots()
+    {
+        return [
+            'invalid json' => ['not-valid-json'],
+            'missing data' => [json_encode(['memo' => ['id' => 'abc', 'name' => 'foo'], 'checksum' => 'hash'])],
+            'missing memo' => [json_encode(['data' => [], 'checksum' => 'hash'])],
+            'missing checksum' => [json_encode(['data' => [], 'memo' => ['id' => 'abc', 'name' => 'foo']])],
+            'missing memo.id' => [json_encode(['data' => [], 'memo' => ['name' => 'foo'], 'checksum' => 'hash'])],
+            'missing memo.name' => [json_encode(['data' => [], 'memo' => ['id' => 'abc'], 'checksum' => 'hash'])],
+        ];
+    }
+
+    #[DataProvider('malformedCalls')]
+    public function test_malformed_calls_returns_404($calls): void
+    {
+        // Disable debug mode to test production HTTP responses (404/419)...
+        config()->set('app.debug', false);
+
+        $snapshot = json_encode(['data' => [], 'memo' => ['id' => 'abc', 'name' => 'foo'], 'checksum' => 'hash']);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson('/livewire/update', ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => $calls],
+            ]]);
+
+        $response->assertNotFound();
+    }
+
+    public static function malformedCalls()
+    {
+        return [
+            'missing method' => [[['params' => []]]],
+            'missing params' => [[['method' => 'doSomething']]],
+            'non-string method' => [[['method' => 123, 'params' => []]]],
+            'non-array params' => [[['method' => 'doSomething', 'params' => 'bad']]],
+        ];
+    }
+
+    public function test_bad_checksum_returns_419(): void
+    {
+        // Disable debug mode to test production HTTP responses (404/419)...
+        config()->set('app.debug', false);
+
+        $testable = Livewire::test(new class extends TestComponent {});
+
+        $snapshot = json_encode([
+            'data' => [],
+            'memo' => [
+                'id' => 'abc',
+                'name' => $testable->snapshot['memo']['name'],
+            ],
+            'checksum' => 'invalid-checksum-value',
+        ]);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson('/livewire/update', ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertStatus(419);
+    }
+
+    public function test_type_mismatched_update_value_returns_419(): void
+    {
+        // Disable debug mode to test production HTTP responses (404/419)...
+        config()->set('app.debug', false);
+
+        $testable = Livewire::test(new class extends TestComponent {
+            public array $items = [];
+        });
+
+        $snapshotJson = json_encode($testable->snapshot);
+
+        // Send a string where an array property is expected...
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson('/livewire/update', ['components' => [
+                ['snapshot' => $snapshotJson, 'updates' => ['items' => 'not_an_array'], 'calls' => []],
+            ]]);
+
+        $response->assertStatus(419);
+    }
+
+    public function test_valid_request_returns_200(): void
+    {
+        // Disable debug mode to test production HTTP responses (404/419)...
+        config()->set('app.debug', false);
+
+        $testable = Livewire::test(new class extends TestComponent {});
+        $snapshotJson = json_encode($testable->snapshot);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson('/livewire/update', ['components' => [
+                ['snapshot' => $snapshotJson, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertOk();
+        $this->assertArrayHasKey('components', $response->json());
     }
 
     public function test_default_livewire_update_route_is_registered(): void
@@ -61,9 +187,14 @@ class UnitTest extends TestCase
             return 'catch-all';
         })->where('all', '.*');
 
-        // Livewire's update route should still be matched
+        $testable = Livewire::test(new class extends TestComponent {});
+        $snapshotJson = json_encode($testable->snapshot);
+
+        // Livewire's update route should still be matched, not the catch-all
         $response = $this->withHeaders(['X-Livewire' => 'true'])
-            ->post('/livewire/update', ['components' => []]);
+            ->postJson('/livewire/update', ['components' => [
+                ['snapshot' => $snapshotJson, 'updates' => [], 'calls' => []],
+            ]]);
 
         $response->assertOk();
         $this->assertArrayHasKey('components', $response->json());


### PR DESCRIPTION
Backport of #9970 to v3. Validates malformed update request payloads and returns appropriate HTTP status codes (404 for structurally invalid requests, 419 for checksum/type/locked property failures) instead of unhandled 500 exceptions.

Fixes #9819