### PR TITLE
[4.x] Fix authorization denied with class name as the only parameter on `#[Authorize]` attribute

### DIFF
--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -78,6 +78,6 @@ class BaseAuthorize extends LivewireAttribute
             return [$ability, $arguments];
         }
 
-        return [$this->getName(), $ability];
+        return [$this->normalizeGuessedAbilityName($this->getName()), $ability];
     }
 }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -3,14 +3,18 @@
 namespace Livewire\Features\SupportAuthorization;
 
 use Attribute;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Gate;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use UnitEnum;
+
+use function Illuminate\Support\enum_value;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
 class BaseAuthorize extends LivewireAttribute
 {
+    use AuthorizesRequests;
+
     public function __construct(
         public UnitEnum|string $ability,
         public array|string|null $argument = null,
@@ -20,7 +24,7 @@ class BaseAuthorize extends LivewireAttribute
     {
         // Action that does not require a model or class...
         if (is_null($this->argument)) {
-            Gate::authorize($this->ability);
+            $this->authorize($this->ability);
 
             return;
         }
@@ -33,7 +37,7 @@ class BaseAuthorize extends LivewireAttribute
             $resolved[] = $this->resolveArgument($arg, $parameters);
         }
 
-        Gate::authorize($this->ability, $resolved);
+        $this->authorize($this->ability, $resolved);
     }
 
     /**
@@ -64,5 +68,16 @@ class BaseAuthorize extends LivewireAttribute
 
         // Fall back to component property
         return data_get($this->component, $arg);
+    }
+
+    protected function parseAbilityAndArguments($ability, $arguments)
+    {
+        $ability = enum_value($ability);
+
+        if (is_string($ability) && ! str_contains($ability, '\\')) {
+            return [$ability, $arguments];
+        }
+
+        return [$this->getName(), $ability];
     }
 }

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -697,6 +697,22 @@ class UnitTest extends TestCase
             ->call('editComment', comment: 1, post: 2)
             ->assertForbidden();
     }
+
+    public function test_can_authorize_with_only_class_name_and_no_arguments()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize(AuthorizationPost::class)]
+                public function create() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('create')
+            ->assertOk();
+    }
 }
 
 class AuthorizationUser extends AuthUser

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -698,7 +698,26 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
-    public function test_can_authorize_with_only_class_name_and_no_arguments()
+    public function test_can_authorize_using_defined_gate_with_only_class_name_as_argument()
+    {
+        Gate::define('create', function (AuthorizationUser $user) : bool
+        {
+            return (int) $user->id === 1;
+        });
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize(AuthorizationPost::class)]
+                public function create() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('create')
+            ->assertOk();
+    }
+
+    public function test_can_authorize_using_policy_with_only_class_name_and_no_arguments()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
 

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -732,6 +732,22 @@ class UnitTest extends TestCase
             ->call('create')
             ->assertOk();
     }
+
+    public function test_can_authorize_using_policy_resource_ability_mapping_with_only_class_name()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize(AuthorizationPost::class)]
+                public function store() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('store')
+            ->assertOk();
+    }
 }
 
 class AuthorizationUser extends AuthUser


### PR DESCRIPTION
## Scenario

**Requirement**: policy method name / defined gate name should be same with component action name

When user only provide class name as parameter on `#[Authorize]` attribute, the authorization will be denied. However, using only class name as parameter on `$this->authorize()` works as expected.

Devs would expect it works either way using attribute or component trait method. Just like using transition  works both way

```php
#[Transition(type: 'forward')] // ✅
public function next()
{
    $this->transition(type: 'forward'); // ✅
}
```

## Problem
In `BaseAuthorize::call()`, it directly calls `Gate::authorize` without parsing/guessing the ability name
```php
if (is_null($this->argument)) {
    Gate::authorize($this->ability);

    return;
}
```
`$this->authorize()` flow works inside component action because when no ability provided, **AuthorizesRequests** trait will guess the ability name from action name. So for example

```php
class PostPolicy
{
    public function createPost(User $user)
    {
        return true;
    }
}
```

```php
public function createPost()
{
    $this->authorize(Post::class); // ✅
}
```
Laravel will determine that policy name would be `createPost`.

However, this flow breaks when its called inside attribute because the method name from backtracing would be `call` NOT `createPost`.
```php
#[Authorize(Post::class)] // ❌
public function createPost()
{
    //
}
```

## Solution

Either way, this will make `#[Authorize]` attribute align with `AuthorizesRequests` from component.

**Option 1** (This PR)

Use **AuthorizesRequests** trait inside **BaseAuthorize** and override the `parseAbilityAndArguments` method to return action name instead backtracing method name.

```php
protected function parseAbilityAndArguments($ability, $arguments)
{
    $ability = enum_value($ability);

    if (is_string($ability) && ! str_contains($ability, '\\')) {
        return [$ability, $arguments];
    }

    // Removed
    // $method = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2]['function'];

    return [$this->normalizeGuessedAbilityName($this->getName()), $ability];
}
```

**Option 2** (Avoid trait conflict)

- Check the ability using `class_exists` or contains `\`
- If exists and no argument provided, parse the ability (just like `AuthorizesRequests` did) before authorization.

Something like

```php
public function call(array $parameters) : void
{
    // Action that does not require a model or class...
    if (is_null($this->argument)) {
        [$ability, $arguments] = $this->parseAbilityAndArguments($this->ability, $this->argument);

        Gate::authorize($ability, $arguments);

        return;
    }

    $arguments = Arr::wrap($this->argument);

    // Resolve each argument (prioritize method parameters first, then component properties)
    $resolved = [];
    foreach ($arguments as $arg) {
        $resolved[] = $this->resolveArgument($arg, $parameters);
    }

    Gate::authorize($this->ability, $resolved);
}

protected function parseAbilityAndArguments($ability, $arguments)
{
    $ability = enum_value($ability);

    if (is_string($ability) && ! str_contains($ability, '\\')) {
        return [$ability, $arguments];
    }

    return [$this->getName(), $ability];
}
```

## File Changed
- `src/Features/SupportAuthorization/BaseAuthorize.php`

Fixes: https://github.com/livewire/livewire/issues/10318