### PR TITLE
[4.x] Fix slots disappearing on lazy/deferred components

### DIFF
--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -779,6 +779,29 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_slot_content_is_preserved_on_lazy_component()
+    {
+        Livewire::visit([new class extends Component {
+            public function render() { return <<<'HTML'
+            <div>
+                <livewire:child lazy>
+                    <span id="slot-content">Slot works!</span>
+                </livewire:child>
+            </div>
+            HTML; }
+        }, 'child' => new class extends Component {
+            public function render() { return <<<'HTML'
+            <div id="child">
+                {{ $slot }}
+            </div>
+            HTML; }
+        }])
+        ->waitFor('#child')
+        ->waitFor('#slot-content')
+        ->assertSee('Slot works!')
+        ;
+    }
+
 }
 
 class Page extends Component {

--- a/src/Features/SupportSlots/HandlesSlots.php
+++ b/src/Features/SupportSlots/HandlesSlots.php
@@ -55,5 +55,18 @@ trait HandlesSlots
         return $this;
     }
 
+    public function withHydratedSlots(array $slots): self
+    {
+        foreach ($slots as $slot) {
+            if (isset($slot['content'])) {
+                $this->slots[] = new Slot($slot['name'], $slot['content'], $slot['componentId'], $slot['parentId']);
+            } else {
+                $this->slots[] = new PlaceholderSlot($slot['name'], $slot['componentId'], $slot['parentId']);
+            }
+        }
+
+        return $this;
+    }
+
 
 }

--- a/src/Features/SupportSlots/HandlesSlots.php
+++ b/src/Features/SupportSlots/HandlesSlots.php
@@ -58,11 +58,7 @@ trait HandlesSlots
     public function withHydratedSlots(array $slots): self
     {
         foreach ($slots as $slot) {
-            if (isset($slot['content'])) {
-                $this->slots[] = new Slot($slot['name'], $slot['content'], $slot['componentId'], $slot['parentId']);
-            } else {
-                $this->slots[] = new PlaceholderSlot($slot['name'], $slot['componentId'], $slot['parentId']);
-            }
+            $this->slots[] = new Slot($slot['name'], $slot['content'], $slot['componentId'], $slot['parentId']);
         }
 
         return $this;

--- a/src/Features/SupportSlots/SupportSlots.php
+++ b/src/Features/SupportSlots/SupportSlots.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportSlots;
 use Livewire\ComponentHook;
 
 use function Livewire\on;
+use function Livewire\store;
 
 class SupportSlots extends ComponentHook
 {
@@ -44,11 +45,17 @@ class SupportSlots extends ComponentHook
 
     function hydrate($memo)
     {
-        // When a child component re-renders, we will need to stub out the known slots
-        // with placeholders so that they can be rendered and morph'd correctly...
         $slots = $memo['slots'] ?? [];
 
-        if (! empty($slots)) {
+        if (empty($slots)) return;
+
+        // If slot content was persisted (e.g. from a lazy component that skipped its
+        // initial render), restore full Slots so {{ $slot }} renders the content...
+        $hasContent = collect($slots)->contains(fn ($s) => isset($s['content']));
+
+        if ($hasContent) {
+            $this->component->withHydratedSlots($slots);
+        } else {
             $this->component->withPlaceholderSlots($slots);
         }
     }
@@ -77,11 +84,19 @@ class SupportSlots extends ComponentHook
         $slotMemo = [];
 
         foreach ($slots as $slot) {
-            $slotMemo[] = [
+            $entry = [
                 'name' => $slot->getName(),
                 'componentId' => $slot->getComponentId(),
                 'parentId' => $slot->getParentId(),
             ];
+
+            // If the slot has content and the render was skipped (e.g. lazy loading),
+            // persist the content so it survives the dehydrate → hydrate cycle...
+            if ($slot instanceof Slot && store($this->component)->get('skipRender', false)) {
+                $entry['content'] = $slot->content;
+            }
+
+            $slotMemo[] = $entry;
         }
 
         if (! empty($slotMemo)) {

--- a/src/Features/SupportSlots/SupportSlots.php
+++ b/src/Features/SupportSlots/SupportSlots.php
@@ -45,18 +45,14 @@ class SupportSlots extends ComponentHook
 
     function hydrate($memo)
     {
+        // When a child component re-renders, we will need to restore the known slots so
+        // that they can be rendered and morph'd correctly. Full Slots are restored when
+        // content was persisted from a skipped render (e.g. lazy components); otherwise
+        // placeholders are used...
         $slots = $memo['slots'] ?? [];
 
-        if (empty($slots)) return;
-
-        // If slot content was persisted (e.g. from a lazy component that skipped its
-        // initial render), restore full Slots so {{ $slot }} renders the content...
-        $hasContent = collect($slots)->contains(fn ($s) => isset($s['content']));
-
-        if ($hasContent) {
+        if (! empty($slots)) {
             $this->component->withHydratedSlots($slots);
-        } else {
-            $this->component->withPlaceholderSlots($slots);
         }
     }
 

--- a/src/Features/SupportSlots/SupportSlots.php
+++ b/src/Features/SupportSlots/SupportSlots.php
@@ -48,11 +48,11 @@ class SupportSlots extends ComponentHook
         // that they can be rendered and morph'd correctly. Full Slots are restored when
         // content was persisted from a skipped render (e.g. lazy components); otherwise
         // placeholders are used...
-        $slots = $memo['slots'] ?? [];
+        [$hydrated, $placeholders] = collect($memo['slots'] ?? [])
+            ->partition(fn ($s) => isset($s['content']));
 
-        if (! empty($slots)) {
-            $this->component->withHydratedSlots($slots);
-        }
+        if ($hydrated->isNotEmpty()) $this->component->withHydratedSlots($hydrated->all());
+        if ($placeholders->isNotEmpty()) $this->component->withPlaceholderSlots($placeholders->all());
     }
 
     public function dehydrate($context)

--- a/src/Features/SupportSlots/SupportSlots.php
+++ b/src/Features/SupportSlots/SupportSlots.php
@@ -5,7 +5,6 @@ namespace Livewire\Features\SupportSlots;
 use Livewire\ComponentHook;
 
 use function Livewire\on;
-use function Livewire\store;
 
 class SupportSlots extends ComponentHook
 {
@@ -88,7 +87,7 @@ class SupportSlots extends ComponentHook
 
             // If the slot has content and the render was skipped (e.g. lazy loading),
             // persist the content so it survives the dehydrate → hydrate cycle...
-            if ($slot instanceof Slot && store($this->component)->get('skipRender', false)) {
+            if ($slot instanceof Slot && $this->storeGet('skipRender', false)) {
                 $entry['content'] = $slot->content;
             }
 


### PR DESCRIPTION
## Summary

Slot content passed into a lazy or deferred component disappears after the component loads. The child renders correctly but `{{ $slot }}` produces empty output.

```blade
<livewire:child lazy>
    <h1>This disappears</h1>
</livewire:child>
```

Fixes #10255

## The problem

During a normal mount, slot content flows through cleanly: the parent captures it via `ob_start()`, `withSlots()` attaches it to the child, the child renders `{{ $slot }}`, and `Slot::toHtml()` outputs it wrapped in fragment markers.

For lazy components, `SupportLazyLoading::mount()` calls `skipMount()` and `skipRender()` before the child ever renders. The slot content is attached to the component but never rendered. Then `SupportSlots::dehydrate()` saves only slot **metadata** (name, componentId, parentId) into the memo — not the HTML content. When `__lazyLoad` fires and the child hydrates, it reconstructs empty `PlaceholderSlot` objects from the metadata, and `{{ $slot }}` renders nothing.

The content is lost in the dehydrate → hydrate cycle because the memo was never designed to carry it.

## The fix

When a component's render is skipped (the `skipRender` flag is set), `SupportSlots::dehydrate()` now also persists the slot's HTML `content` in the memo alongside the existing metadata. On hydrate, if `content` is present, full `Slot` objects are restored instead of empty `PlaceholderSlot`s. The `__lazyLoad` render then calls `{{ $slot }}` and gets real content.

Three files changed:

- **`SupportSlots.php`** — `dehydrate()` conditionally includes `content` when render was skipped; `hydrate()` restores full `Slot`s when content is present
- **`HandlesSlots.php`** — new `withHydratedSlots()` method that creates `Slot` or `PlaceholderSlot` per entry depending on whether content exists
- **`BrowserTest.php`** — test that slot content survives lazy loading

## Why this approach

The alternative is to emit slot HTML as a `slotFragments` effect on the lazy placeholder and handle it in JS — stashing the fragments until `__lazyLoad` morphs in the real DOM, then retrying them. That works but introduces a new JS-side timing pattern (stash + retry after morph) and renders slot content in two passes, which can flash empty.

This approach keeps the fix entirely in PHP within the existing render cycle. The slot content rides in the snapshot for exactly one round-trip (the `__lazyLoad` request), then on subsequent renders the parent takes over delivering fresh content via `slotFragments` as usual. No JS changes, no timing complexity.

## Test plan

- [ ] Browser test: `test_slot_content_is_preserved_on_lazy_component`
- [ ] Manual: render a `#[Lazy]` component with slot content, verify it appears after lazy load
- [ ] Manual: render a `#[Defer]` component with slot content, same verification
- [ ] Verify normal (non-lazy) slot behavior is unchanged


🤖 Generated with [Claude Code](https://claude.com/claude-code)