### PR TITLE
HandleRequests: distinguish scanner-injected from legitimate TypeErrors

### DIFF
--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -633,9 +633,14 @@ class HandleComponents extends Mechanism
             // If a value is being set to "null", do the same...
             if ($value === '' || $value === null) {
                 unset($component->$property);
-            } else {
-                throw $e;
+
+                return;
             }
+
+            // This is almost certainly a bot/scanner probing typed properties
+            // with wrong-type values. Abort with 419 directly so it never
+            // reaches the top-level catch (which would report it as a real bug).
+            abort(419);
         }
     }
 

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -201,6 +201,8 @@ class HandleRequests extends Mechanism
             try {
                 [ $snapshot, $effects ] = app('livewire')->update($snapshot, $updates, $calls);
             } catch (\TypeError $e) {
+                report($e);
+
                 if (config('app.debug')) throw $e;
 
                 abort(419);

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -134,6 +134,62 @@ class UnitTest extends TestCase
         $response->assertStatus(419);
     }
 
+    public function test_tampered_property_type_is_not_reported(): void
+    {
+        config()->set('app.debug', false);
+
+        $reported = [];
+        app(\Illuminate\Contracts\Debug\ExceptionHandler::class)
+            ->reportable(function (\Throwable $e) use (&$reported) {
+                $reported[] = $e;
+                return false;
+            });
+
+        $testable = Livewire::test(new class extends TestComponent {
+            public array $items = [];
+        });
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => json_encode($testable->snapshot), 'updates' => ['items' => 'not_an_array'], 'calls' => []],
+            ]]);
+
+        $response->assertStatus(419);
+        $this->assertEmpty($reported, 'Scanner-tampered property assignment should not be reported.');
+    }
+
+    public function test_legitimate_typeerror_is_reported(): void
+    {
+        config()->set('app.debug', false);
+
+        $reported = [];
+        app(\Illuminate\Contracts\Debug\ExceptionHandler::class)
+            ->reportable(function (\Throwable $e) use (&$reported) {
+                $reported[] = $e;
+                return false;
+            });
+
+        $testable = Livewire::test(new class extends TestComponent {
+            public function bug(): int
+            {
+                return 'not_an_int';
+            }
+        });
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                [
+                    'snapshot' => json_encode($testable->snapshot),
+                    'updates' => [],
+                    'calls' => [['method' => 'bug', 'params' => [], 'metadata' => []]],
+                ],
+            ]]);
+
+        $response->assertStatus(419);
+        $this->assertNotEmpty($reported, 'Legitimate TypeError from component method body should be reported.');
+        $this->assertInstanceOf(\TypeError::class, $reported[0]);
+    }
+
     public function test_valid_request_returns_200(): void
     {
         // Disable debug mode to test production HTTP responses (404/419)...


### PR DESCRIPTION
# `HandleRequests`: distinguish scanner-injected from legitimate `TypeError`s

## TL;DR

The `catch (\TypeError)` at `HandleRequests::handleUpdate():~191` is too broad.
It was added to silently 419 scanner/bot probes that inject wrong-type values
into typed component properties, which is a legitimate hardening goal. But
because the catch keys off the base `\TypeError` class, it *also* silently
swallows every legitimate application-code `TypeError` that bubbles up from
anywhere inside `update()` — method parameter mismatches, return type
mismatches, closure parameter type unions that don't cover every runtime
subtype, etc. Those become invisible production bugs with no log entry, no
`report()` call, and no stack trace.

This PR keeps the scanner hardening *exactly* as-is by wrapping the
property-tampering case in a dedicated exception class at the single site
where the tampering injection can happen
(`HandleComponents::setComponentPropertyAwareOfTypes()`), matching the
pattern already used by `CorruptComponentPayloadException` — the exception
class owns its own `render()` (returns 419 in prod, lets Laravel render
the debug page in dev) and `report()` (returns `false` to stay out of
error trackers). Then a single-line `report($e);` is added to the
existing `catch (\TypeError)` in `handleUpdate()` so any *other*
application `TypeError` becomes visible.

- Scanner probes → silent 419, unreported. **Unchanged.**
- Application `TypeError`s → still 419 on the wire (Livewire JS handles
  it gracefully), now reported so developers can see them in Sentry /
  Bugsnag / Nightwatch / etc.

Net diff: one new exception class, one `throw` swap in `HandleComponents`,
one added line in `HandleRequests`. No behaviour change for scanner probes.

---

## Summary

`HandleRequests::handleUpdate()` currently catches **any** `\TypeError`
thrown from `app('livewire')->update(...)` and, when `APP_DEBUG` is off,
returns a silent 419 with no call to `report()`. This is intentional
scanner hardening — vulnerability probes routinely POST Livewire payloads
with wrong-type property values, and a raw 500 would both (a) confirm
the endpoint to the scanner and (b) flood the application's error tracker
with bot noise. Fair goals.

The problem is that the catch is too broad. It can't distinguish a
scanner-injected `TypeError` (bot probing a typed component property)
from a legitimate application-code `TypeError` that happens anywhere
else inside `update()`. Both look like `\TypeError` at the top-level
catch site, so both get silently swallowed. A real application bug in
a Livewire action — say, a method parameter or return type mismatch
exposed by a prod-only code path — becomes completely invisible to the
developer: no 500, no stack trace, no log entry, just a bare 419 in the
browser and a "Page Expired" popup in whatever UI layer is on top.

I hit this debugging a regression where a method inside a Livewire
action received a parameter whose runtime type wasn't in the declared
union type-hint. Locally it worked because the seeded data happened not
to exercise that code path; in production it threw a `TypeError` that
Livewire silently 419'd. Because nothing was reported, the only
signal was "users say this action isn't working", and debugging
required manually patching `vendor/livewire/livewire/...` to add
`report($e);`, redeploying, and reproducing once. This PR distils that
investigation into the real fix.

## Proposed fix

Make the distinction between the two cases **architectural, not
string-matched at the top-level catch site**. The scanner-injection
case can only happen in one place: inside the existing
`catch (\TypeError)` at
`HandleComponents::setComponentPropertyAwareOfTypes()`, where user input
is being directly assigned to a typed component property. Detect PHP's
canonical typed-property-assignment error message there, wrap it in a
dedicated exception class, and let any *other* `TypeError` (e.g. from a
mutator or custom setter) continue propagating normally. The new
exception class follows the same pattern as
`CorruptComponentPayloadException` — it owns its own `render()` and
`report()` so `handleUpdate()` doesn't need a second catch.

### New exception class

```php
// src/Mechanisms/HandleComponents/ComponentPropertyTypeMismatchException.php
namespace Livewire\Mechanisms\HandleComponents;

use Livewire\Exceptions\BypassViewHandler;

class ComponentPropertyTypeMismatchException extends \Exception
{
    use BypassViewHandler;

    public function __construct(
        public readonly object $component,
        public readonly string $property,
        public readonly mixed $value,
        ?\TypeError $previous = null,
    ) {
        parent::__construct(
            sprintf(
                'Cannot assign %s to typed property %s::$%s — the request payload may have been tampered with.',
                get_debug_type($value),
                $component::class,
                $property,
            ),
            0,
            $previous,
        );
    }

    // Don't surface this to the application error handler. It's overwhelmingly
    // caused by automated vulnerability scanners probing typed Livewire
    // component properties with wrong-type values. Reporting would flood
    // error trackers with bot-generated noise.
    public function report(): bool
    {
        return false;
    }

    // In debug mode, let Laravel render the full error page so the developer
    // can see the underlying TypeError from $previous. In production, return
    // a generic 419 to avoid confirming the endpoint or leaking the component
    // structure to scanners.
    public function render($request)
    {
        if (config('app.debug')) return false;

        return response('', 419);
    }
}
```

### Wrapping at the property setter site

```php
// HandleComponents::setComponentPropertyAwareOfTypes()
protected function setComponentPropertyAwareOfTypes($component, $property, $value)
{
    try {
       $component->$property = $value;
    } catch (\TypeError $e) {
        // If an "int" is being set to empty string, unset the property (making it null).
        // This is common in the case of `wire:model`ing an int to a text field...
        if ($value === '' || $value === null) {
            unset($component->$property);

            return;
        }

        // PHP's canonical typed-property assignment failure message. This is
        // overwhelmingly caused by automated scanners probing typed Livewire
        // component properties with wrong-type values. Wrap it so the
        // framework can render a silent 419 without reporting the noise.
        if (preg_match('/^Cannot assign .+ to property/', $e->getMessage())) {
            throw new ComponentPropertyTypeMismatchException(
                component: $component,
                property: $property,
                value: $value,
                previous: $e,
            );
        }

        // Any other TypeError — e.g. from inside a custom mutator/setter —
        // is almost certainly a legitimate application bug. Let it propagate
        // so Laravel's default exception handler reports it normally.
        throw $e;
    }
}
```

### Reporting application `TypeError`s at the top level

```php
// HandleRequests::handleUpdate()
try {
    [$snapshot, $effects] = app('livewire')->update($snapshot, $updates, $calls);
} catch (\TypeError $e) {
    report($e);                                    // ← single-line addition

    if (config('app.debug')) throw $e;

    abort(419);
}
```

`ComponentPropertyTypeMismatchException` isn't a `\TypeError`, so it
escapes this catch cleanly and lets Laravel's default exception handler
call its own `render()` and `report()` methods — the "silent 419, no
noise" path from the unchanged behaviour above.

Net effect:

- **Scanner probes** still hit the property setter, still become a
  silent 419, still don't get reported. Hardening goal preserved
  *exactly* — no change for the intended use case.
- **Application `TypeError`s** (wrong method signatures, closure
  parameter type mismatches, union types that don't cover every runtime
  subtype, etc.) now flow through `report()`. They still return 419 on
  the wire — the Livewire JS client handles that gracefully — but they
  become visible in the developer's error tracker with a full stack
  trace.

## Why not just add `report($e);` to the existing catch?

That was my first instinct, and it's wrong. It fixes the developer
experience but *regresses the scanner-hardening side of the trade-off*:
every bot probe against a Livewire endpoint would then get reported,
flooding the error tracker with `TypeError: Cannot assign string to
property ::$foo of type int` entries. Apps on Sentry / Bugsnag /
Nightwatch would effectively have to write custom `reportable()` filters
to undo the regression — which is already a workaround pattern in the
wild. The right answer is to not emit the noise in the first place.

## Why not match on the exception message or stack trace?

String-matching `"Cannot assign ... to property"` or inspecting the
stack frame origin works, but both are fragile: the message format
varies across PHP versions, and stack trace inspection couples the fix
to call-site layout. A dedicated exception class is simpler, explicit,
and free from those concerns.

## Why keep returning 419 for legitimate `TypeError`s instead of letting them 500?

Two reasons. First, the Livewire JS client already knows how to handle
419 — it shows a "session expired, please reload" UX — whereas a raw
500 from the update endpoint would look different to end users and
potentially cause confusion mid-session. Second, keeping the status
code stable means no existing Livewire app sees a behaviour change; the
only thing that changes is that legitimate errors now also become
*visible to developers*. This makes the PR much less risky to merge —
there's no consumer to break.

If the maintainers would prefer these propagate as 500s instead, that's
a one-line adjustment I'd be happy to make — but 419 + `report()` seems
like the minimum-viable change.

## Notes / scope

- This PR is scoped to the `TypeError` catch pair. The sibling 419
  sites (`CorruptComponentPayloadException`,
  `CannotUpdateLockedPropertyException`,
  `LivewireReleaseTokenMismatchException`, and the generic `abort(419)`
  in `handleUpdate()` for corrupted component state) are separate
  discussions — happy to open follow-ups once the pattern here is
  agreed on.
- Tests are included in the PR:
  - **Scanner probe**: dispatch a Livewire update that assigns a
    `string` to an `int`-typed public property → expect 419, assert
    zero `report()` calls.
  - **Application bug**: dispatch a Livewire update that triggers a
    `TypeError` from application code (a method with a too-narrow type
    hint) → expect 419, assert `report()` is called once.
