### PR TITLE
[4.x] Replace some of form object method with existing `InteractsWithProperties` trait

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -90,7 +90,7 @@ trait InteractsWithProperties
         }
     }
 
-    protected function resetExcept(...$properties)
+    public function resetExcept(...$properties)
     {
         if (count($properties) && is_array($properties[0])) {
             $properties = $properties[0];

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -15,14 +15,12 @@ use Livewire\Concerns\InteractsWithProperties;
 
 class Form implements Arrayable
 {
-    use InteractsWithProperties {
-        resetExcept as public;
-    }
-
     use HandlesValidation {
         validate as parentValidate;
         validateOnly as parentValidateOnly;
     }
+
+    use InteractsWithProperties;
 
     function __construct(
         protected Component $component,

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -11,9 +11,12 @@ use function Livewire\invade;
 use Illuminate\Support\Arr;
 use Livewire\Drawer\Utils;
 use Livewire\Component;
+use Livewire\Concerns\InteractsWithProperties;
 
 class Form implements Arrayable
 {
+    use InteractsWithProperties;
+
     use HandlesValidation {
         validate as parentValidate;
         validateOnly as parentValidateOnly;
@@ -95,55 +98,6 @@ class Form implements Arrayable
         return $this->toArray();
     }
 
-    public function only($properties)
-    {
-        $results = [];
-
-        foreach (is_array($properties) ? $properties : func_get_args() as $property) {
-            $results[$property] = $this->hasProperty($property) ? $this->getPropertyValue($property) : null;
-        }
-
-        return $results;
-    }
-
-    public function except($properties)
-    {
-        $properties = is_array($properties) ? $properties : func_get_args();
-
-        return array_diff_key($this->all(), array_flip($properties));
-    }
-
-    public function hasProperty($prop)
-    {
-        return property_exists($this, Utils::beforeFirstDot($prop));
-    }
-
-    public function getPropertyValue($name)
-    {
-        $value = $this->{Utils::beforeFirstDot($name)};
-
-        if (Utils::containsDots($name)) {
-            return data_get($value, Utils::afterFirstDot($name));
-        }
-
-        return $value;
-    }
-
-    public function fill($values)
-    {
-        $publicProperties = array_keys($this->all());
-
-        if ($values instanceof Model) {
-            $values = $values->toArray();
-        }
-
-        foreach ($values as $key => $value) {
-            if (in_array(Utils::beforeFirstDot($key), $publicProperties)) {
-                data_set($this, $key, $value);
-            }
-        }
-    }
-
     public function reset(...$properties)
     {
         $properties = count($properties) && is_array($properties[0])
@@ -172,23 +126,6 @@ class Form implements Arrayable
         }
 
         $this->reset($keysToReset);
-    }
-
-    public function pull($properties = null)
-    {
-        $wantsASingleValue = is_string($properties);
-
-        $properties = is_array($properties) ? $properties : func_get_args();
-
-        $beforeReset = match (true) {
-            empty($properties) => $this->all(),
-            $wantsASingleValue => $this->getPropertyValue($properties[0]),
-            default => $this->only($properties),
-        };
-
-        $this->reset($properties);
-
-        return $beforeReset;
     }
 
     public function toArray()

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -15,7 +15,9 @@ use Livewire\Concerns\InteractsWithProperties;
 
 class Form implements Arrayable
 {
-    use InteractsWithProperties;
+    use InteractsWithProperties {
+        resetExcept as public;
+    }
 
     use HandlesValidation {
         validate as parentValidate;

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -113,21 +113,6 @@ class Form implements Arrayable
         }
     }
 
-    public function resetExcept(...$properties)
-    {
-        if (count($properties) && is_array($properties[0])) {
-            $properties = $properties[0];
-        }
-
-        $keysToReset = array_diff(array_keys($this->all()), $properties);
-
-        if($keysToReset === []) {
-            return;
-        }
-
-        $this->reset($keysToReset);
-    }
-
     public function toArray()
     {
         return Utils::getPublicProperties($this);

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -5,7 +5,6 @@ namespace Livewire\Features\SupportFormObjects;
 use Livewire\Features\SupportValidation\HandlesValidation;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\MessageBag;
 use function Livewire\invade;
 use Illuminate\Support\Arr;


### PR DESCRIPTION
I notice that some methods inside `Form` class is exactly the same with methods in `InteractsWithProperties` trait. So, instead duplicating the same code, why not just use this trait? afterall, class method override trait method (See [Example #3](https://www.php.net/manual/en/language.oop5.traits.php))

My first thought was maybe its duplicated to avoid conflict with `Component` traits which also use `InteractsWithProperties` however all tests passed so it's all good.

| Similar methods | Removed |
| --- | --- |
| `hasProperty()` | ✅ |
| `getPropertyValue()` | ✅ |
| `only()` | ✅ |
| `except()` | ✅ |
| `fill()` | ✅ |
| `pull()` | ✅ |
| `resetExcept()` | ✅ |
| `reset()` | ❌ |

`reset()` method has different flow so I dont want to touch that part because it will become recursive.

The only thing that should be aware is something like this

```php
class PostForm extends From
{
    use InteractsWithProperties; // ❌

    public $title;

    public $body;
}
```
This will override it all.

### File Changed
- `src/Features/SupportFormObjects/Form.php`