### PR TITLE
[4.x] add failing test for SFC island imports

### DIFF
--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -9,6 +9,15 @@ use Illuminate\Support\Facades\File;
 
 class UnitTest extends TestCase
 {
+    public function test_sfc_island_carries_imports_from_the_component()
+    {
+        app('livewire.finder')->addLocation(viewPath: __DIR__ . '/fixtures');
+
+        Livewire::test('sfc-island-with-import')
+            ->assertSee('Outside island:')
+            ->assertSee('Inside island:');
+    }
+
     public function test_class_component_island_recovers_when_cached_file_is_deleted_between_requests()
     {
         $component = Livewire::test(new class extends \Livewire\Component {

--- a/src/Features/SupportIslands/fixtures/sfc-island-with-import.blade.php
+++ b/src/Features/SupportIslands/fixtures/sfc-island-with-import.blade.php
@@ -1,0 +1,19 @@
+<?php
+
+use Carbon\Carbon;
+
+new class extends Livewire\Component {
+    public function with()
+    {
+        return ['timestamp' => Carbon::now()->timestamp];
+    }
+};
+?>
+
+<div>
+    <div>Outside island: {{ Carbon::createFromTimestamp($timestamp)->timestamp }}</div>
+
+    @island
+        <div>Inside island: {{ Carbon::createFromTimestamp($timestamp)->timestamp }}</div>
+    @endisland
+</div>


### PR DESCRIPTION
Change-Id: Ifa6a9ac47ee380b8a0e3ad4a8b83c2353c81f1eb

## Description

This reproduction intentionally covers the SFC import case reported in #10278.
It does not attempt to define the expected behavior for `@use`, MFC, or class
components while the implementation direction is still being discussed.

Imports declared in an SFC are available in the regular component view, but
are not carried into the separately compiled island view.

The fixture uses:

```php
use Carbon\Carbon;
and references Carbon from inside an @island block.
```

## Current behavior
The new test fails with:
```test
Class "Carbon" not found
```

## Expected behavior
Imports declared in the SFC should also be available inside its islands.

## Scope
This PR intentionally contains only a failing regression test. It does not
include a framework fix.

## Test

```bash
vendor/bin/phpunit --configuration phpunit.xml.dist \
  --testsuite Unit \
  --filter test_sfc_island_carries_imports_from_the_component
```

This test currently fails as expected with:

```text
Class "Carbon" not found
```