### PR TITLE
[4.x] Add original filename option to temporary upload URLs

### DIFF
--- a/src/Drawer/Utils.php
+++ b/src/Drawer/Utils.php
@@ -65,7 +65,7 @@ class Utils extends BaseUtils
             fn ($headers) => response($content, 200, $headers));
     }
 
-    static function pretendPreviewResponseIsPreviewFile($filename)
+    static function pretendPreviewResponseIsPreviewFile($filename, $downloadName = null)
     {
         $file = FileUploadConfiguration::path($filename);
         $storage = FileUploadConfiguration::storage();
@@ -73,7 +73,7 @@ class Utils extends BaseUtils
         $lastModified = FileUploadConfiguration::lastModified($file);
 
         return self::cachedFileResponse($filename, $mimeType, $lastModified,
-            fn ($headers) => $storage->download($file, $filename, $headers));
+            fn ($headers) => $storage->download($file, $downloadName ?? $filename, $headers));
     }
 
     static private function cachedFileResponse($filename, $contentType, $lastModified, $downloadCallback)

--- a/src/Features/SupportFileUploads/FilePreviewController.php
+++ b/src/Features/SupportFileUploads/FilePreviewController.php
@@ -19,6 +19,12 @@ class FilePreviewController implements HasMiddleware
     {
         abort_unless(request()->hasValidSignature(), 401);
 
-        return Utils::pretendPreviewResponseIsPreviewFile($filename);
+        $downloadName = null;
+
+        if (request()->boolean('useOriginalFilename')) {
+            $downloadName = (new TemporaryUploadedFile($filename, FileUploadConfiguration::disk()))->getClientOriginalName();
+        }
+
+        return Utils::pretendPreviewResponseIsPreviewFile($filename, $downloadName);
     }
 }

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -117,7 +117,7 @@ class TemporaryUploadedFile extends UploadedFile
         return @getimagesize(stream_get_meta_data($tmpFile)['uri']);
     }
 
-    public function temporaryUrl()
+    public function temporaryUrl(bool $useOriginalFilename = false)
     {
         if (!$this->isPreviewable()) {
             throw new FileNotPreviewableException($this);
@@ -136,8 +136,14 @@ class TemporaryUploadedFile extends UploadedFile
             return $this->storage->temporaryUrl($this->path, now()->addDay());
         }
 
+        $parameters = ['filename' => $this->getFilename()];
+
+        if ($useOriginalFilename) {
+            $parameters['useOriginalFilename'] = true;
+        }
+
         return URL::temporarySignedRoute(
-            'livewire.preview-file', now()->addMinutes(30)->endOfHour(), ['filename' => $this->getFilename()]
+            'livewire.preview-file', now()->addMinutes(30)->endOfHour(), $parameters
         );
     }
 

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -527,6 +527,44 @@ class UnitTest extends \Tests\TestCase
         $this->assertTrue($photo->isPreviewable());
     }
 
+    public function test_temporary_preview_url_without_options_uses_temporary_filename_for_content_disposition()
+    {
+        Storage::fake('avatars');
+
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->viewData('photo');
+
+        // Due to Livewire object still being in memory, we need to
+        // reset the "shouldDisableBackButtonCache" property back to its default
+        // which is false to ensure it's not applied to the below route
+        \Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+
+        $this->get($photo->temporaryUrl())
+            ->assertDownload($photo->getFilename());
+    }
+
+    public function test_temporary_preview_url_can_use_original_filename_for_content_disposition()
+    {
+        Storage::fake('avatars');
+
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', $file)
+            ->viewData('photo');
+
+        // Due to Livewire object still being in memory, we need to
+        // reset the "shouldDisableBackButtonCache" property back to its default
+        // which is false to ensure it's not applied to the below route
+        \Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+
+        $this->get($photo->temporaryUrl(useOriginalFilename: true))
+            ->assertDownload('avatar.jpg');
+    }
+
     public function test_file_is_not_sent_on_cache_hit()
     {
         Storage::fake('avatars');


### PR DESCRIPTION
# The Scenario

When rendering a temporary upload preview link, Livewire's generated `temporaryUrl()` points at the `livewire.preview-file` endpoint. If that preview link is downloaded, the response currently suggests Livewire's temporary filename instead of the user's original upload name.

See screencapture in the solution below for the before and after.

```blade
<div>
    <input type="file" wire:model="photo">

    @if ($photo)
        <a href="{{ $photo->temporaryUrl() }}" target="_blank">
            Preview
        </a>
    @endif
</div>
```

# The Problem

`TemporaryUploadedFile::temporaryUrl()` currently generates a signed local preview URL with only the temporary filename.

`FilePreviewController` passes that filename to `Utils::pretendPreviewResponseIsPreviewFile()`, and `Utils` uses it as both the storage lookup name and the public download name for `Storage::download()`.

This means the local preview endpoint's `Content-Disposition` filename is tied to Livewire's internal temporary filename.

# The Solution

This is a follow up of PR #10354, which changed it, but that was a breaking change, so this is an alternative solution.

The solution is adding an opt-in `useOriginalFilename` parameter to `TemporaryUploadedFile::temporaryUrl()`.

```blade
<img src="{{ $photo->temporaryUrl(useOriginalFilename: true) }}">
```

When `useOriginalFilename` is false or not present, Livewire keeps the existing response filename behaviour. When true, Livewire includes a signed `useOriginalFilename` flag in the preview URL.

The preview controller verifies the signed URL before deriving the original upload name from `TemporaryUploadedFile`.

It then sets the `Content-Disposition` filename to the original upload name so the downloaded file has the expected name.

<img width="800" height="502" alt="CleanShot 2026-07-03 at 10 44 21" src="https://github.com/user-attachments/assets/a5f94418-6fa3-440a-8447-34c31feaaf08" />

Refs #10354
