### PR TITLE
[Spike] Stock `fil` JS synth: rich `TemporaryUpload` objects

### DIFF
--- a/docs/synthesizers.md
+++ b/docs/synthesizers.md
@@ -350,6 +350,31 @@ Now the same `Address` concept exists on both sides of the wire:
 
 You can still mutate individual fields (`$wire.address.street = '...'` or `wire:model="address.street"`) — when a rich value changes, Livewire sends its entire dehydrated form to the server, where the PHP synthesizer hydrates it back into an `Address`.
 
+### Reactivity
+
+Rich values participate in Alpine's reactivity at the property level. Any effect that reads the property — `x-text`, `$wire.$watch()`, `wire:dirty` — re-runs whenever the property is _replaced_:
+
+```blade
+<!-- This re-renders when $wire.publishedAt is assigned a new value... -->
+<div x-text="$wire.publishedAt.toDateString()"></div>
+
+<!-- ...whether from the client: -->
+<button x-on:click="$wire.publishedAt = new Date()">Publish now</button>
+```
+
+The same applies when the property changes server-side: because rich values are atomic, Livewire replaces the whole value when merging a server response, which triggers any effects reading it. And when a rich value _hasn't_ changed, Livewire keeps the existing object (same identity) so effects don't re-run needlessly.
+
+Rich values built from plain classes — like the `Address` example above — are also deeply reactive, just like plain objects: mutating `$wire.address.street` re-runs an effect reading `$wire.address.full`.
+
+The one exception is in-place mutation of native objects like `Date`:
+
+```blade
+<!-- This will NOT re-render the x-text above: -->
+<button x-on:click="$wire.publishedAt.setFullYear(2030)">Won't react</button>
+```
+
+JavaScript proxies can't intercept a `Date`'s internal methods, so Alpine (like Vue) can't observe the mutation. The change is still detected by Livewire's state diffing and sent to the server on the next request — but no frontend effects fire. Treat values like dates as immutable: assign a new instance instead of mutating.
+
 ### Things to know
 
 * **Registration is global per key.** Registering a synth for `cbn` upgrades _every_ Carbon and native date property across your entire application, so make sure your frontend code is prepared for that.

--- a/docs/synthesizers.md
+++ b/docs/synthesizers.md
@@ -244,3 +244,117 @@ class AddressSynth extends Synth
     }
 }
 ```
+
+## JavaScript synthesizers
+
+Synthesizers make rich values like Carbon dates usable on the server, but by default, JavaScript only ever sees the raw dehydrated value. For example, given the following component:
+
+```php
+use Carbon\Carbon;
+
+class ShowPost extends Component
+{
+    public Carbon $publishedAt;
+}
+```
+
+Accessing `$wire.publishedAt` in JavaScript returns a plain ISO date string like `"2021-01-01T00:00:00+00:00"` — not something you can call date methods on.
+
+JavaScript synthesizers are the client-side counterpart to PHP synthesizers. By registering one for the same synth key, the raw value is upgraded into a rich JavaScript object when component state reaches the frontend, and converted back to its raw wire format when updates are sent to the server.
+
+Register a JavaScript synthesizer using `Livewire.synth()` inside a `livewire:init` listener so it's available before components initialize:
+
+```js
+document.addEventListener('livewire:init', () => {
+    Livewire.synth('cbn', {
+        match: (value) => value instanceof Date,
+
+        hydrate: (value, meta) => new Date(value),
+
+        dehydrate: (value) => value.toISOString(),
+    })
+})
+```
+
+With this synth registered, every Carbon property is a real `Date` object on the frontend:
+
+```blade
+<span x-text="$wire.publishedAt.toLocaleDateString()"></span>
+
+<button x-on:click="$wire.publishedAt = new Date()">Publish now</button>
+```
+
+When you assign a fresh `Date` and the next request is sent, Livewire calls `dehydrate()` and the server receives the ISO string, which the PHP `CarbonSynth` hydrates back into a Carbon instance.
+
+Let's break down the three required functions:
+
+The first parameter of `Livewire.synth()` is the key of the PHP synthesizer you are pairing with — the same key found in the `s` field of the property's [metadata tuple](/docs/4.x/hydration#deeply-nested-tuples) (`cbn` is the key of Livewire's internal Carbon synthesizer).
+
+`hydrate()` receives the raw wire value along with its full metadata tuple and returns the rich JavaScript value. It is called whenever component state arrives from the server: on the initial page load and after every subsequent request.
+
+```js
+hydrate: (value, meta) => new Date(value),
+```
+
+`dehydrate()` does the inverse: it receives the rich value and must return the raw wire format. It is called when Livewire compares component state and builds the update payload for the server. Whatever it returns must be a value the PHP synthesizer's `hydrate()` method understands — typically the same format the server sent down in the first place.
+
+```js
+dehydrate: (value) => value.toISOString(),
+```
+
+`match()` identifies rich values inside component state. Livewire uses it to know which values should be treated as atomic units when diffing, and which synthesizer should dehydrate a brand-new instance you've assigned (like the `new Date()` above, which never came from the server).
+
+```js
+match: (value) => value instanceof Date,
+```
+
+### Pairing with a custom PHP synthesizer
+
+JavaScript synthesizers really shine when paired with a custom PHP synthesizer. Continuing the `Address` example from above, you can give the frontend a matching rich object:
+
+```js
+class Address {
+    constructor({ street, city, state, zip }) {
+        this.street = street
+        this.city = city
+        this.state = state
+        this.zip = zip
+    }
+
+    get full() {
+        return `${this.street}, ${this.city}, ${this.state} ${this.zip}`
+    }
+}
+
+document.addEventListener('livewire:init', () => {
+    Livewire.synth('address', {
+        match: (value) => value instanceof Address,
+
+        hydrate: (value) => new Address(value),
+
+        dehydrate: (value) => ({
+            street: value.street,
+            city: value.city,
+            state: value.state,
+            zip: value.zip,
+        }),
+    })
+})
+```
+
+Now the same `Address` concept exists on both sides of the wire:
+
+```blade
+<span x-text="$wire.address.full"></span>
+```
+
+You can still mutate individual fields (`$wire.address.street = '...'` or `wire:model="address.street"`) — when a rich value changes, Livewire sends its entire dehydrated form to the server, where the PHP synthesizer hydrates it back into an `Address`.
+
+### Things to know
+
+* **Registration is global per key.** Registering a synth for `cbn` upgrades _every_ Carbon and native date property across your entire application, so make sure your frontend code is prepared for that.
+* **Rich values are atomic.** Livewire never diffs _inside_ a rich value. When one changes, its full dehydrated form is sent to the server and the corresponding property update fires at the property's path.
+* **Rich values also work as action parameters.** Calling `$wire.save(new Date())` dehydrates the parameter before it's sent to the server.
+* **Binding inputs directly to a rich property** (`wire:model="publishedAt"`) sets the input's raw string value onto the property. The string is sent to the server as-is and re-hydrated there, but the input will display the browser's string representation of the rich object — for form inputs, prefer binding to nested fields or handling conversion yourself.
+
+For reference, these are the keys of Livewire's built-in synthesizers: `arr` (arrays), `cbn` (Carbon/DateTime), `clctn` (Collections), `str` (Stringables), `enm` (Enums), `std` (stdClass), `mdl` (Eloquent models), `elcln` (Eloquent collections), `wrbl` (Wireables), `form` (Form objects), and `fil` (file uploads).

--- a/docs/synthesizers.md
+++ b/docs/synthesizers.md
@@ -308,6 +308,23 @@ dehydrate: (value) => value.toISOString(),
 match: (value) => value instanceof Date,
 ```
 
+### Hydration context
+
+`hydrate()` receives a third argument: a context object containing the owning `component` and the value's `path` in component state (`'date'`, `'items.2'`, etc.). Rich values can hold onto it to know where they live — for example, to update or remove themselves through `component.$wire`:
+
+```js
+hydrate: (value, meta, context) => new Reminder(value, context),
+
+// Inside the rich class:
+dismiss() {
+    this.context.component.$wire.$set(this.context.path, null)
+}
+```
+
+### Values without a wire representation
+
+`dehydrate()` may return `undefined` to signal that a value has no server-side representation yet. Livewire will never send such a value to the server: it's skipped in update payloads, and omitted from arrays entirely (rather than serialized as `null`). This enables optimistic client-side values — Livewire's rich upload objects use it to represent in-flight uploads, exposing reactive `progress` state on the property while the file is still uploading.
+
 ### Pairing with a custom PHP synthesizer
 
 JavaScript synthesizers really shine when paired with a custom PHP synthesizer. Continuing the `Address` example from above, you can give the frontend a matching rich object:

--- a/js/component.js
+++ b/js/component.js
@@ -33,9 +33,9 @@ export class Component {
         this.originalEffects = deepClone(this.effects)
 
         // "canonical" data represents the last known server state.
-        this.canonical = extractData(deepClone(this.snapshot.data))
+        this.canonical = extractData(deepClone(this.snapshot.data), { component: this })
         // "ephemeral" represents the most current state. (This can be freely manipulated by end users)
-        this.ephemeral = extractData(deepClone(this.snapshot.data))
+        this.ephemeral = extractData(deepClone(this.snapshot.data), { component: this })
         // "reactive" is just ephemeral, except when you mutate it, front-ends like Vue react.
         this.reactive = Alpine.reactive(this.ephemeral)
 
@@ -77,10 +77,10 @@ export class Component {
 
         // Canonical can contain rich synth values that don't survive JSON
         // cloning, so re-extract a fresh copy from the old raw snapshot...
-        let oldCanonical = extractData(deepClone(this.snapshot.data))
+        let oldCanonical = extractData(deepClone(this.snapshot.data), { component: this })
         let updatedOldCanonical = this.applyUpdates(oldCanonical, updates)
 
-        let newCanonical = extractData(deepClone(snapshot.data))
+        let newCanonical = extractData(deepClone(snapshot.data), { component: this })
 
         let dirty = diff(updatedOldCanonical, newCanonical)
 
@@ -90,9 +90,9 @@ export class Component {
 
         this.effects = effects
 
-        this.canonical = extractData(deepClone(snapshot.data))
+        this.canonical = extractData(deepClone(snapshot.data), { component: this })
 
-        let newData = extractData(deepClone(snapshot.data))
+        let newData = extractData(deepClone(snapshot.data), { component: this })
 
         // Diff old vs new and patch differences onto the reactive proxy. Walks
         // the trees directly, avoiding dot-notated paths which break when

--- a/js/component.js
+++ b/js/component.js
@@ -1,4 +1,5 @@
 import { dataSet, deepClone, diff, diffAndConsolidate, diffAndPatchRecursive, extractData} from '@/utils'
+import { dehydrateTree } from '@/synths'
 import { generateWireObject } from '@/$wire'
 import { findComponentByEl, findComponent, hasComponent } from '@/store'
 import { trigger } from '@/hooks'
@@ -74,7 +75,9 @@ export class Component {
     mergeNewSnapshot(snapshotEncoded, effects, updates = {}) {
         let snapshot = JSON.parse(snapshotEncoded)
 
-        let oldCanonical = deepClone(this.canonical)
+        // Canonical can contain rich synth values that don't survive JSON
+        // cloning, so re-extract a fresh copy from the old raw snapshot...
+        let oldCanonical = extractData(deepClone(this.snapshot.data))
         let updatedOldCanonical = this.applyUpdates(oldCanonical, updates)
 
         let newCanonical = extractData(deepClone(snapshot.data))
@@ -103,7 +106,7 @@ export class Component {
         // These updates will be applied first on the server
         // on the next request, then trickle back to the
         // client on the next request that gets sent.
-        this.queuedUpdates[propertyName] = value
+        this.queuedUpdates[propertyName] = dehydrateTree(value)
     }
 
     mergeQueuedUpdates(diff) {

--- a/js/directives/wire-dirty.js
+++ b/js/directives/wire-dirty.js
@@ -1,6 +1,6 @@
 import { directive, getDirectives } from '@/directives'
 import { toggleBooleanStateDirective } from './shared'
-import { dataGet, WeakBag } from '@/utils'
+import { dataGet, deeplyEqual, WeakBag } from '@/utils'
 import { on } from '@/hooks'
 
 let refreshDirtyStatesByComponent = new WeakBag
@@ -45,17 +45,17 @@ export function checkDirty(component, targets) {
     let isDirty = false
 
     if (targets === undefined) {
-        isDirty = JSON.stringify(component.canonical) !== JSON.stringify(component.reactive)
+        isDirty = ! deeplyEqual(component.canonical, component.reactive)
     } else if (Array.isArray(targets)) {
         for (let i = 0; i < targets.length; i++) {
             if (isDirty) break;
 
             let target = targets[i]
 
-            isDirty = JSON.stringify(dataGet(component.canonical, target)) !== JSON.stringify(dataGet(component.reactive, target))
+            isDirty = ! deeplyEqual(dataGet(component.canonical, target), dataGet(component.reactive, target))
         }
     } else {
-        isDirty = JSON.stringify(dataGet(component.canonical, targets)) !== JSON.stringify(dataGet(component.reactive, targets))
+        isDirty = ! deeplyEqual(dataGet(component.canonical, targets), dataGet(component.reactive, targets))
     }
 
     return isDirty

--- a/js/features/supportFileUploads.js
+++ b/js/features/supportFileUploads.js
@@ -1,4 +1,53 @@
 import { getCsrfToken } from '@/utils';
+import { registerSynth } from '@/synths';
+
+/**
+ * The rich JS counterpart to PHP's TemporaryUploadedFile. Wraps the raw
+ * "livewire-file:..." wire value so file properties are useful objects
+ * on the frontend instead of opaque serialized strings.
+ */
+export class TemporaryUpload {
+    constructor(serialized, meta = {}) {
+        this.serialized = serialized
+        this.meta = meta
+    }
+
+    // The original filename from the user's machine...
+    get name() { return this.meta.name ?? this.filename }
+
+    // The hashed temporary filename on the server (used by $wire.removeUpload())...
+    get filename() { return this.serialized.replace('livewire-file:', '') }
+
+    get extension() { return this.filename.split('.').pop() }
+
+    get isPreviewable() { return this.meta.previewUrl !== undefined }
+
+    temporaryUrl() { return this.meta.previewUrl ?? null }
+
+    // Degrade to the raw wire value when stringified or JSON-serialized...
+    toString() { return this.serialized }
+
+    toJSON() { return this.serialized }
+}
+
+registerSynth('fil', {
+    match: (value) => value instanceof TemporaryUpload,
+
+    hydrate: (value, meta) => {
+        if (typeof value !== 'string' || value === '') return value
+
+        // Legacy multiple-file format: hydrate into an array of rich objects...
+        if (value.startsWith('livewire-files:')) {
+            return JSON.parse(value.replace('livewire-files:', '')).map(
+                filename => new TemporaryUpload('livewire-file:' + filename)
+            )
+        }
+
+        return new TemporaryUpload(value, meta)
+    },
+
+    dehydrate: (value) => value.serialized,
+})
 
 let uploadManagers = new WeakMap
 

--- a/js/features/supportFileUploads.js
+++ b/js/features/supportFileUploads.js
@@ -1,31 +1,95 @@
-import { getCsrfToken } from '@/utils';
+import { getCsrfToken, dataGet, dataSet } from '@/utils';
 import { registerSynth } from '@/synths';
+
+// Client-side blob URLs for uploaded files, keyed by their temporary server
+// filename. Lets previews keep using the local file after the upload
+// finishes instead of fetching the file back from the server...
+let objectUrls = new Map
 
 /**
  * The rich JS counterpart to PHP's TemporaryUploadedFile. Wraps the raw
  * "livewire-file:..." wire value so file properties are useful objects
  * on the frontend instead of opaque serialized strings.
+ *
+ * Also represents in-flight uploads: while a file is uploading, the property
+ * optimistically holds a pending instance exposing reactive progress state.
  */
 export class TemporaryUpload {
-    constructor(serialized, meta = {}) {
+    constructor(serialized, meta = {}, context = undefined) {
         this.serialized = serialized
         this.meta = meta
+        this.context = context
+        this.file = null
+        this._progress = 0
+        this._objectUrl = null
     }
 
+    // An optimistic instance for an in-flight upload, created from the
+    // browser's native File object before the server knows anything...
+    static pending(file, context) {
+        let instance = new TemporaryUpload(null, {}, context)
+
+        instance.file = file
+
+        return instance
+    }
+
+    get isUploading() { return this.serialized === null }
+
+    get progress() { return this.isUploading ? this._progress : 100 }
+
     // The original filename from the user's machine...
-    get name() { return this.meta.name ?? this.filename }
+    get name() { return this.file?.name ?? this.meta.name ?? this.filename }
 
     // The hashed temporary filename on the server (used by $wire.removeUpload())...
-    get filename() { return this.serialized.replace('livewire-file:', '') }
+    get filename() { return this.serialized === null ? null : this.serialized.replace('livewire-file:', '') }
 
-    get extension() { return this.filename.split('.').pop() }
+    get extension() { return this.name?.split('.').pop() }
 
-    get isPreviewable() { return this.meta.previewUrl !== undefined }
+    get isPreviewable() { return this.meta.previewUrl !== undefined || this.file !== null }
 
+    // The best available preview URL: the local file's blob URL when we have
+    // it (instant, no server request), otherwise the signed server URL...
+    get previewUrl() {
+        if (this.file) return this._objectUrl ??= URL.createObjectURL(this.file)
+
+        if (this.filename && objectUrls.has(this.filename)) return objectUrls.get(this.filename)
+
+        return this.meta.previewUrl ?? null
+    }
+
+    // The signed server-side preview URL (equivalent of PHP's temporaryUrl())...
     temporaryUrl() { return this.meta.previewUrl ?? null }
 
+    // Remove this upload from the property it lives on. Cancels the upload
+    // if it's still in flight...
+    remove(finishCallback = () => {}) {
+        if (! this.context) throw 'Cannot remove an upload that isn\'t attached to a component property'
+
+        if (this.isUploading) {
+            return cancelUpload(this.context.component, this._propertyName)
+        }
+
+        if (objectUrls.has(this.filename)) {
+            URL.revokeObjectURL(objectUrls.get(this.filename))
+            objectUrls.delete(this.filename)
+        }
+
+        return removeUpload(this.context.component, this._propertyName, this.filename, finishCallback)
+    }
+
+    // The property this upload lives on: its state path minus any trailing
+    // array index ('photos.1' → 'photos')...
+    get _propertyName() {
+        let segments = this.context.path.split('.')
+
+        if (/^\d+$/.test(segments[segments.length - 1])) segments.pop()
+
+        return segments.join('.')
+    }
+
     // Degrade to the raw wire value when stringified or JSON-serialized...
-    toString() { return this.serialized }
+    toString() { return this.serialized ?? '' }
 
     toJSON() { return this.serialized }
 }
@@ -33,20 +97,22 @@ export class TemporaryUpload {
 registerSynth('fil', {
     match: (value) => value instanceof TemporaryUpload,
 
-    hydrate: (value, meta) => {
+    hydrate: (value, meta, context) => {
         if (typeof value !== 'string' || value === '') return value
 
         // Legacy multiple-file format: hydrate into an array of rich objects...
         if (value.startsWith('livewire-files:')) {
             return JSON.parse(value.replace('livewire-files:', '')).map(
-                filename => new TemporaryUpload('livewire-file:' + filename)
+                filename => new TemporaryUpload('livewire-file:' + filename, {}, context)
             )
         }
 
-        return new TemporaryUpload(value, meta)
+        return new TemporaryUpload(value, meta, context)
     },
 
-    dehydrate: (value) => value.serialized,
+    // Pending uploads have no wire representation yet (undefined tells
+    // Livewire to never send them to the server)...
+    dehydrate: (value) => value.serialized ?? undefined,
 })
 
 let uploadManagers = new WeakMap
@@ -237,6 +303,8 @@ class UploadManager {
             e.detail = {}
             e.detail.progress = Math.floor((e.loaded * 100) / e.total)
 
+            this.updatePendingProgress(name, e.detail.progress)
+
             this.uploadBag.first(name).progressCallback(e)
         })
 
@@ -272,15 +340,71 @@ class UploadManager {
             return { name: file.name, size: file.size, type: file.type }
         })
 
+        this.setPendingUploads(name, uploadObject)
+
         this.component.$wire.call('_startUpload', name, fileInfos, uploadObject.multiple);
 
         setUploadLoading(this.component, name)
+    }
+
+    // Optimistically place pending rich upload objects on the property so
+    // frontends get reactive progress/isUploading/previewUrl state while
+    // the upload is still in flight...
+    setPendingUploads(name, uploadObject) {
+        let context = { component: this.component, path: name }
+
+        let pendings = uploadObject.files.map(file => TemporaryUpload.pending(file, context))
+
+        uploadObject.previousValue = dataGet(this.component.ephemeral, name)
+
+        if (uploadObject.multiple) {
+            let existing = uploadObject.append ? (dataGet(this.component.ephemeral, name) || []) : []
+
+            dataSet(this.component.reactive, name, [...existing, ...pendings])
+
+            uploadObject.pendings = dataGet(this.component.reactive, name).slice(-pendings.length)
+        } else {
+            dataSet(this.component.reactive, name, pendings[0])
+
+            uploadObject.pendings = [dataGet(this.component.reactive, name)]
+        }
+    }
+
+    updatePendingProgress(name, progress) {
+        let uploadObject = this.uploadBag.first(name)
+
+        if (! uploadObject || ! uploadObject.pendings) return
+
+        uploadObject.pendings.forEach(pending => pending._progress = progress)
+    }
+
+    // Restore the property to its pre-upload value (upload errored or was cancelled)...
+    revertPendingUploads(name, uploadObject) {
+        if (! uploadObject || ! uploadObject.pendings) return
+
+        uploadObject.pendings.forEach(pending => {
+            if (pending._objectUrl) URL.revokeObjectURL(pending._objectUrl)
+        })
+
+        dataSet(this.component.reactive, name, uploadObject.previousValue === undefined ? null : uploadObject.previousValue)
     }
 
     markUploadFinished(name, tmpFilenames) {
         unsetUploadLoading(this.component)
 
         let uploadObject = this.uploadBag.shift(name)
+
+        // Graduate the pending objects: give them their wire value (flips
+        // isUploading reactively) and keep their local blob URLs available
+        // for previews after the server swaps in hydrated instances...
+        ;(uploadObject.pendings || []).forEach((pending, i) => {
+            if (! tmpFilenames[i]) return
+
+            if (pending._objectUrl) objectUrls.set(tmpFilenames[i], pending._objectUrl)
+
+            pending.serialized = 'livewire-file:' + tmpFilenames[i]
+        })
+
         uploadObject.finishCallback(uploadObject.multiple ? tmpFilenames : tmpFilenames[0])
 
         if (this.uploadBag.get(name).length > 0) this.startUpload(name, this.uploadBag.last(name))
@@ -289,7 +413,11 @@ class UploadManager {
     markUploadErrored(name) {
         unsetUploadLoading(this.component)
 
-        this.uploadBag.shift(name).errorCallback()
+        let uploadObject = this.uploadBag.shift(name)
+
+        this.revertPendingUploads(name, uploadObject)
+
+        uploadObject.errorCallback()
 
         if (this.uploadBag.get(name).length > 0) this.startUpload(name, this.uploadBag.last(name))
     }
@@ -305,6 +433,8 @@ class UploadManager {
             }
 
             this.uploadBag.shift(name).cancelledCallback();
+
+            this.revertPendingUploads(name, uploadItem)
 
             if (cancelledCallback) cancelledCallback()
         }

--- a/js/features/supportQueryString.js
+++ b/js/features/supportQueryString.js
@@ -1,5 +1,6 @@
 import { on } from '@/hooks'
 import { dataGet } from '@/utils'
+import { dehydrateTree } from '@/synths'
 import Alpine from 'alpinejs'
 import { track } from '@/plugins/history'
 
@@ -13,13 +14,15 @@ on('effect', ({ component, effects, cleanup }) => {
 
         if (! as) as = name
 
-        let initialValue = [false, null, undefined].includes(except) ? dataGet(component.ephemeral, name) : except
+        // Rich synth values can't be serialized into a URL, so they're
+        // converted back to their raw wire format at this boundary...
+        let initialValue = [false, null, undefined].includes(except) ? dehydrateTree(dataGet(component.ephemeral, name)) : except
 
         let { replace, push, pop } = track(as, initialValue, alwaysShow, except)
 
         if (use === 'replace') {
             let effectReference = Alpine.effect(() => {
-                replace(dataGet(component.reactive, name))
+                replace(dehydrateTree(dataGet(component.reactive, name)))
             })
 
             cleanup(() => Alpine.release(effectReference))
@@ -29,10 +32,10 @@ on('effect', ({ component, effects, cleanup }) => {
             let forgetCommitHandler = on('commit', ({ component: commitComponent, succeed }) => {
                 if (component !== commitComponent) return
 
-                let beforeValue = dataGet(component.canonical, name)
+                let beforeValue = dehydrateTree(dataGet(component.canonical, name))
 
                 succeed(() => {
-                    let afterValue = dataGet(component.canonical, name)
+                    let afterValue = dehydrateTree(dataGet(component.canonical, name))
 
                     if (JSON.stringify(beforeValue) === JSON.stringify(afterValue)) return
 
@@ -64,7 +67,7 @@ on('effect', ({ component, effects, cleanup }) => {
 
             // If the current property value differs from the initial value
             // (e.g. restored from session), sync the URL via replaceState...
-            let currentValue = dataGet(component.ephemeral, name)
+            let currentValue = dehydrateTree(dataGet(component.ephemeral, name))
 
             if (JSON.stringify(currentValue) !== JSON.stringify(initialValue)) {
                 replace(currentValue)

--- a/js/index.js
+++ b/js/index.js
@@ -3,11 +3,13 @@ import { find, first, getByName, all } from './store'
 import { start } from './lifecycle'
 import { on as hook, trigger, triggerAsync } from './hooks'
 import { directive } from './directives'
+import { registerSynth } from './synths'
 import Alpine from 'alpinejs'
 import { fireAction, interceptAction, interceptMessage, interceptRequest } from '@/request'
 
 let Livewire = {
     directive,
+    synth: registerSynth,
     dispatchTo,
     // @todo: See if this can be injected from a v4 feature...
     interceptAction: (callback) => interceptAction(callback),

--- a/js/request/action.js
+++ b/js/request/action.js
@@ -1,3 +1,4 @@
+import { dehydrateTree } from '@/synths'
 
 export default class Action {
     squashedActions = new Set()
@@ -21,7 +22,9 @@ export default class Action {
     constructor(component, name, params = [], metadata = {}, origin = null) {
         this.component = component
         this.name = name
-        this.params = params
+        // Convert any rich synth values back to their raw wire format
+        // so they can be serialized into the request payload...
+        this.params = dehydrateTree(params)
         this.metadata = metadata
         this.origin = origin
 

--- a/js/synths.js
+++ b/js/synths.js
@@ -1,0 +1,85 @@
+/**
+ * JavaScript synthesizers ("synths") are the client-side counterpart to
+ * Livewire's PHP property synthesizers. A PHP synth dehydrates a rich PHP
+ * value (a Carbon date, a DTO, etc.) into a JSON-safe value plus a metadata
+ * tuple: [value, { s: 'key', ... }]. By default, JavaScript only ever sees
+ * that raw JSON value.
+ *
+ * Registering a JS synth for the same key upgrades the raw value into a rich
+ * JavaScript object when component state is hydrated on the frontend, and
+ * converts it back to its raw wire format when state is diffed and sent to
+ * the server.
+ */
+
+let synths = {}
+
+export function registerSynth(key, synth) {
+    if (typeof key !== 'string' || key === '') {
+        throw `Livewire.synth() requires a key matching the PHP synthesizer's static $key property`
+    }
+
+    for (let method of ['match', 'hydrate', 'dehydrate']) {
+        if (typeof synth[method] !== 'function') {
+            throw `Livewire.synth('${key}') requires a "${method}" function`
+        }
+    }
+
+    synths[key] = synth
+}
+
+export function flushSynths() {
+    synths = {}
+}
+
+export function hasSynths() {
+    return Object.keys(synths).length > 0
+}
+
+/**
+ * Find a registered synth whose match() recognizes the given rich value.
+ * Used to identify synth values in state trees so they can be treated
+ * atomically and dehydrated back to their wire format.
+ */
+export function findSynthByValue(value) {
+    if (typeof value !== 'object' || value === null) return
+
+    for (let key in synths) {
+        if (synths[key].match(value)) return synths[key]
+    }
+}
+
+/**
+ * Hydrate a raw wire value into a rich JS value if a synth is registered
+ * for the metadata's synth key. Otherwise pass the raw value through.
+ */
+export function hydrateValue(value, meta) {
+    let synth = meta && synths[meta.s]
+
+    return synth ? synth.hydrate(value, meta) : value
+}
+
+/**
+ * Walk a value tree and return a copy with every rich synth value converted
+ * back to its raw wire format. Never mutates the original tree.
+ */
+export function dehydrateTree(value) {
+    if (! hasSynths()) return value
+
+    return dehydrateTreeRecursive(value)
+}
+
+function dehydrateTreeRecursive(value) {
+    let synth = findSynthByValue(value)
+
+    if (synth) value = synth.dehydrate(value)
+
+    if (typeof value !== 'object' || value === null) return value
+
+    let copy = Array.isArray(value) ? [] : {}
+
+    Object.entries(value).forEach(([key, child]) => {
+        copy[key] = dehydrateTreeRecursive(child)
+    })
+
+    return copy
+}

--- a/js/synths.js
+++ b/js/synths.js
@@ -12,6 +12,7 @@
  */
 
 let synths = {}
+let synthList = []
 
 export function registerSynth(key, synth) {
     if (typeof key !== 'string' || key === '') {
@@ -24,15 +25,19 @@ export function registerSynth(key, synth) {
         }
     }
 
+    if (synths[key]) synthList = synthList.filter(i => i !== synths[key])
+
     synths[key] = synth
+    synthList.push(synth)
 }
 
 export function flushSynths() {
     synths = {}
+    synthList = []
 }
 
 export function hasSynths() {
-    return Object.keys(synths).length > 0
+    return synthList.length > 0
 }
 
 /**
@@ -43,8 +48,8 @@ export function hasSynths() {
 export function findSynthByValue(value) {
     if (typeof value !== 'object' || value === null) return
 
-    for (let key in synths) {
-        if (synths[key].match(value)) return synths[key]
+    for (let i = 0; i < synthList.length; i++) {
+        if (synthList[i].match(value)) return synthList[i]
     }
 }
 
@@ -59,8 +64,10 @@ export function hydrateValue(value, meta) {
 }
 
 /**
- * Walk a value tree and return a copy with every rich synth value converted
- * back to its raw wire format. Never mutates the original tree.
+ * Walk a value tree and convert every rich synth value back to its raw wire
+ * format. Never mutates the original tree. Copy-on-write: subtrees without
+ * rich values are returned by reference, so trees of plain data pass through
+ * with zero allocations.
  */
 export function dehydrateTree(value) {
     if (! hasSynths()) return value
@@ -75,11 +82,23 @@ function dehydrateTreeRecursive(value) {
 
     if (typeof value !== 'object' || value === null) return value
 
-    let copy = Array.isArray(value) ? [] : {}
+    let copy = null
 
-    Object.entries(value).forEach(([key, child]) => {
-        copy[key] = dehydrateTreeRecursive(child)
-    })
+    for (let key in value) {
+        let child = value[key]
 
-    return copy
+        // Primitives can never be rich values, so skip recursing into them...
+        if (typeof child !== 'object' || child === null) continue
+
+        let dehydrated = dehydrateTreeRecursive(child)
+
+        // Only clone this node once a descendant actually changed...
+        if (copy === null && dehydrated !== child) {
+            copy = Array.isArray(value) ? [...value] : { ...value }
+        }
+
+        if (copy !== null) copy[key] = dehydrated
+    }
+
+    return copy ?? value
 }

--- a/js/synths.js
+++ b/js/synths.js
@@ -56,11 +56,12 @@ export function findSynthByValue(value) {
 /**
  * Hydrate a raw wire value into a rich JS value if a synth is registered
  * for the metadata's synth key. Otherwise pass the raw value through.
+ * Context ({ component, path }) tells the rich value where it lives.
  */
-export function hydrateValue(value, meta) {
+export function hydrateValue(value, meta, context = undefined) {
     let synth = meta && synths[meta.s]
 
-    return synth ? synth.hydrate(value, meta) : value
+    return synth ? synth.hydrate(value, meta, context) : value
 }
 
 /**
@@ -100,5 +101,10 @@ function dehydrateTreeRecursive(value) {
         if (copy !== null) copy[key] = dehydrated
     }
 
-    return copy ?? value
+    if (copy === null) return value
+
+    // Values that dehydrate to undefined have no wire representation yet
+    // (e.g. pending uploads) — omit them entirely so they can't corrupt
+    // the payload as JSON nulls...
+    return Array.isArray(copy) ? copy.filter(child => child !== undefined) : copy
 }

--- a/js/synths.spec.js
+++ b/js/synths.spec.js
@@ -249,3 +249,99 @@ describe('hydrateValue', () => {
         expect(hydrateValue('foo', { s: 'cbn' })).toBe('foo')
     })
 })
+
+describe('hydration context', () => {
+    beforeEach(() => flushSynths())
+
+    it('passes the component and state path to hydrate', () => {
+        let contexts = []
+
+        registerSynth('cbn', {
+            match: (value) => value instanceof Date,
+            hydrate: (value, meta, context) => {
+                contexts.push(context)
+
+                return new Date(value)
+            },
+            dehydrate: (value) => value.toISOString(),
+        })
+
+        let component = { id: 'fake' }
+
+        extractData({
+            date: ['2021-01-01T00:00:00+00:00', { s: 'cbn' }],
+            items: [
+                [['2022-02-02T00:00:00+00:00', { s: 'cbn' }]],
+                { s: 'arr' },
+            ],
+        }, { component })
+
+        expect(contexts[0]).toEqual({ component, path: 'date' })
+        expect(contexts[1]).toEqual({ component, path: 'items.0' })
+    })
+
+    it('passes no context when extractData is called without one', () => {
+        let receivedContext = 'unset'
+
+        registerSynth('cbn', {
+            match: (value) => value instanceof Date,
+            hydrate: (value, meta, context) => {
+                receivedContext = context
+
+                return new Date(value)
+            },
+            dehydrate: (value) => value.toISOString(),
+        })
+
+        extractData({ date: ['2021-01-01T00:00:00+00:00', { s: 'cbn' }] })
+
+        expect(receivedContext).toBeUndefined()
+    })
+})
+
+describe('values that dehydrate to undefined (no wire representation)', () => {
+    class PendingThing {
+        constructor(serialized = null) { this.serialized = serialized }
+    }
+
+    let registerPendingSynth = () => registerSynth('thing', {
+        match: (value) => value instanceof PendingThing,
+        hydrate: (value) => new PendingThing(value),
+        dehydrate: (value) => value.serialized ?? undefined,
+    })
+
+    beforeEach(() => flushSynths())
+
+    it('never includes them in diffs', () => {
+        registerPendingSynth()
+
+        expect(diffAndConsolidate({ thing: null }, { thing: new PendingThing() })).toEqual({})
+        expect(diff({ thing: null }, { thing: new PendingThing() })).toEqual({})
+    })
+
+    it('omits them from arrays instead of sending null', () => {
+        registerPendingSynth()
+
+        let tree = { things: [new PendingThing('a'), new PendingThing()] }
+
+        expect(dehydrateTree(tree)).toEqual({ things: ['a'] })
+    })
+
+    it('drops consolidated diffs that only differ by pending values', () => {
+        registerPendingSynth()
+
+        let left = { things: [new PendingThing('a')] }
+        let right = { things: [new PendingThing('a'), new PendingThing()] }
+
+        expect(diffAndConsolidate(left, right)).toEqual({})
+    })
+
+    it('still diffs settled values alongside pending ones', () => {
+        registerPendingSynth()
+
+        let left = { things: [new PendingThing('a')] }
+        let right = { things: [new PendingThing('b'), new PendingThing()] }
+
+        expect(diffAndConsolidate(left, right)).toEqual({ things: ['b'] })
+    })
+})

--- a/js/synths.spec.js
+++ b/js/synths.spec.js
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { registerSynth, flushSynths, dehydrateTree, hydrateValue, findSynthByValue } from './synths'
+import { extractData, deeplyEqual, diff, diffAndConsolidate, diffAndPatchRecursive } from './utils'
+
+class Money {
+    constructor(amount, currency) {
+        this.amount = amount
+        this.currency = currency
+    }
+
+    formatted() {
+        return `${this.amount / 100} ${this.currency}`
+    }
+}
+
+let registerDateSynth = () => registerSynth('cbn', {
+    match: (value) => value instanceof Date,
+    hydrate: (value) => new Date(value),
+    dehydrate: (value) => value.toISOString(),
+})
+
+let registerMoneySynth = () => registerSynth('money', {
+    match: (value) => value instanceof Money,
+    hydrate: (value) => new Money(value.amount, value.currency),
+    dehydrate: (value) => ({ amount: value.amount, currency: value.currency }),
+})
+
+describe('registerSynth', () => {
+    beforeEach(() => flushSynths())
+
+    it('requires a string key', () => {
+        expect(() => registerSynth(null, {})).toThrow()
+    })
+
+    it('requires match, hydrate, and dehydrate functions', () => {
+        expect(() => registerSynth('foo', {})).toThrow()
+        expect(() => registerSynth('foo', { match: () => {}, hydrate: () => {} })).toThrow()
+    })
+})
+
+describe('extractData', () => {
+    beforeEach(() => flushSynths())
+
+    it('hydrates tuples whose synth key has a registered synth', () => {
+        registerDateSynth()
+
+        let data = extractData({
+            title: 'Hello',
+            date: ['2021-01-01T00:00:00+00:00', { s: 'cbn', type: 'carbon' }],
+        })
+
+        expect(data.title).toBe('Hello')
+        expect(data.date).toBeInstanceOf(Date)
+        expect(data.date.toISOString()).toBe('2021-01-01T00:00:00.000Z')
+    })
+
+    it('leaves tuples without a registered synth as raw values', () => {
+        let data = extractData({
+            date: ['2021-01-01T00:00:00+00:00', { s: 'cbn', type: 'carbon' }],
+        })
+
+        expect(data.date).toBe('2021-01-01T00:00:00+00:00')
+    })
+
+    it('passes the full metadata to hydrate', () => {
+        let receivedMeta
+
+        registerSynth('cbn', {
+            match: (value) => value instanceof Date,
+            hydrate: (value, meta) => {
+                receivedMeta = meta
+
+                return new Date(value)
+            },
+            dehydrate: (value) => value.toISOString(),
+        })
+
+        extractData({ date: ['2021-01-01T00:00:00+00:00', { s: 'cbn', type: 'carbon' }] })
+
+        expect(receivedMeta).toEqual({ s: 'cbn', type: 'carbon' })
+    })
+
+    it('hydrates children before parents', () => {
+        registerMoneySynth()
+
+        let data = extractData({
+            prices: [
+                {
+                    first: [{ amount: [100, { s: 'int' }], currency: 'USD' }, { s: 'money' }],
+                },
+                { s: 'arr' },
+            ],
+        })
+
+        expect(data.prices.first).toBeInstanceOf(Money)
+        expect(data.prices.first.amount).toBe(100)
+    })
+})
+
+describe('dehydrateTree', () => {
+    beforeEach(() => flushSynths())
+
+    it('returns the value untouched when no synths are registered', () => {
+        let tree = { foo: 'bar' }
+
+        expect(dehydrateTree(tree)).toBe(tree)
+    })
+
+    it('converts rich values back to their wire format without mutating the original tree', () => {
+        registerDateSynth()
+
+        let date = new Date('2021-01-01T00:00:00Z')
+        let tree = { nested: { date }, list: [date] }
+
+        let raw = dehydrateTree(tree)
+
+        expect(raw.nested.date).toBe('2021-01-01T00:00:00.000Z')
+        expect(raw.list[0]).toBe('2021-01-01T00:00:00.000Z')
+        expect(tree.nested.date).toBe(date)
+    })
+})
+
+describe('deeplyEqual', () => {
+    beforeEach(() => flushSynths())
+
+    it('compares rich values by their dehydrated wire format', () => {
+        registerDateSynth()
+
+        expect(deeplyEqual(new Date('2021-01-01T00:00:00Z'), new Date('2021-01-01T00:00:00Z'))).toBe(true)
+        expect(deeplyEqual(new Date('2021-01-01T00:00:00Z'), new Date('2022-02-02T00:00:00Z'))).toBe(false)
+    })
+
+    it('compares a rich value against its raw wire format', () => {
+        registerDateSynth()
+
+        expect(deeplyEqual(new Date('2021-01-01T00:00:00Z'), '2021-01-01T00:00:00.000Z')).toBe(true)
+    })
+})
+
+describe('diffing rich values', () => {
+    beforeEach(() => flushSynths())
+
+    it('detects no changes between equal rich values', () => {
+        registerDateSynth()
+
+        let left = { date: new Date('2021-01-01T00:00:00Z') }
+        let right = { date: new Date('2021-01-01T00:00:00Z') }
+
+        expect(diffAndConsolidate(left, right)).toEqual({})
+        expect(diff(left, right)).toEqual({})
+    })
+
+    it('emits changed rich values in their dehydrated wire format', () => {
+        registerDateSynth()
+
+        let left = { date: new Date('2021-01-01T00:00:00Z') }
+        let right = { date: new Date('2022-02-02T00:00:00Z') }
+
+        expect(diffAndConsolidate(left, right)).toEqual({ date: '2022-02-02T00:00:00.000Z' })
+        expect(diff(left, right)).toEqual({ date: '2022-02-02T00:00:00.000Z' })
+    })
+
+    it('treats rich values atomically instead of diffing their internals', () => {
+        registerMoneySynth()
+
+        let left = { price: new Money(100, 'USD') }
+        let right = { price: new Money(200, 'USD') }
+
+        expect(diffAndConsolidate(left, right)).toEqual({ price: { amount: 200, currency: 'USD' } })
+    })
+
+    it('dehydrates rich values nested inside consolidated diffs', () => {
+        registerDateSynth()
+
+        let left = { dates: [new Date('2021-01-01T00:00:00Z')] }
+        let right = { dates: [new Date('2021-01-01T00:00:00Z'), new Date('2022-02-02T00:00:00Z')] }
+
+        // The array grew, so the diff consolidates to the parent level and
+        // must contain wire-format values, not rich ones...
+        expect(diffAndConsolidate(left, right)).toEqual({
+            dates: ['2021-01-01T00:00:00.000Z', '2022-02-02T00:00:00.000Z'],
+        })
+    })
+})
+
+describe('diffAndPatchRecursive with rich values', () => {
+    beforeEach(() => flushSynths())
+
+    it('preserves the identity of unchanged rich values', () => {
+        registerDateSynth()
+
+        let date = new Date('2021-01-01T00:00:00Z')
+        let target = { date }
+        let left = { date: new Date('2021-01-01T00:00:00Z') }
+        let right = { date: new Date('2021-01-01T00:00:00Z') }
+
+        diffAndPatchRecursive(left, right, target)
+
+        expect(target.date).toBe(date)
+    })
+
+    it('treats an unchanged rich value as equal to its raw wire format', () => {
+        registerDateSynth()
+
+        let date = new Date('2021-01-01T00:00:00Z')
+        let target = { date }
+        // Simulates an applied update where the sent value was raw...
+        let left = { date: '2021-01-01T00:00:00.000Z' }
+        let right = { date: new Date('2021-01-01T00:00:00Z') }
+
+        diffAndPatchRecursive(left, right, target)
+
+        expect(target.date).toBe(date)
+    })
+
+    it('replaces changed rich values atomically', () => {
+        registerMoneySynth()
+
+        let target = { price: new Money(100, 'USD') }
+        let left = { price: new Money(100, 'USD') }
+        let right = { price: new Money(200, 'EUR') }
+
+        diffAndPatchRecursive(left, right, target)
+
+        expect(target.price).toBe(right.price)
+        expect(target.price.formatted()).toBe('2 EUR')
+    })
+})
+
+describe('findSynthByValue', () => {
+    beforeEach(() => flushSynths())
+
+    it('only consults match for the values a synth recognizes', () => {
+        registerDateSynth()
+        registerMoneySynth()
+
+        expect(findSynthByValue(new Money(1, 'USD'))).toBeDefined()
+        expect(findSynthByValue({ amount: 1, currency: 'USD' })).toBeUndefined()
+        expect(findSynthByValue('string')).toBeUndefined()
+        expect(findSynthByValue(null)).toBeUndefined()
+    })
+})
+
+describe('hydrateValue', () => {
+    beforeEach(() => flushSynths())
+
+    it('passes values through when meta is missing or unregistered', () => {
+        expect(hydrateValue('foo', undefined)).toBe('foo')
+        expect(hydrateValue('foo', { s: 'cbn' })).toBe('foo')
+    })
+})

--- a/js/utils.js
+++ b/js/utils.js
@@ -170,7 +170,11 @@ export function diff(left, right, diffs = {}, path = '') {
     // Rich synth values are atomic: compare their dehydrated wire formats
     // instead of recursing into them...
     if (hasSynths() && (findSynthByValue(left) || findSynthByValue(right))) {
-        if (! deeplyEqual(left, right)) diffs[path] = dehydrateTree(right)
+        let rightRaw = dehydrateTree(right)
+
+        // A synth may dehydrate to undefined, signaling the value has no wire
+        // representation yet (e.g. a pending upload) — never send those...
+        if (rightRaw !== undefined && ! deeplyEqual(left, right)) diffs[path] = rightRaw
 
         return diffs
     }
@@ -225,7 +229,18 @@ export function diffAndConsolidate(left, right) {
     // inside them. Convert everything back to raw wire format so the diff
     // is safe to send to the server...
     if (hasSynths()) {
-        Object.entries(diffs).forEach(([key, value]) => diffs[key] = dehydrateTree(value))
+        Object.entries(diffs).forEach(([key, value]) => {
+            let dehydrated = dehydrateTree(value)
+
+            // Values without a wire representation (e.g. pending uploads) are
+            // omitted during dehydration, which can leave a subtree identical
+            // to what the server already has — drop those diffs entirely...
+            if (deeplyEqual(dehydrated, dehydrateTree(dataGet(left, key)))) {
+                delete diffs[key]
+            } else {
+                diffs[key] = dehydrated
+            }
+        })
     }
 
     return diffs
@@ -238,6 +253,10 @@ function diffRecursive(left, right, path, diffs, rootLeft, rootRight) {
     // Rich synth values are atomic: compare their dehydrated wire formats
     // instead of recursing into them...
     if (hasSynths() && (findSynthByValue(left) || findSynthByValue(right))) {
+        // A synth may dehydrate to undefined, signaling the value has no wire
+        // representation yet (e.g. a pending upload) — never send those...
+        if (dehydrateTree(right) === undefined) return { changed: false, consolidated: false }
+
         if (deeplyEqual(left, right)) return { changed: false, consolidated: false }
 
         diffs[path] = right
@@ -429,19 +448,21 @@ export function diffAndPatchRecursive(left, right, target) {
  * method we're extracting the plain JS object of only the raw values.
  *
  * If a JS synth has been registered for a tuple's synth key, the raw value
- * is hydrated into a rich JS value (children are hydrated first).
+ * is hydrated into a rich JS value (children are hydrated first). The synth
+ * receives a context object ({ component, path }) so rich values can know
+ * where they live in component state.
  */
-export function extractData(payload) {
+export function extractData(payload, context = undefined, path = '') {
     let value = isSynthetic(payload) ? payload[0] : payload
     let meta = isSynthetic(payload) ? payload[1] : undefined
 
     if (isObjecty(value)) {
         Object.entries(value).forEach(([key, iValue]) => {
-            value[key] = extractData(iValue)
+            value[key] = extractData(iValue, context, path === '' ? key : `${path}.${key}`)
         })
     }
 
-    return hydrateValue(value, meta)
+    return hydrateValue(value, meta, context ? { ...context, path } : undefined)
 }
 
 /**

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,3 +1,4 @@
+import { hasSynths, findSynthByValue, hydrateValue, dehydrateTree } from '@/synths'
 
 export class Bag {
     constructor() { this.arrays = {} }
@@ -66,9 +67,10 @@ export function isPrimitive(subject) { return typeof subject !== 'object' || sub
 export function deepClone(obj) { return JSON.parse(JSON.stringify(obj)) }
 
 /**
- * Determine if two objects take the exact same shape.
+ * Determine if two objects take the exact same shape. Rich synth values
+ * are compared by their dehydrated wire format.
  */
-export function deeplyEqual(a, b) { return JSON.stringify(a) === JSON.stringify(b) }
+export function deeplyEqual(a, b) { return JSON.stringify(dehydrateTree(a)) === JSON.stringify(dehydrateTree(b)) }
 
 /**
  * An easy way to loop through arrays and objects.
@@ -165,6 +167,14 @@ export function diff(left, right, diffs = {}, path = '') {
     // Are they the same?
     if (left === right) return diffs
 
+    // Rich synth values are atomic: compare their dehydrated wire formats
+    // instead of recursing into them...
+    if (hasSynths() && (findSynthByValue(left) || findSynthByValue(right))) {
+        if (! deeplyEqual(left, right)) diffs[path] = dehydrateTree(right)
+
+        return diffs
+    }
+
     // Are they COMPLETELY different?
     if (typeof left !== typeof right || (isObject(left) && isArray(right)) || (isArray(left) && isObject(right))) {
         diffs[path] = right;
@@ -211,12 +221,29 @@ export function diffAndConsolidate(left, right) {
 
     diffRecursive(left, right, '', diffs, left, right)
 
+    // Consolidated diffs can contain subtrees with rich synth values nested
+    // inside them. Convert everything back to raw wire format so the diff
+    // is safe to send to the server...
+    if (hasSynths()) {
+        Object.entries(diffs).forEach(([key, value]) => diffs[key] = dehydrateTree(value))
+    }
+
     return diffs
 }
 
 function diffRecursive(left, right, path, diffs, rootLeft, rootRight) {
     // Are they the same?
     if (left === right) return { changed: false, consolidated: false }
+
+    // Rich synth values are atomic: compare their dehydrated wire formats
+    // instead of recursing into them...
+    if (hasSynths() && (findSynthByValue(left) || findSynthByValue(right))) {
+        if (deeplyEqual(left, right)) return { changed: false, consolidated: false }
+
+        diffs[path] = right
+
+        return { changed: true, consolidated: false }
+    }
 
     // Track if we're doing a type conversion from empty array/null/undefined to object
     // In this case, we want granular diffs, not consolidation
@@ -363,6 +390,14 @@ export function diffAndPatchRecursive(left, right, target) {
 
         if (deeplyEqual(left?.[key], right[key])) return
 
+        // Rich synth values are atomic: replace them wholesale instead of
+        // recursing into and merging their internals...
+        if (hasSynths() && (findSynthByValue(left?.[key]) || findSynthByValue(right[key]) || findSynthByValue(target[key]))) {
+            target[key] = right[key]
+
+            return
+        }
+
         if (isObjecty(left?.[key]) && isObjecty(right[key]) && isObjecty(target[key])
             && isArray(right[key]) === isArray(target[key])) {
             diffAndPatchRecursive(left[key], right[key], target[key])
@@ -392,6 +427,9 @@ export function diffAndPatchRecursive(left, right, target) {
  * The data that's passed between the browser and server is in the form of
  * nested tuples consisting of the schema: [rawValue, metadata]. In this
  * method we're extracting the plain JS object of only the raw values.
+ *
+ * If a JS synth has been registered for a tuple's synth key, the raw value
+ * is hydrated into a rich JS value (children are hydrated first).
  */
 export function extractData(payload) {
     let value = isSynthetic(payload) ? payload[0] : payload
@@ -403,7 +441,7 @@ export function extractData(payload) {
         })
     }
 
-    return value
+    return hydrateValue(value, meta)
 }
 
 /**

--- a/src/Features/SupportFileUploads/BrowserTest.php
+++ b/src/Features/SupportFileUploads/BrowserTest.php
@@ -62,6 +62,71 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_file_uploads_hydrate_into_rich_js_objects()
+    {
+        Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photo;
+
+            function render() { return <<<'HTML'
+            <div>
+                <input type="file" wire:model="photo" dusk="upload">
+
+                <span dusk="name" x-text="$wire.photo?.name"></span>
+                <span dusk="extension" x-text="$wire.photo?.extension"></span>
+
+                <template x-if="$wire.photo?.isPreviewable">
+                    <img dusk="preview" x-bind:src="$wire.photo.temporaryUrl()">
+                </template>
+            </div>
+            HTML; }
+        })
+        ->attach('@upload', __DIR__ . '/browser_test_image.png')
+        // The rich object exposes the original client-side filename...
+        ->waitForTextIn('@name', 'browser_test_image.png')
+        ->assertSeeIn('@extension', 'png')
+        // And a preview URL usable entirely from JavaScript — the image must actually load...
+        ->waitFor('@preview')
+        ->waitUntil('document.querySelector(\'[dusk="preview"]\').naturalWidth > 0');
+    }
+
+    public function test_multiple_file_uploads_hydrate_into_arrays_of_rich_objects_and_support_removal()
+    {
+        Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photos = [];
+
+            function render() { return <<<'HTML'
+            <div>
+                <input type="file" wire:model="photos" dusk="upload" multiple>
+
+                <span dusk="names" x-text="$wire.photos.map(photo => photo.name).join(',')"></span>
+
+                <button dusk="remove-first" type="button" x-on:click="$wire.removeUpload('photos', $wire.photos[0].filename)">Remove first</button>
+            </div>
+            HTML; }
+        })
+        ->attach('@upload', __DIR__ . '/browser_test_image.png')
+        ->waitUntil('window.Livewire.all()[0].$wire.photos.length === 1')
+        // Dusk's attach() accumulates files on a multiple input, so clear the
+        // selection between attaches to avoid re-uploading the first file...
+        ->tap(fn ($b) => $b->script('document.querySelector(\'[dusk="upload"]\').value = null'))
+        ->attach('@upload', __DIR__ . '/browser_test_image2.png')
+        ->waitUntil('window.Livewire.all()[0].$wire.photos.length === 2')
+        ->assertSeeIn('@names', 'browser_test_image.png,browser_test_image2.png')
+        // The rich object's temp filename feeds the existing removeUpload API...
+        ->click('@remove-first')
+        ->waitUntil('window.Livewire.all()[0].$wire.photos.length === 1')
+        ->waitForTextIn('@names', 'browser_test_image2.png')
+        ->assertDontSeeIn('@names', 'browser_test_image.png,');
+    }
+
     public function test_can_cancel_an_upload()
     {
         if (getenv('FORCE_RUN') !== '1') {

--- a/src/Features/SupportFileUploads/BrowserTest.php
+++ b/src/Features/SupportFileUploads/BrowserTest.php
@@ -93,6 +93,74 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->waitUntil('document.querySelector(\'[dusk="preview"]\').naturalWidth > 0');
     }
 
+    public function test_rich_upload_objects_expose_reactive_progress_state_and_client_side_previews()
+    {
+        Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photo;
+
+            function render() { return <<<'HTML'
+            <div>
+                <input type="file" wire:model="photo" dusk="upload">
+
+                {{-- Log every reactive change to the upload's lifecycle state... --}}
+                <div x-effect="window.__log = window.__log || []; window.__log.push($wire.photo ? [$wire.photo.progress, $wire.photo.isUploading] : null)"></div>
+
+                <template x-if="$wire.photo">
+                    <img dusk="preview" x-bind:src="$wire.photo.previewUrl">
+                </template>
+
+                <span dusk="status" x-text="$wire.photo ? ($wire.photo.isUploading ? 'uploading' : 'finished') : 'empty'"></span>
+            </div>
+            HTML; }
+        })
+        ->assertSeeIn('@status', 'empty')
+        ->attach('@upload', __DIR__ . '/browser_test_image.png')
+        ->waitForTextIn('@status', 'finished')
+        // The property held a pending object during the upload (progress state
+        // was observable before the server ever responded)...
+        ->assertScript('window.__log.some(entry => entry && entry[1] === true)', true)
+        // ...and settled at progress 100 / not uploading...
+        ->assertScript('window.__log[window.__log.length - 1][0]', 100)
+        ->assertScript('window.__log[window.__log.length - 1][1]', false)
+        // The preview never needed the server: it's a local blob URL, live
+        // during the upload AND after it settled...
+        ->assertScript('document.querySelector(\'[dusk="preview"]\').src.startsWith("blob:")', true)
+        ->waitUntil('document.querySelector(\'[dusk="preview"]\').naturalWidth > 0')
+        // And the settled object still exposes its server-side wire identity...
+        ->assertScript('window.Livewire.all()[0].$wire.photo.serialized.startsWith("livewire-file:")', true);
+    }
+
+    public function test_rich_upload_objects_can_remove_themselves()
+    {
+        Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photo;
+
+            function render() { return <<<'HTML'
+            <div>
+                <input type="file" wire:model="photo" dusk="upload">
+
+                <span dusk="status" x-text="$wire.photo ? $wire.photo.name : 'empty'"></span>
+
+                <button dusk="remove" type="button" x-on:click="$wire.photo.remove()">Remove</button>
+            </div>
+            HTML; }
+        })
+        ->attach('@upload', __DIR__ . '/browser_test_image.png')
+        ->waitForTextIn('@status', 'browser_test_image.png')
+        ->click('@remove')
+        ->waitForTextIn('@status', 'empty')
+        // Removing also clears the file input so the same file can be re-selected...
+        ->assertScript('document.querySelector(\'[dusk="upload"]\').value', '');
+    }
+
     public function test_multiple_file_uploads_hydrate_into_arrays_of_rich_objects_and_support_removal()
     {
         Storage::persistentFake('tmp-for-tests');
@@ -108,7 +176,7 @@ class BrowserTest extends \Tests\BrowserTestCase
 
                 <span dusk="names" x-text="$wire.photos.map(photo => photo.name).join(',')"></span>
 
-                <button dusk="remove-first" type="button" x-on:click="$wire.removeUpload('photos', $wire.photos[0].filename)">Remove first</button>
+                <button dusk="remove-first" type="button" x-on:click="$wire.photos[0].remove()">Remove first</button>
             </div>
             HTML; }
         })

--- a/src/Features/SupportFileUploads/FileUploadSynth.php
+++ b/src/Features/SupportFileUploads/FileUploadSynth.php
@@ -13,7 +13,35 @@ class FileUploadSynth extends Synth {
     }
 
     function dehydrate($target) {
-        return [$this->dehydratePropertyFromWithFileUploads($target), []];
+        return [
+            $this->dehydratePropertyFromWithFileUploads($target),
+            $target instanceof TemporaryUploadedFile ? static::metaFor($target) : [],
+        ];
+    }
+
+    public static function metaFor(TemporaryUploadedFile $file)
+    {
+        $meta = [];
+
+        try {
+            $name = $file->getClientOriginalName();
+
+            // Names extracted from hashed file paths can decode into binary
+            // garbage that would corrupt the snapshot's JSON encoding...
+            if (is_string($name) && mb_check_encoding($name, 'UTF-8')) {
+                $meta['name'] = $name;
+            }
+        } catch (\Throwable $e) {
+            //
+        }
+
+        try {
+            $meta['previewUrl'] = $file->temporaryUrl();
+        } catch (\Throwable $e) {
+            // Not previewable, or the disk doesn't support temporary URLs...
+        }
+
+        return $meta;
     }
 
     public function dehydratePropertyFromWithFileUploads($value)

--- a/src/Features/SupportJsSynthesizers/BrowserTest.php
+++ b/src/Features/SupportJsSynthesizers/BrowserTest.php
@@ -222,6 +222,85 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertSeeIn('@server', '2030');
     }
 
+    public function test_wire_dirty_tracks_rich_values()
+    {
+        Livewire::visit(new class extends Component {
+            public Carbon $date;
+
+            public function mount(): void
+            {
+                $this->date = Carbon::parse('2021-01-01 00:00:00', 'UTC');
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <script>
+                        document.addEventListener('livewire:init', () => {
+                            Livewire.synth('cbn', {
+                                match: (value) => value instanceof Date,
+                                hydrate: (value) => new Date(value),
+                                dehydrate: (value) => value.toISOString(),
+                            })
+                        })
+                    </script>
+
+                    <div wire:dirty wire:target="date">Unsaved changes...</div>
+
+                    <button dusk="mutate" type="button" x-on:click="$wire.date = new Date('2030-05-05T00:00:00Z')">Mutate</button>
+
+                    <button dusk="revert" type="button" x-on:click="$wire.date = new Date('2021-01-01T00:00:00Z')">Revert</button>
+                </div>
+                HTML;
+            }
+        })
+        ->assertDontSee('Unsaved changes...')
+        ->click('@mutate')
+        ->waitForText('Unsaved changes...')
+        // Reverting to an equal-but-different Date instance should read as clean...
+        ->click('@revert')
+        ->waitUntilMissingText('Unsaved changes...');
+    }
+
+    public function test_url_bound_rich_values_are_dehydrated_into_the_query_string()
+    {
+        Livewire::visit(new class extends Component {
+            #[\Livewire\Attributes\Url]
+            public Carbon $date;
+
+            public function mount(): void
+            {
+                $this->date = Carbon::parse('2021-01-01 00:00:00', 'UTC');
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <script>
+                        document.addEventListener('livewire:init', () => {
+                            Livewire.synth('cbn', {
+                                match: (value) => value instanceof Date,
+                                hydrate: (value) => new Date(value),
+                                dehydrate: (value) => value.toISOString(),
+                            })
+                        })
+                    </script>
+
+                    <span dusk="output">{{ $date->toDateString() }}</span>
+
+                    <button dusk="change" type="button" x-on:click="$wire.$set('date', new Date('2030-05-05T00:00:00Z'))">Change</button>
+                </div>
+                HTML;
+            }
+        })
+        ->waitForLivewire()->click('@change')
+        ->assertSeeIn('@output', '2030-05-05')
+        // The URL must carry the raw wire format, not a stringified Date object...
+        ->assertScript('new URLSearchParams(window.location.search).get("date")', '2030-05-05T00:00:00.000Z');
+    }
+
     public function test_rich_values_dispatched_to_server_side_listeners_are_dehydrated()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportJsSynthesizers/BrowserTest.php
+++ b/src/Features/SupportJsSynthesizers/BrowserTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Livewire\Features\SupportJsSynthesizers;
+
+use Carbon\Carbon;
+use Livewire\Component;
+use Livewire\Livewire;
+use Livewire\Wireable;
+
+class BrowserTest extends \Tests\BrowserTestCase
+{
+    public function test_a_js_synth_hydrates_backend_values_into_rich_js_values()
+    {
+        Livewire::visit(new class extends Component {
+            public Carbon $date;
+
+            public function mount(): void
+            {
+                $this->date = Carbon::parse('2021-01-01 00:00:00', 'UTC');
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <script>
+                        document.addEventListener('livewire:init', () => {
+                            Livewire.synth('cbn', {
+                                match: (value) => value instanceof Date,
+                                hydrate: (value) => new Date(value),
+                                dehydrate: (value) => value.toISOString(),
+                            })
+                        })
+                    </script>
+
+                    <button dusk="check" type="button" x-on:click="$refs.type.textContent = $wire.date instanceof Date ? 'is-date:' + $wire.date.getUTCFullYear() : 'not-date'">Check</button>
+
+                    <span x-ref="type" dusk="type"></span>
+                </div>
+                HTML;
+            }
+        })
+        ->click('@check')
+        ->assertSeeIn('@type', 'is-date:2021');
+    }
+
+    public function test_assigning_a_fresh_rich_value_sends_its_dehydrated_form_to_the_server()
+    {
+        Livewire::visit(new class extends Component {
+            public Carbon $date;
+
+            public function mount(): void
+            {
+                $this->date = Carbon::parse('2021-01-01 00:00:00', 'UTC');
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <script>
+                        document.addEventListener('livewire:init', () => {
+                            Livewire.synth('cbn', {
+                                match: (value) => value instanceof Date,
+                                hydrate: (value) => new Date(value),
+                                dehydrate: (value) => value.toISOString(),
+                            })
+                        })
+                    </script>
+
+                    <span dusk="output">{{ $date->toDateString() }}</span>
+
+                    <button dusk="mutate" type="button" x-on:click="$wire.date = new Date('2030-05-05T00:00:00Z')">Mutate</button>
+
+                    <button dusk="refresh" type="button" wire:click="$refresh">Refresh</button>
+
+                    <button dusk="set" type="button" x-on:click="$wire.$set('date', new Date('2032-03-03T00:00:00Z'))">Set</button>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@output', '2021-01-01')
+        ->click('@mutate')
+        ->waitForLivewire()->click('@refresh')
+        ->assertSeeIn('@output', '2030-05-05')
+        ->waitForLivewire()->click('@set')
+        ->assertSeeIn('@output', '2032-03-03');
+    }
+
+    public function test_unchanged_rich_values_survive_a_round_trip_with_their_identity_preserved()
+    {
+        Livewire::visit(new class extends Component {
+            public Carbon $date;
+
+            public function mount(): void
+            {
+                $this->date = Carbon::parse('2021-01-01 00:00:00', 'UTC');
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <script>
+                        document.addEventListener('livewire:init', () => {
+                            Livewire.synth('cbn', {
+                                match: (value) => value instanceof Date,
+                                hydrate: (value) => new Date(value),
+                                dehydrate: (value) => value.toISOString(),
+                            })
+                        })
+                    </script>
+
+                    <button dusk="store" type="button" x-on:click="window.__dateRef = $wire.date">Store</button>
+
+                    <button dusk="refresh" type="button" wire:click="$refresh">Refresh</button>
+
+                    <button dusk="compare" type="button" x-on:click="$refs.same.textContent = window.__dateRef === $wire.date ? 'same' : 'different'">Compare</button>
+
+                    <span x-ref="same" dusk="same"></span>
+                </div>
+                HTML;
+            }
+        })
+        ->click('@store')
+        ->waitForLivewire()->click('@refresh')
+        ->click('@compare')
+        ->assertSeeIn('@same', 'same');
+    }
+
+    public function test_a_custom_rich_object_supports_nested_data_binding()
+    {
+        Livewire::visit(new class extends Component {
+            public AddressDto $address;
+
+            public function mount(): void
+            {
+                $this->address = new AddressDto('123 Main St', 'Anytown');
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <script>
+                        class JsAddress {
+                            constructor({ street, city }) {
+                                this.street = street
+                                this.city = city
+                            }
+
+                            get full() {
+                                return this.street + ', ' + this.city
+                            }
+                        }
+
+                        document.addEventListener('livewire:init', () => {
+                            Livewire.synth('wrbl', {
+                                match: (value) => value instanceof JsAddress,
+                                hydrate: (value) => new JsAddress(value),
+                                dehydrate: (value) => ({ street: value.street, city: value.city }),
+                            })
+                        })
+                    </script>
+
+                    <input dusk="street" type="text" wire:model.live="address.street" />
+
+                    <span dusk="server">{{ $address->street }}</span>
+
+                    <span dusk="full" x-text="$wire.address.full"></span>
+                </div>
+                HTML;
+            }
+        })
+        ->waitForTextIn('@full', '123 Main St, Anytown')
+        ->type('@street', '456 Oak Ave')
+        ->waitForTextIn('@server', '456 Oak Ave')
+        ->assertSeeIn('@full', '456 Oak Ave, Anytown');
+    }
+
+    public function test_rich_values_passed_as_action_parameters_are_dehydrated()
+    {
+        Livewire::visit(new class extends Component {
+            public Carbon $date;
+
+            public function mount(): void
+            {
+                $this->date = Carbon::parse('2021-01-01 00:00:00', 'UTC');
+            }
+
+            public function setDate($value): void
+            {
+                $this->date = Carbon::parse($value);
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <script>
+                        document.addEventListener('livewire:init', () => {
+                            Livewire.synth('cbn', {
+                                match: (value) => value instanceof Date,
+                                hydrate: (value) => new Date(value),
+                                dehydrate: (value) => value.toISOString(),
+                            })
+                        })
+                    </script>
+
+                    <span dusk="output">{{ $date->toDateString() }}</span>
+
+                    <button dusk="call" type="button" x-on:click="$wire.setDate(new Date('2033-07-07T00:00:00Z'))">Call</button>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@output', '2021-01-01')
+        ->waitForLivewire()->click('@call')
+        ->assertSeeIn('@output', '2033-07-07');
+    }
+}
+
+class AddressDto implements Wireable
+{
+    public function __construct(
+        public string $street,
+        public string $city,
+    ) {}
+
+    public function toLivewire()
+    {
+        return ['street' => $this->street, 'city' => $this->city];
+    }
+
+    public static function fromLivewire($value)
+    {
+        return new static($value['street'], $value['city']);
+    }
+}

--- a/src/Features/SupportJsSynthesizers/BrowserTest.php
+++ b/src/Features/SupportJsSynthesizers/BrowserTest.php
@@ -128,6 +128,48 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertSeeIn('@same', 'same');
     }
 
+    public function test_rich_values_dispatched_to_server_side_listeners_are_dehydrated()
+    {
+        Livewire::visit(new class extends Component {
+            public Carbon $date;
+
+            public function mount(): void
+            {
+                $this->date = Carbon::parse('2021-01-01 00:00:00', 'UTC');
+            }
+
+            #[\Livewire\Attributes\On('date-picked')]
+            public function handleDatePicked($value): void
+            {
+                $this->date = Carbon::parse($value);
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <script>
+                        document.addEventListener('livewire:init', () => {
+                            Livewire.synth('cbn', {
+                                match: (value) => value instanceof Date,
+                                hydrate: (value) => new Date(value),
+                                dehydrate: (value) => value.toISOString(),
+                            })
+                        })
+                    </script>
+
+                    <span dusk="output">{{ $date->toDateString() }}</span>
+
+                    <button dusk="dispatch" type="button" x-on:click="$wire.$dispatch('date-picked', { value: new Date('2034-09-09T00:00:00Z') })">Dispatch</button>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@output', '2021-01-01')
+        ->waitForLivewire()->click('@dispatch')
+        ->assertSeeIn('@output', '2034-09-09');
+    }
+
     public function test_a_custom_rich_object_supports_nested_data_binding()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportJsSynthesizers/BrowserTest.php
+++ b/src/Features/SupportJsSynthesizers/BrowserTest.php
@@ -128,6 +128,100 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertSeeIn('@same', 'same');
     }
 
+    public function test_replacing_a_rich_value_triggers_alpine_reactivity()
+    {
+        Livewire::visit(new class extends Component {
+            public Carbon $date;
+
+            public function mount(): void
+            {
+                $this->date = Carbon::parse('2021-01-01 00:00:00', 'UTC');
+            }
+
+            public function advance(): void
+            {
+                $this->date = $this->date->addYear();
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <script>
+                        document.addEventListener('livewire:init', () => {
+                            Livewire.synth('cbn', {
+                                match: (value) => value instanceof Date,
+                                hydrate: (value) => new Date(value),
+                                dehydrate: (value) => value.toISOString(),
+                            })
+                        })
+                    </script>
+
+                    <span dusk="text" x-text="$wire.date.getUTCFullYear()"></span>
+
+                    <button dusk="assign" type="button" x-on:click="$wire.date = new Date('2025-06-06T00:00:00Z')">Assign</button>
+
+                    <button dusk="advance" type="button" wire:click="advance">Advance</button>
+                </div>
+                HTML;
+            }
+        })
+        // Initial hydration renders through the effect...
+        ->waitForTextIn('@text', '2021')
+        // A client-side assignment fires the effect without any request...
+        ->click('@assign')
+        ->waitForTextIn('@text', '2025')
+        // A server-side change patches the reactive property and fires the effect...
+        ->waitForLivewire()->click('@advance')
+        ->waitForTextIn('@text', '2026');
+    }
+
+    public function test_mutating_a_date_in_place_is_not_reactive_but_is_still_sent_to_the_server()
+    {
+        Livewire::visit(new class extends Component {
+            public Carbon $date;
+
+            public function mount(): void
+            {
+                $this->date = Carbon::parse('2021-01-01 00:00:00', 'UTC');
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <script>
+                        document.addEventListener('livewire:init', () => {
+                            Livewire.synth('cbn', {
+                                match: (value) => value instanceof Date,
+                                hydrate: (value) => new Date(value),
+                                dehydrate: (value) => value.toISOString(),
+                            })
+                        })
+                    </script>
+
+                    <span dusk="text" x-text="$wire.date.getUTCFullYear()"></span>
+
+                    <span dusk="server">{{ $date->year }}</span>
+
+                    <button dusk="mutate" type="button" x-on:click="$wire.date.setUTCFullYear(2030)">Mutate</button>
+
+                    <button dusk="refresh" type="button" wire:click="$refresh">Refresh</button>
+                </div>
+                HTML;
+            }
+        })
+        ->waitForTextIn('@text', '2021')
+        // In-place mutation doesn't replace the property, so no effect fires.
+        // (Dates can't be proxied, same as Vue's documented behavior.)
+        ->click('@mutate')
+        ->pause(100)
+        ->assertSeeIn('@text', '2021')
+        // But state diffing still detects the mutation and sends it up...
+        ->waitForLivewire()->click('@refresh')
+        ->assertSeeIn('@server', '2030');
+    }
+
     public function test_rich_values_dispatched_to_server_side_listeners_are_dehydrated()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
Acid test for #10397 — builds a real stock file-upload synth on top of the JS synthesizer API to validate it before merge. Draft, targeting the `js-synths` branch.

## What it does

File properties are rich objects on the frontend instead of `"livewire-file:..."` strings:

```blade
<span x-text="$wire.photo.name"></span>          <!-- original client filename -->
<span x-text="$wire.photo.extension"></span>
<img x-bind:src="$wire.photo.temporaryUrl()">    <!-- previews without a Blade re-render -->

<button x-on:click="$wire.removeUpload('photos', $wire.photos[0].filename)">Remove</button>
```

Two pieces:

- **PHP**: `FileUploadSynth::dehydrate()` now ships `name` (original client filename) and `previewUrl` (signed preview URL, when previewable) in the tuple metadata.
- **JS**: a `TemporaryUpload` class + `Livewire.synth('fil', ...)` registered by default in `supportFileUploads.js`. `toString()`/`toJSON()` degrade to the raw wire value.

## API verdict

The `Livewire.synth()` API survived unchanged — no signature additions needed:

- **The `meta` parameter proved essential and sufficient.** The original filename isn't derivable client-side (it lives in a server-side `.json` sidecar), and preview URLs must be signed server-side. Both travel naturally in the dehydration tuple's metadata — no component/path context param was needed.
- **Arrays of rich values worked with zero special-casing** — multiple uploads are per-element tuples, so each hydrates independently; splicing one out diffs and round-trips correctly.
- **The upload machinery needed no changes** — uploads set properties server-side, so the rich object is purely a read-side upgrade; `removeUpload`/`cancelUpload`/loading states all work untouched.

## Findings along the way

- `getClientOriginalName()` can decode binary garbage from hashed paths (seen in unit tests) — meta generation guards with `mb_check_encoding` so snapshots can't fail JSON encoding.
- Registering by default means `$wire.photo` changes type from string → object: **a BC decision, not a technical one**. `toString()`/`toJSON()` soften it, but code doing `$wire.photo.startsWith(...)` would break. Shipping it opt-in first is also viable.
- Cost: one tiny storage read (name sidecar) + one URL signing per file property per response, and ~250 bytes of snapshot meta per file.

## Tests

- Entire existing `SupportFileUploads` browser suite passes with the synth **enabled by default** (the real BC signal).
- New browser tests: rich single upload (name/extension/preview image actually loads), multiple uploads as rich arrays, removal via the rich object's temp filename.
- All 55 file-upload PHP unit tests pass with the new meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)