### PR TITLE
[4.x] Honor scoped route bindings for `mount()` method injection

### DIFF
--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -27,10 +27,43 @@ class ImplicitRouteBinding
 
     public function resolveAllParameters(Route $route, Component $component)
     {
-        $props = $this->resolveComponentProps($route, $component);
-        $params = $this->resolveMountParameters($route, $component);
+        // Resolve every bindable route parameter in URI order first (like Laravel's
+        // own implicit binding) so that scoped child bindings always see their
+        // parent as an already-resolved model, regardless of whether the parent
+        // is a public property or a mount() parameter...
+        $this->resolveRouteParametersInOrder($route, $component);
 
-        return $props->merge($params)->all();
+        $params = $this->resolveMountParameters($route, $component);
+        $props = $this->resolveComponentProps($route, $component);
+
+        return $params->merge($props)->all();
+    }
+
+    protected function resolveRouteParametersInOrder(Route $route, Component $component)
+    {
+        $types = $this->getPublicPropertyTypes($component)
+            ->merge($this->getMountParameterTypes($component)->filter())
+            ->filter(function ($className) {
+                return $className && (is_subclass_of($className, UrlRoutable::class) || is_subclass_of($className, BackedEnum::class));
+            });
+
+        foreach ($route->parametersWithoutNulls() as $name => $value) {
+            if (! $types->has($name)) continue;
+
+            $route->setParameter($name, $this->resolveParameter($route, $name, $types->get($name)));
+        }
+    }
+
+    protected function getMountParameterTypes(Component $component)
+    {
+        if (! method_exists($component, 'mount')) {
+            return new Collection();
+        }
+
+        return collect((new ReflectionMethod($component, 'mount'))->getParameters())
+            ->mapWithKeys(function ($parameter) {
+                return [$parameter->getName() => Reflector::getParameterClassName($parameter)];
+            });
     }
 
     public function resolveMountParameters(Route $route, Component $component)

--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -27,10 +27,10 @@ class ImplicitRouteBinding
 
     public function resolveAllParameters(Route $route, Component $component)
     {
-        $params = $this->resolveMountParameters($route, $component);
         $props = $this->resolveComponentProps($route, $component);
+        $params = $this->resolveMountParameters($route, $component);
 
-        return $params->merge($props)->all();
+        return $props->merge($params)->all();
     }
 
     public function resolveMountParameters(Route $route, Component $component)

--- a/src/Drawer/Tests/ImplicitRouteBindingUnitTest.php
+++ b/src/Drawer/Tests/ImplicitRouteBindingUnitTest.php
@@ -135,6 +135,15 @@ class ImplicitRouteBindingUnitTest extends \Tests\TestCase
             ->assertSeeText('Store ID: 2')
             ->assertSeeText('Book ID: 2');
     }
+
+    public function test_scope_binding_is_honored_when_parent_is_mount_param_and_child_is_prop()
+    {
+        Route::get('/scoped-prop-child/{store:name}/{book:name}', ComponentWithMountParentAndPropChild::class)->scopeBindings();
+
+        $this->get('/scoped-prop-child/Second/Foo')
+            ->assertSeeText('Store ID: 2')
+            ->assertSeeText('Book ID: 2');
+    }
 }
 
 class PropBoundModel extends Model
@@ -441,6 +450,28 @@ class ComponentWithScopeBindingsReversedProps extends Component
         return <<<'BLADE'
             <div>
                 Store ID: {{ $store->id }}
+                Book ID: {{ $book->id }}
+            </div>
+        BLADE;
+    }
+}
+
+class ComponentWithMountParentAndPropChild extends Component
+{
+    public Book $book;
+
+    public $storeId;
+
+    public function mount(Store $store)
+    {
+        $this->storeId = $store->id;
+    }
+
+    public function render()
+    {
+        return <<<'BLADE'
+            <div>
+                Store ID: {{ $storeId }}
                 Book ID: {{ $book->id }}
             </div>
         BLADE;

--- a/src/Drawer/Tests/ImplicitRouteBindingUnitTest.php
+++ b/src/Drawer/Tests/ImplicitRouteBindingUnitTest.php
@@ -102,6 +102,39 @@ class ImplicitRouteBindingUnitTest extends \Tests\TestCase
         $this->get('/foo/1')
             ->assertSeeText('prop:John');
     }
+
+    public function test_mount_param_honors_scope_binding()
+    {
+        Route::get('/scoped-mount/{store:name}/{book:name}', ComponentWithScopedMountBinding::class)->scopeBindings();
+
+        $this->get('/scoped-mount/First/Foo')
+            ->assertSeeText('Book ID: 1');
+
+        $this->get('/scoped-mount/Second/Foo')
+            ->assertSeeText('Book ID: 2');
+    }
+
+    public function test_mount_param_and_prop_resolve_the_same_scoped_model()
+    {
+        Route::get('/scoped-mount-and-prop/{store:name}/{book:name}', ComponentWithScopedMountBindingAndProp::class)->scopeBindings();
+
+        $this->get('/scoped-mount-and-prop/Second/Foo')
+            ->assertSeeText('Mount Book ID: 2')
+            ->assertSeeText('Prop Book ID: 2');
+    }
+
+    public function test_scope_binding_is_honored_when_parent_and_child_are_both_mount_params()
+    {
+        Route::get('/scoped-mount-only/{store:name}/{book:name}', ComponentWithParentAndChildMountBindings::class)->scopeBindings();
+
+        $this->get('/scoped-mount-only/First/Foo')
+            ->assertSeeText('Store ID: 1')
+            ->assertSeeText('Book ID: 1');
+
+        $this->get('/scoped-mount-only/Second/Foo')
+            ->assertSeeText('Store ID: 2')
+            ->assertSeeText('Book ID: 2');
+    }
 }
 
 class PropBoundModel extends Model
@@ -332,6 +365,70 @@ class Book extends Model
             'name' => 'Foo',
         ],
     ];
+}
+
+class ComponentWithScopedMountBinding extends Component
+{
+    public Store $store;
+    public $bookId;
+
+    public function mount(Book $book)
+    {
+        $this->bookId = $book->id;
+    }
+
+    public function render()
+    {
+        return <<<'BLADE'
+            <div>
+                Book ID: {{ $bookId }}
+            </div>
+        BLADE;
+    }
+}
+
+class ComponentWithScopedMountBindingAndProp extends Component
+{
+    public Store $store;
+    public Book $book;
+    public $mountBookId;
+
+    public function mount(Book $book)
+    {
+        $this->mountBookId = $book->id;
+    }
+
+    public function render()
+    {
+        return <<<'BLADE'
+            <div>
+                Mount Book ID: {{ $mountBookId }}
+                Prop Book ID: {{ $book->id }}
+            </div>
+        BLADE;
+    }
+}
+
+class ComponentWithParentAndChildMountBindings extends Component
+{
+    public $storeId;
+    public $bookId;
+
+    public function mount(Store $store, Book $book)
+    {
+        $this->storeId = $store->id;
+        $this->bookId = $book->id;
+    }
+
+    public function render()
+    {
+        return <<<'BLADE'
+            <div>
+                Store ID: {{ $storeId }}
+                Book ID: {{ $bookId }}
+            </div>
+        BLADE;
+    }
 }
 
 class ComponentWithScopeBindingsReversedProps extends Component


### PR DESCRIPTION
## The Scenario
Consider a full page Livewire component behind scoped route bindings, where a child route key is not globally unique. Here's a common shape:

```php
Route::get('{event}/channels/{channel}', Channel::class)
    ->name('channels.show')
    ->scopeBindings();
```

`Channel` uses slug as its route key, and slugs are only unique within an event (two events can have a channel named "General" with a slug `general`). The `scopeBindings()` call tells laravel to resolve `{channel}` through its parent `{event}` relationship. The component injects the child in `mount()`:

```php
public Event $event;
public Channel $channel;

public function mount(Channel $channel): void
{
    $this->authorize('view', $channel);
}
```

## The Problem
The `Channel` injected into `mount()` was resolved with a global, unscoped lookup, so it could be the channel belonging to a different event (the first that matches that slug). Authorization and any logic afterwards will run against the wrong record, causing 403 or 404s.

The cause lives in `ImplicitRouteBinding::resolveAllParameters()`, which resolved `mount()` parameters before public properties. Resolving mount parameters runs Laravel implicit binding over only the `mount` method signature (`channel`, in this case). At this moment the parent `event` parameter is still a raw slug string rather than a resolved model, so Laravel scoped branch is skipped and it falls back to an unscoped `resolveRouteBinding`. The result is that when a model is both a typed public property and a `mount` parameter, both resolved to the unscoped record.

## The Solution
Resolve public properties before `mount` parameters. Properties resolve in route order, so the parent `event` becomes a resolved model and is seeded into the route via `setParameter` before the child resolves. By the time `mount` parameter resoulution runs, the parent is a `UrlRoutable` and laravel applies the scoped lookup.