### PR TITLE
[4.x] Fix authorization using `#[Authorize]`  always fallback to component property

### DIFF
--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -57,9 +57,21 @@ class BaseAuthorize extends LivewireAttribute
         );
 
         if ($methodArgument instanceof \ReflectionParameter) {
-            $routeBindingValue = $this->getRouteBindingValue($arg, $methodArgument->getPosition(), $parameters);
+            $routeBinding = null;
 
-            $model = app($methodArgument->getType()->getName())->resolveRouteBinding($routeBindingValue);
+            // parameter keys can be a string if user pass named argument to be resolved
+            // e.g wire:click="$dispatch('edit-post', { post: '2' })"
+            if (isset($parameters[$arg])) {
+                $routeBinding = $parameters[$arg];
+            }
+
+            // parameter keys can be a numeric if user only pass an id to be resolved
+            // e.g wire:click="editPost('2')"
+            elseif (isset($parameters[$methodArgument->getPosition()])) {
+                $routeBinding = $parameters[$methodArgument->getPosition()];
+            }
+
+            $model = app($methodArgument->getType()->getName())->resolveRouteBinding($routeBinding);
 
             if (! $model) {
                 throw (new \Illuminate\Database\Eloquent\ModelNotFoundException)->setModel($methodArgument->getType()->getName());
@@ -70,23 +82,6 @@ class BaseAuthorize extends LivewireAttribute
 
         // Fall back to component property
         return data_get($this->component, $arg);
-    }
-
-    protected function getRouteBindingValue($name, $position, $parameters)
-    {
-        // parameter keys can be a string if user pass named argument to be resolved
-        // e.g wire:click="$dispatch('edit-post', { post: '2' })"
-        if (isset($parameters[$name])) {
-            return $parameters[$name];
-        }
-
-        // parameter keys can be a numeric if user only pass an id to be resolved
-        // e.g wire:click="editPost('2')"
-        if (isset($parameters[$position])) {
-            return $parameters[$position];
-        }
-
-        return null;
     }
 
     protected function parseAbilityAndArguments($ability, $arguments)

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -57,21 +57,9 @@ class BaseAuthorize extends LivewireAttribute
         );
 
         if ($methodArgument instanceof \ReflectionParameter) {
-            $routeBinding = null;
+            $routeBindingValue = $this->getRouteBindingValue($arg, $methodArgument->getPosition(), $parameters);
 
-            // parameter keys can be a string if user pass named argument to be resolved
-            // e.g wire:click="$dispatch('edit-post', { post: '2' })"
-            if (isset($parameters[$arg])) {
-                $routeBinding = $parameters[$arg];
-            }
-
-            // parameter keys can be a numeric if user only pass an id to be resolved
-            // e.g wire:click="editPost('2')"
-            elseif (isset($parameters[$methodArgument->getPosition()])) {
-                $routeBinding = $parameters[$methodArgument->getPosition()];
-            }
-
-            $model = app($methodArgument->getType()->getName())->resolveRouteBinding($routeBinding);
+            $model = app($methodArgument->getType()->getName())->resolveRouteBinding($routeBindingValue);
 
             if (! $model) {
                 throw (new \Illuminate\Database\Eloquent\ModelNotFoundException)->setModel($methodArgument->getType()->getName());
@@ -82,6 +70,23 @@ class BaseAuthorize extends LivewireAttribute
 
         // Fall back to component property
         return data_get($this->component, $arg);
+    }
+
+    protected function getRouteBindingValue($name, $position, $parameters)
+    {
+        // parameter keys can be a string if user pass named argument to be resolved
+        // e.g wire:click="$dispatch('edit-post', { post: '2' })"
+        if (isset($parameters[$name])) {
+            return $parameters[$name];
+        }
+
+        // parameter keys can be a numeric if user only pass an id to be resolved
+        // e.g wire:click="editPost('2')"
+        if (isset($parameters[$position])) {
+            return $parameters[$position];
+        }
+
+        return null;
     }
 
     protected function parseAbilityAndArguments($ability, $arguments)

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -59,16 +59,16 @@ class BaseAuthorize extends LivewireAttribute
         if ($methodArgument instanceof \ReflectionParameter) {
             $routeBinding = null;
 
-            // parameter keys can be a numeric if user only pass an id to be resolved
-            // e.g wire:click="editPost('2')"
-            if (isset($parameters[$methodArgument->getPosition()])) {
-                $routeBinding = $parameters[$methodArgument->getPosition()];
-            }
-
             // parameter keys can be a string if user pass named argument to be resolved
             // e.g wire:click="$dispatch('edit-post', { post: '2' })"
             if (isset($parameters[$arg])) {
                 $routeBinding = $parameters[$arg];
+            }
+
+            // parameter keys can be a numeric if user only pass an id to be resolved
+            // e.g wire:click="editPost('2')"
+            elseif (isset($parameters[$methodArgument->getPosition()])) {
+                $routeBinding = $parameters[$methodArgument->getPosition()];
             }
 
             $model = app($methodArgument->getType()->getName())->resolveRouteBinding($routeBinding);

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -66,7 +66,7 @@ class BaseAuthorize extends LivewireAttribute
             }
 
             // parameter keys can be a string if user pass named argument to be resolved
-            // e.g wire:click="$dispatch('edit-post', { user: '2' })"
+            // e.g wire:click="$dispatch('edit-post', { post: '2' })"
             if (isset($parameters[$arg])) {
                 $routeBinding = $parameters[$arg];
             }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -56,8 +56,8 @@ class BaseAuthorize extends LivewireAttribute
             fn (\ReflectionParameter $parameter) : bool => $parameter->getName() === $arg,
         );
 
-        if ($methodArgument instanceof \ReflectionParameter && isset($parameters[$arg])) {
-            $model = app($methodArgument->getType()->getName())->resolveRouteBinding($parameters[$arg]);
+        if ($methodArgument instanceof \ReflectionParameter && isset($parameters[$methodArgument->getPosition()])) {
+            $model = app($methodArgument->getType()->getName())->resolveRouteBinding($parameters[$methodArgument->getPosition()]);
 
             if (! $model) {
                 throw (new \Illuminate\Database\Eloquent\ModelNotFoundException)->setModel($methodArgument->getType()->getName());

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -56,8 +56,22 @@ class BaseAuthorize extends LivewireAttribute
             fn (\ReflectionParameter $parameter) : bool => $parameter->getName() === $arg,
         );
 
-        if ($methodArgument instanceof \ReflectionParameter && isset($parameters[$methodArgument->getPosition()])) {
-            $model = app($methodArgument->getType()->getName())->resolveRouteBinding($parameters[$methodArgument->getPosition()]);
+        if ($methodArgument instanceof \ReflectionParameter) {
+            $routeBinding = null;
+
+            // parameter keys can be a numeric if user only pass an id to be resolved
+            // e.g wire:click="editPost('2')"
+            if (isset($parameters[$methodArgument->getPosition()])) {
+                $routeBinding = $parameters[$methodArgument->getPosition()];
+            }
+
+            // parameter keys can be a string if user pass named argument to be resolved
+            // e.g wire:click="$dispatch('edit-post', { user: '2' })"
+            if (isset($parameters[$arg])) {
+                $routeBinding = $parameters[$arg];
+            }
+
+            $model = app($methodArgument->getType()->getName())->resolveRouteBinding($routeBinding);
 
             if (! $model) {
                 throw (new \Illuminate\Database\Eloquent\ModelNotFoundException)->setModel($methodArgument->getType()->getName());

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -193,7 +193,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editPost', post: 1)
+            ->call('editPost', '1')
             ->assertOk();
 
         Livewire::actingAs(AuthorizationUser::find(2))
@@ -204,7 +204,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editPost', post: 1)
+            ->call('editPost', '1')
             ->assertForbidden();
     }
 
@@ -227,7 +227,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editPost', post: 1)
+            ->call('editPost', '1')
             ->assertOk();
 
         Livewire::actingAs(AuthorizationUser::find(2))
@@ -245,7 +245,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editPost', post: 1)
+            ->call('editPost', '1')
             ->assertForbidden();
     }
 
@@ -384,7 +384,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', post: 1)
+            ->call('createComment', '1')
             ->assertOk();
 
         // AssertOk using class name and component property
@@ -422,7 +422,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', post: 1)
+            ->call('createComment', '1')
             ->assertOk();
 
         // AssertForbidden using class name and method argument
@@ -434,7 +434,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', post: 2)
+            ->call('createComment', '2')
             ->assertForbidden();
 
         // AssertForbidden using class name and component property
@@ -472,7 +472,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', post: 2)
+            ->call('createComment', '2')
             ->assertForbidden();
     }
 
@@ -489,7 +489,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', post: 1)
+            ->call('createComment', '1')
             ->assertOk();
 
         // AssertOk using class name and component property
@@ -527,7 +527,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', post: 1)
+            ->call('createComment', '1')
             ->assertOk();
 
         // AssertForbidden using class name and method argument
@@ -539,7 +539,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', post: 2)
+            ->call('createComment', '2')
             ->assertForbidden();
 
         // AssertForbidden using class name and component property
@@ -577,7 +577,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', post: 2)
+            ->call('createComment', '2')
             ->assertForbidden();
     }
 
@@ -594,7 +594,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editComment', comment: 1, post: 1)
+            ->call('editComment', '1', '1')
             ->assertOk();
 
         // AssertOk using component properties
@@ -638,7 +638,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editComment', comment: 1, post: 1)
+            ->call('editComment', '1', '1')
             ->assertOk();
 
         // AssertForbidden using method arguments
@@ -650,7 +650,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editComment', comment: 1, post: 2)
+            ->call('editComment', '1', '2')
             ->assertForbidden();
 
         // AssertForbidden using component properties
@@ -694,7 +694,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editComment', comment: 1, post: 2)
+            ->call('editComment', '1', '2')
             ->assertForbidden();
     }
 

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -193,7 +193,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editPost', '1')
+            ->call('editPost', post: 1)
             ->assertOk();
 
         Livewire::actingAs(AuthorizationUser::find(2))
@@ -204,7 +204,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editPost', '1')
+            ->call('editPost', post: 1)
             ->assertForbidden();
     }
 
@@ -227,7 +227,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editPost', '1')
+            ->call('editPost', post: 1)
             ->assertOk();
 
         Livewire::actingAs(AuthorizationUser::find(2))
@@ -245,7 +245,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editPost', '1')
+            ->call('editPost', post: 1)
             ->assertForbidden();
     }
 
@@ -369,6 +369,35 @@ class UnitTest extends TestCase
         $this->assertTrue(Session::has('event-was-handled'));
     }
 
+    public function test_authorize_allows_authorized_event_listeners_with_named_argument()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[\Livewire\Attributes\On('edit-post')]
+                #[Authorize('edit', 'post')]
+                public function editPost(AuthorizationPost $post) : bool
+                {
+                    return true;
+                }
+            })
+            ->dispatch('edit-post', post: 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[\Livewire\Attributes\On('edit-post')]
+                #[Authorize('edit', 'post')]
+                public function editPost(AuthorizationPost $post) : bool
+                {
+                    return true;
+                }
+            })
+            ->dispatch('edit-post', post: 1)
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_defined_gates_with_array_as_argument()
     {
         Gate::define('create-comment', function (AuthorizationUser $user, string $commentClass, AuthorizationPost $post) {
@@ -384,7 +413,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', '1')
+            ->call('createComment', post: 1)
             ->assertOk();
 
         // AssertOk using class name and component property
@@ -422,7 +451,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', '1')
+            ->call('createComment', post: 1)
             ->assertOk();
 
         // AssertForbidden using class name and method argument
@@ -434,7 +463,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', '2')
+            ->call('createComment', post: 2)
             ->assertForbidden();
 
         // AssertForbidden using class name and component property
@@ -472,7 +501,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', '2')
+            ->call('createComment', post: 2)
             ->assertForbidden();
     }
 
@@ -489,7 +518,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', '1')
+            ->call('createComment', post: 1)
             ->assertOk();
 
         // AssertOk using class name and component property
@@ -527,7 +556,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', '1')
+            ->call('createComment', post: 1)
             ->assertOk();
 
         // AssertForbidden using class name and method argument
@@ -539,7 +568,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', '2')
+            ->call('createComment', post: 2)
             ->assertForbidden();
 
         // AssertForbidden using class name and component property
@@ -577,7 +606,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('createComment', '2')
+            ->call('createComment', post: 2)
             ->assertForbidden();
     }
 
@@ -594,7 +623,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editComment', '1', '1')
+            ->call('editComment', comment: 1, post: 1)
             ->assertOk();
 
         // AssertOk using component properties
@@ -638,7 +667,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editComment', '1', '1')
+            ->call('editComment', comment: 1, post: 1)
             ->assertOk();
 
         // AssertForbidden using method arguments
@@ -650,7 +679,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editComment', '1', '2')
+            ->call('editComment', comment: 1, post: 2)
             ->assertForbidden();
 
         // AssertForbidden using component properties
@@ -694,7 +723,7 @@ class UnitTest extends TestCase
                     return true;
                 }
             })
-            ->call('editComment', '1', '2')
+            ->call('editComment', comment: 1, post: 2)
             ->assertForbidden();
     }
 


### PR DESCRIPTION
First of all, I want to apologize for the oversight on this PR https://github.com/livewire/livewire/pull/10260. I notice this bug from this comment https://github.com/livewire/livewire/pull/10292#pullrequestreview-4494752116

The authorization should prioritize action argument then fall back to component property if there was no argument found but even if the argument on action can be resolved, it always fall back to component property which lead authorization bypassed.

# Scenario

In Livewire component, user can pass a model `id` as argument to be resolved like route model binding in Laravel

This will pass on testing however, it bypassed the authorization if used on Livewire component.

```php
class PostPolicy
{
    public function edit(User $user, Post $post)
    {
        return (int) $post->id === 1
    }
}

new class extends Component
{
    public ?Post $post;

    public function mount()
    {
        $this->post = Post::find(1);
    }

    #[Authorize['edit', 'post'] // this SHOULD be denied, however it BYPASSED
    public function editPost(Post $post)
    {
        // authorization bypassed
    }
}
```
```blade
<button wire:click="editPost('2')">Edit</button>
```

# Problem

In `BaseAuthorize::resolveArgument()`, it only check if provided argument is set in action parameters. This will pass on unit test because all `call()` action using named argument,

```php
Livewire::actingAs(AuthorizationUser::find(1))
    ->test(new class extends TestComponent {
        #[Authorize('edit', 'post')]
        public function editPost(AuthorizationPost $post) : bool
        {
            return true;
        }
    })
    ->call('editPost', post: 1) // here
    ->assertOk();
```

However this will make authorization bypassed if user only provide an `id` to be resolved.

```php
if ($methodArgument instanceof \ReflectionParameter && isset($parameters[$arg)) { // ❌ 
    $model = app($methodArgument->getType()->getName())->resolveRouteBinding($parameters[$arg]); // ❌ 

    if (! $model) {
        throw (new \Illuminate\Database\Eloquent\ModelNotFoundException)->setModel($methodArgument->getType()->getName());
    }

    return $model;
}

// Fall back to component property
return data_get($this->component, $arg);
```
Using the scenario, this will ALWAYS fall back to component property.

# Solution

Check action parameters has either named argument or model `id`.
```php
if ($methodArgument instanceof \ReflectionParameter) {
    $routeBinding = null;

    // parameter keys can be a string if user pass named argument to be resolved
    // e.g wire:click="$dispatch('edit-post', { post: '2' })"
    if (isset($parameters[$arg])) {
        $routeBinding = $parameters[$arg];
    }

    // parameter keys can be a numeric if user only pass an id to be resolved
    // e.g wire:click="editPost('2')"
    elseif (isset($parameters[$methodArgument->getPosition()])) {
        $routeBinding = $parameters[$methodArgument->getPosition()];
    }

    $model = app($methodArgument->getType()->getName())->resolveRouteBinding($routeBinding);

    if (! $model) {
        throw (new \Illuminate\Database\Eloquent\ModelNotFoundException)->setModel($methodArgument->getType()->getName());
    }

    return $model;
}
```

# Test Case
```php
class PostPolicy
{
    public function edit(User $user, Post $post)
    {
        return (int) $post->id === 1
    }
}

new class extends Component
{
    public ?Post $post;

    public function mount()
    {
        $this->post = Post::find(1);
    }

    #[On('edit-post')]
    #[Authorize['edit', 'post']
    public function editPost(Post $post)
    {
        //
    }
}
```
```blade
<button wire:click="editPost('1')">Edit</button> // ✔️ 
<button wire:click="editPost({ post: '1' })">Edit</button> // ✔️ 
<button wire:click="$dispatch('edit-post', { post: '1'})">Edit</button> // ✔️ 

<button wire:click="editPost('2')">Edit</button> // ❌ 
<button wire:click="editPost({ post: '2' })">Edit</button> // ❌ 
<button wire:click="$dispatch('edit-post', { post: '2'})">Edit</button> // ❌ 
```

# Files Changed
- `src/Features/SupportAuthorization/BaseAuthorize.php`
- `src/Features/SupportAuthorization/UnitTest.php`