### PR TITLE
[4.x] Fix duplicate `RequireLivewireHeaders` middleware

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -101,7 +101,10 @@ class HandleRequests extends Mechanism
         }
 
         // Ensure the header guard middleware is always present, even on custom routes.
-        $route->middleware(RequireLivewireHeaders::class);
+        // Only append if its not exists on current middleware stack
+        if (! in_array(RequireLivewireHeaders::class, $route->middleware())) {
+            $route->middleware(RequireLivewireHeaders::class);
+        }
 
         // Append `livewire.update` to the existing name, if any.
         if (! str($route->getName())->endsWith('livewire.update')) {

--- a/src/Mechanisms/HandleRequests/RequireLivewireHeaders.php
+++ b/src/Mechanisms/HandleRequests/RequireLivewireHeaders.php
@@ -16,14 +16,6 @@ class RequireLivewireHeaders
             abort(404);
         }
 
-        // Remove duplicate middleware from middleware stack
-        // Without this, `RequireLivewireHeaders` will be applied twice
-        if (($route = $request->route()) && isset($route->action['middleware'])) {
-            $route->action['middleware'] = array_unique(array_values(
-                array_filter($route->middleware(), fn ($m) => is_string($m))
-            ));
-        }
-
         return $next($request);
     }
 }

--- a/src/Mechanisms/HandleRequests/RequireLivewireHeaders.php
+++ b/src/Mechanisms/HandleRequests/RequireLivewireHeaders.php
@@ -16,6 +16,14 @@ class RequireLivewireHeaders
             abort(404);
         }
 
+        // Remove duplicate middleware from middleware stack
+        // Without this, `RequireLivewireHeaders` will be applied twice
+        if (($route = request()->route()) && isset($route->action['middleware'])) {
+            $route->action['middleware'] = array_unique(array_values(
+                array_filter($route->getAction('middleware'), fn ($m) => is_string($m))
+            ));
+        }
+
         return $next($request);
     }
 }

--- a/src/Mechanisms/HandleRequests/RequireLivewireHeaders.php
+++ b/src/Mechanisms/HandleRequests/RequireLivewireHeaders.php
@@ -18,7 +18,7 @@ class RequireLivewireHeaders
 
         // Remove duplicate middleware from middleware stack
         // Without this, `RequireLivewireHeaders` will be applied twice
-        if (($route = request()->route()) && isset($route->action['middleware'])) {
+        if (($route = $request->route()) && isset($route->action['middleware'])) {
             $route->action['middleware'] = array_unique(array_values(
                 array_filter($route->getAction('middleware'), fn ($m) => is_string($m))
             ));

--- a/src/Mechanisms/HandleRequests/RequireLivewireHeaders.php
+++ b/src/Mechanisms/HandleRequests/RequireLivewireHeaders.php
@@ -20,7 +20,7 @@ class RequireLivewireHeaders
         // Without this, `RequireLivewireHeaders` will be applied twice
         if (($route = $request->route()) && isset($route->action['middleware'])) {
             $route->action['middleware'] = array_unique(array_values(
-                array_filter($route->getAction('middleware'), fn ($m) => is_string($m))
+                array_filter($route->middleware(), fn ($m) => is_string($m))
             ));
         }
 

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use Livewire\Livewire;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
+use Livewire\Mechanisms\HandleRequests\RequireLivewireHeaders;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tests\TestComponent;
@@ -319,6 +320,30 @@ class UnitTest extends TestCase
                     ['method' => 'loadItems', 'params' => []],
                 ]],
             ]]);
+    }
+
+    public function test_require_livewire_headers_middleware_is_not_duplicated_on_update(): void
+    {
+        $testable = Livewire::test(new class extends TestComponent {});
+        $encodedSnapshot = json_encode($testable->snapshot);
+
+        // Livewire's update route should still be matched, not the catch-all
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                ['snapshot' => $encodedSnapshot, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertOk();
+
+        $route = collect(Route::getRoutes()->getRoutes())->first(function ($route) {
+            return $route->getName() === 'default-livewire.update';
+        });
+
+        $middlewareCount = count(
+            array_filter($route->middleware(), fn ($m) => $m === RequireLivewireHeaders::class)
+        );
+
+        $this->assertEquals(1, $middlewareCount);
     }
 
     public function test_get_update_uri_works_when_update_route_property_is_null(): void

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -324,6 +324,16 @@ class UnitTest extends TestCase
 
     public function test_require_livewire_headers_middleware_is_not_duplicated_on_update(): void
     {
+        $beforeActionRoute = collect(Route::getRoutes()->getRoutes())->first(function ($route) {
+            return $route->getName() === 'default-livewire.update';
+        });
+
+        $beforeActionCount = count(
+            array_filter($beforeActionRoute->middleware(), fn ($m) => $m === RequireLivewireHeaders::class)
+        );
+
+        $this->assertEquals(1, $beforeActionCount);
+        
         $testable = Livewire::test(new class extends TestComponent {});
         $encodedSnapshot = json_encode($testable->snapshot);
 
@@ -335,15 +345,15 @@ class UnitTest extends TestCase
 
         $response->assertOk();
 
-        $route = collect(Route::getRoutes()->getRoutes())->first(function ($route) {
+        $afterActionRoute = collect(Route::getRoutes()->getRoutes())->first(function ($route) {
             return $route->getName() === 'default-livewire.update';
         });
 
-        $middlewareCount = count(
-            array_filter($route->middleware(), fn ($m) => $m === RequireLivewireHeaders::class)
+        $afterActionCount = count(
+            array_filter($afterActionRoute->middleware(), fn ($m) => $m === RequireLivewireHeaders::class)
         );
 
-        $this->assertEquals(1, $middlewareCount);
+        $this->assertEquals(1, $afterActionCount);
     }
 
     public function test_get_update_uri_works_when_update_route_property_is_null(): void


### PR DESCRIPTION
Based on https://github.com/livewire/livewire/pull/10288

## Scenario
Using [Laravel debugbar](https://github.com/fruitcake/laravel-debugbar), each time component updates (action, lazy, or defer) **`RequireLivewireHeaders`** appended twice for single Livewire request. 

I tried to check if its really Livewire issue using logger inside this middleware, however the log only triggered once. I thought maybe this is debugbar issue. But after that, I try to create new test for this case and it actually failed. So I'm convinced that it really appended twice.

## Problem
In `setUpdateRoute()` , there was no guard to check if its exists in route middleware stack before append it. It always append it regardless if its already exists or not therefore its getting duplicated (only for default Livewire route)

```php
function setUpdateRoute($callback)
{
    ...

    // There is no guard if its already exists in middleware stack so code below always append it.

    // Ensure the header guard middleware is always present, even on custom routes.
    $route->middleware(RequireLivewireHeaders::class);

    ...
}
```

This case is okay if custom routes was registered because developers never register this middleware on route level. However thats not the case if its default route. This middleware already registered along with `web` middleware here:

```php
function boot()
{
    // Register the default route immediately (before routes files load)
    // so it's positioned before any catch-all routes.
    if (! $this->updateRoute && ! $this->updateRouteExists()) {
        app($this::class)->setUpdateRoute(function ($handle) {
            return Route::post(EndpointResolver::updatePath(), $handle)
                ->middleware(['web', RequireLivewireHeaders::class])
                ->name('default-livewire.update');
        });
    }

    $this->skipRequestPayloadTamperingMiddleware();
}
```

## Solution
Check if its exists before append it to middleware stack
```php
// Ensure the header guard middleware is always present, even on custom routes.
// Only append if its not exists on current middleware stack
if (! in_array(RequireLivewireHeaders::class, $route->middleware())) {
    $route->middleware(RequireLivewireHeaders::class);
}
```

This will ensure **RequireLivewireHeaders** middleware not duplicated for both default and custom route

## Files Changes
- `src/Mechanisms/HandleRequests/HandleRequests.php`
- `src/Mechanisms/HandleRequests/UnitTest.php` (new test added)

Fix: https://github.com/livewire/livewire/issues/10287