### PR TITLE
[4.x] Fix duplicate x-if output after browser history navigation

### DIFF
--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -174,6 +174,8 @@ export default function (Alpine) {
                 onSwap: (callback) => swapCallbacks.push(callback)
             })
 
+            cleanupAlpineElementsOnThePageThatArentInsideAPersistedElement()
+
             // Update the snapshot (not the history state, as the history state has
             // already changed to the new page due to the popstate event).
             // This ensures the current HTML has the latest snapshot.

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -101,6 +101,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             HTML));
 
             Route::get('/page-with-alpine-for-loop', PageWithAlpineForLoop::class);
+            Route::get('/page-with-conditional-alpine-button', PageWithConditionalAlpineButton::class);
             Route::get('/page-with-redirect-to-internal-which-has-external-link', PageWithRedirectToInternalWhichHasExternalLinkPage::class)->middleware('web');
             Route::get('/page-with-redirect-to-external-page', PageWithRedirectToExternalPage::class)->middleware('web');
             Route::get('/script-component', ScriptComponent::class);
@@ -797,6 +798,27 @@ class BrowserTest extends \Tests\BrowserTestCase
                 ->assertSeeIn('@text', 'a,b,c')
                 ->assertScript('document.getElementById(\'alpine-for-loop\').querySelectorAll(\'p\').length', 3)
                 ->assertConsoleLogMissingWarning('value is not defined')
+            ;
+        });
+    }
+
+    public function test_browser_history_navigation_does_not_recapture_alpine_if_output()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/page-with-conditional-alpine-button')
+                ->waitFor('@add-button')
+                ->assertCount('@add-button', 1)
+                ->waitForNavigate()->click('@link.to.second')
+                ->assertSee('On second')
+                ->waitForNavigate()->back()
+                ->waitFor('@add-button')
+                ->assertCount('@add-button', 1)
+                ->waitForNavigate()->forward()
+                ->assertSee('On second')
+                ->waitForNavigate()->back()
+                ->waitFor('@add-button')
+                ->assertCount('@add-button', 1)
             ;
         });
     }
@@ -1763,6 +1785,24 @@ class PageWithAlpineForLoop extends Component
             <div id="alpine-for-loop">
                 <template x-for="(value, index) in items" :key="index">
                     <p x-text="value"></p>
+                </template>
+            </div>
+        </div>
+        HTML;
+    }
+}
+
+class PageWithConditionalAlpineButton extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        <div x-data="{ canAdd: true }">
+            <a href="/second" wire:navigate dusk="link.to.second">Go to second page</a>
+
+            <div>
+                <template x-if="canAdd">
+                    <button type="button" dusk="add-button">Add passkey</button>
                 </template>
             </div>
         </div>


### PR DESCRIPTION
# The Scenario

If we have a page with content rendered by Alpine's `x-if`, that content can be duplicated after navigating through browser history with `wire:navigate`.

For example, if we visit this page, navigate to another page using `wire:navigate`, then use the browser back and forward buttons, the `x-if` content can be rendered more than once.

<img width="800" height="649" alt="CleanShot 2026-06-09 at 17 38 37" src="https://github.com/user-attachments/assets/c6f5d886-f823-4a37-b15f-536d52538762" />

```php
use Livewire\Attributes\Layout;
use Livewire\Component;

new #[Layout('components.layouts.app')] class extends Component
{
    public function render()
    {
        return <<<'HTML'
        <div x-data="{ canAdd: true }">
            <a href="/second" wire:navigate>Go to second page</a>

            <div>
                <template x-if="canAdd">
                    <button type="button">Conditional item</button>
                </template>
            </div>
        </div>
        HTML;
    }
};
```

# The Problem

When Livewire navigates away from a page using `wire:navigate`, it cleans up Alpine-rendered template output before storing the outgoing page HTML for browser history restores.

However, the browser back/forward path also updates the current page in Livewire's snapshot cache, and that path was missing the same cleanup step.

This means a restored page could be cached again while its DOM contained both the original `<template x-if>` and the button Alpine had rendered from it. When that cached page was restored again, Alpine initialised the template and rendered another button.

# The Solution

This reuses the existing Alpine cleanup before recapturing the current page into the browser-history snapshot cache.

<img width="800" height="649" alt="CleanShot 2026-06-09 at 17 39 50" src="https://github.com/user-attachments/assets/e6f4496e-5e3c-4dab-b2ed-c86fe607bad5" />

Fixes #10335
Fixes https://github.com/laravel/maestro/issues/151