### PR TITLE
[4.x] Fix memory leak: release the file upload property watcher when its element is removed

### DIFF
--- a/js/features/supportFileUploads.js
+++ b/js/features/supportFileUploads.js
@@ -1,4 +1,5 @@
-import { getCsrfToken } from '@/utils';
+import { dataGet, getCsrfToken } from '@/utils';
+import Alpine from 'alpinejs'
 
 let uploadManagers = new WeakMap
 
@@ -46,10 +47,14 @@ export function handleFileUpload(el, property, component, cleanup) {
     el.addEventListener('change', eventHandler)
 
     // If the Livewire property has changed to null or an empty string, then reset the input...
-    component.$wire.$watch(property, (value) => {
-        // This watch will only be released when the component is removed. However, the
-        // actual file-upload element may be removed from the DOM withou the entire
-        // component being removed. In this case, let's just bail early on this.
+    // This watch is registered through Alpine directly instead of $wire.$watch so it can be
+    // released by the element-scoped cleanup below. $wire.$watch registers a component-lifetime
+    // cleanup whose callback closes over `el`, which would strand the input (and the entire
+    // detached subtree it lived in) every time a conditionally rendered file input is removed
+    // from a long-lived component...
+    let unwatchValueReset = Alpine.watch(() => dataGet(component.reactive, property), (value) => {
+        // The element may be removed from the DOM before this watch fires. In this case,
+        // let's just bail early on this.
         if (! el.isConnected) return
 
         if (value === null || value === '') {
@@ -74,6 +79,9 @@ export function handleFileUpload(el, property, component, cleanup) {
     cleanup(() => {
         el.removeEventListener('change', eventHandler)
         el.removeEventListener('click', clearFileInputValue)
+        el.removeEventListener('livewire-upload-cancel', clearFileInputValue)
+
+        unwatchValueReset()
     })
 }
 

--- a/src/Features/SupportFileUploads/BrowserTest.php
+++ b/src/Features/SupportFileUploads/BrowserTest.php
@@ -273,6 +273,50 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_removing_a_conditionally_rendered_file_input_does_not_accumulate_component_cleanups()
+    {
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photo;
+
+            public $showUpload = false;
+
+            function render() { return <<<'HTML'
+                <div>
+                    <button wire:click="$toggle('showUpload')" dusk="toggle">Toggle</button>
+
+                    @if ($showUpload)
+                        <input type="file" wire:model="photo" dusk="upload">
+                    @endif
+                </div>
+                HTML;
+            }
+        })
+        // One full mount/teardown cycle so any one-time registrations have happened...
+        ->waitForLivewire()->click('@toggle')
+        ->waitForLivewire()->click('@toggle')
+        ->tap(function ($b) use (&$cleanupsAfterFirstCycle) {
+            $cleanupsAfterFirstCycle = $b->script('return window.Livewire.all()[0].cleanups.length')[0];
+        })
+        ->waitForLivewire()->click('@toggle')
+        ->waitForLivewire()->click('@toggle')
+        ->waitForLivewire()->click('@toggle')
+        ->waitForLivewire()->click('@toggle')
+        ->tap(function ($b) use (&$cleanupsAfterFirstCycle) {
+            $cleanupsAfterThreeMoreCycles = $b->script('return window.Livewire.all()[0].cleanups.length')[0];
+
+            // Before the fix, every mount/teardown of the file input left a component-lifetime
+            // cleanup behind (its $watch closure), stranding the input's detached DOM subtree...
+            $this->assertSame(
+                $cleanupsAfterFirstCycle,
+                $cleanupsAfterThreeMoreCycles,
+                'Tearing down a wire:model file input leaked a component-lifetime cleanup per cycle',
+            );
+        })
+        ;
+    }
+
     public function test_finish_upload_rejects_forged_unsigned_paths()
     {
         Storage::persistentFake('tmp-for-tests');


### PR DESCRIPTION
### The bug

A conditionally rendered `<input type="file" wire:model="...">` inside a long-lived
component leaks its **entire detached DOM subtree** every time the condition
toggles off — plus one component-lifetime cleanup and one JS event listener per
cycle. The leak survives forced GC and grows without bound, so persistent
components (modals, drawers, tabbed forms) that show/hide an upload field leak
until the page is reloaded. In a real-world app with a ~100-field form next to
the file input, this leaked ~59,000 DOM nodes per open/close cycle.

### Root cause

`handleFileUpload` in `js/features/supportFileUploads.js` resets the input when
the bound property is cleared by registering a watch through the component:

```js
component.$wire.$watch(property, (value) => {
    if (! el.isConnected) return
    // ... resets el.value
})
```

`$wire.$watch` registers its unwatch via `component.addCleanup(...)`
(`js/$wire.js`), which only runs when the **whole component** is destroyed. The
watch callback closes over the file input `el`. The element-scoped
`cleanup(...)` at the bottom of `handleFileUpload` removes the DOM event
listeners — but never releases the watch.

So every time a conditionally rendered file input is morphed away:

- one watch closure stays behind in `component.cleanups` (rooted by the live component), and
- that closure's scope chain still reaches the detached `<input>`, which via
  `parentNode`/`childNodes` links pins the **entire detached subtree** it lived in.

(The existing `el.isConnected` guard in the callback handles the *behavior* of a
removed element, and its comment even notes the watch outlives the element — but
the closure itself is what pins the memory.)

### Reproduction

Runnable repro with a scripted measurement harness:
**https://github.com/tomasrybensky/livewire-fileupload-leak-repro**

```bash
git clone https://github.com/tomasrybensky/livewire-fileupload-leak-repro
cd livewire-fileupload-leak-repro
composer install && npm install
# serve it (Herd-parked dir works out of the box), then:
node harness/measure.mjs            # BEFORE numbers
node harness/apply-fix.mjs          # apply this PR's fix to the vendor dist bundle
node harness/measure.mjs            # AFTER numbers
```

The setup: fresh Laravel 13 app, Livewire v4.3.1, one persistent page component:

```blade
<button wire:click="$toggle('show')">Toggle</button>

@if ($show)
    <input type="file" wire:model="upload">
    {{-- + 50 plain text inputs as subtree padding --}}
@endif
```

Toggle open/closed repeatedly; after each cycle force GC twice via CDP and read
`Memory.getDOMCounters()` and `component.cleanups.length` (headless Chrome,
puppeteer-core). DOM-node count is used rather than heap MB because detached-DOM
memory lives in the renderer's native allocator, not `usedJSHeapSize`.

### Measurements (1 warm-up + 6 cycles)

Before (v4.3.1 stock):

| point | nodes | Δnodes | listeners | Δlisteners | component.cleanups |
|---|---|---|---|---|---|
| after warm-up | 516 | | 27 | | 1 |
| cycle 1 | 982 | +466 | 28 | +1 | 2 |
| cycle 2 | 1448 | +466 | 29 | +1 | 3 |
| cycle 3 | 1914 | +466 | 30 | +1 | 4 |
| cycle 4 | 2380 | +466 | 31 | +1 | 5 |
| cycle 5 | 2846 | +466 | 32 | +1 | 6 |
| cycle 6 | 3312 | +466 | 33 | +1 | 7 |

After (this PR):

| point | nodes | Δnodes | listeners | Δlisteners | component.cleanups |
|---|---|---|---|---|---|
| after warm-up | 50 | | 26 | | 0 |
| cycles 1–6 | 50 | **0** | 26 | **0** | **0** |

### The fix

Register the watch directly with `Alpine.watch(...)` (the exact mechanism
`$wire.$watch` wraps) and release it in the element-scoped `cleanup()`, so the
watcher's lifetime matches the element's — the same as the event listeners next
to it. Alpine also runs element cleanups when the whole component is torn down,
so nothing is lost on component destroy.

Note: just capturing `$wire.$watch`'s return value and calling it in
`cleanup()` would **not** be enough — the unwatch closure would still be rooted
in `component.cleanups` (it would also have to be spliced out of that array).
Using `Alpine.watch` directly keeps the fix from reaching into component
internals.

The cleanup now also removes the `livewire-upload-cancel` listener that was
added but never removed (same omission, one line).

### Tests

- Adds a browser regression test:
  `test_removing_a_conditionally_rendered_file_input_does_not_accumulate_component_cleanups`
  — fails on the current `main` build (+1 cleanup per toggle cycle), passes with the fix.
- Existing behavior is covered by
  `test_can_clear_out_file_input_after_property_has_been_reset` /
  `..._multiple_file_input_...`, which still pass: the watch callback is
  unchanged, only its registration/release mechanism moved.
- JS unit suite: 100 passed, 1 skipped (unchanged).
