### PR TITLE
[4.x] Add `#[Middleware]` attribute

### DIFF
--- a/src/Attributes/Middleware.php
+++ b/src/Attributes/Middleware.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Attribute;
+use Livewire\Features\SupportActionMiddleware\BaseMiddleware;
+
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
+class Middleware extends BaseMiddleware
+{
+    //
+}

--- a/src/Features/SupportActionMiddleware/BaseMiddleware.php
+++ b/src/Features/SupportActionMiddleware/BaseMiddleware.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Livewire\Features\SupportActionMiddleware;
+
+use Attribute;
+use Illuminate\Support\Arr;
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
+use function Livewire\store;
+
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
+class BaseMiddleware extends LivewireAttribute
+{
+    public function __construct(public string $middleware)
+    {
+        //
+    }
+
+    public function boot()
+    {
+        store($this->component)->push(
+            'middlewareFromAttributes',
+            $this->getName() ?? '$refresh',
+            $this->middleware
+        );
+    }
+}

--- a/src/Features/SupportActionMiddleware/BaseMiddleware.php
+++ b/src/Features/SupportActionMiddleware/BaseMiddleware.php
@@ -3,7 +3,6 @@
 namespace Livewire\Features\SupportActionMiddleware;
 
 use Attribute;
-use Illuminate\Support\Arr;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
 use function Livewire\store;

--- a/src/Features/SupportActionMiddleware/BaseMiddleware.php
+++ b/src/Features/SupportActionMiddleware/BaseMiddleware.php
@@ -14,13 +14,4 @@ class BaseMiddleware extends LivewireAttribute
     {
         //
     }
-
-    public function boot()
-    {
-        store($this->component)->push(
-            'middlewareFromAttributes',
-            $this->getName() ?? '$refresh',
-            $this->middleware
-        );
-    }
 }

--- a/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
+++ b/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Livewire\Features\SupportActionMiddleware;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Livewire\Attributes\On;
+use Livewire\ComponentHook;
+use Livewire\Features\SupportEvents\BaseOn;
+use Livewire\Features\SupportEvents\SupportEvents;
+use Livewire\Features\SupportPageComponents\SupportPageComponents;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+
+use function Livewire\invade;
+use function Livewire\store;
+
+class SupportActionMiddleware extends ComponentHook
+{
+    // Since this might runs before all component hooks (e.g on snapshot verified)
+    // we need to retrieve all methods from middleware attribute on dehydrate
+    // and store it in component payload memo so later can be used to determine method name
+    public static function getActionNameFromComponent($component)
+    {
+        // Contains [middleware => method]
+        $middlewareFromAttributes = store($component)->get('middlewareFromAttributes', []);
+
+        return collect($middlewareFromAttributes)
+            ->values()
+            ->unique()
+            ->all();
+    }
+
+    public static function gatherActionMiddleware(Request $request, array $actions)
+    {
+        if (! $componentClass = static::routeActionIsAPageComponent($request->route())) {
+            return [];
+        }
+
+        $component = new $componentClass;
+
+        // Since an action can be called as event listener
+        // we need to retrieve all event listener to resolve method name
+        $listeners = static::getComponentListeners($component);
+
+        $calls = $request->input('components.0.calls');
+        
+        $call = Arr::first($calls, function ($call) use ($component, $actions, $listeners) {
+            $method = static::resolveMethodFromCall($call, $listeners);
+
+            return method_exists($component, $method) && in_array($method, $actions, true);
+        });
+
+        $methodName = $call ? static::resolveMethodFromCall($call, $listeners) : null;
+
+        if (! $methodName) return [];
+
+        return static::resolveAttributeMiddleware($component, $methodName);
+    }
+
+    protected static function resolveMethodFromCall(array $call, array $listeners)
+    {
+        $method = $call['method'] ?? '';
+
+        if ($method === '__dispatch') {
+            [$name] = $call['params'] ?? [];
+
+            return $listeners[$name] ?? '';
+        }
+
+        return $method;
+    }
+
+    protected static function resolveAttributeMiddleware($component, $method)
+    {
+        $reflectionMethod = new \ReflectionMethod($component, $method);
+        $attributes = $reflectionMethod->getAttributes(BaseMiddleware::class, \ReflectionAttribute::IS_INSTANCEOF);
+
+        $arguments = collect($attributes)
+            ->map(fn ($attr) => $attr->newInstance()->middleware)
+            ->values()
+            ->all();
+
+        return app('router')->resolveMiddleware($arguments);
+    }
+
+    protected static function getComponentListeners($component)
+    {
+        $reflectionClass = new \ReflectionClass($component);
+        $reflectionMethods = $reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC);
+        
+        $hasMiddlewareAttribute = array_filter($reflectionMethods, function ($method) {
+            return $method->getAttributes(BaseOn::class, \ReflectionAttribute::IS_INSTANCEOF)
+                && $method->getAttributes(BaseMiddleware::class, \ReflectionAttribute::IS_INSTANCEOF);
+        });
+
+        $listeners = [];
+        foreach ($hasMiddlewareAttribute as $method) {
+            foreach ($method->getAttributes() as $attribute) {
+                if (is_subclass_of($attribute->getName(), BaseOn::class)) {
+                    $arguments = $attribute->getArguments();
+                    $listeners[$arguments[0]] = $method->getName();
+                }
+            }
+        }
+
+        return $listeners;
+    }
+
+    protected static function routeActionIsAPageComponent($route)
+    {
+        return SupportPageComponents::routeActionIsAPageComponent($route);
+    }
+}

--- a/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
+++ b/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
@@ -4,14 +4,10 @@ namespace Livewire\Features\SupportActionMiddleware;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
-use Livewire\Attributes\On;
 use Livewire\ComponentHook;
 use Livewire\Features\SupportEvents\BaseOn;
-use Livewire\Features\SupportEvents\SupportEvents;
 use Livewire\Features\SupportPageComponents\SupportPageComponents;
-use Livewire\Mechanisms\HandleComponents\ComponentContext;
 
-use function Livewire\invade;
 use function Livewire\store;
 
 class SupportActionMiddleware extends ComponentHook

--- a/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
+++ b/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
@@ -45,8 +45,9 @@ class SupportActionMiddleware extends ComponentHook
         $component = new $componentClass;
 
         // Since an action can be called as event listener
-        // we need to retrieve all event listener to resolve method name
-        $reflectionMethods = static::getComponentListeners($component);
+        // we need to store all event listener to $listeners property
+        // and use all reflected methods to resolve attribute middleware
+        $methods = static::getComponentMetadata($component);
 
         $calls = $request->input('components.0.calls');
         
@@ -62,7 +63,7 @@ class SupportActionMiddleware extends ComponentHook
 
         if (! $methodName) return [];
 
-        return static::resolveAttributeMiddleware($methodName, $reflectionMethods);
+        return static::resolveAttributeMiddleware($methodName, $methods);
     }
 
     protected static function resolveMethodFromCall(array $call)
@@ -78,45 +79,47 @@ class SupportActionMiddleware extends ComponentHook
         return $method;
     }
 
-    protected static function resolveAttributeMiddleware($method, $reflectionMethods)
+    protected static function resolveAttributeMiddleware($method, $methods)
     {
-        $reflectionMethod = Arr::first($reflectionMethods, function ($reflected) use ($method) {
-            return $reflected->getName() === $method;
-        });
+        $reflectionMethod = $methods[$method] ?? null;
 
-        $attributes = $reflectionMethod->getAttributes(BaseMiddleware::class, \ReflectionAttribute::IS_INSTANCEOF);
+        if (! $reflectionMethod) return [];
 
-        $arguments = collect($attributes)
-            ->map(fn ($attr) => $attr->newInstance()->middleware)
-            ->values()
-            ->all();
+        $attributes = $reflectionMethod->getAttributes(
+            BaseMiddleware::class,
+            \ReflectionAttribute::IS_INSTANCEOF
+        );
 
-        return app('router')->resolveMiddleware($arguments);
+        $middleware = array_map(
+            fn ($attribute) => $attribute->newInstance()->middleware,
+            $attributes
+        );
+
+        return app('router')->resolveMiddleware($middleware);
     }
 
-    protected static function getComponentListeners($component)
+    protected static function getComponentMetadata($component)
     {
-        $reflectionClass = new \ReflectionClass($component);
-        $reflectionMethods = $reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC);
-        
-        $hasMiddlewareAttribute = array_filter($reflectionMethods, function ($method) {
-            return $method->getAttributes(BaseOn::class, \ReflectionAttribute::IS_INSTANCEOF)
-                && $method->getAttributes(BaseMiddleware::class, \ReflectionAttribute::IS_INSTANCEOF);
-        });
+        $reflectionMethods = (new \ReflectionClass($component))
+            ->getMethods(\ReflectionMethod::IS_PUBLIC);
 
+        $methods = [];
         $listeners = [];
-        foreach ($hasMiddlewareAttribute as $method) {
-            foreach ($method->getAttributes() as $attribute) {
-                if (is_subclass_of($attribute->getName(), BaseOn::class)) {
-                    $arguments = $attribute->getArguments();
-                    $listeners[$arguments[0]] = $method->getName();
-                }
+        foreach ($reflectionMethods as $method) {
+            if (! $method->getAttributes(BaseMiddleware::class, \ReflectionAttribute::IS_INSTANCEOF)) {
+                continue;
+            }
+
+            $methods[$method->getName()] = $method;
+
+            foreach ($method->getAttributes(BaseOn::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                $listeners[$attribute->getArguments()[0]] = $method->getName();
             }
         }
 
         static::$listeners = $listeners;
 
-        return $reflectionMethods;
+        return $methods;
     }
 
     protected static function routeActionIsAPageComponent($route)

--- a/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
+++ b/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
@@ -34,9 +34,7 @@ class SupportActionMiddleware extends ComponentHook
 
         $middleware = static::resolveAttributeMiddleware($methodName, $actions);
 
-        $route->middleware($middleware);
-
-        return $middleware;
+        return tap($middleware, $route->middleware(...));
     }
 
     protected static function resolveMethodFromCall($call, $listeners)

--- a/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
+++ b/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
@@ -54,14 +54,9 @@ class SupportActionMiddleware extends ComponentHook
 
         if (! $reflectionMethod) return [];
 
-        $attributes = $reflectionMethod->getAttributes(
-            BaseMiddleware::class,
-            \ReflectionAttribute::IS_INSTANCEOF
-        );
-
         $middleware = array_map(
             fn ($attribute) => $attribute->newInstance()->middleware,
-            $attributes
+            $reflectionMethod->getAttributes()
         );
 
         return app('router')->resolveMiddleware($middleware);

--- a/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
+++ b/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
@@ -8,10 +8,20 @@ use Livewire\ComponentHook;
 use Livewire\Features\SupportEvents\BaseOn;
 use Livewire\Features\SupportPageComponents\SupportPageComponents;
 
+use function Livewire\on;
 use function Livewire\store;
 
 class SupportActionMiddleware extends ComponentHook
 {
+    protected static $listeners = [];
+
+    public static function provide()
+    {
+        on('flush-state', function () {
+            static::$listeners = [];
+        });
+    }
+
     // Since this might runs before all component hooks (e.g on snapshot verified)
     // we need to retrieve all methods from middleware attribute on dehydrate
     // and store it in component payload memo so later can be used to determine method name
@@ -36,39 +46,44 @@ class SupportActionMiddleware extends ComponentHook
 
         // Since an action can be called as event listener
         // we need to retrieve all event listener to resolve method name
-        $listeners = static::getComponentListeners($component);
+        $reflectionMethods = static::getComponentListeners($component);
 
         $calls = $request->input('components.0.calls');
         
-        $call = Arr::first($calls, function ($call) use ($component, $actions, $listeners) {
-            $method = static::resolveMethodFromCall($call, $listeners);
+        $methodName = null;
+        foreach ($calls as $call) {
+            $method = static::resolveMethodFromCall($call);
 
-            return method_exists($component, $method) && in_array($method, $actions, true);
-        });
-
-        $methodName = $call ? static::resolveMethodFromCall($call, $listeners) : null;
+            if (method_exists($component, $method) && in_array($method, $actions, true)) {
+                $methodName = $method;
+                break;
+            }
+        }
 
         if (! $methodName) return [];
 
-        return static::resolveAttributeMiddleware($component, $methodName);
+        return static::resolveAttributeMiddleware($methodName, $reflectionMethods);
     }
 
-    protected static function resolveMethodFromCall(array $call, array $listeners)
+    protected static function resolveMethodFromCall(array $call)
     {
         $method = $call['method'] ?? '';
 
         if ($method === '__dispatch') {
             [$name] = $call['params'] ?? [];
 
-            return $listeners[$name] ?? '';
+            return static::$listeners[$name] ?? '';
         }
 
         return $method;
     }
 
-    protected static function resolveAttributeMiddleware($component, $method)
+    protected static function resolveAttributeMiddleware($method, $reflectionMethods)
     {
-        $reflectionMethod = new \ReflectionMethod($component, $method);
+        $reflectionMethod = Arr::first($reflectionMethods, function ($reflected) use ($method) {
+            return $reflected->getName() === $method;
+        });
+
         $attributes = $reflectionMethod->getAttributes(BaseMiddleware::class, \ReflectionAttribute::IS_INSTANCEOF);
 
         $arguments = collect($attributes)
@@ -99,7 +114,9 @@ class SupportActionMiddleware extends ComponentHook
             }
         }
 
-        return $listeners;
+        static::$listeners = $listeners;
+
+        return $reflectionMethods;
     }
 
     protected static function routeActionIsAPageComponent($route)

--- a/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
+++ b/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
@@ -18,18 +18,13 @@ class SupportActionMiddleware extends ComponentHook
         // we need to retrieve all that using middleware attribute
         [$actions, $listeners] = static::getComponentMetadata($component);
 
-        $methods = array_unique(array_merge(
-            array_keys($actions),       // [method => reflection]
-            array_values($listeners)    // [event => method]
-        ));
-
         $calls = $request->input('components.0.calls');
 
         $methodName = null;
         foreach ($calls as $call) {
             $method = static::resolveMethodFromCall($call, $listeners);
 
-            if (method_exists($component, $method) && in_array($method, $methods, true)) {
+            if (method_exists($component, $method) && in_array($method, array_keys($actions), true)) {
                 $methodName = $method;
                 break;
             }

--- a/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
+++ b/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
@@ -2,60 +2,34 @@
 
 namespace Livewire\Features\SupportActionMiddleware;
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
 use Livewire\ComponentHook;
 use Livewire\Features\SupportEvents\BaseOn;
 use Livewire\Features\SupportPageComponents\SupportPageComponents;
 
-use function Livewire\on;
-use function Livewire\store;
-
 class SupportActionMiddleware extends ComponentHook
 {
-    protected static $listeners = [];
-
-    public static function provide()
+    public static function gatherActionMiddleware($request)
     {
-        on('flush-state', function () {
-            static::$listeners = [];
-        });
-    }
-
-    // Since this might runs before all component hooks (e.g on snapshot verified)
-    // we need to retrieve all methods from middleware attribute on dehydrate
-    // and store it in component payload memo so later can be used to determine method name
-    public static function getActionNameFromComponent($component)
-    {
-        // Contains [middleware => method]
-        $middlewareFromAttributes = store($component)->get('middlewareFromAttributes', []);
-
-        return collect($middlewareFromAttributes)
-            ->values()
-            ->unique()
-            ->all();
-    }
-
-    public static function gatherActionMiddleware(Request $request, array $actions)
-    {
-        if (! $componentClass = static::routeActionIsAPageComponent($request->route())) {
+        if (! $component = static::routeActionIsAPageComponent($request->route())) {
             return [];
         }
 
-        $component = new $componentClass;
-
         // Since an action can be called as event listener
-        // we need to store all event listener to $listeners property
-        // and use all reflected methods to resolve attribute middleware
-        $methods = static::getComponentMetadata($component);
+        // we need to retrieve all that using middleware attribute
+        [$actions, $listeners] = static::getComponentMetadata($component);
+
+        $methods = array_unique(array_merge(
+            array_keys($actions),       // [method => reflection]
+            array_values($listeners)    // [event => method]
+        ));
 
         $calls = $request->input('components.0.calls');
-        
+
         $methodName = null;
         foreach ($calls as $call) {
-            $method = static::resolveMethodFromCall($call);
+            $method = static::resolveMethodFromCall($call, $listeners);
 
-            if (method_exists($component, $method) && in_array($method, $actions, true)) {
+            if (method_exists($component, $method) && in_array($method, $methods, true)) {
                 $methodName = $method;
                 break;
             }
@@ -63,25 +37,25 @@ class SupportActionMiddleware extends ComponentHook
 
         if (! $methodName) return [];
 
-        return static::resolveAttributeMiddleware($methodName, $methods);
+        return static::resolveAttributeMiddleware($methodName, $actions);
     }
 
-    protected static function resolveMethodFromCall(array $call)
+    protected static function resolveMethodFromCall($call, $listeners)
     {
         $method = $call['method'] ?? '';
 
         if ($method === '__dispatch') {
             [$name] = $call['params'] ?? [];
 
-            return static::$listeners[$name] ?? '';
+            return $listeners[$name] ?? '';
         }
 
         return $method;
     }
 
-    protected static function resolveAttributeMiddleware($method, $methods)
+    protected static function resolveAttributeMiddleware($method, $actions)
     {
-        $reflectionMethod = $methods[$method] ?? null;
+        $reflectionMethod = $actions[$method] ?? null;
 
         if (! $reflectionMethod) return [];
 
@@ -117,9 +91,7 @@ class SupportActionMiddleware extends ComponentHook
             }
         }
 
-        static::$listeners = $listeners;
-
-        return $methods;
+        return [$methods, $listeners];
     }
 
     protected static function routeActionIsAPageComponent($route)

--- a/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
+++ b/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
@@ -8,9 +8,9 @@ use Livewire\Features\SupportPageComponents\SupportPageComponents;
 
 class SupportActionMiddleware extends ComponentHook
 {
-    public static function gatherActionMiddleware($request)
+    public static function gatherActionMiddleware($request, $route)
     {
-        if (! $component = static::routeActionIsAPageComponent($request->route())) {
+        if (! $component = static::routeActionIsAPageComponent($route)) {
             return [];
         }
 
@@ -18,7 +18,7 @@ class SupportActionMiddleware extends ComponentHook
         // we need to retrieve all that using middleware attribute
         [$actions, $listeners] = static::getComponentMetadata($component);
 
-        $calls = $request->input('components.0.calls');
+        $calls = $request->array('components.0.calls', []);
 
         $methodName = null;
         foreach ($calls as $call) {
@@ -32,7 +32,11 @@ class SupportActionMiddleware extends ComponentHook
 
         if (! $methodName) return [];
 
-        return static::resolveAttributeMiddleware($methodName, $actions);
+        $middleware = static::resolveAttributeMiddleware($methodName, $actions);
+
+        $route->middleware($middleware);
+
+        return $middleware;
     }
 
     protected static function resolveMethodFromCall($call, $listeners)
@@ -56,7 +60,7 @@ class SupportActionMiddleware extends ComponentHook
 
         $middleware = array_map(
             fn ($attribute) => $attribute->newInstance()->middleware,
-            $reflectionMethod->getAttributes()
+            $reflectionMethod->getAttributes(BaseMiddleware::class, \ReflectionAttribute::IS_INSTANCEOF)
         );
 
         return app('router')->resolveMiddleware($middleware);

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -231,7 +231,7 @@ class SupportPageComponents extends ComponentHook
         return method_exists(app('router'), 'substituteImplicitBindingsUsing');
     }
 
-    protected static function routeActionIsAPageComponent($route)
+    public static function routeActionIsAPageComponent($route)
     {
         $action = $route->action;
 

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -205,7 +205,8 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
             Features\SupportEvents\SupportEvents::class,
             Features\SupportSlots\SupportSlots::class,
             Features\SupportJson\SupportJson::class,
-
+            Features\SupportActionMiddleware\SupportActionMiddleware::class,
+            
             // Some features we want to have priority over others...
             Features\SupportLifecycleHooks\SupportLifecycleHooks::class,
             Features\SupportLegacyModels\SupportLegacyModels::class,

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -86,22 +86,6 @@ class PersistentMiddleware extends Mechanism
         return $middleware;
     }
 
-    protected function extractActionNameFromComponent($component)
-    {
-        if (app(HandleRequests::class)->isLivewireRoute()) {
-            return $this->actions;
-        }
-
-        return SupportActionMiddleware::getActionNameFromComponent($component);
-    }
-
-    protected function extractActionNameFromSnapshot($snapshot)
-    {
-        if (! isset($snapshot['memo']['actions'])) return;
-
-        $this->actions = $snapshot['memo']['actions'];
-    }
-
     protected function extractPathAndMethodFromRequest()
     {
         if (app(HandleRequests::class)->isLivewireRoute()) {

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -77,13 +77,11 @@ class PersistentMiddleware extends Mechanism
         return $this->resolvedRouteModels[$class.':'.$key] ?? null;
     }
 
-    protected function gatherActionMiddleware($request)
+    protected function applyActionMiddleware($request, $route)
     {
-        $middleware = SupportActionMiddleware::gatherActionMiddleware($request);
+        $middleware = SupportActionMiddleware::gatherActionMiddleware($request, $route);
 
         $this->addPersistentMiddleware($middleware);
-
-        return $middleware;
     }
 
     protected function extractPathAndMethodFromRequest()
@@ -186,11 +184,9 @@ class PersistentMiddleware extends Mechanism
 
         if (! $route) return [];
 
-        $routeMiddleware = app('router')->gatherRouteMiddleware($route);
-
-        $actionMiddleware = $this->gatherActionMiddleware($request);
-
-        $middleware = array_merge($routeMiddleware, $actionMiddleware);
+        $this->applyActionMiddleware($request, $route);
+        
+        $middleware = app('router')->gatherRouteMiddleware($route);
 
         return $this->filterMiddlewareByPersistentMiddleware($middleware);
     }

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -27,7 +27,6 @@ class PersistentMiddleware extends Mechanism
 
     protected $path;
     protected $method;
-    protected $actions = [];
     protected $middlewareAppliedFor = [];
     protected $resolvedRouteModels = [];
 
@@ -35,18 +34,14 @@ class PersistentMiddleware extends Mechanism
     {
         on('dehydrate', function ($component, $context) {
             [$path, $method] = $this->extractPathAndMethodFromRequest();
-            $actions = $this->extractActionNameFromComponent($component);
 
             $context->addMemo('path', $path);
             $context->addMemo('method', $method);
-            $context->addMemo('actions', $actions);
         });
 
         on('snapshot-verified', function ($snapshot) {
             // Only apply middleware to requests hitting the Livewire update endpoint, and not any fake requests such as a test.
             if (! app(HandleRequests::class)->isLivewireRoute()) return;
-
-            $this->extractActionNameFromSnapshot($snapshot);
 
             $this->extractPathAndMethodFromSnapshot($snapshot);
 
@@ -57,7 +52,6 @@ class PersistentMiddleware extends Mechanism
             // Only flush these at the end of a full request, so that child components have access to this data.
             $this->path = null;
             $this->method = null;
-            $this->actions = [];
             $this->middlewareAppliedFor = [];
             $this->resolvedRouteModels = [];
         });
@@ -83,9 +77,9 @@ class PersistentMiddleware extends Mechanism
         return $this->resolvedRouteModels[$class.':'.$key] ?? null;
     }
 
-    protected function gatherActionMiddleware($request, $actions)
+    protected function gatherActionMiddleware($request)
     {
-        $middleware = SupportActionMiddleware::gatherActionMiddleware($request, $actions);
+        $middleware = SupportActionMiddleware::gatherActionMiddleware($request);
 
         $this->addPersistentMiddleware($middleware);
 
@@ -210,7 +204,7 @@ class PersistentMiddleware extends Mechanism
 
         $routeMiddleware = app('router')->gatherRouteMiddleware($route);
 
-        $actionMiddleware = $this->gatherActionMiddleware($request, $this->actions);
+        $actionMiddleware = $this->gatherActionMiddleware($request);
 
         $middleware = array_merge($routeMiddleware, $actionMiddleware);
 

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use function Livewire\on;
 use Illuminate\Support\Str;
 use Livewire\Drawer\Utils;
+use Livewire\Features\SupportActionMiddleware\SupportActionMiddleware;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
 
 class PersistentMiddleware extends Mechanism
@@ -26,6 +27,7 @@ class PersistentMiddleware extends Mechanism
 
     protected $path;
     protected $method;
+    protected $actions = [];
     protected $middlewareAppliedFor = [];
     protected $resolvedRouteModels = [];
 
@@ -33,14 +35,18 @@ class PersistentMiddleware extends Mechanism
     {
         on('dehydrate', function ($component, $context) {
             [$path, $method] = $this->extractPathAndMethodFromRequest();
+            $actions = $this->extractActionNameFromComponent($component);
 
             $context->addMemo('path', $path);
             $context->addMemo('method', $method);
+            $context->addMemo('actions', $actions);
         });
 
         on('snapshot-verified', function ($snapshot) {
             // Only apply middleware to requests hitting the Livewire update endpoint, and not any fake requests such as a test.
             if (! app(HandleRequests::class)->isLivewireRoute()) return;
+
+            $this->extractActionNameFromSnapshot($snapshot);
 
             $this->extractPathAndMethodFromSnapshot($snapshot);
 
@@ -51,6 +57,7 @@ class PersistentMiddleware extends Mechanism
             // Only flush these at the end of a full request, so that child components have access to this data.
             $this->path = null;
             $this->method = null;
+            $this->actions = [];
             $this->middlewareAppliedFor = [];
             $this->resolvedRouteModels = [];
         });
@@ -74,6 +81,31 @@ class PersistentMiddleware extends Mechanism
     function getResolvedRouteModel($class, $key)
     {
         return $this->resolvedRouteModels[$class.':'.$key] ?? null;
+    }
+
+    protected function gatherActionMiddleware($request, $actions)
+    {
+        $middleware = SupportActionMiddleware::gatherActionMiddleware($request, $actions);
+
+        $this->addPersistentMiddleware($middleware);
+
+        return $middleware;
+    }
+
+    protected function extractActionNameFromComponent($component)
+    {
+        if (app(HandleRequests::class)->isLivewireRoute()) {
+            return $this->actions;
+        }
+
+        return SupportActionMiddleware::getActionNameFromComponent($component);
+    }
+
+    protected function extractActionNameFromSnapshot($snapshot)
+    {
+        if (! isset($snapshot['memo']['actions'])) return;
+
+        $this->actions = $snapshot['memo']['actions'];
     }
 
     protected function extractPathAndMethodFromRequest()
@@ -176,7 +208,11 @@ class PersistentMiddleware extends Mechanism
 
         if (! $route) return [];
 
-        $middleware = app('router')->gatherRouteMiddleware($route);
+        $routeMiddleware = app('router')->gatherRouteMiddleware($route);
+
+        $actionMiddleware = $this->gatherActionMiddleware($request, $this->actions);
+
+        $middleware = array_merge($routeMiddleware, $actionMiddleware);
 
         return $this->filterMiddlewareByPersistentMiddleware($middleware);
     }


### PR DESCRIPTION
Another approach from https://github.com/livewire/livewire/pull/10374

This PR introduces a new `#[Middleware]` attribute like Laravel [middleware attribute](https://laravel.com/docs/13.x/controllers#middleware-attributes) allowing users to apply middleware directly to individual component actions/methods only.

**Important Note**
- Only for component actions/methods
- Only support string as an argument (either full class name or middleware alias)
- `Closure` as argument **not supported** yet

# Feature flow

Applying middleware from attribute to the route and append it as persistent middleware.

Inside `SupportActionMiddleware::gatherActionMiddleware($request)`, all component methods that using `#[Middleware]` attribute resolved using reflection including the one that also use `#[On]` attribute so method name can be resolved if its an event listener.

# Examples

### Basic usage

```php
#[Middleware('auth')]
#[Middleware(EnsureUserIsSubscribed::class)
public function showContent()
{
    //
}

#[Middleware('guest')]
public function bookmarkPost()
{
    //
}
```

### Trigger middleware with an event

```php
#[On('mark-as-read')]
#[Middleware('auth')]
public function markAsRead()
{
    //
}
```

