### PR TITLE
[4.x] Fix fetch responses with a http redirect being parsed as Livewire payloads

### DIFF
--- a/js/request/index.js
+++ b/js/request/index.js
@@ -527,6 +527,9 @@ async function sendRequest(request, handlers) {
 
     if (response.redirected) {
         handlers.redirect(response.url)
+        handlers.finish()
+
+        return
     }
 
     /**

--- a/src/Features/SupportRedirects/BrowserTest.php
+++ b/src/Features/SupportRedirects/BrowserTest.php
@@ -2,15 +2,38 @@
 
 namespace Livewire\Features\SupportRedirects;
 
-use Livewire\Attributes\On;
-use Tests\BrowserTestCase;
-use Livewire\Livewire;
-use Livewire\Component;
-use Livewire\Attributes\Reactive;
+use Closure;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Livewire\Attributes\On;
+use Livewire\Attributes\Reactive;
+use Livewire\Component;
+use Livewire\Livewire;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\BrowserTestCase;
 
 class BrowserTest extends BrowserTestCase
 {
+    public static function tweakApplicationHook()
+    {
+        return function () {
+            Livewire::addPersistentMiddleware(RedirectLivewireUpdateToHtml::class);
+
+            Route::get('/redirected-livewire-update', RedirectedLivewireUpdatePage::class)
+                ->middleware(['web', RedirectLivewireUpdateToHtml::class]);
+
+            Route::get('/redirected-livewire-update/login', fn () => response(<<<'HTML'
+                <!DOCTYPE html>
+                <html>
+                    <body>
+                        <h1 dusk="redirected-html">Redirected HTML response</h1>
+                    </body>
+                </html>
+                HTML))
+                ->middleware('web');
+        };
+    }
+
     public function test_can_redirect()
     {
         Livewire::visit([new class extends Component {
@@ -129,6 +152,22 @@ class BrowserTest extends BrowserTestCase
             ->waitForTextIn('@foo', '1')
             ->waitForTextIn('@session-message', 'Flash cleared');
     }
+
+    public function test_http_redirects_from_livewire_update_requests_do_not_continue_processing_redirected_html()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/redirected-livewire-update')
+                ->waitForLivewireToLoad()
+                ->waitForLivewire()->click('@arm-redirect')
+                ->waitForTextIn('@status', 'Armed')
+                ->waitForLivewire()->click('@trigger-redirected-update')
+                ->assertPathIs('/redirected-livewire-update/login')
+                ->assertSee('Redirected HTML response')
+                ->assertConsoleLogHasNoErrors()
+            ;
+        });
+    }
 }
 
 class RedirectComponent extends Component {
@@ -143,4 +182,48 @@ class RedirectComponent extends Component {
             </div>
         </div>
     HTML; }
+}
+
+class RedirectLivewireUpdateToHtml
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (
+            $request->hasHeader('X-Livewire')
+            && $request->session()->pull('redirect_livewire_update_to_html', false)
+        ) {
+            return redirect('/redirected-livewire-update/login');
+        }
+
+        return $next($request);
+    }
+}
+
+class RedirectedLivewireUpdatePage extends Component
+{
+    public string $status = 'Ready';
+
+    public function armRedirect(): void
+    {
+        session()->put('redirect_livewire_update_to_html', true);
+
+        $this->status = 'Armed';
+    }
+
+    public function triggerRedirectedUpdate(): void
+    {
+        $this->status = 'Updated';
+    }
+
+    public function render(): string
+    {
+        return <<<'HTML'
+        <div>
+            <button type="button" dusk="arm-redirect" wire:click="armRedirect">Arm redirect</button>
+            <button type="button" dusk="trigger-redirected-update" wire:click="triggerRedirectedUpdate">Trigger redirected update</button>
+
+            <span dusk="status">{{ $status }}</span>
+        </div>
+        HTML;
+    }
 }


### PR DESCRIPTION
# The Scenario

When a Livewire update request receives a normal HTTP redirect, the browser follows that redirect internally and Livewire receives the final response body. If the redirect target is an HTML page such as a login page, Livewire can briefly show an error modal or log a JSON parse error before the browser finishes navigating to the redirected URL.

```php
use Livewire\Component;

new class extends Component
{
    public function save(): void
    {
        // Any Livewire action that sends an update request...
    }
};
```

```php
public function handle($request, Closure $next)
{
    if ($request->hasHeader('X-Livewire')) {
        return redirect('/login');
    }

    return $next($request);
}
```

# The Problem

Livewire detects `response.redirected` and calls the redirect handler, which sets `window.location.href` to the final fetch URL.

```js
if (response.redirected) {
    handlers.redirect(response.url)
}
```

The request flow then continues into dump detection and JSON parsing when it shouldn't.

```js
if (contentIsFromDump(responseBody)) {
    let dump

    [dump, responseBody] = splitDumpFromContent(responseBody)

    handlers.dump(dump)
}

let responseJson = JSON.parse(responseBody)
```

For normal HTTP redirects followed by `fetch()`, the response body is often the redirected HTML page rather than a Livewire JSON payload. That means Livewire can try to parse HTML as JSON even though it has already started a top-level redirect.

# The Solution

The solution is to treat a redirected fetch response as the end of the Livewire request once the existing redirect handler has run.

Livewire already detects `response.redirected` and calls `handlers.redirect(response.url)`. This change finishes the request and returns immediately after that point, so the redirected HTML body is not passed through dump detection, JSON parsing, or the error modal fallback.

```js
if (response.redirected) {
    handlers.redirect(response.url)
    handlers.finish()

    return
}
```

Fixes #10365
