### PR TITLE
[4.x] Fix checking empty array against `is_null` instead empty-array comparison

### DIFF
--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -115,7 +115,7 @@ class PersistentMiddleware extends Mechanism
         $middleware = $this->getApplicablePersistentMiddleware($request);
 
         // Only send through pipeline if there are middleware found
-        if (is_null($middleware)) return;
+        if ($middleware === []) return;
 
         Utils::applyMiddleware($request, $middleware);
 

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -112,6 +112,7 @@ class PersistentMiddleware extends Mechanism
 
         $request = $this->makeFakeRequest();
 
+        // If no middleware found, this returns `[]`
         $middleware = $this->getApplicablePersistentMiddleware($request);
 
         // Only send through pipeline if there are middleware found

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -116,7 +116,7 @@ class PersistentMiddleware extends Mechanism
         $middleware = $this->getApplicablePersistentMiddleware($request);
 
         // Only send through pipeline if there are middleware found
-        if ($middleware === []) return;
+        if (is_null($middleware) || $middleware === []) return;
 
         Utils::applyMiddleware($request, $middleware);
 


### PR DESCRIPTION
## Problem
In **PersistentMiddleware** class, applicable middleware was checked using `is_null` eventhough it returns an array
```php
protected function applyMiddleware()
{
    ...

    $middleware = $this->getApplicablePersistentMiddleware($request);

    // Only send through pipeline if there are middleware found
    if (is_null($middleware)) return;

    ...
}

protected function getApplicablePersistentMiddleware($request)
{
    $route = $this->getRouteFromRequest($request);

    if (! $route) return [];

    $middleware = app('router')->gatherRouteMiddleware($route);

    return $this->filterMiddlewareByPersistentMiddleware($middleware);
}

protected function filterMiddlewareByPersistentMiddleware($middleware)
{
    $middleware = collect($middleware);

    $persistentMiddleware = collect(app(PersistentMiddleware::class)->getPersistentMiddleware());

    return $middleware
        ->filter(function ($value, $key) use ($persistentMiddleware) {
            return $persistentMiddleware->contains(function($iValue, $iKey) use ($value) {
                // Some middlewares can be closures.
                if (! is_string($value)) return false;

                // Ensure any middleware arguments aren't included in the comparison
                return Str::before($value, ':') == $iValue;
            });
        })
        ->values()
        ->all();
}
```
This returns **false** therefore this check will always passed

## Solution
Change the checking using comparison
```php
if (is_null($middleware) || $middleware === []) return;
```

## File Changes
- `src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php`