### PR TITLE
[4.x] Use existing component authorization instead Gate facade

### DIFF
--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -4,7 +4,6 @@ namespace Livewire\Features\SupportAuthorization;
 
 use Attribute;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Gate;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use UnitEnum;
 
@@ -20,7 +19,7 @@ class BaseAuthorize extends LivewireAttribute
     {
         // Action that does not require a model or class...
         if (is_null($this->argument)) {
-            Gate::authorize($this->ability);
+            $this->component->authorize($this->ability);
 
             return;
         }
@@ -33,7 +32,7 @@ class BaseAuthorize extends LivewireAttribute
             $resolved[] = $this->resolveArgument($arg, $parameters);
         }
 
-        Gate::authorize($this->ability, $resolved);
+        $this->component->authorize($this->ability, $resolved);
     }
 
     /**


### PR DESCRIPTION
Maybe this is just personal preference but Livewire component already use `AuthorizesRequests` trait from Laravel so calling `Gate` facade inside **BaseAuthorize** attribute seems redundant.

With this, 
- authorization goes through Component layer rather than bypassing it
- remove slight performance overhead (negligible) from facade.

**Before**
```php
public function call(array $params)
{
    // Action that does not require a model or class...
    if (is_null($this->argument)) {
       Gate::authorize($this->ability);

        return;
    }
    ...
    Gate::authorize($this->ability, $resolved);
}
```
**After**
```php
public function call(array $params)
{
    // Action that does not require a model or class...
    if (is_null($this->argument)) {
       $this->component->authorize($this->ability);

        return;
    }
    ...
    $this->component->authorize($this->ability, $resolved);
}
```