### PR TITLE
[4.x] docs: add missing $this->validate() calls to file upload examples

### DIFF
--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -19,6 +19,8 @@ new class extends Component {
 
     public function save()
     {
+        $this->validate();
+
         $this->photo->store(path: 'photos');
     }
 };
@@ -101,6 +103,8 @@ new class extends Component {
 
     public function save()
     {
+        $this->validate();
+
         foreach ($this->photos as $photo) {
             $photo->store(path: 'photos');
         }


### PR DESCRIPTION
## What

Adds `$this->validate();` as the first line of the `save()` methods in the two file-upload documentation examples (single file and multiple files) in `docs/uploads.md`.

## Why

The examples rely solely on a `#[Validate('image|max:1024')]` attribute on the property, with a `save()` method that stores the file directly. This leaves a validation hole:

- Update-time validation runs when the file property updates, but the property is still assigned the `TemporaryUploadedFile` even when that validation fails — the error message shows, but the file remains set on the component.
- Actions do **not** auto-validate `#[Validate]` properties, so clicking the submit button stores the invalid file anyway.

This was verified empirically: uploading a 1.5MB file against the `max:1024` rule showed the validation error in the UI **and** still successfully stored the file to disk when the form was submitted.

Adding `$this->validate();` at the top of `save()` closes the hole — it re-runs the attribute rules and throws before the file is stored. This matches the pattern used elsewhere in the docs (e.g. the forms documentation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)