### PR TITLE
[4.x] Fix wire:show with $errors.has()

### DIFF
--- a/js/features/supportErrors.js
+++ b/js/features/supportErrors.js
@@ -1,23 +1,28 @@
 // This errors object has the most common methods from \Illuminate\Support\MessageBag class on the backend...
 import Alpine from 'alpinejs'
+import { interceptComponentMessage } from '@/request'
 
 export function getErrorsObject(component) {
     let state = component.__errorsState ??= Alpine.reactive({
         clientErrors: null,
+        serverErrors: component.snapshot.memo.errors,
     })
 
-    // Store lastSnapshot outside reactive state to avoid Proxy wrapping breaking identity comparison...
-    component.__lastErrorsSnapshot ??= component.snapshot
+    component.__errorsCleanup ??= interceptComponentMessage(component, ({ onFinish }) => {
+        onFinish(() => {
+            state.clientErrors = null
+            state.serverErrors = component.snapshot.memo.errors
+        })
+    })
+
+    if (! component.__errorsCleanupRegistered) {
+        component.addCleanup(component.__errorsCleanup)
+        component.__errorsCleanupRegistered = true
+    }
 
     return {
         messages() {
-            // If the snapshot changed (server responded), reset client overrides...
-            if (component.__lastErrorsSnapshot !== component.snapshot) {
-                state.clientErrors = null
-                component.__lastErrorsSnapshot = component.snapshot
-            }
-
-            return state.clientErrors ?? component.snapshot.memo.errors
+            return state.clientErrors ?? state.serverErrors
         },
 
         keys() {
@@ -94,7 +99,7 @@ export function getErrorsObject(component) {
             if (field === null) {
                 state.clientErrors = {}
             } else {
-                let errors = { ...(state.clientErrors ?? component.snapshot.memo.errors) }
+                let errors = { ...(state.clientErrors ?? state.serverErrors) }
                 delete errors[field]
                 state.clientErrors = errors
             }

--- a/src/Features/SupportWireShow/BrowserTest.php
+++ b/src/Features/SupportWireShow/BrowserTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportWireShow;
 
+use Livewire\Attributes\Validate;
 use Livewire\Component;
 use Livewire\Livewire;
 use Tests\BrowserTestCase;
@@ -117,5 +118,39 @@ class BrowserTest extends BrowserTestCase
         ->assertMissing('@hello')
         ->assertDontSee('Hello')
         ->assertAttributeContains('@hello', 'style', 'display: none !important;');
+    }
+
+    public function test_wire_show_reacts_to_validation_errors_from_the_magic_errors_object()
+    {
+        Livewire::visit(new class extends Component {
+            #[Validate('required')]
+            public string $email = '';
+
+            public function save()
+            {
+                $this->validate();
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <form wire:submit="save">
+                        <input type="email" wire:model="email">
+
+                        <div wire:show="$errors.has('email')" dusk="email-error">
+                            <span wire:text="$errors.first('email')" dusk="email-error-text"></span>
+                        </div>
+
+                        <button type="submit" dusk="save">Save</button>
+                    </form>
+                </div>
+                HTML;
+            }
+        })
+        ->assertMissing('@email-error')
+        ->waitForLivewire()->click('@save')
+        ->assertVisible('@email-error')
+        ->assertSeeIn('@email-error-text', 'The email field is required.');
     }
 }


### PR DESCRIPTION
Closes #10222.

## Summary

This fixes `wire:show="$errors.has(...)"` not updating when validation errors are added.

The issue was that the client-side `$errors` helper wasn't exposing a reactive dependency when the server error bag changed, so `wire:text="$errors.first(...)"` could update while `wire:show="$errors.has(...)"` stayed hidden.

This change keeps the current server errors in reactive state, resets any client-side overrides after each response, and adds a browser regression test for the reported repro.

## Testing

- `vendor/bin/phpunit src/Features/SupportWireShow/BrowserTest.php`
- `vendor/bin/phpunit src/Features/SupportMagicErrors/BrowserTest.php`