### PR TITLE
[4.x] Fix duplicate Alpine x-if elements after back/forward navigation

### DIFF
--- a/js/plugins/navigate/history.spec.js
+++ b/js/plugins/navigate/history.spec.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+    pushUrl,
+    updateCurrentPageHtmlInSnapshotCacheForLaterBackButtonClicks,
+    whenTheBackOrForwardButtonIsClicked,
+} from './history'
+
+function setPageHtml(bodyHtml) {
+    document.documentElement.innerHTML = `<head></head><body>${bodyHtml}</body>`
+}
+
+function countRenderedButtonsInHtml(html) {
+    let doc = (new DOMParser()).parseFromString(html, 'text/html')
+    let container = doc.getElementById('alpine-if-container')
+
+    if (! container) return 0
+
+    let count = 0
+
+    container.querySelectorAll('template[x-if]').forEach(template => {
+        let sibling = template.nextElementSibling
+
+        while (sibling) {
+            if (sibling.matches('button')) count++
+
+            sibling = sibling.nextElementSibling
+        }
+    })
+
+    return count
+}
+
+// Mirrors Alpine.destroyTree() behavior for x-if: rendered nodes live as siblings after the template.
+function cleanupAlpineXIfOutput(root = document.body) {
+    root.querySelectorAll('template[x-if]').forEach(template => {
+        let sibling = template.nextElementSibling
+
+        while (sibling) {
+            let next = sibling.nextElementSibling
+
+            sibling.remove()
+
+            sibling = next
+        }
+    })
+}
+
+function pageUrl(path) {
+    return new URL(path, window.location.href)
+}
+
+async function flushHistoryCoordinator() {
+    await new Promise(queueMicrotask)
+}
+
+describe('navigate history snapshots', () => {
+    beforeEach(() => {
+        window.history.replaceState({}, '', '/')
+
+        setPageHtml('<div>reset</div>')
+    })
+
+    it('does not cache alpine x-if rendered output when cleanup runs before updating a snapshot', async () => {
+        setPageHtml(`
+            <div id="alpine-if-container">
+                <template x-if="true"><button>Add passkey</button></template>
+            </div>
+        `)
+
+        pushUrl(pageUrl('/page-a'), document.documentElement.outerHTML)
+
+        await flushHistoryCoordinator()
+
+        let pageAKey = window.history.state.alpine.snapshotIdx
+
+        setPageHtml('<div>page-b</div>')
+
+        pushUrl(pageUrl('/page-b'), document.documentElement.outerHTML)
+
+        await flushHistoryCoordinator()
+
+        // Alpine has re-initialized x-if on page-a, leaving rendered output in the live DOM.
+        setPageHtml(`
+            <div id="alpine-if-container">
+                <template x-if="true"><button>Add passkey</button></template>
+                <button>Add passkey</button>
+            </div>
+        `)
+
+        cleanupAlpineXIfOutput()
+
+        updateCurrentPageHtmlInSnapshotCacheForLaterBackButtonClicks(pageAKey, pageUrl('/page-a'))
+
+        let retrievedHtml = null
+
+        whenTheBackOrForwardButtonIsClicked(() => {}, html => {
+            retrievedHtml = html
+        })
+
+        window.history.back()
+
+        await flushHistoryCoordinator()
+
+        expect(countRenderedButtonsInHtml(retrievedHtml)).toBe(0)
+    })
+})

--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -163,9 +163,11 @@ export default function (Alpine) {
 
             if (prevented) return
 
-            // @todo: see if there's a way to update the current HTML BEFORE
-            // the back button is hit, and not AFTER:
             storeScrollInformationInHtmlBeforeNavigatingAway()
+
+            // Clean up Alpine x-if/x-for output before caching the page we're leaving.
+            // Without this, back/forward navigation restores duplicate DOM nodes.
+            cleanupAlpineElementsOnThePageThatArentInsideAPersistedElement()
 
             // Fire the navigating event, allowing listeners to register onSwap callbacks
             let swapCallbacks = []

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -101,6 +101,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             HTML));
 
             Route::get('/page-with-alpine-for-loop', PageWithAlpineForLoop::class);
+            Route::get('/page-with-alpine-if', PageWithAlpineIf::class);
             Route::get('/page-with-redirect-to-internal-which-has-external-link', PageWithRedirectToInternalWhichHasExternalLinkPage::class)->middleware('web');
             Route::get('/page-with-redirect-to-external-page', PageWithRedirectToExternalPage::class)->middleware('web');
             Route::get('/script-component', ScriptComponent::class);
@@ -797,6 +798,39 @@ class BrowserTest extends \Tests\BrowserTestCase
                 ->assertSeeIn('@text', 'a,b,c')
                 ->assertScript('document.getElementById(\'alpine-for-loop\').querySelectorAll(\'p\').length', 3)
                 ->assertConsoleLogMissingWarning('value is not defined')
+            ;
+        });
+    }
+
+    public function test_alpine_if_does_not_duplicate_elements_after_back_and_forward_navigation()
+    {
+        $this->browse(function (Browser $browser) {
+            $assertSinglePasskeyButton = fn (Browser $browser) => $browser
+                ->waitFor('@add-button')
+                ->assertScript('document.getElementById(\'alpine-if-container\').querySelectorAll(\'button\').length', 1)
+                ->assertConsoleLogMissingWarning('is not defined');
+
+            $browser
+                ->visit('/page-with-alpine-if')
+                ->tap(fn (Browser $browser) => $assertSinglePasskeyButton($browser))
+
+                ->waitForNavigate()->click('@link.to.second')
+                ->assertSee('On second')
+
+                ->waitForNoNavigateRequest()->back()
+                ->tap(fn (Browser $browser) => $assertSinglePasskeyButton($browser))
+
+                ->forward()
+                ->assertSee('On second')
+
+                ->waitForNoNavigateRequest()->back()
+                ->tap(fn (Browser $browser) => $assertSinglePasskeyButton($browser))
+
+                ->forward()
+                ->assertSee('On second')
+
+                ->waitForNoNavigateRequest()->back()
+                ->tap(fn (Browser $browser) => $assertSinglePasskeyButton($browser))
             ;
         });
     }
@@ -1763,6 +1797,24 @@ class PageWithAlpineForLoop extends Component
             <div id="alpine-for-loop">
                 <template x-for="(value, index) in items" :key="index">
                     <p x-text="value"></p>
+                </template>
+            </div>
+        </div>
+        HTML;
+    }
+}
+
+class PageWithAlpineIf extends Component
+{
+    #[Layout('test-views::layout')]
+    public function render()
+    {
+        return <<<'HTML'
+        <div dusk="page-with-alpine-if" x-data="{ supported: true, showForm: false }">
+            <a href="/second" wire:navigate dusk="link.to.second">Go to second page</a>
+            <div id="alpine-if-container">
+                <template x-if="supported && !showForm">
+                    <button type="button" dusk="add-button">Add passkey</button>
                 </template>
             </div>
         </div>


### PR DESCRIPTION
## Summary

- Fixes duplicate DOM nodes when using browser back/forward buttons with `wire:navigate` and Alpine `x-if` / `x-for` templates
- Cleans up Alpine-rendered output before caching the page snapshot on `popstate`, matching the behavior already used when navigating away via a `wire:navigate` link
- Adds a browser regression test that reproduces the passkey button duplication reported in the Laravel starter kit, plus a Vitest test for snapshot caching behavior

Fixes #10335 (reported via [laravel/maestro#151](https://github.com/laravel/maestro/issues/151))

## Root cause

When leaving a page via `wire:navigate`, Livewire calls `cleanupAlpineElementsOnThePageThatArentInsideAPersistedElement()` before storing the page in the back-button snapshot cache. This removes Alpine `x-if` / `x-for` rendered output so only the original `<template>` tags are cached.

When leaving a page via the browser back/forward buttons, the snapshot was updated **without** this cleanup. The cached HTML then contained both the `<template x-if>` tag and Alpine's rendered output. On restore, Alpine initialized again and rendered duplicate elements.

## Test plan

- [x] `npm run test:run` — all Vitest tests pass (including new `history.spec.js`)
- [x] `composer test:unit` — all unit tests pass (1267 tests)
- [x] Browser test `test_alpine_if_does_not_duplicate_elements_after_back_and_forward_navigation` passes
- [x] Verified the new browser test **fails without the fix** (2 buttons instead of 1 after repeated back/forward)
- [x] Existing navigate regression tests pass: `test_alpine_for_loop_still_functions_after_navigation`, `test_back_and_forward_buttons_work_after_page_refresh`