### PR TITLE
[4.x] Fix `IslandCompiler` cache directory mode breaking POSIX ACL deployments

### DIFF
--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -99,7 +99,7 @@ class IslandCompiler
         $innerContent = $scopeProviderCode . $innerContent;
 
         // Ensure the cached directory exists...
-        File::ensureDirectoryExists(dirname($cachedPath));
+        File::ensureDirectoryExists(dirname($cachedPath), 0777);
 
         // Write the cached island to the file system...
         file_put_contents($cachedPath, $innerContent);


### PR DESCRIPTION
# The Scenario

In a "zero-downtime" setup where a deployment user (e.g. `deployer`) and the web-server user (e.g. `www-data`) both write to a shared `storage/` directory, hitting a page that uses `@island` fails after `php artisan view:cache` with :

    ErrorException: tempnam(): file created in the system's temporary directory

# The Problem

`Features\SupportIslands\Compiler\IslandCompiler::compileIsland()` calls `File::ensureDirectoryExists()` without a mode argument:

    File::ensureDirectoryExists(dirname($cachedPath));

The default mode in `Illuminate\Filesystem\Filesystem::ensureDirectoryExists()` is `0755`, inconsistent with the rest of `CacheManager` which uses `0777` everywhere.

`view:cache` does not instantiate components and only triggers Blade compilation, so `IslandCompiler` is the first thing to create `storage/framework/views/livewire/`. Its recursive `mkdir` creates both `livewire/` and `livewire/islands/` with mode `0755`.

POSIX ACL semantics clamp the ACL mask to the requested group bits whenever a directory is created with an explicit mode. The named user entries stay `rwx` but effective permissions collapse:

    $ getfacl storage/framework/views/livewire/
    user:www-data:rwx               #effective:r-x
    user:deployer:rwx               #effective:r-x
    mask::r-x

At runtime, `CacheManager::writeClassFile()` then tries to create `livewire/classes/` with `0777`, but the parent `livewire/` already exists with the clamped mask. The inner `mkdir` fails silently (`@mkdir` with `force=true` swallows the error), and `File::replace()` then calls `tempnam()` on a non-existent directory, falls back to the system temp dir, and emits the error above (except Windows, who happily ignores all of this and gets on with its life).

# The Solution

Pass `0777` explicitly to align with the rest of `CacheManager` and let the process umask do its job. No regression for single-user setups (with `umask 0022`, `0777 & ~0022 = 0755`, identical to current behavior). Shared-write deployments running with `umask 0002` get `0775`, which preserves the ACL mask and lets both users write.