### PR TITLE
[3.x] File preview original name

### DIFF
--- a/src/Features/SupportFileUploads/FilePreviewController.php
+++ b/src/Features/SupportFileUploads/FilePreviewController.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportFileUploads;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Controllers\Middleware;
 use Livewire\Drawer\Utils;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 
 class FilePreviewController implements HasMiddleware
 {
@@ -19,6 +20,21 @@ class FilePreviewController implements HasMiddleware
     {
         abort_unless(request()->hasValidSignature(), 401);
 
-        return Utils::pretendPreviewResponseIsPreviewFile($filename);
+        $response = Utils::pretendPreviewResponseIsPreviewFile($filename);
+
+        // Cache hit
+        if ($response->getStatusCode() === 304) {
+            return $response;
+        }
+
+        $temporaryFile = new TemporaryUploadedFile($filename, FileUploadConfiguration::disk());
+        $originalName = $temporaryFile->getClientOriginalName();
+
+        $response->headers->set(
+            'Content-Disposition',
+            HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $originalName),
+        );
+
+        return $response;
     }
 }

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -476,11 +476,11 @@ class UnitTest extends \Tests\TestCase
         \Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButtonCache::$disableBackButtonCache = false;
 
         ob_start();
-        $this->get($photo->temporaryUrl())->sendContent();
+        $response = $this->get($photo->temporaryUrl())->sendContent();
         $rawFileContents = ob_get_clean();
 
         $this->assertEquals($file->get(), $rawFileContents);
-
+        $this->assertEquals('attachment; filename=avatar.jpg', $response->headers->get('content-disposition'));
         $this->assertTrue($photo->isPreviewable());
     }
 
@@ -532,10 +532,12 @@ class UnitTest extends \Tests\TestCase
         \Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButtonCache::$disableBackButtonCache = false;
 
         ob_start();
-        $this->get($photo->temporaryUrl())->sendContent();
+        $response = $this->get($photo->temporaryUrl());
+        $response->sendContent();
         $rawFileContents = ob_get_clean();
 
         $this->assertEquals($file->get(), $rawFileContents);
+        $this->assertEquals('attachment; filename=avatar.jpg', $response->headers->get('content-disposition'));
 
         $this->assertTrue($photo->isPreviewable());
     }
@@ -623,10 +625,12 @@ class UnitTest extends \Tests\TestCase
         // When testing, rather than trying to hit an s3 server, we just serve
         // the local driver preview URL.
         ob_start();
-        $this->get($photo->temporaryUrl())->sendContent();
+        $response = $this->get($photo->temporaryUrl());
+        $response->sendContent();
         $rawFileContents = ob_get_clean();
 
         $this->assertEquals($file->get(), $rawFileContents);
+        $this->assertEquals('attachment; filename=avatar.jpg', $response->headers->get('content-disposition'));
     }
 
     public function test_removing_first_item_from_array_of_temporary_uploaded_files_serializes_correctly()


### PR DESCRIPTION
### v3.x version of [[4.x] File preview original name](https://github.com/livewire/livewire/pull/10352)

### Background
I didn't check if this was a requested fix. I ran into this issue and wanted to create a PR. Feel free to shoot it down if the previous behaviour was intended. If the code is not up to standard, I don't mind changing it.

I was working on a Form with an overview step. The overview step showed recently temporarily uploaded files, and completed uploaded files in one overview. All of these items should be previewable and clickable. Our completed media files could be downloaded or previewed using a custom endpoint, and the others using Livewire's built-in endpoint.
Files downloaded from the livewire.preview-file endpoint, did not have the original filename the user provided, but an encoded version in Livewire v3 and a hash name in v4. I would like the original filename to be returned as to not expose any of the internal file structure of the website.

### Info
I want the original filename to be returned so as not to expose any of the internal file structure of the website.
I added tests to verify this works with S3 buckets and remote storage. It handles cache hits. Im not sure about performance.