### PR TITLE
[4.x] Fix `wire:show` not reacting to `$errors` changes

### DIFF
--- a/js/features/supportErrors.js
+++ b/js/features/supportErrors.js
@@ -17,7 +17,8 @@ export function getErrorsObject(component) {
                 component.__lastErrorsSnapshot = component.snapshot
             }
 
-            return state.clientErrors ?? component.snapshot.memo.errors
+            // Assign into reactive state so Alpine can track changes...
+            return state.clientErrors ??= component.snapshot.memo.errors
         },
 
         keys() {

--- a/src/Features/SupportMagicErrors/BrowserTest.php
+++ b/src/Features/SupportMagicErrors/BrowserTest.php
@@ -178,4 +178,44 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertSeeIn('@has-email', 'false')
             ;
     }
+
+    public function test_wire_show_reacts_to_validation_errors_appearing_and_clearing()
+    {
+        Livewire::visit(new class extends \Livewire\Component {
+            #[Validate('required|email')]
+            public string $email = '';
+
+            public function save()
+            {
+                $this->validate();
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <form wire:submit="save">
+                    <input type="email" wire:model="email" dusk="email">
+
+                    <div wire:show="$errors.has('email')" dusk="email-error">
+                        <span wire:text="$errors.first('email')" dusk="email-error-text"></span>
+                    </div>
+
+                    <button type="submit" dusk="save">Save</button>
+                </form>
+            </div>
+            HTML; }
+        })
+            // Initially hidden...
+            ->assertAttributeContains('@email-error', 'style', 'display: none')
+
+            // Submit empty: error appears...
+            ->waitForLivewire()->click('@save')
+            ->assertVisible('@email-error')
+            ->assertSeeIn('@email-error-text', 'The email field is required.')
+
+            // Fix the input, resubmit: error hides again...
+            ->type('@email', 'foo@bar.test')
+            ->waitForLivewire()->click('@save')
+            ->assertAttributeContains('@email-error', 'style', 'display: none')
+            ;
+    }
 }


### PR DESCRIPTION
# The Scenario

When using `wire:show` with `$errors.has()` to conditionally display validation errors, the error message never becomes visible. The `wire:show` element keeps `style="display: none"` even after validation fails, despite `wire:text="$errors.first()"` on a sibling element updating correctly.

```php
<?php

use Livewire\Attributes\Validate;

new class extends Livewire\Component {
    #[Validate('required')]
    public string $email = '';

    public function save()
    {
        $this->validate();
    }
};
?>

<div>
    <form wire:submit="save">
        <input type="email" wire:model="email">

        <div wire:show="$errors.has('email')">
            <span wire:text="$errors.first('email')"></span>
        </div>

        <button type="submit">Save</button>
    </form>
</div>
```

# The Problem

The client-side `$errors` helper stores its state in an `Alpine.reactive()` object (`state.clientErrors`), but when no client-side override exists, `messages()` falls back to returning `component.snapshot.memo.errors` directly. That plain object isn't tracked by Alpine's reactivity system, so when the server responds with new errors, Alpine has no idea anything changed and never re-evaluates the `wire:show` expression.

`wire:text` appeared to work because DOM morphing triggers Alpine to re-initialise the element's text content, but `wire:show` (backed by `x-show`) relies purely on Alpine's effect system to detect changes.

# The Solution

Instead of returning the non-reactive snapshot errors directly, the fallback now assigns them into `state.clientErrors` via `??=`. This ensures Alpine always reads errors through its reactive proxy, so any change (new errors from the server, or clearing via `$wire.$errors.clear()`) triggers re-evaluation of dependent directives like `wire:show`.

```js
// Before:
return state.clientErrors ?? component.snapshot.memo.errors

// After:
return state.clientErrors ??= component.snapshot.memo.errors
```

Fixes #10222