### PR TITLE
[4.x] Prevent file download responses from leaking into action returns

### DIFF
--- a/src/Features/SupportFileDownloads/UnitTest.php
+++ b/src/Features/SupportFileDownloads/UnitTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Component;
 use Livewire\Livewire;
+use Livewire\Mechanisms\HandleRequests\EndpointResolver;
 use PHPUnit\Framework\ExpectationFailedException;
 
 class UnitTest extends \Tests\TestCase
@@ -23,6 +24,29 @@ class UnitTest extends \Tests\TestCase
         Livewire::test(FileDownloadComponent::class)
                 ->call('streamDownload', 'download.txt')
                 ->assertFileDownloaded('download.txt', 'alpinejs');
+    }
+
+    public function test_file_download_responses_are_not_included_in_action_returns()
+    {
+        $testable = Livewire::test(FileDownloadComponent::class);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                [
+                    'snapshot' => json_encode($testable->snapshot),
+                    'updates' => [],
+                    'calls' => [
+                        [
+                            'method' => 'download',
+                            'params' => ['download.txt'],
+                        ],
+                    ],
+                ],
+            ]]);
+
+        $response->assertOk();
+        $response->assertJsonPath('components.0.effects.download.name', 'download.txt');
+        $response->assertJsonPath('components.0.effects.returns.0', null);
     }
 
     public function can_download_a_responsable(){

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -13,6 +13,8 @@ use Livewire\Exceptions\TooManyCallsException;
 use Livewire\Drawer\Utils;
 use Livewire\Features\SupportFormObjects\Form;
 use Illuminate\Support\Facades\View;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class HandleComponents extends Mechanism
 {
@@ -676,7 +678,9 @@ class HandleComponents extends Mechanism
             $finish = trigger('call', $root, $method, $params, $componentContext, $returnEarly, $metadata, $idx);
 
             if ($earlyReturnCalled) {
-                $returns[] = $finish($earlyReturn);
+                $return = $finish($earlyReturn);
+
+                $returns[] = $return instanceof StreamedResponse || $return instanceof BinaryFileResponse ? null : $return;
 
                 continue;
             }
@@ -697,7 +701,9 @@ class HandleComponents extends Mechanism
             $return = wrap($root)->{$method}(...$params);
             if (config('app.debug')) trigger('profile', 'call'.$idx, $root->getId(), [$start, microtime(true)]);
 
-            $returns[] = $finish($return);
+            $return = $finish($return);
+
+            $returns[] = $return instanceof StreamedResponse || $return instanceof BinaryFileResponse ? null : $return;
 
             // Support `Wire:click.renderless`...
             if ($metadata['renderless'] ?? false) {

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -680,6 +680,8 @@ class HandleComponents extends Mechanism
             if ($earlyReturnCalled) {
                 $return = $finish($earlyReturn);
 
+                // File downloads are sent to the browser through the download effect,
+                // so keep the return slot aligned without leaking the response object into JSON.
                 $returns[] = $return instanceof StreamedResponse || $return instanceof BinaryFileResponse ? null : $return;
 
                 continue;
@@ -703,6 +705,8 @@ class HandleComponents extends Mechanism
 
             $return = $finish($return);
 
+            // File downloads are sent to the browser through the download effect,
+            // so keep the return slot aligned without leaking the response object into JSON.
             $returns[] = $return instanceof StreamedResponse || $return instanceof BinaryFileResponse ? null : $return;
 
             // Support `Wire:click.renderless`...


### PR DESCRIPTION
# The Scenario

A Livewire action can return a Laravel file download response. Livewire correctly converts the response into a `download` effect, but the original response object is also included in the action `returns` effect.

```php
use Illuminate\Support\Facades\Storage;
use Livewire\Component;

class BugPlayground extends Component
{
    public function downloadFileDownloadWay()
    {
        return Storage::disk('local')->download(
            'livewire-downloads/test.txt',
            'test-download-way.txt',
            [
                'Content-Type' => 'text/plain',
            ]
        );
    }
}
```

# The Problem

`SupportFileDownloads` detects `StreamedResponse` and `BinaryFileResponse` instances and converts them into a JSON-safe `download` effect.

However, `HandleComponents::callMethods()` still stores the original action return value in `effects.returns`. For file downloads, that means a Symfony response object can leak into the final Livewire JSON payload.

Returning `null` from the file-download hook is not enough with the current hook pipeline: component hook finish callbacks are used for side effects, and the event bus treats `null` as “keep the original forwarded value”.

# The Solution

After method call hooks finish, Livewire now normalises `StreamedResponse` and `BinaryFileResponse` action returns to `null` before adding them to `effects.returns`.

The `download` effect remains the browser-facing instruction, and the `returns` array keeps a `null` entry so action return indexes stay aligned with the submitted calls.

Fixes #10326
