### PR TITLE
[4.x] Validate file uploads against component rules before transfer

### DIFF
--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -127,18 +127,16 @@ Like we've discussed, validating file uploads with Livewire is the same as handl
 
 For more information on file validation, consult [Laravel's file validation documentation](https://laravel.com/docs/validation#available-validation-rules).
 
-### Pre-upload validation
+### Validation runs before upload when it can
 
-When you declare a rule on a file property, Livewire will evaluate the rules that can be checked against the browser-supplied file metadata (size, name, extension) **before** the file is actually transferred to the server. If a 1GB file violates a `max:1024` rule, the user sees the error immediately and the bytes are never sent.
+When you declare a `max`, `extensions`, or any other size/name-based rule on a file property, Livewire checks the file against those rules *before* it's transferred to the server. If a user picks a 1GB file for a property with `max:1024`, they see the error immediately — the upload never even starts.
 
-```php
-#[Validate(['file', 'max:1024'])] // 1MB Max
-public $photo;
-```
+The following rules are evaluated against the browser's file metadata up front: `max`, `min`, `size`, `between`, `extensions`, `file`, `required`, `nullable`, `sometimes`, `present`, `filled`, and `bail`. Rules that need to read the actual file — `image`, `dimensions`, `mimes`, `mimetypes`, custom `Rule` objects, and closures — are skipped at this stage and run after the file lands in temporary storage, just like before.
 
-The pre-upload check covers `max`, `min`, `size`, `between`, `extensions`, `file`, `required`, `nullable`, `sometimes`, `present`, `filled`, and `bail`. Rules that need access to the actual file contents — `image`, `dimensions`, `mimes`, `mimetypes`, custom `Rule` objects, and closures — are skipped at pre-upload time and run as normal after the file lands in temporary storage.
+This works the same way for [form objects](/docs/4.x/forms#extracting-a-form-object) — rules declared on a form property like `form.photo` are walked into and checked up front.
 
-Pre-upload validation is purely a UX optimization. The browser-supplied size and name are not trusted as a security boundary — Livewire still re-validates the real file after it's uploaded.
+> [!info] This is a UX optimization, not a security boundary
+> The browser-supplied file size and name aren't trusted. Livewire still re-validates the real file after it's uploaded — the up-front check exists purely to spare users from waiting on an upload that's going to fail anyway.
 
 ## Temporary preview URLs
 

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -127,6 +127,19 @@ Like we've discussed, validating file uploads with Livewire is the same as handl
 
 For more information on file validation, consult [Laravel's file validation documentation](https://laravel.com/docs/validation#available-validation-rules).
 
+### Pre-upload validation
+
+When you declare a rule on a file property, Livewire will evaluate the rules that can be checked against the browser-supplied file metadata (size, name, extension) **before** the file is actually transferred to the server. If a 1GB file violates a `max:1024` rule, the user sees the error immediately and the bytes are never sent.
+
+```php
+#[Validate(['file', 'max:1024'])] // 1MB Max
+public $photo;
+```
+
+The pre-upload check covers `max`, `min`, `size`, `between`, `extensions`, `file`, `required`, `nullable`, `sometimes`, `present`, `filled`, and `bail`. Rules that need access to the actual file contents — `image`, `dimensions`, `mimes`, `mimetypes`, custom `Rule` objects, and closures — are skipped at pre-upload time and run as normal after the file lands in temporary storage.
+
+Pre-upload validation is purely a UX optimization. The browser-supplied size and name are not trusted as a security boundary — Livewire still re-validates the real file after it's uploaded.
+
 ## Temporary preview URLs
 
 After a user chooses a file, you should typically show them a preview of that file before they submit the form and store the file.

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -986,6 +986,161 @@ class UnitTest extends \Tests\TestCase
         Storage::disk('avatars')->assertExists('avatar.jpg');
         Storage::disk('tmp-for-tests')->assertExists($tmpPath);
     }
+
+    public function test_oversized_files_are_rejected_before_being_uploaded_when_a_max_rule_is_present()
+    {
+        Storage::fake('avatars');
+
+        // 2MB file, but the component's #[Validate] rule says max:1024 (1MB).
+        $file = UploadedFile::fake()->create('big.bin', 2048);
+
+        Livewire::test(PreUploadValidationComponent::class)
+            ->upload('photo', [$file])
+            ->assertSet('photo', null)
+            ->assertHasErrors(['photo' => 'max'])
+            ->assertDispatched('upload:errored', name: 'photo')
+            ->assertNotDispatched('upload:generatedSignedUrl')
+            ->assertNotDispatched('upload:generatedSignedUrlForS3');
+    }
+
+    public function test_oversized_files_are_rejected_before_upload_when_a_max_rule_is_present_for_s3()
+    {
+        config()->set('filesystems.disks.s3', [
+            'driver' => 's3',
+            'key' => 'test',
+            'secret' => 'test',
+            'region' => 'us-east-1',
+            'bucket' => 'test',
+        ]);
+        config()->set('filesystems.default', 's3');
+
+        Storage::fake('avatars');
+
+        $file = UploadedFile::fake()->create('big.bin', 2048);
+
+        Livewire::test(PreUploadValidationComponent::class)
+            ->upload('photo', [$file])
+            ->assertSet('photo', null)
+            ->assertHasErrors(['photo' => 'max'])
+            ->assertDispatched('upload:errored', name: 'photo')
+            ->assertNotDispatched('upload:generatedSignedUrlForS3');
+    }
+
+    public function test_files_within_the_max_rule_still_upload_normally()
+    {
+        Storage::fake('avatars');
+
+        $file = UploadedFile::fake()->create('small.bin', 500); // 500KB, under the 1MB rule
+
+        Livewire::test(PreUploadValidationComponent::class)
+            ->upload('photo', [$file])
+            ->assertHasNoErrors()
+            ->assertNotDispatched('upload:errored')
+            ->tap(function ($component) {
+                $this->assertNotNull($component->viewData('photo'));
+            });
+    }
+
+    public function test_extensions_rule_is_evaluated_before_upload()
+    {
+        Storage::fake('avatars');
+
+        // .bin extension, but the rule allows only jpg/png.
+        $file = UploadedFile::fake()->create('file.bin', 100);
+
+        Livewire::test(PreUploadValidationExtensionComponent::class)
+            ->upload('photo', [$file])
+            ->assertSet('photo', null)
+            ->assertHasErrors(['photo' => 'extensions'])
+            ->assertDispatched('upload:errored', name: 'photo')
+            ->assertNotDispatched('upload:generatedSignedUrl');
+    }
+
+    public function test_rules_that_need_real_file_content_are_skipped_during_pre_upload_validation()
+    {
+        // The component's only rule is `image`, which requires real file content.
+        // A pre-upload check on a fake file with no real image data would always
+        // fail; we want it to fall through and let the post-upload validator
+        // (which sees the actual content) decide.
+        Storage::fake('avatars');
+
+        $file = UploadedFile::fake()->image('avatar.jpg', 50, 50); // real fake image
+
+        Livewire::test(PreUploadValidationImageOnlyComponent::class)
+            ->upload('photo', [$file])
+            ->assertHasNoErrors()
+            ->assertNotDispatched('upload:errored')
+            ->tap(function ($component) {
+                $this->assertNotNull($component->viewData('photo'));
+            });
+    }
+
+    public function test_pre_upload_validation_does_nothing_when_property_has_no_rules()
+    {
+        Storage::fake('avatars');
+
+        // FileUploadComponent declares no #[Validate] attribute on $photo, so there
+        // are no rules to check at pre-upload time. The upload should proceed
+        // normally and only the global controller-level rules apply.
+        $file = UploadedFile::fake()->image('avatar.jpg')->size(50);
+
+        Livewire::test(FileUploadComponent::class)
+            ->upload('photo', [$file])
+            ->assertHasNoErrors()
+            ->assertNotDispatched('upload:errored');
+    }
+
+    public function test_multiple_uploads_pre_validate_against_array_rules()
+    {
+        Storage::fake('avatars');
+
+        $small = UploadedFile::fake()->create('one.bin', 200);
+        $big = UploadedFile::fake()->create('two.bin', 2048); // exceeds photos.* max:1024
+
+        Livewire::test(PreUploadValidationMultipleComponent::class)
+            ->upload('photos', [$small, $big], isMultiple: true)
+            ->assertHasErrors(['photos.1' => 'max'])
+            ->assertDispatched('upload:errored', name: 'photos')
+            ->assertNotDispatched('upload:generatedSignedUrl');
+    }
+}
+
+class PreUploadValidationComponent extends TestComponent
+{
+    use WithFileUploads;
+
+    #[\Livewire\Attributes\Validate(['file', 'max:1024'])]
+    public $photo;
+}
+
+class PreUploadValidationExtensionComponent extends TestComponent
+{
+    use WithFileUploads;
+
+    #[\Livewire\Attributes\Validate(['file', 'extensions:jpg,png'])]
+    public $photo;
+}
+
+class PreUploadValidationImageOnlyComponent extends TestComponent
+{
+    use WithFileUploads;
+
+    #[\Livewire\Attributes\Validate(['image'])]
+    public $photo;
+}
+
+class PreUploadValidationMultipleComponent extends TestComponent
+{
+    use WithFileUploads;
+
+    public $photos;
+
+    public function rules()
+    {
+        return [
+            'photos.*' => ['file', 'max:1024'],
+        ];
+    }
 }
 
 class FileUploadToDefaultDiskComponent extends TestComponent

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -1103,6 +1103,46 @@ class UnitTest extends \Tests\TestCase
             ->assertDispatched('upload:errored', name: 'photos')
             ->assertNotDispatched('upload:generatedSignedUrl');
     }
+
+    public function test_pre_upload_validation_walks_into_form_objects()
+    {
+        Storage::fake('avatars');
+
+        // The rule lives on the Form class, not on the component.
+        // Pre-upload validation should defer to the form just like validateOnly() does.
+        $file = UploadedFile::fake()->create('big.bin', 2048);
+
+        Livewire::test(PreUploadFormObjectComponent::class)
+            ->upload('form.photo', [$file])
+            ->assertHasErrors(['form.photo' => 'max'])
+            ->assertDispatched('upload:errored', name: 'form.photo')
+            ->assertNotDispatched('upload:generatedSignedUrl');
+    }
+
+    public function test_form_object_uploads_within_the_max_rule_still_upload_normally()
+    {
+        Storage::fake('avatars');
+
+        $file = UploadedFile::fake()->create('small.bin', 500);
+
+        Livewire::test(PreUploadFormObjectComponent::class)
+            ->upload('form.photo', [$file])
+            ->assertHasNoErrors()
+            ->assertNotDispatched('upload:errored');
+    }
+}
+
+class PreUploadFormObjectForm extends \Livewire\Form
+{
+    #[\Livewire\Attributes\Validate(['file', 'max:1024'])]
+    public $photo;
+}
+
+class PreUploadFormObjectComponent extends TestComponent
+{
+    use WithFileUploads;
+
+    public PreUploadFormObjectForm $form;
 }
 
 class PreUploadValidationComponent extends TestComponent

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -7,7 +7,9 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Http\UploadedFile;
 use Livewire\Attributes\Renderless;
 use Livewire\Facades\GenerateSignedUploadUrlFacade;
+use Livewire\Features\SupportFormObjects\Form;
 
+use function Livewire\invade;
 use function Livewire\store;
 
 trait WithFileUploads
@@ -45,14 +47,31 @@ trait WithFileUploads
      */
     protected function validateUploadBeforeTransfer($name, $fileInfo, $isMultiple)
     {
-        $rules = $this->getRules();
+        // If the upload property lives on a form object (e.g. wire:model="form.photo"),
+        // walk into the form so we look up rules and messages from there instead of
+        // the component. Mirrors how validateOnly() defers to form objects.
+        $target = $this;
+        $localName = $name;
+
+        if (str_contains($name, '.')) {
+            [$head, $rest] = explode('.', $name, 2);
+
+            $value = $this->{$head} ?? null;
+
+            if ($value instanceof Form) {
+                $target = $value;
+                $localName = $rest;
+            }
+        }
+
+        $rules = $target->getRules();
 
         $applicable = [];
-        if (isset($rules[$name])) {
-            $applicable[$name] = $this->filterRulesForPreUploadValidation($rules[$name]);
+        if (isset($rules[$localName])) {
+            $applicable[$localName] = $this->filterRulesForPreUploadValidation($rules[$localName]);
         }
-        if ($isMultiple && isset($rules[$name.'.*'])) {
-            $applicable[$name.'.*'] = $this->filterRulesForPreUploadValidation($rules[$name.'.*']);
+        if ($isMultiple && isset($rules[$localName.'.*'])) {
+            $applicable[$localName.'.*'] = $this->filterRulesForPreUploadValidation($rules[$localName.'.*']);
         }
 
         // Drop empty rule sets so the validator doesn't choke on []...
@@ -65,9 +84,14 @@ trait WithFileUploads
             $fileInfo
         );
 
-        $data = [$name => $isMultiple ? $files : $files[0]];
+        $data = [$localName => $isMultiple ? $files : $files[0]];
 
-        $validator = Validator::make($data, $applicable, $this->getMessages(), $this->getValidationAttributes());
+        $validator = Validator::make(
+            $data,
+            $applicable,
+            invade($target)->getMessages(),
+            invade($target)->getValidationAttributes(),
+        );
 
         if ($validator->fails()) {
             // _startUpload is marked Renderless for the happy path, but on failure
@@ -75,6 +99,21 @@ trait WithFileUploads
             store($this)->set('skipRender', false);
 
             $this->dispatch('upload:errored', name: $name)->self();
+
+            // For form-object uploads, prefix the error keys with the form
+            // property name so they surface under the dot-path the developer
+            // wrote on the input (e.g. `form.photo`). Mirrors the prefixing
+            // Form::validateOnly() does on its own ValidationException.
+            if ($target !== $this) {
+                $messages = invade($validator)->messages ?: $validator->errors();
+                invade($validator)->messages = new \Illuminate\Support\MessageBag(
+                    \Illuminate\Support\Arr::prependKeysWith($messages->toArray(), $head.'.')
+                );
+                invade($validator)->failedRules = \Illuminate\Support\Arr::prependKeysWith(
+                    invade($validator)->failedRules,
+                    $head.'.'
+                );
+            }
 
             throw new ValidationException($validator);
         }

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -52,71 +52,70 @@ trait WithFileUploads
         // the component. Mirrors how validateOnly() defers to form objects.
         $target = $this;
         $localName = $name;
+        $formPrefix = null;
 
         if (str_contains($name, '.')) {
             [$head, $rest] = explode('.', $name, 2);
 
-            $value = $this->{$head} ?? null;
-
-            if ($value instanceof Form) {
+            if (($value = $this->{$head} ?? null) instanceof Form) {
                 $target = $value;
                 $localName = $rest;
+                $formPrefix = $head;
             }
         }
 
         $rules = $target->getRules();
 
-        $applicable = [];
-        if (isset($rules[$localName])) {
-            $applicable[$localName] = $this->filterRulesForPreUploadValidation($rules[$localName]);
-        }
-        if ($isMultiple && isset($rules[$localName.'.*'])) {
-            $applicable[$localName.'.*'] = $this->filterRulesForPreUploadValidation($rules[$localName.'.*']);
-        }
-
-        // Drop empty rule sets so the validator doesn't choke on []...
-        $applicable = array_filter($applicable, fn ($r) => ! empty($r));
+        $applicable = array_filter([
+            $localName => isset($rules[$localName])
+                ? $this->filterRulesForPreUploadValidation($rules[$localName])
+                : [],
+            $localName.'.*' => $isMultiple && isset($rules[$localName.'.*'])
+                ? $this->filterRulesForPreUploadValidation($rules[$localName.'.*'])
+                : [],
+        ]);
 
         if (empty($applicable)) return;
 
         $files = array_map(
-            fn ($info) => UploadedFile::fake()->create($info['name'], (int) ($info['size'] / 1024), $info['type']),
+            fn ($info) => UploadedFile::fake()->create(
+                (string) ($info['name'] ?? ''),
+                (int) ((is_numeric($info['size'] ?? null) ? $info['size'] : 0) / 1024),
+                (string) ($info['type'] ?? ''),
+            ),
             $fileInfo
         );
 
-        $data = [$localName => $isMultiple ? $files : $files[0]];
-
         $validator = Validator::make(
-            $data,
+            [$localName => $isMultiple ? $files : $files[0]],
             $applicable,
             invade($target)->getMessages(),
             invade($target)->getValidationAttributes(),
         );
 
-        if ($validator->fails()) {
-            // _startUpload is marked Renderless for the happy path, but on failure
-            // we need the component to re-render so the error message shows up.
-            store($this)->set('skipRender', false);
+        if ($validator->passes()) return;
 
-            $this->dispatch('upload:errored', name: $name)->self();
+        // _startUpload is marked Renderless for the happy path, but on failure
+        // we need the component to re-render so the error message shows up.
+        store($this)->set('skipRender', false);
 
-            // For form-object uploads, prefix the error keys with the form
-            // property name so they surface under the dot-path the developer
-            // wrote on the input (e.g. `form.photo`). Mirrors the prefixing
-            // Form::validateOnly() does on its own ValidationException.
-            if ($target !== $this) {
-                $messages = invade($validator)->messages ?: $validator->errors();
-                invade($validator)->messages = new \Illuminate\Support\MessageBag(
-                    \Illuminate\Support\Arr::prependKeysWith($messages->toArray(), $head.'.')
-                );
-                invade($validator)->failedRules = \Illuminate\Support\Arr::prependKeysWith(
-                    invade($validator)->failedRules,
-                    $head.'.'
-                );
-            }
+        $this->dispatch('upload:errored', name: $name)->self();
 
-            throw new ValidationException($validator);
+        // For form-object uploads, prefix the error keys with the form property
+        // name so they surface under the dot-path the developer wrote on the
+        // input (e.g. `form.photo`). Mirrors what Form::validateOnly() does to
+        // its own ValidationException.
+        if ($formPrefix !== null) {
+            invade($validator)->messages = new \Illuminate\Support\MessageBag(
+                \Illuminate\Support\Arr::prependKeysWith(invade($validator)->messages->toArray(), $formPrefix.'.')
+            );
+            invade($validator)->failedRules = \Illuminate\Support\Arr::prependKeysWith(
+                invade($validator)->failedRules,
+                $formPrefix.'.'
+            );
         }
+
+        throw new ValidationException($validator);
     }
 
     /**

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -3,15 +3,20 @@
 namespace Livewire\Features\SupportFileUploads;
 
 use Illuminate\Validation\ValidationException;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Http\UploadedFile;
 use Livewire\Attributes\Renderless;
 use Livewire\Facades\GenerateSignedUploadUrlFacade;
+
+use function Livewire\store;
 
 trait WithFileUploads
 {
     #[Renderless]
     function _startUpload($name, $fileInfo, $isMultiple)
     {
+        $this->validateUploadBeforeTransfer($name, $fileInfo, $isMultiple);
+
         if (FileUploadConfiguration::isUsingS3()) {
             throw_if($isMultiple, S3DoesntSupportMultipleFileUploads::class);
 
@@ -23,6 +28,80 @@ trait WithFileUploads
         }
 
         $this->dispatch('upload:generatedSignedUrl', name: $name, url: GenerateSignedUploadUrlFacade::forLocal())->self();
+    }
+
+    /**
+     * Run any of the component's validation rules that can be evaluated against
+     * file metadata (size, name, extension) BEFORE the file is actually transferred.
+     *
+     * This is a UX optimization — it lets us reject obviously-invalid uploads (e.g.
+     * a 1GB file when the rule is `max:1024`) without first eating the bandwidth and
+     * temp-storage cost of the full transfer. Rules that need real file contents
+     * (image, dimensions, mimes, mimetypes, custom Rule objects, closures) are
+     * skipped here and still run post-upload via the existing validation pass.
+     *
+     * The browser-supplied size/name/type are NOT trusted — server-side validation
+     * still runs after the upload completes. This is purely an early-exit hint.
+     */
+    protected function validateUploadBeforeTransfer($name, $fileInfo, $isMultiple)
+    {
+        $rules = $this->getRules();
+
+        $applicable = [];
+        if (isset($rules[$name])) {
+            $applicable[$name] = $this->filterRulesForPreUploadValidation($rules[$name]);
+        }
+        if ($isMultiple && isset($rules[$name.'.*'])) {
+            $applicable[$name.'.*'] = $this->filterRulesForPreUploadValidation($rules[$name.'.*']);
+        }
+
+        // Drop empty rule sets so the validator doesn't choke on []...
+        $applicable = array_filter($applicable, fn ($r) => ! empty($r));
+
+        if (empty($applicable)) return;
+
+        $files = array_map(
+            fn ($info) => UploadedFile::fake()->create($info['name'], (int) ($info['size'] / 1024), $info['type']),
+            $fileInfo
+        );
+
+        $data = [$name => $isMultiple ? $files : $files[0]];
+
+        $validator = Validator::make($data, $applicable, $this->getMessages(), $this->getValidationAttributes());
+
+        if ($validator->fails()) {
+            // _startUpload is marked Renderless for the happy path, but on failure
+            // we need the component to re-render so the error message shows up.
+            store($this)->set('skipRender', false);
+
+            $this->dispatch('upload:errored', name: $name)->self();
+
+            throw new ValidationException($validator);
+        }
+    }
+
+    /**
+     * Keep only the rules that are safe to evaluate against a fake UploadedFile
+     * built from browser-supplied metadata. Anything else (rules that need real
+     * file contents like `image`/`dimensions`/`mimes`, custom Rule objects, or
+     * closures) is skipped here and falls through to the post-upload validation
+     * pass on the real file contents.
+     */
+    protected function filterRulesForPreUploadValidation($rules)
+    {
+        static $safe = [
+            'required', 'nullable', 'sometimes', 'present', 'filled', 'bail',
+            'file', 'max', 'min', 'size', 'between', 'extensions',
+        ];
+
+        if (is_string($rules)) $rules = explode('|', $rules);
+        if (! is_array($rules)) $rules = [$rules];
+
+        return array_values(array_filter($rules, function ($rule) use ($safe) {
+            if (! is_string($rule)) return false;
+
+            return in_array(explode(':', $rule)[0], $safe, true);
+        }));
     }
 
     function _finishUpload($name, $tmpPath, $isMultiple, $append = true)

--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -296,6 +296,18 @@ class Testable
             $isMultiple,
         );
 
+        // If pre-upload validation rejected the file, _startUpload will have
+        // dispatched 'upload:errored' instead of a signed-url event. The real
+        // JavaScript client short-circuits on that signal and never makes the
+        // upload-file request, so the test helper has to mirror that behavior.
+        $dispatched = collect(data_get($this->effects, 'dispatches', []))->pluck('name')->all();
+        if (in_array('upload:errored', $dispatched, true)
+            && ! in_array('upload:generatedSignedUrl', $dispatched, true)
+            && ! in_array('upload:generatedSignedUrlForS3', $dispatched, true)
+        ) {
+            return $this;
+        }
+
         // This is where either the pre-signed S3 url or the regular Livewire signed
         // upload url would do its thing and return a hashed version of the uploaded
         // file in a tmp directory.


### PR DESCRIPTION
A Livewire user can declare per-property file rules — `#[Validate('file|max:1024')] public $photo;` — but the rules only run after the file has been fully uploaded to the temp location. Pick a 1GB file for a `max:1024` property and you wait through the entire 1GB transfer before the validator finally kicks in and rejects it.

```php
new class extends Component {
    use WithFileUploads;

    #[Validate(['file', 'max:1024'])] // 1MB max
    public $photo;
};
```

```
Before:  pick 2MB file → upload all 2MB → save → "must not be greater than 1024 kilobytes"
After:   pick 2MB file → "must not be greater than 1024 kilobytes" (zero bytes transferred)
```

This is the long-standing complaint in [#5245](https://github.com/livewire/livewire/discussions/5245) and [#1400](https://github.com/livewire/livewire/discussions/1400).

## Findings

- Component-level rules (`#[Validate]`, `rules()`, `$rules`) currently only fire when `$this->validate()` is called, which happens *after* `_finishUpload` has already written the file to temp storage.
- The controller-side check at `FileUploadController::validateAndStore` runs against `livewire.temporary_file_upload.rules` (default `max:12288` / 12MB), not the property's actual rule. So a `max:1024` rule provides zero bandwidth protection on its own.
- For S3 direct uploads it's even worse: there's no chance to intercept mid-flight, so the user pays full S3 egress before learning the file was over the limit.
- The browser already sends file metadata (`name`, `size`, `type`) to `_startUpload` for the existing fake-file-from-metadata flow on the S3 path. We're already touching this data — we just don't validate against it.
- Many of Laravel's file rules can be evaluated against metadata alone: `max`, `min`, `size`, `between`, `extensions`, `file`, `required`, etc. Only rules that read actual file bytes (`image`, `dimensions`, `mimes`, `mimetypes`, custom `Rule` objects) need the real file.

## Potential solutions

- **Move all validation client-side in JS.** Removes the PHP round-trip but introduces a second source of truth (rules declared in PHP, mirrored in JS). Drift risk and a much bigger surface to maintain.
- **Add a separate `clientMaxSize:` rule.** Explicit but forces every existing user with a `max:` rule to opt in by changing their code. New vocabulary for an existing concept.
- **Tighten the global controller rules.** Doesn't help — the global rules are intentionally broad and operate per-installation, not per-property.
- **Validate the existing rules against fake files at the top of `_startUpload`.** Reuses the rule definitions the developer already wrote, single source of truth, no new API. ← chosen.

## Proposed solution

`_startUpload` now runs the component's per-property rules against a fake `UploadedFile` built from the browser-supplied metadata before issuing a signed URL or kicking off the local upload. On failure, the component dispatches `upload:errored`, throws `ValidationException`, and the user sees the error immediately — no bytes transferred.

The rule check is filtered to a hard-coded allowlist of "metadata-safe" rules:

```
required, nullable, sometimes, present, filled, bail,
file, max, min, size, between, extensions
```

Rules that need real file contents — `image`, `dimensions`, `mimes`, `mimetypes`, custom `Rule` objects, and closures — are silently skipped at this stage and continue to run post-upload via the existing validation pass. Running `image` against an empty fake file would always fail and incorrectly reject every legitimate upload.

`mimes:` is in the skip list because Laravel's check uses `finfo` on actual file bytes; the browser-supplied `type` field is close but not equivalent and would drift. `extensions:` (Laravel 11+) handles the same use case via `getClientOriginalExtension()` and is in the allowlist.

### Trust model

| Concern | Mitigation |
|---|---|
| Client lies about size to bypass `max:` | Server still re-validates the real file via `FileUploadController::validateAndStore` (global rules) and the developer's eventual `$this->validate()` call (component rules). The pre-check is purely an early-exit hint. |
| Client sends a non-numeric `size` to crash PHP 8.4 | `array_map` defends with `is_numeric` and `(string) ?? ''` casts on `name`/`type`. |
| Property-name reflection via `$this->{$head}` | Only used to detect Form objects. Reads only, no writes; non-Form values fall through to the standard rule lookup. |

### Form objects

When `wire:model="form.photo"` points at a property on a Form object, `validateUploadBeforeTransfer` walks into the Form to look up rules from `$form->getRules()` instead of the component. Errors are then prefixed with the form property name (`form.photo`) so they surface under the dot-path the developer wrote on the input. Mirrors what `Form::validateOnly()` does for its own `ValidationException`.

### Render handling

`_startUpload` is marked `#[Renderless]` for the happy path. On pre-validation failure we undo the renderless behavior so the error message actually surfaces:

```php
store($this)->set('skipRender', false);
```

Same idiom already used elsewhere in the file uploads code path.

### Test helper change

`Testable::upload()` now mirrors what the JS client does in production: if `_startUpload` dispatched `upload:errored` and no signed-URL event, it short-circuits instead of pretending the upload-file request happened. Without this, the test helper would have falsely reported successful uploads after pre-validation rejected them.

### Test plan

9 new tests in `src/Features/SupportFileUploads/UnitTest.php`:

- Oversized file rejected before transfer (local path)
- Oversized file rejected before transfer (S3 path)
- File within the limit still uploads normally
- `extensions:` rule rejects pre-upload
- `image` rule passthrough — proves real-content rules are correctly skipped, not double-rejected
- No-rules no-op — components without `#[Validate]` are unaffected
- Multi-file `photos.*` — only the offending file is rejected
- Form-object pre-validation walks into the form
- Form-object happy path still uploads normally

Verified locally:
- 66/66 in `src/Features/SupportFileUploads/UnitTest.php`
- 66/66 in `src/Features/SupportTesting/`
- 61/61 in `src/Features/SupportValidation/UnitTest.php`
- 43/43 in `src/Features/SupportFormObjects/UnitTest.php`

End-to-end browser verification in a Herd-served playground via Playwright: 2MB file against `max:1024` produces exactly **one** `/update` network request, zero file transfer, error renders inline. Same for the `form.photo` case. 500KB file uploads normally (3 network requests, full happy path).

### Limitations

- **`mimes:` is skipped at pre-upload.** Documented in the trait and in `docs/uploads.md`. Users who care about pre-upload extension checks should reach for the Laravel-11+ `extensions:` rule, which is in the allowlist.
- **Custom `Rule` objects are skipped.** Even ones that *would* be safe to evaluate against metadata. There's no reliable way to introspect a Rule object's intent without running it, and running an arbitrary closure against a fake file is a worse failure mode than skipping.
- **Coordinates with #10198 (chunked uploads).** That open PR also touches `_startUpload` to add chunk-config branching at the bottom of the method. This change adds the pre-validation call at the top. Mechanical conflict is small and the two features are complementary — with both landed, oversized files get caught in `_startUpload` before chunking is even initiated, and #10198's chunk init endpoint becomes defense-in-depth for the chunked path. Happy to rebase whichever lands second.
- **Prior attempt #9712** tried something similar but only for the S3 path, used the global `FileUploadConfiguration::rules()` instead of the component's rules, and ran all rules without an allowlist. Closed in January. This PR is differentiated: component rules, both S3 and local paths, metadata-safe filtering, and form-object support.

---

No new public API. No new config flags. No new traits. No JS changes. Behavior is opt-in by virtue of declaring rules on the file property — components without rules behave exactly as they do today.

Closes #5245.
