### PR TITLE
[4.x] Fix `#[Computed]` priority over legacy computed methods

### DIFF
--- a/src/Features/SupportComputed/SupportLegacyComputedPropertySyntax.php
+++ b/src/Features/SupportComputed/SupportLegacyComputedPropertySyntax.php
@@ -16,34 +16,34 @@ class SupportLegacyComputedPropertySyntax extends ComponentHook
     static function provide()
     {
         on('__get', function ($target, $property, $returnValue) {
-            // Handle legacy computed properties (getXxxProperty pattern)...
-            if (static::hasComputedProperty($target, $property)) {
-                $returnValue(static::getComputedProperty($target, $property));
-
-                return;
-            }
-
-            // Handle #[Computed] attribute properties...
+            // Handle #[Computed] attribute properties (takes priority over legacy)...
             $attribute = static::findComputedAttribute($target, $property);
 
             if ($attribute) {
                 $attribute->handleMagicGet($returnValue);
-            }
-        });
-
-        on('__unset', function ($target, $property) {
-            // Handle legacy computed properties (getXxxProperty pattern)...
-            if (static::hasComputedProperty($target, $property)) {
-                store($target)->unset('computedProperties', $property);
 
                 return;
             }
 
-            // Handle #[Computed] attribute properties...
+            // Handle legacy computed properties (getXxxProperty pattern)...
+            if (static::hasComputedProperty($target, $property)) {
+                $returnValue(static::getComputedProperty($target, $property));
+            }
+        });
+
+        on('__unset', function ($target, $property) {
+            // Handle #[Computed] attribute properties (takes priority over legacy)...
             $attribute = static::findComputedAttribute($target, $property);
 
             if ($attribute) {
                 $attribute->handleMagicUnset();
+
+                return;
+            }
+
+            // Handle legacy computed properties (getXxxProperty pattern)...
+            if (static::hasComputedProperty($target, $property)) {
+                store($target)->unset('computedProperties', $property);
             }
         });
 

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -483,6 +483,20 @@ class UnitTest extends TestCase
             ->assertSee('false');
     }
 
+    public function test_computed_attribute_takes_priority_over_legacy_get_property_syntax()
+    {
+        Livewire::test(new class extends TestComponent {
+            use HasLegacyComputedProperty;
+
+            #[Computed]
+            public function foo(): string
+            {
+                return 'computed';
+            }
+        })
+            ->assertSetStrict('foo', 'computed');
+    }
+
     public function test_it_supports_legacy_computed_properties()
     {
         Livewire::test(new class extends TestComponent {
@@ -638,6 +652,14 @@ class FalseIssetComputedPropertyStub extends Component{
             {{ var_dump(isset($this->foo)) }}
         </div>
         HTML;
+    }
+}
+
+trait HasLegacyComputedProperty
+{
+    public function getFooProperty(): string
+    {
+        return 'legacy';
     }
 }
 


### PR DESCRIPTION
# The Scenario

When migrating a Livewire 3 application to v4, a `#[Computed]` property that was intended to override a legacy `getXxxProperty()` method defined in a trait silently returns the wrong value. The legacy trait method wins instead of the component's `#[Computed]` method.

```php
<?php

use Livewire\Component;
use Livewire\Attributes\Computed;

trait HasLegacy
{
    public function getFooProperty(): string
    {
        return 'legacy';
    }
}

class MyComponent extends Component
{
    use HasLegacy;

    #[Computed]
    public function foo(): string
    {
        return 'computed';
    }
}

// $this->foo returns 'legacy', expected 'computed'
```

# The Problem

In PR #10022, computed property resolution was consolidated into `SupportLegacyComputedPropertySyntax::provide()` to fix an Octane memory leak. Both `#[Computed]` and legacy `getXxxProperty` methods are now resolved in the same `__get` handler, but legacy methods are checked first with an early `return`. When both patterns exist for the same property name, the legacy method always wins silently.

```php
on('__get', function ($target, $property, $returnValue) {
    // Legacy is checked first and returns early...
    if (static::hasComputedProperty($target, $property)) {
        $returnValue(static::getComputedProperty($target, $property));
        return; // #[Computed] is never reached
    }

    // #[Computed] is checked second...
    $attribute = static::findComputedAttribute($target, $property);
    // ...
});
```

# The Solution

Swap the priority order in both the `__get` and `__unset` handlers so that `#[Computed]` attribute methods are checked first, falling back to legacy `getXxxProperty()` only when no `#[Computed]` attribute is found. This restores the v3 behaviour where the newer syntax takes priority and ensures legacy-only components continue to work unchanged.

```php
on('__get', function ($target, $property, $returnValue) {
    // Handle #[Computed] attribute properties (takes priority over legacy)...
    $attribute = static::findComputedAttribute($target, $property);

    if ($attribute) {
        $attribute->handleMagicGet($returnValue);

        return;
    }

    // Handle legacy computed properties (getXxxProperty pattern)...
    if (static::hasComputedProperty($target, $property)) {
        $returnValue(static::getComputedProperty($target, $property));
    }
});
```

Fixes #10212