### PR TITLE
[4.x] Adds documentation for authorization with additional context

### DIFF
--- a/docs/attribute-authorize.md
+++ b/docs/attribute-authorize.md
@@ -78,7 +78,7 @@ new class extends Component {
     public Post $post;
 
     #[Authorize('create', [Comment::class, 'post'])] // [tl! highlight]
-    public function createComment() // [tl! highlight]
+    public function createComment()
     {
         $this->post->comments()->create([
             'body' => 'New comment'

--- a/docs/attribute-authorize.md
+++ b/docs/attribute-authorize.md
@@ -62,6 +62,31 @@ new class extends Component {
 > [!important]
 > If you resolve a model via a method parameter, a type-hint (e.g., `Comment $comment`) is required. Without it, Livewire cannot determine which model to resolve and the authorization check will fail.
 
+## Additional context
+
+When authorizing actions using policies, you may pass an array as the second argument. The first element in the array will be used to determine which policy should be invoked, while the rest of the array elements are passed as parameters to the policy method.
+
+```php
+<?php
+
+use Livewire\Attributes\Authorize;
+use Livewire\Component;
+use App\Models\Comment;
+use App\Models\Post;
+
+new class extends Component {
+    public Post $post;
+
+    #[Authorize('create', [Comment::class, 'post'])] // [tl! highlight]
+    public function createComment() // [tl! highlight]
+    {
+        $this->post->comments()->create([
+            'body' => 'New comment'
+        ]);
+    }
+};
+```
+
 ## Stacking multiple checks
 
 The attribute is repeatable, so you can stack multiple authorization checks on a single method:


### PR DESCRIPTION
In https://github.com/livewire/livewire/pull/10260, I forgot to add the documentation about it.

This PR adds information to `docs\attribute-authorize.md` documentation about supplying additional context when using **`Authorize`** attribute.
