### PR TITLE
[4.x] Fix #[Validate()] and rules() rules for shared fields being incorrectly merged

### DIFF
--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -118,7 +118,7 @@ trait HandlesValidation
             )
         );
 
-        return array_merge($rulesFromComponent, $rulesFromOutside);
+        return array_merge_recursive($rulesFromComponent, $rulesFromOutside);
     }
 
     protected function getMessages()

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -925,6 +925,29 @@ class UnitTest extends \Tests\TestCase
             ->assertSee('second error')
             ->assertHasErrors(['first', 'second']);
     }
+
+    public function test_validate_attribute_and_rules_method_rules_are_merged_for_the_same_property()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Validate(['required', 'string'])]
+            public $foo = '';
+
+            public function rules()
+            {
+                return [
+                    'foo' => ['min:3'],
+                ];
+            }
+
+            function save() { $this->validate(); }
+        })
+            ->set('foo', 'ok')
+            ->call('save')
+            ->assertHasErrors(['foo' => 'min'])
+            ->set('foo', '')
+            ->call('save')
+            ->assertHasErrors(['foo' => 'required']);
+    }
 }
 
 class ComponentWithRulesProperty extends TestComponent


### PR DESCRIPTION
# The Scenario

When a component property has rules defined both in a \`rules()\` method and via a \`#[Validate()]\` attribute, only the attribute rules survive.

```php
class MyComponent extends Component
{
    #[Validate(['required', 'string'])]
    public string $name = '';

    public function rules(): array
    {
        return ['name' => ['min:3']];
    }
}
```

In this example, calling \`getRules()\` returns only \`['name' => ['required', 'string']]\` — the \`min:3\` rule from \`rules()\` is lost entirely.

# The Problem

\`getRules()\` ends with:

```php
return array_merge($rulesFromComponent, $rulesFromOutside);
```

Because \`array_merge\` overwrites string keys, any field appearing in both sources loses its \`rules()\` rules and keeps only the attribute rules.

# The Solution

Change \`array_merge\` to \`array_merge_recursive\` so that per-field rules from both sources are combined into a single array rather than the later source overwriting the earlier one.

Fixes #10364