### PR TITLE
[4.x] Extract synth orchestration into a `HandleSynths` mechanism

### DIFF
--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -4,6 +4,7 @@ namespace Livewire;
 
 use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
+use Livewire\Mechanisms\HandleSynths\HandleSynths;
 use Livewire\Mechanisms\HandleComponents\HandleComponents;
 use Livewire\Mechanisms\HandleComponents\ComponentContext;
 use Livewire\Mechanisms\FrontendAssets\FrontendAssets;
@@ -56,7 +57,7 @@ class LivewireManager
 
     function propertySynthesizer($synth)
     {
-        app(HandleComponents::class)->registerPropertySynthesizer($synth);
+        app(HandleSynths::class)->registerSynth($synth);
     }
 
     function directive($name, $callback)
@@ -123,7 +124,7 @@ class LivewireManager
 
     function findSynth($keyOrTarget, $component)
     {
-        return app(HandleComponents::class)->findSynth($keyOrTarget, $component);
+        return app(HandleSynths::class)->find($keyOrTarget, $component);
     }
 
     function update($snapshot, $diff, $calls)

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -74,6 +74,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         return [
             Mechanisms\PersistentMiddleware\PersistentMiddleware::class,
+            Mechanisms\HandleSynths\HandleSynths::class,
             Mechanisms\HandleComponents\HandleComponents::class,
             Mechanisms\HandleRequests\HandleRequests::class,
             Mechanisms\HandleRouting\HandleRouting::class,

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -3,9 +3,8 @@
 namespace Livewire\Mechanisms\HandleComponents;
 
 use function Livewire\{on, store, trigger, wrap };
-use ReflectionUnionType;
 use Livewire\Mechanisms\Mechanism;
-use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+use Livewire\Mechanisms\HandleSynths\HandleSynths;
 use Livewire\Exceptions\PublicPropertyNotFoundException;
 use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Exceptions\MaxNestingDepthExceededException;
@@ -16,20 +15,6 @@ use Illuminate\Support\Facades\View;
 
 class HandleComponents extends Mechanism
 {
-    protected $propertySynthesizers = [
-        Synthesizers\CarbonSynth::class,
-        Synthesizers\CollectionSynth::class,
-        Synthesizers\StringableSynth::class,
-        Synthesizers\EnumSynth::class,
-        Synthesizers\StdClassSynth::class,
-        Synthesizers\ArraySynth::class,
-        Synthesizers\IntSynth::class,
-        Synthesizers\FloatSynth::class
-    ];
-
-    // Performance optimization: Cache which synthesizer matches which type
-    protected $synthesizerTypeCache = [];
-
     public static $renderStack = [];
     public static $componentStack = [];
 
@@ -40,13 +25,6 @@ class HandleComponents extends Mechanism
             static::$componentStack = [];
             Utils::flushReflectionCache();
         });
-    }
-
-    public function registerPropertySynthesizer($synth)
-    {
-        foreach ((array) $synth as $class) {
-            array_unshift($this->propertySynthesizers, $class);
-        }
     }
 
     public function mount($name, $params = [], $key = null, $slots = [])
@@ -303,30 +281,10 @@ class HandleComponents extends Mechanism
         $data = Utils::getPublicPropertiesDefinedOnSubclass($component);
 
         foreach ($data as $key => $value) {
-            $data[$key] = $this->dehydrate($value, $context, $key);
+            $data[$key] = app(HandleSynths::class)->dehydrate($value, $context, $key);
         }
 
         return $data;
-    }
-
-    protected function dehydrate($target, $context, $path)
-    {
-        if (Utils::isAPrimitive($target)) {
-            // Normalize negative zero (-0.0) to 0 to prevent checksum mismatches
-            if ($target === -0.0) return 0;
-
-            return $target;
-        }
-
-        $synth = $this->propertySynth($target, $context, $path);
-
-        [ $data, $meta ] = $synth->dehydrate($target, function ($name, $child) use ($context, $path) {
-            return $this->dehydrate($child, $context, "{$path}.{$name}");
-        });
-
-        $meta['s'] = $synth::getKey();
-
-        return [ $data, $meta ];
     }
 
     protected function hydrateProperties($component, $data, $context)
@@ -334,59 +292,13 @@ class HandleComponents extends Mechanism
         foreach ($data as $key => $value) {
             if (! property_exists($component, $key)) continue;
 
-            $child = $this->hydrate($value, $context, $key);
+            $child = app(HandleSynths::class)->hydrate($value, $context, $key);
 
             // Typed properties shouldn't be set back to "null". It will throw an error...
             if ((new \ReflectionProperty($component, $key))->getType() && is_null($child)) continue;
 
             $component->$key = $child;
         }
-    }
-
-    protected function hydrate($valueOrTuple, $context, $path)
-    {
-        if (! Utils::isSyntheticTuple($value = $tuple = $valueOrTuple)) return $value;
-
-        [$value, $meta] = $tuple;
-
-        // Nested properties get set as `__rm__` when they are removed. We don't want to hydrate these.
-        if ($this->isRemoval($value) && str($path)->contains('.')) {
-            return $value;
-        }
-
-        // Validate class against denylist before any synthesizer can instantiate it...
-        if (isset($meta['class'])) {
-            SecurityPolicy::validateClass($meta['class']);
-        }
-
-        $synth = $this->propertySynth($meta['s'], $context, $path);
-
-        return $synth->hydrate($value, $meta, function ($name, $child) use ($context, $path) {
-            return $this->hydrate($child, $context, "{$path}.{$name}");
-        });
-    }
-
-    protected function hydratePropertyUpdate($valueOrTuple, $context, $path)
-    {
-        if (! Utils::isSyntheticTuple($value = $tuple = $valueOrTuple)) return $value;
-
-        [$value, $meta] = $tuple;
-
-        // Nested properties get set as `__rm__` when they are removed. We don't want to hydrate these.
-        if ($this->isRemoval($value) && str($path)->contains('.')) {
-            return $value;
-        }
-
-        // Validate class against denylist before any synthesizer can instantiate it...
-        if (isset($meta['class'])) {
-            SecurityPolicy::validateClass($meta['class']);
-        }
-
-        $synth = $this->propertySynth($meta['s'], $context, $path);
-
-        return $synth->hydrate($value, $meta, function ($name, $child) {
-            return $child;
-        });
     }
 
     protected function render($component, $default = null)
@@ -480,7 +392,7 @@ class HandleComponents extends Mechanism
         $finishes = [];
 
         foreach ($updates as $path => $value) {
-            $value = $this->hydrateForUpdate($data, $path, $value, $context);
+            $value = app(HandleSynths::class)->hydrateForUpdate($data, $path, $value, $context);
 
             // We only want to run "updated" hooks after all properties have
             // been updated so that each individual hook has the ability
@@ -543,54 +455,6 @@ class HandleComponents extends Mechanism
         return $finish;
     }
 
-    protected function hydrateForUpdate($raw, $path, $value, $context)
-    {
-        $meta = $this->getMetaForPath($raw, $path);
-
-        // If we have meta data already for this property, let's use that to get a synth...
-        if ($meta) {
-            return $this->hydratePropertyUpdate([$value, $meta], $context, $path);
-        }
-
-        // If we don't, let's check to see if it's a typed property and fetch the synth that way...
-        $parent = str($path)->contains('.')
-            ? data_get($context->component, str($path)->beforeLast('.')->toString())
-            : $context->component;
-
-        $childKey = str($path)->afterLast('.');
-
-        if ($parent && is_object($parent) && property_exists($parent, $childKey) && Utils::propertyIsTyped($parent, $childKey)) {
-            $type = Utils::getProperty($parent, $childKey)->getType();
-
-            $types = $type instanceof ReflectionUnionType ? $type->getTypes() : [$type];
-
-            foreach ($types as $type) {
-                $synth = $this->getSynthesizerByType($type->getName(), $context, $path);
-
-                if ($synth) return $synth->hydrateFromType($type->getName(), $value);
-            }
-        }
-
-        return $value;
-    }
-
-    protected function getMetaForPath($raw, $path)
-    {
-        $segments = explode('.', $path);
-
-        $first = array_shift($segments);
-
-        [$data, $meta] = Utils::isSyntheticTuple($raw) ? $raw : [$raw, null];
-
-        if ($path !== '') {
-            $value = $data[$first] ?? null;
-
-            return $this->getMetaForPath($value, implode('.', $segments));
-        }
-
-        return $meta;
-    }
-
     protected function recursivelySetValue($baseProperty, $target, $leafValue, $segments, $index = 0, $context = null)
     {
         $isLastSegment = count($segments) === $index + 1;
@@ -599,7 +463,9 @@ class HandleComponents extends Mechanism
 
         $path = implode('.', array_slice($segments, 0, $index + 1));
 
-        $synth = $this->propertySynth($target, $context, $path);
+        $synths = app(HandleSynths::class);
+
+        $synth = $synths->resolve($target, $context, $path);
 
         if ($isLastSegment) {
             $toSet = $leafValue;
@@ -618,7 +484,7 @@ class HandleComponents extends Mechanism
             $toSet = $this->recursivelySetValue($baseProperty, $propertyTarget, $leafValue, $segments, $index + 1, $context);
         }
 
-        $method = ($this->isRemoval($leafValue) && $isLastSegment) ? 'unset' : 'set';
+        $method = ($synths->isRemoval($leafValue) && $isLastSegment) ? 'unset' : 'set';
 
         $pathThusFar = collect([$baseProperty, ...$segments])->slice(0, $index + 1)->join('.');
         $fullPath = collect([$baseProperty, ...$segments])->join('.');
@@ -708,65 +574,6 @@ class HandleComponents extends Mechanism
         $componentContext->addEffect('returns', $returns);
     }
 
-    public function findSynth($keyOrTarget, $component): ?Synth
-    {
-        $context = new ComponentContext($component);
-        try {
-            return $this->propertySynth($keyOrTarget, $context, null);
-        } catch (\Exception $e) {
-            return null;
-        }
-    }
-
-    public function propertySynth($keyOrTarget, $context, $path): Synth
-    {
-        return is_string($keyOrTarget)
-            ? $this->getSynthesizerByKey($keyOrTarget, $context, $path)
-            : $this->getSynthesizerByTarget($keyOrTarget, $context, $path);
-    }
-
-    protected function getSynthesizerByKey($key, $context, $path)
-    {
-        foreach ($this->propertySynthesizers as $synth) {
-            if ($synth::getKey() === $key) {
-                return new $synth($context, $path);
-            }
-        }
-
-        throw new \Exception('No synthesizer found for key: "'.$key.'"');
-    }
-
-    protected function getSynthesizerByTarget($target, $context, $path)
-    {
-        // Performance optimization: Cache synthesizer matches by runtime type...
-        $type = get_debug_type($target);
-
-        if (! isset($this->synthesizerTypeCache[$type])) {
-            foreach ($this->propertySynthesizers as $synth) {
-                if ($synth::match($target)) {
-                    $this->synthesizerTypeCache[$type] = $synth;
-
-                    return new $synth($context, $path);
-                }
-            }
-
-            throw new \Exception('Property type not supported in Livewire for property: ['.json_encode($target).']');
-        }
-
-        return new $this->synthesizerTypeCache[$type]($context, $path);
-    }
-
-    protected function getSynthesizerByType($type, $context, $path)
-    {
-        foreach ($this->propertySynthesizers as $synth) {
-            if ($synth::matchByType($type)) {
-                return new $synth($context, $path);
-            }
-        }
-
-        return null;
-    }
-
     protected function pushOntoComponentStack($component)
     {
         array_push($this::$componentStack, $component);
@@ -775,9 +582,5 @@ class HandleComponents extends Mechanism
     protected function popOffComponentStack()
     {
         array_pop($this::$componentStack);
-    }
-
-    protected function isRemoval($value) {
-        return $value === '__rm__';
     }
 }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -18,6 +18,13 @@ class HandleComponents extends Mechanism
     public static $renderStack = [];
     public static $componentStack = [];
 
+    // Holding the HandleSynths instance directly avoids resolving it from the
+    // container on every property in the dehydrate/hydrate loops below. This
+    // relies on HandleSynths being registered before HandleComponents in
+    // LivewireServiceProvider::getMechanisms() so the singleton is already
+    // bound when the container builds this mechanism.
+    public function __construct(protected HandleSynths $synths) {}
+
     public function boot()
     {
         on('flush-state', function () {
@@ -281,7 +288,7 @@ class HandleComponents extends Mechanism
         $data = Utils::getPublicPropertiesDefinedOnSubclass($component);
 
         foreach ($data as $key => $value) {
-            $data[$key] = app(HandleSynths::class)->dehydrate($value, $context, $key);
+            $data[$key] = $this->synths->dehydrate($value, $context, $key);
         }
 
         return $data;
@@ -292,7 +299,7 @@ class HandleComponents extends Mechanism
         foreach ($data as $key => $value) {
             if (! property_exists($component, $key)) continue;
 
-            $child = app(HandleSynths::class)->hydrate($value, $context, $key);
+            $child = $this->synths->hydrate($value, $context, $key);
 
             // Typed properties shouldn't be set back to "null". It will throw an error...
             if ((new \ReflectionProperty($component, $key))->getType() && is_null($child)) continue;
@@ -392,7 +399,7 @@ class HandleComponents extends Mechanism
         $finishes = [];
 
         foreach ($updates as $path => $value) {
-            $value = app(HandleSynths::class)->hydrateForUpdate($data, $path, $value, $context);
+            $value = $this->synths->hydrateForUpdate($data, $path, $value, $context);
 
             // We only want to run "updated" hooks after all properties have
             // been updated so that each individual hook has the ability
@@ -463,7 +470,7 @@ class HandleComponents extends Mechanism
 
         $path = implode('.', array_slice($segments, 0, $index + 1));
 
-        $synths = app(HandleSynths::class);
+        $synths = $this->synths;
 
         $synth = $synths->resolve($target, $context, $path);
 

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -18,11 +18,6 @@ class HandleComponents extends Mechanism
     public static $renderStack = [];
     public static $componentStack = [];
 
-    // Holding the HandleSynths instance directly avoids resolving it from the
-    // container on every property in the dehydrate/hydrate loops below. This
-    // relies on HandleSynths being registered before HandleComponents in
-    // LivewireServiceProvider::getMechanisms() so the singleton is already
-    // bound when the container builds this mechanism.
     public function __construct(protected HandleSynths $synths) {}
 
     public function boot()

--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleSynths;
+
+use Livewire\Mechanisms\Mechanism;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+use Livewire\Mechanisms\HandleComponents\SecurityPolicy;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+use Livewire\Mechanisms\HandleComponents\Synthesizers;
+use Livewire\Drawer\Utils;
+use ReflectionUnionType;
+
+class HandleSynths extends Mechanism
+{
+    protected array $synthesizers = [
+        Synthesizers\CarbonSynth::class,
+        Synthesizers\CollectionSynth::class,
+        Synthesizers\StringableSynth::class,
+        Synthesizers\EnumSynth::class,
+        Synthesizers\StdClassSynth::class,
+        Synthesizers\ArraySynth::class,
+        Synthesizers\IntSynth::class,
+        Synthesizers\FloatSynth::class,
+    ];
+
+    // Performance optimization: Cache which synthesizer matches which type
+    protected array $typeCache = [];
+
+    public function registerSynth($synth)
+    {
+        foreach ((array) $synth as $class) {
+            array_unshift($this->synthesizers, $class);
+        }
+    }
+
+    public function dehydrate($target, $context, $path)
+    {
+        if (Utils::isAPrimitive($target)) {
+            // Normalize negative zero (-0.0) to 0 to prevent checksum mismatches
+            if ($target === -0.0) return 0;
+
+            return $target;
+        }
+
+        $synth = $this->resolve($target, $context, $path);
+
+        [ $data, $meta ] = $synth->dehydrate($target, function ($name, $child) use ($context, $path) {
+            return $this->dehydrate($child, $context, "{$path}.{$name}");
+        });
+
+        $meta['s'] = $synth::getKey();
+
+        return [ $data, $meta ];
+    }
+
+    public function hydrate($valueOrTuple, $context, $path)
+    {
+        if (! Utils::isSyntheticTuple($value = $tuple = $valueOrTuple)) return $value;
+
+        [$value, $meta] = $tuple;
+
+        // Nested properties get set as `__rm__` when they are removed. We don't want to hydrate these.
+        if ($this->isRemoval($value) && str($path)->contains('.')) {
+            return $value;
+        }
+
+        // Validate class against denylist before any synthesizer can instantiate it...
+        if (isset($meta['class'])) {
+            SecurityPolicy::validateClass($meta['class']);
+        }
+
+        $synth = $this->resolve($meta['s'], $context, $path);
+
+        return $synth->hydrate($value, $meta, function ($name, $child) use ($context, $path) {
+            return $this->hydrate($child, $context, "{$path}.{$name}");
+        });
+    }
+
+    public function hydratePropertyUpdate($valueOrTuple, $context, $path)
+    {
+        if (! Utils::isSyntheticTuple($value = $tuple = $valueOrTuple)) return $value;
+
+        [$value, $meta] = $tuple;
+
+        // Nested properties get set as `__rm__` when they are removed. We don't want to hydrate these.
+        if ($this->isRemoval($value) && str($path)->contains('.')) {
+            return $value;
+        }
+
+        // Validate class against denylist before any synthesizer can instantiate it...
+        if (isset($meta['class'])) {
+            SecurityPolicy::validateClass($meta['class']);
+        }
+
+        $synth = $this->resolve($meta['s'], $context, $path);
+
+        return $synth->hydrate($value, $meta, function ($name, $child) {
+            return $child;
+        });
+    }
+
+    public function hydrateForUpdate($raw, $path, $value, $context)
+    {
+        $meta = $this->getMetaForPath($raw, $path);
+
+        // If we have meta data already for this property, let's use that to get a synth...
+        if ($meta) {
+            return $this->hydratePropertyUpdate([$value, $meta], $context, $path);
+        }
+
+        // If we don't, let's check to see if it's a typed property and fetch the synth that way...
+        $parent = str($path)->contains('.')
+            ? data_get($context->component, str($path)->beforeLast('.')->toString())
+            : $context->component;
+
+        $childKey = str($path)->afterLast('.');
+
+        if ($parent && is_object($parent) && property_exists($parent, $childKey) && Utils::propertyIsTyped($parent, $childKey)) {
+            $type = Utils::getProperty($parent, $childKey)->getType();
+
+            $types = $type instanceof ReflectionUnionType ? $type->getTypes() : [$type];
+
+            foreach ($types as $type) {
+                $synth = $this->findByType($type->getName(), $context, $path);
+
+                if ($synth) return $synth->hydrateFromType($type->getName(), $value);
+            }
+        }
+
+        return $value;
+    }
+
+    public function find($keyOrTarget, $component): ?Synth
+    {
+        $context = new ComponentContext($component);
+        try {
+            return $this->resolve($keyOrTarget, $context, null);
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    public function resolve($keyOrTarget, $context, $path): Synth
+    {
+        return is_string($keyOrTarget)
+            ? $this->findByKey($keyOrTarget, $context, $path)
+            : $this->findByTarget($keyOrTarget, $context, $path);
+    }
+
+    public function isRemoval($value)
+    {
+        return $value === '__rm__';
+    }
+
+    protected function findByKey($key, $context, $path)
+    {
+        foreach ($this->synthesizers as $synth) {
+            if ($synth::getKey() === $key) {
+                return new $synth($context, $path);
+            }
+        }
+
+        throw new \Exception('No synthesizer found for key: "'.$key.'"');
+    }
+
+    protected function findByTarget($target, $context, $path)
+    {
+        // Performance optimization: Cache synthesizer matches by runtime type...
+        $type = get_debug_type($target);
+
+        if (! isset($this->typeCache[$type])) {
+            foreach ($this->synthesizers as $synth) {
+                if ($synth::match($target)) {
+                    $this->typeCache[$type] = $synth;
+
+                    return new $synth($context, $path);
+                }
+            }
+
+            throw new \Exception('Property type not supported in Livewire for property: ['.json_encode($target).']');
+        }
+
+        return new ($this->typeCache[$type])($context, $path);
+    }
+
+    protected function findByType($type, $context, $path)
+    {
+        foreach ($this->synthesizers as $synth) {
+            if ($synth::matchByType($type)) {
+                return new $synth($context, $path);
+            }
+        }
+
+        return null;
+    }
+
+    protected function getMetaForPath($raw, $path)
+    {
+        $segments = explode('.', $path);
+
+        $first = array_shift($segments);
+
+        [$data, $meta] = Utils::isSyntheticTuple($raw) ? $raw : [$raw, null];
+
+        if ($path !== '') {
+            $value = $data[$first] ?? null;
+
+            return $this->getMetaForPath($value, implode('.', $segments));
+        }
+
+        return $meta;
+    }
+}

--- a/src/Mechanisms/HandleSynths/UnitTest.php
+++ b/src/Mechanisms/HandleSynths/UnitTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleSynths;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\CollectionSynth;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+use Tests\TestComponent;
+
+class UnitTest extends \Tests\TestCase
+{
+    public function test_dehydrate_passes_primitives_through_unchanged()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $this->assertSame(42, $synths->dehydrate(42, $context, ''));
+        $this->assertSame('foo', $synths->dehydrate('foo', $context, ''));
+        $this->assertTrue($synths->dehydrate(true, $context, ''));
+        $this->assertNull($synths->dehydrate(null, $context, ''));
+    }
+
+    public function test_dehydrate_returns_a_synthetic_tuple_for_non_primitives()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        [$data, $meta] = $synths->dehydrate(collect([1, 2, 3]), $context, '');
+
+        $this->assertSame([1, 2, 3], $data);
+        $this->assertSame(CollectionSynth::$key, $meta['s']);
+        $this->assertSame(Collection::class, $meta['class']);
+    }
+
+    public function test_hydrate_round_trips_a_collection()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $original = collect([1, 2, 3]);
+
+        $tuple = $synths->dehydrate($original, $context, '');
+        $hydrated = $synths->hydrate($tuple, $context, '');
+
+        $this->assertInstanceOf(Collection::class, $hydrated);
+        $this->assertSame([1, 2, 3], $hydrated->all());
+    }
+
+    public function test_hydrate_passes_non_tuple_values_through_unchanged()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $this->assertSame(42, $synths->hydrate(42, $context, ''));
+        $this->assertSame('foo', $synths->hydrate('foo', $context, ''));
+        $this->assertSame(['plain', 'array'], $synths->hydrate(['plain', 'array'], $context, ''));
+    }
+
+    public function test_find_resolves_a_synth_by_key()
+    {
+        $synths = app(HandleSynths::class);
+
+        $synth = $synths->find(CollectionSynth::$key, new TestComponent);
+
+        $this->assertInstanceOf(CollectionSynth::class, $synth);
+    }
+
+    public function test_find_resolves_a_synth_by_target_value()
+    {
+        $synths = app(HandleSynths::class);
+
+        $synth = $synths->find(collect([1, 2, 3]), new TestComponent);
+
+        $this->assertInstanceOf(CollectionSynth::class, $synth);
+    }
+
+    public function test_find_returns_null_for_an_unknown_key()
+    {
+        $synths = app(HandleSynths::class);
+
+        $this->assertNull($synths->find('not-a-real-synth-key', new TestComponent));
+    }
+
+    public function test_register_synth_adds_a_synth_to_the_registry()
+    {
+        $synths = app(HandleSynths::class);
+
+        $synths->registerSynth(CustomThingSynth::class);
+
+        $synth = $synths->find(new CustomThing, new TestComponent);
+
+        $this->assertInstanceOf(CustomThingSynth::class, $synth);
+    }
+
+    public function test_is_removal_recognises_the_removal_sentinel()
+    {
+        $synths = app(HandleSynths::class);
+
+        $this->assertTrue($synths->isRemoval('__rm__'));
+        $this->assertFalse($synths->isRemoval('rm'));
+        $this->assertFalse($synths->isRemoval(null));
+        $this->assertFalse($synths->isRemoval(''));
+    }
+}
+
+class CustomThing
+{
+    public function __construct(public string $value = 'default') {}
+}
+
+class CustomThingSynth extends Synth
+{
+    public static $key = 'custom-thing';
+
+    public static function match($target)
+    {
+        return $target instanceof CustomThing;
+    }
+
+    public function dehydrate($target)
+    {
+        return [['value' => $target->value], []];
+    }
+
+    public function hydrate($value)
+    {
+        return new CustomThing($value['value']);
+    }
+}

--- a/src/Mechanisms/HandleSynths/UnitTest.php
+++ b/src/Mechanisms/HandleSynths/UnitTest.php
@@ -103,6 +103,34 @@ class UnitTest extends \Tests\TestCase
         $this->assertFalse($synths->isRemoval(null));
         $this->assertFalse($synths->isRemoval(''));
     }
+
+    public function test_hydrate_blocks_denylisted_classes_via_the_security_policy()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        // A forged tuple whose meta declares a denylisted gadget class. The
+        // SecurityPolicy denylist must fire before any synth instantiates it.
+        $tuple = [['x' => 1], ['s' => 'arr', 'class' => \Symfony\Component\Process\Process::class]];
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not allowed to be instantiated');
+
+        $synths->hydrate($tuple, $context, 'evil');
+    }
+
+    public function test_hydrate_property_update_blocks_denylisted_classes_via_the_security_policy()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $tuple = [['x' => 1], ['s' => 'arr', 'class' => \Symfony\Component\Process\Process::class]];
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not allowed to be instantiated');
+
+        $synths->hydratePropertyUpdate($tuple, $context, 'evil');
+    }
 }
 
 class CustomThing


### PR DESCRIPTION
# The Scenario

`HandleComponents` currently owns both the component lifecycle (`mount`, `snapshot`, `update`, `render`) and the synth-based serialisation pipeline (registry, resolution, recursive dehydrate/hydrate). Any feature (like `#[Session]`) that wants to use synths at the moment has to reference the `HandleComponents` mechanism to do it. Came up during review of #10252.

# The Solution

This PR extracts the synths system into its own mechanism class `Livewire\Mechanisms\HandleSynths\HandleSynths`.

`Livewire::propertySynthesizer(...)` and `Livewire::findSynth(...)` now delegate to `HandleSynths`, so the public API is unchanged.

This will let the fix for #10250 leverage `HandleSynths` directly, which is cleaner than reaching into `HandleComponents`.

One thing to note: all the built-in synth classes (`CarbonSynth`, `CollectionSynth`, the `Synth` base, etc.) are still in their original location (`Livewire\Mechanisms\HandleComponents\Synthesizers\*`). The docs demonstrate extending `Synth` from userland, so moving them would be a breaking change. We could move them and add shell classes at the old location if you'd prefer.