### PR TITLE
Enforce property validation rules on uploads (preflight size rejection + never attach invalid files)

### DIFF
--- a/src/Features/SupportFileUploads/BrowserTest.php
+++ b/src/Features/SupportFileUploads/BrowserTest.php
@@ -62,6 +62,52 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_upload_violating_property_size_rules_is_rejected_before_uploading_and_never_attached()
+    {
+        Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            #[BaseValidate('image|max:1024')]
+            public $photo;
+
+            function mount()
+            {
+                Storage::disk('tmp-for-tests')->deleteDirectory('livewire-tmp');
+            }
+
+            function render() { return <<<'HTML'
+            <div>
+                <input type="file" wire:model="photo" dusk="upload">
+
+                @error('photo') <span dusk="error">{{ $message }}</span> @enderror
+
+                <div>
+                    @if ($photo)
+                        <img src="{{ $photo->temporaryUrl() }}" dusk="preview">
+                    @endif
+                </div>
+            </div>
+            HTML; }
+        })
+        ->assertMissing('@error')
+        // This file is ~1041KB — over the property's 1024KB max...
+        ->attach('@upload', __DIR__ . '/browser_test_image_big.jpg')
+        ->waitFor('@error')
+        ->assertSeeIn('@error', 'The photo field must not be greater than 1024 kilobytes.')
+        ->assertMissing('@preview')
+        ->tap(function () {
+            // The declared size was rejected during the handshake — no bytes ever moved...
+            $this->assertEmpty(Storage::disk('tmp-for-tests')->files('livewire-tmp'));
+        })
+        // A valid file afterwards uploads normally and clears the error...
+        ->attach('@upload', __DIR__ . '/browser_test_image.png')
+        ->waitFor('@preview')
+        ->assertMissing('@error')
+        ;
+    }
+
     public function test_can_cancel_an_upload()
     {
         if (getenv('FORCE_RUN') !== '1') {

--- a/src/Features/SupportFileUploads/DeclaredSizeRules.php
+++ b/src/Features/SupportFileUploads/DeclaredSizeRules.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Livewire\Features\SupportFileUploads;
+
+use Livewire\Features\SupportFormObjects\Form;
+
+/**
+ * Extracts the size-based constraints (max, min, size, between — all in
+ * kilobytes) that a property's validation rules declare, so an upload can be
+ * rejected from the metadata the browser sends before any bytes move.
+ *
+ * Only constraints verifiable from a declared byte count are extracted —
+ * content rules (image, mimes, dimensions) still run against the real file
+ * after it's uploaded. The declared size is client-supplied, so this is a
+ * fast-fail courtesy: the authoritative check happens server-side either way.
+ */
+class DeclaredSizeRules
+{
+    public static function for($component, $name, $isMultiple)
+    {
+        // Rules from #[Validate] on form object properties are registered on
+        // the form object itself, not the root component...
+        $root = (string) str($name)->before('.');
+
+        if (($component->all()[$root] ?? null) instanceof Form) {
+            $component = $component->all()[$root];
+            $name = (string) str($name)->after('.');
+        }
+
+        $rules = $component->getRules();
+
+        // Match nested paths (photos.2) against their wildcard rules (photos.*)...
+        $key = $component->ruleWithNumbersReplacedByStars($name);
+
+        $rulesForProperty = $isMultiple
+            ? ($rules["{$key}.*"] ?? $rules[$key] ?? [])
+            : ($rules[$key] ?? $rules["{$key}.*"] ?? []);
+
+        if (is_string($rulesForProperty)) $rulesForProperty = explode('|', $rulesForProperty);
+
+        $constraints = [];
+
+        foreach ((array) $rulesForProperty as $rule) {
+            if (! is_string($rule)) continue;
+
+            if (preg_match('/^(max|min|size):(\d+)$/', $rule, $matches)) {
+                $constraints[$matches[1]] = (int) $matches[2];
+            } elseif (preg_match('/^between:(\d+),(\d+)$/', $rule, $matches)) {
+                $constraints['between'] = [(int) $matches[1], (int) $matches[2]];
+            }
+        }
+
+        return $constraints;
+    }
+}

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Http\Testing\FileFactory;
 use Illuminate\Support\Arr;
+use Livewire\Attributes\Validate;
 use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
@@ -943,6 +944,134 @@ class UnitTest extends \Tests\TestCase
         Storage::disk('default-disk')->assertExists('images/avatar.jpg');
         Storage::disk('tmp-for-tests')->assertMissing('images/avatar.jpg');
     }
+
+    public function test_upload_is_rejected_from_declared_metadata_when_it_violates_the_property_max_rule()
+    {
+        Storage::fake('tmp-for-tests');
+
+        $file = UploadedFile::fake()->create('photo.png', 2048, 'image/png');
+
+        $test = Livewire::test(FileUploadWithValidateAttributeComponent::class)
+            ->set('photo', $file);
+
+        $this->assertEquals(
+            ['The photo field must not be greater than 1024 kilobytes.'],
+            $test->errors()->get('photo')
+        );
+
+        $test->assertSetStrict('photo', null);
+
+        // The reject decision came from the declared metadata — no bytes ever moved...
+        $this->assertEmpty(Storage::disk('tmp-for-tests')->allFiles());
+    }
+
+    public function test_upload_is_rejected_from_declared_metadata_when_it_violates_the_property_min_rule()
+    {
+        Storage::fake('tmp-for-tests');
+
+        $file = UploadedFile::fake()->create('photo.png', 50, 'image/png');
+
+        $test = Livewire::test(FileUploadWithMinRuleComponent::class)
+            ->set('photo', $file);
+
+        $this->assertEquals(
+            ['The photo field must be at least 100 kilobytes.'],
+            $test->errors()->get('photo')
+        );
+
+        $test->assertSetStrict('photo', null);
+
+        $this->assertEmpty(Storage::disk('tmp-for-tests')->allFiles());
+    }
+
+    public function test_multiple_uploads_are_rejected_from_declared_metadata_when_one_violates_the_wildcard_max_rule()
+    {
+        Storage::fake('tmp-for-tests');
+
+        $smallFile = UploadedFile::fake()->create('small.png', 100, 'image/png');
+        $bigFile = UploadedFile::fake()->create('big.png', 2048, 'image/png');
+
+        $test = Livewire::test(MultipleFileUploadWithValidateAttributeComponent::class)
+            ->set('photos', [$smallFile, $bigFile]);
+
+        $this->assertEquals(
+            ['The photos.1 field must not be greater than 1024 kilobytes.'],
+            $test->errors()->get('photos.1')
+        );
+
+        $test->assertSetStrict('photos', []);
+
+        $this->assertEmpty(Storage::disk('tmp-for-tests')->allFiles());
+    }
+
+    public function test_upload_that_fails_property_rules_after_upload_is_deleted_and_never_attached()
+    {
+        Storage::fake('tmp-for-tests');
+
+        // Passes the declared-size preflight, but fails the "image" rule
+        // against the real file after upload...
+        $file = UploadedFile::fake()->create('document.txt', 100, 'text/plain');
+
+        $test = Livewire::test(FileUploadWithValidateAttributeComponent::class)
+            ->set('photo', $file)
+            ->assertHasErrors('photo')
+            ->assertSetStrict('photo', null)
+            ->assertDispatched('upload:errored');
+
+        // The rejected temporary file (and its metadata sidecar) are cleaned up...
+        $this->assertEmpty(Storage::disk('tmp-for-tests')->allFiles());
+    }
+
+    public function test_upload_that_passes_property_rules_is_attached()
+    {
+        Storage::fake('tmp-for-tests');
+
+        $file = UploadedFile::fake()->image('photo.png')->size(500);
+
+        $test = Livewire::test(FileUploadWithValidateAttributeComponent::class)
+            ->set('photo', $file)
+            ->assertHasNoErrors()
+            ->assertDispatched('upload:finished');
+
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $test->viewData('photo'));
+    }
+
+    public function test_a_failed_upload_clears_when_a_valid_file_is_uploaded_after_it()
+    {
+        Storage::fake('tmp-for-tests');
+
+        $test = Livewire::test(FileUploadWithValidateAttributeComponent::class)
+            ->set('photo', UploadedFile::fake()->create('photo.png', 2048, 'image/png'))
+            ->assertHasErrors('photo')
+            ->set('photo', UploadedFile::fake()->image('photo.png')->size(500))
+            ->assertHasNoErrors();
+
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $test->viewData('photo'));
+    }
+}
+
+class FileUploadWithValidateAttributeComponent extends TestComponent
+{
+    use WithFileUploads;
+
+    #[Validate('image|max:1024')]
+    public $photo;
+}
+
+class FileUploadWithMinRuleComponent extends TestComponent
+{
+    use WithFileUploads;
+
+    #[Validate('file|min:100')]
+    public $photo;
+}
+
+class MultipleFileUploadWithValidateAttributeComponent extends TestComponent
+{
+    use WithFileUploads;
+
+    #[Validate(['photos.*' => 'image|max:1024'])]
+    public $photos = [];
 }
 
 class FileUploadToDefaultDiskComponent extends TestComponent

--- a/src/Features/SupportFileUploads/UploadPlanner.php
+++ b/src/Features/SupportFileUploads/UploadPlanner.php
@@ -18,7 +18,7 @@ use Livewire\Facades\S3MultipartUploadFacade;
  */
 class UploadPlanner
 {
-    public function plan($fileInfos, $isMultiple)
+    public function plan($fileInfos, $isMultiple, $sizeRules = [])
     {
         $fileInfos = collect($fileInfos)->values()->map(fn ($info) => [
             'name' => is_string($info['name'] ?? null) ? $info['name'] : '',
@@ -27,7 +27,7 @@ class UploadPlanner
             'lastModified' => (int) ($info['lastModified'] ?? 0),
         ]);
 
-        if ($errors = $this->declaredSizeViolations($fileInfos)) {
+        if ($errors = $this->declaredSizeViolations($fileInfos, $sizeRules)) {
             return ['strategy' => 'reject', 'errors' => json_encode(['errors' => $errors])];
         }
 
@@ -106,22 +106,48 @@ class UploadPlanner
         ];
     }
 
-    protected function declaredSizeViolations($fileInfos)
+    protected function declaredSizeViolations($fileInfos, $sizeRules = [])
     {
         $maxKilobytes = FileUploadConfiguration::maxDeclaredSizeInKilobytes();
 
-        if (! $maxKilobytes) return null;
+        if (! $maxKilobytes && ! $sizeRules) return null;
 
         $errors = [];
 
         foreach ($fileInfos as $index => $info) {
-            if ($info['size'] > $maxKilobytes * 1024) {
-                $message = trans('validation.max.file', ['attribute' => 'files.'.$index, 'max' => $maxKilobytes]);
-
+            if ($message = $this->declaredSizeViolation($info['size'], $maxKilobytes, $sizeRules, 'files.'.$index)) {
                 $errors['files.'.$index] = [$message];
             }
         }
 
         return $errors ?: null;
+    }
+
+    protected function declaredSizeViolation($bytes, $globalMaxKilobytes, $sizeRules, $attribute)
+    {
+        // These comparisons mirror Laravel's file size validation exactly
+        // (kilobytes, boundary-inclusive) so a file the preflight lets through
+        // never fails the same rule after upload — and vice versa...
+        if ($globalMaxKilobytes && $bytes > $globalMaxKilobytes * 1024) {
+            return trans('validation.max.file', ['attribute' => $attribute, 'max' => $globalMaxKilobytes]);
+        }
+
+        if (isset($sizeRules['max']) && $bytes > $sizeRules['max'] * 1024) {
+            return trans('validation.max.file', ['attribute' => $attribute, 'max' => $sizeRules['max']]);
+        }
+
+        if (isset($sizeRules['min']) && $bytes < $sizeRules['min'] * 1024) {
+            return trans('validation.min.file', ['attribute' => $attribute, 'min' => $sizeRules['min']]);
+        }
+
+        if (isset($sizeRules['size']) && $bytes !== $sizeRules['size'] * 1024) {
+            return trans('validation.size.file', ['attribute' => $attribute, 'size' => $sizeRules['size']]);
+        }
+
+        if (isset($sizeRules['between']) && ($bytes < $sizeRules['between'][0] * 1024 || $bytes > $sizeRules['between'][1] * 1024)) {
+            return trans('validation.between.file', ['attribute' => $attribute, 'min' => $sizeRules['between'][0], 'max' => $sizeRules['between'][1]]);
+        }
+
+        return null;
     }
 }

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -10,7 +10,9 @@ trait WithFileUploads
     #[Renderless]
     function _startUpload($name, $fileInfo, $isMultiple)
     {
-        $plan = app(UploadPlanner::class)->plan($fileInfo, $isMultiple);
+        $plan = app(UploadPlanner::class)->plan(
+            $fileInfo, $isMultiple, DeclaredSizeRules::for($this, $name, $isMultiple)
+        );
 
         $this->dispatch('upload:plan', name: $name, plan: $plan)->self();
     }
@@ -32,11 +34,12 @@ trait WithFileUploads
             return $path;
         })->toArray();
 
+        $uploads = collect($tmpPath)->map(function ($i) {
+            return TemporaryUploadedFile::createFromLivewire($i);
+        });
+
         if ($isMultiple) {
-            $file = collect($tmpPath)->map(function ($i) {
-                return TemporaryUploadedFile::createFromLivewire($i);
-            })->toArray();
-            $this->dispatch('upload:finished', name: $name, tmpFilenames: collect($file)->map->getFilename()->toArray())->self();
+            $file = $uploads->toArray();
 
             if ($append) {
                 $existing = $this->getPropertyValue($name);
@@ -47,8 +50,7 @@ trait WithFileUploads
                 }
             }
         } else {
-            $file = TemporaryUploadedFile::createFromLivewire($tmpPath[0]);
-            $this->dispatch('upload:finished', name: $name, tmpFilenames: [$file->getFilename()])->self();
+            $file = $uploads->first();
 
             // If the property is an array, but the upload ISNT set to "multiple"
             // then APPEND the upload to the array, rather than replacing it.
@@ -57,7 +59,49 @@ trait WithFileUploads
             }
         }
 
+        // A file that fails the property's validation rules should never be
+        // attached to the component — reject it before announcing success...
+        $this->validateIncomingUpload($name, $file, $uploads);
+
+        $this->dispatch('upload:finished', name: $name, tmpFilenames: $uploads->map->getFilename()->toArray())->self();
+
         app('livewire')->updateProperty($this, $name, $file);
+    }
+
+    protected function validateIncomingUpload($name, $candidate, $uploads)
+    {
+        // Rules from #[Validate] on form object properties are registered on
+        // the form object itself, not the root component...
+        $target = $this;
+        $field = $name;
+        $root = (string) str($name)->before('.');
+
+        if (($this->all()[$root] ?? null) instanceof \Livewire\Features\SupportFormObjects\Form) {
+            $target = $this->all()[$root];
+            $field = (string) str($name)->after('.');
+        }
+
+        if ($target->missingRuleFor($field)) return;
+
+        try {
+            if (is_array($candidate) || $candidate instanceof \Illuminate\Support\Collection) {
+                // Validate each incoming file against the property's wildcard
+                // rules — files already attached passed when they arrived...
+                $total = count($candidate);
+
+                for ($i = $total - $uploads->count(); $i < $total; $i++) {
+                    $target->validateOnly("{$field}.{$i}", dataOverrides: [$field => $candidate]);
+                }
+            } else {
+                $target->validateOnly($field, dataOverrides: [$field => $candidate]);
+            }
+        } catch (ValidationException $e) {
+            $uploads->each->delete();
+
+            $this->dispatch('upload:errored', name: $name)->self();
+
+            throw $e;
+        }
     }
 
     function _uploadErrored($name, $errorsInJson, $isMultiple) {

--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -296,6 +296,19 @@ class Testable
             $isMultiple,
         );
 
+        // Mirror the JavaScript: a "reject" plan means the declared file sizes
+        // already violate the rules, so the upload never starts...
+        $plan = collect(data_get($this->effects, 'dispatches', []))
+            ->filter(fn ($dispatch) => ($dispatch['name'] ?? null) === 'upload:plan' && data_get($dispatch, 'params.name') === $name)
+            ->map(fn ($dispatch) => data_get($dispatch, 'params.plan'))
+            ->last();
+
+        if (data_get($plan, 'strategy') === 'reject') {
+            $this->call('_uploadErrored', $name, data_get($plan, 'errors'), $isMultiple);
+
+            return $this;
+        }
+
         // This is where either the pre-signed S3 url or the regular Livewire signed
         // upload url would do its thing and return a hashed version of the uploaded
         // file in a tmp directory.


### PR DESCRIPTION
## The problem

With `#[Validate('image|max:1024')]` on an upload property, a too-big file was still fully uploaded to temp storage, attached to the property (preview and all), with the validation error displayed alongside it. Verified end-to-end: a 1.5MB file against `max:1024` showed the error, rendered its `temporaryUrl()` preview, and — since actions don't auto-validate — was storable by any action that didn't call `$this->validate()`.

For strings that set-then-error behavior is right. For files it means burning the full transfer (whatever the global rules allow) to produce an error the server could have thrown at byte zero, and leaving an invalid server-side artifact attached to component state.

## The fix — two layers

**1. Preflight, in the `UploadPlanner` handshake.** `DeclaredSizeRules` extracts the size-based constraints (`max`/`min`/`size`/`between`, string rules only — component, form object, and wildcard rules all resolve) from the property's own validation rules. Declared sizes are checked during `_startUpload` and a violating file gets the existing `reject` plan — the exact message post-upload validation would produce ("The photo field must not be greater than 1024 kilobytes."), before any bytes move. Comparisons mirror Laravel's kilobyte semantics exactly so preflight and post-upload can never disagree. Declared sizes are client-supplied, so this is a fast-fail courtesy — the authoritative check still runs server-side.

**2. Attach-time, in `_finishUpload`.** The real temporary file is validated against the property's full rules (via `validateOnly` + `dataOverrides`) *before* assignment. This catches what metadata can't: content rules (`image`, `mimes`, `dimensions`) and spoofed sizes. A failing file is deleted from temp storage, `upload:errored` is dispatched so the frontend unwinds its state, and the validation error surfaces — the property is never set and no preview renders. Multiple uploads validate each incoming index against wildcard rules; previously-attached files aren't re-validated.

`Testable::upload` now honors `reject` plans, so the test-mode flow mirrors the JavaScript.

## Behavior change

Files diverge deliberately from other property types: a failed upload validation now leaves the property **unset** instead of set-with-error. Inline `$this->validate()` calls in `updated*()` hooks keep today's semantics (rules passed directly aren't property rules). `$this->validate()` in actions is still required — properties can be populated by other means.

## Verification

- 6 new unit tests (preflight max/min, wildcard multiple, post-upload content-rule rejection + temp cleanup, valid-file regression, error-clearing on retry)
- 1 new browser test through real Chrome: big file → error before upload with empty temp dir and no preview; valid file after → uploads and clears the error
- Full `SupportFileUploads` (91), `SupportFormObjects`/`SupportValidation`/chunked/S3 unit suites (139), upload + chunked browser suites — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)