### PR TITLE
[3.x] Fix wire:model.blur recreating deleted array entries

### DIFF
--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -60,7 +60,7 @@ directive('model', ({ el, directive, component, cleanup }) => {
 
 function getModifierTail(modifiers) {
     modifiers = modifiers.filter(i => ! [
-        'lazy', 'defer'
+        'lazy', 'defer', 'blur'
     ].includes(i))
 
     if (modifiers.length === 0) return ''

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -276,4 +276,40 @@ class BrowserTest extends BrowserTestCase
             ->assertSeeIn('@item-count', '1')
         ;
     }
+
+    public function test_blur_modifier_does_not_recreate_deleted_array_entries_when_submitting_with_enter()
+    {
+        Livewire::visit(new class extends Component {
+            public array $items = [
+                ['name' => ''],
+            ];
+
+            public function save(): void
+            {
+                $this->items = [];
+            }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <div dusk="item-count">{{ count($items) }}</div>
+
+                        @if (count($items))
+                            <form wire:submit="save">
+                                <input wire:model.blur="items.0.name" dusk="name" />
+                                <button type="submit" dusk="save">Save</button>
+                            </form>
+                        @endif
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertSeeIn('@item-count', '1')
+            ->type('@name', 'foo')
+            ->waitForLivewire()->keys('@name', '{enter}')
+            ->assertSeeIn('@item-count', '0')
+            ->assertMissing('@name')
+        ;
+    }
 }


### PR DESCRIPTION


1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes. This fixes a regression in `wire:model.blur` where a stale model update can recreate an array item that was removed by the submit action.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
 Yes

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No
4️⃣ Does it include tests? (Required)
 Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.


Fixes a regression where `wire:model.blur` could recreate a deleted array item after submit.

  `blur` is already handled by Livewire, so it should not be forwarded to Alpine's `x-model` modifiers.