### PR TITLE
[3.x] Handle unknown components during release token verification

### DIFF
--- a/src/Features/SupportReleaseTokens/ReleaseToken.php
+++ b/src/Features/SupportReleaseTokens/ReleaseToken.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportReleaseTokens;
 
+use Livewire\Exceptions\ComponentNotFoundException;
 use Livewire\Exceptions\LivewireReleaseTokenMismatchException;
 use Livewire\Mechanisms\ComponentRegistry;
 
@@ -13,7 +14,11 @@ class ReleaseToken {
 
     static function verify($snapshot): void
     {
-        $componentClass = app(ComponentRegistry::class)->getClass($snapshot['memo']['name']);
+        try {
+            $componentClass = app(ComponentRegistry::class)->getClass($snapshot['memo']['name']);
+        } catch (ComponentNotFoundException) {
+            throw new LivewireReleaseTokenMismatchException;
+        }
 
         if (!isset($snapshot['memo']['release']) || $snapshot['memo']['release'] !== static::generate($componentClass)) {
             throw new LivewireReleaseTokenMismatchException;

--- a/src/Features/SupportReleaseTokens/UnitTest.php
+++ b/src/Features/SupportReleaseTokens/UnitTest.php
@@ -102,6 +102,20 @@ class UnitTest extends \Tests\TestCase
         // NOT CorruptComponentPayloadException from the checksum mismatch...
         Checksum::verify($snapshot);
     }
+
+    public function test_unknown_component_in_snapshot_is_treated_as_release_token_mismatch()
+    {
+        $this->expectException(LivewireReleaseTokenMismatchException::class);
+
+        Checksum::verify([
+            'memo' => [
+                'name' => 'page.component',
+                'id' => 'test-id',
+            ],
+            'data' => [],
+            'checksum' => str_repeat('0', 64),
+        ]);
+    }
 }
 
 class ComponentWithReleaseToken extends Component


### PR DESCRIPTION
# The Scenario

Applications can receive Livewire update requests with snapshots that reference component names the server cannot resolve, likely from forged requests or stale browser sessions. These requests currently surface as application errors in logs:

<img width="1497" height="602" alt="CleanShot 2026-06-02 at 11 16 50@2x" src="https://github.com/user-attachments/assets/a0e167a6-e073-46c2-9349-3a792b4f81cb" />

```json
{
  "components": [
    {
      "snapshot": "{\"data\":[],\"memo\":{\"name\":\"page.component\",\"id\":\"test-id\"},\"checksum\":\"0000000000000000000000000000000000000000000000000000000000000000\"}",
      "updates": [],
      "calls": []
    }
  ]
}
```

# The Problem

Release token verification runs from the `checksum.verify` hook before checksum comparison. That ordering is intentional because release tokens detect frontend/backend contract changes before snapshot checksum validation.

However, `ReleaseToken::verify()` resolves the component class from the snapshot name before comparing the token:

```php
$componentClass = app(ComponentRegistry::class)->getClass($snapshot['memo']['name']);
```

If the snapshot contains an unknown component name, `ComponentRegistry` throws `ComponentNotFoundException`. That exception escapes as a noisy application error instead of returning the existing 419 release token mismatch response.

# The Solution

Catch `ComponentNotFoundException` during release token verification and convert it to `LivewireReleaseTokenMismatchException`.

This preserves the existing release-token-before-checksum behaviour while ensuring unknown components in stale or invalid snapshots use the same 419 path as other release token mismatches.

**Upmerge To v4**

When this is upmerged to v4, replace the v3 component resolver with v4's factory resolver:

```diff
- $componentClass = app(ComponentRegistry::class)->getClass($snapshot['memo']['name']);
+ $componentClass = app('livewire.factory')->resolveComponentClass($snapshot['memo']['name']);
```
