### PR TITLE
Fix TemporaryUploadedFile::getSize() after storeAs() (#10238)

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -46,11 +46,11 @@ class TemporaryUploadedFile extends UploadedFile
 
     public function getSize(): int
     {
-        if (app()->runningUnitTests()) {
-            if (isset($this->metaFileData()['size'])) {
-                return $this->metaFileData()['size'];
-            }
+        if (isset($this->metaFileData()['size'])) {
+            return $this->metaFileData()['size'];
+        }
 
+        if (app()->runningUnitTests()) {
             // This is for backwards compatibility when test file meta data was stored in the filename...
             if (str($this->getFilename())->contains('-size=')) {
                 return (int) str($this->getFilename())->between('-size=', '.')->__toString();


### PR DESCRIPTION
Fixes #10238

In Livewire v4, `storeAs()` uses a same-disk move optimization. After the move, `getSize()` called `$this->storage->size($this->path)` which fails because the file no longer exists at the original path.

This fix checks the metadata file for the size (which is always stored at upload time) before falling back to the storage size call. This follows the same pattern as `getClientOriginalName()` which already relies on metadata.