### PR TITLE
[4.x] Fix authorization checked twice when applied on route and component action

### DIFF
--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -34,13 +34,7 @@ class BaseAuthorize extends LivewireAttribute
         $arguments = Arr::wrap($this->argument);
         
         // Check if authorization already applied on route level
-        $abilityModel = app(PersistentMiddleware::class)->getAuthorizeMiddleware();
-        
-        if ($abilityModel !== []) {
-            [$ability, $model] = $abilityModel;
-            
-            if (enum_value($this->ability) === $ability && in_array($model, $arguments)) return;
-        }
+        if ($this->isAlreadyAuthorizedByMiddleware($arguments)) return;
 
         // Resolve each argument (prioritize method parameters first, then component properties)
         $resolved = [];
@@ -51,9 +45,6 @@ class BaseAuthorize extends LivewireAttribute
         Gate::authorize($this->ability, $resolved);
     }
 
-    /**
-     * Resolve a single argument.
-     */
     protected function resolveArgument(string $arg, array $parameters): mixed
     {
         // Action that does not require a model, for example a 'create' action...
@@ -79,5 +70,41 @@ class BaseAuthorize extends LivewireAttribute
 
         // Fall back to component property
         return data_get($this->component, $arg);
+    }
+
+    protected function isAlreadyAuthorizedByMiddleware($arguments): bool
+    {
+        $middleware = app(PersistentMiddleware::class)->getAuthorizeMiddleware();
+
+        if ($middleware === []) {
+            return false;
+        }
+
+        return collect($middleware)
+            ->map(fn (string $m) => $this->parseMiddlewareArgument($m))
+            ->filter()
+            ->contains(fn (array $item) =>
+                $item['ability'] === enum_value($this->ability) 
+                && in_array($item['model'], $arguments, true)
+            );
+    }
+
+    protected function parseMiddlewareArgument(string $middleware): ?array
+    {
+        $parts = explode(':', $middleware, 2);
+        if (count($parts) !== 2) {
+            return null;
+        }
+
+        $abilityAndModel = explode(',', $parts[1], 2);
+
+        if (count($abilityAndModel) !== 2) {
+            return null;
+        }
+
+        return [
+            'ability' => trim($abilityAndModel[0]),
+            'model'   => trim($abilityAndModel[1]),
+        ];
     }
 }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -3,10 +3,8 @@
 namespace Livewire\Features\SupportAuthorization;
 
 use Attribute;
-use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Str;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
 use UnitEnum;

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -10,7 +10,6 @@ use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
 use UnitEnum;
 
 use function Illuminate\Support\enum_value;
-use function Livewire\str;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
 class BaseAuthorize extends LivewireAttribute

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -11,6 +11,7 @@ use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
 use UnitEnum;
 
+use function Illuminate\Support\enum_value;
 use function Livewire\str;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
@@ -38,7 +39,7 @@ class BaseAuthorize extends LivewireAttribute
         if ($abilityModel !== []) {
             [$ability, $model] = $abilityModel;
             
-            if ($this->ability === $ability && in_array($model, $arguments)) return;
+            if (enum_value($this->ability) === $ability && in_array($model, $arguments)) return;
         }
 
         // Resolve each argument (prioritize method parameters first, then component properties)

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -3,10 +3,15 @@
 namespace Livewire\Features\SupportAuthorization;
 
 use Attribute;
+use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
 use UnitEnum;
+
+use function Livewire\str;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
 class BaseAuthorize extends LivewireAttribute
@@ -26,6 +31,15 @@ class BaseAuthorize extends LivewireAttribute
         }
 
         $arguments = Arr::wrap($this->argument);
+        
+        // Check if authorization already applied on route level
+        $abilityModel = app(PersistentMiddleware::class)->getAuthorizeMiddleware();
+        
+        if ($abilityModel !== []) {
+            [$ability, $model] = $abilityModel;
+            
+            if ($this->ability === $ability && in_array($model, $arguments)) return;
+        }
 
         // Resolve each argument (prioritize method parameters first, then component properties)
         $resolved = [];

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -73,15 +73,15 @@ class BaseAuthorize extends LivewireAttribute
 
     protected function isAuthorizedByMiddleware($ability, $arguments): bool
     {
-        $routeAuthorizeMiddleware = app(PersistentMiddleware::class)->getAuthorizeMiddleware();
+        $authorizeMiddleware = app(PersistentMiddleware::class)->getAuthorizeMiddleware();
 
-        if ($routeAuthorizeMiddleware === []) {
+        if ($authorizeMiddleware === []) {
             return false;
         }
 
         // Using Laravel's Authorize middleware to parse the ability and arguments for comparison
-        $authorizeMiddleware = AuthorizeMiddleware::using($ability, ...Arr::wrap($arguments));
+        $middleware = AuthorizeMiddleware::using($ability, ...Arr::wrap($arguments));
 
-        return in_array($authorizeMiddleware, $routeAuthorizeMiddleware, true);
+        return in_array($middleware, $authorizeMiddleware, true);
     }
 }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -33,7 +33,7 @@ class BaseAuthorize extends LivewireAttribute
         $arguments = Arr::wrap($this->argument);
         
         // Check if authorization already applied on route level
-        if ($this->isAuthorizedByMiddleware($arguments)) return;
+        if ($this->isAuthorizedByMiddleware($this->ability, $arguments)) return;
 
         // Resolve each argument (prioritize method parameters first, then component properties)
         $resolved = [];
@@ -71,7 +71,7 @@ class BaseAuthorize extends LivewireAttribute
         return data_get($this->component, $arg);
     }
 
-    protected function isAuthorizedByMiddleware($arguments): bool
+    protected function isAuthorizedByMiddleware($ability, $arguments): bool
     {
         $middleware = app(PersistentMiddleware::class)->getAuthorizeMiddleware();
 
@@ -80,7 +80,7 @@ class BaseAuthorize extends LivewireAttribute
         }
 
         // Using Laravel's Authorize middleware to parse the ability and arguments for comparison
-        $authorizeMiddleware = AuthorizeMiddleware::using($this->ability, ...$arguments);
+        $authorizeMiddleware = AuthorizeMiddleware::using($ability, ...$arguments);
 
         return in_array($authorizeMiddleware, $middleware, true);
     }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -23,6 +23,9 @@ class BaseAuthorize extends LivewireAttribute
 
     public function call(array $parameters) : void
     {
+        // Check if authorization already applied on route level
+        if ($this->isAuthorizedByMiddleware($this->ability, $this->argument)) return;
+
         // Action that does not require a model or class...
         if (is_null($this->argument)) {
             Gate::authorize($this->ability);
@@ -32,9 +35,6 @@ class BaseAuthorize extends LivewireAttribute
 
         $arguments = Arr::wrap($this->argument);
         
-        // Check if authorization already applied on route level
-        if ($this->isAuthorizedByMiddleware($this->ability, $arguments)) return;
-
         // Resolve each argument (prioritize method parameters first, then component properties)
         $resolved = [];
         foreach ($arguments as $arg) {
@@ -80,7 +80,7 @@ class BaseAuthorize extends LivewireAttribute
         }
 
         // Using Laravel's Authorize middleware to parse the ability and arguments for comparison
-        $authorizeMiddleware = AuthorizeMiddleware::using($ability, ...$arguments);
+        $authorizeMiddleware = AuthorizeMiddleware::using($ability, ...Arr::wrap($arguments));
 
         return in_array($authorizeMiddleware, $routeAuthorizeMiddleware, true);
     }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -6,12 +6,9 @@ use Attribute;
 use Illuminate\Auth\Middleware\Authorize as AuthorizeMiddleware;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Str;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
 use UnitEnum;
-
-use function Illuminate\Support\enum_value;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
 class BaseAuthorize extends LivewireAttribute

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportAuthorization;
 
 use Attribute;
+use Illuminate\Auth\Middleware\Authorize as AuthorizeMiddleware;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Str;
@@ -32,7 +33,7 @@ class BaseAuthorize extends LivewireAttribute
         $arguments = Arr::wrap($this->argument);
         
         // Check if authorization already applied on route level
-        if ($this->isAlreadyAuthorizedByMiddleware($arguments)) return;
+        if ($this->isAuthorizedByMiddleware($arguments)) return;
 
         // Resolve each argument (prioritize method parameters first, then component properties)
         $resolved = [];
@@ -70,7 +71,7 @@ class BaseAuthorize extends LivewireAttribute
         return data_get($this->component, $arg);
     }
 
-    protected function isAlreadyAuthorizedByMiddleware($arguments): bool
+    protected function isAuthorizedByMiddleware($arguments): bool
     {
         $middleware = app(PersistentMiddleware::class)->getAuthorizeMiddleware();
 
@@ -78,28 +79,9 @@ class BaseAuthorize extends LivewireAttribute
             return false;
         }
 
-        return collect($middleware)
-            ->map(fn (string $m) => $this->parseMiddlewareArgument($m))
-            ->filter()
-            ->contains(fn (array $item) =>
-                $item['ability'] === enum_value($this->ability) 
-                && in_array($item['model'], $arguments, true)
-            );
-    }
+        // Using Laravel's Authorize middleware to parse the ability and arguments for comparison
+        $authorizeMiddleware = AuthorizeMiddleware::using($this->ability, ...$arguments);
 
-    protected function parseMiddlewareArgument(string $middleware): ?array
-    {
-        $middlewareArgument = Str::after($middleware, ':');
-
-        $abilityAndModel = explode(',', $middlewareArgument, 2);
-
-        if (count($abilityAndModel) !== 2) {
-            return null;
-        }
-
-        return [
-            'ability' => trim($abilityAndModel[0]),
-            'model'   => trim($abilityAndModel[1]),
-        ];
+        return in_array($authorizeMiddleware, $middleware, true);
     }
 }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -91,13 +91,15 @@ class BaseAuthorize extends LivewireAttribute
     {
         $middlewareArgument = Str::after($middleware, ':');
 
-        $ability = Str::before($middlewareArgument, ',');
+        $abilityAndModel = explode(',', $middlewareArgument, 2);
 
-        $model = Str::after($middlewareArgument, ',');
+        if (count($abilityAndModel) !== 2) {
+            return null;
+        }
 
         return [
-            'ability' => trim($ability),
-            'model'   => trim($model),
+            'ability' => trim($abilityAndModel[0]),
+            'model'   => trim($abilityAndModel[1]),
         ];
     }
 }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportAuthorization;
 use Attribute;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
 use UnitEnum;
@@ -88,12 +89,9 @@ class BaseAuthorize extends LivewireAttribute
 
     protected function parseMiddlewareArgument(string $middleware): ?array
     {
-        $parts = explode(':', $middleware, 2);
-        if (count($parts) !== 2) {
-            return null;
-        }
+        $middlewareArgument = Str::after($middleware, ':');
 
-        $abilityAndModel = explode(',', $parts[1], 2);
+        $abilityAndModel = explode(',', $middlewareArgument, 2);
 
         if (count($abilityAndModel) !== 2) {
             return null;

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -73,15 +73,15 @@ class BaseAuthorize extends LivewireAttribute
 
     protected function isAuthorizedByMiddleware($ability, $arguments): bool
     {
-        $middleware = app(PersistentMiddleware::class)->getAuthorizeMiddleware();
+        $routeAuthorizeMiddleware = app(PersistentMiddleware::class)->getAuthorizeMiddleware();
 
-        if ($middleware === []) {
+        if ($routeAuthorizeMiddleware === []) {
             return false;
         }
 
         // Using Laravel's Authorize middleware to parse the ability and arguments for comparison
         $authorizeMiddleware = AuthorizeMiddleware::using($ability, ...$arguments);
 
-        return in_array($authorizeMiddleware, $middleware, true);
+        return in_array($authorizeMiddleware, $routeAuthorizeMiddleware, true);
     }
 }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -91,15 +91,13 @@ class BaseAuthorize extends LivewireAttribute
     {
         $middlewareArgument = Str::after($middleware, ':');
 
-        $abilityAndModel = explode(',', $middlewareArgument, 2);
+        $ability = Str::before($middlewareArgument, ',');
 
-        if (count($abilityAndModel) !== 2) {
-            return null;
-        }
+        $model = Str::after($middlewareArgument, ',');
 
         return [
-            'ability' => trim($abilityAndModel[0]),
-            'model'   => trim($abilityAndModel[1]),
+            'ability' => trim($ability),
+            'model'   => trim($model),
         ];
     }
 }

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -5,8 +5,11 @@ namespace Livewire\Features\SupportAuthorization;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User as AuthUser;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
 use Livewire\Attributes\Authorize;
+use Livewire\Component;
+use Livewire\Drawer\Utils;
 use Livewire\Livewire;
 use Sushi\Sushi;
 use Tests\TestCase;
@@ -697,6 +700,102 @@ class UnitTest extends TestCase
             ->call('editComment', comment: 1, post: 2)
             ->assertForbidden();
     }
+
+    public function test_deduplicates_authorization_from_route_and_component_using_class()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        $count = 0;
+
+        Gate::before(function (AuthorizationUser $user) use (&$count) {
+            if (app('livewire')->isLivewireRequest()) {
+                $count++;
+            }
+            return null;
+        });
+
+        Route::livewire('/posts/create', CreatePost::class)
+            ->can('create', AuthorizationPost::class)
+            ->middleware('web');
+
+        // GET the page to mount the component and get a valid snapshot
+        $response = $this->actingAs(AuthorizationUser::find(1))
+            ->withoutExceptionHandling()
+            ->get('/posts/create');
+
+        $response->assertOk();
+        $response->assertSee('Create');
+
+        // Extract snapshot from the rendered HTML
+        $html = $response->getContent();
+        $snapshot = Utils::extractAttributeDataFromHtml($html, 'wire:snapshot');
+        $encodedSnapshot = json_encode($snapshot);
+
+        // Flush state from the initial render
+        app('livewire')->flushState();
+
+        // POST to the update endpoint to trigger an update request
+        $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(app('livewire')->getUpdateUri(), [
+                'components' => [
+                    [
+                        'snapshot' => $encodedSnapshot,
+                        'calls' => [['method' => 'createPost', 'params' => [], 'path' => '']],
+                        'updates' => [],
+                    ],
+                ],
+            ])->assertOk();
+
+        $this->assertEquals(1, $count);
+    }
+
+    public function test_deduplicates_authorization_from_route_and_component_using_route_model_binding()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        $count = 0;
+
+        Gate::before(function (AuthorizationUser $user, string $ability) use (&$count) {
+            if (app('livewire')->isLivewireRequest()) {
+                $count++;
+            }
+            return null;
+        });
+
+        Route::livewire('/posts/{post}', EditPost::class)
+            ->can('edit', 'post')
+            ->middleware('web');
+
+        // GET the page to mount the component and get a valid snapshot
+        $response = $this->actingAs(AuthorizationUser::find(1))
+            ->withoutExceptionHandling()
+            ->get('/posts/1');
+
+        $response->assertOk();
+        $response->assertSee('Save');
+
+        // Extract snapshot from the rendered HTML
+        $html = $response->getContent();
+        $snapshot = Utils::extractAttributeDataFromHtml($html, 'wire:snapshot');
+        $encodedSnapshot = json_encode($snapshot);
+
+        // Flush state from the initial render
+        app('livewire')->flushState();
+
+        // POST to the update endpoint to trigger an update request
+        $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(app('livewire')->getUpdateUri(), [
+                'components' => [
+                    [
+                        'snapshot' => $encodedSnapshot,
+                        'calls' => [['method' => 'saveChanges', 'params' => [], 'path' => '']],
+                        'updates' => [],
+                    ],
+                ],
+            ])->assertOk();
+
+        $this->assertEquals(1, $count);
+    }
 }
 
 class AuthorizationUser extends AuthUser
@@ -751,5 +850,35 @@ class AuthorizationCommentPolicy
     public function edit(AuthorizationUser $user, AuthorizationComment $comment, AuthorizationPost $post) : bool
     {
         return (int) $comment->post_id === (int) $post->id && (int) $comment->user_id === (int) $user->id;
+    }
+}
+
+class CreatePost extends Component
+{
+    #[Authorize('create', AuthorizationPost::class)]
+    public function createPost()
+    {
+        //
+    }
+
+    public function render()
+    {
+        return '<div>Create</div>';
+    }
+}
+
+class EditPost extends Component
+{
+    public AuthorizationPost $post;
+
+    #[Authorize('edit', 'post')]
+    public function saveChanges()
+    {
+        //
+    }
+
+    public function render()
+    {
+        return '<div>Save</div>';
     }
 }

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -701,6 +701,56 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_deduplicates_authorization_from_route_and_component_without_argument()
+    {
+        Gate::define('interact', function (AuthorizationUser $user) {
+            return (int) $user->id === 1;
+        });
+
+        $count = 0;
+
+        Gate::before(function (AuthorizationUser $user) use (&$count) {
+            if (app('livewire')->isLivewireRequest()) {
+                $count++;
+            }
+            return null;
+        });
+
+        Route::livewire('/posts/create', CreatePost::class)
+            ->can('interact')
+            ->middleware('web');
+
+        // GET the page to mount the component and get a valid snapshot
+        $response = $this->actingAs(AuthorizationUser::find(1))
+            ->withoutExceptionHandling()
+            ->get('/posts/create');
+
+        $response->assertOk();
+        $response->assertSee('Create');
+
+        // Extract snapshot from the rendered HTML
+        $html = $response->getContent();
+        $snapshot = Utils::extractAttributeDataFromHtml($html, 'wire:snapshot');
+        $encodedSnapshot = json_encode($snapshot);
+
+        // Flush state from the initial render
+        app('livewire')->flushState();
+
+        // POST to the update endpoint to trigger an update request
+        $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(app('livewire')->getUpdateUri(), [
+                'components' => [
+                    [
+                        'snapshot' => $encodedSnapshot,
+                        'calls' => [['method' => 'interactWithPost', 'params' => [], 'path' => '']],
+                        'updates' => [],
+                    ],
+                ],
+            ])->assertOk();
+
+        $this->assertEquals(1, $count);
+    }
+
     public function test_deduplicates_authorization_from_route_and_component_using_class()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
@@ -857,6 +907,12 @@ class CreatePost extends Component
 {
     #[Authorize('create', AuthorizationPost::class)]
     public function createPost()
+    {
+        //
+    }
+
+    #[Authorize('interact')]
+    public function interactWithPost()
     {
         //
     }

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -2,8 +2,10 @@
 
 namespace Livewire\Mechanisms\PersistentMiddleware;
 
+use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Arr;
 use Livewire\Mechanisms\Mechanism;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use function Livewire\on;
@@ -27,6 +29,7 @@ class PersistentMiddleware extends Mechanism
     protected $path;
     protected $method;
     protected $middlewareAppliedFor = [];
+    protected $applicableMiddleware = [];
     protected $resolvedRouteModels = [];
 
     function boot()
@@ -52,6 +55,7 @@ class PersistentMiddleware extends Mechanism
             $this->path = null;
             $this->method = null;
             $this->middlewareAppliedFor = [];
+            $this->applicableMiddleware = [];
             $this->resolvedRouteModels = [];
         });
     }
@@ -69,6 +73,38 @@ class PersistentMiddleware extends Mechanism
     function getPersistentMiddleware()
     {
         return static::$persistentMiddleware;
+    }
+
+    function getAuthorizeMiddleware()
+    {
+        $middleware = $this->applicableMiddleware;
+
+        if ($middleware === []) {
+            return [];
+        }
+
+        $authorizeMiddleware = Arr::first($middleware, function ($m) {
+            return Str::startsWith($m, Authorize::class);
+        });
+        
+        if (is_null($authorizeMiddleware)) {
+            return [];
+        }
+
+        $classArguments = explode(':', $authorizeMiddleware, 2);
+
+        if (count($classArguments) !== 2) {
+            return [];
+        }
+
+        $abilityModel = explode(',', $classArguments[1], 2);
+
+        if (count($abilityModel) !== 2) {
+            return [];
+        }
+
+        // returns `[$ability, $model]`
+        return $abilityModel;
     }
 
     function getResolvedRouteModel($class, $key)
@@ -112,12 +148,12 @@ class PersistentMiddleware extends Mechanism
 
         $request = $this->makeFakeRequest();
 
-        $middleware = $this->getApplicablePersistentMiddleware($request);
+        $this->applicableMiddleware = $this->getApplicablePersistentMiddleware($request);
 
         // Only send through pipeline if there are middleware found
-        if (is_null($middleware)) return;
+        if ($this->applicableMiddleware === []) return;
 
-        Utils::applyMiddleware($request, $middleware);
+        Utils::applyMiddleware($request, $this->applicableMiddleware);
 
         $this->middlewareAppliedFor[$routeKey] = true;
 

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -5,7 +5,6 @@ namespace Livewire\Mechanisms\PersistentMiddleware;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\Router;
-use Illuminate\Support\Arr;
 use Livewire\Mechanisms\Mechanism;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use function Livewire\on;
@@ -83,28 +82,15 @@ class PersistentMiddleware extends Mechanism
             return [];
         }
 
-        $authorizeMiddleware = Arr::first($middleware, function ($m) {
+        $authorizeMiddleware = collect($middleware)->filter(function ($m) {
             return Str::startsWith($m, Authorize::class);
         });
-        
-        if (is_null($authorizeMiddleware)) {
+
+        if ($authorizeMiddleware->isEmpty()) {
             return [];
         }
 
-        $classArguments = explode(':', $authorizeMiddleware, 2);
-
-        if (count($classArguments) !== 2) {
-            return [];
-        }
-
-        $abilityModel = explode(',', $classArguments[1], 2);
-
-        if (count($abilityModel) !== 2) {
-            return [];
-        }
-
-        // returns `[$ability, $model]`
-        return $abilityModel;
+        return $authorizeMiddleware->all();
     }
 
     function getResolvedRouteModel($class, $key)

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -82,15 +82,15 @@ class PersistentMiddleware extends Mechanism
             return [];
         }
 
-        $authorizeMiddleware = collect($middleware)->filter(function ($m) {
+        $authorizeMiddleware = array_filter($middleware, function ($m) {
             return Str::startsWith($m, Authorize::class);
         });
 
-        if ($authorizeMiddleware->isEmpty()) {
+        if ($authorizeMiddleware === []) {
             return [];
         }
 
-        return $authorizeMiddleware->all();
+        return $authorizeMiddleware;
     }
 
     function getResolvedRouteModel($class, $key)

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -76,21 +76,9 @@ class PersistentMiddleware extends Mechanism
 
     function getAuthorizeMiddleware()
     {
-        $middleware = $this->applicableMiddleware;
-
-        if ($middleware === []) {
-            return [];
-        }
-
-        $authorizeMiddleware = array_filter($middleware, function ($m) {
+        return array_filter($this->applicableMiddleware, function ($m) {
             return Str::startsWith($m, Authorize::class);
         });
-
-        if ($authorizeMiddleware === []) {
-            return [];
-        }
-
-        return $authorizeMiddleware;
     }
 
     function getResolvedRouteModel($class, $key)

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -125,7 +125,7 @@ class PersistentMiddleware extends Mechanism
         $this->applicableMiddleware = $this->getApplicablePersistentMiddleware($request);
 
         // Only send through pipeline if there are middleware found
-        if ($this->applicableMiddleware === []) return;
+        if (is_null($this->applicableMiddleware)) return;
 
         Utils::applyMiddleware($request, $this->applicableMiddleware);
 

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -122,12 +122,14 @@ class PersistentMiddleware extends Mechanism
 
         $request = $this->makeFakeRequest();
 
-        $this->applicableMiddleware = $this->getApplicablePersistentMiddleware($request);
+        $middleware = $this->getApplicablePersistentMiddleware($request);
+
+        $this->applicableMiddleware = $middleware;
 
         // Only send through pipeline if there are middleware found
-        if (is_null($this->applicableMiddleware)) return;
+        if (is_null($middleware)) return;
 
-        Utils::applyMiddleware($request, $this->applicableMiddleware);
+        Utils::applyMiddleware($request, $middleware);
 
         $this->middlewareAppliedFor[$routeKey] = true;
 

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -77,7 +77,7 @@ class PersistentMiddleware extends Mechanism
     function getAuthorizeMiddleware()
     {
         return array_filter($this->applicableMiddleware, function ($m) {
-            return Str::startsWith($m, Authorize::class);
+            return Str::before($m, ':') == Authorize::class;
         });
     }
 


### PR DESCRIPTION
## Scenario
When user applied authorization on route level as middleware for page component then inside child component also using **`#[Authorize]`** attribute with the same ability and class/model. The authorization checked twice See (https://github.com/livewire/livewire/issues/10291). This is confirmed using debugbar and logger inside policy and turns out its logged twice.

## Problem
In **`BaseAuthorize::call()`** there are no guard against authorization middleware already applied using persistent middleware therefore its getting checked twice in single request

## Solution
- Store applicable middleware before applying it inside **PersistentMiddleware** class
- Reset the applicable middleware on `flush-state` callback
- Create dedicate function to retrieve only authorization middleware from applicable middleware
- Before running authorization in **`BaseAuthorize::call()`**, check if authorization middleware already has the same ability and class/model.
- If its the same `ability` and `class` / `model`, early return;

## Files Changes
- `src/Features/SupportAuthorization/BaseAuthorize.php`
- `src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php`

If there are more clean way to solve this. Feel free to close this, thanks!

Fix: https://github.com/livewire/livewire/issues/10291
