### PR TITLE
Fix view method call in attribute-layout.md

### DIFF
--- a/docs/attribute-layout.md
+++ b/docs/attribute-layout.md
@@ -77,7 +77,7 @@ use Livewire\Component;
 new class extends Component {
     public function render()
     {
-        return view('livewire.posts.index')
+        return $this->view()
             ->layout('layouts::dashboard', ['title' => 'Posts']); // [tl! highlight]
     }
 };


### PR DESCRIPTION
There is a typo in the path: it should be 'pages', not 'livewire'. Since the file name contains the ⚡ emoji, we also need to explicitly reference it in the view method: view('pages.posts.⚡index'). 
For single-file components, though, I think using $this->view() is the better practice.