### PR TITLE
[4.x] Fix `@island` directive breaking when expression contains nested parentheses

### DIFF
--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -53,7 +53,7 @@ class IslandCompiler
         $result = $this->restoreBladeComments($result, $comments);
 
         for ($i=$maxNestingLevel; $i >= $currentNestingLevel; $i--) {
-            $result = preg_replace_callback('/(\[STARTISLAND:([0-9]+):' . $i . '\])\((.*?)\)(.*?)(\[ENDISLAND:' . $i . '\])/s', function ($matches) use ($i) {
+            $result = preg_replace_callback('/(\[STARTISLAND:([0-9]+):' . $i . '\])\(((?:[^()]++|\((?3)\))*)\)(.*?)(\[ENDISLAND:' . $i . '\])/s', function ($matches) use ($i) {
                 $occurrence = $matches[2];
                 $innerContent = $matches[4];
                 $expression = $matches[3];

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -453,6 +453,22 @@ class UnitTest extends TestCase
         $this->assertCount(1, $fragments, 'Expected only one island fragment but got ' . count($fragments));
     }
 
+    public function test_island_directive_supports_nested_parentheses_in_expression()
+    {
+        Livewire::test(new class extends \Livewire\Component {
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    @island(with: ['value' => strtoupper(trim('  hello  '))])
+                        <div>value: {{ $value ?? 'not set' }}</div>
+                    @endisland
+                </div>
+                HTML;
+            }
+        })
+            ->assertSee('value: HELLO');
+    }
+
     public function test_island_tokens_are_stable_across_different_base_paths()
     {
         $path = '/resources/views/components/foo.blade.php';


### PR DESCRIPTION
# The Scenario

The `@island` directive throws a parse error and renders broken output when its expression contains nested parentheses, such as a function call inside the `with:` array or a chained method call:

```blade
<?php

new class extends \Livewire\Component
{
    //
} ?>

<div>
    @island(defer: cache()->missing('user'))
        {{-- ... --}}
    @endisland
</div>
```

# The Problem

`IslandCompiler` first lets Blade parse the directive (Blade balances parens correctly via `hasEvenNumberOfParentheses`), then re-extracts the expression from a placeholder marker using a regex:

```php
'/(\[STARTISLAND:([0-9]+):' . $i . '\])\((.*?)\)(.*?)(\[ENDISLAND:' . $i . '\])/s'
```

The expression group `\((.*?)\)` is non-greedy and stops at the **first** closing `)`. For `[STARTISLAND:1:1](defer: cache()->missing('user'))…`, it captures `defer: cache(` as the expression and leaks `->missing('user'))` into the inner content, producing malformed compiled output.

# The Solution

Replace the non-greedy expression group with a recursive subpattern that matches balanced parentheses to any depth:

```php
'/(\[STARTISLAND:([0-9]+):' . $i . '\])\(((?:[^()]++|\((?3)\))*)\)(.*?)(\[ENDISLAND:' . $i . '\])/s'
```

The old pattern, `\((.*?)\)`, simply grabbed everything up to the *first* closing `)` it found. The new pattern reads the expression character by character instead: it consumes any run of non-parenthesis characters (`[^()]++`), and whenever it hits an opening `(`, it matches a whole balanced `(...)` block before carrying on.

That balanced block is matched with `\((?3)\)`. The `(?3)` is a reference to subpattern 3, which is the expression group itself, so the pattern calls itself recursively. Because it can recurse with no fixed limit, it correctly handles parentheses nested to any depth, e.g. `cache()->missing('user')` or `strtoupper(trim('  hello  '))`.

The outer capture groups keep the same numbering, so the surrounding callback code that reads `$matches[2]`, `$matches[3]` and `$matches[4]` needs no changes.

Fixes #10277