### PR TITLE
[4.x] Use dedicated feature for `BaseRenderless`

### DIFF
--- a/src/Attributes/Renderless.php
+++ b/src/Attributes/Renderless.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Attributes;
 
-use Livewire\Mechanisms\HandleComponents\BaseRenderless;
+use Livewire\Features\SupportRenderless\BaseRenderless;
 
 #[\Attribute]
 class Renderless extends BaseRenderless

--- a/src/Features/SupportEvents/SupportEvents.php
+++ b/src/Features/SupportEvents/SupportEvents.php
@@ -9,7 +9,7 @@ use Livewire\Features\SupportAttributes\AttributeLevel;
 use Livewire\ComponentHook;
 use Livewire\Exceptions\EventHandlerDoesNotExist;
 use Livewire\Features\SupportAuthorization\BaseAuthorize;
-use Livewire\Mechanisms\HandleComponents\BaseRenderless;
+use Livewire\Features\SupportRenderless\BaseRenderless;
 
 class SupportEvents extends ComponentHook
 {

--- a/src/Features/SupportRenderless/BaseRenderless.php
+++ b/src/Features/SupportRenderless/BaseRenderless.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Livewire\Mechanisms\HandleComponents;
+namespace Livewire\Features\SupportRenderless;
 
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 

--- a/src/Features/SupportRenderless/BrowserTest.php
+++ b/src/Features/SupportRenderless/BrowserTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Livewire\Features\SupportRenderless;
+
+use Illuminate\Support\Facades\Blade;
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    public function test_dont_call_render_using_renderless_attribute()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            #[BaseRenderless]
+            function renderlessAction() { }
+
+            function render()
+            {
+                $this->count++;
+
+                return Blade::render(<<<'HTML'
+                <div>
+                    <button wire:click="renderlessAction" dusk="button">{{ $count }}</button>
+                </div>
+                HTML, ['count' => $this->count]);
+            }
+        })
+            ->assertSeeIn('@button', '1')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@button', '1');
+    }
+
+    public function test_dont_call_render_using_renderless_modifier()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            function renderlessAction() { }
+
+            function render()
+            {
+                $this->count++;
+
+                return Blade::render(<<<'HTML'
+                <div>
+                    <button wire:click.renderless="renderlessAction" dusk="button">{{ $count }}</button>
+                </div>
+                HTML, ['count' => $this->count]);
+            }
+        })
+            ->assertSeeIn('@button', '1')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@button', '1');
+    }
+}


### PR DESCRIPTION
`BaseRenderless` was placed inside mechanism like an orphan feature. So I think it would make more sense to use dedicated `SupportRenderless` feature for this just like `Async` attribute

## Before
```text
src/
├── Mechanisms/
│   ├── HandleComponents/
│   │   ├── BaseRenderless.php
```

## After
```text
src/
├── Features/
│   ├── SupportRenderless/
│   │   ├── BaseRenderless.php
```
