### PR TITLE
[4.x] Re-order custom route endpoint middleware

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -92,9 +92,6 @@ class HandleRequests extends Mechanism
     {
         $route = $callback([self::class, 'handleUpdate'], EndpointResolver::updatePath());
 
-        // Ensure the header guard middleware is always present, even on custom routes.
-        $route->middleware(RequireLivewireHeaders::class);
-
         // Ensure the route includes the `web` middleware group.
         // Without it, CSRF protection is lost entirely on the update endpoint.
         // Note: we use middleware() (not gatherMiddleware()) to avoid polluting
@@ -102,6 +99,9 @@ class HandleRequests extends Mechanism
         if (! in_array('web', $route->middleware())) {
             $route->middleware('web');
         }
+
+        // Ensure the header guard middleware is always present, even on custom routes.
+        $route->middleware(RequireLivewireHeaders::class);
 
         // Append `livewire.update` to the existing name, if any.
         if (! str($route->getName())->endsWith('livewire.update')) {


### PR DESCRIPTION
## Scenario
For general livewire update route endpoint, the middleware always returns
```php
array:2 [▼
    0 => "web"
    1 => "Livewire\Mechanisms\HandleRequests\RequireLivewireHeaders"
]
```
However, for custom update route endpoint, the middleware order becomes
```php
array:2 [▼
    0 => "Livewire\Mechanisms\HandleRequests\RequireLivewireHeaders"
    1 => "web"
]
```

## Problem
In `HandleRequests::setUpdateRoute()`, `RequireLivewireHeader` was append first then `web` middleware. This PR to ensure that middleware always applied at same order for general update endpoint or custom.
```php
function setUpdateRoute($callback)
{
    $route = $callback([self::class, 'handleUpdate'], EndpointResolver::updatePath());

    // Ensure the header guard middleware is always present, even on custom routes.
    $route->middleware(RequireLivewireHeaders::class);

    // Ensure the route includes the `web` middleware group.
    // Without it, CSRF protection is lost entirely on the update endpoint.
    // Note: we use middleware() (not gatherMiddleware()) to avoid polluting
    // the route's computed middleware cache before it's fully configured.
    if (! in_array('web', $route->middleware())) {
        $route->middleware('web');
    }

    ...
}
```

## Solution
Change the order middleware applied. First must be `web` middleware then `RequireLivewireHeader`.
```php
function setUpdateRoute($callback)
{
    $route = $callback([self::class, 'handleUpdate'], EndpointResolver::updatePath());

    // Ensure the route includes the `web` middleware group.
    // Without it, CSRF protection is lost entirely on the update endpoint.
    // Note: we use middleware() (not gatherMiddleware()) to avoid polluting
    // the route's computed middleware cache before it's fully configured.
    if (! in_array('web', $route->middleware())) {
        $route->middleware('web');
    }    

    // Ensure the header guard middleware is always present, even on custom routes.
    $route->middleware(RequireLivewireHeaders::class);
    ...
}
```

### File changes
- `src/Mechanisms/HandleRequests/HandleRequests.php`