### PR TITLE
[4.x] Fix redirect from `AuthenticationException` not being handled properly

### DIFF
--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -209,6 +209,9 @@ class HandleRequests extends Mechanism
                 if (config('app.debug')) throw $e;
 
                 abort(419);
+            } catch (\Illuminate\Auth\AuthenticationException $e) {
+                $effects['redirect'] = $e->redirectTo(request());
+                $effects['redirectUsingNavigate'] = true;
             }
 
             $componentResponses[] = [

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Livewire\Livewire;
@@ -433,5 +434,19 @@ class UnitTest extends TestCase
         $uri = $handleRequests->getUpdateUri();
 
         $this->assertEquals(EndpointResolver::updatePath(), $uri);
+    }
+
+    public function test_can_handle_redirect_from_authentication_exception()
+    {
+        Route::livewire('/login-page', new class extends TestComponent {})->name('login');
+
+        Livewire::test(new class extends TestComponent {
+            public function save()
+            {
+                throw new AuthenticationException();
+            }
+        })
+        ->call('save')
+        ->assertRedirectToRoute('login');
     }
 }


### PR DESCRIPTION
# Scenario
If `AuthenticationException` thrown before component dehydrate, the redirect from this exception will be handled by Livewire custom redirector which will throw an exception as shown below

<img width="730" height="203" alt="image" src="https://github.com/user-attachments/assets/57e4fbf1-5637-4d1a-895d-70a53a507b0b" />

```php
<?php

new class extends Component
{
    public function save()
    {
        throw new AuthenticationException();
    }
}
```
```blade
<div>
    <button type="button" wire:click="save">Save</button>
</div>
```

# Problem
In `HandleRequests::handleUpdate()`, it only catch `TypeError` but swallow `AuthenticationException` that has redirect mechanism to login route. Because Laravel redirector being swapped during component hook boot time, any redirect response during request lifecycle will be handled by Livewire custom redirector which will throw an exception as shown above.

# Solution
Catch `AuthenticationException` and set redirect `effects` 

```php
try {
    [ $snapshot, $effects ] = app('livewire')->update($snapshot, $updates, $calls);
} catch (\TypeError $e) {
    report($e);

    if (config('app.debug')) throw $e;

    abort(419);
} catch (\Illuminate\Auth\AuthenticationException $e) {
    $effects['redirect'] = $e->redirectTo(request());
    $effects['redirectUsingNavigate'] = true;
}
```
I've look up for Laravel exception that has redirect response and `AuthenticationException` was the only one.