### PR TITLE
Revert "[4.x] Move temporary file if disks are same"

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -180,14 +180,9 @@ class TemporaryUploadedFile extends UploadedFile
 
         $newPath = trim($path.'/'.$name, '/');
 
-        // Same disk and no extra options — move instead of copy for performance.
-        if ($this->disk === $disk && empty($options)) {
-            Storage::disk($disk)->move($this->path, $newPath);
-        } else {
-            Storage::disk($disk)->put(
-                $newPath, $this->storage->readStream($this->path), $options
-            );
-        }
+        Storage::disk($disk)->put(
+            $newPath, $this->storage->readStream($this->path), $options
+        );
 
         return $newPath;
     }

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -941,51 +941,6 @@ class UnitTest extends \Tests\TestCase
         Storage::disk('default-disk')->assertExists('images/avatar.jpg');
         Storage::disk('tmp-for-tests')->assertMissing('images/avatar.jpg');
     }
-
-    public function test_same_disk_store_moves_file_instead_of_copying()
-    {
-        Storage::fake('tmp-for-tests');
-
-        $file = UploadedFile::fake()->image('avatar.jpg');
-
-        $component = Livewire::test(FileUploadSameDiskComponent::class)
-            ->set('photo', $file);
-
-        $tmpFile = $component->viewData('photo');
-        $tmpPath = FileUploadConfiguration::directory().'/'.$tmpFile->getFilename();
-
-        // The temp file exists before storing.
-        Storage::disk('tmp-for-tests')->assertExists($tmpPath);
-
-        $component->call('save');
-
-        // After storing to the same disk, the file was moved (temp file gone).
-        Storage::disk('tmp-for-tests')->assertExists('photos/avatar.jpg');
-        Storage::disk('tmp-for-tests')->assertMissing($tmpPath);
-    }
-
-    public function test_different_disk_store_copies_file()
-    {
-        Storage::fake('tmp-for-tests');
-        Storage::fake('avatars');
-
-        $file = UploadedFile::fake()->image('avatar.jpg');
-
-        $component = Livewire::test(FileUploadComponent::class)
-            ->set('photo', $file);
-
-        $tmpFile = $component->viewData('photo');
-        $tmpPath = FileUploadConfiguration::directory().'/'.$tmpFile->getFilename();
-
-        // The temp file exists before storing.
-        Storage::disk('tmp-for-tests')->assertExists($tmpPath);
-
-        $component->call('upload', 'avatar.jpg');
-
-        // After storing to a different disk, the file was copied (temp file still exists).
-        Storage::disk('avatars')->assertExists('avatar.jpg');
-        Storage::disk('tmp-for-tests')->assertExists($tmpPath);
-    }
 }
 
 class FileUploadToDefaultDiskComponent extends TestComponent
@@ -997,18 +952,6 @@ class FileUploadToDefaultDiskComponent extends TestComponent
     public function save()
     {
         $this->photo->storeAs('images', 'avatar.jpg');
-    }
-}
-
-class FileUploadSameDiskComponent extends TestComponent
-{
-    use WithFileUploads;
-
-    public $photo;
-
-    public function save()
-    {
-        $this->photo->storeAs('photos', 'avatar.jpg', 'tmp-for-tests');
     }
 }
 


### PR DESCRIPTION
Reverts livewire/livewire#9772

This same-disk move optimization changed `storeAs()`'s behaviour away from Laravel's own `UploadedFile::storeAs()` contract, which always copies the file and never touches the source. Once the temporary file has been moved, any code reading from it afterward (`getSize()`, `getMimeType()`, etc.) throws. See #10238.

#10309 proposes fixing this by falling back to the file's cached `.json` metadata when reading these values, but that file is deliberately never written for S3 uploads, as it would require an extra signed upload for every file. That fix would only work for non-S3 disks, meaning affected code would work locally in development and still break in production for anyone using S3. That's worse than the current, consistent failure, since it wouldn't be caught before deploying.

So after a lot of thought and digging, I think reverting is the best option. This revert restores the always-copy behaviour so `storeAs()` matches Laravel's contract on every disk.

I considered adding a `moveAs()` method or something like that, but Laravel has no precedence for it. So have opted just for the revert for this PR.