### PR TITLE
[4.x] Replace `EndpointResolver::updatePath()` with path from callback

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -23,8 +23,8 @@ class HandleRequests extends Mechanism
         // Register the default route immediately (before routes files load)
         // so it's positioned before any catch-all routes.
         if (! $this->updateRoute && ! $this->updateRouteExists()) {
-            app($this::class)->setUpdateRoute(function ($handle) {
-                return Route::post(EndpointResolver::updatePath(), $handle)
+            app($this::class)->setUpdateRoute(function ($handle, $path) {
+                return Route::post($path, $handle)
                     ->middleware(['web', RequireLivewireHeaders::class])
                     ->name('default-livewire.update');
             });


### PR DESCRIPTION
In `setUpdateRoute()`, the update path already passed into the callback
```php
function setUpdateRoute($callback)
{
    $route = $callback([self::class, 'handleUpdate'], EndpointResolver::updatePath());
    
    ...
}
```
but in `boot()` also use `EndpointResolver::updatePath()` again instead using path from the callback

```php
// app($this::class)->setUpdateRoute(function ($handle) {  // ❌
    // return Route::post(EndpointResolver::updatePath(), $handle) // ❌

app($this::class)->setUpdateRoute(function ($handle, $path) { // ✅
    return Route::post($path, $handle) // ✅
        ->middleware(['web', RequireLivewireHeaders::class])
        ->name('default-livewire.update');
});
```