### PR TITLE
[4.x] Handle exceptions from form lifecycle hooks

### DIFF
--- a/src/ComponentHookRegistry.php
+++ b/src/ComponentHookRegistry.php
@@ -82,7 +82,7 @@ class ComponentHookRegistry
         });
 
         on('exception', function ($target, $e, $stopPropagation) {
-            if ($target instanceof Form) {
+            if ($target instanceof \Livewire\Form) {
                 $target = $target->getComponent();
             }
 

--- a/src/ComponentHookRegistry.php
+++ b/src/ComponentHookRegistry.php
@@ -82,7 +82,7 @@ class ComponentHookRegistry
         });
 
         on('exception', function ($target, $e, $stopPropagation) {
-            if ($target instanceof \Livewire\Form) {
+            if ($target instanceof \Livewire\Features\SupportFormObjects\Form) {
                 $target = $target->getComponent();
             }
 

--- a/src/ComponentHookRegistry.php
+++ b/src/ComponentHookRegistry.php
@@ -82,6 +82,10 @@ class ComponentHookRegistry
         });
 
         on('exception', function ($target, $e, $stopPropagation) {
+            if ($target instanceof Form) {
+                $target = $target->getComponent();
+            }
+
             if ($target instanceof \Livewire\Component) {
                 static::proxyCallToHooks($target, 'callException')($e, $stopPropagation);
             }

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -894,6 +894,17 @@ class UnitTest extends \Tests\TestCase
         ;
     }
 
+    function test_can_perform_validate_only_inside_form_updated_hook()
+    {
+        Livewire::test(new class extends TestComponent {
+            public FormWithValidateOnlyInUpdatedHookStub $form;
+        })
+        ->assertHasNoErrors()
+        ->set('form.number', 'abc')
+        ->assertHasErrors('form.number')
+        ;
+    }
+
     function test_can_reset_and_return_property_with_pull_method()
     {
         Livewire::test(new class extends TestComponent {
@@ -1403,5 +1414,20 @@ class FormWithValidationInLifecycleHookStub extends Form
     public function rules()
     {
         return ['title' => 'required'];
+    }
+}
+
+class FormWithValidateOnlyInUpdatedHookStub extends Form
+{
+    public $number = '';
+
+    public function updated(string $property, mixed $value): void
+    {
+        $this->validateOnly($property);
+    }
+
+    public function rules(): array
+    {
+        return ['number' => 'required|integer'];
     }
 }

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -883,6 +883,17 @@ class UnitTest extends \Tests\TestCase
         ;
     }
 
+    function test_can_perform_validation_inside_lifecycle_hooks()
+    {
+        Livewire::test(new class extends TestComponent {
+            public FormWithValidationInLifecycleHookStub $form;
+        })
+        ->assertHasNoErrors()
+        ->set('form.title', '')
+        ->assertHasErrors('form.title')
+        ;
+    }
+
     function test_can_reset_and_return_property_with_pull_method()
     {
         Livewire::test(new class extends TestComponent {
@@ -1378,5 +1389,19 @@ class FormWithUpdatedHookStub extends Form
     public function updated(string $property)
     {
         $this->updated_properties[] = $property;
+    }
+}
+
+class FormWithValidationInLifecycleHookStub extends Form
+{
+    public string $title = '';
+
+    public function updated() {
+        $this->validate();
+    }
+
+    public function rules()
+    {
+        return ['title' => 'required'];
     }
 }

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -905,6 +905,17 @@ class UnitTest extends \Tests\TestCase
         ;
     }
 
+    function test_can_perform_validation_inside_lifecycle_hooks_on_form_extending_base_class()
+    {
+        Livewire::test(new class extends TestComponent {
+            public BaseFormWithValidationInLifecycleHookStub $form;
+        })
+        ->assertHasNoErrors()
+        ->set('form.title', '')
+        ->assertHasErrors('form.title')
+        ;
+    }
+
     function test_can_reset_and_return_property_with_pull_method()
     {
         Livewire::test(new class extends TestComponent {
@@ -1407,7 +1418,8 @@ class FormWithValidationInLifecycleHookStub extends Form
 {
     public string $title = '';
 
-    public function updated() {
+    public function updated()
+    {
         $this->validate();
     }
 
@@ -1429,5 +1441,20 @@ class FormWithValidateOnlyInUpdatedHookStub extends Form
     public function rules(): array
     {
         return ['number' => 'required|integer'];
+    }
+}
+
+class BaseFormWithValidationInLifecycleHookStub extends \Livewire\Features\SupportFormObjects\Form
+{
+    public string $title = '';
+
+    public function updated()
+    {
+        $this->validate();
+    }
+
+    public function rules()
+    {
+        return ['title' => 'required'];
     }
 }

--- a/src/Wrapped.php
+++ b/src/Wrapped.php
@@ -28,9 +28,7 @@ class Wrapped
                 $shouldPropagate = false;
             };
 
-            $target = $this->target instanceof Form ? $this->target->getComponent() : $this->target;
-
-            trigger('exception', $target, $e, $stopPropagation);
+            trigger('exception', $this->target, $e, $stopPropagation);
 
             $shouldPropagate && throw $e;
         }

--- a/src/Wrapped.php
+++ b/src/Wrapped.php
@@ -28,7 +28,9 @@ class Wrapped
                 $shouldPropagate = false;
             };
 
-            trigger('exception', $this->target, $e, $stopPropagation);
+            $target = $this->target instanceof Form ? $this->target->getComponent() : $this->target;
+
+            trigger('exception', $target, $e, $stopPropagation);
 
             $shouldPropagate && throw $e;
         }


### PR DESCRIPTION
Fixes #10373

## Summary

This fixes an issue where exceptions thrown from `Livewire\Form` lifecycle hooks are not handled by Livewire's component exception pipeline.

Form lifecycle hooks are invoked via `wrap($form)`, which dispatches exceptions against the `Form` instance. Since component exception hooks are only registered against `Livewire\Component` instances, exceptions thrown from form hooks bypass Livewire's exception handling and instead propagate to Laravel's global exception handler.

For `ValidationException`, this results in Laravel attempting to generate a redirect response (`Redirector::withInput()`), causing a `BadMethodCallException` during a Livewire request.

**Note**: This implementation handles `Livewire\Form` explicitly within `Wrapped` so that exceptions are dispatched against the owning component. If there's a preferred abstraction for mapping wrapped targets to their exception target, I'm happy to update accordingly.

