### PR TITLE
Livewire encountered corrupt data when trying to hydrate when a variable that has -0.0

### DIFF
--- a/src/Mechanisms/HandleComponents/BrowserTest.php
+++ b/src/Mechanisms/HandleComponents/BrowserTest.php
@@ -12,7 +12,7 @@ class BrowserTest extends \Tests\BrowserTestCase
         Livewire::visit(new class extends \Livewire\Component {
             public $subsequentRequest = false;
 
-            public $negativeZero = -0;
+            public $negativeZero = -0.0;
 
             public $associativeArrayWithStringAndNumericKeys = [
                 '2' => 'two',

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -311,7 +311,12 @@ class HandleComponents extends Mechanism
 
     protected function dehydrate($target, $context, $path)
     {
-        if (Utils::isAPrimitive($target)) return $target;
+        if (Utils::isAPrimitive($target)) {
+            // Normalize negative zero (-0.0) to 0 to prevent checksum mismatches
+            if ($target === -0.0) return 0;
+
+            return $target;
+        }
 
         $synth = $this->propertySynth($target, $context, $path);
 

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -247,6 +247,26 @@ class UnitTest extends \Tests\TestCase
             $this->assertEquals(['data-foo' => 'bar'], $component->instance()->getHtmlAttributes());
         });
     }
+
+    public function test_negative_zero_float_does_not_cause_checksum_corruption()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $value;
+            public $refreshed = false;
+
+            public function mount()
+            {
+                $this->value = -0.0;
+            }
+
+            public function refresh()
+            {
+                $this->refreshed = true;
+            }
+        })
+        ->call('refresh')
+        ->assertSetStrict('refreshed', true);
+    }
 }
 
 class BasicComponent extends TestComponent


### PR DESCRIPTION
Fix for: Livewire encountered corrupt data when trying to hydrate when a variable that has -0.0

See: https://github.com/livewire/livewire/issues/2717
