### PR TITLE
Fix `#[Session]` on non-primitive properties under JSON session serialization

### DIFF
--- a/src/Features/SupportSession/BaseSession.php
+++ b/src/Features/SupportSession/BaseSession.php
@@ -3,6 +3,9 @@
 namespace Livewire\Features\SupportSession;
 
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+use Livewire\Mechanisms\HandleSynths\HandleSynths;
+use Livewire\Drawer\Utils;
 use Illuminate\Support\Facades\Session;
 use Attribute;
 
@@ -34,12 +37,34 @@ class BaseSession extends LivewireAttribute
 
     protected function read()
     {
-        return Session::get($this->key());
+        $value = Session::get($this->key());
+
+        // If a synth tuple was stored (because the session is JSON serialized),
+        // hydrate it back into its original type (Collection, Carbon, etc.)...
+        if (Utils::isSyntheticTuple($value)) {
+            $value = app(HandleSynths::class)->hydrate($value, new ComponentContext($this->component), $this->getName());
+        }
+
+        return $value;
     }
 
     protected function write()
     {
-        Session::put($this->key(), $this->getValue());
+        $value = $this->getValue();
+
+        // JSON serialized sessions can't store PHP objects, so dehydrate the
+        // value into a JSON-safe synth tuple that `read()` can restore later.
+        // PHP serialized sessions store objects natively, so skip the overhead...
+        if ($this->sessionIsJsonSerialized() && ! Utils::isAPrimitive($value)) {
+            $value = app(HandleSynths::class)->dehydrate($value, new ComponentContext($this->component), $this->getName());
+        }
+
+        Session::put($this->key(), $value);
+    }
+
+    protected function sessionIsJsonSerialized()
+    {
+        return config('session.serialization', 'php') === 'json';
     }
 
     protected function key()

--- a/src/Features/SupportSession/JsonSerializationBrowserTest.php
+++ b/src/Features/SupportSession/JsonSerializationBrowserTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Livewire\Features\SupportSession;
+
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Session;
+use Tests\BrowserTestCase;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class JsonSerializationBrowserTest extends BrowserTestCase
+{
+    public static function tweakApplicationHook()
+    {
+        return function () {
+            config(['session.serialization' => 'json']);
+        };
+    }
+
+    public function test_can_persist_a_collection_property_to_a_json_serialized_session()
+    {
+        Livewire::visit(new class extends Component {
+            #[Session]
+            public ?Collection $list = null;
+
+            public function mount(): void
+            {
+                $this->list ??= collect();
+            }
+
+            public function add(): void
+            {
+                $this->list->push($this->list->count() + 1);
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button dusk="button" wire:click="add">Add</button>
+                <span dusk="list">{{ $list->implode(', ') }}</span>
+            </div>
+            HTML; }
+        })
+            ->assertSeeIn('@list', '')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@list', '1')
+            ->refresh()
+            ->assertSeeIn('@list', '1')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@list', '1, 2')
+            ;
+    }
+}

--- a/src/Features/SupportSession/UnitTest.php
+++ b/src/Features/SupportSession/UnitTest.php
@@ -2,8 +2,11 @@
 
 namespace Livewire\Features\SupportSession;
 
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Session as FacadesSession;
 use Livewire\Attributes\Session;
+use Livewire\Component;
 use Tests\TestCase;
 use Livewire\Livewire;
 use Tests\TestComponent;
@@ -42,5 +45,80 @@ class UnitTest extends TestCase
         });
 
         $this->assertTrue(FacadesSession::has('baz.2'));
+    }
+
+    public function test_non_primitive_properties_survive_json_session_serialization()
+    {
+        config(['session.serialization' => 'json']);
+
+        // Rebuild the session store so the serialization config takes effect...
+        app('session')->forgetDrivers();
+
+        $date = Carbon::parse('2026-01-15 10:00:00');
+
+        Livewire::test(ComponentWithTypedSessionProperties::class)
+            ->call('add')
+            ->call('add')
+            ->set('when', $date)
+            ->call('increment');
+
+        // Force a real json_encode/json_decode round-trip on the session,
+        // like what happens between two real requests...
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentWithTypedSessionProperties::class)
+            ->assertSet('list', fn ($list) => $list instanceof Collection && count($list) === 2)
+            ->assertSet('when', fn ($when) => $when instanceof Carbon && $when->equalTo($date))
+            ->assertSet('count', 1);
+    }
+
+    public function test_non_primitive_properties_are_stored_raw_when_using_php_session_serialization()
+    {
+        Livewire::test(ComponentWithTypedSessionProperties::class)
+            ->call('add');
+
+        // Under the default "php" serialization, values are stored as-is...
+        $stored = collect(session()->all())->first(fn ($value, $key) => str_starts_with($key, 'lw') && $value instanceof Collection);
+
+        $this->assertInstanceOf(Collection::class, $stored);
+
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentWithTypedSessionProperties::class)
+            ->assertSet('list', fn ($list) => $list instanceof Collection && count($list) === 1);
+    }
+}
+
+class ComponentWithTypedSessionProperties extends Component
+{
+    #[Session]
+    public ?Collection $list = null;
+
+    #[Session]
+    public ?Carbon $when = null;
+
+    #[Session]
+    public int $count = 0;
+
+    public function mount(): void
+    {
+        $this->list ??= collect();
+    }
+
+    public function add(): void
+    {
+        $this->list->push(random_int(0, 100));
+    }
+
+    public function increment(): void
+    {
+        $this->count++;
+    }
+
+    public function render()
+    {
+        return '<div>{{ $list->implode(", ") }}</div>';
     }
 }


### PR DESCRIPTION
# The Scenario

Laravel now ships new apps with `'serialization' => 'json'` for sessions. Under JSON serialization, `#[Session]` stores the raw property value, so a `Collection` (or `Carbon`, enum, model, etc.) gets `json_encode`d into a plain array. On the next request, `mount()` reads that array back and assigns it to the typed property:

```
TypeError: Cannot assign array to property ...::$list of type ?Illuminate\Support\Collection
```

Fixes #10250.

# The Solution

This is the follow-up to #10252 (thanks @joshhanley — you're credited as co-author), rebuilt on top of the `HandleSynths` mechanism that was extracted in #10276 for exactly this purpose. It addresses the three review notes from the original PR:

**Write path** — when `session.serialization` is `json` and the value is non-primitive, dehydrate it through `HandleSynths` into a JSON-safe synth tuple before `Session::put()`.

**Read path** — if the stored value is a synth tuple, hydrate it back through `HandleSynths`. Anything else (primitives, raw objects from `php`-serialized sessions, values written before this change) is returned untouched.

### Re: the hydration pathway concern (A)

- The input to this hydrate call is the server-side session store, and the only writer of these tuples is our own `write()`. Unlike the snapshot path, no client-supplied data ever enters it — tampering with it requires session-write access, which is already game over.
- It goes through the same `HandleSynths::hydrate()` the snapshot pipeline uses, so `SecurityPolicy::validateClass()` runs on any `class` meta, only registered synths can be dispatched to, and nothing ever touches `unserialize()`.

### Re: the abstraction leak (B)

No more reaching into `HandleComponents` protected internals — this uses the public `HandleSynths` mechanism that #10276 extracted for this purpose. Custom synths and `ModelSynth` (registered via `Livewire::propertySynthesizer()`) flow through automatically.

### Re: performance (C)

- Apps on `php` serialization (the historical default): **zero change** — values are stored raw exactly as before, and the read-side tuple check is a cheap `is_array` + shape check that never matches.
- Apps on `json` serialization: dehydrate only runs for non-primitive values (primitives skip it entirely). These are the values that were previously broken, so there's no case where working behavior got slower.

# Tests

- Unit: Collection/Carbon/int `#[Session]` properties survive a real `json_encode`/`json_decode` session round-trip (`session()->save()` + `session()->start()`). Fails on `main` with the exact `TypeError` from the issue; passes with this change.
- Unit: under `php` serialization, values are still stored raw in the session (guards the zero-change claim).
- Browser: the reporter's exact scenario — `#[Session] public ?Collection $list`, click to push, refresh, push again — under JSON-serialized file sessions. Also fails on `main`, passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
