### PR TITLE
[4.x] Rebind wire:model when the target changes

### DIFF
--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -11,7 +11,13 @@ directive('model', ({ el, directive, component, cleanup }) => {
     component = findComponentByEl(el)
 
     let { expression, modifiers } = directive
-    let getCurrentExpression = () => el.getAttribute(directive.raw) ?? expression
+    let getCurrentExpression = () => {
+        let currentExpression = el.getAttribute(directive.raw) ?? expression
+
+        return componentIsMissingProperty(component, currentExpression)
+            ? expression
+            : currentExpression
+    }
 
     if (! expression) {
         return console.warn('Livewire: [wire:model] is missing a value.', el)

--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -11,6 +11,7 @@ directive('model', ({ el, directive, component, cleanup }) => {
     component = findComponentByEl(el)
 
     let { expression, modifiers } = directive
+    let getCurrentExpression = () => el.getAttribute(directive.raw) ?? expression
 
     if (! expression) {
         return console.warn('Livewire: [wire:model] is missing a value.', el)
@@ -68,13 +69,15 @@ directive('model', ({ el, directive, component, cleanup }) => {
 
     // Trigger a network request
     let update = () => {
+        let currentExpression = getCurrentExpression()
+
         setNextActionOrigin({ el, directive })
 
         if (isLive || isDebounced) {
             setNextActionMetadata({ type: 'model.live' })
         }
 
-        expression.startsWith('$parent')
+        currentExpression.startsWith('$parent')
             ? component.$wire.$parent.$commit()
             : component.$wire.$commit()
     }
@@ -112,10 +115,10 @@ directive('model', ({ el, directive, component, cleanup }) => {
     bindings['x-model' + xModelTail] = () => {
         return {
             get() {
-                return dataGet(component.$wire, expression)
+                return dataGet(component.$wire, getCurrentExpression())
             },
             set(value) {
-                dataSet(component.$wire, expression, value)
+                dataSet(component.$wire, getCurrentExpression(), value)
 
                 // If .live is present and no specific network triggers, fire on every ephemeral sync
                 if (shouldSendNetwork && ! hasNetworkTriggers) {

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -246,6 +246,48 @@ class BrowserTest extends BrowserTestCase
             ->assertSelected('@child', 'bar');
     }
 
+    public function test_wire_model_rebinds_when_a_conditional_input_switches_to_a_different_property()
+    {
+        Livewire::visit(new class extends Component {
+            public string $current = 'first';
+
+            public string $firstEmail = '';
+
+            public string $secondName = '';
+
+            public function nextStep()
+            {
+                $this->current = 'second';
+            }
+
+            public function render(): string
+            {
+                return <<<'blade'
+                    <div>
+                        <button wire:click="nextStep" dusk="next">Next</button>
+
+                        @if ($current === 'first')
+                            <input type="email" wire:model.live.debounce.100ms="firstEmail" dusk="step-input" />
+                        @else
+                            <input type="text" wire:model.live.debounce.100ms="secondName" dusk="step-input" />
+                        @endif
+
+                        <div dusk="first-email">{{ $firstEmail }}</div>
+                        <div dusk="second-name">{{ $secondName }}</div>
+                    </div>
+                blade;
+            }
+        })
+            ->type('@step-input', 'alice@example.com')
+            ->waitForTextIn('@first-email', 'alice@example.com')
+            ->assertSeeIn('@second-name', '')
+            ->waitForLivewire()->click('@next')
+            ->type('@step-input', 'Acme')
+            ->waitForTextIn('@second-name', 'Acme')
+            ->assertSeeIn('@first-email', 'alice@example.com')
+            ->assertSeeIn('@second-name', 'Acme');
+    }
+
     function test_wire_data_reflects_key_order_changes()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
Closes #10227.

## Summary

This fixes a stale `wire:model` binding when a conditional branch morphs an existing input into another input with the same `wire:model...` attribute name but a different target.

In that case, typing into the new input could still update the previous property. This shows up in multistep forms where one step swaps to another input bound to a different property or form field.

The fix makes `wire:model` resolve the current attribute value at runtime for reads, writes, and live commits, so reused inputs rebind correctly after morphing.

## Tests

- `vendor/bin/phpunit src/Features/SupportDataBinding/BrowserTest.php --filter "test_wire_model_rebinds_when_a_conditional_input_switches_to_a_different_property"`
- `vendor/bin/phpunit src/Features/SupportDataBinding/BrowserTest.php`