### PR TITLE
[4.x] Move errors onto the component as a reactive property

### DIFF
--- a/js/component.js
+++ b/js/component.js
@@ -38,6 +38,8 @@ export class Component {
         // "reactive" is just ephemeral, except when you mutate it, front-ends like Vue react.
         this.reactive = Alpine.reactive(this.ephemeral)
 
+        this.errors = Alpine.reactive({ messages: this.snapshot.memo.errors ?? {} })
+
         this.queuedUpdates = {}
 
         this.jsActions = {}
@@ -84,6 +86,8 @@ export class Component {
         this.snapshotEncoded = snapshotEncoded
 
         this.snapshot = snapshot
+
+        this.errors.messages = snapshot.memo.errors ?? {}
 
         this.effects = effects
 

--- a/js/features/supportErrors.js
+++ b/js/features/supportErrors.js
@@ -1,35 +1,8 @@
 // This errors object has the most common methods from \Illuminate\Support\MessageBag class on the backend...
-import Alpine from 'alpinejs'
-import { on } from '@/hooks'
-
-// After every server response, invalidate the cached errors so any Alpine
-// effects depending on $wire.$errors (like wire:show / wire:text) re-read
-// the fresh errors from the new snapshot. Without this, components that
-// skip rendering would never trigger that re-read...
-on('effect', ({ component }) => {
-    if (! component.__errorsState) return
-
-    component.__errorsState.clientErrors = null
-})
-
 export function getErrorsObject(component) {
-    let state = component.__errorsState ??= Alpine.reactive({
-        clientErrors: null,
-    })
-
-    // Store lastSnapshot outside reactive state to avoid Proxy wrapping breaking identity comparison...
-    component.__lastErrorsSnapshot ??= component.snapshot
-
     return {
         messages() {
-            // If the snapshot changed (server responded), reset client overrides...
-            if (component.__lastErrorsSnapshot !== component.snapshot) {
-                state.clientErrors = null
-                component.__lastErrorsSnapshot = component.snapshot
-            }
-
-            // Assign into reactive state so Alpine can track changes...
-            return state.clientErrors ??= component.snapshot.memo.errors
+            return component.errors.messages
         },
 
         keys() {
@@ -104,11 +77,11 @@ export function getErrorsObject(component) {
 
         clear(field = null) {
             if (field === null) {
-                state.clientErrors = {}
+                component.errors.messages = {}
             } else {
-                let errors = { ...(state.clientErrors ?? component.snapshot.memo.errors) }
+                let errors = { ...component.errors.messages }
                 delete errors[field]
-                state.clientErrors = errors
+                component.errors.messages = errors
             }
         },
     }


### PR DESCRIPTION
This PR is an alternative to PR #10269, as suggested by @ganyicz on that PR.

# The Scenario

When `skipRender()` is called inside a component (e.g. from `updated()`), validation errors arriving in the response are not reflected in the DOM through `wire:show` and `wire:text` directives that depend on `$errors`.

```php
<?php

use Livewire\Attributes\Validate;
use Livewire\Component;

new class extends Component {
    #[Validate(['required', 'min:5', 'max:10'])]
    public $title = '';

    public function updated()
    {
        $this->skipRender();
    }
}; ?>

<div>
    <input type="text" wire:model.live="title">

    <div wire:show="$errors.has('title')">
        <span wire:text="$errors.first('title')"></span>
    </div>
</div>
```

# The Problem

In `js/features/supportErrors.js`, `$wire.$errors` caches its messages in an `Alpine.reactive` cache that is only invalidated lazily — *when something reads `messages()`*:

```js
messages() {
    if (component.__lastErrorsSnapshot !== component.snapshot) {
        state.clientErrors = null
        component.__lastErrorsSnapshot = component.snapshot
    }
    return state.clientErrors ??= component.snapshot.memo.errors
},
```

In the normal flow, the morph step after a request causes Alpine to re-evaluate bindings, which calls `messages()`, which triggers the reactive update. With `skipRender()`, no morph runs, so nothing reads `messages()` and the cache is never invalidated, leaving dependent effects with stale errors.

# The Solution

Promote `errors` to a first-class reactive property on the `Component` class, alongside `this.reactive`. Initialise it in the constructor; update it in `mergeNewSnapshot`. `supportErrors.js` then reads/writes `component.errors.messages` directly, dropping the lazy cache, the snapshot tracking, and the cache-invalidation plumbing entirely.

```js
// js/component.js
this.errors = Alpine.reactive({ messages: this.snapshot.memo.errors ?? {} })

// in mergeNewSnapshot
this.errors.messages = snapshot.memo.errors ?? {}
```

```js
// js/features/supportErrors.js
messages() {
    return component.errors.messages
}
```

Net change: ~25 fewer lines, no functional difference, all existing tests still pass.

Fixes #10263