### PR TITLE
[4.x] Validate page query parameter in SupportPagination

### DIFF
--- a/src/Features/SupportPagination/SupportPagination.php
+++ b/src/Features/SupportPagination/SupportPagination.php
@@ -80,7 +80,13 @@ class SupportPagination extends ComponentHook
         Paginator::currentPageResolver(function ($pageName) {
             $this->ensurePaginatorIsInitialized($pageName);
 
-            return (int) $this->component->paginators[$pageName];
+            $page = $this->component->paginators[$pageName];
+
+            if (filter_var($page, FILTER_VALIDATE_INT) !== false && (int) $page >= 1) {
+                return (int) $page;
+            }
+
+            return 1;
         });
     }
 

--- a/src/Features/SupportPagination/UnitTest.php
+++ b/src/Features/SupportPagination/UnitTest.php
@@ -108,6 +108,29 @@ class UnitTest extends \Tests\TestCase
         })->assertSee('Custom simple pagination theme');
     }
 
+    public function test_invalid_page_query_string_falls_back_to_first_page()
+    {
+        $cases = [
+            '12123123123213123123213', // overflows PHP_INT_MAX, would throw on PHP 8.4 cast
+            'not-a-number',
+            '0',
+            '-3',
+        ];
+
+        foreach ($cases as $value) {
+            Livewire::withQueryParams(['page' => $value])
+                ->test(ComponentExposingResolvedPageStub::class)
+                ->assertSetStrict('resolvedPage', 1);
+        }
+    }
+
+    public function test_valid_page_query_string_resolves_to_int()
+    {
+        Livewire::withQueryParams(['page' => '3'])
+            ->test(ComponentExposingResolvedPageStub::class)
+            ->assertSetStrict('resolvedPage', 3);
+    }
+
     public function test_calling_pagination_getPage_before_paginate_method_resolve_the_correct_page_number_in_first_visit_or_after_reload()
     {
         Livewire::withQueryParams(['page' => 5])->test(new class extends Component {
@@ -145,6 +168,31 @@ class UnitTest extends \Tests\TestCase
 class ComponentWithPaginationStub extends TestComponent
 {
     use WithPagination;
+}
+
+class ComponentExposingResolvedPageStub extends Component
+{
+    use WithPagination;
+
+    public int $resolvedPage = 0;
+
+    #[Computed]
+    function posts()
+    {
+        $paginator = PaginatorPostTestModel::paginate();
+        $this->resolvedPage = $paginator->currentPage();
+        return $paginator;
+    }
+
+    function render()
+    {
+        return <<<'HTML'
+        <div>
+            @foreach ($this->posts as $post)
+            @endforeach
+        </div>
+        HTML;
+    }
 }
 
 class PaginatorPostTestModel extends Model


### PR DESCRIPTION
Companion fix for #10311 (3.x).

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes. `SupportPagination`'s `currentPageResolver` silently truncates overflow-large `?page=` query values to `PHP_INT_MAX` and accepts non-numeric, zero, and negative values without validation. The same unvalidated `(int)` cast on 3.x throws `ErrorException` on PHP 8.4+ and returned a 500 in production (Bingbot crawl, companion PR #10311). No prior discussion. Regression described in section 5️⃣ below.

2️⃣ Did you create a branch for your fix/feature?

Yes. `fix/pagination-page-overflow` off `main`.

3️⃣ Does it contain multiple, unrelated changes?

No. One method changed, one regression test added.

4️⃣ Does it include tests?

Yes. New unit test in `src/Features/SupportPagination/UnitTest.php` covering overflow-large strings, non-numeric strings, zero, negative numbers, and the happy path. Tests fail on the unfixed `main` checkout and pass with the fix applied.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

## Problem

`SupportPagination`'s registered `currentPageResolver` closure does an unguarded `(int)` cast on a value sourced from the untrusted `?page=` query string.

On 3.x, this throws `ErrorException` for overflow-large values on PHP 8.4+ and returns a 500 (production trace in the companion PR).

On `main`, the cast does not throw. Overflow values silently truncate to `PHP_INT_MAX` (9223372036854775807) and resolve as the current page, producing empty result sets without an error log entry. Non-numeric strings, zero, and negative numbers are also accepted without validation and produce incorrect page numbers downstream.

## Fix

Validate inside the resolver closure with `FILTER_VALIDATE_INT`, falling back to page 1 for invalid, out-of-range, zero, or negative values. Mirrors Laravel's stock `currentPageResolver` in `PaginationState::resolveUsing()` line for line.

```php
Paginator::currentPageResolver(function ($pageName) {
    $this->ensurePaginatorIsInitialized($pageName);

    $page = $this->component->paginators[$pageName];

    if (filter_var($page, FILTER_VALIDATE_INT) !== false && (int) $page >= 1) {
        return (int) $page;
    }

    return 1;
});
```

The validation has to be at the resolver closure (the read point) rather than inside `resolvePage()`. `addUrlHook()` registers a `PaginationUrl` attribute that calls `setPropertyFromQueryString()`, which overwrites `paginators[$pageName]` with the raw query string after `resolvePage()` has returned. Validating at the closure covers both the initial-resolution path and the URL-hook path.

Cursor pagination is unaffected. The `CursorPaginator::currentCursorResolver` closure passes the value to `Cursor::fromEncoded()` and never casts to int.