### PR TITLE
[4.x] Refactor `SupportAttributes`

### DIFF
--- a/src/Features/SupportAttributes/SupportAttributes.php
+++ b/src/Features/SupportAttributes/SupportAttributes.php
@@ -15,7 +15,7 @@ class SupportAttributes extends ComponentHook
             }
         };
 
-        $this->invokeLivewireAttribute($callback);
+        $this->getLivewireAttributes()->each($callback);
     }
 
     function mount(...$params)
@@ -26,7 +26,7 @@ class SupportAttributes extends ComponentHook
             }
         };
 
-        $this->invokeLivewireAttribute($callback);
+        $this->getLivewireAttributes()->each($callback);
     }
 
     function hydrate(...$params)
@@ -37,7 +37,7 @@ class SupportAttributes extends ComponentHook
             }
         };
 
-        $this->invokeLivewireAttribute($callback);
+        $this->getLivewireAttributes()->each($callback);
     }
 
     function update($propertyName, $fullPath, $newValue)
@@ -103,7 +103,7 @@ class SupportAttributes extends ComponentHook
             }
         };
 
-        $this->invokeLivewireAttribute($callback);
+        $this->getLivewireAttributes()->each($callback);
     }
 
     function destroy(...$params)
@@ -114,7 +114,7 @@ class SupportAttributes extends ComponentHook
             }
         };
 
-        $this->invokeLivewireAttribute($callback);
+        $this->getLivewireAttributes()->each($callback);
     }
 
     function exception(...$params)
@@ -125,11 +125,6 @@ class SupportAttributes extends ComponentHook
             }
         };
 
-        $this->invokeLivewireAttribute($callback);
-    }
-
-    protected function invokeLivewireAttribute(callable $callback)
-    {
         $this->getLivewireAttributes()->each($callback);
     }
 

--- a/src/Features/SupportAttributes/SupportAttributes.php
+++ b/src/Features/SupportAttributes/SupportAttributes.php
@@ -9,35 +9,29 @@ class SupportAttributes extends ComponentHook
 {
     function boot(...$params)
     {
-        $callback = function ($attribute) use ($params) {
+        $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
             if (method_exists($attribute, 'boot')) {
                 $attribute->boot(...$params);
             }
-        };
-
-        $this->getLivewireAttributes()->each($callback);
+        });
     }
 
     function mount(...$params)
     {
-        $callback = function ($attribute) use ($params) {
+        $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
             if (method_exists($attribute, 'mount')) {
                 $attribute->mount(...$params);
             }
-        };
-
-        $this->getLivewireAttributes()->each($callback);
+        });
     }
 
     function hydrate(...$params)
     {
-        $callback = function ($attribute) use ($params) {
+        $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
             if (method_exists($attribute, 'hydrate')) {
                 $attribute->hydrate(...$params);
             }
-        };
-
-        $this->getLivewireAttributes()->each($callback);
+        });
     }
 
     function update($propertyName, $fullPath, $newValue)
@@ -97,35 +91,29 @@ class SupportAttributes extends ComponentHook
 
     function dehydrate(...$params)
     {
-        $callback = function ($attribute) use ($params) {
+        $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
             if (method_exists($attribute, 'dehydrate')) {
                 $attribute->dehydrate(...$params);
             }
-        };
-
-        $this->getLivewireAttributes()->each($callback);
+        });
     }
 
     function destroy(...$params)
     {
-        $callback = function ($attribute) use ($params) {
+        $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
             if (method_exists($attribute, 'destroy')) {
                 $attribute->destroy(...$params);
             }
-        };
-
-        $this->getLivewireAttributes()->each($callback);
+        });
     }
 
     function exception(...$params)
     {
-        $callback = function ($attribute) use ($params) {
+        $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
             if (method_exists($attribute, 'exception')) {
                 $attribute->exception(...$params);
             }
-        };
-
-        $this->getLivewireAttributes()->each($callback);
+        });
     }
 
     protected function getLivewireAttributes()

--- a/src/Features/SupportAttributes/SupportAttributes.php
+++ b/src/Features/SupportAttributes/SupportAttributes.php
@@ -9,45 +9,40 @@ class SupportAttributes extends ComponentHook
 {
     function boot(...$params)
     {
-        $this->component
-            ->getAttributes()
-            ->whereInstanceOf(LivewireAttribute::class)
-            ->each(function ($attribute) use ($params) {
-                if (method_exists($attribute, 'boot')) {
-                    $attribute->boot(...$params);
-                }
-            });
+        $callback = function ($attribute) use ($params) {
+            if (method_exists($attribute, 'boot')) {
+                $attribute->boot(...$params);
+            }
+        };
+
+        $this->invokeLivewireAttribute($callback);
     }
 
     function mount(...$params)
     {
-        $this->component
-            ->getAttributes()
-            ->whereInstanceOf(LivewireAttribute::class)
-            ->each(function ($attribute) use ($params) {
-                if (method_exists($attribute, 'mount')) {
-                    $attribute->mount(...$params);
-                }
-            });
+        $callback = function ($attribute) use ($params) {
+            if (method_exists($attribute, 'mount')) {
+                $attribute->mount(...$params);
+            }
+        };
+
+        $this->invokeLivewireAttribute($callback);
     }
 
     function hydrate(...$params)
     {
-        $this->component
-            ->getAttributes()
-            ->whereInstanceOf(LivewireAttribute::class)
-            ->each(function ($attribute) use ($params) {
-                if (method_exists($attribute, 'hydrate')) {
-                    $attribute->hydrate(...$params);
-                }
-            });
+        $callback = function ($attribute) use ($params) {
+            if (method_exists($attribute, 'hydrate')) {
+                $attribute->hydrate(...$params);
+            }
+        };
+
+        $this->invokeLivewireAttribute($callback);
     }
 
     function update($propertyName, $fullPath, $newValue)
     {
-        $callbacks = $this->component
-            ->getAttributes()
-            ->whereInstanceOf(LivewireAttribute::class)
+        $callbacks = $this->getLivewireAttributes()
             ->filter(fn ($attr) => $attr->getLevel() === AttributeLevel::PROPERTY)
             // Call "update" on the root property attribute even if it's a deep update...
             ->filter(fn ($attr) => str($fullPath)->startsWith($attr->getName() . '.') || $fullPath === $attr->getName())
@@ -66,9 +61,7 @@ class SupportAttributes extends ComponentHook
 
     function call($method, $params, $returnEarly)
     {
-        $callbacks = $this->component
-            ->getAttributes()
-            ->whereInstanceOf(LivewireAttribute::class)
+        $callbacks = $this->getLivewireAttributes()
             ->filter(fn ($attr) => $attr->getLevel() === AttributeLevel::METHOD)
             ->filter(fn ($attr) => $attr->getName() === $method)
             ->map(function ($attribute) use ($params, $returnEarly) {
@@ -86,9 +79,7 @@ class SupportAttributes extends ComponentHook
 
     function render(...$params)
     {
-        $callbacks = $this->component
-            ->getAttributes()
-            ->whereInstanceOf(LivewireAttribute::class)
+        $callbacks = $this->getLivewireAttributes()
             ->map(function ($attribute) use ($params) {
                 if (method_exists($attribute, 'render')) {
                     return $attribute->render(...$params);
@@ -106,38 +97,46 @@ class SupportAttributes extends ComponentHook
 
     function dehydrate(...$params)
     {
-        $this->component
-            ->getAttributes()
-            ->whereInstanceOf(LivewireAttribute::class)
-            ->each(function ($attribute) use ($params) {
-                if (method_exists($attribute, 'dehydrate')) {
-                    $attribute->dehydrate(...$params);
-                }
-            });
+        $callback = function ($attribute) use ($params) {
+            if (method_exists($attribute, 'dehydrate')) {
+                $attribute->dehydrate(...$params);
+            }
+        };
+
+        $this->invokeLivewireAttribute($callback);
     }
 
     function destroy(...$params)
     {
-        $this->component
-            ->getAttributes()
-            ->whereInstanceOf(LivewireAttribute::class)
-            ->each(function ($attribute) use ($params) {
-                if (method_exists($attribute, 'destroy')) {
-                    $attribute->destroy(...$params);
-                }
-            });
+        $callback = function ($attribute) use ($params) {
+            if (method_exists($attribute, 'destroy')) {
+                $attribute->destroy(...$params);
+            }
+        };
+
+        $this->invokeLivewireAttribute($callback);
     }
 
     function exception(...$params)
     {
-        $this->component
-            ->getAttributes()
-            ->whereInstanceOf(LivewireAttribute::class)
-            ->each(function ($attribute) use ($params) {
-                if (method_exists($attribute, 'exception')) {
-                    $attribute->exception(...$params);
-                }
-            });
+        $callback = function ($attribute) use ($params) {
+            if (method_exists($attribute, 'exception')) {
+                $attribute->exception(...$params);
+            }
+        };
+
+        $this->invokeLivewireAttribute($callback);
     }
 
+    protected function invokeLivewireAttribute(callable $callback)
+    {
+        $this->getLivewireAttributes()->each($callback);
+    }
+
+    protected function getLivewireAttributes()
+    {
+        return $this->component
+            ->getAttributes()
+            ->whereInstanceOf(LivewireAttribute::class);
+    }
 }


### PR DESCRIPTION
I notice that most of `SupportAttributes` lifecycle hook use the same pattern

```php
$this->component
    ->getAttributes()
    ->whereInstanceOf(LivewireAttribute::class)
    ->each(...)
```

It can be extracted to dedicate method and pass the callback

### Before
```php
function boot(...$params)
{
    $this->component
        ->getAttributes()
        ->whereInstanceOf(LivewireAttribute::class)
        ->each(function ($attribute) use ($params) {
            if (method_exists($attribute, 'boot')) {
                $attribute->boot(...$params);
            }
        });
}

function render(...$params)
{
    $callbacks = $this->component
        ->getAttributes()
        ->whereInstanceOf(LivewireAttribute::class)
        ->map(function ($attribute) use ($params) {
            if (method_exists($attribute, 'render')) {
                return $attribute->render(...$params);
            }
        });

    return function (...$params) use ($callbacks) {
        foreach ($callbacks as $callback) {
            if (is_callable($callback)) {
                $callback(...$params);
            }
        }
    };
}
```

### After
```php
function boot(...$params)
{
    $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
        if (method_exists($attribute, 'boot')) {
            $attribute->boot(...$params);
        }
    });
}

function render(...$params)
{
    $callbacks = $this->getLivewireAttributes()
        ->map(function ($attribute) use ($params) {
            if (method_exists($attribute, 'render')) {
                return $attribute->render(...$params);
            }
        });

    return function (...$params) use ($callbacks) {
        foreach ($callbacks as $callback) {
            if (is_callable($callback)) {
                $callback(...$params);
            }
        }
    };
}

protected function getLivewireAttributes()
{
    return $this->component
        ->getAttributes()
        ->whereInstanceOf(LivewireAttribute::class);
}
```

This clean a bit the repetitive code.