### PR TITLE
[4.x] Use Laravel compiled view path for Livewire compiler

### DIFF
--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -178,7 +178,7 @@ PHP;
     {
         $instance = new class (
             app('files'),
-            storage_path('framework/views/livewire'),
+            rtrim(config('view.compiled'), '/\\') . '/livewire',
         ) extends \Illuminate\View\Compilers\BladeCompiler {
             /**
              * Make this method public...

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -58,7 +58,7 @@ class UnitTest extends TestCase
     public function test_sfc_island_recovers_when_cached_file_is_deleted_between_requests()
     {
         // Create a temporary view file to simulate an SFC's compiled view...
-        $viewPath = storage_path('framework/views/livewire/test-sfc-island.blade.php');
+        $viewPath = app('livewire.compiler')->cacheManager->cacheDirectory . '/test-sfc-island.blade.php';
         File::ensureDirectoryExists(dirname($viewPath));
         File::put($viewPath, <<<'HTML'
         <div>
@@ -469,4 +469,41 @@ class UnitTest extends TestCase
         $this->assertSame($islandA, $islandB);
     }
 
+    public function test_livewire_compiler_uses_laravels_configured_compiled_view_path()
+    {
+        $compiledPath = sys_get_temp_dir() . '/laravel-custom-compiled-' . uniqid();
+
+        config()->set('view.compiled', $compiledPath);
+        app()->forgetInstance('livewire.compiler');
+        app()->forgetInstance('livewire.factory');
+
+        $this->assertSame($compiledPath . '/livewire', app('livewire.compiler')->cacheManager->cacheDirectory);
+
+        File::deleteDirectory($compiledPath);
+    }
+
+    public function test_island_compiler_writes_cached_islands_inside_laravels_configured_compiled_view_path()
+    {
+        $compiledPath = sys_get_temp_dir() . '/laravel-custom-islands-' . uniqid();
+
+        config()->set('view.compiled', $compiledPath);
+        app()->forgetInstance('livewire.compiler');
+        app()->forgetInstance('livewire.factory');
+
+        IslandCompiler::compile(__FILE__, <<<'HTML'
+        <div>
+            @island(name: 'counter')
+                <div>count: {{ $count }}</div>
+            @endisland
+        </div>
+        HTML);
+
+        $token = app('livewire.compiler')->cacheManager->getHash(__FILE__) . '-1';
+        $cachedPath = IslandCompiler::getCachedPathFromToken($token);
+
+        $this->assertSame($compiledPath . '/livewire/islands/' . $token . '.blade.php', $cachedPath);
+        $this->assertFileExists($cachedPath);
+
+        File::deleteDirectory($compiledPath);
+    }
 }

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -43,7 +43,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->app->singleton('livewire.compiler', function () {
             return new Compiler(
                 new CacheManager(
-                    storage_path('framework/views/livewire')
+                    rtrim(config('view.compiled'), '/\\') . '/livewire'
                 )
             );
         });


### PR DESCRIPTION
A follow up to https://github.com/livewire/livewire/pull/10234

This uses Laravel's value of `config('view.compiled')` which defaults to `storage_path('framework/views')` instead of hardcoding the path to be `storage_path('framework/views/livewire')`.

This preservers the customization of your `view.compiled` path while still putting it in the `livewire` path after that by setting the path to `config('view.compiled').'/livewire'` directly.
