### PR TITLE
Fix typos in request comments

### DIFF
--- a/js/request/index.js
+++ b/js/request/index.js
@@ -535,7 +535,6 @@ async function sendRequest(request, handlers) {
      * render the dump in a modal and allow Livewire to continue with the
      * request.
      */
-    
     if (contentIsFromDump(responseBody)) {
         let dump
 

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -531,10 +531,11 @@ async function sendRequest(request, handlers) {
 
     /**
      * Sometimes a response will be prepended with html to render a dump, so we
-     * will seperate the dump html from Livewire's JSON response content and
+     * will separate the dump html from Livewire's JSON response content and
      * render the dump in a modal and allow Livewire to continue with the
      * request.
      */
+    
     if (contentIsFromDump(responseBody)) {
         let dump
 
@@ -644,7 +645,7 @@ function getDestination(uri, response) {
 
     // If there was no redirect triggered by the URL that was fetched...
     if ((destination.pathname + destination.search) === (finalDestination.pathname + finalDestination.search)) {
-        // Then let's cary over any "hash" entries on the URL.
+        // Then let's carry over any "hash" entries on the URL.
         // We have to do this because hashes aren't sent to
         // the server by "fetch", so it needs to get added
         finalDestination.hash = destination.hash


### PR DESCRIPTION
This PR fixes two minor typos in comments within `js/request/index.js`.

Changes:

- `seperate` → `separate`
- `cary` → `carry`

This is a comment-only change and does not affect runtime behavior, public APIs, build output, or application logic. No tests were added because no functional code was changed.

The PR is submitted from a dedicated branch: `fix/comment-typos-in-request-js`.