### PR TITLE
[4.x] Fix SFC half-compiled cache state when class is written before view

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -71,6 +71,13 @@ class Compiler
             $this->cacheManager->writeGlobalStyleFile($path, $globalStyleContents);
         }
 
+        $this->cacheManager->writeViewFile($path, $parser->generateViewContents());
+
+        // The class file is written last so its presence on disk implies every
+        // file it references (view, placeholder, script, styles) is already
+        // there. `CacheManager::hasBeenCompiled()` checks only the class file,
+        // so a concurrent reader that observes the class is guaranteed to see
+        // a complete cache rather than a half-written one.
         $this->cacheManager->writeClassFile($path, $parser->generateClassContents(
             $viewFileName,
             $placeholderFileName,
@@ -78,8 +85,6 @@ class Compiler
             $styleFileName,
             $globalStyleFileName,
         ));
-
-        $this->cacheManager->writeViewFile($path, $parser->generateViewContents());
     }
 
     public function clearCompiled($output = null)

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -73,11 +73,9 @@ class Compiler
 
         $this->cacheManager->writeViewFile($path, $parser->generateViewContents());
 
-        // The class file is written last so its presence on disk implies every
-        // file it references (view, placeholder, script, styles) is already
-        // there. `CacheManager::hasBeenCompiled()` checks only the class file,
-        // so a concurrent reader that observes the class is guaranteed to see
-        // a complete cache rather than a half-written one.
+        // Ensure the class file is the last write, as it's used
+        // in the hasBeenCompiled() check, so its presence on
+        // disk means everything has been compiled...
         $this->cacheManager->writeClassFile($path, $parser->generateClassContents(
             $viewFileName,
             $placeholderFileName,


### PR DESCRIPTION
# The Scenario

After a deploy or `optimize:clear`, concurrent requests for a single-file component can throw:

```
Illuminate\Contracts\Filesystem\FileNotFoundException:
File does not exist at path …/storage/framework/views/livewire/views/<hash>.blade.php.
```

```blade
<?php

use Livewire\Component;

new class extends Component
{
    public int $count = 0;
};
?>

<div>Count: {{ $count }}</div>
```

# The Problem

When two concurrent requests hit an uncompiled single-file component, the first request starts compiling. If it finishes writing the class file but hasn't written the view file yet, the second request checks `CacheManager::hasBeenCompiled()`, sees the class on disk, assumes the cache is ready, and renders. The render then throws because the view file doesn't exist yet.

# The Solution

Reorder the writes in `Compiler::compilePath()` so the class file is written last. `hasBeenCompiled()` only checks the class file, so making the class the final write means its presence implies every file it references is already there.

Fixes #10251