### PR TITLE
Fix: Guess ability from method name when #[Authorize] receives only a class name

### DIFF
--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -18,6 +18,17 @@ class BaseAuthorize extends LivewireAttribute
 
     public function call(array $parameters) : void
     {
+        // If ability is a class name (contains backslash) and no argument was
+        // provided, guess the ability from the component method name — matching
+        // the behavior of Laravel's AuthorizesRequests::authorize(Model::class).
+        if (is_null($this->argument) && is_string($this->ability) && str_contains($this->ability, '\\')) {
+            $ability = $this->normalizeGuessedAbilityName($this->getName());
+
+            Gate::authorize($ability, [$this->ability]);
+
+            return;
+        }
+
         // Action that does not require a model or class...
         if (is_null($this->argument)) {
             Gate::authorize($this->ability);
@@ -34,6 +45,34 @@ class BaseAuthorize extends LivewireAttribute
         }
 
         Gate::authorize($this->ability, $resolved);
+    }
+
+    /**
+     * Normalize the ability name guessed from the method name.
+     * Mirrors AuthorizesRequests::normalizeGuessedAbilityName().
+     */
+    protected function normalizeGuessedAbilityName(string $ability) : string
+    {
+        $map = $this->resourceAbilityMap();
+
+        return $map[$ability] ?? $ability;
+    }
+
+    /**
+     * Get the map of resource method names to ability names.
+     * Mirrors AuthorizesRequests::resourceAbilityMap().
+     */
+    protected function resourceAbilityMap() : array
+    {
+        return [
+            'index' => 'viewAny',
+            'show' => 'view',
+            'create' => 'create',
+            'store' => 'create',
+            'edit' => 'update',
+            'update' => 'update',
+            'destroy' => 'delete',
+        ];
     }
 
     /**

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -113,6 +113,57 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_policy_by_guessing_ability_from_method_name_when_only_class_provided()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        // Ability is guessed from method name "createPost" -> "createPost" (no resource map match)
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize(AuthorizationPost::class)]
+                public function createPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('createPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[Authorize(AuthorizationPost::class)]
+                public function createPost() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('createPost')
+            ->assertForbidden();
+
+        // Ability guessed from method name "store" -> "create" (resource map match)
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize(AuthorizationPost::class)]
+                public function store() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('store')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[Authorize(AuthorizationPost::class)]
+                public function store() : bool
+                {
+                    return true;
+                }
+            })
+            ->call('store')
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_policy_with_class()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
@@ -731,6 +782,11 @@ class AuthorizationComment extends Model
 class AuthorizationPostPolicy
 {
     public function create(AuthorizationUser $user) : bool
+    {
+        return (int) $user->id === 1;
+    }
+
+    public function createPost(AuthorizationUser $user) : bool
     {
         return (int) $user->id === 1;
     }


### PR DESCRIPTION
## Problem

When using `#[Authorize(Post::class)]` with only a class name (no explicit ability), authorization always fails. This is because `BaseAuthorize::call()` passes the FQCN directly as the ability to `Gate::authorize()`:

```
Gate::authorize("App\Models\Post")  // ❌ no such ability exists
```

However, using `$this->authorize(Post::class)` inside the method **works** because Laravel's `AuthorizesRequests::authorize()` guesses the ability from the calling method name via `debug_backtrace()`.

Reported in #10318.

## Solution

Mirror `AuthorizesRequests::parseAbilityAndArguments()` behavior in `BaseAuthorize::call()`:

- When `$ability` contains `\` (class name) and `$argument` is null, guess the ability from the component method name
- Apply Laravel's `resourceAbilityMap()` normalization (`store` → `create`, `edit` → `update`, etc.)
- Pass the class name as the argument to `Gate::authorize()`

```php
// Before: #[Authorize(Post::class)] on method createPost()
Gate::authorize("App\Models\Post")  // ❌ fails

// After:
Gate::authorize("createPost", ["App\Models\Post"])  // ✅ works
```

## Changes

- **`BaseAuthorize.php`** — Added ability-guessing logic when class name used as sole parameter. Added `normalizeGuessedAbilityName()` and `resourceAbilityMap()` mirroring Laravel's `AuthorizesRequests`.
- **`UnitTest.php`** — Added test covering both direct method-name matching (`createPost` → `createPost`) and resource map matching (`store` → `create`).