### PR TITLE
Add security hardening docs for `temporary_file_upload` rules

### DIFF
--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -424,6 +424,54 @@ If you wish to customize these rules, you can do so inside your application's `c
 ],
 ```
 
+### Hardening temporary file upload rules
+
+By default, Livewire accepts any file up to 12MB in temporary uploads:
+
+```php
+// config/livewire.php
+'temporary_file_upload' => [
+    'rules' => null, // Default: ['required', 'file', 'max:12288']
+],
+```
+
+This default is intentionally permissive so the package works out of the box. For production applications, you should restrict this to the file types your app actually accepts.
+
+#### Example: image-only uploads
+
+```php
+'rules' => ['file', 'mimes:png,jpg,jpeg,webp', 'max:5120'], // 5MB
+```
+
+#### Example: images and media
+
+```php
+'rules' => ['file', 'mimes:png,jpg,jpeg,webp,mp3,mp4', 'max:12288'], // 12MB
+```
+
+#### Why this matters
+
+Without restrictive global rules, a malicious user can upload:
+
+- Executable files (`.php`, `.exe`, `.sh`) — usually mitigated by server config, but defense in depth helps
+- Oversized files that consume temp storage (local disk or S3)
+- Unexpected file types that bypass component-level validation if a developer forgets to validate
+
+Global rules in `config/livewire.php` apply to every Livewire upload across your app, acting as a safety net even if an individual component's `rules()` method is missing or incomplete.
+
+#### Per-component validation still matters
+
+Global rules don't replace component-level validation — they complement it. Always validate uploads in your component too:
+
+```php
+public function save()
+{
+    $this->validate([
+        'photo' => ['required', 'image', 'max:2048'],
+    ]);
+}
+```
+
 ### Global middleware
 
 The temporary file upload endpoint is assigned a throttling middleware by default. You can customize exactly what middleware this endpoint uses via the following configuration option:


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide
                                                                                                                                                                                                                                                                                                                            
  - [x] Is this something that is wanted/needed? **Yes — hardening guidance for a permissive default that's easy to miss.**                                                                                                                                                                                                 
  - [x] Have you created a discussion about it first? **Opening a docs PR directly since it's additive and non-breaking.**                                                                                                                                                                                                  
  - [ ] Did you create a branch for your PullRequest? (Main branch PR's will be closed) **— using `docs/harden-temporary-file-upload-rules`**                                                                                                                                                                               
  - [ ] Does it contain multiple, unrelated changes? Please separate the PRs out. **No — single focused change.**                                                                                                                                                                                                           
  - [x] Does it include tests? **N/A — docs-only**                                                                                                                                                                                                                                                                          
  - [x] Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful. **See below.**                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                            
  ---                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                            
  ## Summary                                                                                                                                                                                                                                                                                                                
                  
  Adds a "Hardening temporary file upload rules" section to `docs/uploads.md`, explaining why developers should restrict the default permissive `temporary_file_upload.rules` in production apps.                                                                                                                           
   
  ## Why                                                                                                                                                                                                                                                                                                                    
                  
  The default rules (`['required', 'file', 'max:12288']`) accept any file type up to 12MB. This is intentional for out-of-the-box usability, but many developers don't realize they should tighten it for production. Without restrictive global rules:                                                                     
   
  - Malicious users can upload unexpected file types (defense-in-depth concern)                                                                                                                                                                                                                                             
  - Oversized files consume temp storage unnecessarily
  - Missing per-component validation becomes a vulnerability instead of just a bug                                                                                                                                                                                                                                          
                  
  ## What's Added                                                                                                                                                                                                                                                                                                           
   
  - Explanation of what the default allows and why to restrict it                                                                                                                                                                                                                                                           
  - Two practical examples (image-only, image+media)
  - Clarification that global rules complement — not replace — per-component validation
  - Guidance that the global config acts as a safety net across the app
                                                                                                                                                                                                                                                                                                                            
  ## Notes
                                                                                                                                                                                                                                                                                                                            
  Docs-only change. No code or default behavior modified. Purely additive — no existing content changed. Added at lines 427–474, after the existing "Global validation" subsection.                                                                                                                                         
   
  Thanks for contributing! 🙏                                                                                                                                                                                                                                                                                               
                  