### PR TITLE
[4.x] Improve `#[Authorize]` argument resolution

### DIFF
--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -6,6 +6,7 @@ use Attribute;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Arr;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+use Livewire\ImplicitlyBoundMethod;
 use UnitEnum;
 
 use function Illuminate\Support\enum_value;
@@ -31,10 +32,20 @@ class BaseAuthorize extends LivewireAttribute
 
         $arguments = Arr::wrap($this->argument);
 
+        // Resolve method dependencies lazily, then reuse them for multi-argument authorization checks...
+        $methodDependencies = null;
+        $resolveMethodDependencies = function () use (&$methodDependencies, $parameters): array {
+            return $methodDependencies ??= ImplicitlyBoundMethod::resolveMethodDependencies(
+                app(),
+                [$this->component, $this->getName()],
+                $parameters,
+            );
+        };
+
         // Resolve each argument (prioritize method parameters first, then component properties)
         $resolved = [];
         foreach ($arguments as $arg) {
-            $resolved[] = $this->resolveArgument($arg, $parameters);
+            $resolved[] = $this->resolveArgument($arg, $parameters, $resolveMethodDependencies);
         }
 
         $this->authorize($this->ability, $resolved);
@@ -43,7 +54,7 @@ class BaseAuthorize extends LivewireAttribute
     /**
      * Resolve a single argument.
      */
-    protected function resolveArgument(string $arg, array $parameters): mixed
+    protected function resolveArgument(string $arg, array $parameters, \Closure $resolveMethodDependencies): mixed
     {
         // Action that does not require a model, for example a 'create' action...
         if (class_exists($arg)) {
@@ -57,27 +68,9 @@ class BaseAuthorize extends LivewireAttribute
         );
 
         if ($methodArgument instanceof \ReflectionParameter) {
-            $routeBinding = null;
+            $methodDependencies = $resolveMethodDependencies();
 
-            // parameter keys can be a string if user pass named argument to be resolved
-            // e.g wire:click="$dispatch('edit-post', { post: '2' })"
-            if (isset($parameters[$arg])) {
-                $routeBinding = $parameters[$arg];
-            }
-
-            // parameter keys can be a numeric if user only pass an id to be resolved
-            // e.g wire:click="editPost('2')"
-            elseif (isset($parameters[$methodArgument->getPosition()])) {
-                $routeBinding = $parameters[$methodArgument->getPosition()];
-            }
-
-            $model = app($methodArgument->getType()->getName())->resolveRouteBinding($routeBinding);
-
-            if (! $model) {
-                throw (new \Illuminate\Database\Eloquent\ModelNotFoundException)->setModel($methodArgument->getType()->getName());
-            }
-
-            return $model;
+            return $methodDependencies['named'][$arg];
         }
 
         // Fall back to component property

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -4,6 +4,7 @@ namespace Livewire\Features\SupportAuthorization;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User as AuthUser;
+use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Session;
 use Livewire\Attributes\Authorize;
@@ -181,6 +182,33 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_policy_with_positional_model_id_argument()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize('edit', 'post')]
+                public function editPost(AuthorizationPost $post) : bool
+                {
+                    return true;
+                }
+            })
+            ->call('editPost', 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[Authorize('edit', 'post')]
+                public function editPost(AuthorizationPost $post) : bool
+                {
+                    return true;
+                }
+            })
+            ->call('editPost', 1)
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_policy_with_model_id_argument()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
@@ -202,6 +230,60 @@ class UnitTest extends TestCase
                 public function editPost(AuthorizationPost $post) : bool
                 {
                     return true;
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_policy_with_dependency_injection_and_positional_model_id_argument()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize('edit', 'post')]
+                public function editPost(UrlGenerator $generator, AuthorizationPost $post) : bool
+                {
+                    return $generator->to('/some-url') !== '';
+                }
+            })
+            ->call('editPost', 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[Authorize('edit', 'post')]
+                public function editPost(UrlGenerator $generator, AuthorizationPost $post) : bool
+                {
+                    return $generator->to('/some-url') !== '';
+                }
+            })
+            ->call('editPost', 1)
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_policy_with_dependency_injection_and_named_model_id_argument()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize('edit', 'post')]
+                public function editPost(UrlGenerator $generator, AuthorizationPost $post) : bool
+                {
+                    return $generator->to('/some-url') !== '';
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[Authorize('edit', 'post')]
+                public function editPost(UrlGenerator $generator, AuthorizationPost $post) : bool
+                {
+                    return $generator->to('/some-url') !== '';
                 }
             })
             ->call('editPost', post: 1)

--- a/src/ImplicitlyBoundMethod.php
+++ b/src/ImplicitlyBoundMethod.php
@@ -12,16 +12,35 @@ class ImplicitlyBoundMethod extends BoundMethod
 {
     protected static function getMethodDependencies($container, $callback, array $parameters = [])
     {
-        $dependencies = [];
+        return static::resolveMethodDependencies($container, $callback, $parameters)['positional'];
+    }
+
+    public static function resolveMethodDependencies($container, $callback, array $parameters = [])
+    {
+        $positional = [];
+        $named = [];
         $paramIndex = 0;
 
         foreach (static::getCallReflector($callback)->getParameters() as $parameter) {
+            $parameterPosition = count($positional);
+
             static::substituteNameBindingForCallParameter($parameter, $parameters, $paramIndex);
             static::substituteImplicitBindingForCallParameter($container, $parameter, $parameters);
-            static::addDependencyForCallParameter($container, $parameter, $parameters, $dependencies);
+            static::addDependencyForCallParameter($container, $parameter, $parameters, $positional);
+
+            $parameterDependencies = array_slice($positional, $parameterPosition);
+
+            if ($parameterDependencies) {
+                $named[$parameter->getName()] = $parameter->isVariadic()
+                    ? $parameterDependencies
+                    : $parameterDependencies[0];
+            }
         }
 
-        return array_values(array_merge($dependencies, $parameters));
+        return [
+            'positional' => array_values(array_merge($positional, $parameters)),
+            'named' => $named,
+        ];
     }
 
     protected static function substituteNameBindingForCallParameter($parameter, array &$parameters, int &$paramIndex)


### PR DESCRIPTION
# The Scenario

Livewire actions can receive arguments positionally or by name, and those arguments can be mixed with container-injected dependencies.

```php
use Illuminate\Routing\UrlGenerator;
use Livewire\Attributes\Authorize;
use Livewire\Component;

new class extends Component {
    #[Authorize('edit', 'post')]
    public function editPost(UrlGenerator $generator, Post $post): bool
    {
        return true;
    }
};
```

# The Problem

`#[Authorize]` had its own argument resolution path for method parameters.

That meant it needed to keep track of the same positional, named, dependency injection, and implicit binding behaviour that Livewire already handles when calling component methods.

# The Solution

The solution is to route `#[Authorize]` method argument resolution through Livewire’s existing method dependency handling.

`ImplicitlyBoundMethod` now exposes resolved method dependencies through `resolveMethodDependencies`, returning both `positional` and `named` arguments. `BaseAuthorize` uses the named dependencies when an authorisation argument matches a method parameter, while still falling back to component properties when there is no matching method parameter.

Method dependencies are resolved lazily inside `BaseAuthorize`, so repeated checks against method parameters in the same authorisation attribute can reuse the same resolved dependency set.