### PR TITLE
[4.x] Fix `BaseAuthorze` and `BaseRenderless` not triggered using event

### DIFF
--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -877,6 +877,23 @@ class UnitTest extends TestCase
             ->dispatch('some-event')
             ->assertOk();
     }
+
+    public function test_base_authorize_attribute_blocks_unauthorized_user_via_event()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[BaseAuthorize(AuthorizationPost::class)]
+                #[BaseOn('some-event')]
+                public function store() : bool
+                {
+                    return true;
+                }
+            })
+            ->dispatch('some-event')
+            ->assertForbidden();
+    }
 }
 
 class AuthorizationUser extends AuthUser

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Session;
 use Livewire\Attributes\Authorize;
+use Livewire\Features\SupportEvents\BaseOn;
 use Livewire\Livewire;
 use Sushi\Sushi;
 use Tests\TestCase;
@@ -857,6 +858,23 @@ class UnitTest extends TestCase
                 }
             })
             ->call('store')
+            ->assertOk();
+    }
+
+    public function test_can_trigger_base_authorize_attribute_using_event()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Authorize(AuthorizationPost::class)]
+                #[BaseOn('some-event')]
+                public function store() : bool
+                {
+                    return true;
+                }
+            })
+            ->dispatch('some-event')
             ->assertOk();
     }
 }

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -867,7 +867,7 @@ class UnitTest extends TestCase
 
         Livewire::actingAs(AuthorizationUser::find(1))
             ->test(new class extends TestComponent {
-                #[Authorize(AuthorizationPost::class)]
+                #[BaseAuthorize(AuthorizationPost::class)]
                 #[BaseOn('some-event')]
                 public function store() : bool
                 {

--- a/src/Features/SupportEvents/SupportEvents.php
+++ b/src/Features/SupportEvents/SupportEvents.php
@@ -30,7 +30,7 @@ class SupportEvents extends ComponentHook
             // its normal "call" hook doesn't get run when the method
             // is called as an event listener...
             $this->component->getAttributes()
-                ->filter(fn ($i) => is_subclass_of($i, BaseAuthorize::class))
+                ->filter(fn ($i) => $i instanceof BaseAuthorize)
                 ->filter(fn ($i) => $i->getName() === $method)
                 ->filter(fn ($i) => $i->getLevel() === AttributeLevel::METHOD)
                 ->each(fn ($i) => $i->call($params));
@@ -43,7 +43,7 @@ class SupportEvents extends ComponentHook
             // is "renderless" as it's normal "call" hook doesn't get run when
             // the method is called as an event listener...
             $isRenderless = $this->component->getAttributes()
-                ->filter(fn ($i) => is_subclass_of($i, BaseRenderless::class))
+                ->filter(fn ($i) => $i instanceof BaseRenderless)
                 ->filter(fn ($i) => $i->getName() === $method)
                 ->filter(fn ($i) => $i->getLevel() === AttributeLevel::METHOD)
                 ->count() > 0;

--- a/src/Features/SupportRenderless/BrowserTest.php
+++ b/src/Features/SupportRenderless/BrowserTest.php
@@ -4,6 +4,7 @@ namespace Livewire\Features\SupportRenderless;
 
 use Illuminate\Support\Facades\Blade;
 use Livewire\Component;
+use Livewire\Features\SupportEvents\BaseOn;
 use Livewire\Livewire;
 use Tests\BrowserTestCase;
 
@@ -24,6 +25,31 @@ class BrowserTest extends BrowserTestCase
                 return Blade::render(<<<'HTML'
                 <div>
                     <button wire:click="renderlessAction" dusk="button">{{ $count }}</button>
+                </div>
+                HTML, ['count' => $this->count]);
+            }
+        })
+            ->assertSeeIn('@button', '1')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@button', '1');
+    }
+
+    public function test_dont_call_render_using_base_renderless_attribute_with_event()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            #[BaseRenderless]
+            #[BaseOn('some-event')]
+            function renderlessAction() { }
+
+            function render()
+            {
+                $this->count++;
+
+                return Blade::render(<<<'HTML'
+                <div>
+                    <button wire:click="$dispatch('some-event')" dusk="button">{{ $count }}</button>
                 </div>
                 HTML, ['count' => $this->count]);
             }


### PR DESCRIPTION
# Scenario

When user wants to contribute to this repo and preparing some browser / unit test related to `#[Authorize]` and `#[Renderless]` attribute, they might be not aware that using `#[BaseAuthorize]` or `#[BaseRenderless]` wont be triggered if action called as event listener.

I'm aware that all `Base*` attribute should be strictly for internal use as stated here https://github.com/livewire/livewire/pull/10346#issuecomment-4809466315.

# Problem

Inside `SupportEvents::call`, both renderless and authorize attribute checked using `is_subclass_of`

```php
$this->component->getAttributes()
    ->filter(fn ($i) => is_subclass_of($i, BaseAuthorize::class) // here
    ->filter(fn ($i) => $i->getName() === $method)
    ->filter(fn ($i) => $i->getLevel() === AttributeLevel::METHOD)
    ->each(fn ($i) => $i->call($params));
```
I think the intent here is a good one that prevent using `Base**` attribute as public API. But, this will cause some unsual issue when running tests. Therefore, I still think this need to be fixed.

# Solution

Change `is_subclass_of` to `instanceof`

```php
$this->component->getAttributes()
    ->filter(fn ($i) => $i instanceof BaseAuthorize)
    ->filter(fn ($i) => $i->getName() === $method)
    ->filter(fn ($i) => $i->getLevel() === AttributeLevel::METHOD)
    ->each(fn ($i) => $i->call($params));
```

I have added regression test for both authorize unit test and renderless browser test.

# Files Changed
- `src/Features/SupportEvents/SupportEvents.php`
- `src/Features/SupportAuthorization/UnitTest.php`
- `src/Features/SupportRenderless/BrowserTest.php`

Fix: https://github.com/livewire/livewire/issues/10383