### PR TITLE
[4.x] Fix lazy components receiving events before mount

### DIFF
--- a/js/features/supportListeners.js
+++ b/js/features/supportListeners.js
@@ -8,6 +8,8 @@ function registerListeners(component, listeners) {
     listeners.forEach(name => {
         // Register a global listener...
         let handler = (e) => {
+            if (component.isLazy && ! component.hasBeenLazyLoaded) return
+
             if (e.__livewire) e.__livewire.receivedBy.push(component)
 
             component.$wire.call('__dispatch', name, e.detail || {})
@@ -19,6 +21,8 @@ function registerListeners(component, listeners) {
 
         // Register a listener for when "to" or "self"
         component.el.addEventListener(name, (e) => {
+            if (component.isLazy && ! component.hasBeenLazyLoaded) return
+
             // We don't care about non-Livewire dispatches...
             if (! e.__livewire) return
 

--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Route;
 use Tests\BrowserTestCase;
 use Livewire\Livewire;
 use Livewire\Component;
+use Livewire\Attributes\On;
 use Livewire\Attributes\Reactive;
 
 class BrowserTest extends BrowserTestCase
@@ -604,6 +605,131 @@ class BrowserTest extends BrowserTestCase
 
         // All three defer components should be bundled into a single request
         ->assertScript('window.requestCount', 1)
+        ;
+    }
+
+    public function test_lazy_component_outside_viewport_ignores_global_dispatch()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public function render() {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="$dispatch('refresh-child')" dusk="button">Refresh</button>
+                        <div dusk="parent">Parent</div>
+                        <div style="height: 200vh"></div>
+                        <livewire:child lazy />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public $title = '';
+
+                public function mount()
+                {
+                    $this->title = 'Mounted';
+                }
+
+                #[On('refresh-child')]
+                public function refresh() {}
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div id="child">
+                        Title: {{ $title }}
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+        ->assertMissing('#child')
+        ->click('@button')
+        ->pause(500)
+        ->assertMissing('#child')
+        ;
+    }
+
+    public function test_lazy_component_outside_viewport_ignores_dispatch_to()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public function render() {
+                    return <<<'HTML'
+                    <div>
+                        <button @click="window.Livewire.dispatchTo('child', 'refresh-child')" dusk="button">Refresh</button>
+                        <div dusk="parent">Parent</div>
+                        <div style="height: 200vh"></div>
+                        <livewire:child lazy />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public $title = '';
+
+                public function mount()
+                {
+                    $this->title = 'Mounted';
+                }
+
+                #[On('refresh-child')]
+                public function refresh() {}
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div id="child">
+                        Title: {{ $title }}
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+        ->assertMissing('#child')
+        ->click('@button')
+        ->pause(500)
+        ->assertMissing('#child')
+        ;
+    }
+
+    public function test_lazy_component_receives_events_after_being_loaded()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public function render() {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="$dispatch('refresh-child')" dusk="button">Refresh</button>
+                        <livewire:child lazy />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public $count = 0;
+
+                #[On('refresh-child')]
+                public function refresh()
+                {
+                    $this->count++;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div id="child">
+                        <span dusk="count">{{ $count }}</span>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+        ->waitFor('#child')
+        ->assertSeeIn('@count', '0')
+        ->waitForLivewire()->click('@button')
+        ->assertSeeIn('@count', '1')
         ;
     }
 


### PR DESCRIPTION
# The Scenario

When a lazy-loaded component has an event listener (via `#[On]` or `$listeners`) and hasn't been mounted yet (e.g., it's outside the viewport), dispatching that event causes the component to receive it and render without `mount()` ever being called. This leads to errors because properties initialised in `mount()` are uninitialised.

A common real-world case is a page with a list of items, each containing a modal with lazy-loaded tab content. When one item dispatches a refresh event, lazy components in other items that haven't been opened yet receive the event and break.

```php
<?php

use Livewire\Component;
use Livewire\Attributes\On;

// Parent component
new class extends Component {
    public function render()
    {
        return <<<'HTML'
        <div>
            <button wire:click="$dispatch('refresh-child')">Refresh</button>

            <div style="height: 200vh"></div>

            <livewire:child lazy />
        </div>
        HTML;
    }
};
```

```php
<?php

use Livewire\Component;
use Livewire\Attributes\On;

// Child component — errors because $title is never set
new class extends Component {
    public string $title;

    public function mount()
    {
        $this->title = 'Hello';
    }

    #[On('refresh-child')]
    public function refresh() {}

    public function render()
    {
        return <<<'HTML'
        <div>{{ $title }}</div>
        HTML;
    }
};
```

# The Problem

When a lazy component is initially rendered, `mount()` is skipped and a placeholder is output instead. However, `SupportEvents` still adds the component's event listeners to the dehydrated effects during this placeholder mount. On the JavaScript side, `supportListeners.js` registers global `window` event listeners and element-level listeners for "to"/"self" dispatches immediately, with no check for whether the component has actually been mounted.

When an event is dispatched, the JS handler fires `component.$wire.call('__dispatch', ...)`, sending a server request that calls the listener method on a component whose `mount()` was never executed.

# The Solution

Added a guard in both the global and element-level listener handlers in `supportListeners.js` to skip event dispatch when the component is lazy and hasn't been loaded yet:

```js
if (component.isLazy && ! component.hasBeenLazyLoaded) return
```

This uses the same pattern already established in `component.js` for skipping reactive prop updates on unmounted lazy children. Once the component is lazy-loaded via `x-intersect`, `hasBeenLazyLoaded` becomes `true` and events work normally.

Fixes #10216