### PR TITLE
Fix PHP 8.5 null array offset deprecation in EloquentCollectionSynth::hydrate()

### DIFF
--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -63,7 +63,7 @@ class EloquentCollectionSynth extends Synth {
         $modelClass = $meta['modelClass'];
 
         // If no alias found, this returns `null`
-        $modelAlias = Relation::getMorphedModel($modelClass);
+        $modelAlias = $modelClass ? Relation::getMorphedModel($modelClass) : null;
 
         if (! is_null($modelAlias)) {
             $modelClass = $modelAlias;

--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -325,25 +325,32 @@ class UnitTest extends \Tests\TestCase
         $this->assertCount(1, array_values($articleQueries));
     }
 
-    public function test_eloquent_collection_synth_handles_null_model_class_without_deprecation()
+    public function test_hydrating_an_empty_eloquent_collection_does_not_trigger_deprecations()
     {
-        $component = Livewire::test(ArticleComponent::class);
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public Collection $articles;
 
-        $synth = new EloquentCollectionSynth(
-            new \Livewire\Mechanisms\HandleComponents\ComponentContext($component->instance()),
-            'articles'
-        );
+            public function mount() {
+                $this->articles = new Collection();
+            }
 
-        $meta = [
-            'class' => Collection::class,
-            'modelClass' => null,
-            'keys' => [],
-        ];
+            public function render() { return <<<'HTML'
+                <div>count: {{ count($articles) }}</div>
+            HTML; }
+        });
 
-        // Should not trigger "Using null as an array offset" deprecation
-        $result = $synth->hydrate(null, $meta, fn ($v) => $v);
+        // An empty collection dehydrates with `modelClass` as `null`. Convert
+        // deprecations to exceptions so the test fails if hydrating passes
+        // that `null` as an array offset (deprecated in PHP 8.5)...
+        set_error_handler(function ($severity, $message) {
+            throw new \ErrorException($message, 0, $severity);
+        }, E_DEPRECATED | E_USER_DEPRECATED);
 
-        $this->assertInstanceOf(Collection::class, $result);
+        try {
+            $component->call('$refresh')->assertSee('count: 0');
+        } finally {
+            restore_error_handler();
+        }
     }
 }
 

--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -324,6 +324,27 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertCount(1, array_values($articleQueries));
     }
+
+    public function test_eloquent_collection_synth_handles_null_model_class_without_deprecation()
+    {
+        $component = Livewire::test(ArticleComponent::class);
+
+        $synth = new EloquentCollectionSynth(
+            new \Livewire\Mechanisms\HandleComponents\ComponentContext($component->instance()),
+            'articles'
+        );
+
+        $meta = [
+            'class' => Collection::class,
+            'modelClass' => null,
+            'keys' => [],
+        ];
+
+        // Should not trigger "Using null as an array offset" deprecation
+        $result = $synth->hydrate(null, $meta, fn ($v) => $v);
+
+        $this->assertInstanceOf(Collection::class, $result);
+    }
 }
 
 #[\Attribute]


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
This fixes a PHP 8.5 deprecation warning. No discussion needed as it's a clear bug fix.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes, the branch is named `fix/php85-null-array-offset-eloquent-collection-synth`

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No

4️⃣ Does it include tests? (Required)
Yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

**Fixes #10379** 

## Problem

PHP 8.5 deprecated using `null` as an array offset.

In `EloquentCollectionSynth::hydrate()`, when an empty Eloquent Collection is dehydrated, `$meta['modelClass']` is stored as `null` (because `getQueueableClass()` returns `null` for empty collections). During hydration, this `null` is passed to `Relation::getMorphedModel($modelClass)`, which uses it as an array key (`static::$morphMap[$alias]`), triggering the deprecation.

## Fix

Guard against `null` before calling `getMorphedModel()`, matching the guard already present in `dehydrate()` (line 34).
