### PR TITLE
[4.x] Add `assertOnlyHasErrors` method

### DIFF
--- a/src/Features/SupportValidation/TestsValidation.php
+++ b/src/Features/SupportValidation/TestsValidation.php
@@ -61,6 +61,8 @@ trait TestsValidation
         $unexpectedErrorKeys = Arr::except($this->errors()->toArray(), $expectedErrorKeys);
 
         PHPUnit::assertTrue(count($unexpectedErrorKeys) === 0, "Component has unexpected errors: ".implode(', ', array_keys($unexpectedErrorKeys)));
+
+        return $this;
     }
 
     protected function makeErrorAssertion($key = null, $value = null) {

--- a/src/Features/SupportValidation/TestsValidation.php
+++ b/src/Features/SupportValidation/TestsValidation.php
@@ -3,13 +3,14 @@
 namespace Livewire\Features\SupportValidation;
 
 use Closure;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use function Livewire\store;
+use Illuminate\Support\Collection;
+use Illuminate\Support\MessageBag;
+use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidationRule;
-use function Livewire\store;
-use PHPUnit\Framework\Assert as PHPUnit;
-use Illuminate\Support\Str;
-use Illuminate\Support\MessageBag;
-use Illuminate\Support\Arr;
 
 trait TestsValidation
 {
@@ -50,6 +51,16 @@ trait TestsValidation
         }
 
         return $this;
+    }
+
+    public function assertOnlyHasErrors($keys = [])
+    {
+        $this->assertHasErrors($keys);
+
+        $expectedErrorKeys = (new Collection($keys))->map(fn ($value, $key) => is_int($key) ? $value : $key)->all();
+        $unexpectedErrorKeys = Arr::except($this->errors()->toArray(), $expectedErrorKeys);
+
+        PHPUnit::assertTrue(count($unexpectedErrorKeys) === 0, "Component has unexpected errors: ".implode(', ', array_keys($unexpectedErrorKeys)));
     }
 
     protected function makeErrorAssertion($key = null, $value = null) {

--- a/src/Features/SupportValidation/TestsValidation.php
+++ b/src/Features/SupportValidation/TestsValidation.php
@@ -3,14 +3,14 @@
 namespace Livewire\Features\SupportValidation;
 
 use Closure;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use function Livewire\store;
-use Illuminate\Support\Collection;
-use Illuminate\Support\MessageBag;
-use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidationRule;
+use function Livewire\store;
+use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\Arr;
 
 trait TestsValidation
 {

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -2,19 +2,20 @@
 
 namespace Livewire\Features\SupportValidation;
 
-use Tests\TestComponent;
-use Livewire\Wireable;
 use Livewire\Livewire;
-use Livewire\Exceptions\MissingRulesException;
+use Livewire\Wireable;
 use Livewire\Component;
-use Livewire\Attributes\Validate;
+use Tests\TestComponent;
 use Livewire\Attributes\Rule;
-use Illuminate\Support\ViewErrorBag;
+use Livewire\Attributes\Validate;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\ViewErrorBag;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Collection;
+use PHPUnit\Framework\AssertionFailedError;
+use Livewire\Exceptions\MissingRulesException;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -998,6 +999,42 @@ class UnitTest extends \Tests\TestCase
         })
             ->call('save')
             ->assertHasErrors(['prompt' => 'required']);
+    }
+
+    public function test_assert_only_has_errors()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[Validate('required')]
+            #[Validate('min:100')]
+            public $foo = '';
+
+            #[Validate('required')]
+            #[Validate('min:100')]
+            public $bar = '';
+
+            public function runValidation()
+            {
+                $this->validate();
+            }
+        })->set('foo', 'invalid')->set('bar', 'also-invalid')->call('runValidation');
+
+        try {
+            $component->assertOnlyHasErrors('foo');
+            $this->fail();
+        } catch (AssertionFailedError $e) {
+            $this->assertStringStartsWith('Component has unexpected errors: bar', $e->getMessage());
+        }
+
+        $component->assertOnlyHasErrors(['foo', 'bar']);
+
+        try {
+            $component->assertOnlyHasErrors(['foo' => 'min']);
+            $this->fail();
+        } catch (AssertionFailedError $e) {
+            $this->assertStringStartsWith('Component has unexpected errors: bar', $e->getMessage());
+        }
+
+        $component->assertOnlyHasErrors(['foo' => 'min', 'bar' => 'min']);
     }
 }
 

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -2,20 +2,20 @@
 
 namespace Livewire\Features\SupportValidation;
 
-use Livewire\Livewire;
-use Livewire\Wireable;
-use Livewire\Component;
 use Tests\TestComponent;
-use Livewire\Attributes\Rule;
+use Livewire\Wireable;
+use Livewire\Livewire;
+use Livewire\Exceptions\MissingRulesException;
+use Livewire\Component;
 use Livewire\Attributes\Validate;
-use Illuminate\Support\Collection;
+use Livewire\Attributes\Rule;
+use Illuminate\Support\ViewErrorBag;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Lang;
-use Illuminate\Support\ViewErrorBag;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\AssertionFailedError;
-use Livewire\Exceptions\MissingRulesException;
 
 class UnitTest extends \Tests\TestCase
 {


### PR DESCRIPTION
Sometimes you want to test that a validation error is present, but you want to be sure that no other validation error occurred. Currently, there is no easy way to do that, unless you provide every possible validation error key to the assertHasNoErrors method call.

```php
// Will fail if 'email' error is missing OR if 'name' error is present
// BUT nothing will fail if 'phone' error is present
$component
    ->assertHasErrors(['email'])
    ->assertHasNoErrors(['name']);
```

This PR fixes that by creating a method that checks if the provided errors are present, but also asserts that no other validation errors occurred:

```php
// Will fail if 'email' error is missing OR if 'name' error is present OR if any other error is present
$component->assertOnlyHasErrors(['email']);
```

This works the same way as the `assertOnlyJsonValidationErrors` method that I added in Laravel (https://github.com/laravel/framework/pull/54678). 