### PR TITLE
[4.x] Fix SFC island imports

### DIFF
--- a/src/Compiler/Parser/Parser.php
+++ b/src/Compiler/Parser/Parser.php
@@ -209,15 +209,7 @@ PHP
     {
         // Extract everything between <?php and "new"
         if (preg_match('/\<\?php(.*?)new/s', $classPortion, $matches)) {
-            $preamble = $matches[1];
-
-            // Use (*SKIP)(*FAIL) to ignore "use" statements inside comments...
-            $skipComments = '(?:\/\/[^\n]*|\/\*.*?\*\/)(*SKIP)(*FAIL)';
-
-            // Extract all use statements
-            if (preg_match_all('/' . $skipComments . '|use\s+[^;]+;/s', $preamble, $useMatches)) {
-                $useStatements = implode("\n", $useMatches[0]);
-            }
+            $useStatements = static::extractUseStatements($matches[1]);
         }
 
         // Only add PHP tags and use statements if we found any
@@ -226,5 +218,18 @@ PHP
         }
 
         return $contents;
+    }
+
+    public static function extractUseStatements(string $contents): ?string
+    {
+        // Use (*SKIP)(*FAIL) to ignore "use" statements inside comments...
+        $skipComments = '(?:\/\/[^\n]*|\/\*.*?\*\/)(*SKIP)(*FAIL)';
+
+        // Extract all use statements (excluding closure `use (...)` clauses)...
+        if (! preg_match_all('/' . $skipComments . '|\buse\s+[^;()]+;/s', $contents, $useMatches)) {
+            return null;
+        }
+
+        return $useMatches[0] ? implode("\n", $useMatches[0]) : null;
     }
 }

--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -98,6 +98,9 @@ class IslandCompiler
         $scopeProviderCode = $this->generateScopeProviderCode($expression);
         $innerContent = $scopeProviderCode . $innerContent;
 
+        // Carry SFC import aliases into separately compiled island views...
+        $innerContent = $this->injectUseStatementsFromCompiledView($innerContent);
+
         // Ensure the cached directory exists...
         File::ensureDirectoryExists(dirname($cachedPath));
 
@@ -107,6 +110,33 @@ class IslandCompiler
         app('livewire.compiler')->cacheManager->prepareGeneratedFileForCompilation($cachedPath);
 
         return $output;
+    }
+
+    protected function injectUseStatementsFromCompiledView(string $contents): string
+    {
+        $useStatements = $this->extractUseStatementsFromCompiledView();
+
+        if (! $useStatements) {
+            return $contents;
+        }
+
+        return "<?php\n" . $useStatements . "\n?>\n\n" . $contents;
+    }
+
+    protected function extractUseStatementsFromCompiledView(): string
+    {
+        if (! preg_match('/\A\s*<\?php(.*?)\?>/s', $this->contents, $matches)) {
+            return '';
+        }
+
+        $preamble = $matches[1];
+        $skipComments = '(?:\/\/[^\n]*|\/\*.*?\*\/)(*SKIP)(*FAIL)';
+
+        if (! preg_match_all('/' . $skipComments . '|\buse\s+(?:function\s+|const\s+)?[^;]+;/s', $preamble, $useMatches)) {
+            return '';
+        }
+
+        return implode("\n", array_map('trim', $useMatches[0]));
     }
 
     protected function generateScopeProviderCode(string $expression): string

--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -4,16 +4,23 @@ namespace Livewire\Features\SupportIslands\Compiler;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Arr;
+use Livewire\Compiler\Parser\Parser;
 
 class IslandCompiler
 {
     protected string $mutableContents;
+
+    protected ?string $imports;
 
     public function __construct(
         public string $pathSignature,
         public string $contents,
     ) {
         $this->mutableContents = $contents;
+
+        // Islands are extracted into separately compiled views, so any imports
+        // from the top of the view need to be carried into each island...
+        $this->imports = $this->extractImports();
     }
 
     public static function compile(string $pathSignature, string $contents): string
@@ -98,8 +105,10 @@ class IslandCompiler
         $scopeProviderCode = $this->generateScopeProviderCode($expression);
         $innerContent = $scopeProviderCode . $innerContent;
 
-        // Carry SFC import aliases into separately compiled island views...
-        $innerContent = $this->injectImportsFromCompiledView($innerContent);
+        // Carry imports from the top of the view into the extracted island view...
+        if ($this->imports) {
+            $innerContent = $this->imports . "\n\n" . $innerContent;
+        }
 
         // Ensure the cached directory exists...
         File::ensureDirectoryExists(dirname($cachedPath), 0777);
@@ -112,54 +121,28 @@ class IslandCompiler
         return $output;
     }
 
-    protected function injectImportsFromCompiledView(string $contents): string
+    protected function extractImports(): ?string
     {
-        $imports = $this->extractImportsFromCompiledView();
+        $prefix = explode('@island', $this->contents, 2)[0];
 
-        if (! $imports) {
-            return $contents;
-        }
-
-        return $imports . "\n\n" . $contents;
-    }
-
-    protected function extractImportsFromCompiledView(): string
-    {
-        // Compile only the leading contents so existing Blade handling for
-        // directives like `@use(...)` has already been applied before we copy
-        // import blocks into the extracted island view.
-        $compiledPrefix = app('blade.compiler')->compileString(
-            explode('@island', $this->contents, 2)[0]
-        );
-
-        return $this->extractLeadingImportBlocks($compiledPrefix);
-    }
-
-    protected function extractLeadingImportBlocks(string $contents): string
-    {
         $imports = [];
 
-        while (preg_match('/\A\s*<\?php(.*?)\?>/s', $contents, $matches)) {
-            if (! $this->phpBlockContainsOnlyImports($matches[1])) {
-                break;
+        // Collect `use` statements from leading PHP blocks (the compiler hoists
+        // an SFC's imports into one of these at the top of the view)...
+        while (preg_match('/\A\s*<\?php(.*?)\?>/s', $prefix, $matches)) {
+            if ($statements = Parser::extractUseStatements($matches[1])) {
+                $imports[] = "<?php\n" . $statements . "\n?>";
             }
 
-            $imports[] = trim($matches[0]);
-            $contents = substr($contents, strlen($matches[0]));
+            $prefix = substr($prefix, strlen($matches[0]));
         }
 
-        return implode("\n", $imports);
-    }
+        // Collect `@use(...)` directives as-is and let Blade compile them within the island...
+        if (preg_match_all('/(?<![@\w])@use\s*\([^)]*\)/', $prefix, $matches)) {
+            $imports = array_merge($imports, $matches[0]);
+        }
 
-    protected function phpBlockContainsOnlyImports(string $contents): bool
-    {
-        $withoutCommentsOrUses = preg_replace(
-            '/(?:\/\/[^\n]*|\/\*.*?\*\/)|\buse\s+(?:function\s+|const\s+)?[^;]+;/s',
-            '',
-            $contents,
-        );
-
-        return trim($withoutCommentsOrUses) === '';
+        return $imports ? implode("\n", $imports) : null;
     }
 
     protected function generateScopeProviderCode(string $expression): string

--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -99,7 +99,7 @@ class IslandCompiler
         $innerContent = $scopeProviderCode . $innerContent;
 
         // Carry SFC import aliases into separately compiled island views...
-        $innerContent = $this->injectUseStatementsFromCompiledView($innerContent);
+        $innerContent = $this->injectImportsFromCompiledView($innerContent);
 
         // Ensure the cached directory exists...
         File::ensureDirectoryExists(dirname($cachedPath));
@@ -112,31 +112,57 @@ class IslandCompiler
         return $output;
     }
 
-    protected function injectUseStatementsFromCompiledView(string $contents): string
+    protected function injectImportsFromCompiledView(string $contents): string
     {
-        $useStatements = $this->extractUseStatementsFromCompiledView();
+        $imports = $this->extractImportsFromCompiledView();
 
-        if (! $useStatements) {
+        if (! $imports) {
             return $contents;
         }
 
-        return "<?php\n" . $useStatements . "\n?>\n\n" . $contents;
+        return $imports . "\n\n" . $contents;
     }
 
-    protected function extractUseStatementsFromCompiledView(): string
+    protected function extractImportsFromCompiledView(): string
     {
+        return collect([
+            $this->extractPhpUseStatementsFromCompiledView(),
+            $this->extractBladeUseStatementsFromCompiledView(),
+        ])->filter()->implode("\n");
+    }
+
+    protected function extractPhpUseStatementsFromCompiledView(): string
+    {
+        // Match a leading PHP preamble so SFC `use` statements injected into the
+        // compiled view can be copied into each separately compiled island view.
         if (! preg_match('/\A\s*<\?php(.*?)\?>/s', $this->contents, $matches)) {
             return '';
         }
 
         $preamble = $matches[1];
+
+        // Match PHP `use`, `use function`, and `use const` statements while
+        // ignoring anything that looks like a use statement inside PHP comments.
         $skipComments = '(?:\/\/[^\n]*|\/\*.*?\*\/)(*SKIP)(*FAIL)';
 
         if (! preg_match_all('/' . $skipComments . '|\buse\s+(?:function\s+|const\s+)?[^;]+;/s', $preamble, $useMatches)) {
             return '';
         }
 
-        return implode("\n", array_map('trim', $useMatches[0]));
+        return "<?php\n" . implode("\n", array_map('trim', $useMatches[0])) . "\n?>";
+    }
+
+    protected function extractBladeUseStatementsFromCompiledView(): string
+    {
+        $contentsBeforeFirstIsland = explode('@island', $this->contents, 2)[0];
+
+        // Match Blade `@use(...)` directives before the first island so aliases
+        // declared by the parent view remain available in extracted island views.
+        if (! preg_match_all('/@use\s*(\((?:[^()]++|(?1))*\))/s', $contentsBeforeFirstIsland, $useMatches)) {
+            return '';
+        }
+
+        return implode("\n", array_map(fn ($statement) => '@use' . trim($statement), $useMatches[1]));
     }
 
     protected function generateScopeProviderCode(string $expression): string

--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -125,44 +125,41 @@ class IslandCompiler
 
     protected function extractImportsFromCompiledView(): string
     {
-        return collect([
-            $this->extractPhpUseStatementsFromCompiledView(),
-            $this->extractBladeUseStatementsFromCompiledView(),
-        ])->filter()->implode("\n");
+        // Compile only the leading contents so existing Blade handling for
+        // directives like `@use(...)` has already been applied before we copy
+        // import blocks into the extracted island view.
+        $compiledPrefix = app('blade.compiler')->compileString(
+            explode('@island', $this->contents, 2)[0]
+        );
+
+        return $this->extractLeadingImportBlocks($compiledPrefix);
     }
 
-    protected function extractPhpUseStatementsFromCompiledView(): string
+    protected function extractLeadingImportBlocks(string $contents): string
     {
-        // Match a leading PHP preamble so SFC `use` statements injected into the
-        // compiled view can be copied into each separately compiled island view.
-        if (! preg_match('/\A\s*<\?php(.*?)\?>/s', $this->contents, $matches)) {
-            return '';
+        $imports = [];
+
+        while (preg_match('/\A\s*<\?php(.*?)\?>/s', $contents, $matches)) {
+            if (! $this->phpBlockContainsOnlyImports($matches[1])) {
+                break;
+            }
+
+            $imports[] = trim($matches[0]);
+            $contents = substr($contents, strlen($matches[0]));
         }
 
-        $preamble = $matches[1];
-
-        // Match PHP `use`, `use function`, and `use const` statements while
-        // ignoring anything that looks like a use statement inside PHP comments.
-        $skipComments = '(?:\/\/[^\n]*|\/\*.*?\*\/)(*SKIP)(*FAIL)';
-
-        if (! preg_match_all('/' . $skipComments . '|\buse\s+(?:function\s+|const\s+)?[^;]+;/s', $preamble, $useMatches)) {
-            return '';
-        }
-
-        return "<?php\n" . implode("\n", array_map('trim', $useMatches[0])) . "\n?>";
+        return implode("\n", $imports);
     }
 
-    protected function extractBladeUseStatementsFromCompiledView(): string
+    protected function phpBlockContainsOnlyImports(string $contents): bool
     {
-        $contentsBeforeFirstIsland = explode('@island', $this->contents, 2)[0];
+        $withoutCommentsOrUses = preg_replace(
+            '/(?:\/\/[^\n]*|\/\*.*?\*\/)|\buse\s+(?:function\s+|const\s+)?[^;]+;/s',
+            '',
+            $contents,
+        );
 
-        // Match Blade `@use(...)` directives before the first island so aliases
-        // declared by the parent view remain available in extracted island views.
-        if (! preg_match_all('/@use\s*(\((?:[^()]++|(?1))*\))/s', $contentsBeforeFirstIsland, $useMatches)) {
-            return '';
-        }
-
-        return implode("\n", array_map(fn ($statement) => '@use' . trim($statement), $useMatches[1]));
+        return trim($withoutCommentsOrUses) === '';
     }
 
     protected function generateScopeProviderCode(string $expression): string

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -119,6 +119,45 @@ class UnitTest extends TestCase
         File::delete($viewPath);
     }
 
+    public function test_sfc_island_can_use_imports_from_parent_view()
+    {
+        // Create a temporary view file to simulate an SFC's compiled view...
+        $viewPath = app('livewire.compiler')->cacheManager->cacheDirectory . '/test-sfc-island-imports.blade.php';
+        File::ensureDirectoryExists(dirname($viewPath));
+        File::put($viewPath, <<<'HTML'
+        <?php
+        use Carbon\Carbon;
+        ?>
+
+        <div>
+            @island(name: 'timestamp', with: ['timestamp' => Carbon::parse('2024-01-01')->timestamp])
+                <div>year: {{ Carbon::createFromTimestamp($timestamp)->year }}</div>
+            @endisland
+        </div>
+        HTML);
+
+        try {
+            Livewire::test(new class($viewPath) extends \Livewire\Component {
+                protected static string $viewPath;
+
+                public function __construct($viewPath = null)
+                {
+                    if ($viewPath) {
+                        static::$viewPath = $viewPath;
+                    }
+                }
+
+                // SFCs use view() instead of render()...
+                protected function view($data = [])
+                {
+                    return app('view')->file(static::$viewPath, $data);
+                }
+            }, ['viewPath' => $viewPath])->assertSee('year: 2024');
+        } finally {
+            File::delete($viewPath);
+        }
+    }
+
     public function test_render_island_directives()
     {
         Livewire::test(new class extends \Livewire\Component {

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -119,6 +119,13 @@ class UnitTest extends TestCase
         File::delete($viewPath);
     }
 
+    public function test_sfc_island_can_use_imports_from_the_component_class()
+    {
+        app('livewire.finder')->addLocation(viewPath: __DIR__ . '/fixtures');
+
+        Livewire::test('sfc-island-imports')->assertSee('year: 2024');
+    }
+
     public function test_sfc_island_can_use_php_imports_from_parent_view()
     {
         // Create a temporary view file to simulate an SFC's compiled view...

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -119,7 +119,7 @@ class UnitTest extends TestCase
         File::delete($viewPath);
     }
 
-    public function test_sfc_island_can_use_imports_from_parent_view()
+    public function test_sfc_island_can_use_php_imports_from_parent_view()
     {
         // Create a temporary view file to simulate an SFC's compiled view...
         $viewPath = app('livewire.compiler')->cacheManager->cacheDirectory . '/test-sfc-island-imports.blade.php';
@@ -128,6 +128,43 @@ class UnitTest extends TestCase
         <?php
         use Carbon\Carbon;
         ?>
+
+        <div>
+            @island(name: 'timestamp', with: ['timestamp' => Carbon::parse('2024-01-01')->timestamp])
+                <div>year: {{ Carbon::createFromTimestamp($timestamp)->year }}</div>
+            @endisland
+        </div>
+        HTML);
+
+        try {
+            Livewire::test(new class($viewPath) extends \Livewire\Component {
+                protected static string $viewPath;
+
+                public function __construct($viewPath = null)
+                {
+                    if ($viewPath) {
+                        static::$viewPath = $viewPath;
+                    }
+                }
+
+                // SFCs use view() instead of render()...
+                protected function view($data = [])
+                {
+                    return app('view')->file(static::$viewPath, $data);
+                }
+            }, ['viewPath' => $viewPath])->assertSee('year: 2024');
+        } finally {
+            File::delete($viewPath);
+        }
+    }
+
+    public function test_sfc_island_can_use_blade_use_imports_from_parent_view()
+    {
+        // Create a temporary view file to simulate an SFC's compiled view...
+        $viewPath = app('livewire.compiler')->cacheManager->cacheDirectory . '/test-sfc-island-blade-use-imports.blade.php';
+        File::ensureDirectoryExists(dirname($viewPath));
+        File::put($viewPath, <<<'HTML'
+        @use('Carbon\Carbon')
 
         <div>
             @island(name: 'timestamp', with: ['timestamp' => Carbon::parse('2024-01-01')->timestamp])

--- a/src/Features/SupportIslands/fixtures/sfc-island-imports.blade.php
+++ b/src/Features/SupportIslands/fixtures/sfc-island-imports.blade.php
@@ -1,0 +1,17 @@
+<?php
+
+use Carbon\Carbon;
+
+new class extends Livewire\Component {
+    public function with()
+    {
+        return ['timestamp' => Carbon::parse('2024-01-01')->timestamp];
+    }
+};
+?>
+
+<div>
+    @island
+        <span>year: {{ Carbon::createFromTimestamp($timestamp)->year }}</span>
+    @endisland
+</div>


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes. This fixes #10278. The issue already has a detailed reproduction, and Josh mentioned that a PR with a possible solution would be welcome.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes. The branch is named `fix-sfc-island`.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No. This only changes SFC island compilation so imported PHP aliases are available inside separately compiled island views.

4️⃣ Does it include tests? (Required)

Yes. I added a regression test for an SFC island using an imported `Carbon` alias.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

SFC views can include PHP imports like:

```php
use Carbon\Carbon;
```

The compiled parent SFC view can resolve that alias correctly, but `@island` blocks are extracted into separate compiled Blade files. Those extracted island views previously did not receive the parent view's PHP imports, so using the same alias inside an island failed with:

```text
Class "Carbon" not found
```

For example:

```blade
@island(name: 'timestamp', with: ['timestamp' => Carbon::parse('2024-01-01')->timestamp])
    <div>{{ Carbon::createFromTimestamp($timestamp)->year }}</div>
@endisland
```

This PR carries PHP `use` statements from the compiled SFC view into each separately compiled island view, allowing imported aliases to work in both the island `with:` expression and island body.

Tests:

```bash
composer test:unit -- --filter="sfc_island_can_use_imports_from_parent_view"
composer test:unit -- --filter="SupportIslands"
```

Thanks for contributing! 🙌