### PR TITLE
[4.x] Add "@return $this" docblocks to MakesAssertions for static analysis tools to work better in userland tests

### DIFF
--- a/src/Features/SupportTesting/MakesAssertions.php
+++ b/src/Features/SupportTesting/MakesAssertions.php
@@ -8,7 +8,9 @@ use Illuminate\Support\Arr;
 
 trait MakesAssertions
 {
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertSee($values, $escape = true, $stripInitialData = true)
     {
         foreach (Arr::wrap($values) as $value) {
@@ -21,7 +23,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertDontSee($values, $escape = true, $stripInitialData = true)
     {
         foreach (Arr::wrap($values) as $value) {
@@ -34,7 +38,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertSeeHtml($values)
     {
         foreach (Arr::wrap($values) as $value) {
@@ -47,7 +53,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertSeeHtmlInOrder($values)
     {
         PHPUnit::assertThat(
@@ -58,7 +66,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertDontSeeHtml($values)
     {
         foreach (Arr::wrap($values) as $value) {
@@ -71,7 +81,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertSeeText($value, $escape = true)
     {
         $value = Arr::wrap($value);
@@ -89,7 +101,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertDontSeeText($value, $escape = true)
     {
         $value = Arr::wrap($value);
@@ -107,7 +121,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertSet($name, $value, $strict = false)
     {
         $actual = $this->get($name);
@@ -121,7 +137,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertNotSet($name, $value, $strict = false)
     {
         $actual = $this->get($name);
@@ -131,7 +149,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertSetStrict($name, $value)
     {
         $this->assertSet($name, $value, true);
@@ -139,7 +159,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertNotSetStrict($name, $value)
     {
         $this->assertNotSet($name, $value, true);
@@ -147,7 +169,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertCount($name, $value)
     {
         PHPUnit::assertCount($value, $this->get($name));
@@ -155,7 +179,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertSnapshotSet($name, $value, $strict = false)
     {
         $data = $this->lastState->getSnapshotData();
@@ -169,7 +195,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertSnapshotNotSet($name, $value, $strict = false)
     {
         $data = $this->lastState->getSnapshotData();
@@ -183,7 +211,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertSnapshotSetStrict($name, $value)
     {
         $this->assertSnapshotSet($name, $value, true);
@@ -191,7 +221,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     function assertSnapshotNotSetStrict($name, $value)
     {
         $this->assertSnapshotNotSet($name, $value, true);
@@ -199,7 +231,9 @@ trait MakesAssertions
         return $this;
     }
 
-    /** @return $this */
+    /**
+     * @return $this
+     */
     public function assertReturned($value)
     {
         $data = data_get($this->lastState->getEffects(), 'returns.0');

--- a/src/Features/SupportTesting/MakesAssertions.php
+++ b/src/Features/SupportTesting/MakesAssertions.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 
 trait MakesAssertions
 {
+    /** @return $this */
     function assertSee($values, $escape = true, $stripInitialData = true)
     {
         foreach (Arr::wrap($values) as $value) {
@@ -20,6 +21,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertDontSee($values, $escape = true, $stripInitialData = true)
     {
         foreach (Arr::wrap($values) as $value) {
@@ -32,6 +34,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertSeeHtml($values)
     {
         foreach (Arr::wrap($values) as $value) {
@@ -44,6 +47,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertSeeHtmlInOrder($values)
     {
         PHPUnit::assertThat(
@@ -54,6 +58,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertDontSeeHtml($values)
     {
         foreach (Arr::wrap($values) as $value) {
@@ -66,6 +71,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertSeeText($value, $escape = true)
     {
         $value = Arr::wrap($value);
@@ -83,6 +89,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertDontSeeText($value, $escape = true)
     {
         $value = Arr::wrap($value);
@@ -100,6 +107,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertSet($name, $value, $strict = false)
     {
         $actual = $this->get($name);
@@ -113,6 +121,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertNotSet($name, $value, $strict = false)
     {
         $actual = $this->get($name);
@@ -122,6 +131,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertSetStrict($name, $value)
     {
         $this->assertSet($name, $value, true);
@@ -129,6 +139,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertNotSetStrict($name, $value)
     {
         $this->assertNotSet($name, $value, true);
@@ -136,6 +147,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertCount($name, $value)
     {
         PHPUnit::assertCount($value, $this->get($name));
@@ -143,6 +155,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertSnapshotSet($name, $value, $strict = false)
     {
         $data = $this->lastState->getSnapshotData();
@@ -156,6 +169,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertSnapshotNotSet($name, $value, $strict = false)
     {
         $data = $this->lastState->getSnapshotData();
@@ -169,6 +183,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertSnapshotSetStrict($name, $value)
     {
         $this->assertSnapshotSet($name, $value, true);
@@ -176,6 +191,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     function assertSnapshotNotSetStrict($name, $value)
     {
         $this->assertSnapshotNotSet($name, $value, true);
@@ -183,6 +199,7 @@ trait MakesAssertions
         return $this;
     }
 
+    /** @return $this */
     public function assertReturned($value)
     {
         $data = data_get($this->lastState->getEffects(), 'returns.0');


### PR DESCRIPTION
Running PHPStan over a project's tests directory causes some issues with Livewire tests - because the assertions have no return type:

```
 ------ ------------------------------------------ 
  Line   tests/Feature/ApiTokensSettingsTest.php   
 ------ ------------------------------------------ 
  :121   Cannot call method call() on mixed.       
         🪪  method.nonObject                      
  :122   Cannot call method assertSet() on mixed.  
         🪪  method.nonObject                      
 ------ ------------------------------------------ 
```

As `Testable` has docblocks denoting `@return $this`, I figure it's also appropriate to add them to the `MakesAssertions` trait too, so it covers that section of userland-used code.