### PR TITLE
Add renderless wire model

### DIFF
--- a/docs/wire-model.md
+++ b/docs/wire-model.md
@@ -304,6 +304,18 @@ Bracket notation is also supported as an alternative:
 
 Both notations are equivalent — `address['city']` resolves the same path as `address.city`. Bracket and dot notation can be mixed freely within a single expression.
 
+## Skipping renders
+
+The `.renderless` modifier sends a live model update to the server without re-rendering the component:
+
+```blade
+<input type="text" wire:model.renderless.live="search">
+```
+
+This is useful for model updates that should be persisted on the server but should not morph the current DOM after the message completes.
+
+Because `.renderless` only affects server messages, use it with `.live`.
+
 ## Going deeper
 
 For a more complete documentation on using `wire:model` in the context of HTML forms, visit the [Livewire forms documentation page](/docs/4.x/forms).
@@ -339,4 +351,5 @@ wire:model="property[0]"
 | `.boolean` | Cast value to `bool` on the server |
 | `.fill` | Use initial value from HTML `value` attribute |
 | `.deep` | Also listen to events from child elements |
+| `.renderless` | Skip re-rendering after a live model update |
 | `.preserve-scroll` | Maintain scroll position during updates |

--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -12,6 +12,8 @@ directive('model', ({ el, directive, component, cleanup }) => {
 
     let { expression, modifiers } = directive
 
+    modifiers = modifiers.filter(m => m !== 'renderless')
+
     if (! expression) {
         return console.warn('Livewire: [wire:model] is missing a value.', el)
     }

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -635,6 +635,43 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_wire_model_renderless_live_updates_without_rendering()
+    {
+        Livewire::visit(new class extends Component {
+            public $title = '';
+
+            public $renders = 0;
+
+            public function render()
+            {
+                $this->renders++;
+
+                return <<<'BLADE'
+                    <div>
+                        <input dusk="input" type="text" wire:model.renderless.live="title" />
+                        <button dusk="refresh" type="button" wire:click="$commit">Refresh</button>
+
+                        <span dusk="ephemeral" x-text="$wire.title"></span>
+                        <span dusk="server">{{ $title }}</span>
+                        <span dusk="renders">{{ $renders }}</span>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertSeeNothingIn('@ephemeral')
+            ->assertSeeNothingIn('@server')
+            ->assertSeeIn('@renders', '1')
+            ->type('@input', 'hello')
+            ->pause(500)
+            ->assertSeeIn('@ephemeral', 'hello')
+            ->assertSeeNothingIn('@server')
+            ->assertSeeIn('@renders', '1')
+            ->waitForLivewire()->click('@refresh')
+            ->assertSeeIn('@server', 'hello')
+            ->assertSeeIn('@renders', '2')
+        ;
+    }
+
     public function test_wire_model_live_blur_ephemeral_immediate_network_on_blur()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -672,6 +672,38 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_wire_click_renderless_magic_action_updates_without_rendering()
+    {
+        Livewire::visit(new class extends Component {
+            public $title = '';
+
+            public $renders = 0;
+
+            public function render()
+            {
+                $this->renders++;
+
+                return <<<'BLADE'
+                    <div>
+                        <button dusk="set" type="button" wire:click.renderless="$set('title', 'hello')">Set</button>
+                        <button dusk="refresh" type="button" wire:click="$commit">Refresh</button>
+
+                        <span dusk="server">{{ $title }}</span>
+                        <span dusk="renders">{{ $renders }}</span>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertSeeIn('@renders', '1')
+            ->waitForLivewire()->click('@set')
+            ->assertSeeNothingIn('@server')
+            ->assertSeeIn('@renders', '1')
+            ->waitForLivewire()->click('@refresh')
+            ->assertSeeIn('@server', 'hello')
+            ->assertSeeIn('@renders', '2')
+        ;
+    }
+
     public function test_wire_model_live_blur_ephemeral_immediate_network_on_blur()
     {
         Livewire::visit(new class extends Component {

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -687,10 +687,9 @@ class HandleComponents extends Mechanism
                     $return = null;
                 }
 
-                // Here we check if the `wire:model` have `.live` and `.renderless` modifiers
-                // then we should skip the rendering of component
-                if (($metadata['renderless'] ?? false) && ($metadata['type'] ?? null) === 'model.live') {
-                        $root->skipRender();
+                // Support `.renderless` on magic actions like `wire:model.renderless.live`...
+                if ($metadata['renderless'] ?? false) {
+                    $root->skipRender();
                 }
 
                 $returns[] = $return;

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -687,6 +687,12 @@ class HandleComponents extends Mechanism
                     $return = null;
                 }
 
+                // Here we check if the `wire:model` have `.live` and `.renderless` modifiers
+                // then we should skip the rendering of component
+                if (($metadata['renderless'] ?? false) && ($metadata['type'] ?? null) === 'model.live') {
+                        $root->skipRender();
+                }
+
                 $returns[] = $return;
 
                 continue;


### PR DESCRIPTION
### The Scenario

Livewire already supports renderless actions with directives like `wire:click.renderless`. This lets an action run on the server without re-rendering the component afterward.

This PR adds the same renderless behavior to live model updates:

```blade
<input type="text" wire:model.renderless.live="title">
```

With this syntax, Livewire sends the updated model value to the server, but skips the component render for that model request.

This is useful for model updates that need to be persisted or processed on the server without morphing the current DOM, such as updating validation state that can be accessed from JavaScript through $errors.

### The Feature

`wire:model.renderless.live` now works as a Livewire-only rendering modifier for live model updates.

Because `wire:model` internally creates an Alpine `x-model` binding, Livewire removes `renderless` before building the Alpine binding. This keeps `renderless` scoped to Livewire and avoids passing it to Alpine as an `x-model` modifier.

```js
modifiers = modifiers.filter(m => m !== 'renderless')
```

The original directive modifiers remain available on `directive.modifiers`, so the request layer can still detect `.renderless` and mark the outgoing model request as renderless.

### Backend Behavior

Live model updates are sent as `$commit` magic actions. This PR adds scoped backend handling for renderless model commits:

```php
($metadata['renderless'] ?? false)
&& ($metadata['type'] ?? null) === 'model.live'
&& $method === '$commit'
```

This ensures only live model commits marked as renderless skip rendering, and prevents other magic actions from accidentally inheriting renderless behavior.

### Test Coverage

A browser regression test was added for:

```blade
wire:model.renderless.live="title"
```

The test verifies that the model value is sent to the server while the component does not re-render until a later normal commit.