### PR TITLE
[4.x] Add a Compiled Path option for the config

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -119,6 +119,19 @@ return [
 
     /*
     |---------------------------------------------------------------------------
+    | Compiled Path
+    |---------------------------------------------------------------------------
+    |
+    | This value determines where Livewire stores compiled view-based component
+    | artifacts such as generated classes, extracted Blade views, placeholders,
+    | scripts, styles, and island templates.
+    |
+    */
+
+    'compiled_path' => env('LIVEWIRE_COMPILED_PATH', realpath(storage_path('framework/views/livewire'))),
+
+    /*
+    |---------------------------------------------------------------------------
     | Temporary File Uploads
     |---------------------------------------------------------------------------
     |

--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -178,7 +178,7 @@ PHP;
     {
         $instance = new class (
             app('files'),
-            storage_path('framework/views/livewire'),
+            config('livewire.compiled_path'),
         ) extends \Illuminate\View\Compilers\BladeCompiler {
             /**
              * Make this method public...

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -469,4 +469,41 @@ class UnitTest extends TestCase
         $this->assertSame($islandA, $islandB);
     }
 
+    public function test_livewire_compiler_uses_configured_compiled_path()
+    {
+        $compiledPath = sys_get_temp_dir() . '/livewire-custom-compiled-' . uniqid();
+
+        config()->set('livewire.compiled_path', $compiledPath);
+        app()->forgetInstance('livewire.compiler');
+        app()->forgetInstance('livewire.factory');
+
+        $this->assertSame($compiledPath, app('livewire.compiler')->cacheManager->cacheDirectory);
+
+        File::deleteDirectory($compiledPath);
+    }
+
+    public function test_island_compiler_writes_cached_islands_to_configured_compiled_path()
+    {
+        $compiledPath = sys_get_temp_dir() . '/livewire-custom-islands-' . uniqid();
+
+        config()->set('livewire.compiled_path', $compiledPath);
+        app()->forgetInstance('livewire.compiler');
+        app()->forgetInstance('livewire.factory');
+
+        IslandCompiler::compile(__FILE__, <<<'HTML'
+        <div>
+            @island(name: 'counter')
+                <div>count: {{ $count }}</div>
+            @endisland
+        </div>
+        HTML);
+
+        $token = app('livewire.compiler')->cacheManager->getHash(__FILE__) . '-1';
+        $cachedPath = IslandCompiler::getCachedPathFromToken($token);
+
+        $this->assertSame($compiledPath . '/islands/' . $token . '.blade.php', $cachedPath);
+        $this->assertFileExists($cachedPath);
+
+        File::deleteDirectory($compiledPath);
+    }
 }

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -43,7 +43,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->app->singleton('livewire.compiler', function () {
             return new Compiler(
                 new CacheManager(
-                    storage_path('framework/views/livewire')
+                    config('livewire.compiled_path')
                 )
             );
         });


### PR DESCRIPTION
This is a complement to the config option for `view.compiled` in Laravel: https://github.com/laravel/framework/blob/13.x/config/view.php#L20-L35

Right now the compiled path is configured to be hardcoded to `storage_path('framework/views/livewire')` which doesn't match the customization Laravel has for blade views.

The other option instead of this or as a default in this config would be to default it to `config('view.compiled').'/livewire'`

---

Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
No, but matches Laravel's config.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.
Included at top.

Thanks for contributing! 🙌
