### PR TITLE
Add existing session errors to support validation

### DIFF
--- a/src/Features/SupportValidation/SupportValidation.php
+++ b/src/Features/SupportValidation/SupportValidation.php
@@ -18,7 +18,11 @@ class SupportValidation extends ComponentHook
 
     function render($view, $data)
     {
-        $errors = (new ViewErrorBag)->put('default', $this->component->getErrorBag());
+        $errors = request()->hasSession()
+            ? session()->get('errors', new ViewErrorBag)
+            : new ViewErrorBag;
+
+        $errors->put('default', $this->component->getErrorBag());
 
         $revert = Utils::shareWithViews('errors', $errors);
 
@@ -31,7 +35,13 @@ class SupportValidation extends ComponentHook
 
     function renderIsland($name, $view, $data)
     {
-        $errors = (new ViewErrorBag)->put('default', $this->component->getErrorBag());
+        // Lazy islands will not be able to forward the session, this is a
+        // known issue...
+        $errors = request()->hasSession()
+            ? session()->get('errors', new ViewErrorBag)
+            : new ViewErrorBag;
+
+        $errors->put('default', $this->component->getErrorBag());
 
         $revert = Utils::shareWithViews('errors', $errors);
 

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -724,6 +724,22 @@ class UnitTest extends \Tests\TestCase
             ->assertSee('sharedError:The bar field is required');
     }
 
+    public function test_validation_errors_supports_existing_named_error_bags()
+    {
+        Route::get('/full-page-component', NamedErrorBag::class)->middleware('web');
+        Route::post('/non-livewire-form', function () {
+            Validator::make(
+                ['bar' => ''],
+                ['bar' => 'required'],
+            )->validateWithBag('foo');
+        });
+
+        $this->from('/full-page-component')
+            ->followingRedirects()
+            ->post(url('/non-livewire-form'))
+            ->assertSee('The bar field is required.');
+    }
+
     public function test_multi_word_validation_rules_failing_are_assertable()
     {
         $component = Livewire::test(ForValidation::class);
@@ -1435,5 +1451,22 @@ class AddErrorInMount extends Component
     public function render()
     {
         return view('show-errors');
+    }
+}
+
+class NamedErrorBag extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+            <div>
+                <h1>Named errors</h1>
+
+                @foreach ($errors->foo->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </div>
+        HTML;
+
     }
 }


### PR DESCRIPTION
This PR resolves #10306. In summary, when progressively migrating to Livewire 4, named error bags generated during traditional HTTP redirects or internal component validation fail to render on Livewire page components. 

While the default error bag works as intended, data contained within custom-named error bags appears to be lost during Livewire's hydration and rendering cycles.

This creates a barrier for incremental adoption, as developers cannot cleanly mix Livewire components with legacy forms that rely heavily on named error bags.

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes, there have been several discussions and pr attempts to resolve this issue.
- PR attempt: https://github.com/livewire/livewire/pull/4795
- Raised issue: https://github.com/livewire/livewire/pull/7265#issuecomment-1806547989
- PR attempt: https://github.com/livewire/livewire/pull/6715
- Discussion: https://github.com/livewire/livewire/discussions/2585#discussioncomment-1136714

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

4️⃣ Does it include tests? (Required)

Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Details in #10306 
