### PR TITLE
[4.x] Fix `wire:sort:item` ids on lazy components

### DIFF
--- a/js/features/supportWireSort.js
+++ b/js/features/supportWireSort.js
@@ -2,6 +2,23 @@ import { setNextActionOrigin } from '@/request'
 import { evaluateActionExpression } from '../evaluator'
 import Alpine from 'alpinejs'
 import { extractDirective } from '@/directives'
+import { on } from '@/hooks'
+
+on('directive.init', ({ el, directive }) => {
+    if (! directive.rawName.startsWith('wire:sort:item')) return
+
+    if (el._x_sort_key !== undefined) return
+
+    let modifierString = directive.modifiers.join('.')
+
+    let expression = directive.expression
+
+    Alpine.bind(el, {
+        ['x-sort:item' + modifierString]() {
+            return expression
+        }
+    })
+})
 
 Alpine.interceptInit(el => {
     for (let i = 0; i < el.attributes.length; i++) {

--- a/src/Features/SupportWireSort/BrowserTest.php
+++ b/src/Features/SupportWireSort/BrowserTest.php
@@ -116,6 +116,79 @@ class BrowserTest extends BrowserTestCase
         ->assertSeeIn('@result', 'item:item-1,position:2');
     }
 
+    public function test_wire_sort_item_id_is_passed_for_lazy_child_components()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public $result = '';
+
+                public function sortItem($item, $position)
+                {
+                    $this->result = "item:{$item},position:{$position}";
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <ul dusk="sortable" wire:sort="sortItem">
+                            <livewire:child wire:key="item-1" wire:sort:item="item-1" lazy>
+                                Item 1
+                            </livewire:child>
+
+                            <livewire:child wire:key="item-2" wire:sort:item="item-2" lazy>
+                                Item 2
+                            </livewire:child>
+                        </ul>
+
+                        <div dusk="result">{{ $result }}</div>
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public function placeholder()
+                {
+                    return <<<'HTML'
+                    <li>Loading...</li>
+                    HTML;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <li {{ $attributes }}>
+                        Child {{ $slot }}
+                    </li>
+                    HTML;
+                }
+            },
+        ])
+        ->waitForText('Child Item 2')
+        ->tap(function ($b) {
+            $b->script(<<<'JS'
+                let el = document.querySelector('[dusk="sortable"]')
+                let item = el.querySelector('[wire\\:sort\\:item="item-2"]')
+
+                el.insertBefore(item, el.firstElementChild)
+
+                let key = Object.keys(el).find(k => k.startsWith('Sortable'))
+                let instance = el[key]
+
+                instance.options.onSort({
+                    item: item,
+                    from: el,
+                    to: el,
+                    target: el,
+                    newIndex: 0,
+                    oldIndex: 1,
+                })
+            JS);
+        })
+        ->waitForTextIn('@result', 'item:item-2,position:0')
+        ->assertSeeIn('@result', 'item:item-2,position:0');
+    }
+
     public function test_wire_sort_works_without_sort_id()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
# The Scenario

When a sortable list renders lazy child components and forwards `wire:sort:item` to each child root element, sorting those children can call the sort action with a missing item id. The lazy child renders correctly, but the sort action receives `null` instead of the forwarded item id.

```blade
<div>
    <ul wire:sort="sortItem">
        <livewire:child wire:key="item-1" wire:sort:item="item-1" lazy>
            Item 1
        </livewire:child>

        <livewire:child wire:key="item-2" wire:sort:item="item-2" lazy>
            Item 2
        </livewire:child>
    </ul>

    <div>{{ $result }}</div>
</div>
```

# The Problem

Lazy component placeholders are Alpine-initialised before the forwarded `wire:sort:item` attribute exists on the child component root element.

When the lazy component loads, Livewire morphs the placeholder into the rendered child and adds the forwarded `wire:sort:item` attribute. However, the existing `Alpine.interceptInit` path has already run for that element, so Alpine Sort never initialises the equivalent `x-sort:item` directive and never sets `_x_sort_key`.

That means when Sortable fires, Alpine Sort cannot find the item key and Livewire receives `null` for the item id.

# The Solution

This PR adds support for initialising `wire:sort:item` when the directive is added after an element has already gone through Alpine initialisation.

That covers lazy component roots, where the placeholder is initialised first and the forwarded `wire:sort:item` attribute is only applied after the lazy component renders. When that later directive initialisation happens, Livewire binds the matching `x-sort:item` directive so Alpine Sort can register the item key and pass it through to the sort action.

Fixes #10325