### PR TITLE
[4.x] Fix `writeToHistory()` mutating the current history state

### DIFF
--- a/js/plugins/history/coordinator.js
+++ b/js/plugins/history/coordinator.js
@@ -53,7 +53,7 @@ class HistoryCoordinator {
     }
 
     writeToHistory(method, url, callback) {
-        let state = window.history.state || {}
+        let state = window.history.state ? { ...window.history.state } : {}
         if (!state.alpine) state.alpine = {}
 
         // Process the state using the callback...

--- a/js/plugins/history/coordinator.js
+++ b/js/plugins/history/coordinator.js
@@ -53,7 +53,8 @@ class HistoryCoordinator {
     }
 
     writeToHistory(method, url, callback) {
-        let state = window.history.state ? { ...window.history.state } : {}
+        let state = window.history.state || {}
+        // let state = window.history.state ? { ...window.history.state } : {}
         if (!state.alpine) state.alpine = {}
 
         // Process the state using the callback...

--- a/js/plugins/history/coordinator.js
+++ b/js/plugins/history/coordinator.js
@@ -53,8 +53,7 @@ class HistoryCoordinator {
     }
 
     writeToHistory(method, url, callback) {
-        let state = window.history.state || {}
-        // let state = window.history.state ? { ...window.history.state } : {}
+        let state = window.history.state ? { ...window.history.state } : {}
         if (!state.alpine) state.alpine = {}
 
         // Process the state using the callback...

--- a/js/plugins/history/coordinator.spec.js
+++ b/js/plugins/history/coordinator.spec.js
@@ -1,7 +1,13 @@
-import { describe, it, vi, expect } from 'vitest'
+import { afterEach, describe, it, vi, expect } from 'vitest'
 import coordinator from './coordinator'
 
 describe('History Coordinator', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+
+        window.history.replaceState(null, '', '/')
+    })
+
     it('should replace state', async () => {
         let replaceSpy = vi.spyOn(window.history, 'replaceState')
 
@@ -57,6 +63,27 @@ describe('History Coordinator', () => {
         )
 
         expect(window.history.state).toEqual({ alpine: { foo: 'baz' }, other: 'bob' })
+    })
+
+    it('should not mutate the current history state before calling replaceState', async () => {
+        window.history.replaceState({ alpine: { foo: 'bar' } }, '', '/home')
+
+        let originalReplaceState = window.history.replaceState
+        let stateWhenReplaceStateWasCalled
+
+        let replaceSpy = vi.spyOn(window.history, 'replaceState').mockImplementation((state, unused, url) => {
+            stateWhenReplaceStateWasCalled = window.history.state
+
+            originalReplaceState.call(window.history, state, unused, url)
+        })
+
+        coordinator.replaceState('/home', { foo: 'baz' })
+
+        await new Promise(queueMicrotask)
+
+        expect(replaceSpy).toHaveBeenCalledOnce()
+        expect(stateWhenReplaceStateWasCalled).toEqual({ alpine: { foo: 'bar' } })
+        expect(window.history.state).toEqual({ alpine: { foo: 'baz' } })
     })
 
     it('should push state', async () => {
@@ -126,6 +153,9 @@ describe('History Coordinator', () => {
     it('can have a custom error handler', async () => {
         let error = new Error('test')
         let url = '/home'
+        window.history.replaceState({ alpine: { foo: 'before' } }, '', url)
+        let consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
         vi.spyOn(window.history, 'replaceState').mockImplementation(() => {
           throw error
         })
@@ -140,7 +170,8 @@ describe('History Coordinator', () => {
 
         expect(errorHandler).toHaveBeenCalledOnce()
         expect(errorHandler).toHaveBeenCalledWith(error, url)
+        expect(consoleErrorSpy).toHaveBeenCalledWith(error)
 
-        expect(window.history.state).toEqual({ alpine: { foo: 'bar' } })
+        expect(window.history.state).toEqual({ alpine: { foo: 'before' } })
     })
 })

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -37,6 +37,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             Livewire::component('second-tracked-asset-page', SecondTrackedAssetPage::class);
             Livewire::component('second-remote-asset', SecondRemoteAsset::class);
             Livewire::component('first-scroll-page', FirstScrollPage::class);
+            Livewire::component('first-scroll-page-with-filament-replace-state-wrapper', FirstScrollPageWithFilamentReplaceStateWrapper::class);
             Livewire::component('second-scroll-page', SecondScrollPage::class);
             Livewire::component('first-click-handler-page', FirstClickHandlerPage::class);
             Livewire::component('second-click-handler-page', SecondClickHandlerPage::class);
@@ -74,6 +75,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             Route::get('/second-asset', SecondAssetPage::class)->middleware('web');
             Route::get('/third-asset', ThirdAssetPage::class)->middleware('web');
             Route::get('/first-scroll', FirstScrollPage::class)->middleware('web');
+            Route::get('/first-scroll-with-filament-replace-state-wrapper', FirstScrollPageWithFilamentReplaceStateWrapper::class)->middleware('web');
             Route::get('/second-scroll', SecondScrollPage::class)->middleware('web');
             Route::get('/first-click-handler', FirstClickHandlerPage::class)->middleware('web');
             Route::get('/second-click-handler', SecondClickHandlerPage::class)->middleware('web');
@@ -593,6 +595,36 @@ class BrowserTest extends \Tests\BrowserTestCase
                 ->forward()
                 ->waitForText('On second')
                 ->assertInViewPort('@second-target')
+            ;
+        });
+    }
+
+    /**
+     * Filament wraps history.replaceState() and skips calls when the incoming state
+     * already matches window.history.state. Livewire needs to avoid mutating the
+     * current state before calling replaceState() so Filament still writes the
+     * navigate snapshot used to restore scroll on back navigation.
+     *
+     * @see https://github.com/filamentphp/filament/issues/20017
+     */
+    public function test_navigate_back_preserves_scroll_when_filament_wraps_replace_state()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/first-scroll-with-filament-replace-state-wrapper')
+                ->assertVisible('@first-target')
+                ->assertNotInViewPort('@first-target')
+                ->scrollTo('@first-target')
+                ->assertInViewPort('@first-target')
+
+                ->waitForNavigate()->click('@link.to.second')
+                ->waitForText('On second')
+                ->assertNotInViewPort('@second-target')
+                ->scrollTo('@second-target')
+
+                ->waitForNavigate()->back()
+                ->waitForText('On first')
+                ->assertInViewPort('@first-target')
             ;
         });
     }
@@ -1723,6 +1755,52 @@ class FirstScrollPage extends Component
 
             <div style="height: 100vh;">spacer</div>
         </div>
+        HTML;
+    }
+}
+
+class FirstScrollPageWithFilamentReplaceStateWrapper extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <div>On first</div>
+
+            <div style="height: 100vh;">spacer</div>
+
+            <div dusk="first-target">below the fold</div>
+
+            <a href="/second-scroll" wire:navigate.hover dusk="link.to.second">Go to second page</a>
+
+            <div style="height: 100vh;">spacer</div>
+        </div>
+
+        @push('scripts')
+            <script>
+                if (! window.livewireReplaceStateWrapperInstalled) {
+                    window.livewireReplaceStateWrapperInstalled = true
+                    window.livewireReplaceStateSkipped = false
+
+                    let originalReplaceState = window.history.replaceState.bind(window.history)
+
+                    originalReplaceState({ library: { scroll: true } }, '', window.location.href)
+
+                    window.history.replaceState = function (state, title, url) {
+                        if (
+                            window.history.state !== null &&
+                            JSON.stringify(window.history.state) === JSON.stringify(state)
+                        ) {
+                            window.livewireReplaceStateSkipped = true
+
+                            return
+                        }
+
+                        return originalReplaceState(state, title, url)
+                    }
+                }
+            </script>
+        @endpush
         HTML;
     }
 }

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -1239,47 +1239,6 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
-    public function test_can_update_query_string_when_page_script_wraps_replace_state()
-    {
-        Livewire::visit([
-            new class extends Component
-            {
-                #[Url]
-                public string $search = '';
-
-                public function render()
-                {
-                    return <<<'HTML'
-                    <div>
-                        <input dusk="search" wire:model.live="search" />
-                    </div>
-
-                    @push('scripts')
-                        <script>
-                            let originalReplaceState = window.history.replaceState.bind(window.history)
-
-                            window.history.replaceState = function (state, title, url) {
-                                if (
-                                    window.history.state !== null &&
-                                    JSON.stringify(window.history.state) === JSON.stringify(state)
-                                ) {
-                                    return
-                                }
-
-                                return originalReplaceState(state, title, url)
-                            }
-                        </script>
-                    @endpush
-                    HTML;
-                }
-            },
-        ])
-            ->waitForLivewireToLoad()
-            ->assertQueryStringMissing('search')
-            ->waitForLivewire()->type('@search', 'bob')
-            ->waitForQueryString('search', 'bob');
-    }
-
     public function test_push_mode_syncs_url_on_initial_load_when_value_restored_from_session()
     {
         $this->beforeServingApplication(function () {

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -1209,6 +1209,47 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_can_update_query_string_when_page_script_wraps_replace_state()
+    {
+        Livewire::visit([
+            new class extends Component
+            {
+                #[Url]
+                public string $search = '';
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <input dusk="search" wire:model.live="search" />
+                    </div>
+
+                    @push('scripts')
+                        <script>
+                            let originalReplaceState = window.history.replaceState.bind(window.history)
+
+                            window.history.replaceState = function (state, title, url) {
+                                if (
+                                    window.history.state !== null &&
+                                    JSON.stringify(window.history.state) === JSON.stringify(state)
+                                ) {
+                                    return
+                                }
+
+                                return originalReplaceState(state, title, url)
+                            }
+                        </script>
+                    @endpush
+                    HTML;
+                }
+            },
+        ])
+            ->waitForLivewireToLoad()
+            ->assertScript('return window.location.search', '')
+            ->waitForLivewire()->type('@search', 'bob')
+            ->waitForScript('window.location.search', '?search=bob');
+    }
+
     public function test_push_mode_syncs_url_on_initial_load_when_value_restored_from_session()
     {
         $this->beforeServingApplication(function () {

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -1245,9 +1245,9 @@ class BrowserTest extends \Tests\BrowserTestCase
             },
         ])
             ->waitForLivewireToLoad()
-            ->assertScript('return window.location.search', '')
+            ->assertQueryStringMissing('search')
             ->waitForLivewire()->type('@search', 'bob')
-            ->waitForScript('window.location.search', '?search=bob');
+            ->waitForQueryString('search', 'bob');
     }
 
     public function test_push_mode_syncs_url_on_initial_load_when_value_restored_from_session()


### PR DESCRIPTION

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes. Related to filamentphp/filament#20017.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

4️⃣ Does it include tests? (Required)

Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

The history coordinator was reusing `window.history.state` directly before calling `replaceState`.

  That means the current history state could be mutated before the browser history entry was actually replaced. If another library wraps `replaceState` and compares the incoming
  state with `window.history.state`, it can see the already-mutated object and skip the real `replaceState` call.

  This clones the current state before applying Livewire's updates, so `window.history.state` only changes when `replaceState` succeeds.
