### PR TITLE
Add .claude to export-ignore in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 /github_banner.png  export-ignore
 /.github            export-ignore
 /.vscode            export-ignore
+/.claude            export-ignore
 /babel.config.js    export-ignore
 /jest.config.js     export-ignore
 /rollup.config.js   export-ignore


### PR DESCRIPTION
I saw my Claude going through those directories while trying to implement a new feature. 

I believe this directory should not be included when the project is imported with Composer.
