### PR TITLE
[4.x] Restore existing attributes after `wire:loading.attr`

### DIFF
--- a/js/directives/shared.js
+++ b/js/directives/shared.js
@@ -11,11 +11,21 @@ export function toggleBooleanStateDirective(el, directive, isTruthy, cachedDispl
             el.classList.remove(...classes)
         }
     } else if (directive.modifiers.includes('attr')) {
+        let attribute = directive.expression
+        let hadAttribute = el.hasAttribute(attribute)
+        let value = el.getAttribute(attribute)
+
+        let restore = hadAttribute
+            ? () => el.setAttribute(attribute, value)
+            : undefined
+
         if (isTruthy) {
-            el.setAttribute(directive.expression, true)
+            el.setAttribute(attribute, true)
         } else {
-            el.removeAttribute(directive.expression)
+            el.removeAttribute(attribute)
         }
+
+        return restore
     } else {
         let cache = cachedDisplay ?? window
             .getComputedStyle(el, null)

--- a/js/directives/shared.js
+++ b/js/directives/shared.js
@@ -15,9 +15,10 @@ export function toggleBooleanStateDirective(el, directive, isTruthy, cachedDispl
         let hadAttribute = el.hasAttribute(attribute)
         let value = el.getAttribute(attribute)
 
+        // A callback that puts the attribute back exactly as it was before loading...
         let restore = hadAttribute
             ? () => el.setAttribute(attribute, value)
-            : undefined
+            : () => el.removeAttribute(attribute)
 
         if (isTruthy) {
             el.setAttribute(attribute, true)

--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -9,14 +9,16 @@ directive('loading', ({ el, directive, component, cleanup }) => {
 
     let [delay, abortDelay] = applyDelay(directive)
 
+    let restoreLoadingState
+
     let cleanupA = whenTargetsArePartOfRequest(component, el, targets, inverted, [
-        () => delay(() => toggleBooleanStateDirective(el, directive, true)),
-        () => abortDelay(() => toggleBooleanStateDirective(el, directive, false)),
+        () => delay(() => restoreLoadingState = toggleBooleanStateDirective(el, directive, true)),
+        () => abortDelay(() => restoreLoadingState ? restoreLoadingState() : toggleBooleanStateDirective(el, directive, false)),
     ])
 
     let cleanupB = whenTargetsArePartOfFileUpload(component, targets, [
-        () => delay(() => toggleBooleanStateDirective(el, directive, true)),
-        () => abortDelay(() => toggleBooleanStateDirective(el, directive, false)),
+        () => delay(() => restoreLoadingState = toggleBooleanStateDirective(el, directive, true)),
+        () => abortDelay(() => restoreLoadingState ? restoreLoadingState() : toggleBooleanStateDirective(el, directive, false)),
     ])
 
     cleanup(() => {

--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -24,6 +24,10 @@ directive('loading', ({ el, directive, component, cleanup }) => {
     }
 
     function endLoading() {
+        // Guard against unbalanced end triggers, otherwise a stray one would
+        // drive the count negative and stop the directive ever applying again...
+        if (activeLoadingCount === 0) return
+
         activeLoadingCount--
 
         // Only restore/remove once every overlapping loading trigger has finished...
@@ -71,23 +75,31 @@ function applyDelay(directive) {
         }
     })
 
-    let timeout
-    let started = false
+    // Each delay cycle gets its own state, otherwise overlapping loading
+    // cycles would share one timeout and swallow each other's end callback...
+    let cycles = []
 
     return [
         (callback) => { // Initiate delay...
-            timeout = setTimeout(() => {
+            let cycle = { started: false }
+
+            cycle.timeout = setTimeout(() => {
                 callback()
 
-                started = true
+                cycle.started = true
             }, duration)
+
+            cycles.push(cycle)
         },
         async (callback) => { // Execute or abort...
-            if (started) {
+            let cycle = cycles.shift()
+
+            if (! cycle) return
+
+            if (cycle.started) {
                 await callback()
-                started = false
             } else {
-                clearTimeout(timeout)
+                clearTimeout(cycle.timeout)
             }
         },
     ]

--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -9,16 +9,37 @@ directive('loading', ({ el, directive, component, cleanup }) => {
 
     let [delay, abortDelay] = applyDelay(directive)
 
+    let activeLoadingCount = 0
     let restoreLoadingState
 
+    function startLoading() {
+        // Only capture the pre-loading attribute state on the first of any
+        // overlapping loading triggers, otherwise we'd capture the state
+        // that a previous overlapping trigger already set...
+        if (activeLoadingCount === 0) {
+            restoreLoadingState = toggleBooleanStateDirective(el, directive, true)
+        }
+
+        activeLoadingCount++
+    }
+
+    function endLoading() {
+        activeLoadingCount--
+
+        // Only restore/remove once every overlapping loading trigger has finished...
+        if (activeLoadingCount === 0) {
+            restoreLoadingState ? restoreLoadingState() : toggleBooleanStateDirective(el, directive, false)
+        }
+    }
+
     let cleanupA = whenTargetsArePartOfRequest(component, el, targets, inverted, [
-        () => delay(() => restoreLoadingState = toggleBooleanStateDirective(el, directive, true)),
-        () => abortDelay(() => restoreLoadingState ? restoreLoadingState() : toggleBooleanStateDirective(el, directive, false)),
+        () => delay(startLoading),
+        () => abortDelay(endLoading),
     ])
 
     let cleanupB = whenTargetsArePartOfFileUpload(component, targets, [
-        () => delay(() => restoreLoadingState = toggleBooleanStateDirective(el, directive, true)),
-        () => abortDelay(() => restoreLoadingState ? restoreLoadingState() : toggleBooleanStateDirective(el, directive, false)),
+        () => delay(startLoading),
+        () => abortDelay(endLoading),
     ])
 
     cleanup(() => {

--- a/src/Features/SupportWireLoading/BrowserTest.php
+++ b/src/Features/SupportWireLoading/BrowserTest.php
@@ -104,6 +104,41 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    function test_wire_loading_attr_restores_pre_loading_attribute_state_after_renderless_action()
+    {
+        Livewire::visit(new class extends Component {
+            public bool $disabled = true;
+
+            #[\Livewire\Attributes\Renderless]
+            public function renderlessAction() {
+                usleep(250000);
+            }
+
+            public function render() {
+                return <<<'HTML'
+                    <div>
+                        <button type="button" wire:click="renderlessAction" dusk="renderless">
+                            Renderless action
+                        </button>
+
+                        <button
+                            type="button"
+                            x-bind:disabled="$wire.$get('disabled')"
+                            wire:loading.attr="disabled"
+                            dusk="some-action">
+                            Some action
+                        </button>
+                    </div>
+                HTML;
+            }
+        })
+        ->waitUntil('document.querySelector(\'[dusk="some-action"]\').disabled === true')
+        ->assertScript('document.querySelector(\'[dusk="some-action"]\').disabled', true)
+        ->waitForLivewire()->click('@renderless')
+        ->assertScript('document.querySelector(\'[dusk="some-action"]\').disabled', true)
+        ;
+    }
+
     function test_wire_loading_attr_doesnt_conflict_with_exist_one()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportWireLoading/BrowserTest.php
+++ b/src/Features/SupportWireLoading/BrowserTest.php
@@ -176,6 +176,55 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->click('@start')
         ->assertAttribute('@target', 'disabled', 'true')
         ->click('@finish')
+        ->assertAttribute('@target', 'disabled', 'true')
+        ->click('@finish')
+        ->assertAttributeMissing('@target', 'disabled')
+        ;
+    }
+
+    function test_wire_loading_delay_attr_still_works_after_overlapping_loading_events()
+    {
+        Livewire::visit(new class extends Component {
+            public function render() {
+                return <<<'HTML'
+                    <div>
+                        <button
+                            type="button"
+                            x-on:click="window.dispatchEvent(new CustomEvent('livewire-upload-start', { detail: { id: $wire.$id, property: 'file' } }))"
+                            dusk="start">
+                            Start loading
+                        </button>
+
+                        <button
+                            type="button"
+                            x-on:click="window.dispatchEvent(new CustomEvent('livewire-upload-finish', { detail: { id: $wire.$id, property: 'file' } }))"
+                            dusk="finish">
+                            Finish loading
+                        </button>
+
+                        <button
+                            type="button"
+                            wire:loading.delay.shortest.attr="disabled"
+                            dusk="target">
+                            Target
+                        </button>
+                    </div>
+                HTML;
+            }
+        })
+        ->waitForLivewireToLoad()
+        ->assertAttributeMissing('@target', 'disabled')
+        ->click('@start')
+        ->click('@start')
+        ->pause(150) // Wait for both delay timeouts to fire...
+        ->assertAttribute('@target', 'disabled', 'true')
+        ->click('@finish')
+        ->click('@finish')
+        ->assertAttributeMissing('@target', 'disabled')
+        // A fresh loading cycle should still apply the attribute...
+        ->click('@start')
+        ->pause(150)
+        ->assertAttribute('@target', 'disabled', 'true')
         ->click('@finish')
         ->assertAttributeMissing('@target', 'disabled')
         ;

--- a/src/Features/SupportWireLoading/BrowserTest.php
+++ b/src/Features/SupportWireLoading/BrowserTest.php
@@ -139,6 +139,48 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    function test_wire_loading_attr_is_removed_after_overlapping_loading_events()
+    {
+        Livewire::visit(new class extends Component {
+            public function render() {
+                return <<<'HTML'
+                    <div>
+                        <button
+                            type="button"
+                            x-on:click="window.dispatchEvent(new CustomEvent('livewire-upload-start', { detail: { id: $wire.$id, property: 'file' } }))"
+                            dusk="start">
+                            Start loading
+                        </button>
+
+                        <button
+                            type="button"
+                            x-on:click="window.dispatchEvent(new CustomEvent('livewire-upload-finish', { detail: { id: $wire.$id, property: 'file' } }))"
+                            dusk="finish">
+                            Finish loading
+                        </button>
+
+                        <button
+                            type="button"
+                            wire:loading.attr="disabled"
+                            dusk="target">
+                            Target
+                        </button>
+                    </div>
+                HTML;
+            }
+        })
+        ->waitForLivewireToLoad()
+        ->assertAttributeMissing('@target', 'disabled')
+        ->click('@start')
+        ->assertAttribute('@target', 'disabled', 'true')
+        ->click('@start')
+        ->assertAttribute('@target', 'disabled', 'true')
+        ->click('@finish')
+        ->click('@finish')
+        ->assertAttributeMissing('@target', 'disabled')
+        ;
+    }
+
     function test_wire_loading_attr_doesnt_conflict_with_exist_one()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
# The Scenario

If an element already has an attribute set, such as by Alpine, and that same attribute is changed by `wire:loading.attr`, the attribute can be removed when loading finishes.

In the browser this can leave a button enabled even though the Alpine/Livewire state still says it should be disabled. Renderless actions make this visible because there is no morph afterwards to re-apply the attribute.

<img width="794" height="800" alt="CleanShot 2026-06-09 at 21 34 49" src="https://github.com/user-attachments/assets/7465144a-e636-48c6-8d69-63eb893ab965" />

```blade
<button wire:click="save">Save</button>

<button
    x-bind:disabled="$wire.$get('disabled')"
    wire:loading.attr="disabled"
>
    Submit
</button>
```

# The Problem

`wire:loading.attr` currently removes the attribute when loading ends. That is correct when Livewire added the attribute temporarily, but incorrect when the attribute already existed before loading started.

A later morph or Alpine effect can sometimes hide the issue by re-applying the attribute. Renderless actions expose it because they do not trigger a morph, so the attribute remains removed.

# Potential solutions

- **Re-run Alpine effects after renderless responses** (#10334) — fixes the reported case but only covers `x-bind`, relies on a private Alpine API, and misses server-rendered attributes.
- **Skip applying the attribute when it already exists** — avoids clobbering, but then loading state can't override the attribute's value during the request (e.g. restore an original `aria-*` value afterwards).
- **Capture the pre-loading state and restore it when loading ends** — general, and matches the save/restore precedent already used for `display` in `toggleBooleanStateDirective`. Chosen.

# The Solution

`toggleBooleanStateDirective` now captures the attribute state before applying `wire:loading.attr` and returns a restore callback that puts the attribute back exactly as it was — re-setting the original value if it existed, removing it if it didn't (which also fixes `.attr.remove` re-adding a never-present attribute with the value `"true"`).

`wire-loading` tracks overlapping loading cycles with a counter so that:

- the pre-loading state is only captured on the first of any overlapping triggers (otherwise a later trigger would capture the state a previous one already set and the attribute would never unset), and
- the state is only restored once every overlapping trigger has finished (previously the first cycle to finish removed the attribute while others were still loading).

Because the counter requires every start to be matched by an end, `applyDelay` now keeps per-cycle `timeout`/`started` state. Previously all cycles shared one closure, so with `.delay` two overlapping cycles could swallow one end callback — harmless before (the next cycle self-healed) but permanent with a counter (it would wedge above zero and the directive would stop applying entirely). A guard against unbalanced end triggers (e.g. a stray `livewire-upload-finish`) protects the counter in the other direction.

<img width="794" height="800" alt="CleanShot 2026-06-09 at 21 33 22" src="https://github.com/user-attachments/assets/ad121d37-181e-40f2-ba01-0edeb607aa41" />

Fixes #10332

---

Note: `wire:loading.class` still has the sibling issue (a pre-existing class is removed when loading ends), as do `wire:dirty.attr`/`wire:offline.attr` which share `toggleBooleanStateDirective` but don't consume the restore callback. Left for a follow-up to keep this scoped.
