### PR TITLE
[4.x] Fix commented out `use` statements being injected into compiled view

### DIFF
--- a/src/Compiler/Parser/Parser.php
+++ b/src/Compiler/Parser/Parser.php
@@ -211,8 +211,11 @@ PHP
         if (preg_match('/\<\?php(.*?)new/s', $classPortion, $matches)) {
             $preamble = $matches[1];
 
+            // Use (*SKIP)(*FAIL) to ignore "use" statements inside comments...
+            $skipComments = '(?:\/\/[^\n]*|\/\*.*?\*\/)(*SKIP)(*FAIL)';
+
             // Extract all use statements
-            if (preg_match_all('/use\s+[^;]+;/s', $preamble, $useMatches)) {
+            if (preg_match_all('/' . $skipComments . '|use\s+[^;]+;/s', $preamble, $useMatches)) {
                 $useStatements = implode("\n", $useMatches[0]);
             }
         }

--- a/src/Compiler/UnitTest.php
+++ b/src/Compiler/UnitTest.php
@@ -523,6 +523,98 @@ class UnitTest extends \Tests\TestCase
         $this->assertEquals($expectedOutput, $generatedClassContents);
     }
 
+    #[DataProvider('commentedUseStatementProvider')]
+    public function test_commented_use_statements_are_not_injected_into_view_contents($classPortion, $shouldNotContain, $shouldContain)
+    {
+        $parser = new SingleFileParser(
+            path: '',
+            contents: '',
+            scriptPortion: null,
+            stylePortion: null,
+            globalStylePortion: null,
+            classPortion: $classPortion,
+            placeholderPortion: null,
+            viewPortion: '<div></div>',
+        );
+
+        $viewContents = $parser->generateViewContents();
+
+        foreach ($shouldNotContain as $needle) {
+            $this->assertStringNotContainsString($needle, $viewContents);
+        }
+
+        foreach ($shouldContain as $needle) {
+            $this->assertStringContainsString($needle, $viewContents);
+        }
+    }
+
+    public static function commentedUseStatementProvider()
+    {
+        return [
+            'single-line // comment with use statement' => [
+                <<<'EOT'
+                <?php
+                // use App\Actions\One\MyAction;
+                use App\Actions\Two\MyAction;
+                use Livewire\Component;
+
+                new class extends Component {
+                };
+                ?>
+                EOT,
+                ['use App\Actions\One\MyAction;'],
+                ['use App\Actions\Two\MyAction;', 'use Livewire\Component;'],
+            ],
+            'multi-line /* */ comment with use statement' => [
+                <<<'EOT'
+                <?php
+                /* use App\Actions\One\MyAction; */
+                use App\Actions\Two\MyAction;
+                use Livewire\Component;
+
+                new class extends Component {
+                };
+                ?>
+                EOT,
+                ['use App\Actions\One\MyAction;'],
+                ['use App\Actions\Two\MyAction;', 'use Livewire\Component;'],
+            ],
+            'docblock /** */ comment with use statement' => [
+                <<<'EOT'
+                <?php
+                /**
+                 * use App\Actions\One\MyAction;
+                 */
+                use App\Actions\Two\MyAction;
+                use Livewire\Component;
+
+                new class extends Component {
+                };
+                ?>
+                EOT,
+                ['use App\Actions\One\MyAction;'],
+                ['use App\Actions\Two\MyAction;', 'use Livewire\Component;'],
+            ],
+            'multi-line block comment spanning multiple use statements' => [
+                <<<'EOT'
+                <?php
+                /*
+                use App\Actions\One\MyAction;
+                use App\Actions\Three\AnotherAction;
+                */
+                use App\Actions\Two\MyAction;
+                use Livewire\Component;
+
+                new class extends Component {
+                };
+                ?>
+                EOT,
+                ['use App\Actions\One\MyAction;', 'use App\Actions\Three\AnotherAction;'],
+                ['use App\Actions\Two\MyAction;', 'use Livewire\Component;'],
+            ],
+        ];
+    }
+
     public static function classReturnProvider()
     {
         return [


### PR DESCRIPTION
# The Scenario

When a `use` statement is commented out in a single-file Livewire component, the compiler strips the comment marker and emits the `use` statement into the compiled view anyway. If the commented-out `use` aliases the same short name as an active `use` (a common pattern when switching between two implementations), the compiled view ends up with duplicate aliases and PHP throws a fatal error.

```php
<?php
// use App\Actions\One\MyAction;
use App\Actions\Two\MyAction;
use Livewire\Component;

new class extends Component {
};
?>

<div>
    //
</div>
```

The compiled view (`storage/framework/views/livewire/views/<hash>.blade.php`) ends up as:

```php
<?php
use App\Actions\One\MyAction;
use App\Actions\Two\MyAction;
use Livewire\Component;
?>

<div>
    //
</div>
```

# The Problem

`Parser::injectUseStatementsFromClassPortion()` extracts `use` statements from the class portion's preamble and re-injects them into the view portion so the view can reference imported classes. The extraction regex is:

```php
preg_match_all('/use\s+[^;]+;/s', $preamble, $useMatches)
```

This regex has no notion of PHP comments, so it matches `use App\Actions\One\MyAction;` regardless of whether it's preceded by `//` or wrapped in `/* */`. Only the `use ...;` portion is captured, so the comment marker is dropped when the matches are re-emitted.

# The Solution

Skip matches inside `//` and `/* */` comments using the `(*SKIP)(*FAIL)` PCRE pattern that's already used in the same file by `ensureAnonymousClassHasReturn()` and `ensureAnonymousClassHasTrailingSemicolon()`:

```php
$skipComments = '(?:\/\/[^\n]*|\/\*.*?\*\/)(*SKIP)(*FAIL)';

if (preg_match_all('/' . $skipComments . '|use\s+[^;]+;/s', $preamble, $useMatches)) {
    $useStatements = implode("\n", $useMatches[0]);
}
```

Tests cover single-line `//` comments, single-line `/* */` comments, docblock `/** */` comments, and multi-line block comments that span multiple `use` statements.

Fixes #10244