### PR TITLE
[4.x] Fix cursor pagination crash on an empty page

### DIFF
--- a/src/Features/SupportPagination/UnitTest.php
+++ b/src/Features/SupportPagination/UnitTest.php
@@ -3,10 +3,12 @@
 namespace Livewire\Features\SupportPagination;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Pagination\Cursor;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
 use Livewire\Livewire;
 use Livewire\WithPagination;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Sushi\Sushi;
 use Tests\TestComponent;
 
@@ -140,11 +142,97 @@ class UnitTest extends \Tests\TestCase
             ->assertSetStrict('page', 3)
             ->assertSetStrict('paginators.page', 3);
     }
+
+    #[DataProvider('cursorPaginationThemeProvider')]
+    public function test_cursor_pagination_does_not_crash_when_a_forward_cursor_lands_on_an_empty_page($theme)
+    {
+        // A forward cursor pointing past the available data (e.g. a stale/bookmarked
+        // cursor, or records removed since) resolves to an empty page that is not the
+        // first page. `previousCursor()` is then null, which previously crashed the
+        // view via `previousCursor()->encode()`. The previous link should instead fall
+        // back to the current cursor (reloading the same page, mirroring Laravel).
+        $cursor = (new Cursor(['id' => 3], true))->encode();
+
+        Livewire::withQueryParams(['page' => $cursor])
+            ->test(new CursorPaginationStub($theme))
+            ->assertSuccessful()
+            ->assertSee($cursor);
+    }
+
+    #[DataProvider('cursorPaginationThemeProvider')]
+    public function test_cursor_pagination_does_not_crash_when_a_backward_cursor_lands_on_an_empty_page($theme)
+    {
+        // A backward cursor (clicking "previous") landing on an empty page reports
+        // `hasMorePages()` as true while `nextCursor()` is null, which previously
+        // crashed the view via `nextCursor()->encode()`. The next link should instead
+        // fall back to the current cursor.
+        $cursor = (new Cursor(['id' => 1], false))->encode();
+
+        Livewire::withQueryParams(['page' => $cursor])
+            ->test(new CursorPaginationStub($theme))
+            ->assertSuccessful()
+            ->assertSee($cursor);
+    }
+
+    public static function cursorPaginationThemeProvider()
+    {
+        return [
+            'tailwind' => ['tailwind'],
+            'bootstrap' => ['bootstrap'],
+        ];
+    }
 }
 
 class ComponentWithPaginationStub extends TestComponent
 {
     use WithPagination;
+}
+
+class CursorPaginationStub extends Component
+{
+    use WithPagination;
+
+    public string $theme;
+
+    public function __construct($theme = 'tailwind')
+    {
+        $this->theme = $theme;
+    }
+
+    public function paginationSimpleView()
+    {
+        return 'livewire::simple-'.$this->theme;
+    }
+
+    #[Computed]
+    public function posts()
+    {
+        return CursorPaginatorPostTestModel::orderBy('id')->cursorPaginate(3, ['*'], 'page');
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            @foreach ($this->posts as $post)
+                <span wire:key="post-{{ $post->id }}">{{ $post->title }}</span>
+            @endforeach
+
+            {{ $this->posts->links() }}
+        </div>
+        HTML;
+    }
+}
+
+class CursorPaginatorPostTestModel extends Model
+{
+    use Sushi;
+
+    protected $rows = [
+        ['title' => 'Post #1'],
+        ['title' => 'Post #2'],
+        ['title' => 'Post #3'],
+    ];
 }
 
 class PaginatorPostTestModel extends Model

--- a/src/Features/SupportPagination/views/simple-bootstrap.blade.php
+++ b/src/Features/SupportPagination/views/simple-bootstrap.blade.php
@@ -21,8 +21,10 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                     </li>
                 @else
                     @if(method_exists($paginator,'getCursorName'))
+                        {{-- On an empty page the previous cursor is null, so fall back to the current cursor (reloads the same page, mirroring Laravel's null page URL) --}}
+                        @php($previousCursor = $paginator->previousCursor() ?? $paginator->cursor())
                         <li class="page-item">
-                            <button dusk="previousPage" type="button" class="page-link" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->previousCursor()->encode() }}" wire:click="setPage('{{$paginator->previousCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled">@lang('pagination.previous')</button>
+                            <button dusk="previousPage" type="button" class="page-link" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $previousCursor?->encode() }}" wire:click="setPage('{{ $previousCursor?->encode() }}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled">@lang('pagination.previous')</button>
                         </li>
                     @else
                         <li class="page-item">
@@ -34,8 +36,10 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                 {{-- Next Page Link --}}
                 @if ($paginator->hasMorePages())
                     @if(method_exists($paginator,'getCursorName'))
+                        {{-- On an empty page the next cursor is null, so fall back to the current cursor (reloads the same page, mirroring Laravel's null page URL) --}}
+                        @php($nextCursor = $paginator->nextCursor() ?? $paginator->cursor())
                         <li class="page-item">
-                            <button dusk="nextPage" type="button" class="page-link" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->nextCursor()->encode() }}" wire:click="setPage('{{$paginator->nextCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled">@lang('pagination.next')</button>
+                            <button dusk="nextPage" type="button" class="page-link" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $nextCursor?->encode() }}" wire:click="setPage('{{ $nextCursor?->encode() }}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled">@lang('pagination.next')</button>
                         </li>
                     @else
                         <li class="page-item">

--- a/src/Features/SupportPagination/views/simple-tailwind.blade.php
+++ b/src/Features/SupportPagination/views/simple-tailwind.blade.php
@@ -21,7 +21,9 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                     </span>
                 @else
                     @if(method_exists($paginator,'getCursorName'))
-                        <button type="button" dusk="previousPage" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->previousCursor()->encode() }}" wire:click="setPage('{{$paginator->previousCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-blue-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+                        {{-- On an empty page the previous cursor is null, so fall back to the current cursor (reloads the same page, mirroring Laravel's null page URL) --}}
+                        @php($previousCursor = $paginator->previousCursor() ?? $paginator->cursor())
+                        <button type="button" dusk="previousPage" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $previousCursor?->encode() }}" wire:click="setPage('{{ $previousCursor?->encode() }}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-blue-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
                                 {!! __('pagination.previous') !!}
                         </button>
                     @else
@@ -37,7 +39,9 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                 {{-- Next Page Link --}}
                 @if ($paginator->hasMorePages())
                     @if(method_exists($paginator,'getCursorName'))
-                        <button type="button" dusk="nextPage" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $paginator->nextCursor()->encode() }}" wire:click="setPage('{{$paginator->nextCursor()->encode()}}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-blue-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
+                        {{-- On an empty page the next cursor is null, so fall back to the current cursor (reloads the same page, mirroring Laravel's null page URL) --}}
+                        @php($nextCursor = $paginator->nextCursor() ?? $paginator->cursor())
+                        <button type="button" dusk="nextPage" wire:key="cursor-{{ $paginator->getCursorName() }}-{{ $nextCursor?->encode() }}" wire:click="setPage('{{ $nextCursor?->encode() }}','{{ $paginator->getCursorName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:ring ring-blue-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:focus:border-blue-700 dark:active:bg-gray-700 dark:active:text-gray-300">
                                 {!! __('pagination.next') !!}
                         </button>
                     @else


### PR DESCRIPTION
# The Scenario

If a component uses cursor pagination and is on a page other than the first, and the result set then becomes empty, for example records are deleted, a filter is applied, or a stale cursor URL is opened, Livewire throws an error instead of rendering the empty page:

<img width="800" height="579" alt="Screenshot 2026-05-21 at 10 31 01AM" src="https://github.com/user-attachments/assets/4f2e51ce-7ed3-4d16-9146-7e3b16eb7a8a" />

```blade
<?php

use App\Models\User;
use Livewire\Component;
use Livewire\WithPagination;

new class extends Component {
    use WithPagination;

    public function deleteLatest()
    {
        User::where('id', '>', 3)->delete();
    }

    public function with()
    {
        return ['users' => User::orderBy('id')->cursorPaginate(3, ['*'], 'page')];
    }
}; ?>

<div>
    <button type="button" wire:click="deleteLatest">Delete latest</button>

    @foreach ($users as $user)
        <p wire:key="user-{{ $user->id }}">{{ $user->name }}</p>
    @endforeach

    {{ $users->links() }}
</div>
```

# The Problem

The simple pagination views call `->encode()` on the cursor directly:

```blade
wire:click="setPage('{{ $paginator->previousCursor()->encode() }}', '{{ $paginator->getCursorName() }}')"
```

`previousCursor()` and `nextCursor()` are derived from the page's items, so they return `null` when the page is empty. But the buttons still render in that state: the previous button shows whenever `onFirstPage()` is `false`, and the next button shows whenever `hasMorePages()` is `true`. So on an empty page the view calls `->encode()` on `null` and throws the error.

# The Solution

Capture the cursor and fall back to the current cursor (`$paginator->cursor()`) when it's `null`.

```blade
@php($previousCursor = $paginator->previousCursor() ?? $paginator->cursor())

wire:click="setPage('{{ $previousCursor?->encode() }}', '{{ $paginator->getCursorName() }}')"
```

This mirrors Laravel's own pagination views, which never dereference the cursor directly. They navigate by URL through the null-safe `previousPageUrl()`/`nextPageUrl()` helpers, which return `null` when there's no cursor:

```php
public function previousPageUrl()
{
    if (is_null($previousCursor = $this->previousCursor())) {
        return null;
    }

    return $this->url($previousCursor);
}
```

So Laravel renders `href=""` on an empty page, reloading the same page instead of throwing. Livewire navigates via `wire:click` rather than URLs, so it needs the encoded cursor; falling back to the current cursor reproduces that same "reload the same page" behaviour.

Applied to both `simple-tailwind.blade.php` and `simple-bootstrap.blade.php`, covering the previous and next links, with regression tests for both empty-page cases across both themes.

Fixes #10297