### PR TITLE
[3.x] Only report corrupt component payloads in debug mode

### DIFF
--- a/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
+++ b/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
@@ -2,10 +2,9 @@
 
 namespace Livewire\Mechanisms\HandleComponents;
 
-use Illuminate\Contracts\Debug\ShouldntReport;
 use Livewire\Exceptions\BypassViewHandler;
 
-class CorruptComponentPayloadException extends \Exception implements ShouldntReport
+class CorruptComponentPayloadException extends \Exception
 {
     use BypassViewHandler;
 
@@ -15,6 +14,11 @@ class CorruptComponentPayloadException extends \Exception implements ShouldntRep
             "Livewire encountered corrupt data when trying to hydrate a component. \n".
             "Ensure that the [name, id, data] of the Livewire component wasn't tampered with between requests."
         );
+    }
+
+    public function report(): bool
+    {
+        return ! config('app.debug');
     }
 
     // In debug mode, let Laravel render the full error page.

--- a/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
+++ b/src/Mechanisms/HandleComponents/CorruptComponentPayloadException.php
@@ -2,9 +2,10 @@
 
 namespace Livewire\Mechanisms\HandleComponents;
 
+use Illuminate\Contracts\Debug\ShouldntReport;
 use Livewire\Exceptions\BypassViewHandler;
 
-class CorruptComponentPayloadException extends \Exception
+class CorruptComponentPayloadException extends \Exception implements ShouldntReport
 {
     use BypassViewHandler;
 

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -112,6 +112,37 @@ class UnitTest extends TestCase
         $response->assertStatus(419);
     }
 
+    public function test_bad_checksum_is_not_reported(): void
+    {
+        config()->set('app.debug', false);
+
+        $reported = [];
+        app(\Illuminate\Contracts\Debug\ExceptionHandler::class)
+            ->reportable(function (\Throwable $e) use (&$reported) {
+                $reported[] = $e;
+                return false;
+            });
+
+        $testable = Livewire::test(new class extends TestComponent {});
+
+        $snapshot = json_encode([
+            'data' => [],
+            'memo' => [
+                'id' => 'abc',
+                'name' => $testable->snapshot['memo']['name'],
+            ],
+            'checksum' => 'invalid-checksum-value',
+        ]);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson('/livewire/update', ['components' => [
+                ['snapshot' => $snapshot, 'updates' => [], 'calls' => []],
+            ]]);
+
+        $response->assertStatus(419);
+        $this->assertEmpty($reported);
+    }
+
     public function test_type_mismatched_update_value_returns_419(): void
     {
         // Disable debug mode to test production HTTP responses (404/419)...

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Livewire\Livewire;
+use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
@@ -112,35 +114,38 @@ class UnitTest extends TestCase
         $response->assertStatus(419);
     }
 
-    public function test_bad_checksum_is_not_reported(): void
+    public function test_bad_checksum_exception_is_not_reported_when_debug_is_disabled(): void
     {
         config()->set('app.debug', false);
 
         $reported = [];
-        app(\Illuminate\Contracts\Debug\ExceptionHandler::class)
-            ->reportable(function (\Throwable $e) use (&$reported) {
+        app(ExceptionHandler::class)
+            ->reportable(function (CorruptComponentPayloadException $e) use (&$reported) {
                 $reported[] = $e;
+
                 return false;
             });
 
-        $testable = Livewire::test(new class extends TestComponent {});
+        app(ExceptionHandler::class)->report(new CorruptComponentPayloadException);
 
-        $snapshot = json_encode([
-            'data' => [],
-            'memo' => [
-                'id' => 'abc',
-                'name' => $testable->snapshot['memo']['name'],
-            ],
-            'checksum' => 'invalid-checksum-value',
-        ]);
-
-        $response = $this->withHeaders(['X-Livewire' => 'true'])
-            ->postJson('/livewire/update', ['components' => [
-                ['snapshot' => $snapshot, 'updates' => [], 'calls' => []],
-            ]]);
-
-        $response->assertStatus(419);
         $this->assertEmpty($reported);
+    }
+
+    public function test_bad_checksum_exception_is_reported_when_debug_is_enabled(): void
+    {
+        config()->set('app.debug', true);
+
+        $reported = [];
+        app(ExceptionHandler::class)
+            ->reportable(function (CorruptComponentPayloadException $e) use (&$reported) {
+                $reported[] = $e;
+
+                return false;
+            });
+
+        app(ExceptionHandler::class)->report(new CorruptComponentPayloadException);
+
+        $this->assertCount(1, $reported);
     }
 
     public function test_type_mismatched_update_value_returns_419(): void


### PR DESCRIPTION
## What changed

Marks `CorruptComponentPayloadException` as `ShouldntReport` so invalid/tampered Livewire snapshots still receive the existing production 419 response without being reported to Laravel exception reporters.

Adds a regression test proving a bad checksum returns 419 and does not hit registered report callbacks.

## Why

Livewire update endpoints are exposed to the public internet and get probed with stale or tampered snapshots. A checksum failure means Livewire rejected the request correctly; it should be treated as expected boundary traffic rather than application error noise in Flare/Sentry/Bugsnag.

## Validation

- `./vendor/bin/phpunit src/Mechanisms/HandleRequests/UnitTest.php`
- `./vendor/bin/phpunit src/Tests/ComponentsAreSecureUnitTest.php`
- `./vendor/bin/phpunit --testsuite Unit --filter='HandleRequests|ComponentsAreSecure'`