### PR TITLE
[4.x] Fix false-positive SFC detection and parser class return prepending

### DIFF
--- a/src/Compiler/Parser/Parser.php
+++ b/src/Compiler/Parser/Parser.php
@@ -57,12 +57,12 @@ class Parser
         // Use (*SKIP)(*FAIL) to ignore "new" inside comments...
         $skipComments = '(?:\/\/[^\n]*|\/\*.*?\*\/)(*SKIP)(*FAIL)';
 
-        // Find the position of the first "new" outside of comments...
-        if (preg_match('/' . $skipComments . '|\bnew\b/s', $contents, $newMatch, PREG_OFFSET_CAPTURE)) {
+        // Find the position of the first "new class" outside of comments...
+        if (preg_match('/' . $skipComments . '|\bnew\b[^;{}]*?\bclass\b/s', $contents, $newMatch, PREG_OFFSET_CAPTURE)) {
             $newPosition = $newMatch[0][1];
 
-            // Check if "return new" exists outside of comments and find where "new" starts in that match...
-            $hasReturnNew = preg_match('/' . $skipComments . '|\breturn\s+(new\b)/s', $contents, $returnNewMatch, PREG_OFFSET_CAPTURE);
+            // Check if "return new class" exists outside of comments and find where "new" starts in that match...
+            $hasReturnNew = preg_match('/' . $skipComments . '|\breturn\s+(new\b[^;{}]*?\bclass\b)/s', $contents, $returnNewMatch, PREG_OFFSET_CAPTURE);
 
             // If "return new" does not exist or "new" is not at the same position as "return new", add "return"...
             if (!$hasReturnNew || $returnNewMatch[1][1] !== $newPosition) {
@@ -78,7 +78,7 @@ class Parser
         // Use (*SKIP)(*FAIL) to ignore "new" inside comments...
         $skipComments = '(?:\/\/[^\n]*|\/\*.*?\*\/)(*SKIP)(*FAIL)';
 
-        if (!preg_match('/' . $skipComments . '|\bnew\b/s', $contents)) {
+        if (!preg_match('/' . $skipComments . '|\bnew\b[^;{}]*?\bclass\b/s', $contents)) {
             return $contents;
         }
 

--- a/src/Compiler/UnitTest.php
+++ b/src/Compiler/UnitTest.php
@@ -926,6 +926,30 @@ class UnitTest extends \Tests\TestCase
 
                 EOT,
             ],
+            'new instantiation before new class' => [
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                $x = new Collection();
+                new class extends Component {
+                    //
+                };
+                ?>
+                EOT,
+                <<<'EOT'
+                <?php
+
+                use Livewire\Component;
+
+                $x = new Collection();
+                return new class extends Component {
+                    //
+                };
+
+                EOT,
+            ],
         ];
     }
 }

--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -393,9 +393,11 @@ class Finder
         }
 
         // Light touch check: Look for the pattern that indicates an SFC
-        // Pattern: <?php followed by 'new' and 'class' (with potential attributes/newlines between)
-        // This distinguishes SFCs from regular Blade views
-        return preg_match('/\<\?php.*new\s+.*class/s', $contents) === 1;
+        // Pattern: <?php followed by 'new class' (with potential attributes/comments/newlines between)
+        // This distinguishes SFCs from regular Blade views and Volt components
+        $skipComments = '(?:\/\/[^\n]*|\/\*.*?\*\/)(*SKIP)(*FAIL)';
+
+        return preg_match('/<\?php[\s\S]*?(?:' . $skipComments . '|\bnew\b[^;{}]*?\bclass\b)/s', $contents) === 1;
     }
 
     protected function hasValidMultiFileComponentSource(string $dir, string $fileBaseName): bool

--- a/src/Finder/UnitTest.php
+++ b/src/Finder/UnitTest.php
@@ -680,6 +680,29 @@ class UnitTest extends \Tests\TestCase
         // Already-canonical names pass through unchanged.
         $this->assertEquals('pages::a.b.c', $finder->normalizeName('pages::a.b.c'));
     }
+
+    public function test_does_not_resolve_volt_component_with_new_and_html_class_as_single_file_component()
+    {
+        $finder = new Finder();
+        $finder->addLocation(viewPath: __DIR__ . '/Fixtures');
+
+        // We create a temporary file that looks like a Volt component with new and HTML class
+        $tempFile = __DIR__ . '/Fixtures/volt-style-component.blade.php';
+        file_put_contents($tempFile, <<<'HTML'
+<?php
+$export = new SomeExport();
+?>
+<div class="some-class">Volt component</div>
+HTML
+        );
+
+        try {
+            $path = $finder->resolveSingleFileComponentPath('volt-style-component');
+            $this->assertNull($path);
+        } finally {
+            unlink($tempFile);
+        }
+    }
 }
 
 class SingleSegmentComponent extends Component


### PR DESCRIPTION
Fixes #10351

As reported in the issue, returning a file download response (like `Excel::download()`) from a Volt functional component crashes the compiled view with syntax/parse errors like `unexpected token 'new'` or `unexpected token 'return'`.

This happens because the SFC finder uses a very loose regex:
`/\<\?php.*new\s+.*class/s`

If a Volt component (or any regular view) instantiates a class in its PHP block (e.g. `$export = new SomeExport()`) and has a `class="..."` attribute in the HTML portion, it gets falsely detected as a Livewire Single-File Component. Once matched, the parser tries to prepend `return` to the first `new` statement it finds, resulting in invalid code: `$export = return new SomeExport()`.

This PR updates the detection and parsing regexes to specifically search for actual `new class` structures (supporting optional attributes/comments) so we don't end up matching standard `new` statements.

Added unit tests to cover these scenarios.
