### PR TITLE
[4.x] HeadObject size audit + parallel S3 multipart parts

### DIFF
--- a/js/features/supportFileUploads.js
+++ b/js/features/supportFileUploads.js
@@ -273,6 +273,7 @@ class UploadManager {
         let { chunkSize, retryDelays, initUrl } = config
         let { onProgress, onComplete, onError, isAborted, setCurrentXhr } = callbacks
         let csrfToken = getCsrfToken()
+        let concurrency = 3
 
         let initXhr = new XMLHttpRequest()
         setCurrentXhr(initXhr)
@@ -290,20 +291,28 @@ class UploadManager {
             let { partSize, numParts, signPartUrl, completeUrl, abortUrl } = JSON.parse(initXhr.responseText)
             abortUrls.add(abortUrl)
 
-            let bytesUploaded = 0
-            let partIndex = 0
-            let retryCount = 0
+            let completedParts = 0
+            let nextPart = 0
+            let inFlight = 0
+            let failed = false
+            let completedBytes = 0
+            let partProgress = new Array(numParts).fill(0)
 
-            let signAndUploadNext = () => {
-                if (isAborted()) return
+            let reportProgress = () => {
+                let inFlightBytes = partProgress.reduce((sum, b) => sum + b, 0)
+                onProgress(completedBytes + inFlightBytes)
+            }
 
-                if (partIndex >= numParts) {
-                    completeUpload()
-                    return
+            let launchParts = () => {
+                while (nextPart < numParts && inFlight < concurrency && !failed && !isAborted()) {
+                    signAndUpload(nextPart++)
+                    inFlight++
                 }
+            }
 
-                let partNumber = partIndex + 1
-                let start = partIndex * partSize
+            let signAndUpload = (idx) => {
+                let partNumber = idx + 1
+                let start = idx * partSize
                 let end = Math.min(start + partSize, file.size)
                 let body = file.slice(start, end)
 
@@ -314,43 +323,50 @@ class UploadManager {
                 if (csrfToken) signXhr.setRequestHeader('X-CSRF-TOKEN', csrfToken)
 
                 signXhr.addEventListener('load', () => {
-                    if (isAborted()) return
-                    if (signXhr.status !== 200) return retryOrFail()
+                    if (isAborted() || failed) return
+                    if (signXhr.status !== 200) { fail(); return }
 
                     let { url } = JSON.parse(signXhr.responseText)
-                    putPart(url, body)
+                    putPart(url, body, idx)
                 })
-                signXhr.addEventListener('error', () => isAborted() || retryOrFail())
+                signXhr.addEventListener('error', () => { if (!isAborted() && !failed) fail() })
                 signXhr.send()
             }
 
-            let putPart = (signedUrl, body) => {
+            let putPart = (signedUrl, body, idx) => {
                 let putXhr = new XMLHttpRequest()
                 setCurrentXhr(putXhr)
                 putXhr.open('PUT', signedUrl)
 
                 putXhr.upload.addEventListener('progress', (e) => {
                     if (!e.lengthComputable) return
-                    onProgress(bytesUploaded + e.loaded)
+                    partProgress[idx] = e.loaded
+                    reportProgress()
                 })
 
                 putXhr.addEventListener('load', () => {
-                    if (isAborted()) return
+                    if (isAborted() || failed) return
 
                     if (putXhr.status === 200) {
-                        bytesUploaded += body.size
-                        partIndex++
-                        retryCount = 0
-                        signAndUploadNext()
+                        partProgress[idx] = 0
+                        completedBytes += body.size
+                        completedParts++
+                        inFlight--
+
+                        if (completedParts === numParts) {
+                            completeUpload()
+                        } else {
+                            launchParts()
+                        }
                     } else if (putXhr.status === 403) {
-                        if (retryCount < 1) { retryCount++; signAndUploadNext() }
-                        else onError(extractErrorBody(putXhr))
+                        // Expired signature — re-sign this part
+                        signAndUpload(idx)
                     } else {
-                        retryOrFail()
+                        fail()
                     }
                 })
 
-                putXhr.addEventListener('error', () => isAborted() || retryOrFail())
+                putXhr.addEventListener('error', () => { if (!isAborted() && !failed) fail() })
                 putXhr.send(body)
             }
 
@@ -372,16 +388,13 @@ class UploadManager {
                 xhr.send()
             }
 
-            let retryOrFail = () => {
-                if (retryCount < retryDelays.length) {
-                    let delay = retryDelays[retryCount++]
-                    setTimeout(() => isAborted() || signAndUploadNext(), delay)
-                } else {
-                    onError(null)
-                }
+            let fail = () => {
+                if (failed) return
+                failed = true
+                onError(null)
             }
 
-            signAndUploadNext()
+            launchParts()
         })
 
         initXhr.addEventListener('error', () => isAborted() || onError(null))

--- a/src/Features/SupportFileUploads/S3MultipartUploadController.php
+++ b/src/Features/SupportFileUploads/S3MultipartUploadController.php
@@ -70,7 +70,7 @@ class S3MultipartUploadController implements HasMiddleware
         // All upload state is embedded in the signed URLs — no server-side
         // manifest needed. The signature prevents the client from tampering
         // with key, hash, or numParts.
-        $params = compact('uploadId', 'key', 'hash', 'numParts');
+        $params = compact('uploadId', 'key', 'hash', 'numParts', 'totalSize');
 
         return response()->json([
             'uploadId' => $uploadId,
@@ -124,6 +124,7 @@ class S3MultipartUploadController implements HasMiddleware
         $key = $request->query('key');
         $hash = $request->query('hash');
         $numParts = (int) $request->query('numParts');
+        $claimedSize = (int) $request->query('totalSize');
 
         $client = FileUploadConfiguration::s3Client();
         $bucket = FileUploadConfiguration::s3Bucket();
@@ -155,6 +156,17 @@ class S3MultipartUploadController implements HasMiddleware
             ]);
         } catch (S3Exception $e) {
             throw new HttpException(422, 'Multipart completion failed: ' . $e->getAwsErrorCode());
+        }
+
+        // Verify the assembled object's actual size matches the claimed size
+        // from init. This catches a malicious client that lies about file size
+        // to bypass pre-transfer max: validation then uploads different bytes.
+        $head = $client->headObject(['Bucket' => $bucket, 'Key' => $key]);
+        $actualSize = (int) $head['ContentLength'];
+
+        if ($actualSize !== $claimedSize) {
+            $client->deleteObject(['Bucket' => $bucket, 'Key' => $key]);
+            abort(422, "Uploaded size ({$actualSize} bytes) does not match claimed size ({$claimedSize} bytes).");
         }
 
         return response()->json([

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -202,6 +202,31 @@ trait WithFileUploads
             return $path;
         })->toArray();
 
+        // For S3 uploads, verify actual file sizes against the configured
+        // max rule. Catches a client that lies about size to pass pre-transfer
+        // validation, then uploads larger bytes via the presigned URL.
+        if (FileUploadConfiguration::isUsingS3() && ! app()->runningUnitTests()) {
+            $maxBytes = FileUploadConfiguration::maxUploadSizeInBytes();
+
+            if ($maxBytes) {
+                $client = FileUploadConfiguration::s3Client();
+                $bucket = FileUploadConfiguration::s3Bucket();
+
+                foreach ($tmpPath as $path) {
+                    $key = FileUploadConfiguration::path($path);
+                    $head = $client->headObject(['Bucket' => $bucket, 'Key' => $key]);
+
+                    if ((int) $head['ContentLength'] > $maxBytes) {
+                        $client->deleteObject(['Bucket' => $bucket, 'Key' => $key]);
+
+                        throw \Illuminate\Validation\ValidationException::withMessages([
+                            $name => 'The uploaded file exceeds the maximum allowed size.',
+                        ]);
+                    }
+                }
+            }
+        }
+
         if ($isMultiple) {
             $file = collect($tmpPath)->map(function ($i) {
                 return TemporaryUploadedFile::createFromLivewire($i);


### PR DESCRIPTION
Four improvements to the S3 upload pipeline that shipped in #10213.

## 1. HeadObject size audit (security)

A malicious client can lie about file size during pre-transfer validation, then upload larger bytes via the presigned URL. This adds server-side verification:

- **Multipart** — `complete` endpoint calls `HeadObject` after `CompleteMultipartUpload`, compares `ContentLength` against the claimed `totalSize` (embedded in signed URL). Deletes + 422 on mismatch.
- **Single-PUT** — `_finishUpload` calls `HeadObject` on each S3 file, compares against `maxUploadSizeInBytes()`. Deletes + validation error on violation.

## 2. Parallel part uploads (performance)

Parts now upload 3 at a time instead of sequentially. Progress aggregates per-part for smooth UI updates. On a 20-part file, this roughly 3x's throughput.

## 3. Resume after page refresh (resilience)

After init, the upload session is saved to localStorage keyed by file fingerprint (`name-size-lastModified`). On re-upload of the same file:

1. Load session from localStorage
2. Call `listParts` to discover which parts S3 already has
3. Resume from the first missing part (skips init entirely)
4. If session is stale (expired URLs), start fresh transparently

Cleared on complete, abort, or failure.

## 4. S3 browser tests with minio in CI (quality)

New `S3BrowserTest` with `@group s3`:
- `test_s3_multipart_upload_via_browser` — 6MB file via 2-part multipart, verifies object at correct size
- `test_s3_multi_file_upload_via_browser` — 2 small files via single-PUT

CI gets a dedicated "S3 Browser" job that spins up minio as a Docker service container, creates the bucket, and runs `--group s3` tests with Chrome. Tests skip locally when `MINIO_ENDPOINT` isn't set.

## Verification

All verified via Playwright against local minio:
- Parallel parts: network trace shows sign-part GETs firing before PUTs complete
- HeadObject: complete endpoint succeeds (size matches)
- Resume: localStorage save/clear lifecycle confirmed
- 117 unit tests pass locally