### PR TITLE
[4.x] Update `wire:key` documentation to include conditionals

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,7 +18,7 @@ There are lots of reasons why you may encounter these messages, but the most com
 
 ### Adding `wire:key`
 
-Any time you have a loop or a conditional in your Blade templates using something like `@foreach`, `@if`/`@else`, or `@switch`/`@case`, you need to add `wire:key` to the opening tag of the first element:
+Any time you have a loop or switch case in your Blade templates using something like `@foreach`, or `@switch`/`@case`, you need to add `wire:key` to the opening tag of the first element:
 
 ```blade
 @foreach($posts as $post)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,7 +18,7 @@ There are lots of reasons why you may encounter these messages, but the most com
 
 ### Adding `wire:key`
 
-Any time you have a loop in your Blade templates using something like `@foreach`, you need to add `wire:key` to the opening tag of the first element within the loop:
+Any time you have a loop or a conditional in your Blade templates using something like `@foreach`, `@if`/`@else`, or `@switch`/`@case`, you need to add `wire:key` to the opening tag of the first element:
 
 ```blade
 @foreach($posts as $post)
@@ -28,7 +28,7 @@ Any time you have a loop in your Blade templates using something like `@foreach`
 @endforeach
 ```
 
-This ensures that Livewire can keep track of different elements in the loop when the loop changes.
+This ensures that Livewire can keep track of different elements in the loop or conditional when it changes.
 
 The same applies to Livewire components within a loop:
 


### PR DESCRIPTION
# The Scenario

A user is rendering one of two structurally similar inputs based on a property, each bound to a different `wire:model` target:

```blade
<div>
    <button wire:click="$set('current', 'company')">Company</button>

    @switch($current)
        @case('user')
            <flux:card>
                <flux:input wire:model="email" />
            </flux:card>
        @break

        @case('company')
            <flux:card>
                <flux:input wire:model="name" />
            </flux:card>
        @break
    @endswitch
</div>
```

After clicking the button to switch from `'user'` to `'company'`, typing into the visible input updates `$email` instead of `$name`. The same problem occurs with `@if/@else` branches that contain structurally similar elements bound to different properties.

# The Problem

Livewire's morph engine sees the same `<flux:input>` element at the same DOM position before and after the switch, so it patches attributes in place rather than replacing the element. The `wire:model` directive's bound property reference is set when the directive initialises and isn't re-resolved when the attribute value changes during morph, so it stays pointing at the original property.

This is the same class of issue as missing `wire:key` on `@foreach` items, but the existing `wire:key` troubleshooting docs only mention loops, not conditionals.

# The Solution

Update the `Adding wire:key` section of `docs/troubleshooting.md` to mention that `@if/@else` and `@switch/@case` branches need `wire:key` for the same reason as loops.

## Why a docs change rather than a code fix

We prototyped an automatic fix where the precompiler injects `<!--[if BRANCH:hash]-->` / `<!--[if ENDBRANCH:hash]-->` markers inside each branch of `@if/@else/@elseif/@endif`, with the intent to extend the same approach to `@switch/@case/@default` and other conditional directives. PHP's natural branching gates which markers actually render, so morph could compare hashes and replace branches wholesale on mismatch (avoiding the stale `wire:model` binding problem entirely, with no user-supplied `wire:key` required).

The PoC compiled correctly but added meaningful overhead to Blade compilation. Benchmark on a representative template (10 top-level `@if`s, mix of standalone / `@else` / `@elseif`, with nesting up to 3 levels deep, ~1.5 KB), 1000 iterations:

| Approach                                       | Per-compile | Overhead vs baseline |
|------------------------------------------------|-------------|----------------------|
| Baseline (no BRANCH markers)                   | ~2.7 ms     |                      |
| Standalone precompiler (chunked, O(n) build)   | ~3.5 ms     | **+730 µs (~28%)**   |
| Integrated into `compileDirectives` reverse loop | ~3.7 ms   | **+985 µs (~35%)**   |

A more sustainable home for this kind of compile-time transformation would be an AST-based pipeline (e.g. extending `livewire/blaze`'s tokenizer + parser with directive nodes), where BRANCH markers, BLOCK markers, and smart wire-keys all become trivial visitors over a single parse. That's a larger investment than this issue warrants, so for now we just document the workaround.

Fixes #10227