### PR TITLE
[4.x] Fix flaky test in `PersistentMiddleware` browser test

### DIFF
--- a/src/Mechanisms/PersistentMiddleware/BrowserTest.php
+++ b/src/Mechanisms/PersistentMiddleware/BrowserTest.php
@@ -192,10 +192,12 @@ JS;
                 $script = <<<'JS'
                     let unDecoratedFetch = window.fetch
                     let decoratedFetch = (...args) => {
-                        window.localStorage.setItem(
-                            'lastFetchArgs',
-                            JSON.stringify(args),
-                        )
+                        setTimeout(() => {
+                            window.localStorage.setItem(
+                                'lastFetchArgs',
+                                JSON.stringify(args),
+                            )
+                        }, 500)
 
                         return unDecoratedFetch(...args)
                     }
@@ -207,6 +209,11 @@ JS;
             ->waitForLivewire()->click('@changeProtected')
             ->assertDontSee('Protected Content')
             ->assertSee('Still Secure Content')
+            ->tap(function ($b) {
+                // Wait until the fetch args have been stored, otherwise we might try and replay the request before the args are stored
+                // to prevent race conditions in the test.
+                $b->waitUntil("!!localStorage.getItem('lastFetchArgs')", 5);
+            })
             ->visit('/force-login/2')
             ->tap(function ($b) {
                 $script = <<<'JS'

--- a/src/Mechanisms/PersistentMiddleware/BrowserTest.php
+++ b/src/Mechanisms/PersistentMiddleware/BrowserTest.php
@@ -192,12 +192,10 @@ JS;
                 $script = <<<'JS'
                     let unDecoratedFetch = window.fetch
                     let decoratedFetch = (...args) => {
-                        setTimeout(() => {
-                            window.localStorage.setItem(
-                                'lastFetchArgs',
-                                JSON.stringify(args),
-                            )
-                        }, 500)
+                        window.localStorage.setItem(
+                            'lastFetchArgs',
+                            JSON.stringify(args),
+                        )
 
                         return unDecoratedFetch(...args)
                     }
@@ -210,7 +208,7 @@ JS;
             ->assertDontSee('Protected Content')
             ->assertSee('Still Secure Content')
             ->tap(function ($b) {
-                // Wait until the fetch args have been stored, otherwise we might try and replay the request before the args are stored
+                // Wait until the fetch args have been stored in localStorage
                 // to prevent race conditions in the test.
                 $b->waitUntil("!!localStorage.getItem('lastFetchArgs')", 5);
             })


### PR DESCRIPTION
## Problem
The `test_that_authorization_middleware_is_re_applied()` test sometimes failed due to a race condition. The test decorates the browser's fetch function to capture request arguments in `localStorage`, but it was attempting to access those arguments before they were reliably set.

## Root Cause
After triggering a Livewire action with `click('@changeProtected')`, the test immediately navigated to a new page and tried to parse `localStorage.getItem('lastFetchArgs')`. However, the asynchronous fetch interception that stores these arguments may not have completed yet, resulting test failures that only occurred sometimes (when network/timing was slow)

## Solution
Added an explicit wait using `waitUntil()` to ensure `lastFetchArgs` is present in `localStorage` before navigating to the next page.