### PR TITLE
[4.x] Fix Authorize attribute doesnt support `array` for additional context

### DIFF
--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -11,9 +11,6 @@ use UnitEnum;
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
 class BaseAuthorize extends LivewireAttribute
 {
-    /**
-     * @param  array<string>|string|null  $argument
-     */
     public function __construct(
         public UnitEnum|string $ability,
         public array|string|null $argument = null,

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -11,9 +11,12 @@ use UnitEnum;
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
 class BaseAuthorize extends LivewireAttribute
 {
+    /**
+     * @param  array<string>|string|null  $argument
+     */
     public function __construct(
         public UnitEnum|string $ability,
-        public string|null $argument = null,
+        public array|string|null $argument = null,
     ) {}
 
     public function call(array $parameters) : void
@@ -25,32 +28,44 @@ class BaseAuthorize extends LivewireAttribute
             return;
         }
 
-        // Action that does not require a model, for example a 'create' action...
-        if (is_string($this->argument) && class_exists($this->argument)) {
-            Gate::authorize($this->ability, $this->argument);
+        $arguments = Arr::wrap($this->argument);
 
-            return;
+        // Resolve each argument (prioritize method parameters first, then component properties)
+        $resolved = [];
+        foreach ($arguments as $arg) {
+            $resolved[] = $this->resolveArgument($arg, $parameters);
         }
 
+        Gate::authorize($this->ability, $resolved);
+    }
+
+    /**
+     * Resolve a single argument.
+     */
+    protected function resolveArgument(string $arg, array $parameters): mixed
+    {
+        // Action that does not require a model, for example a 'create' action...
+        if (class_exists($arg)) {
+            return $arg;
+        }
+
+        // Try method parameter first (prioritized per rules)
         $methodArgument = Arr::first(
             (new \ReflectionObject($this->component))->getMethod($this->getName())->getParameters(),
-            fn (\ReflectionParameter $parameter) : bool => $parameter->getName() === $this->argument,
+            fn (\ReflectionParameter $parameter) : bool => $parameter->getName() === $arg,
         );
 
-        // Action that requires a model, extracted from the called method...
-        if ($methodArgument instanceof \ReflectionParameter && isset($parameters[$this->argument])) {
-            $model = app($methodArgument->getType()->getName())->resolveRouteBinding($parameters[$this->argument]);
+        if ($methodArgument instanceof \ReflectionParameter && isset($parameters[$arg])) {
+            $model = app($methodArgument->getType()->getName())->resolveRouteBinding($parameters[$arg]);
 
             if (! $model) {
                 throw (new \Illuminate\Database\Eloquent\ModelNotFoundException)->setModel($methodArgument->getType()->getName());
             }
 
-            Gate::authorize($this->ability, $model);
-
-            return;
+            return $model;
         }
 
-        // Action that requires a model, extracted from the component...
-        Gate::authorize($this->ability, data_get($this->component, $this->argument));
+        // Fall back to component property
+        return data_get($this->component, $arg);
     }
 }

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -437,6 +437,17 @@ class UnitTest extends TestCase
             })
             ->call('createComment', post: 1)
             ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[Authorize('create', [AuthorizationComment::class, 'post'])]
+                public function createComment(AuthorizationPost $post)
+                {
+                    return true;
+                }
+            })
+            ->call('createComment', post: 1)
+            ->assertForbidden();
     }
 
     public function test_can_authorize_policy_with_array_of_models()

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -375,6 +375,7 @@ class UnitTest extends TestCase
             return (int) $user->id === 1 && $post->id === 1;
         });
 
+        // AssertOk using class name and method argument
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 #[Authorize('create-comment', [AuthorizationComment::class, 'post'])]
@@ -386,6 +387,7 @@ class UnitTest extends TestCase
             ->call('createComment', post: 1)
             ->assertOk();
 
+        // AssertOk using class name and component property
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 public AuthorizationPost $post;
@@ -404,6 +406,26 @@ class UnitTest extends TestCase
             ->call('createComment')
             ->assertOk();
 
+        // AssertOk using class name and method argument prioritized first
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                #[Authorize('create-comment', [AuthorizationComment::class, 'post'])]
+                public function createComment(AuthorizationPost $post)
+                {
+                    return true;
+                }
+            })
+            ->call('createComment', post: 1)
+            ->assertOk();
+
+        // AssertForbidden using class name and method argument
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 #[Authorize('create-comment', [AuthorizationComment::class, 'post'])]
@@ -415,6 +437,7 @@ class UnitTest extends TestCase
             ->call('createComment', post: 2)
             ->assertForbidden();
 
+        // AssertForbidden using class name and component property
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 public AuthorizationPost $post;
@@ -432,14 +455,8 @@ class UnitTest extends TestCase
             })
             ->call('createComment')
             ->assertForbidden();
-    }
-
-    public function test_can_authorize_defined_gates_with_array_using_component_property()
-    {
-        Gate::define('create-comment', function (AuthorizationUser $user, string $commentClass, AuthorizationPost $post) {
-            return (int) $user->id === 1 && $post->id === 1;
-        });
-
+        
+        // AssertForbidden using class name and method argument prioritized first
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 public AuthorizationPost $post;
@@ -450,30 +467,12 @@ class UnitTest extends TestCase
                 }
 
                 #[Authorize('create-comment', [AuthorizationComment::class, 'post'])]
-                public function createComment()
+                public function createComment(AuthorizationPost $post)
                 {
                     return true;
                 }
             })
-            ->call('createComment')
-            ->assertOk();
-
-        Livewire::actingAs(AuthorizationUser::find(1))
-            ->test(new class extends TestComponent {
-                public AuthorizationPost $post;
-
-                public function mount(): void
-                {
-                    $this->post = AuthorizationPost::find(2);
-                }
-
-                #[Authorize('create-comment', [AuthorizationComment::class, 'post'])]
-                public function createComment()
-                {
-                    return true;
-                }
-            })
-            ->call('createComment')
+            ->call('createComment', post: 2)
             ->assertForbidden();
     }
 
@@ -481,6 +480,7 @@ class UnitTest extends TestCase
     {
         Gate::policy(AuthorizationComment::class, AuthorizationCommentPolicy::class);
 
+        // AssertOk using class name and method argument
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 #[Authorize('create', [AuthorizationComment::class, 'post'])]
@@ -492,6 +492,7 @@ class UnitTest extends TestCase
             ->call('createComment', post: 1)
             ->assertOk();
 
+        // AssertOk using class name and component property
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 public AuthorizationPost $post;
@@ -510,6 +511,26 @@ class UnitTest extends TestCase
             ->call('createComment')
             ->assertOk();
 
+        // AssertOk using class name and method argument prioritized first
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                #[Authorize('create', [AuthorizationComment::class, 'post'])]
+                public function createComment(AuthorizationPost $post)
+                {
+                    return true;
+                }
+            })
+            ->call('createComment', post: 1)
+            ->assertOk();
+
+        // AssertForbidden using class name and method argument
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 #[Authorize('create', [AuthorizationComment::class, 'post'])]
@@ -521,6 +542,7 @@ class UnitTest extends TestCase
             ->call('createComment', post: 2)
             ->assertForbidden();
 
+        // AssertForbidden using class name and component property
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 public AuthorizationPost $post;
@@ -538,12 +560,32 @@ class UnitTest extends TestCase
             })
             ->call('createComment')
             ->assertForbidden();
+        
+        // AssertForbidden using class name and method argument prioritized first
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('create', [AuthorizationComment::class, 'post'])]
+                public function createComment(AuthorizationPost $post)
+                {
+                    return true;
+                }
+            })
+            ->call('createComment', post: 2)
+            ->assertForbidden();
     }
 
     public function test_can_authorize_policy_with_array_of_models()
     {
         Gate::policy(AuthorizationComment::class, AuthorizationCommentPolicy::class);
 
+        // AssertOk using method arguments
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 #[Authorize('edit', ['comment', 'post'])]
@@ -555,6 +597,7 @@ class UnitTest extends TestCase
             ->call('editComment', comment: 1, post: 1)
             ->assertOk();
 
+        // AssertOk using component properties
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 public AuthorizationComment $comment;
@@ -576,6 +619,29 @@ class UnitTest extends TestCase
             ->call('editComment')
             ->assertOk();
 
+        // AssertOk using method arguments prioritized first
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationComment $comment;
+
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->comment = AuthorizationComment::find(1);
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                #[Authorize('edit', ['comment', 'post'])]
+                public function editComment(AuthorizationComment $comment, AuthorizationPost $post)
+                {
+                    return true;
+                }
+            })
+            ->call('editComment', comment: 1, post: 1)
+            ->assertOk();
+
+        // AssertForbidden using method arguments
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 #[Authorize('edit', ['comment', 'post'])]
@@ -587,6 +653,7 @@ class UnitTest extends TestCase
             ->call('editComment', comment: 1, post: 2)
             ->assertForbidden();
 
+        // AssertForbidden using component properties
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 public AuthorizationComment $comment;
@@ -606,6 +673,28 @@ class UnitTest extends TestCase
                 }
             })
             ->call('editComment')
+            ->assertForbidden();
+        
+        // AssertForbidden using method arguments prioritized first
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationComment $comment;
+
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->comment = AuthorizationComment::find(1);
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('edit', ['comment', 'post'])]
+                public function editComment(AuthorizationComment $comment, AuthorizationPost $post)
+                {
+                    return true;
+                }
+            })
+            ->call('editComment', comment: 1, post: 2)
             ->assertForbidden();
     }
 }

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -371,11 +371,20 @@ class UnitTest extends TestCase
 
     public function test_can_authorize_defined_gates_with_array_as_argument()
     {
-        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
-
         Gate::define('create-comment', function (AuthorizationUser $user, string $commentClass, AuthorizationPost $post) {
-            return (int) $user->id === 1 && $post->user_id === 1;
+            return (int) $user->id === 1 && $post->id === 1;
         });
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize('create-comment', [AuthorizationComment::class, 'post'])]
+                public function createComment(AuthorizationPost $post)
+                {
+                    return true;
+                }
+            })
+            ->call('createComment', post: 1)
+            ->assertOk();
 
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
@@ -387,21 +396,48 @@ class UnitTest extends TestCase
                 }
 
                 #[Authorize('create-comment', [AuthorizationComment::class, 'post'])]
+                public function createComment()
+                {
+                    return true;
+                }
+            })
+            ->call('createComment')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize('create-comment', [AuthorizationComment::class, 'post'])]
                 public function createComment(AuthorizationPost $post)
                 {
                     return true;
                 }
             })
-            ->call('createComment', post: 1)
-            ->assertOk();
+            ->call('createComment', post: 2)
+            ->assertForbidden();
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                #[Authorize('create-comment', [AuthorizationComment::class, 'post'])]
+                public function createComment()
+                {
+                    return true;
+                }
+            })
+            ->call('createComment')
+            ->assertForbidden();
     }
 
     public function test_can_authorize_defined_gates_with_array_using_component_property()
     {
-        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
-
         Gate::define('create-comment', function (AuthorizationUser $user, string $commentClass, AuthorizationPost $post) {
-            return (int) $user->id === 1 && $post->user_id === 1;
+            return (int) $user->id === 1 && $post->id === 1;
         });
 
         Livewire::actingAs(AuthorizationUser::find(1))
@@ -421,6 +457,24 @@ class UnitTest extends TestCase
             })
             ->call('createComment')
             ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                #[Authorize('create-comment', [AuthorizationComment::class, 'post'])]
+                public function createComment()
+                {
+                    return true;
+                }
+            })
+            ->call('createComment')
+            ->assertForbidden();
     }
 
     public function test_can_authorize_policy_with_array_of_class_and_model()
@@ -438,7 +492,25 @@ class UnitTest extends TestCase
             ->call('createComment', post: 1)
             ->assertOk();
 
-        Livewire::actingAs(AuthorizationUser::find(2))
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('create', [AuthorizationComment::class, 'post'])]
+                public function createComment()
+                {
+                    return true;
+                }
+            })
+            ->call('createComment')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 #[Authorize('create', [AuthorizationComment::class, 'post'])]
                 public function createComment(AuthorizationPost $post)
@@ -446,7 +518,25 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', post: 1)
+            ->call('createComment', post: 2)
+            ->assertForbidden();
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                #[Authorize('create', [AuthorizationComment::class, 'post'])]
+                public function createComment()
+                {
+                    return true;
+                }
+            })
+            ->call('createComment')
             ->assertForbidden();
     }
 
@@ -465,7 +555,28 @@ class UnitTest extends TestCase
             ->call('editComment', comment: 1, post: 1)
             ->assertOk();
 
-        Livewire::actingAs(AuthorizationUser::find(2))
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationComment $comment;
+
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->comment = AuthorizationComment::find(1);
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('edit', ['comment', 'post'])]
+                public function editComment()
+                {
+                    return true;
+                }
+            })
+            ->call('editComment')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
                 #[Authorize('edit', ['comment', 'post'])]
                 public function editComment(AuthorizationComment $comment, AuthorizationPost $post)
@@ -473,7 +584,28 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editComment', comment: 1, post: 1)
+            ->call('editComment', comment: 1, post: 2)
+            ->assertForbidden();
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationComment $comment;
+
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->comment = AuthorizationComment::find(1);
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                #[Authorize('edit', ['comment', 'post'])]
+                public function editComment()
+                {
+                    return true;
+                }
+            })
+            ->call('editComment')
             ->assertForbidden();
     }
 }

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -369,7 +369,7 @@ class UnitTest extends TestCase
         $this->assertTrue(Session::has('event-was-handled'));
     }
 
-    public function test_can_authorize_with_array_as_argument()
+    public function test_can_authorize_defined_gates_with_array_as_argument()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
 
@@ -396,7 +396,7 @@ class UnitTest extends TestCase
             ->assertOk();
     }
 
-    public function test_can_authorize_with_array_using_component_property()
+    public function test_can_authorize_defined_gates_with_array_using_component_property()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
 
@@ -421,6 +421,49 @@ class UnitTest extends TestCase
             })
             ->call('createComment')
             ->assertOk();
+    }
+
+    public function test_can_authorize_policy_with_array_of_class_and_model()
+    {
+        Gate::policy(AuthorizationComment::class, AuthorizationCommentPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize('create', [AuthorizationComment::class, 'post'])]
+                public function createComment(AuthorizationPost $post)
+                {
+                    return true;
+                }
+            })
+            ->call('createComment', post: 1)
+            ->assertOk();
+    }
+
+    public function test_can_authorize_policy_with_array_of_models()
+    {
+        Gate::policy(AuthorizationComment::class, AuthorizationCommentPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize('edit', ['comment', 'post'])]
+                public function editComment(AuthorizationComment $comment, AuthorizationPost $post)
+                {
+                    return true;
+                }
+            })
+            ->call('editComment', comment: 1, post: 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[Authorize('edit', ['comment', 'post'])]
+                public function editComment(AuthorizationComment $comment, AuthorizationPost $post)
+                {
+                    return true;
+                }
+            })
+            ->call('editComment', comment: 1, post: 1)
+            ->assertForbidden();
     }
 }
 
@@ -449,7 +492,7 @@ class AuthorizationComment extends Model
     use Sushi;
 
     protected $rows = [
-        ['id' => 1, 'post_id' => 1, 'content' => 'Test comment'],
+        ['id' => 1, 'user_id' => 1, 'post_id' => 1, 'content' => 'Test comment'],
     ];
 }
 
@@ -463,5 +506,18 @@ class AuthorizationPostPolicy
     public function edit(AuthorizationUser $user, AuthorizationPost $post) : bool
     {
         return (int) $post->user_id === (int) $user->id;
+    }
+}
+
+class AuthorizationCommentPolicy
+{
+    public function create(AuthorizationUser $user, AuthorizationPost $post) : bool
+    {
+        return (int) $user->id === 1 && (int) $post->id === 1;
+    }
+
+    public function edit(AuthorizationUser $user, AuthorizationComment $comment, AuthorizationPost $post) : bool
+    {
+        return (int) $comment->post_id === (int) $post->id && (int) $comment->user_id === (int) $user->id;
     }
 }

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -368,6 +368,60 @@ class UnitTest extends TestCase
 
         $this->assertTrue(Session::has('event-was-handled'));
     }
+
+    public function test_can_authorize_with_array_as_argument()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Gate::define('create-comment', function (AuthorizationUser $user, string $commentClass, AuthorizationPost $post) {
+            return (int) $user->id === 1 && $post->user_id === 1;
+        });
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('create-comment', [AuthorizationComment::class, 'post'])]
+                public function createComment(AuthorizationPost $post)
+                {
+                    return true;
+                }
+            })
+            ->call('createComment', post: 1)
+            ->assertOk();
+    }
+
+    public function test_can_authorize_with_array_using_component_property()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Gate::define('create-comment', function (AuthorizationUser $user, string $commentClass, AuthorizationPost $post) {
+            return (int) $user->id === 1 && $post->user_id === 1;
+        });
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('create-comment', [AuthorizationComment::class, 'post'])]
+                public function createComment()
+                {
+                    return true;
+                }
+            })
+            ->call('createComment')
+            ->assertOk();
+    }
 }
 
 class AuthorizationUser extends AuthUser
@@ -387,6 +441,15 @@ class AuthorizationPost extends Model
     protected $rows = [
         ['id' => 1, 'title' => 'First', 'user_id' => 1],
         ['id' => 2, 'title' => 'Second', 'user_id' => 2],
+    ];
+}
+
+class AuthorizationComment extends Model
+{
+    use Sushi;
+
+    protected $rows = [
+        ['id' => 1, 'post_id' => 1, 'content' => 'Test comment'],
     ];
 }
 


### PR DESCRIPTION
Support `array` as argument for additional context. Laravel version 10+ already support this.
 https://laravel.com/docs/13.x/authorization#supplying-additional-context

See https://github.com/livewire/livewire/issues/10257 for the explanation.

Related PR: https://github.com/livewire/livewire/pull/10089

Fix: https://github.com/livewire/livewire/issues/10257

