### PR TITLE
[3.x] Apply `web` middleware to custom route endpoint if not exists

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -82,6 +82,14 @@ class HandleRequests extends Mechanism
     {
         $route = $callback([self::class, 'handleUpdate']);
 
+        // Ensure the route includes the `web` middleware group.
+        // Without it, CSRF protection is lost entirely on the update endpoint.
+        // Note: we use middleware() (not gatherMiddleware()) to avoid polluting
+        // the route's computed middleware cache before it's fully configured.
+        if (! in_array('web', $route->middleware())) {
+            $route->middleware('web');
+        }
+
         // Append `livewire.update` to the existing name, if any.
         if (! str($route->getName())->endsWith('livewire.update')) {
             $route->name('livewire.update');


### PR DESCRIPTION
Backport some checking from https://github.com/livewire/livewire/pull/10298 because in [documentation](https://livewire.laravel.com/docs/3.x/installation#configuring-livewires-update-endpoint), there wasn't a mention that `web` middleware should be applied

Also, its actually not appended on subsequent request if its not defined on custom route