### PR TITLE
[4.x] Fix nested unnamed wire:transition not following parent's typed swap

### DIFF
--- a/docs/wire-transition.md
+++ b/docs/wire-transition.md
@@ -155,6 +155,29 @@ class Wizard extends Component
 }
 ```
 
+### Unnamed transitions during a typed swap
+
+When a typed transition is active, Livewire treats the swap as a single orchestrated unit. Any *unnamed* `wire:transition` element inside that swap stays unnamed and rides along with its parent's snapshot, instead of becoming an independent group with the browser's default fade.
+
+```blade
+<div wire:transition="slide">
+    <p>Step content</p>
+
+    {{-- Unnamed: rides along with the parent's "slide" during a typed swap --}}
+    <div wire:transition>
+        <button>Save</button>
+    </div>
+</div>
+```
+
+If you need an inner element to animate independently during a typed swap, give it an explicit name:
+
+```blade
+<div wire:transition="badge">...</div>
+```
+
+Outside of a typed transition (a regular morph, like a validation error appearing), unnamed `wire:transition` elements continue to use `match-element` and animate independently as before.
+
 ## Skipping transitions
 
 Sometimes you may want to disable transitions for specific actions—for example, a "reset" button that should instantly jump to the first step without animation.

--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -14,13 +14,12 @@ function setTransitionNames(root, options = {}) {
 
         let name = el.getAttribute('wire:transition')
 
-        // When an explicit transition type is active (e.g. via #[Transition('forward')]),
-        // the developer is orchestrating the swap as a single visual unit. Unnamed
-        // wire:transition elements should ride along with their parent's snapshot
-        // rather than animate independently and pop with the browser's default fade...
-        if (! name && ! options.type) name = defaultName
+        // When the developer orchestrates a typed swap (e.g. #[Transition('forward')]),
+        // unnamed wire:transition elements stay unnamed so they ride with the parent's
+        // snapshot instead of becoming independent groups with the browser's default fade...
+        if (! name && options.type) return
 
-        if (name) el.style.viewTransitionName = name
+        el.style.viewTransitionName = name || defaultName
     })
 }
 

--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -8,11 +8,19 @@ globalDirective('transition', ({ el, directive, cleanup }) => {
     //
 })
 
-function setTransitionNames(root) {
+function setTransitionNames(root, options = {}) {
     root.querySelectorAll('[wire\\:transition]').forEach(el => {
-        if (! el.style.viewTransitionName) {
-            el.style.viewTransitionName = el.getAttribute('wire:transition') || defaultName
-        }
+        if (el.style.viewTransitionName) return
+
+        let name = el.getAttribute('wire:transition')
+
+        // When an explicit transition type is active (e.g. via #[Transition('forward')]),
+        // the developer is orchestrating the swap as a single visual unit. Unnamed
+        // wire:transition elements should ride along with their parent's snapshot
+        // rather than animate independently and pop with the browser's default fade...
+        if (! name && ! options.type) name = defaultName
+
+        if (name) el.style.viewTransitionName = name
     })
 }
 
@@ -40,7 +48,7 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
     if (document.querySelector('dialog:modal')) return callback()
 
     // Set transition names right before the transition starts (not permanently)...
-    setTransitionNames(fromEl)
+    setTransitionNames(fromEl, options)
 
     // Disable root transitions for the page...
     let style = document.createElement('style')
@@ -73,7 +81,7 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
         // internal queueMicrotask batching delays processing by one microtask hop — and the
         // View Transitions API's "activate" step captures the new DOM state in between,
         // before Alpine has a chance to initialize the directive...
-        setTransitionNames(fromEl)
+        setTransitionNames(fromEl, options)
     }
 
     let transitionConfig = { update }

--- a/src/Features/SupportTransitions/BrowserTest.php
+++ b/src/Features/SupportTransitions/BrowserTest.php
@@ -327,4 +327,112 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertScript('window.__transitionNameSetSynchronously', true)
         ;
     }
+
+    public function test_unnamed_wire_transition_rides_with_parent_during_typed_transition()
+    {
+        $animationsRunning = 'document.getAnimations().some(a => a.playState === "running")';
+
+        Livewire::visit([
+            new class extends \Livewire\Component {
+                public $current = 'first-child';
+
+                #[Transition(type: 'forward')]
+                public function showSecond()
+                {
+                    $this->current = 'second-child';
+                }
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <livewire:is :component="$current" :wire:key="$current" />
+                </div>
+                HTML; }
+            },
+            'first-child' => new class extends \Livewire\Component {
+                public function render() { return <<<'HTML'
+                <div wire:transition="slide">
+                    <button wire:click="$parent.showSecond" dusk="show-second">Show Second</button>
+                </div>
+                HTML; }
+            },
+            'second-child' => new class extends \Livewire\Component {
+                public function render() { return <<<'HTML'
+                <div wire:transition="slide">
+                    <p dusk="second-text">Second Child</p>
+
+                    <div wire:transition dusk="inner">
+                        <p>Inner content</p>
+                    </div>
+                </div>
+                HTML; }
+            },
+        ])
+        ->assertSee('Show Second')
+
+        ->waitForLivewire()->click('@show-second')
+        ->waitUntil($animationsRunning)
+
+        // The named outer wire:transition is still given its explicit name so it
+        // animates as an independent group with the user's "slide" CSS...
+        ->assertScript(
+            "document.querySelector('[wire\\\\:transition=\"slide\"]').style.viewTransitionName",
+            'slide'
+        )
+
+        // The unnamed inner wire:transition is intentionally NOT given a
+        // view-transition-name during a typed transition. This lets the browser
+        // capture it as part of its parent's snapshot so it rides along with the
+        // orchestrated transition instead of popping with a default UA fade...
+        ->assertScript(
+            "document.querySelector('[dusk=\"inner\"]').style.viewTransitionName",
+            ''
+        )
+
+        ->waitUntil("!$animationsRunning")
+        ->assertSee('Second Child')
+        ;
+    }
+
+    public function test_unnamed_wire_transition_still_animates_independently_during_regular_morph()
+    {
+        $animationsRunning = 'document.getAnimations().some(a => a.playState === "running")';
+
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public bool $expanded = false;
+
+                public function toggle()
+                {
+                    $this->expanded = ! $this->expanded;
+                }
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <button wire:click="toggle" dusk="toggle">Toggle</button>
+
+                    @if ($expanded)
+                        <p dusk="extra">Extra content</p>
+                    @endif
+
+                    <div wire:transition dusk="target">
+                        Footer
+                    </div>
+                </div>
+                HTML; }
+            }
+        )
+        ->waitForLivewire()->click('@toggle')
+        ->waitUntil($animationsRunning)
+
+        // No transition type is active, so unnamed wire:transition elements should
+        // still get an auto-generated view-transition-name and animate independently
+        // for in-place layout shifts...
+        ->assertScript(
+            "document.querySelector('[dusk=\"target\"]').style.viewTransitionName !== ''",
+            true
+        )
+
+        ->waitUntil("!$animationsRunning")
+        ;
+    }
 }


### PR DESCRIPTION
# The Scenario

When a parent swaps children with a typed transition (`#[Transition('forward')]`), any nested element with `wire:transition` (no value) animates with the browser's default fade instead of sliding along with the parent's animation.

<img width="800" height="773" alt="Screenshot 2026-04-23 at 09 47 07AM" src="https://github.com/user-attachments/assets/d2764cf2-3d14-4d23-855e-967895dc2da2" />

```php
<?php

use Livewire\Attributes\Transition;
use Livewire\Component;

new class extends Component
{
    public string $mode = 'profile.view-mode';

    #[Transition('forward')]
    public function editMode(): void
    {
        $this->mode = 'profile.edit-mode';
    }
}
```

```blade
{{-- pages/profile.blade.php --}}
<div>
    <livewire:dynamic-component :is="$mode" :wire:key="$mode" />
</div>

{{-- livewire/profile/edit-mode.blade.php --}}
<div wire:transition="slide">
    <form wire:submit="save">
        <flux:input label="Email" wire:model="email" />

        {{-- Animates independently with the default fade during the parent swap --}}
        <div wire:transition>
            <flux:button type="submit">Save changes</flux:button>
        </div>
    </form>
</div>
```

# The Problem

In the View Transitions API, any element with a `view-transition-name` is captured as its own group. Named groups animate independently, and an unnamed element rides along with its parent's snapshot.

`setTransitionNames` always assigns a name to every `wire:transition` element, falling back to `match-element` when none is given:

```js
function setTransitionNames(root) {
    root.querySelectorAll('[wire\\:transition]').forEach(el => {
        if (! el.style.viewTransitionName) {
            el.style.viewTransitionName = el.getAttribute('wire:transition') || defaultName
        }
    })
}
```

So during the typed parent swap, the inner `<div wire:transition>` becomes its own group. It only exists in the new snapshot, has no user CSS targeting it, and falls back to the browser's default ~250ms fade while the surrounding panel slides 600ms with the user's `:active-view-transition-type(forward)` rules.

# The Solution

When a transition has an explicit type, the developer is orchestrating the swap as a single visual unit. Inside that orchestration, only explicitly named `wire:transition` elements should animate independently. Unnamed ones should ride along with the parent.

`setTransitionNames` now skips the `match-element` fallback when `options.type` is set:

```js
function setTransitionNames(root, options = {}) {
    root.querySelectorAll('[wire\\:transition]').forEach(el => {
        if (el.style.viewTransitionName) return

        let name = el.getAttribute('wire:transition')

        if (! name && ! options.type) name = defaultName

        if (name) el.style.viewTransitionName = name
    })
}
```

Named transitions still get their explicit name and animate independently as before. Unnamed transitions during a regular morph (e.g. a layout shift when a validation error appears) continue to be auto-named so they animate independently for the smooth in-place transition users already expect.

<img width="800" height="773" alt="Screenshot 2026-04-23 at 09 34 46AM" src="https://github.com/user-attachments/assets/aca122ec-1e96-40d0-a539-7228ebc2e7db" />

Fixes #10232
