### PR TITLE
[4.x] Fix form `validateOnly()` keeping previous field messages

### DIFF
--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -47,7 +47,7 @@ class Form implements Arrayable
             return $this->parentValidateOnly($field, $rules, $messages, $attributes, $dataOverrides);
         } catch (ValidationException $e) {
             invade($e->validator)->messages = $this->prefixErrorBag(invade($e->validator)->messages)->merge(
-                $this->getComponent()->getErrorBag()
+                $this->getComponent()->errorBagExcept($this->getPropertyName().'.'.$field)
             );
 
             invade($e->validator)->failedRules = $this->prefixArray(invade($e->validator)->failedRules);

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -47,7 +47,7 @@ class Form implements Arrayable
             return $this->parentValidateOnly($field, $rules, $messages, $attributes, $dataOverrides);
         } catch (ValidationException $e) {
             invade($e->validator)->messages = $this->prefixErrorBag(invade($e->validator)->messages)->merge(
-                $this->getComponent()->errorBagExcept($this->getPropertyName().'.'.$field)
+                $this->getComponent()->errorBagExcept($this->getPropertyName() . '.' . $field)
             );
 
             invade($e->validator)->failedRules = $this->prefixArray(invade($e->validator)->failedRules);

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -297,17 +297,22 @@ class UnitTest extends \Tests\TestCase
         ;
     }
 
-    function test_validate_only_replaces_stale_validation_errors_for_same_form_field()
+    function test_form_object_validate_only_replaces_messages_for_the_field_being_validated()
     {
         Livewire::test(new class extends TestComponent {
             public FormWithRequiredIntegerValidation $form;
         })
         ->assertSetStrict('form.number', 1)
-        ->assertHasNoErrors()
         ->set('form.number', '')
-        ->assertHasErrors(['form.number' => 'required'])
+        // Check the message bag directly because rule assertions do not prove
+        // messages were replaced for the same error key.
+        ->tap(function ($component) {
+            $this->assertEquals(
+                ['The number field is required.'],
+                $component->errors()->get('form.number')
+            );
+        })
         ->set('form.number', 'a')
-        ->assertHasErrors(['form.number' => 'integer'])
         ->tap(function ($component) {
             $this->assertEquals(
                 ['The number field must be an integer.'],

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -318,6 +318,27 @@ class UnitTest extends \Tests\TestCase
         );
     }
 
+    function test_validate_only_replaces_stale_validation_errors_for_same_form_field()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public FormWithRequiredIntegerValidation $form;
+
+            function save()
+            {
+                $this->form->validateOnly('number');
+            }
+        })
+        ->assertHasNoErrors()
+        ->call('save')
+        ->set('form.number', 'abc')
+        ;
+
+        $this->assertEquals(
+            ['The number field must be an integer.'],
+            $component->errors()->get('form.number')
+        );
+    }
+
     function test_can_validate_a_specific_rule_for_form_object_with_validate_only()
     {
         Livewire::test(new class extends TestComponent {
@@ -1108,6 +1129,12 @@ class PostFormValidateOnUpdateStub extends Form
     protected $rules = [
         'title' => 'min:5',
     ];
+}
+
+class FormWithRequiredIntegerValidation extends Form
+{
+    #[Validate('required|integer')]
+    public $number = '';
 }
 
 class PostFormWithoutRules extends Form

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -297,6 +297,27 @@ class UnitTest extends \Tests\TestCase
         ;
     }
 
+    function test_validate_only_does_not_merge_stale_validation_errors()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public PostFormValidateStub $form;
+
+            function save()
+            {
+                $this->form->validateOnly('title');
+            }
+        })
+        ->assertHasNoErrors()
+        ->call('save')
+        ->call('save')
+        ;
+
+        $this->assertEquals(
+            ['The title field is required.'],
+            $component->errors()->get('form.title')
+        );
+    }
+
     function test_can_validate_a_specific_rule_for_form_object_with_validate_only()
     {
         Livewire::test(new class extends TestComponent {

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -297,46 +297,24 @@ class UnitTest extends \Tests\TestCase
         ;
     }
 
-    function test_validate_only_does_not_merge_stale_validation_errors()
-    {
-        $component = Livewire::test(new class extends TestComponent {
-            public PostFormValidateStub $form;
-
-            function save()
-            {
-                $this->form->validateOnly('title');
-            }
-        })
-        ->assertHasNoErrors()
-        ->call('save')
-        ->call('save')
-        ;
-
-        $this->assertEquals(
-            ['The title field is required.'],
-            $component->errors()->get('form.title')
-        );
-    }
-
     function test_validate_only_replaces_stale_validation_errors_for_same_form_field()
     {
-        $component = Livewire::test(new class extends TestComponent {
+        Livewire::test(new class extends TestComponent {
             public FormWithRequiredIntegerValidation $form;
-
-            function save()
-            {
-                $this->form->validateOnly('number');
-            }
         })
+        ->assertSetStrict('form.number', 1)
         ->assertHasNoErrors()
-        ->call('save')
-        ->set('form.number', 'abc')
+        ->set('form.number', '')
+        ->assertHasErrors(['form.number' => 'required'])
+        ->set('form.number', 'a')
+        ->assertHasErrors(['form.number' => 'integer'])
+        ->tap(function ($component) {
+            $this->assertEquals(
+                ['The number field must be an integer.'],
+                $component->errors()->get('form.number')
+            );
+        })
         ;
-
-        $this->assertEquals(
-            ['The number field must be an integer.'],
-            $component->errors()->get('form.number')
-        );
     }
 
     function test_can_validate_a_specific_rule_for_form_object_with_validate_only()
@@ -1133,8 +1111,8 @@ class PostFormValidateOnUpdateStub extends Form
 
 class FormWithRequiredIntegerValidation extends Form
 {
-    #[Validate('required|integer')]
-    public $number = '';
+    #[Validate(['required', 'integer'])]
+    public $number = 1;
 }
 
 class PostFormWithoutRules extends Form


### PR DESCRIPTION
Fixes #10372

## Summary

This fixes an issue where validation errors from the previous Livewire request are merged into the current request. As a result, form object `validateOnly()` can display duplicate or stale validation messages for the field being validated.

The fix mirrors what `Livewire\Features\SupportValidation\HandlesValidation` does by excluding the current field when merging messages from the component's error bag.

## Testing

A regression test has been added to cover this issue. The new test fails before this change with the following assertion:

```text
1) Livewire\Features\SupportFormObjects\UnitTest::test_validate_only_does_not_merge_stale_validation_errors
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     0 => 'The title field is required.'
+    1 => 'The title field is required.'
)
```

