### PR TITLE
[4.x] Fix validation throwing TypeError when rules(), messages() or validationAttributes() return a Collection

### DIFF
--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -111,6 +111,8 @@ trait HandlesValidation
         if (method_exists($this, 'rules')) $rulesFromComponent = $this->rules();
         else if (property_exists($this, 'rules')) $rulesFromComponent = $this->rules;
 
+        if ($rulesFromComponent instanceof Arrayable) $rulesFromComponent = $rulesFromComponent->toArray();
+
         $rulesFromOutside = array_merge_recursive(
             ...array_map(
                 fn($i) => value($i),
@@ -128,6 +130,8 @@ trait HandlesValidation
         if (method_exists($this, 'messages')) $messages = $this->messages();
         elseif (property_exists($this, 'messages')) $messages = $this->messages;
 
+        if ($messages instanceof Arrayable) $messages = $messages->toArray();
+
         $messagesFromOutside = array_merge(
             ...array_map(
                 fn($i) => value($i),
@@ -144,6 +148,8 @@ trait HandlesValidation
 
         if (method_exists($this, 'validationAttributes')) $validationAttributes = $this->validationAttributes();
         elseif (property_exists($this, 'validationAttributes')) $validationAttributes = $this->validationAttributes;
+
+        if ($validationAttributes instanceof Arrayable) $validationAttributes = $validationAttributes->toArray();
 
         $validationAttributesFromOutside = array_merge(
             ...array_map(

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -941,6 +941,64 @@ class UnitTest extends \Tests\TestCase
             ->post(url('/non-livewire-form'))
             ->assertSee('The bar field is required');
     }
+
+    public function test_validate_handles_rules_returning_a_collection()
+    {
+        Livewire::test(new class extends TestComponent {
+            public string $prompt = '';
+
+            protected function rules()
+            {
+                return collect(['prompt' => 'required']);
+            }
+
+            function save() { $this->validate(); }
+        })
+            ->call('save')
+            ->assertHasErrors(['prompt' => 'required']);
+    }
+
+    public function test_validate_handles_messages_returning_a_collection()
+    {
+        Livewire::test(new class extends TestComponent {
+            public string $prompt = '';
+
+            protected function rules()
+            {
+                return ['prompt' => 'required'];
+            }
+
+            protected function messages()
+            {
+                return collect(['prompt.required' => 'The prompt is required.']);
+            }
+
+            function save() { $this->validate(); }
+        })
+            ->call('save')
+            ->assertHasErrors(['prompt' => 'required']);
+    }
+
+    public function test_validate_handles_validation_attributes_returning_a_collection()
+    {
+        Livewire::test(new class extends TestComponent {
+            public string $prompt = '';
+
+            protected function rules()
+            {
+                return ['prompt' => 'required'];
+            }
+
+            protected function validationAttributes()
+            {
+                return collect(['prompt' => 'prompt field']);
+            }
+
+            function save() { $this->validate(); }
+        })
+            ->call('save')
+            ->assertHasErrors(['prompt' => 'required']);
+    }
 }
 
 class ComponentWithRulesProperty extends TestComponent


### PR DESCRIPTION
# The Scenario

Calling `$this->validate()` throws a `TypeError` and returns a 500 from the Livewire update endpoint.

<img width="1910" height="1782" alt="Screenshot 2026-05-21 at 10 57 03AM@2x" src="https://github.com/user-attachments/assets/88f34494-2cd7-4184-9bf2-4ba5b21ca11a" />

```php
<?php

use Livewire\Component;

new class extends Component {
    public string $prompt = '';

    protected function rules()
    {
        return ['prompt' => 'required'];
    }

    protected function messages()
    {
        // Returns a Collection, not an array.
        return collect(['prompt.required' => 'A prompt is required.'])
            ->mapWithKeys(fn ($message, $key) => [$key => $message]);
    }

    public function save(): void
    {
        $this->validate();
    }
}; ?>

<div>
    <flux:input wire:model="prompt" label="Prompt" />
    <flux:button wire:click="save">Save</flux:button>
</div>
```

# The Problem

This happens whenever a component's `rules()`, `messages()`, or `validationAttributes()` returns a `Collection` instead of a plain array, for example when those values are built with a collection pipeline.

`getRules()`, `getMessages()`, and `getValidationAttributes()` in `HandlesValidation` read the value supplied by the component and pass it straight into `array_merge()`:

```php
if (method_exists($this, 'messages')) $messages = $this->messages();
elseif (property_exists($this, 'messages')) $messages = $this->messages;

// ...

return array_merge($messages, $messagesFromOutside);
```

`array_merge()` requires an `array` for argument 1. If the component returns a `Collection` (or any other `Arrayable`), PHP throws a `TypeError` before validation can run. The same flaw is present in all three methods.

# The Solution

Normalise the component-supplied value to an array before merging. If it implements `Illuminate\Contracts\Support\Arrayable` (which `Collection` does), convert it via `->toArray()`:

```php
if ($messages instanceof Arrayable) $messages = $messages->toArray();
```

This is applied identically in `getRules()`, `getMessages()`, and `getValidationAttributes()`. It mirrors how Laravel's own validation layer normalises `Arrayable` input, for example [`Rule::in()`](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Validation/Rule.php#L120-L127) and [`Rule::notIn()`](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Validation/Rule.php#L135-L141), which both do `if ($values instanceof Arrayable) $values = $values->toArray();`. Array-returning components are completely unaffected.

Fixes #10301