### PR TITLE
[4.x] Add documentation reference for `$set` and `$toggle` live parameter

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -611,14 +611,6 @@ The `$set` magic action allows you to update a property in your Livewire compone
 
 In this example, when the button is clicked, a network request is dispatched that sets the `$query` property in the component to `''`.
 
-`$set` action accepts a third boolean parameter that determines whether the update should trigger a network request:
-
-```blade
-<button wire:click="$set('query', '', false)">Reset Search (no request)</button>
-```
-- `true` (default): Sends a network request and updates the property on the server.
-- `false`: Updates the property without making a network request.
-
 ### `$refresh`
 
 The `$refresh` action triggers a re-render of your Livewire component. This can be useful when updating the component's view without changing any property values:
@@ -641,20 +633,6 @@ The `$toggle` action is used to toggle the value of a boolean property in your L
 
 In this example, when the button is clicked, the `$sortAsc` property in the component will toggle between `true` and `false`.
 
-`$toggle` action accepts a third boolean parameter that determines whether the update should trigger a network request:
-
-```blade
-<button wire:click="$toggle('showForm', false)">
-    Show Form
-</button>
-
-<form wire:show="showForm">
-    ...
-</form>
-```
-- `true` (default): Sends a network request and updates the property on the server.
-- `false`: Updates the property without making a network request.
-
 ### `$dispatch`
 
 The `$dispatch` action allows you to dispatch a Livewire event directly in the browser. Below is an example of a button that, when clicked, will dispatch the `post-deleted` event:
@@ -672,6 +650,8 @@ The `$event` action may be used within event listeners like `wire:click`. This a
 ```
 
 When the enter key is pressed while a user is typing in the input above, the contents of the input will be passed as a parameter to the `search()` action.
+
+> For more information about magic actions, see [Javascript reference](/docs/4.x/javascript#the-wire-object)
 
 ### Using magic actions from Alpine
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -644,8 +644,13 @@ In this example, when the button is clicked, the `$sortAsc` property in the comp
 `$toggle` action accepts a third boolean parameter that determines whether the update should trigger a network request:
 
 ```blade
-<button wire:click="$toggle('sortAsc', false)" wire:text="sortAsc ? 'Sort Ascending' : 'Sort Descending'">
+<button wire:click="$toggle('showForm', false)">
+    Show Form
 </button>
+
+<form wire:show="showForm">
+    ...
+</form>
 ```
 - `true` (default): Sends a network request and updates the property on the server.
 - `false`: Updates the property without making a network request.

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -651,7 +651,7 @@ The `$event` action may be used within event listeners like `wire:click`. This a
 
 When the enter key is pressed while a user is typing in the input above, the contents of the input will be passed as a parameter to the `search()` action.
 
-> For more information about magic actions, see [Javascript reference](/docs/4.x/javascript#the-wire-object)
+> For more information about magic actions, see [Javascript reference](/docs/4.x/javascript#the-wire-object-1)
 
 ### Using magic actions from Alpine
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -627,7 +627,7 @@ The `$toggle` action is used to toggle the value of a boolean property in your L
 
 ```blade
 <button wire:click="$toggle('sortAsc')">
-    Sort {{ $sortAsc ? 'Ascending' : 'Descending' }}
+    Sort {{ $sortAsc ? 'Descending' : 'Ascending' }}
 </button>
 ```
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -611,6 +611,14 @@ The `$set` magic action allows you to update a property in your Livewire compone
 
 In this example, when the button is clicked, a network request is dispatched that sets the `$query` property in the component to `''`.
 
+`$set` action accepts a third boolean parameter that determines whether the update should trigger a network request:
+
+```blade
+<button wire:click="$set('query', '', false)">Reset Search (no request)</button>
+```
+- `true` (default): Sends a network request and updates the property on the server.
+- `false`: Updates the property without making a network request.
+
 ### `$refresh`
 
 The `$refresh` action triggers a re-render of your Livewire component. This can be useful when updating the component's view without changing any property values:
@@ -627,11 +635,20 @@ The `$toggle` action is used to toggle the value of a boolean property in your L
 
 ```blade
 <button wire:click="$toggle('sortAsc')">
-    Sort {{ $sortAsc ? 'Descending' : 'Ascending' }}
+    Sort {{ $sortAsc ? 'Ascending' : 'Descending' }}
 </button>
 ```
 
 In this example, when the button is clicked, the `$sortAsc` property in the component will toggle between `true` and `false`.
+
+`$toggle` action accepts a third boolean parameter that determines whether the update should trigger a network request:
+
+```blade
+<button wire:click="$toggle('sortAsc', false)" wire:text="sortAsc ? 'Sort Ascending' : 'Sort Descending'">
+</button>
+```
+- `true` (default): Sends a network request and updates the property on the server.
+- `false`: Updates the property without making a network request.
 
 ### `$dispatch`
 


### PR DESCRIPTION
Magic actions `$set` and `$toggle` accepts third parameter (boolean) whether it should trigger network request or not. 

However, there is no information about third parameter of `$set` and `$toggle` magic actions on the **Magic Actions** documentation. This PR adds reference link to `$wire` object details.

The third parameter often used for custom select dropdown which usually set the value based on `wire:model` or `wire:model.live`. With this information, user can use the magic actions and customize the syncing should be live or not.