### PR TITLE
[4.x] Add documentation for `$errors.missing()`

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -665,6 +665,7 @@ Livewire provides a `$errors` magic property for client-side access to validatio
 ### Available methods
 
 - `$errors.has('field')` - Check if a field has errors
+- `$errors.missing('field')` - Check if a field doesn't have errors
 - `$errors.first('field')` - Get the first error message for a field
 - `$errors.get('field')` - Get all error messages for a field
 - `$errors.all()` - Get all errors for all fields


### PR DESCRIPTION
Add missing documentation for `missing()` methods from `$errors`

### Before
<img width="504" height="168" alt="image" src="https://github.com/user-attachments/assets/4ad87c01-2b64-4164-aa52-fef4c666e6c4" />

### After
<img width="510" height="199" alt="image" src="https://github.com/user-attachments/assets/eb1607cc-77d8-42a6-a439-fb308430592b" />
