### PR TITLE
[4.x] Prevent `wire:model.live.blur` from triggering redundant requests

### DIFF
--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -1,4 +1,5 @@
 import { directive } from '@/directives'
+import { checkDirty } from '@/directives/wire-dirty'
 import { handleFileUpload } from '@/features/supportFileUploads'
 import { findComponentByEl } from '@/store'
 import { dataGet, dataSet } from '@/utils'
@@ -95,7 +96,17 @@ directive('model', ({ el, directive, component, cleanup }) => {
 
     // Network event listeners (for modifiers after .live, or .lazy backwards compat)
     if (shouldSendNetwork && networkOnBlur) {
-        bindings['@blur'] = () => update()
+        bindings['@blur'] = () => {
+            // Wait a microtask so an ephemeral blur sync (`.blur.live.blur`) lands before the dirty check...
+            queueMicrotask(() => {
+                let target = expression.startsWith('$parent') ? component.parent : component
+
+                // Skip the request if nothing has changed since the last server sync...
+                if (target && ! checkDirty(target)) return
+
+                update()
+            })
+        }
     }
 
     if (shouldSendNetwork && networkOnChange) {

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -663,6 +663,45 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_wire_model_live_blur_does_not_send_network_request_when_value_has_not_changed()
+    {
+        Livewire::visit(new class extends Component {
+            public $title = '';
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div x-init="window.requestCount = 0">
+                        <input dusk="input" type="text" wire:model.live.blur="title" />
+                        <span dusk="server">{{ $title }}</span>
+                        <button dusk="blur-target">Blur Target</button>
+                    </div>
+
+                    @script
+                    <script>
+                        this.intercept(({ onSend }) => {
+                            onSend(() => {
+                                window.requestCount++
+                            })
+                        })
+                    </script>
+                    @endscript
+                BLADE;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->assertScript('window.requestCount', 0)
+            ->typeSlowly('@input', 'hello', 50)
+            ->waitForLivewire()->click('@blur-target')
+            ->assertSeeIn('@server', 'hello')
+            ->assertScript('window.requestCount', 1)
+            ->click('@input')
+            ->click('@blur-target')
+            ->pause(200)
+            ->assertScript('window.requestCount', 1)
+        ;
+    }
+
     public function test_wire_model_blur_live_ephemeral_on_blur_network_on_blur()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes. This adds coverage for `wire:model.live.blur` sending another request when the value has not changed. I did not open a discussion first because this PR only adds a failing test.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

4️⃣ Does it include tests? (Required)

Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This adds a browser test for an unchanged `wire:model.live.blur` input.

The first blur sends the expected model update. The second blur leaves the value unchanged, but still sends another Livewire request. This PR only captures that behavior so the request handling can be fixed separately.