### PR TITLE
[4.x] Fix nested query parameters with `#[Url]` attribute

### DIFF
--- a/js/plugins/history/index.js
+++ b/js/plugins/history/index.js
@@ -1,4 +1,4 @@
-import { isObjecty } from "@/utils"
+import { dataDelete, dataGet, dataSet, isObjecty } from "@/utils"
 import historyCoordinator from "./coordinator"
 import { unwrap } from "./utils"
 
@@ -155,7 +155,7 @@ function queryStringUtils() {
 
             let data = fromQueryString(search, key)
 
-            return Object.keys(data).includes(key)
+            return dataGet(data, key) !== undefined
         },
         get(url, key) {
             let search = url.search
@@ -164,12 +164,12 @@ function queryStringUtils() {
 
             let data = fromQueryString(search, key)
 
-            return data[key]
+            return dataGet(data, key)
         },
         set(url, key, value) {
             let data = fromQueryString(url.search, key)
 
-            data[key] = stripNulls(unwrap(value))
+            dataSet(data, key, stripNulls(unwrap(value)))
 
             url.search = toQueryString(data)
 
@@ -178,7 +178,7 @@ function queryStringUtils() {
         remove(url, key) {
             let data = fromQueryString(url.search, key)
 
-            delete data[key]
+            dataDelete(data, key)
 
             url.search = toQueryString(data)
 
@@ -263,14 +263,13 @@ function fromQueryString(search, queryKey) {
 
         let decodedKey = decodeURIComponent(key)
 
-        let shouldBeHandledAsArray = decodedKey.includes('[') && decodedKey.startsWith(queryKey)
+        let dotNotatedKey = decodedKey.replaceAll('[', '.').replaceAll(']', '')
+
+        let shouldBeHandledAsArray = decodedKey.includes('[') && (dotNotatedKey === queryKey || dotNotatedKey.startsWith(`${queryKey}.`))
 
         if (!shouldBeHandledAsArray) {
             data[key] = value
         } else {
-            // Convert to dot notation because it's easier...
-            let dotNotatedKey = decodedKey.replaceAll('[', '.').replaceAll(']', '')
-
             insertDotNotatedValueIntoData(dotNotatedKey, value, data)
         }
     })

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportQueryString;
 
+use Illuminate\Support\Arr;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\Features\SupportFormObjects\Form;
 use ReflectionClass;
@@ -136,13 +137,13 @@ class BaseUrl extends LivewireAttribute
     public function getFromUrlQueryString($name, $default = null)
     {
         if (! app('livewire')->isLivewireRequest()) {
-            $value = request()->query($this->urlName(), $default);
+            $value = data_get(request()->query(), $this->urlName(), $default);
 
             // If the property is present in the querystring without a value, then Laravel returns
             // the $default value. We want to return null in this case, so we can differentiate
             // between "not present" and "present with no value". If the request is a Livewire
             // request, we don't have that issue as we use PHP's parse_str function.
-            if (array_key_exists($name, request()->query()) && $value === $default) {
+            if (Arr::has(request()->query(), $name) && $value === $default) {
                 return null;
             }
 
@@ -166,6 +167,6 @@ class BaseUrl extends LivewireAttribute
             parse_str($parsedUrl['query'], $query);
         }
 
-        return $query[$key] ?? $default;
+        return data_get($query, $key, $default);
     }
 }

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -416,6 +416,36 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_can_use_nested_url_aliases()
+    {
+        Livewire::withQueryParams([
+            'form' => ['search' => 'hello'],
+        ])->visit([
+            new class extends Component
+            {
+                #[BaseUrl(as: 'form.search')]
+                public string $search = '';
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <input type="text" dusk="search" wire:model.live="search" />
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->assertInputValue('@search', 'hello')
+            ->assertScript('return window.location.search', '?form[search]=hello')
+            ->waitForLivewire()->type('@search', 'world')
+            ->assertScript('return window.location.search', '?form[search]=world')
+            ->refresh()
+            ->assertInputValue('@search', 'world')
+            ->assertScript('return window.location.search', '?form[search]=world')
+        ;
+    }
+
     public function test_can_use_url_on_string_backed_enum_object_properties()
     {
         Livewire::visit([

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -239,4 +239,30 @@ class UnitTest extends \Tests\TestCase
         $component->assertStatus(200);
         $this->assertSame('hello', $component->instance()->search);
     }
+
+    function test_nested_query_parameter_without_value_is_handled_correctly()
+    {
+        $component = Livewire::withQueryParams([
+            'form' => ['search' => ''],
+        ])->test(new class extends TestComponent {
+            #[BaseUrl(as: 'form.search')]
+            public string $search = 'default';
+        });
+
+        $component->assertStatus(200);
+        $this->assertSame('', $component->instance()->search);
+    }
+
+    function test_nested_query_parameter_is_retrieved_from_referer_on_subsequent_request()
+    {
+        $url = new BaseUrl(as: 'form.search');
+
+        $value = $url->getFromRefererUrlQueryString(
+            'http://localhost/?form[search]=hello',
+            'form.search',
+            'default'
+        );
+
+        $this->assertSame('hello', $value);
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where nested query parameters (e.g. when binding to Form objects like `#[Url(as: 'form.search')]`) were not being correctly read from the query string on page load or subsequent request referers due to flat array key lookups.