### PR TITLE
[4.x] Fix unmatched route parameters bleeding into child Blade component constructors

### DIFF
--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -51,7 +51,15 @@ class ImplicitRouteBinding
             // because that middleware has already ran, we need to run them again.
             $this->container['router']->substituteImplicitBindings($route);
 
-            $parameters = $route->resolveMethodDependencies($route->parameters(), new ReflectionMethod($component, 'mount'));
+            $mountMethod = new ReflectionMethod($component, 'mount');
+
+            // Only pass route parameters that match the mount method's signature.
+            // Without this, unmatched route parameters would be classified as
+            // HTML attributes and bleed into child Blade component constructors.
+            $mountParamNames = array_map(fn ($p) => $p->getName(), $mountMethod->getParameters());
+            $routeParams = array_intersect_key($route->parameters(), array_flip($mountParamNames));
+
+            $parameters = $route->resolveMethodDependencies($routeParams, $mountMethod);
 
             // Restore the original route action...
             $route->setAction($cache);

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Http\Response;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Blade;
 use Livewire\Component;
 use Livewire\Livewire;
 
@@ -453,6 +454,30 @@ class UnitTest extends \Tests\TestCase
             ->assertSeeText('123')
             ->assertSeeText('overview');
     }
+
+    public function test_unmatched_route_params_do_not_bleed_into_child_blade_components()
+    {
+        Blade::component('child-with-team-param', ChildBladeComponentWithTeamParam::class);
+
+        Route::get('/teams/{team}/projects/{project}', ComponentThatOnlyAcceptsProject::class);
+
+        $this->withoutExceptionHandling()
+            ->get('/teams/99/projects/42')
+            ->assertSee('project:42')
+            ->assertSee('team:none');
+    }
+
+    public function test_unmatched_route_params_do_not_bleed_when_component_uses_public_property_instead_of_mount()
+    {
+        Blade::component('child-with-team-param', ChildBladeComponentWithTeamParam::class);
+
+        Route::get('/teams/{team}/projects/{project}', ComponentWithProjectPropertyOnly::class);
+
+        $this->withoutExceptionHandling()
+            ->get('/teams/99/projects/42')
+            ->assertSee('project:42')
+            ->assertSee('team:none');
+    }
 }
 
 class ComponentForRouteWithoutMountParametersTest extends Component
@@ -781,6 +806,54 @@ class ComponentWithStacks extends Component
                     @endpush
                 @endonce
             @endforeach
+        HTML;
+    }
+}
+
+class ComponentThatOnlyAcceptsProject extends Component
+{
+    public $project;
+
+    public function mount($project)
+    {
+        $this->project = $project;
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <x-child-with-team-param :project="$project" />
+        </div>
+        HTML;
+    }
+}
+
+class ComponentWithProjectPropertyOnly extends Component
+{
+    public $project;
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <x-child-with-team-param :project="$project" />
+        </div>
+        HTML;
+    }
+}
+
+class ChildBladeComponentWithTeamParam extends \Illuminate\View\Component
+{
+    public function __construct(
+        public string $project,
+        public ?string $team = null,
+    ) {}
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>project:{{ $project }} team:{{ $team ?? 'none' }}</div>
         HTML;
     }
 }


### PR DESCRIPTION
# The Scenario

When a full-page Livewire component is on a route with parameters it doesn't accept, the leftover route values silently leak into child Blade components. If a child's constructor has a parameter with the same name as the unmatched route parameter, it receives the route value instead of its default.

For example, given a route `/teams/{team}/projects/{project}` where the Livewire component only accepts `$project`:

```php
class ManageProject extends Component
{
    public $project;

    public function mount($project)
    {
        $this->project = $project;
    }
}
```

```blade
{{-- Livewire component view --}}
<div>
    <x-my-component label="test" />
</div>
```

Visiting `/teams/99/projects/42`, any child Blade component with a `$team` constructor parameter silently receives `"99"` instead of its default `null`:

```php
class MyComponent extends \Illuminate\View\Component
{
    public function __construct(
        public string $label,
        public ?string $team = null, // receives "99" instead of null
    ) {}
}
```

This can also cause exceptions when the child expects a typed parameter like `?User $team = null` but receives a raw string.

# The Problem

`ImplicitRouteBinding::resolveMountParameters()` passes *all* route parameters to `resolveMethodDependencies()`, not just the ones matching the `mount()` method signature. The extras flow through `HandleComponents::separateParamsAndAttributes()`, get classified as HTML attributes, and land in the component's `$attributes` bag.

When Laravel compiles a child Blade component, it merges the parent's `$attributes->all()` into the child's constructor data:

```php
$component = Component::resolve($data + (isset($attributes) && $attributes instanceof ComponentAttributeBag ? $attributes->all() : []));
```

So any name collision between an unmatched route parameter and a child constructor parameter causes the route value to be injected.

# The Solution

Filter route parameters to only those matching `mount()` parameter names *before* passing them to `resolveMethodDependencies()`. Unmatched route parameters never enter the pipeline, so they can't leak into the attributes bag.

Container-resolved dependencies and default values are unaffected. Nested Livewire components rendered via `<livewire:component>` tags are also unaffected, as their parameters come from tag attributes, not route parameters.

Fixes #10208