### PR TITLE
[4.x] Fix `$wire.$errors` reactivity when using `skipRender()`

### DIFF
--- a/js/component.js
+++ b/js/component.js
@@ -38,6 +38,8 @@ export class Component {
         // "reactive" is just ephemeral, except when you mutate it, front-ends like Vue react.
         this.reactive = Alpine.reactive(this.ephemeral)
 
+        this.errors = Alpine.reactive({ messages: this.snapshot.memo.errors ?? {} })
+
         this.queuedUpdates = {}
 
         this.jsActions = {}
@@ -84,6 +86,8 @@ export class Component {
         this.snapshotEncoded = snapshotEncoded
 
         this.snapshot = snapshot
+
+        this.errors.messages = snapshot.memo.errors ?? {}
 
         this.effects = effects
 

--- a/js/features/supportErrors.js
+++ b/js/features/supportErrors.js
@@ -1,5 +1,16 @@
 // This errors object has the most common methods from \Illuminate\Support\MessageBag class on the backend...
 import Alpine from 'alpinejs'
+import { on } from '@/hooks'
+
+// After every server response, invalidate the cached errors so any Alpine
+// effects depending on $wire.$errors (like wire:show / wire:text) re-read
+// the fresh errors from the new snapshot. Without this, components that
+// skip rendering would never trigger that re-read...
+on('effect', ({ component }) => {
+    if (! component.__errorsState) return
+
+    component.__errorsState.clientErrors = null
+})
 
 export function getErrorsObject(component) {
     let state = component.__errorsState ??= Alpine.reactive({

--- a/js/features/supportErrors.js
+++ b/js/features/supportErrors.js
@@ -1,35 +1,8 @@
 // This errors object has the most common methods from \Illuminate\Support\MessageBag class on the backend...
-import Alpine from 'alpinejs'
-import { on } from '@/hooks'
-
-// After every server response, invalidate the cached errors so any Alpine
-// effects depending on $wire.$errors (like wire:show / wire:text) re-read
-// the fresh errors from the new snapshot. Without this, components that
-// skip rendering would never trigger that re-read...
-on('effect', ({ component }) => {
-    if (! component.__errorsState) return
-
-    component.__errorsState.clientErrors = null
-})
-
 export function getErrorsObject(component) {
-    let state = component.__errorsState ??= Alpine.reactive({
-        clientErrors: null,
-    })
-
-    // Store lastSnapshot outside reactive state to avoid Proxy wrapping breaking identity comparison...
-    component.__lastErrorsSnapshot ??= component.snapshot
-
     return {
         messages() {
-            // If the snapshot changed (server responded), reset client overrides...
-            if (component.__lastErrorsSnapshot !== component.snapshot) {
-                state.clientErrors = null
-                component.__lastErrorsSnapshot = component.snapshot
-            }
-
-            // Assign into reactive state so Alpine can track changes...
-            return state.clientErrors ??= component.snapshot.memo.errors
+            return component.errors.messages
         },
 
         keys() {
@@ -104,11 +77,11 @@ export function getErrorsObject(component) {
 
         clear(field = null) {
             if (field === null) {
-                state.clientErrors = {}
+                component.errors.messages = {}
             } else {
-                let errors = { ...(state.clientErrors ?? component.snapshot.memo.errors) }
+                let errors = { ...component.errors.messages }
                 delete errors[field]
-                state.clientErrors = errors
+                component.errors.messages = errors
             }
         },
     }

--- a/src/Features/SupportMagicErrors/BrowserTest.php
+++ b/src/Features/SupportMagicErrors/BrowserTest.php
@@ -218,4 +218,39 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertAttributeContains('@email-error', 'style', 'display: none')
             ;
     }
+
+    public function test_wire_show_reacts_to_validation_errors_when_skip_render_is_used()
+    {
+        Livewire::visit(new class extends \Livewire\Component {
+            #[Validate(['required', 'min:5'])]
+            public $title = '';
+
+            public function updated()
+            {
+                $this->skipRender();
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <input type="text" wire:model.live="title" dusk="title">
+
+                <div wire:show="$errors.has('title')" dusk="title-error">
+                    <span wire:text="$errors.first('title')" dusk="title-error-text"></span>
+                </div>
+            </div>
+            HTML; }
+        })
+            // Initially hidden...
+            ->assertAttributeContains('@title-error', 'style', 'display: none')
+
+            // Type something too short: error should appear...
+            ->waitForLivewire()->type('@title', 'a')
+            ->assertVisible('@title-error')
+            ->assertSeeIn('@title-error-text', 'The title field must be at least 5 characters.')
+
+            // Type a valid value: error should hide again...
+            ->waitForLivewire()->type('@title', 'abcdef')
+            ->assertAttributeContains('@title-error', 'style', 'display: none')
+            ;
+    }
 }


### PR DESCRIPTION
@ganyicz suggested we make errors a reactive object on the component, I have done that in a alternative PR #10275

# The Scenario

When `skipRender()` is called inside a component (e.g. from `updated()`), validation errors arriving in the response are not reflected in the DOM through `wire:show` and `wire:text` directives that depend on `$errors`.

```php
<?php

use Livewire\Attributes\Validate;
use Livewire\Component;

new class extends Component {
    #[Validate(['required', 'min:5', 'max:10'])]
    public $title = '';

    public function updated()
    {
        $this->skipRender();
    }
}; ?>

<div>
    <input type="text" wire:model.live="title">

    <div wire:show="$errors.has('title')">
        <span wire:text="$errors.first('title')"></span>
    </div>
</div>
```

# The Problem

In `js/features/supportErrors.js`, `$wire.$errors` caches its messages in `Alpine.reactive` state via `clientErrors`. The cache is only invalidated lazily, *when something reads `messages()`*:

```js
messages() {
    if (component.__lastErrorsSnapshot !== component.snapshot) {
        state.clientErrors = null
        component.__lastErrorsSnapshot = component.snapshot
    }
    return state.clientErrors ??= component.snapshot.memo.errors
},
```

In the normal flow, the morph step after a request causes Alpine to re-evaluate bindings, which calls `messages()`, which triggers the reactive update. With `skipRender()`, no morph runs, so nothing reads `messages()` and `state.clientErrors` is never reassigned, leaving dependent effects with stale errors.

# The Solution

Register an `effect` hook in `supportErrors.js` that invalidates the reactive errors cache after every server response, so any Alpine effect depending on `$wire.$errors` (`wire:show`, `wire:text`, custom Alpine bindings) re-evaluates regardless of whether a morph runs:

```js
on('effect', ({ component }) => {
    if (! component.__errorsState) return

    component.__errorsState.clientErrors = null
})
```

The `__errorsState` guard skips components that have never read `$wire.$errors`, since the reactive state is created lazily.

Fixes #10263