### PR TITLE
[4.x] Allow overriding payload guards per component

### DIFF
--- a/src/Attributes/MaxCalls.php
+++ b/src/Attributes/MaxCalls.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class MaxCalls extends LivewireAttribute
+{
+    public function __construct(
+        public int $maxCalls
+    ) {}
+}

--- a/src/Attributes/MaxNestingDepth.php
+++ b/src/Attributes/MaxNestingDepth.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class MaxNestingDepth extends LivewireAttribute
+{
+    public function __construct(
+        public int $maxDepth
+    ) {}
+}

--- a/src/Exceptions/MaxNestingDepthExceededException.php
+++ b/src/Exceptions/MaxNestingDepthExceededException.php
@@ -7,7 +7,7 @@ class MaxNestingDepthExceededException extends \Exception
     public function __construct(string $path, int $maxDepth)
     {
         $message = "Property path [{$path}] exceeds the maximum nesting depth of {$maxDepth} levels. "
-            . "You can configure this limit in config/livewire.php under 'payload.max_nesting_depth'.";
+            . "You can configure this limit in config/livewire.php under 'payload.max_nesting_depth' or inside the component as \$maxNestingDepth or #[MaxNestingDepth(...)].";
 
         parent::__construct($message);
     }

--- a/src/Exceptions/TooManyCallsException.php
+++ b/src/Exceptions/TooManyCallsException.php
@@ -8,7 +8,7 @@ class TooManyCallsException extends \Exception
     {
         $message = "Too many method calls in a single request ({$count}). "
             . "Maximum allowed is {$maxCalls}. "
-            . "You can configure this limit in config/livewire.php under 'payload.max_calls'.";
+            . "You can configure this limit in config/livewire.php under 'payload.max_calls' or inside the component as \$maxCalls or #[MaxCalls(...)].";
 
         parent::__construct($message);
     }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -514,7 +514,14 @@ class HandleComponents extends Mechanism
     {
         $segments = explode('.', $path);
 
-        $maxDepth = config('livewire.payload.max_nesting_depth');
+        $attribute = $component->getAttributes()->whereInstanceOf(\Livewire\Attributes\MaxNestingDepth::class)->first();
+
+        $maxDepth = $attribute
+            ? $attribute->maxDepth
+            : (property_exists($component, 'maxNestingDepth')
+                ? \Livewire\invade($component)->maxNestingDepth
+                : config('livewire.payload.max_nesting_depth'));
+
         if ($maxDepth !== null && count($segments) > $maxDepth) {
             throw new MaxNestingDepthExceededException($path, $maxDepth);
         }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -518,7 +518,7 @@ class HandleComponents extends Mechanism
 
         $maxDepth = $attribute
             ? $attribute->maxDepth
-            : (property_exists($component, 'maxNestingDepth')
+            : (property_exists($component, 'maxNestingDepth') && ! (new \ReflectionProperty($component, 'maxNestingDepth'))->isPublic()
                 ? \Livewire\invade($component)->maxNestingDepth
                 : config('livewire.payload.max_nesting_depth'));
 
@@ -664,7 +664,7 @@ class HandleComponents extends Mechanism
 
         $maxCalls = $attribute
             ? $attribute->maxCalls
-            : (property_exists($root, 'maxCalls')
+            : (property_exists($root, 'maxCalls') && ! (new \ReflectionProperty($root, 'maxCalls'))->isPublic()
                 ? \Livewire\invade($root)->maxCalls
                 : config('livewire.payload.max_calls'));
 

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -660,7 +660,13 @@ class HandleComponents extends Mechanism
 
     protected function callMethods($root, $calls, $componentContext)
     {
-        $maxCalls = config('livewire.payload.max_calls');
+        $attribute = $root->getAttributes()->whereInstanceOf(\Livewire\Attributes\MaxCalls::class)->first();
+
+        $maxCalls = $attribute
+            ? $attribute->maxCalls
+            : (property_exists($root, 'maxCalls')
+                ? \Livewire\invade($root)->maxCalls
+                : config('livewire.payload.max_calls'));
 
         if ($maxCalls !== null && count($calls) > $maxCalls) {
             throw new TooManyCallsException(count($calls), $maxCalls);

--- a/src/Mechanisms/HandleComponents/NestingDepthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/NestingDepthUnitTest.php
@@ -115,10 +115,51 @@ class NestingDepthUnitTest extends TestCase
         // Should fail fast (< 1 second), not hang for 20 seconds
         $this->assertLessThan(1, $elapsed, "Attack took {$elapsed} seconds - should be blocked instantly");
     }
+    public function test_component_can_override_max_depth_via_attribute()
+    {
+        config()->set('livewire.payload.max_nesting_depth', 3);
+
+        $component = Livewire::test(CustomAttributeNestingDepthComponent::class)
+            ->set('data.a.b.c.d.e', 'value'); // 6 levels, allowed because attribute allows 10
+
+        $this->assertEquals('value', $component->get('data.a.b.c.d.e'));
+    }
+
+    public function test_component_can_override_max_depth_via_property()
+    {
+        config()->set('livewire.payload.max_nesting_depth', 3);
+
+        $component = Livewire::test(CustomPropertyNestingDepthComponent::class)
+            ->set('data.a.b.c.d.e', 'value'); // 6 levels, allowed because property allows 10
+
+        $this->assertEquals('value', $component->get('data.a.b.c.d.e'));
+    }
 }
 
 class NestingDepthComponent extends Component
 {
+    public $data = [];
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+#[\Livewire\Attributes\MaxNestingDepth(10)]
+class CustomAttributeNestingDepthComponent extends Component
+{
+    public $data = [];
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class CustomPropertyNestingDepthComponent extends Component
+{
+    protected $maxNestingDepth = 10;
     public $data = [];
 
     public function render()

--- a/src/Mechanisms/HandleRequests/PayloadGuardsUnitTest.php
+++ b/src/Mechanisms/HandleRequests/PayloadGuardsUnitTest.php
@@ -9,6 +9,7 @@ use Livewire\Exceptions\TooManyComponentsException;
 use Livewire\Exceptions\TooManyCallsException;
 use Tests\TestCase;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
+use Livewire\Attributes\MaxCalls;
 
 class PayloadGuardsUnitTest extends TestCase
 {
@@ -229,6 +230,39 @@ class PayloadGuardsUnitTest extends TestCase
 
 class PayloadGuardComponent extends Component
 {
+    public $count = 0;
+
+    public function increment()
+    {
+        $this->count++;
+    }
+
+    public function render()
+    {
+        return '<div>{{ $count }}</div>';
+    }
+}
+
+#[MaxCalls(5)]
+class PayloadCallsGuardAttributeComponent extends Component
+{
+    public $count = 0;
+
+    public function increment()
+    {
+        $this->count++;
+    }
+
+    public function render()
+    {
+        return '<div>{{ $count }}</div>';
+    }
+}
+
+class PayloadCallsGuardPropertyComponent extends Component
+{
+    protected $maxCalls = 5;
+
     public $count = 0;
 
     public function increment()

--- a/src/Mechanisms/HandleRequests/PayloadGuardsUnitTest.php
+++ b/src/Mechanisms/HandleRequests/PayloadGuardsUnitTest.php
@@ -178,6 +178,36 @@ class PayloadGuardsUnitTest extends TestCase
         $this->assertEquals(3, $component->get('count'));
     }
 
+    public function test_component_can_override_max_calls_via_attribute()
+    {
+        config()->set('livewire.payload.max_calls', 2);
+
+        $component = Livewire::test(PayloadCallsGuardAttributeComponent::class);
+
+        // Component attribute allows 5 calls
+        $component->call('increment')
+            ->call('increment')
+            ->call('increment')
+            ->call('increment');
+
+        $this->assertEquals(4, $component->get('count'));
+    }
+
+    public function test_component_can_override_max_calls_via_property()
+    {
+        config()->set('livewire.payload.max_calls', 2);
+
+        $component = Livewire::test(PayloadCallsGuardPropertyComponent::class);
+
+        // Component property allows 5 calls
+        $component->call('increment')
+            ->call('increment')
+            ->call('increment')
+            ->call('increment');
+
+        $this->assertEquals(4, $component->get('count'));
+    }
+
     public function test_exception_messages_include_config_keys()
     {
         $payloadException = new PayloadTooLargeException(2048, 1024);


### PR DESCRIPTION
Overview: This PR introduces the ability to override global payload security limits on a per-component basis. This is particularly useful for complex components that may require deeper property nesting or more method calls than the global defaults defined in config/livewire.php.

Key Changes:

New Attributes: Added `#[MaxNestingDepth]` and `#[MaxCalls]` PHP attributes to allow declarative limit overrides.
Property Support: Added support for protected $maxNestingDepth and protected $maxCalls properties within component classes.
Mechanism Update: Updated HandleComponents to check for these overrides (Attribute first, then Property) before falling back to the global configuration.
Improved DX: Updated exception messages to inform developers about the new ways they can adjust these limits for specific components.
Testing: Added comprehensive unit tests to ensure overrides work correctly for both attributes and properties.

Example Usage:
```
use Livewire\Attributes\MaxNestingDepth;
use Livewire\Attributes\MaxCalls;
#[MaxNestingDepth(15)]
#[MaxCalls(100)]
class ComplexDashboard extends Component 
{
    // Or via property:
    // protected $maxNestingDepth = 15;
}
```