### PR TITLE
[4.x] Fix `#[Session]` attribute on non-primitive properties under JSON session serialisation

### DIFF
--- a/src/Features/SupportSession/BaseSession.php
+++ b/src/Features/SupportSession/BaseSession.php
@@ -47,7 +47,9 @@ class BaseSession extends LivewireAttribute
     {
         // Dehydrate to a JSON-safe tuple so the original type is restored
         // on read regardless of the session driver's serialisation format...
-        Session::put($this->key(), app(HandleComponents::class)->dehydrate($this->getValue(), new ComponentContext($this->component), ''));
+        $value = app(HandleComponents::class)->dehydrate($this->getValue(), new ComponentContext($this->component), '');
+
+        Session::put($this->key(), $value);
     }
 
     protected function key()

--- a/src/Features/SupportSession/BaseSession.php
+++ b/src/Features/SupportSession/BaseSession.php
@@ -36,26 +36,18 @@ class BaseSession extends LivewireAttribute
 
     protected function read()
     {
+        $value = Session::get($this->key());
+
         // Hydrate via Livewire's synth pipeline so non-primitive types
         // (Collection, Carbon, models) survive JSON-serialised sessions...
-        return app(HandleComponents::class)->hydrate(
-            Session::get($this->key()),
-            new ComponentContext($this->component),
-            '',
-        );
+        return app(HandleComponents::class)->hydrate($value, new ComponentContext($this->component), '');
     }
 
     protected function write()
     {
         // Dehydrate to a JSON-safe tuple so the original type is restored
         // on read regardless of the session driver's serialisation format...
-        $value = app(HandleComponents::class)->dehydrate(
-            $this->getValue(),
-            new ComponentContext($this->component),
-            '',
-        );
-
-        Session::put($this->key(), $value);
+        Session::put($this->key(), app(HandleComponents::class)->dehydrate($this->getValue(), new ComponentContext($this->component), ''));
     }
 
     protected function key()

--- a/src/Features/SupportSession/BaseSession.php
+++ b/src/Features/SupportSession/BaseSession.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportSession;
 
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
 use Livewire\Mechanisms\HandleComponents\HandleComponents;
 use Illuminate\Support\Facades\Session;
 use Attribute;
@@ -37,14 +38,22 @@ class BaseSession extends LivewireAttribute
     {
         // Hydrate via Livewire's synth pipeline so non-primitive types
         // (Collection, Carbon, models) survive JSON-serialised sessions...
-        return app(HandleComponents::class)->hydrateValue($this->component, Session::get($this->key()));
+        return app(HandleComponents::class)->hydrate(
+            Session::get($this->key()),
+            new ComponentContext($this->component),
+            '',
+        );
     }
 
     protected function write()
     {
         // Dehydrate to a JSON-safe tuple so the original type is restored
         // on read regardless of the session driver's serialisation format...
-        $value = app(HandleComponents::class)->dehydrateValue($this->component, $this->getValue());
+        $value = app(HandleComponents::class)->dehydrate(
+            $this->getValue(),
+            new ComponentContext($this->component),
+            '',
+        );
 
         Session::put($this->key(), $value);
     }

--- a/src/Features/SupportSession/BaseSession.php
+++ b/src/Features/SupportSession/BaseSession.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportSession;
 
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+use Livewire\Mechanisms\HandleComponents\HandleComponents;
 use Illuminate\Support\Facades\Session;
 use Attribute;
 
@@ -34,12 +35,18 @@ class BaseSession extends LivewireAttribute
 
     protected function read()
     {
-        return Session::get($this->key());
+        // Hydrate via Livewire's synth pipeline so non-primitive types
+        // (Collection, Carbon, models) survive JSON-serialised sessions...
+        return app(HandleComponents::class)->hydrateValue($this->component, Session::get($this->key()));
     }
 
     protected function write()
     {
-        Session::put($this->key(), $this->getValue());
+        // Dehydrate to a JSON-safe tuple so the original type is restored
+        // on read regardless of the session driver's serialisation format...
+        $value = app(HandleComponents::class)->dehydrateValue($this->component, $this->getValue());
+
+        Session::put($this->key(), $value);
     }
 
     protected function key()

--- a/src/Features/SupportSession/UnitTest.php
+++ b/src/Features/SupportSession/UnitTest.php
@@ -2,8 +2,11 @@
 
 namespace Livewire\Features\SupportSession;
 
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Session as FacadesSession;
 use Livewire\Attributes\Session;
+use Livewire\Component;
 use Tests\TestCase;
 use Livewire\Livewire;
 use Tests\TestComponent;
@@ -42,5 +45,113 @@ class UnitTest extends TestCase
         });
 
         $this->assertTrue(FacadesSession::has('baz.2'));
+    }
+
+    public function test_it_persists_a_collection_property_through_a_json_serialised_session()
+    {
+        $this->forceJsonSessionSerialization();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->call('add', 1)
+            ->call('add', 2);
+
+        $this->roundTripSession();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->assertSet('list', collect([1, 2]))
+            ->call('add', 3)
+            ->assertSet('list', collect([1, 2, 3]));
+    }
+
+    public function test_it_persists_a_carbon_property_through_a_json_serialised_session()
+    {
+        $this->forceJsonSessionSerialization();
+
+        $date = Carbon::parse('2026-01-15 10:00:00');
+
+        Livewire::test(ComponentWithSessionCarbon::class)
+            ->set('when', $date);
+
+        $this->roundTripSession();
+
+        Livewire::test(ComponentWithSessionCarbon::class)
+            ->assertSet('when', $date);
+    }
+
+    public function test_it_persists_a_primitive_property_through_a_json_serialised_session()
+    {
+        $this->forceJsonSessionSerialization();
+
+        Livewire::test(ComponentWithSessionCount::class)
+            ->call('increment')
+            ->call('increment');
+
+        $this->roundTripSession();
+
+        Livewire::test(ComponentWithSessionCount::class)
+            ->assertSet('count', 2);
+    }
+
+    protected function forceJsonSessionSerialization(): void
+    {
+        config(['session.serialization' => 'json']);
+
+        // Rebuild the store so the new serialisation config takes effect...
+        app('session')->forgetDrivers();
+    }
+
+    protected function roundTripSession(): void
+    {
+        // Force a real json_encode + json_decode cycle on the session...
+        session()->save();
+        session()->start();
+    }
+}
+
+class ComponentWithSessionCollection extends Component
+{
+    #[Session]
+    public ?Collection $list = null;
+
+    public function mount(): void
+    {
+        $this->list ??= collect();
+    }
+
+    public function add(int $value): void
+    {
+        $this->list->push($value);
+    }
+
+    public function render()
+    {
+        return '<div>{{ $list->implode(",") }}</div>';
+    }
+}
+
+class ComponentWithSessionCarbon extends Component
+{
+    #[Session]
+    public ?Carbon $when = null;
+
+    public function render()
+    {
+        return '<div>{{ $when }}</div>';
+    }
+}
+
+class ComponentWithSessionCount extends Component
+{
+    #[Session]
+    public int $count = 0;
+
+    public function increment(): void
+    {
+        $this->count++;
+    }
+
+    public function render()
+    {
+        return '<div>{{ $count }}</div>';
     }
 }

--- a/src/Features/SupportSession/UnitTest.php
+++ b/src/Features/SupportSession/UnitTest.php
@@ -47,71 +47,42 @@ class UnitTest extends TestCase
         $this->assertTrue(FacadesSession::has('baz.2'));
     }
 
-    public function test_it_persists_a_collection_property_through_a_json_serialised_session()
-    {
-        $this->forceJsonSessionSerialization();
-
-        Livewire::test(ComponentWithSessionCollection::class)
-            ->call('add', 1)
-            ->call('add', 2);
-
-        $this->roundTripSession();
-
-        Livewire::test(ComponentWithSessionCollection::class)
-            ->assertSet('list', collect([1, 2]))
-            ->call('add', 3)
-            ->assertSet('list', collect([1, 2, 3]));
-    }
-
-    public function test_it_persists_a_carbon_property_through_a_json_serialised_session()
-    {
-        $this->forceJsonSessionSerialization();
-
-        $date = Carbon::parse('2026-01-15 10:00:00');
-
-        Livewire::test(ComponentWithSessionCarbon::class)
-            ->set('when', $date);
-
-        $this->roundTripSession();
-
-        Livewire::test(ComponentWithSessionCarbon::class)
-            ->assertSet('when', $date);
-    }
-
-    public function test_it_persists_a_primitive_property_through_a_json_serialised_session()
-    {
-        $this->forceJsonSessionSerialization();
-
-        Livewire::test(ComponentWithSessionCount::class)
-            ->call('increment')
-            ->call('increment');
-
-        $this->roundTripSession();
-
-        Livewire::test(ComponentWithSessionCount::class)
-            ->assertSet('count', 2);
-    }
-
-    protected function forceJsonSessionSerialization(): void
+    public function test_it_persists_typed_properties_through_a_json_serialised_session()
     {
         config(['session.serialization' => 'json']);
 
         // Rebuild the store so the new serialisation config takes effect...
         app('session')->forgetDrivers();
-    }
 
-    protected function roundTripSession(): void
-    {
+        $date = Carbon::parse('2026-01-15 10:00:00');
+
+        Livewire::test(ComponentWithSessionProperties::class)
+            ->call('add', 1)
+            ->call('add', 2)
+            ->set('when', $date)
+            ->call('increment');
+
         // Force a real json_encode + json_decode cycle on the session...
         session()->save();
         session()->start();
+
+        Livewire::test(ComponentWithSessionProperties::class)
+            ->assertSet('list', collect([1, 2]))
+            ->assertSet('when', $date)
+            ->assertSet('count', 1);
     }
 }
 
-class ComponentWithSessionCollection extends Component
+class ComponentWithSessionProperties extends Component
 {
     #[Session]
     public ?Collection $list = null;
+
+    #[Session]
+    public ?Carbon $when = null;
+
+    #[Session]
+    public int $count = 0;
 
     public function mount(): void
     {
@@ -123,28 +94,6 @@ class ComponentWithSessionCollection extends Component
         $this->list->push($value);
     }
 
-    public function render()
-    {
-        return '<div>{{ $list->implode(",") }}</div>';
-    }
-}
-
-class ComponentWithSessionCarbon extends Component
-{
-    #[Session]
-    public ?Carbon $when = null;
-
-    public function render()
-    {
-        return '<div>{{ $when }}</div>';
-    }
-}
-
-class ComponentWithSessionCount extends Component
-{
-    #[Session]
-    public int $count = 0;
-
     public function increment(): void
     {
         $this->count++;
@@ -152,6 +101,6 @@ class ComponentWithSessionCount extends Component
 
     public function render()
     {
-        return '<div>{{ $count }}</div>';
+        return '<div></div>';
     }
 }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -298,6 +298,16 @@ class HandleComponents extends Mechanism
         return $snapshot;
     }
 
+    public function dehydrateValue($component, $value)
+    {
+        return $this->dehydrate($value, new ComponentContext($component), '');
+    }
+
+    public function hydrateValue($component, $valueOrTuple)
+    {
+        return $this->hydrate($valueOrTuple, new ComponentContext($component), '');
+    }
+
     protected function dehydrateProperties($component, $context)
     {
         $data = Utils::getPublicPropertiesDefinedOnSubclass($component);

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -298,16 +298,6 @@ class HandleComponents extends Mechanism
         return $snapshot;
     }
 
-    public function dehydrateValue($component, $value)
-    {
-        return $this->dehydrate($value, new ComponentContext($component), '');
-    }
-
-    public function hydrateValue($component, $valueOrTuple)
-    {
-        return $this->hydrate($valueOrTuple, new ComponentContext($component), '');
-    }
-
     protected function dehydrateProperties($component, $context)
     {
         $data = Utils::getPublicPropertiesDefinedOnSubclass($component);
@@ -319,7 +309,7 @@ class HandleComponents extends Mechanism
         return $data;
     }
 
-    protected function dehydrate($target, $context, $path)
+    public function dehydrate($target, $context, $path)
     {
         if (Utils::isAPrimitive($target)) {
             // Normalize negative zero (-0.0) to 0 to prevent checksum mismatches
@@ -353,7 +343,7 @@ class HandleComponents extends Mechanism
         }
     }
 
-    protected function hydrate($valueOrTuple, $context, $path)
+    public function hydrate($valueOrTuple, $context, $path)
     {
         if (! Utils::isSyntheticTuple($value = $tuple = $valueOrTuple)) return $value;
 


### PR DESCRIPTION
# The Scenario

Fresh Laravel applications (as of [laravel/laravel@75cef50](https://github.com/laravel/laravel/commit/75cef50)) use JSON session serialisation by default. With this default, `#[Session]` on a non-primitive property (e.g. `Collection`, `Carbon`, an Eloquent model) throws on the next request:

```
TypeError: Cannot assign array to property ::$list of type ?Illuminate\Support\Collection
```

```php
<?php

use Illuminate\Support\Collection;
use Livewire\Attributes\Session;
use Livewire\Component;

new class extends Component {
    #[Session]
    public ?Collection $list = null;

    public function mount(): void
    {
        $this->list ??= collect();
    }

    public function add(): void
    {
        $this->list->push(random_int(0, 100));
    }
}
?>

<div>
    <button wire:click="add">Add</button>
    <p>{{ $this->list->implode(', ') }}</p>
</div>
```

# The Problem

`BaseSession` writes and reads the property value straight from the session without any marshalling. Under PHP serialisation, `serialize()`/`unserialize()` round-trips the object intact. Under JSON serialisation, `json_encode` strips the type (a `Collection` becomes its items, a `Carbon` becomes its ISO string), and `json_decode` brings it back as a plain array or string. The next request hands that decoded value to a typed property and PHP rejects the assignment.

# The Solution

Route the value through Livewire's existing synth-based dehydrate/hydrate pipeline before writing to / reading from the session. The synth system already produces JSON-safe tuples (`[data, meta]`) that round-trip through any session driver and reconstruct the original type on the way back, covering every type Livewire supports (`Collection`, `Carbon`, Eloquent models, `Stringable`, `BackedEnum`, custom collections, etc.).

`HandleComponents::dehydrateValue()` and `HandleComponents::hydrateValue()` are added as thin public wrappers around the existing internal pipeline so `BaseSession` can dehydrate or hydrate a single property value. `hydrateValue()` is a no-op for plain scalars, so primitive-typed `#[Session]` properties and existing PHP-serialised sessions keep working unchanged.

Note: this technically weakens Laravel's JSON session hardening (which exists to keep forged session data inert if `APP_KEY` leaks) because we're instantiating classes again on read. But that's only exploitable if an attacker has `APP_KEY`, and at that point they can already forge Livewire snapshots and hit the same hydrate pipeline on every request — so a Livewire app has bigger problems than `#[Session]` either way.

Fixes #10250