### PR TITLE
[3.x] Fix file uploads hanging silently on network-level failures

### DIFF
--- a/js/features/supportFileUploads.js
+++ b/js/features/supportFileUploads.js
@@ -211,6 +211,10 @@ class UploadManager {
             this.component.$wire.call('_uploadErrored', name, errors, this.uploadBag.first(name).multiple)
         })
 
+        request.addEventListener('error', () => {
+            this.component.$wire.call('_uploadErrored', name, null, this.uploadBag.first(name).multiple)
+        })
+
         this.uploadBag.first(name).request = request
 
         request.send(formData)


### PR DESCRIPTION
# The Scenario

When uploading a file directly to S3, any network-level failure of the upload request causes the upload to hang indefinitely with no feedback. A missing CORS configuration on the bucket, a non-existent bucket, or a dropped connection all leave the loading state stuck on screen. `livewire-upload-error` never fires, the error callback is never called, and the user has no idea anything went wrong.

For example, with a bucket that has no CORS rule for the app's origin, selecting a file in the component below leaves "Uploading…" showing forever:

<img width="800" height="775" alt="Screenshot 2026-05-14 at 06 08 33PM" src="https://github.com/user-attachments/assets/4d85640d-c280-4114-a0cf-235ec33c5368" />

```php
use Livewire\Component;
use Livewire\WithFileUploads;

class UploadPhoto extends Component
{
    use WithFileUploads;

    public $photo;

    public function render()
    {
        return <<<'HTML'
        <div>
            <input type="file" wire:model="photo">

            <div wire:loading wire:target="photo">Uploading…</div>

            <span>@error('photo') {{ $message }} @enderror</span>
        </div>
        HTML;
    }
}
```

# The Problem

`makeRequest()` in `js/features/supportFileUploads.js` registers only two listeners on the `XMLHttpRequest`:

```js
request.upload.addEventListener('progress', e => { /* ... */ })

request.addEventListener('load', () => { /* ... */ })
```

The `load` event only fires once an HTTP response is received, so it correctly handles S3 responding with a `4xx`/`5xx` status. But network-level failures, such as CORS blocks, DNS failures, and dropped connections, fire the `error` event instead, and there is no `error` listener. The request is left hanging, so the upload bag entry is never shifted, the loading state never clears, and neither `_uploadErrored` nor any callback runs.

Both `handleSignedUrl` (local `POST`) and `handleS3PreSignedUrl` (direct-to-S3 `PUT`) flow through `makeRequest`, so both are affected.

# The Solution

Add an `error` event listener to `makeRequest` that calls `_uploadErrored` with `null` errors:

```js
request.addEventListener('error', () => {
    this.component.$wire.call('_uploadErrored', name, null, this.uploadBag.first(name).multiple)
})
```

This mirrors the existing non-`2xx` branch of the `load` handler, which already calls `_uploadErrored` with `null` errors for any non-`422` response.

Because both upload paths share `makeRequest`, the single listener covers local and direct-to-S3 uploads alike.

<img width="800" height="775" alt="Screenshot 2026-05-14 at 06 05 55PM" src="https://github.com/user-attachments/assets/c9ba0e3e-58aa-4392-abc9-f0c6371ac16e" />

---

This was reported against v4, but the same `makeRequest` code exists on `3.x`, so the fix is being made here first and will be up-merged into v4.

Fixes #10281