### PR TITLE
[4.x] Allow `$attributes` in a lazy component's placeholder view

### DIFF
--- a/src/ComponentHook.php
+++ b/src/ComponentHook.php
@@ -71,6 +71,18 @@ abstract class ComponentHook
         };
     }
 
+    function callRenderPlaceholder(...$params) {
+        $callbacks = [];
+
+        if (method_exists($this, 'renderPlaceholder')) $callbacks[] = $this->renderPlaceholder(...$params);
+
+        return function (...$params) use ($callbacks) {
+            foreach ($callbacks as $callback) {
+                if (is_callable($callback)) $callback(...$params);
+            }
+        };
+    }
+
     function callDehydrate(...$params) {
         if (method_exists($this, 'dehydrate')) $this->dehydrate(...$params);
     }

--- a/src/ComponentHookRegistry.php
+++ b/src/ComponentHookRegistry.php
@@ -73,6 +73,10 @@ class ComponentHookRegistry
             return static::proxyCallToHooks($component, 'callRenderIsland')($name, $view, $data);
         });
 
+        on('render.placeholder', function ($component, $view, $data) {
+            return static::proxyCallToHooks($component, 'callRenderPlaceholder')($view, $data);
+        });
+
         on('dehydrate', function ($component, $context) {
             static::proxyCallToHooks($component, 'callDehydrate')($context);
         });

--- a/src/Features/SupportHtmlAttributeForwarding/BrowserTest.php
+++ b/src/Features/SupportHtmlAttributeForwarding/BrowserTest.php
@@ -125,4 +125,71 @@ class BrowserTest extends BrowserTestCase
             ->assertAttribute('@parent-component > div', 'data-testid', 'my-alert')
             ->assertAttribute('@parent-component > div', 'wire:sort:item', '1');
     }
+
+    public function test_html_attributes_are_forwarded_to_a_lazy_components_placeholder_when_it_opts_in()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div dusk="parent-component">
+                        <h1>Parent Component</h1>
+
+                        <livewire:alert
+                            type="error"
+                            class="mb-4"
+                            id="error-alert"
+                            data-testid="my-alert"
+                            dusk="alert-component"
+                            wire:sort:item="1"
+                            lazy
+                        >
+                            Something went wrong!
+                        </livewire:alert>
+                    </div>
+                    HTML;
+                }
+            },
+            'alert' => new class extends Component {
+                public string $type = 'info';
+
+                public function mount()
+                {
+                    usleep(200 * 1000); // 200ms
+                }
+
+                public function placeholder()
+                {
+                    return <<<'HTML'
+                    <div {{ $attributes }}>Loading...</div>
+                    HTML;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div {{ $attributes->merge(['class' => 'alert alert-'.$type]) }}>
+                        <h2>Alert Component</h2>
+
+                        {{ $slot }}
+
+                        <button type="button" wire:click="$refresh" dusk="refresh">Refresh</button>
+                    </div>
+                    HTML;
+                }
+            }
+        ])
+            ->waitForLivewireToLoad()
+            ->assertDontSee('Alert Component')
+            ->assertAttribute('@parent-component > div', 'id', 'error-alert')
+            ->assertAttribute('@parent-component > div', 'data-testid', 'my-alert')
+            ->assertAttribute('@parent-component > div', 'wire:sort:item', '1')
+
+            ->waitForText('Alert Component') // Wait for the lazy component to load
+            ->assertAttribute('@parent-component > div', 'class', 'alert alert-error mb-4')
+            ->assertAttribute('@parent-component > div', 'id', 'error-alert')
+            ->assertAttribute('@parent-component > div', 'data-testid', 'my-alert')
+            ->assertAttribute('@parent-component > div', 'wire:sort:item', '1');
+    }
 }

--- a/src/Features/SupportHtmlAttributeForwarding/SupportHtmlAttributeForwarding.php
+++ b/src/Features/SupportHtmlAttributeForwarding/SupportHtmlAttributeForwarding.php
@@ -21,6 +21,13 @@ class SupportHtmlAttributeForwarding extends ComponentHook
         $view->with(['attributes' => new ComponentAttributeBag($attributes)]);
     }
 
+    public function renderPlaceholder($view, $properties)
+    {
+        $attributes = $this->component->getHtmlAttributes();
+
+        $view->with(['attributes' => new ComponentAttributeBag($attributes)]);
+    }
+
     function hydrate($memo)
     {
         $attributes = $memo['attributes'] ?? [];


### PR DESCRIPTION
# The Scenario

Forwarded HTML attributes are available inside a component's `render()` view via `$attributes`. Referencing the same variable inside a lazy component's `placeholder()` view throws an error instead.

This matters for cases like a sortable list of lazy-loaded items: you'd want an item's placeholder to also carry the forwarded `wire:sort:item` attribute, so the list stays sortable while an item is still loading, rather than only becoming sortable once its real content has finished loading in.

```blade
<ul wire:sort="handleSort">
    <livewire:list-item wire:key="1" wire:sort:item="1" lazy>
        Item 1
    </livewire:list-item>
</ul>
```

```php
class ListItem extends Component
{
    public function placeholder()
    {
        return <<<'HTML'
        <li {{ $attributes }}>Loading...</li>
        HTML;
    }

    public function render()
    {
        return <<<'HTML'
        <li {{ $attributes }}>
            {{ $slot }}
        </li>
        HTML;
    }
}
```

# The Problem

Placeholder rendering was never set up to expose `$attributes` to its view at all. A normal render and an island render both get `$attributes` from `SupportHtmlAttributeForwarding`, but placeholder rendering is handled separately, and nothing wires that feature into it.

# The Solution

The solution is to make `$attributes` available to the placeholder view too, in case someone wants to forward attributes onto it, the same way they're already available to a normal render.

Fixes #10325