### PR TITLE
[4.x] Fix slots disappearing on lazy and deferred components

### DIFF
--- a/js/features/supportSlots.js
+++ b/js/features/supportSlots.js
@@ -6,7 +6,13 @@ import { on } from '@/hooks'
 
 let pending = {}
 
-on('effect', ({ effects }) => (effects.slotFragments || []).forEach(f => renderSlot(null, f)))
+on('effect', ({ effects }) => {
+    let fragments = effects.slotFragments || []
+
+    fragments.forEach(async fragmentHtml => {
+        await renderSlot(null, fragmentHtml)
+    })
+})
 
 interceptMessage(({ message, onSuccess, onStream }) => {
     onSuccess(({ payload, onMorph }) => {
@@ -17,7 +23,12 @@ interceptMessage(({ message, onSuccess, onStream }) => {
                 await renderSlot(message.component, fragmentHtml)
             })
 
-            for (let f of pending[message.component.id] || []) await renderSlot(null, f)
+            let pendingFragments = pending[message.component.id] || []
+
+            pendingFragments.forEach(async fragmentHtml => {
+                await renderSlot(null, fragmentHtml)
+            })
+
             delete pending[message.component.id]
         })
     })

--- a/js/features/supportSlots.js
+++ b/js/features/supportSlots.js
@@ -2,23 +2,48 @@ import { extractFragmentMetadataFromHtml, extractInnerHtmlFromFragmentHtml, find
 import { interceptMessage } from '@/request'
 import { findComponent } from '@/store'
 import { morphFragment } from '@/morph'
+import { on } from '@/hooks'
 
-interceptMessage(({ message, onSuccess, onStream }) => {
+// Slot fragments that arrived before their target's slot markers existed in
+// the DOM (e.g. the target is a lazy child whose placeholder hasn't been
+// replaced yet). Keyed by the target component's id...
+let pendingSlotFragments = {}
+
+// Initial component mount: process any `slotFragments` effects delivered in
+// the parent's full-page render. This is the path lazy components rely on...
+on('effect', ({ component, effects }) => {
+    let fragments = effects.slotFragments || []
+
+    fragments.forEach(fragmentHtml => renderSlotOrStash(fragmentHtml))
+})
+
+// Subsequent messages: process this message's `slotFragments` effects, and
+// retry any fragments that were stashed for this component's id (e.g. its
+// markers have just appeared after a lazy load morph)...
+interceptMessage(({ message, onSuccess }) => {
     onSuccess(({ payload, onMorph }) => {
         onMorph(async () => {
             let fragments = payload.effects.slotFragments || []
 
-            fragments.forEach(async fragmentHtml => {
-                await renderSlot(message.component, fragmentHtml)
-            })
+            for (let fragmentHtml of fragments) {
+                await renderSlotOrStash(fragmentHtml)
+            }
+
+            await applyPendingSlotFragments(message.component.id)
         })
     })
 })
 
 export async function renderSlot(component, fragmentHtml) {
+    await renderSlotOrStash(fragmentHtml)
+}
+
+async function renderSlotOrStash(fragmentHtml) {
     let metadata = extractFragmentMetadataFromHtml(fragmentHtml)
 
-    let targetComponent = findComponent(metadata.id)
+    let targetComponent = findComponent(metadata.id, false)
+
+    if (! targetComponent) return stashSlotFragment(metadata.id, fragmentHtml)
 
     let fragment = findFragment(targetComponent.el, {
         isMatch: ({ name, token }) => {
@@ -26,9 +51,27 @@ export async function renderSlot(component, fragmentHtml) {
         },
     })
 
-    if (! fragment) return
+    if (! fragment) return stashSlotFragment(metadata.id, fragmentHtml)
 
     let strippedContent = extractInnerHtmlFromFragmentHtml(fragmentHtml)
 
     await morphFragment(targetComponent, fragment.startMarkerNode, fragment.endMarkerNode, strippedContent)
+}
+
+function stashSlotFragment(componentId, fragmentHtml) {
+    if (! pendingSlotFragments[componentId]) pendingSlotFragments[componentId] = []
+
+    pendingSlotFragments[componentId].push(fragmentHtml)
+}
+
+async function applyPendingSlotFragments(componentId) {
+    let pending = pendingSlotFragments[componentId]
+
+    if (! pending) return
+
+    delete pendingSlotFragments[componentId]
+
+    for (let fragmentHtml of pending) {
+        await renderSlotOrStash(fragmentHtml)
+    }
 }

--- a/js/features/supportSlots.js
+++ b/js/features/supportSlots.js
@@ -4,74 +4,42 @@ import { findComponent } from '@/store'
 import { morphFragment } from '@/morph'
 import { on } from '@/hooks'
 
-// Slot fragments that arrived before their target's slot markers existed in
-// the DOM (e.g. the target is a lazy child whose placeholder hasn't been
-// replaced yet). Keyed by the target component's id...
-let pendingSlotFragments = {}
+let pending = {}
 
-// Initial component mount: process any `slotFragments` effects delivered in
-// the parent's full-page render. This is the path lazy components rely on...
-on('effect', ({ component, effects }) => {
-    let fragments = effects.slotFragments || []
+on('effect', ({ effects }) => (effects.slotFragments || []).forEach(f => renderSlot(null, f)))
 
-    fragments.forEach(fragmentHtml => renderSlotOrStash(fragmentHtml))
-})
-
-// Subsequent messages: process this message's `slotFragments` effects, and
-// retry any fragments that were stashed for this component's id (e.g. its
-// markers have just appeared after a lazy load morph)...
-interceptMessage(({ message, onSuccess }) => {
+interceptMessage(({ message, onSuccess, onStream }) => {
     onSuccess(({ payload, onMorph }) => {
         onMorph(async () => {
             let fragments = payload.effects.slotFragments || []
 
-            for (let fragmentHtml of fragments) {
-                await renderSlotOrStash(fragmentHtml)
-            }
+            fragments.forEach(async fragmentHtml => {
+                await renderSlot(message.component, fragmentHtml)
+            })
 
-            await applyPendingSlotFragments(message.component.id)
+            for (let f of pending[message.component.id] || []) await renderSlot(null, f)
+            delete pending[message.component.id]
         })
     })
 })
 
 export async function renderSlot(component, fragmentHtml) {
-    await renderSlotOrStash(fragmentHtml)
-}
-
-async function renderSlotOrStash(fragmentHtml) {
     let metadata = extractFragmentMetadataFromHtml(fragmentHtml)
 
     let targetComponent = findComponent(metadata.id, false)
 
-    if (! targetComponent) return stashSlotFragment(metadata.id, fragmentHtml)
-
-    let fragment = findFragment(targetComponent.el, {
+    let fragment = targetComponent && findFragment(targetComponent.el, {
         isMatch: ({ name, token }) => {
             return name === metadata.name && token === metadata.token
         },
     })
 
-    if (! fragment) return stashSlotFragment(metadata.id, fragmentHtml)
+    if (! fragment) {
+        (pending[metadata.id] ??= []).push(fragmentHtml)
+        return
+    }
 
     let strippedContent = extractInnerHtmlFromFragmentHtml(fragmentHtml)
 
     await morphFragment(targetComponent, fragment.startMarkerNode, fragment.endMarkerNode, strippedContent)
-}
-
-function stashSlotFragment(componentId, fragmentHtml) {
-    if (! pendingSlotFragments[componentId]) pendingSlotFragments[componentId] = []
-
-    pendingSlotFragments[componentId].push(fragmentHtml)
-}
-
-async function applyPendingSlotFragments(componentId) {
-    let pending = pendingSlotFragments[componentId]
-
-    if (! pending) return
-
-    delete pendingSlotFragments[componentId]
-
-    for (let fragmentHtml of pending) {
-        await renderSlotOrStash(fragmentHtml)
-    }
 }

--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -38,6 +38,105 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_default_slot_renders_on_lazy_loaded_component()
+    {
+        Livewire::visit([new class extends Component {
+            public function render() { return <<<'HTML'
+            <div>
+                <livewire:child lazy>
+                    Lazy slot content
+                </livewire:child>
+            </div>
+            HTML; }
+        }, 'child' => new class extends Component {
+            public function mount() {
+                sleep(1);
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div id="child">
+                    Child!
+                    {{ $slot }}
+                </div>
+                HTML;
+            }
+        }])
+            ->assertDontSee('Child!')
+            ->assertDontSee('Lazy slot content')
+            ->waitFor('#child')
+            ->assertSee('Child!')
+            ->assertSee('Lazy slot content')
+        ;
+    }
+
+    public function test_default_slot_renders_on_deferred_component()
+    {
+        Livewire::visit([new class extends Component {
+            public function render() { return <<<'HTML'
+            <div>
+                <livewire:child defer>
+                    Deferred slot content
+                </livewire:child>
+            </div>
+            HTML; }
+        }, 'child' => new class extends Component {
+            public function mount() {
+                sleep(1);
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div id="child">
+                    Child!
+                    {{ $slot }}
+                </div>
+                HTML;
+            }
+        }])
+            ->assertDontSee('Child!')
+            ->assertDontSee('Deferred slot content')
+            ->waitFor('#child')
+            ->assertSee('Child!')
+            ->assertSee('Deferred slot content')
+        ;
+    }
+
+    public function test_named_slots_render_on_lazy_loaded_component()
+    {
+        Livewire::visit([new class extends Component {
+            public function render() { return <<<'HTML'
+            <div>
+                <livewire:child lazy>
+                    <livewire:slot name="header">
+                        Header content
+                    </livewire:slot>
+                    Default content
+                </livewire:child>
+            </div>
+            HTML; }
+        }, 'child' => new class extends Component {
+            public function mount() {
+                sleep(1);
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div id="child">
+                    <div>{{ $slot('header') }}</div>
+                    <div>{{ $slot }}</div>
+                </div>
+                HTML;
+            }
+        }])
+            ->assertDontSee('Header content')
+            ->assertDontSee('Default content')
+            ->waitFor('#child')
+            ->assertSee('Header content')
+            ->assertSee('Default content')
+        ;
+    }
+
     public function test_can_defer_lazy_load_a_component()
     {
         Livewire::visit([new class extends Component {

--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -44,7 +44,7 @@ class SupportLazyLoading extends ComponentHook
         });
     }
 
-    public function mount($params)
+    public function mount($params, $parent = null)
     {
         $shouldBeLazy = false;
         $isDeferred = false;
@@ -94,6 +94,12 @@ class SupportLazyLoading extends ComponentHook
             if ($attribute->isolate !== null) $isolate = $attribute->isolate;
         }
 
+        // Hand any slots passed into the lazy component up to the parent so
+        // the parent's response delivers them as `slotFragments` effects;
+        // the JS side stashes them until the lazy load completes and the
+        // matching slot markers appear in the DOM...
+        $this->forwardSlotsToParent($parent);
+
         $this->component->skipMount();
 
         store($this->component)->set('isLazyLoadMounting', true);
@@ -102,6 +108,23 @@ class SupportLazyLoading extends ComponentHook
         $this->component->skipRender(
             $this->generatePlaceholderHtml($params, $isDeferred)
         );
+    }
+
+    protected function forwardSlotsToParent($parent)
+    {
+        if (! $parent) return;
+
+        $slots = $this->component->getSlots();
+
+        if (empty($slots)) return;
+
+        $slotsByName = [];
+
+        foreach ($slots as $slot) {
+            $slotsByName[$slot->getName()] = $slot->content;
+        }
+
+        $parent->withChildSlots($slotsByName, $this->component->getId());
     }
 
     public function hydrate($memo)

--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -44,7 +44,7 @@ class SupportLazyLoading extends ComponentHook
         });
     }
 
-    public function mount($params, $parent = null)
+    public function mount($params)
     {
         $shouldBeLazy = false;
         $isDeferred = false;
@@ -94,12 +94,6 @@ class SupportLazyLoading extends ComponentHook
             if ($attribute->isolate !== null) $isolate = $attribute->isolate;
         }
 
-        // Hand any slots passed into the lazy component up to the parent so
-        // the parent's response delivers them as `slotFragments` effects;
-        // the JS side stashes them until the lazy load completes and the
-        // matching slot markers appear in the DOM...
-        $this->forwardSlotsToParent($parent);
-
         $this->component->skipMount();
 
         store($this->component)->set('isLazyLoadMounting', true);
@@ -108,23 +102,6 @@ class SupportLazyLoading extends ComponentHook
         $this->component->skipRender(
             $this->generatePlaceholderHtml($params, $isDeferred)
         );
-    }
-
-    protected function forwardSlotsToParent($parent)
-    {
-        if (! $parent) return;
-
-        $slots = $this->component->getSlots();
-
-        if (empty($slots)) return;
-
-        $slotsByName = [];
-
-        foreach ($slots as $slot) {
-            $slotsByName[$slot->getName()] = $slot->content;
-        }
-
-        $parent->withChildSlots($slotsByName, $this->component->getId());
     }
 
     public function hydrate($memo)
@@ -142,6 +119,16 @@ class SupportLazyLoading extends ComponentHook
         if (store($this->component)->get('isLazyLoadMounting') === true) {
             $context->addMemo('lazyLoaded', false);
             $context->addMemo('lazyIsolated', store($this->component)->get('isLazyIsolated'));
+
+            // Slots received during the lazy mount are dropped when the
+            // placeholder replaces the child's render. Emit them now as
+            // `slotFragments` so the JS side can stash them and morph them
+            // into the matching slot markers once the lazy load completes...
+            $slots = $this->component->getSlots();
+
+            if (! empty($slots)) {
+                $context->addEffect('slotFragments', array_map(fn ($slot) => $slot->toHtml(), $slots));
+            }
         } elseif (store($this->component)->get('isLazyLoadHydrating') === true) {
             $context->addMemo('lazyLoaded', true);
         }

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -73,7 +73,7 @@ class UnitTest extends \Tests\TestCase
             ->assertDontSee('Hello world!');
     }
 
-    public function test_lazy_components_forward_slot_content_to_parent_as_slot_fragments()
+    public function test_lazy_components_emit_slot_content_as_slot_fragments()
     {
         $component = Livewire::test([
             new class extends Component {
@@ -93,13 +93,9 @@ class UnitTest extends \Tests\TestCase
 
         $component->assertSee('Loading...');
 
-        $effects = $component->effects;
+        $this->assertStringContainsString('slotFragments', $component->html());
 
-        $this->assertArrayHasKey('slotFragments', $effects, 'Expected parent effects to contain slotFragments for the lazy child');
-
-        $this->assertCount(1, $effects['slotFragments']);
-
-        $this->assertStringContainsString('Lazy slot content', $effects['slotFragments'][0]);
+        $this->assertStringContainsString('Lazy slot content', $component->html());
     }
 }
 

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -72,6 +72,35 @@ class UnitTest extends \Tests\TestCase
             ->assertSee('Loading...')
             ->assertDontSee('Hello world!');
     }
+
+    public function test_lazy_components_forward_slot_content_to_parent_as_slot_fragments()
+    {
+        $component = Livewire::test([
+            new class extends Component {
+                public function render() { return <<<'HTML'
+                    <div>
+                        <livewire:child lazy>
+                            Lazy slot content
+                        </livewire:child>
+                    </div>
+                HTML; }
+            },
+            'child' => new class extends Component {
+                public function placeholder() { return '<div>Loading...</div>'; }
+                public function render() { return '<div>{{ $slot }}</div>'; }
+            },
+        ]);
+
+        $component->assertSee('Loading...');
+
+        $effects = $component->effects;
+
+        $this->assertArrayHasKey('slotFragments', $effects, 'Expected parent effects to contain slotFragments for the lazy child');
+
+        $this->assertCount(1, $effects['slotFragments']);
+
+        $this->assertStringContainsString('Lazy slot content', $effects['slotFragments'][0]);
+    }
 }
 
 #[Lazy]


### PR DESCRIPTION
# The Scenario

Slot content passed into a lazy or deferred component disappears. The child component itself loads correctly, but anything between its opening and closing tags is silently dropped.

```blade
<livewire:hello-world>
    <h1>Hello World From Slot</h1>
</livewire:hello-world>
```

```php
new class extends Component
{
    #[Lazy]
    public function render()
    {
        return <<<'HTML'
        <div>
            <div>Hello World From Component</div>
            {{ $slot }}
        </div>
        HTML;
    }
};
```

When the component lazy-loads, only `Hello World From Component` renders. `Hello World From Slot` never appears.

# The Problem

Slot content is captured by the parent at render time and passed to the child via `mount()`, where `$component->withSlots($slots, $parent)` attaches it to the child instance. For a normal component, the child's render is called next and `Slot::toHtml()` inlines the content into the child's HTML output.

For a lazy component, `SupportLazyLoading::mount` calls `skipMount()` and `skipRender()` to swap the child's render for placeholder HTML before the slot ever gets rendered. `SupportSlots::dehydrate` only persists slot **metadata** (`name`, `componentId`, `parentId`) into the child's memo, so by the time `__lazyLoad` fires and the child renders for real, the slot content is gone and `{{ $slot }}` produces empty fragment markers.

# The Solution

Reuse the existing `slotFragments` effect mechanism that's already used to deliver slot updates to a stubbed child on parent re-renders.

When the lazy child dehydrates during its initial mount (the moment the placeholder is being generated), `SupportLazyLoading::dehydrate` now also emits the child's own slots as `slotFragments` on its effects, alongside the existing `lazyLoaded`/`lazyIsolated` memos. So the slot HTML rides along in the lazy placeholder's `wire:effects` — no parent indirection, no encoded snapshot bloat, no new memo fields.

On the JS side, `js/features/supportSlots.js` now also listens on `effect` (not just `interceptMessage`), so `slotFragments` delivered in a component's own initial `wire:effects` are processed too. When a fragment arrives but its target slot markers don't exist yet (because the lazy placeholder hasn't been replaced), it's stashed against the target's component id. After each subsequent message's morph completes, any fragments stashed for that component are retried — so the moment the lazy load morph produces the matching slot markers, the stashed content is morphed in via the existing `morphFragment` helper.

Fixes #10255