### PR TITLE
[4.x] Fix late-added wire:sort:item attributes

### DIFF
--- a/js/features/supportWireSort.js
+++ b/js/features/supportWireSort.js
@@ -1,82 +1,82 @@
 import { setNextActionOrigin } from '@/request'
 import { evaluateActionExpression } from '../evaluator'
 import Alpine from 'alpinejs'
-import { extractDirective } from '@/directives'
+import { on } from '@/hooks'
 
-Alpine.interceptInit(el => {
-    for (let i = 0; i < el.attributes.length; i++) {
-        if (el.attributes[i].name.startsWith('wire:sort:item')) {
-            let directive = extractDirective(el, el.attributes[i].name)
+on('directive.init', ({ el, directive, cleanup }) => {
+    if (! directive.rawName.startsWith('wire:sort')) return
 
-            let modifierString = directive.modifiers.join('.')
+    if (directive.rawName.startsWith('wire:sort:item')) {
+        let modifierString = directive.modifiers.join('.')
 
-            let expression = directive.expression
+        let expression = directive.expression
 
-            Alpine.bind(el, {
-                ['x-sort:item' + modifierString]() {
-                    return expression
-                }
-            })
-        } else if (el.attributes[i].name.startsWith('wire:sort:group-id')) {
-            // This will get read by the wire:sort handler below...
-            continue
-        } else if (el.attributes[i].name.startsWith('wire:sort:group')) {
-            // This will get picked up by Alpine's x-sort source...
-            return
-        } else if (el.attributes[i].name.startsWith('wire:sort')) {
-            let directive = extractDirective(el, el.attributes[i].name)
-
-            let attribute = directive.rawName.replace('wire:', 'x-')
-
-            // Strip .async from Alpine expression because it only concerns Livewire and trips up Alpine...
-            if (directive.modifiers.includes('async')) {
-                attribute = attribute.replace('.async', '')
+        let cleanupBinding = Alpine.bind(el, {
+            ['x-sort:item' + modifierString]() {
+                return expression
             }
+        })
 
-            // Strip .renderless from Alpine expression because it only concerns Livewire and trips up Alpine...
-            if (directive.modifiers.includes('renderless')) {
-                attribute = attribute.replace('.renderless', '')
-            }
+        cleanup(cleanupBinding)
+    } else if (directive.rawName.startsWith('wire:sort:group-id')) {
+        // This will get read by the wire:sort handler below...
+        return
+    } else if (directive.rawName.startsWith('wire:sort:group')) {
+        // This will get picked up by Alpine's x-sort source...
+        return
+    } else if (directive.rawName.startsWith('wire:sort')) {
+        let attribute = directive.rawName.replace('wire:', 'x-')
 
-            // Strip .prepend from Alpine expression because it only concerns Livewire and trips up Alpine...
-            if (directive.modifiers.includes('prepend')) {
-                attribute = attribute.replace('.prepend', '')
-            }
-
-            // Strip .append from Alpine expression because it only concerns Livewire and trips up Alpine...
-            if (directive.modifiers.includes('append')) {
-                attribute = attribute.replace('.append', '')
-            }
-
-            let expression = directive.expression
-
-            Alpine.bind(el, {
-                [attribute]() {
-                    setNextActionOrigin({ el, directive })
-
-                    // Alpine's x-sort provides $position as the raw DOM index (e.newIndex
-                    // from SortableJS), which counts ALL children including non-sortable
-                    // siblings like wire:sort:ignore / x-sort:ignore elements. Recalculate
-                    // as the index among only sortable items (wire:sort:item / x-sort:item).
-                    let sortableChildren = Array.from(el.children).filter(child =>
-                        child.hasAttribute('x-sort:item') || child.hasAttribute('wire:sort:item')
-                    )
-                    let itemPosition = sortableChildren.findIndex(child => child._x_sort_key === this.$item)
-                    let position = itemPosition !== -1 ? itemPosition : this.$position
-
-                    let params = [this.$item, position]
-                    let scope = { $item: this.$item, $position: position }
-
-                    let sortId = el.getAttribute('wire:sort:group-id')
-
-                    if (sortId !== null) {
-                        params.push(sortId)
-                        scope.$id = sortId
-                    }
-
-                    evaluateActionExpression(el, expression, { scope, params })
-                }
-            })
+        // Strip .async from Alpine expression because it only concerns Livewire and trips up Alpine...
+        if (directive.modifiers.includes('async')) {
+            attribute = attribute.replace('.async', '')
         }
+
+        // Strip .renderless from Alpine expression because it only concerns Livewire and trips up Alpine...
+        if (directive.modifiers.includes('renderless')) {
+            attribute = attribute.replace('.renderless', '')
+        }
+
+        // Strip .prepend from Alpine expression because it only concerns Livewire and trips up Alpine...
+        if (directive.modifiers.includes('prepend')) {
+            attribute = attribute.replace('.prepend', '')
+        }
+
+        // Strip .append from Alpine expression because it only concerns Livewire and trips up Alpine...
+        if (directive.modifiers.includes('append')) {
+            attribute = attribute.replace('.append', '')
+        }
+
+        let expression = directive.expression
+
+        let cleanupBinding = Alpine.bind(el, {
+            [attribute]() {
+                setNextActionOrigin({ el, directive })
+
+                // Alpine's x-sort provides $position as the raw DOM index (e.newIndex
+                // from SortableJS), which counts ALL children including non-sortable
+                // siblings like wire:sort:ignore / x-sort:ignore elements. Recalculate
+                // as the index among only sortable items (wire:sort:item / x-sort:item).
+                let sortableChildren = Array.from(el.children).filter(child =>
+                    child.hasAttribute('x-sort:item') || child.hasAttribute('wire:sort:item')
+                )
+                let itemPosition = sortableChildren.findIndex(child => child._x_sort_key === this.$item)
+                let position = itemPosition !== -1 ? itemPosition : this.$position
+
+                let params = [this.$item, position]
+                let scope = { $item: this.$item, $position: position }
+
+                let sortId = el.getAttribute('wire:sort:group-id')
+
+                if (sortId !== null) {
+                    params.push(sortId)
+                    scope.$id = sortId
+                }
+
+                evaluateActionExpression(el, expression, { scope, params })
+            }
+        })
+
+        cleanup(cleanupBinding)
     }
 })

--- a/js/features/supportWireSort.js
+++ b/js/features/supportWireSort.js
@@ -7,17 +7,17 @@ on('directive.init', ({ el, directive, cleanup }) => {
     if (! directive.rawName.startsWith('wire:sort')) return
 
     if (directive.rawName.startsWith('wire:sort:item')) {
-        let modifierString = directive.modifiers.join('.')
+            let modifierString = directive.modifiers.join('.')
 
-        let expression = directive.expression
+            let expression = directive.expression
 
-        let cleanupBinding = Alpine.bind(el, {
-            ['x-sort:item' + modifierString]() {
-                return expression
-            }
-        })
+            let cleanupBinding = Alpine.bind(el, {
+                ['x-sort:item' + modifierString]() {
+                    return expression
+                }
+            })
 
-        cleanup(cleanupBinding)
+            cleanup(cleanupBinding)
     } else if (directive.rawName.startsWith('wire:sort:group-id')) {
         // This will get read by the wire:sort handler below...
         return
@@ -25,58 +25,58 @@ on('directive.init', ({ el, directive, cleanup }) => {
         // This will get picked up by Alpine's x-sort source...
         return
     } else if (directive.rawName.startsWith('wire:sort')) {
-        let attribute = directive.rawName.replace('wire:', 'x-')
+            let attribute = directive.rawName.replace('wire:', 'x-')
 
-        // Strip .async from Alpine expression because it only concerns Livewire and trips up Alpine...
-        if (directive.modifiers.includes('async')) {
-            attribute = attribute.replace('.async', '')
-        }
-
-        // Strip .renderless from Alpine expression because it only concerns Livewire and trips up Alpine...
-        if (directive.modifiers.includes('renderless')) {
-            attribute = attribute.replace('.renderless', '')
-        }
-
-        // Strip .prepend from Alpine expression because it only concerns Livewire and trips up Alpine...
-        if (directive.modifiers.includes('prepend')) {
-            attribute = attribute.replace('.prepend', '')
-        }
-
-        // Strip .append from Alpine expression because it only concerns Livewire and trips up Alpine...
-        if (directive.modifiers.includes('append')) {
-            attribute = attribute.replace('.append', '')
-        }
-
-        let expression = directive.expression
-
-        let cleanupBinding = Alpine.bind(el, {
-            [attribute]() {
-                setNextActionOrigin({ el, directive })
-
-                // Alpine's x-sort provides $position as the raw DOM index (e.newIndex
-                // from SortableJS), which counts ALL children including non-sortable
-                // siblings like wire:sort:ignore / x-sort:ignore elements. Recalculate
-                // as the index among only sortable items (wire:sort:item / x-sort:item).
-                let sortableChildren = Array.from(el.children).filter(child =>
-                    child.hasAttribute('x-sort:item') || child.hasAttribute('wire:sort:item')
-                )
-                let itemPosition = sortableChildren.findIndex(child => child._x_sort_key === this.$item)
-                let position = itemPosition !== -1 ? itemPosition : this.$position
-
-                let params = [this.$item, position]
-                let scope = { $item: this.$item, $position: position }
-
-                let sortId = el.getAttribute('wire:sort:group-id')
-
-                if (sortId !== null) {
-                    params.push(sortId)
-                    scope.$id = sortId
-                }
-
-                evaluateActionExpression(el, expression, { scope, params })
+            // Strip .async from Alpine expression because it only concerns Livewire and trips up Alpine...
+            if (directive.modifiers.includes('async')) {
+                attribute = attribute.replace('.async', '')
             }
-        })
 
-        cleanup(cleanupBinding)
+            // Strip .renderless from Alpine expression because it only concerns Livewire and trips up Alpine...
+            if (directive.modifiers.includes('renderless')) {
+                attribute = attribute.replace('.renderless', '')
+            }
+
+            // Strip .prepend from Alpine expression because it only concerns Livewire and trips up Alpine...
+            if (directive.modifiers.includes('prepend')) {
+                attribute = attribute.replace('.prepend', '')
+            }
+
+            // Strip .append from Alpine expression because it only concerns Livewire and trips up Alpine...
+            if (directive.modifiers.includes('append')) {
+                attribute = attribute.replace('.append', '')
+            }
+
+            let expression = directive.expression
+
+            let cleanupBinding = Alpine.bind(el, {
+                [attribute]() {
+                    setNextActionOrigin({ el, directive })
+
+                    // Alpine's x-sort provides $position as the raw DOM index (e.newIndex
+                    // from SortableJS), which counts ALL children including non-sortable
+                    // siblings like wire:sort:ignore / x-sort:ignore elements. Recalculate
+                    // as the index among only sortable items (wire:sort:item / x-sort:item).
+                    let sortableChildren = Array.from(el.children).filter(child =>
+                        child.hasAttribute('x-sort:item') || child.hasAttribute('wire:sort:item')
+                    )
+                    let itemPosition = sortableChildren.findIndex(child => child._x_sort_key === this.$item)
+                    let position = itemPosition !== -1 ? itemPosition : this.$position
+
+                    let params = [this.$item, position]
+                    let scope = { $item: this.$item, $position: position }
+
+                    let sortId = el.getAttribute('wire:sort:group-id')
+
+                    if (sortId !== null) {
+                        params.push(sortId)
+                        scope.$id = sortId
+                    }
+
+                    evaluateActionExpression(el, expression, { scope, params })
+                }
+            })
+
+            cleanup(cleanupBinding)
     }
 })

--- a/js/features/supportWireSort.js
+++ b/js/features/supportWireSort.js
@@ -1,30 +1,33 @@
 import { setNextActionOrigin } from '@/request'
 import { evaluateActionExpression } from '../evaluator'
 import Alpine from 'alpinejs'
+import { extractDirective } from '@/directives'
 import { on } from '@/hooks'
 
-on('directive.init', ({ el, directive, cleanup }) => {
-    if (! directive.rawName.startsWith('wire:sort')) return
+on('directive.init', ({ el, directive }) => {
+    if (! directive.rawName.startsWith('wire:sort:item')) return
 
-    if (directive.rawName.startsWith('wire:sort:item')) {
-            let modifierString = directive.modifiers.join('.')
+    // This directive was already initialized by interceptInit...
+    if (el._x_sort_key !== undefined) return
 
-            let expression = directive.expression
+    bindSortItem(el, directive)
+})
 
-            let cleanupBinding = Alpine.bind(el, {
-                ['x-sort:item' + modifierString]() {
-                    return expression
-                }
-            })
+Alpine.interceptInit(el => {
+    for (let i = 0; i < el.attributes.length; i++) {
+        if (el.attributes[i].name.startsWith('wire:sort:item')) {
+            let directive = extractDirective(el, el.attributes[i].name)
 
-            cleanup(cleanupBinding)
-    } else if (directive.rawName.startsWith('wire:sort:group-id')) {
-        // This will get read by the wire:sort handler below...
-        return
-    } else if (directive.rawName.startsWith('wire:sort:group')) {
-        // This will get picked up by Alpine's x-sort source...
-        return
-    } else if (directive.rawName.startsWith('wire:sort')) {
+            bindSortItem(el, directive)
+        } else if (el.attributes[i].name.startsWith('wire:sort:group-id')) {
+            // This will get read by the wire:sort handler below...
+            continue
+        } else if (el.attributes[i].name.startsWith('wire:sort:group')) {
+            // This will get picked up by Alpine's x-sort source...
+            return
+        } else if (el.attributes[i].name.startsWith('wire:sort')) {
+            let directive = extractDirective(el, el.attributes[i].name)
+
             let attribute = directive.rawName.replace('wire:', 'x-')
 
             // Strip .async from Alpine expression because it only concerns Livewire and trips up Alpine...
@@ -49,7 +52,7 @@ on('directive.init', ({ el, directive, cleanup }) => {
 
             let expression = directive.expression
 
-            let cleanupBinding = Alpine.bind(el, {
+            Alpine.bind(el, {
                 [attribute]() {
                     setNextActionOrigin({ el, directive })
 
@@ -76,7 +79,18 @@ on('directive.init', ({ el, directive, cleanup }) => {
                     evaluateActionExpression(el, expression, { scope, params })
                 }
             })
-
-            cleanup(cleanupBinding)
+        }
     }
 })
+
+function bindSortItem(el, directive) {
+    let modifierString = directive.modifiers.join('.')
+
+    let expression = directive.expression
+
+    Alpine.bind(el, {
+        ['x-sort:item' + modifierString]() {
+            return expression
+        }
+    })
+}

--- a/src/Features/SupportWireSort/BrowserTest.php
+++ b/src/Features/SupportWireSort/BrowserTest.php
@@ -116,6 +116,216 @@ class BrowserTest extends BrowserTestCase
         ->assertSeeIn('@result', 'item:item-1,position:2');
     }
 
+    public function test_wire_sort_item_id_works_when_added_to_an_already_rendered_element()
+    {
+        Livewire::visit(new class extends Component {
+            public $enabled = false;
+            public $result = '';
+
+            public function enable()
+            {
+                $this->enabled = true;
+            }
+
+            public function sortItem($item, $position)
+            {
+                $this->result = "item:{$item},position:{$position}";
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button type="button" dusk="enable" wire:click="enable">Enable</button>
+
+                    <ul dusk="sortable" wire:sort="sortItem">
+                        <li wire:key="item-1" @if ($enabled) wire:sort:item="item-1" @endif>Item 1</li>
+                        <li wire:key="item-2" @if ($enabled) wire:sort:item="item-2" @endif>Item 2</li>
+                    </ul>
+
+                    <div dusk="result">{{ $result }}</div>
+                </div>
+                HTML;
+            }
+        })
+        ->click('@enable')
+        ->waitForTextIn('[wire\\:key="item-2"]', 'Item 2')
+        ->tap(function ($b) {
+            $b->script(<<<'JS'
+                let el = document.querySelector('[dusk="sortable"]')
+                let item = el.querySelector('[wire\\:sort\\:item="item-2"]')
+
+                el.insertBefore(item, el.firstElementChild)
+
+                let key = Object.keys(el).find(k => k.startsWith('Sortable'))
+                let instance = el[key]
+
+                instance.options.onSort({
+                    item: item,
+                    from: el,
+                    to: el,
+                    target: el,
+                    newIndex: 0,
+                    oldIndex: 1,
+                })
+            JS);
+        })
+        ->waitForTextIn('@result', 'item:item-2,position:0')
+        ->assertSeeIn('@result', 'item:item-2,position:0');
+    }
+
+    public function test_wire_sort_can_be_toggled_on_and_off()
+    {
+        Livewire::visit(new class extends Component {
+            public $editing = false;
+            public $result = '';
+
+            public function toggle()
+            {
+                $this->editing = ! $this->editing;
+            }
+
+            public function sortItem($item, $position)
+            {
+                $this->result = "item:{$item},position:{$position}";
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button type="button" dusk="toggle" wire:click="toggle">
+                        {{ $editing ? 'Save' : 'Edit' }}
+                    </button>
+
+                    <ul dusk="sortable" @if ($editing) wire:sort="sortItem" @endif>
+                        <li wire:key="item-1" wire:sort:item="item-1">Item 1</li>
+                        <li wire:key="item-2" wire:sort:item="item-2">Item 2</li>
+                    </ul>
+
+                    <div dusk="result">{{ $result }}</div>
+                </div>
+                HTML;
+            }
+        })
+        ->waitForText('Edit')
+        ->click('@toggle')
+        ->waitForText('Save')
+        ->tap(function ($b) {
+            // Turning wire:sort on should make the already-rendered <ul> sortable...
+            $b->script(<<<'JS'
+                let el = document.querySelector('[dusk="sortable"]')
+                let item = el.querySelector('[wire\\:sort\\:item="item-2"]')
+
+                el.insertBefore(item, el.firstElementChild)
+
+                let key = Object.keys(el).find(k => k.startsWith('Sortable'))
+                let instance = el[key]
+
+                instance.options.onSort({
+                    item: item,
+                    from: el,
+                    to: el,
+                    target: el,
+                    newIndex: 0,
+                    oldIndex: 1,
+                })
+            JS);
+        })
+        ->waitForTextIn('@result', 'item:item-2,position:0')
+        ->assertSeeIn('@result', 'item:item-2,position:0')
+        ->click('@toggle')
+        ->waitForText('Edit')
+        ->tap(function ($b) {
+            // Turning wire:sort back off should tear down the Sortable instance
+            // entirely, rather than leaving it silently still active. SortableJS's
+            // own destroy() nulls out its instance reference on the element rather
+            // than deleting the key, so check the value rather than the key...
+            $sortableInstanceWasDestroyed = $b->script(<<<'JS'
+                let el = document.querySelector('[dusk="sortable"]')
+                let key = Object.keys(el).find(k => k.startsWith('Sortable'))
+
+                return key === undefined || el[key] === null
+            JS)[0];
+
+            $this->assertTrue($sortableInstanceWasDestroyed, 'Expected the Sortable instance to be destroyed after wire:sort was removed.');
+        })
+        ->assertSeeIn('@result', 'item:item-2,position:0');
+    }
+
+    public function test_wire_sort_item_id_is_passed_for_lazy_child_components()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public $result = '';
+
+                public function sortItem($item, $position)
+                {
+                    $this->result = "item:{$item},position:{$position}";
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <ul dusk="sortable" wire:sort="sortItem">
+                            <livewire:child wire:key="item-1" wire:sort:item="item-1" lazy>
+                                Item 1
+                            </livewire:child>
+
+                            <livewire:child wire:key="item-2" wire:sort:item="item-2" lazy>
+                                Item 2
+                            </livewire:child>
+                        </ul>
+
+                        <div dusk="result">{{ $result }}</div>
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public function placeholder()
+                {
+                    return <<<'HTML'
+                    <li>Loading...</li>
+                    HTML;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <li {{ $attributes }}>
+                        Child {{ $slot }}
+                    </li>
+                    HTML;
+                }
+            },
+        ])
+        ->waitForText('Child Item 2')
+        ->tap(function ($b) {
+            $b->script(<<<'JS'
+                let el = document.querySelector('[dusk="sortable"]')
+                let item = el.querySelector('[wire\\:sort\\:item="item-2"]')
+
+                el.insertBefore(item, el.firstElementChild)
+
+                let key = Object.keys(el).find(k => k.startsWith('Sortable'))
+                let instance = el[key]
+
+                instance.options.onSort({
+                    item: item,
+                    from: el,
+                    to: el,
+                    target: el,
+                    newIndex: 0,
+                    oldIndex: 1,
+                })
+            JS);
+        })
+        ->waitForTextIn('@result', 'item:item-2,position:0')
+        ->assertSeeIn('@result', 'item:item-2,position:0');
+    }
+
     public function test_wire_sort_works_without_sort_id()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportWireSort/BrowserTest.php
+++ b/src/Features/SupportWireSort/BrowserTest.php
@@ -139,8 +139,8 @@ class BrowserTest extends BrowserTestCase
                     <button type="button" dusk="enable" wire:click="enable">Enable</button>
 
                     <ul dusk="sortable" wire:sort="sortItem">
-                        <li wire:key="item-1" @if ($enabled) wire:sort:item="item-1" @endif>Item 1</li>
-                        <li wire:key="item-2" @if ($enabled) wire:sort:item="item-2" @endif>Item 2</li>
+                        <li dusk="item-1" wire:key="item-1" @if ($enabled) wire:sort:item="item-1" @endif>Item 1</li>
+                        <li dusk="item-2" wire:key="item-2" @if ($enabled) wire:sort:item="item-2" @endif>Item 2</li>
                     </ul>
 
                     <div dusk="result">{{ $result }}</div>
@@ -150,106 +150,8 @@ class BrowserTest extends BrowserTestCase
         })
         ->click('@enable')
         ->waitForTextIn('[wire\\:key="item-2"]', 'Item 2')
-        ->tap(function ($b) {
-            $b->script(<<<'JS'
-                let el = document.querySelector('[dusk="sortable"]')
-                let item = el.querySelector('[wire\\:sort\\:item="item-2"]')
-
-                el.insertBefore(item, el.firstElementChild)
-
-                let key = Object.keys(el).find(k => k.startsWith('Sortable'))
-                let instance = el[key]
-
-                instance.options.onSort({
-                    item: item,
-                    from: el,
-                    to: el,
-                    target: el,
-                    newIndex: 0,
-                    oldIndex: 1,
-                })
-            JS);
-        })
+        ->drag('@item-2', '@item-1')
         ->waitForTextIn('@result', 'item:item-2,position:0')
-        ->assertSeeIn('@result', 'item:item-2,position:0');
-    }
-
-    public function test_wire_sort_can_be_toggled_on_and_off()
-    {
-        Livewire::visit(new class extends Component {
-            public $editing = false;
-            public $result = '';
-
-            public function toggle()
-            {
-                $this->editing = ! $this->editing;
-            }
-
-            public function sortItem($item, $position)
-            {
-                $this->result = "item:{$item},position:{$position}";
-            }
-
-            public function render()
-            {
-                return <<<'HTML'
-                <div>
-                    <button type="button" dusk="toggle" wire:click="toggle">
-                        {{ $editing ? 'Save' : 'Edit' }}
-                    </button>
-
-                    <ul dusk="sortable" @if ($editing) wire:sort="sortItem" @endif>
-                        <li wire:key="item-1" wire:sort:item="item-1">Item 1</li>
-                        <li wire:key="item-2" wire:sort:item="item-2">Item 2</li>
-                    </ul>
-
-                    <div dusk="result">{{ $result }}</div>
-                </div>
-                HTML;
-            }
-        })
-        ->waitForText('Edit')
-        ->click('@toggle')
-        ->waitForText('Save')
-        ->tap(function ($b) {
-            // Turning wire:sort on should make the already-rendered <ul> sortable...
-            $b->script(<<<'JS'
-                let el = document.querySelector('[dusk="sortable"]')
-                let item = el.querySelector('[wire\\:sort\\:item="item-2"]')
-
-                el.insertBefore(item, el.firstElementChild)
-
-                let key = Object.keys(el).find(k => k.startsWith('Sortable'))
-                let instance = el[key]
-
-                instance.options.onSort({
-                    item: item,
-                    from: el,
-                    to: el,
-                    target: el,
-                    newIndex: 0,
-                    oldIndex: 1,
-                })
-            JS);
-        })
-        ->waitForTextIn('@result', 'item:item-2,position:0')
-        ->assertSeeIn('@result', 'item:item-2,position:0')
-        ->click('@toggle')
-        ->waitForText('Edit')
-        ->tap(function ($b) {
-            // Turning wire:sort back off should tear down the Sortable instance
-            // entirely, rather than leaving it silently still active. SortableJS's
-            // own destroy() nulls out its instance reference on the element rather
-            // than deleting the key, so check the value rather than the key...
-            $sortableInstanceWasDestroyed = $b->script(<<<'JS'
-                let el = document.querySelector('[dusk="sortable"]')
-                let key = Object.keys(el).find(k => k.startsWith('Sortable'))
-
-                return key === undefined || el[key] === null
-            JS)[0];
-
-            $this->assertTrue($sortableInstanceWasDestroyed, 'Expected the Sortable instance to be destroyed after wire:sort was removed.');
-        })
         ->assertSeeIn('@result', 'item:item-2,position:0');
     }
 
@@ -269,11 +171,11 @@ class BrowserTest extends BrowserTestCase
                     return <<<'HTML'
                     <div>
                         <ul dusk="sortable" wire:sort="sortItem">
-                            <livewire:child wire:key="item-1" wire:sort:item="item-1" lazy>
+                            <livewire:child dusk="item-1" wire:key="item-1" wire:sort:item="item-1" lazy>
                                 Item 1
                             </livewire:child>
 
-                            <livewire:child wire:key="item-2" wire:sort:item="item-2" lazy>
+                            <livewire:child dusk="item-2" wire:key="item-2" wire:sort:item="item-2" lazy>
                                 Item 2
                             </livewire:child>
                         </ul>
@@ -302,28 +204,49 @@ class BrowserTest extends BrowserTestCase
             },
         ])
         ->waitForText('Child Item 2')
-        ->tap(function ($b) {
-            $b->script(<<<'JS'
-                let el = document.querySelector('[dusk="sortable"]')
-                let item = el.querySelector('[wire\\:sort\\:item="item-2"]')
-
-                el.insertBefore(item, el.firstElementChild)
-
-                let key = Object.keys(el).find(k => k.startsWith('Sortable'))
-                let instance = el[key]
-
-                instance.options.onSort({
-                    item: item,
-                    from: el,
-                    to: el,
-                    target: el,
-                    newIndex: 0,
-                    oldIndex: 1,
-                })
-            JS);
-        })
+        ->drag('@item-2', '@item-1')
         ->waitForTextIn('@result', 'item:item-2,position:0')
         ->assertSeeIn('@result', 'item:item-2,position:0');
+    }
+
+    public function test_removing_a_sortable_element_after_wire_sort_is_removed_does_not_error()
+    {
+        Livewire::visit(new class extends Component {
+            public $sorting = true;
+            public $showList = true;
+
+            public function disableSorting()
+            {
+                $this->sorting = false;
+            }
+
+            public function removeList()
+            {
+                $this->showList = false;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button dusk="disable" wire:click="disableSorting">Disable sorting</button>
+                    <button dusk="remove" wire:click="removeList">Remove list</button>
+
+                    @if ($showList)
+                        <ul dusk="sortable" @if ($sorting) wire:sort="sortItem" @endif>
+                            <li wire:sort:item="item-1">Item 1</li>
+                            <li wire:sort:item="item-2">Item 2</li>
+                        </ul>
+                    @endif
+                </div>
+                HTML;
+            }
+        })
+        ->waitForLivewire()->click('@disable')
+        ->assertAttributeMissing('@sortable', 'wire:sort')
+        ->waitForLivewire()->click('@remove')
+        ->waitUntilMissing('@sortable')
+        ->assertConsoleLogHasNoErrors();
     }
 
     public function test_wire_sort_works_without_sort_id()


### PR DESCRIPTION
When a `wire:sort:item` attribute is added after Alpine has already initialized an element, sorting can pass a missing item ID. This happens with lazy child components because Livewire preserves the placeholder root and adds the forwarded attribute later while morphing in the rendered child.

```blade
<ul wire:sort="sortItem">
    <livewire:child wire:key="item-1" wire:sort:item="item-1" lazy>
        Item 1
    </livewire:child>

    <livewire:child wire:key="item-2" wire:sort:item="item-2" lazy>
        Item 2
    </livewire:child>
</ul>
```

## Findings

- `supportWireSort.js` converts `wire:sort:item` to Alpine's `x-sort:item` during `Alpine.interceptInit`.
- `interceptInit` correctly handles the initial Alpine lifecycle, but it does not run again when Livewire later adds an attribute to an already-initialized element.
- Livewire's `directive.init` hook runs for both the initial directive pass and directives added during later morphs.
- Replacing the entire sort initialization path would unnecessarily change the lifecycle of `wire:sort`, group directives, and Alpine's clone handling.

## Proposed solution

Keep the existing `interceptInit` path intact and supplement it with a narrowly scoped `directive.init` listener for late-added `wire:sort:item` directives. Initial items are detected through their existing Alpine sort key so they are not initialized twice.

The browser coverage exercises the behavior through real WebDriver drag interactions rather than calling SortableJS internals. It covers both a conditionally added item directive and lazy child component roots. An additional lifecycle test verifies that removing `wire:sort` and subsequently removing the sortable element does not produce browser errors.

Fixes #10325
