### PR TITLE
[4.x] Add `navigate` helper

### DIFF
--- a/src/Features/SupportRedirects/Redirector.php
+++ b/src/Features/SupportRedirects/Redirector.php
@@ -21,6 +21,13 @@ class Redirector extends BaseRedirector
         return $this->to($path, $status, $headers);
     }
 
+    public function navigate($path)
+    {
+        $this->component->redirect($this->generator->to($path), true);
+
+        return $this;
+    }
+
     public function with($key, $value = null)
     {
         $key = is_array($key) ? $key : [$key => $value];

--- a/src/Features/SupportRedirects/UnitTest.php
+++ b/src/Features/SupportRedirects/UnitTest.php
@@ -9,6 +9,8 @@ use Livewire\Component;
 use Livewire\Livewire;
 use Tests\TestComponent;
 
+use function Livewire\navigate;
+
 class UnitTest extends \Tests\TestCase
 {
     public function test_standard_redirect()
@@ -110,6 +112,37 @@ class UnitTest extends \Tests\TestCase
         $component = Livewire::test(TriggersRedirectStub::class);
 
         $component->runAction('triggerRedirectHelperUsingArrayWith');
+
+        $this->assertEquals(url('foo'), $component->effects['redirect']);
+
+        $this->assertEquals('livewire-is-awesome', Session::get('success'));
+    }
+
+    public function test_navigate_helper()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerNavigateHelper');
+
+        $this->assertEquals(url('foo'), $component->effects['redirect']);
+    }
+
+    public function test_navigate_helper_using_key_value_with()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerNavigateHelperUsingKeyValueWith');
+
+        $this->assertEquals(url('foo'), $component->effects['redirect']);
+
+        $this->assertEquals('livewire-is-awesome', Session::get('success'));
+    }
+
+    public function test_navigate_helper_using_array_with()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerNavigateHelperUsingArrayWith');
 
         $this->assertEquals(url('foo'), $component->effects['redirect']);
 
@@ -296,6 +329,23 @@ class TriggersRedirectStub extends TestComponent
     public function triggerRedirectHelperUsingAway()
     {
         return redirect()->away('foo');
+    }
+
+    public function triggerNavigateHelper()
+    {
+        return navigate('foo');
+    }
+
+    public function triggerNavigateHelperUsingKeyValueWith()
+    {
+        return navigate('foo')->with('success', 'livewire-is-awesome');
+    }
+
+    public function triggerNavigateHelperUsingArrayWith()
+    {
+        return navigate('foo')->with([
+            'success' => 'livewire-is-awesome'
+        ]);
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -171,3 +171,8 @@ function store($instance = null)
         }
     };
 }
+
+function navigate($path)
+{
+    return app('redirect')->navigate($path);
+}


### PR DESCRIPTION
This PR introduces a `navigate()` helper (available both as a global helper and via the redirector) to make programmatic SPA-style navigation from Livewire components cleaner and more intuitive.

# Motivation
Currently, developers often resort to:

`$this->redirect('/home', navigate: true)`

or

```html
<script>
    // ...

    Livewire.navigate('/new/url')
</script>
```

The new helper provides a first-class, chainable API similar to Laravel's `redirect()`.

# Usage

```php
// In a Livewire component
public function save()
{
    // ... logic ...

    return navigate(route('dashboard'));
}

// With flash data
return navigate('/success-page')
    ->with('status', 'Operation completed!');
}
```

# Changes

- Added `navigate($path)` to `SupportRedirects\Redirector`
- Added global `navigate()` helper
- Added corresponding unit tests