### PR TITLE
[4.x] Fix the url reference of wire object in Javascript documentation

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -96,7 +96,7 @@ $wire.$el.querySelector('.modal')
 ```
 
 > [!tip] Complete $wire reference
-> For a comprehensive list of all `$wire` methods and properties, see the [$wire reference](#the-wire-object) at the bottom of this page.
+> For a comprehensive list of all `$wire` methods and properties, see the [$wire reference](#the-wire-object-1) at the bottom of this page.
 
 ## Loading assets
 


### PR DESCRIPTION
There was a wrong url reference on `$wire` object in Javascript section

<img width="719" height="199" alt="image" src="https://github.com/user-attachments/assets/15eca1ab-4dfc-4217-8fef-08ab964e47be" />

The url should be referencing to `#wire-object-1` instead `#wire-object` which was self referencing.

### Before
**`[$wire reference](#the-wire-object)`**

### After
**`[$wire reference](#the-wire-object-1)`**
