### PR TITLE
[4.x] Fix `RedirectResponse` being handled by Livewire redirector during request lifecycle

### DIFF
--- a/src/Features/SupportRedirects/Redirector.php
+++ b/src/Features/SupportRedirects/Redirector.php
@@ -14,11 +14,7 @@ class Redirector extends BaseRedirector
     {
         $this->component->redirect($this->generator->to($path, [], $secure));
 
-        if (app(HandleRequests::class)->isLivewireRoute()) {
-            return parent::to($path, $status, $headers, $secure);
-        }
-
-        return $this;
+        return parent::to($path, $status, $headers, $secure);
     }
 
     public function away($path, $status = 302, $headers = [])

--- a/src/Features/SupportRedirects/Redirector.php
+++ b/src/Features/SupportRedirects/Redirector.php
@@ -4,6 +4,7 @@ namespace Livewire\Features\SupportRedirects;
 
 use Livewire\Component;
 use Illuminate\Routing\Redirector as BaseRedirector;
+use Livewire\Mechanisms\HandleRequests\HandleRequests;
 
 class Redirector extends BaseRedirector
 {
@@ -12,6 +13,10 @@ class Redirector extends BaseRedirector
     public function to($path, $status = 302, $headers = [], $secure = null)
     {
         $this->component->redirect($this->generator->to($path, [], $secure));
+
+        if (app(HandleRequests::class)->isLivewireRoute()) {
+            return parent::to($path, $status, $headers, $secure);
+        }
 
         return $this;
     }

--- a/src/Features/SupportRedirects/Redirector.php
+++ b/src/Features/SupportRedirects/Redirector.php
@@ -4,7 +4,6 @@ namespace Livewire\Features\SupportRedirects;
 
 use Livewire\Component;
 use Illuminate\Routing\Redirector as BaseRedirector;
-use Livewire\Mechanisms\HandleRequests\HandleRequests;
 
 class Redirector extends BaseRedirector
 {

--- a/src/Features/SupportRedirects/Redirector.php
+++ b/src/Features/SupportRedirects/Redirector.php
@@ -21,17 +21,6 @@ class Redirector extends BaseRedirector
         return $this->to($path, $status, $headers);
     }
 
-    public function with($key, $value = null)
-    {
-        $key = is_array($key) ? $key : [$key => $value];
-
-        foreach ($key as $k => $v) {
-            $this->session->flash($k, $v);
-        }
-
-        return $this;
-    }
-
     public function component(Component $component)
     {
         $this->component = $component;


### PR DESCRIPTION
# Scenario
### Case 1
Imagine user create custom exception handler that convert the exception to specific redirect response

### Case 2
When testing this PR https://github.com/livewire/livewire/pull/10388, I found that all redirect response during request lifecycle handled by Livewire will throw an exception as shown below

<img width="730" height="203" alt="image" src="https://github.com/user-attachments/assets/57e4fbf1-5637-4d1a-895d-70a53a507b0b" />

```php
<?php

use Livewire\ComponentHook;

class CustomHook extends ComponentHook
{
    function call()
    {
        // this will return RedirectResponse
        throw new AuthenticationException();

        // or
        return to_route('home');
    }
}
```
```php
<?php

use Livewire\Component;

new class extends Component
{
    public function save()
    {
        throw new AuthenticationException();
    }
}
```

This is caused by `RedirectResponse` handled by Livewire custom redirector.

The exception originally comes from `AuthenticationException` with flow

**AuthenticationException**

↓

`redirect()->guest($url)`

↓

**SupportRedirects/Redirector::to()**

Redirector swap happened during component hook boot time and only restored on dehydrate, which means any redirect response during request lifecycle will be handled by Livewire redirector

# Problem

When `RedirectResponse` handled by Livewire redirector, it return the custom redirector instance.

```php
public function to($path, $status = 302, $headers = [], $secure = null)
{
    $this->component->redirect($this->generator->to($path, [], $secure));

    return $this;
}
```

I dont know the reason why this return Livewire redirector instance eventhough its should return `RedirectResponse` instance and not the redirector itself.

# Solution

Always return parent object to handle redirect response, since its general redirect and not using navigate.

```php
public function to($path, $status = 302, $headers = [], $secure = null)
{
    $this->component->redirect($this->generator->to($path, [], $secure));

    return parent::to($path, $status, $headers, $secure);
}
```
This way, it will handles the `RedirectResponse` properly

> [!NOTE]
> since user can return redirect response inside action that either called as normal call or as event listener, I also have checked that return effect from this response can be json-encoded without throwing any error. I just not sure if it should be exlcluded or not from return effects.


