### PR TITLE
[4.x] Fix unchanged wire:model.live.blur requests

### DIFF
--- a/js/component.js
+++ b/js/component.js
@@ -131,6 +131,11 @@ export class Component {
         return this.mergeQueuedUpdates(propertiesDiff)
     }
 
+    hasUpdates() {
+        return Object.keys(this.queuedUpdates).length > 0
+            || Object.keys(diffAndConsolidate(this.canonical, this.ephemeral)).length > 0
+    }
+
     applyUpdates(object, updates) {
         for (let key in updates) {
             dataSet(object, key, updates[key])

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -189,8 +189,20 @@ export function createOrAddToOutstandingMessage(action) {
 
 function sendMessages() {
     let requests = new Set()
+    let skippedMessages = new Set()
 
     messageBus.eachPendingMessage(message => {
+        if (! messageIsSkippableModelLiveCommit(message)) return
+
+        if (message.component.hasUpdates()) return
+
+        skippedMessages.add(message)
+        message.resolveActionPromises([], [])
+    })
+
+    messageBus.eachPendingMessage(message => {
+        if (skippedMessages.has(message)) return
+
         partitionInterceptors.forEach(callback => {
             callback({
                 message,
@@ -230,7 +242,7 @@ function sendMessages() {
         })
     })
 
-    let messages = messageBus.getPendingMessages()
+    let messages = messageBus.getPendingMessages().filter(message => ! skippedMessages.has(message))
 
     messageBus.clearPendingMessages()
 
@@ -480,6 +492,13 @@ function sendMessages() {
             },
         })
     })
+}
+
+function messageIsSkippableModelLiveCommit(message) {
+    let actions = message.getActions()
+
+    return actions.length > 0
+        && actions.every(action => action.name === '$commit' && action.metadata.type === 'model.live')
 }
 
 async function sendRequest(request, handlers) {

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -619,6 +619,45 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_wire_model_live_blur_does_not_send_network_request_when_value_has_not_changed()
+    {
+        Livewire::visit(new class extends Component {
+            public $title = '';
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div x-init="window.requests = 0">
+                        <input dusk="input" type="text" wire:model.live.blur="title" />
+                        <span dusk="server">{{ $title }}</span>
+                        <button dusk="blur-target">Blur Target</button>
+                    </div>
+
+                    @script
+                    <script>
+                        this.intercept(({ onSend }) => {
+                            onSend(() => {
+                                window.requests++
+                            })
+                        })
+                    </script>
+                    @endscript
+                BLADE;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->assertScript('window.requests', 0)
+            ->typeSlowly('@input', 'hello', 50)
+            ->waitForLivewire()->click('@blur-target')
+            ->assertSeeIn('@server', 'hello')
+            ->assertScript('window.requests', 1)
+            ->click('@input')
+            ->click('@blur-target')
+            ->pause(200)
+            ->assertScript('window.requests', 1)
+        ;
+    }
+
     public function test_wire_model_blur_live_ephemeral_on_blur_network_on_blur()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes. This is related to filamentphp/filament#19764, where an unchanged `live(onBlur: true)` field can still cause an unexpected Livewire round-trip.

I did not open a Livewire discussion first because this is a small fix for a no-op model request.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

4️⃣ Does it include tests? (Required)

Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This skips clean model-triggered commits from `wire:model.live.blur`.

A blur still sends a request when there are pending model updates on the component. It only skips the request when the commit would have no updates to send.
