### PR TITLE
[4.x] Fix autofocus after `wire:navigate`

### DIFF
--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -12,7 +12,6 @@ import { fetchHtml } from "./fetch"
 let enablePersist = true
 let showProgressBar = true
 let restoreScroll = true
-let autofocus = false
 
 export default function (Alpine) {
 
@@ -123,11 +122,8 @@ export default function (Alpine) {
 
                     afterNewScriptsAreDoneLoading(() => {
                         andAfterAllThis(() => {
-                            setTimeout(() => {
-                                autofocus && autofocusElementsWithTheAutofocusAttribute()
-                            })
-
                             nowInitializeAlpineOnTheNewPage(Alpine)
+                            autofocusElementsWithTheAutofocusAttribute()
 
                             fireEventForOtherLibrariesToHookInto('alpine:navigated')
                             showProgressBar && finishAndHideProgressBar()
@@ -201,9 +197,8 @@ export default function (Alpine) {
                     swapCallbacks.forEach(callback => callback())
 
                     andAfterAllThis(() => {
-                        autofocus && autofocusElementsWithTheAutofocusAttribute()
-
                         nowInitializeAlpineOnTheNewPage(Alpine)
+                        autofocusElementsWithTheAutofocusAttribute()
 
                         fireEventForOtherLibrariesToHookInto('alpine:navigated')
                     })

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -26,6 +26,8 @@ class BrowserTest extends \Tests\BrowserTestCase
             Livewire::component('first-page-with-link-outside', FirstPageWithLinkOutside::class);
             Livewire::component('second-page', SecondPage::class);
             Livewire::component('third-page', ThirdPage::class);
+            Livewire::component('first-autofocus-page', FirstAutofocusPage::class);
+            Livewire::component('second-autofocus-page', SecondAutofocusPage::class);
             Livewire::component('first-html-attribute-page', FirstHtmlAttributesPage::class);
             Livewire::component('second-html-attribute-page', SecondHtmlAttributesPage::class);
             Livewire::component('first-asset-page', FirstAssetPage::class);
@@ -64,6 +66,8 @@ class BrowserTest extends \Tests\BrowserTestCase
             Route::get('/second', SecondPage::class)->middleware('web');
             Route::get('/third', ThirdPage::class)->middleware('web');
             Route::get('/fourth', FourthPage::class)->middleware('web');
+            Route::get('/first-autofocus', FirstAutofocusPage::class)->middleware('web');
+            Route::get('/second-autofocus', SecondAutofocusPage::class)->middleware('web');
             Route::get('/first-html-attributes', FirstHtmlAttributesPage::class)->middleware('web');
             Route::get('/second-html-attributes', SecondHtmlAttributesPage::class)->middleware('web');
             Route::get('/first-asset', FirstAssetPage::class)->middleware('web');
@@ -291,6 +295,36 @@ class BrowserTest extends \Tests\BrowserTestCase
                 ->waitFor('@link.to.second')
                 ->assertScript('return window._lw_dusk_test')
                 ->assertSee('On first');
+        });
+    }
+
+    public function test_wire_navigate_focuses_autofocus_element_when_previous_page_also_has_autofocus(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/first-autofocus')
+                ->waitFor('@first-autofocus')
+                ->waitUntil("document.activeElement.id === 'first-autofocus'")
+                ->waitForNavigate()->click('@link.to.second.autofocus')
+                ->waitFor('@second-autofocus')
+                ->waitUntil("document.activeElement.id === 'second-autofocus'")
+                ->assertScript('document.activeElement.id', 'second-autofocus');
+        });
+    }
+
+    public function test_wire_navigate_focuses_autofocus_element_when_returning_to_cached_page(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/first-autofocus')
+                ->waitFor('@first-autofocus')
+                ->waitUntil("document.activeElement.id === 'first-autofocus'")
+                ->waitForNavigate()->click('@link.to.second.autofocus')
+                ->waitFor('@second-autofocus')
+                ->waitForNavigate()->back()
+                ->waitFor('@first-autofocus')
+                ->waitUntil("document.activeElement.id === 'first-autofocus'")
+                ->assertScript('document.activeElement.id', 'first-autofocus');
         });
     }
 
@@ -1498,6 +1532,41 @@ class FourthPage extends Component
                     }
                 })
             </script>
+        </div>
+        HTML;
+    }
+}
+
+class FirstAutofocusPage extends Component
+{
+    public function render(): string
+    {
+        return <<<'HTML'
+        <div>
+            <div>On first autofocus page</div>
+
+            <label for="first-input">First input</label>
+            <input id="first-input" dusk="first-input" type="text">
+
+            <label for="first-autofocus">Second autofocus input</label>
+            <input id="first-autofocus" dusk="first-autofocus" autofocus type="text">
+
+            <a href="/second-autofocus" wire:navigate dusk="link.to.second.autofocus">Go to second autofocus page</a>
+        </div>
+        HTML;
+    }
+}
+
+class SecondAutofocusPage extends Component
+{
+    public function render(): string
+    {
+        return <<<'HTML'
+        <div>
+            <div>On second autofocus page</div>
+
+            <label for="second-autofocus">Second autofocus textarea</label>
+            <textarea id="second-autofocus" dusk="second-autofocus" autofocus></textarea>
         </div>
         HTML;
     }


### PR DESCRIPTION
# The Scenario

If you have two pages, each with an input that has `autofocus` on it, the browser focuses the input when you load the first page.

But if you then `wire:navigate` to the second page, the second page's `autofocus` input isn't focused.

<img width="800" height="701" alt="CleanShot 2026-06-01 at 17 16 55" src="https://github.com/user-attachments/assets/cc558ecd-b004-49d1-ab77-bb1c501b9b57" />

```php
use Livewire\Component;

class FirstAutofocusPage extends Component
{
    public function render(): string
    {
        return <<<'HTML'
        <div>
            <input id="first-input" type="text">
            <input id="first-autofocus" autofocus type="text">

            <a href="/second-autofocus" wire:navigate>Go to second autofocus page</a>
        </div>
        HTML;
    }
}

class SecondAutofocusPage extends Component
{
    public function render(): string
    {
        return <<<'HTML'
        <div>
            <textarea id="second-autofocus" autofocus></textarea>
        </div>
        HTML;
    }
}
```

# The Problem

The browser only applies native `autofocus` automatically during document load. After `wire:navigate` swaps in a new page, the existing document has already processed autofocus, so the newly added element will not be focused automatically.

The navigate plugin already had an `autofocusElementsWithTheAutofocusAttribute()` helper for this case, but it was permanently disabled behind `let autofocus = false`.

# The Solution

This removes the dead `autofocus` flag and runs the existing autofocus helper after the new page has been swapped in and Alpine has initialised.

I did dig back through Livewire's navigate git history and Alpine's navigate git history to see if there was a reason autofocus was disabled and I couldn't find anything that intentionally added it. So I believe it's safe to change it and use it, as I don't think it was disabled to stop a bug.

<img width="800" height="701" alt="CleanShot 2026-06-01 at 17 10 36" src="https://github.com/user-attachments/assets/1060892c-23c0-4ec8-b97b-e9abd5d2cf73" />


Fixes #10299
