### PR TITLE
[4.x] Add `wire:if` and `wire:for` directives

### DIFF
--- a/docs/__nav.md
+++ b/docs/__nav.md
@@ -48,8 +48,8 @@ HTML Directives:
     wire:ref: { uri: /docs/4.x/wire-ref, file: /wire-ref.md }
     wire:replace: { uri: /docs/4.x/wire-replace, file: /wire-replace.md }
     wire:show: { uri: /docs/4.x/wire-show, file: /wire-show.md }
-    wire:if: { uri: /docs/4.x/wire-if, file: /wire-if.md }
     wire:for: { uri: /docs/4.x/wire-for, file: /wire-for.md }
+    wire:if: { uri: /docs/4.x/wire-if, file: /wire-if.md }
     wire:sort: { uri: /docs/4.x/wire-sort, file: /wire-sort.md }
     wire:stream: { uri: /docs/4.x/wire-stream, file: /wire-stream.md }
     wire:text: { uri: /docs/4.x/wire-text, file: /wire-text.md }

--- a/docs/__nav.md
+++ b/docs/__nav.md
@@ -48,6 +48,8 @@ HTML Directives:
     wire:ref: { uri: /docs/4.x/wire-ref, file: /wire-ref.md }
     wire:replace: { uri: /docs/4.x/wire-replace, file: /wire-replace.md }
     wire:show: { uri: /docs/4.x/wire-show, file: /wire-show.md }
+    wire:if: { uri: /docs/4.x/wire-if, file: /wire-if.md }
+    wire:for: { uri: /docs/4.x/wire-for, file: /wire-for.md }
     wire:sort: { uri: /docs/4.x/wire-sort, file: /wire-sort.md }
     wire:stream: { uri: /docs/4.x/wire-stream, file: /wire-stream.md }
     wire:text: { uri: /docs/4.x/wire-text, file: /wire-text.md }

--- a/docs/wire-for.md
+++ b/docs/wire-for.md
@@ -1,0 +1,124 @@
+Livewire's `wire:for` directive renders a list of elements by looping over a component property — entirely on the client, without a server round-trip.
+
+It is the Livewire equivalent of Alpine's [`x-for`](https://alpinejs.dev/directives/for) directive, evaluated against your component's properties instead of Alpine data.
+
+Unlike Blade's `@foreach`, which renders the list on the server, `wire:for` renders in the browser and re-renders instantly whenever the underlying property changes — whether from a server update or a client-side mutation like `$wire.items.push(...)`.
+
+Because the loop contents serve as a repeatable template, `wire:for` must be used on a `<template>` tag:
+
+```blade
+<template wire:for="item in items" wire:key="item.id">
+    <div>...</div>
+</template>
+```
+
+The `<template>` tag itself is never displayed — an element is rendered directly after it for every item in the list.
+
+## Basic usage
+
+Here's an example of rendering a list of tasks:
+
+```php
+use Livewire\Component;
+
+class TaskList extends Component
+{
+    public $tasks = [];
+
+    public function add($task)
+    {
+        $this->tasks[] = ['id' => uniqid(), 'title' => $task];
+    }
+
+    public function remove($id)
+    {
+        $this->tasks = array_values(
+            array_filter($this->tasks, fn ($task) => $task['id'] !== $id)
+        );
+    }
+}
+```
+
+```blade
+<div>
+    <ul>
+        <template wire:for="task in tasks" wire:key="task.id">
+            <li>
+                <span wire:text="task.title"></span>
+
+                <button wire:click="remove(task.id)">Remove</button>
+            </li>
+        </template>
+    </ul>
+</div>
+```
+
+Inside the loop, the iterated item (`task` above) is available to any Livewire or Alpine directive — `wire:text`, `wire:click`, `x-show`, and so on. Notice how `wire:click="remove(task.id)"` passes the current item's id back to the server action.
+
+> [!info] Single root element
+> Like `x-for`, the `<template>` tag must contain a single root element.
+
+## Keying items
+
+Always provide a key so the list can be re-ordered and updated efficiently without recreating every element. Use `wire:key` with an expression that uniquely identifies each item:
+
+```blade
+<template wire:for="task in tasks" wire:key="task.id">
+```
+
+Alpine's `:key` syntax is also supported and behaves identically:
+
+```blade
+<template wire:for="task in tasks" :key="task.id">
+```
+
+If no key is provided, items are keyed by their index in the list.
+
+## Accessing the index
+
+Like `x-for`, you can destructure the loop's index alongside the item:
+
+```blade
+<template wire:for="(task, index) in tasks" wire:key="task.id">
+    <li wire:text="(index + 1) + '. ' + task.title"></li>
+</template>
+```
+
+## Nesting loops
+
+`wire:for` templates can be nested — inner loops can reference the outer loop's item:
+
+```blade
+<template wire:for="column in columns" wire:key="column.id">
+    <div>
+        <h2 wire:text="column.title"></h2>
+
+        <template wire:for="card in column.cards" wire:key="card.id">
+            <p wire:text="card.title"></p>
+        </template>
+    </div>
+</template>
+```
+
+## `wire:for` vs. `@foreach`
+
+Blade's `@foreach` renders on the server: the items are part of the initial HTML, and updating the list requires a network round-trip and re-render. `wire:for` renders in the browser: updates apply instantly from client-side state.
+
+Because the content of `wire:for` is rendered on the client, it isn't present in the initial server-rendered HTML. If the list must be visible to search engines or before JavaScript loads, use `@foreach` instead.
+
+## Reference
+
+```blade
+<template wire:for="item in items" wire:key="item.id">
+    <div>...</div>
+</template>
+```
+
+Supported expression forms:
+
+```blade
+wire:for="item in items"
+wire:for="(item, index) in items"
+```
+
+This directive has no modifiers and must be used on a `<template>` tag containing a single root element.

--- a/docs/wire-for.md
+++ b/docs/wire-for.md
@@ -23,12 +23,10 @@ use Livewire\Component;
 
 class TaskList extends Component
 {
-    public $tasks = [];
-
-    public function add($task)
-    {
-        $this->tasks[] = ['id' => uniqid(), 'title' => $task];
-    }
+    public $tasks = [
+        ['id' => 1, 'title' => 'Write the docs'],
+        ['id' => 2, 'title' => 'Ship the feature'],
+    ];
 
     public function remove($id)
     {
@@ -123,5 +121,7 @@ Supported expression forms:
 wire:for="item in items"
 wire:for="(item, index) in items"
 ```
+
+Key each item with `wire:for:key="expression"` (or Alpine's `:key`).
 
 This directive has no modifiers and must be used on a `<template>` tag containing a single root element.

--- a/docs/wire-for.md
+++ b/docs/wire-for.md
@@ -7,7 +7,7 @@ Unlike Blade's `@foreach`, which renders the list on the server, `wire:for` rend
 Because the loop contents serve as a repeatable template, `wire:for` must be used on a `<template>` tag:
 
 ```blade
-<template wire:for="item in items" wire:key="item.id">
+<template wire:for="item in items" wire:for:key="item.id">
     <div>...</div>
 </template>
 ```
@@ -42,7 +42,7 @@ class TaskList extends Component
 ```blade
 <div>
     <ul>
-        <template wire:for="task in tasks" wire:key="task.id">
+        <template wire:for="task in tasks" wire:for:key="task.id">
             <li>
                 <span wire:text="task.title"></span>
 
@@ -60,10 +60,10 @@ Inside the loop, the iterated item (`task` above) is available to any Livewire o
 
 ## Keying items
 
-Always provide a key so the list can be re-ordered and updated efficiently without recreating every element. Use `wire:key` with an expression that uniquely identifies each item:
+Always provide a key so the list can be re-ordered and updated efficiently without recreating every element. Use `wire:for:key` with an expression that uniquely identifies each item:
 
 ```blade
-<template wire:for="task in tasks" wire:key="task.id">
+<template wire:for="task in tasks" wire:for:key="task.id">
 ```
 
 Alpine's `:key` syntax is also supported and behaves identically:
@@ -74,12 +74,15 @@ Alpine's `:key` syntax is also supported and behaves identically:
 
 If no key is provided, items are keyed by their index in the list.
 
+> [!warning] wire:for:key, not wire:key
+> Elsewhere in Livewire, `wire:key` holds a static string rendered by Blade. A template loop needs a *per-item expression* instead, which is why the key lives on a dedicated attribute. Using `wire:key` on a `wire:for` template logs a console warning and is otherwise ignored.
+
 ## Accessing the index
 
 Like `x-for`, you can destructure the loop's index alongside the item:
 
 ```blade
-<template wire:for="(task, index) in tasks" wire:key="task.id">
+<template wire:for="(task, index) in tasks" wire:for:key="task.id">
     <li wire:text="(index + 1) + '. ' + task.title"></li>
 </template>
 ```
@@ -89,11 +92,11 @@ Like `x-for`, you can destructure the loop's index alongside the item:
 `wire:for` templates can be nested — inner loops can reference the outer loop's item:
 
 ```blade
-<template wire:for="column in columns" wire:key="column.id">
+<template wire:for="column in columns" wire:for:key="column.id">
     <div>
         <h2 wire:text="column.title"></h2>
 
-        <template wire:for="card in column.cards" wire:key="card.id">
+        <template wire:for="card in column.cards" wire:for:key="card.id">
             <p wire:text="card.title"></p>
         </template>
     </div>
@@ -109,7 +112,7 @@ Because the content of `wire:for` is rendered on the client, it isn't present in
 ## Reference
 
 ```blade
-<template wire:for="item in items" wire:key="item.id">
+<template wire:for="item in items" wire:for:key="item.id">
     <div>...</div>
 </template>
 ```

--- a/docs/wire-for.md
+++ b/docs/wire-for.md
@@ -19,10 +19,11 @@ The `<template>` tag itself is never displayed — an element is rendered direct
 Here's an example of rendering a list of tasks:
 
 ```php
+<?php
+
 use Livewire\Component;
 
-class TaskList extends Component
-{
+new class extends Component {
     public $tasks = [
         ['id' => 1, 'title' => 'Write the docs'],
         ['id' => 2, 'title' => 'Ship the feature'],
@@ -34,7 +35,7 @@ class TaskList extends Component
             array_filter($this->tasks, fn ($task) => $task['id'] !== $id)
         );
     }
-}
+};
 ```
 
 ```blade

--- a/docs/wire-if.md
+++ b/docs/wire-if.md
@@ -19,11 +19,12 @@ The `<template>` tag itself is never displayed — when the expression is truthy
 Here's an example of using `wire:if` to reveal a delete confirmation prompt:
 
 ```php
+<?php
+
 use Livewire\Component;
 use App\Models\Post;
 
-class ShowPost extends Component
-{
+new class extends Component {
     public Post $post;
 
     public $confirmingDelete = false;
@@ -36,12 +37,12 @@ class ShowPost extends Component
 
         return $this->redirect('/posts');
     }
-}
+};
 ```
 
 ```blade
 <div>
-    <button x-on:click="$wire.confirmingDelete = true">Delete Post</button>
+    <button wire:click="confirmingDelete = true">Delete Post</button>
 
     <template wire:if="confirmingDelete">
         <div>
@@ -49,13 +50,13 @@ class ShowPost extends Component
 
             <button wire:click="delete">Yes, delete it</button>
 
-            <button x-on:click="$wire.confirmingDelete = false">Cancel</button>
+            <button wire:click="confirmingDelete = false">Cancel</button>
         </div>
     </template>
 </div>
 ```
 
-When the "Delete Post" button is clicked, the confirmation prompt is added to the page instantly — no server round-trip. When cancelled, it's removed from the DOM entirely.
+When the "Delete Post" button is clicked, the confirmation prompt is added to the page instantly — property assignments like `wire:click="confirmingDelete = true"` update client-side state directly, without a server round-trip. When cancelled, it's removed from the DOM entirely.
 
 > [!info] Single root element
 > Like `x-if`, the `<template>` tag must contain a single root element.

--- a/docs/wire-if.md
+++ b/docs/wire-if.md
@@ -1,0 +1,84 @@
+Livewire's `wire:if` directive conditionally renders an element based on the result of an expression — entirely on the client, without a server round-trip.
+
+It is the Livewire equivalent of Alpine's [`x-if`](https://alpinejs.dev/directives/if) directive, evaluated against your component's properties instead of Alpine data.
+
+Unlike `wire:show`, which toggles an element's visibility using CSS (`display: none`), `wire:if` adds and removes the element from the DOM entirely. And unlike Blade's `@if`, the condition is re-evaluated instantly on the client whenever the property changes — no network request required.
+
+Because the content must be able to be added and removed from the page, `wire:if` must be used on a `<template>` tag:
+
+```blade
+<template wire:if="expression">
+    <div>...</div>
+</template>
+```
+
+The `<template>` tag itself is never displayed — when the expression is truthy, its contents are rendered directly after it in the DOM.
+
+## Basic usage
+
+Here's an example of using `wire:if` to reveal a delete confirmation prompt:
+
+```php
+use Livewire\Component;
+use App\Models\Post;
+
+class ShowPost extends Component
+{
+    public Post $post;
+
+    public $confirmingDelete = false;
+
+    public function delete()
+    {
+        $this->authorize('delete', $this->post);
+
+        $this->post->delete();
+
+        return $this->redirect('/posts');
+    }
+}
+```
+
+```blade
+<div>
+    <button x-on:click="$wire.confirmingDelete = true">Delete Post</button>
+
+    <template wire:if="confirmingDelete">
+        <div>
+            <p>Are you sure you want to delete this post?</p>
+
+            <button wire:click="delete">Yes, delete it</button>
+
+            <button x-on:click="$wire.confirmingDelete = false">Cancel</button>
+        </div>
+    </template>
+</div>
+```
+
+When the "Delete Post" button is clicked, the confirmation prompt is added to the page instantly — no server round-trip. When cancelled, it's removed from the DOM entirely.
+
+> [!info] Single root element
+> Like `x-if`, the `<template>` tag must contain a single root element.
+
+## `wire:if` vs. `wire:show`
+
+Both directives toggle content based on an expression, but they behave differently:
+
+* `wire:show` renders the element up-front and toggles its CSS `display` property. Best for content that toggles frequently, or that you want to transition in and out.
+* `wire:if` doesn't render its content until the expression is truthy, and removes it from the DOM completely when it isn't. Best for expensive content, or content that shouldn't exist on the page at all until needed (like elements with autofocus, validation, or third-party widgets).
+
+## `wire:if` vs. `@if`
+
+Blade's `@if` evaluates on the server — toggling it requires a network round-trip and a re-render. `wire:if` evaluates in the browser against your component's client-side state, so it responds instantly, even mid-request.
+
+Because the content of `wire:if` is rendered on the client, it isn't present in the initial server-rendered HTML. If the content must be visible to search engines or before JavaScript loads, use `@if` or `wire:show` instead.
+
+## Reference
+
+```blade
+<template wire:if="expression">
+    <div>...</div>
+</template>
+```
+
+This directive has no modifiers and must be used on a `<template>` tag containing a single root element.

--- a/docs/wire-if.md
+++ b/docs/wire-if.md
@@ -69,7 +69,7 @@ Both directives toggle content based on an expression, but they behave different
 
 ## `wire:if` vs. `@if`
 
-Blade's `@if` evaluates on the server — toggling it requires a network round-trip and a re-render. `wire:if` evaluates in the browser against your component's client-side state, so it responds instantly, even mid-request.
+Blade's `@if` evaluates on the server — toggling it requires a network round-trip and a re-render. `wire:if` evaluates in the browser against your component's client-side state, so it responds instantly.
 
 Because the content of `wire:if` is rendered on the client, it isn't present in the initial server-rendered HTML. If the content must be visible to search engines or before JavaScript loads, use `@if` or `wire:show` instead.
 

--- a/js/directives/index.js
+++ b/js/directives/index.js
@@ -15,4 +15,6 @@ import './wire-init';
 import './wire-poll';
 import './wire-show';
 import './wire-text';
+import './wire-if';
+import './wire-for';
 import './wire-bind';

--- a/js/directives/wire-for.js
+++ b/js/directives/wire-for.js
@@ -1,0 +1,49 @@
+import { contextualizeExpression } from '../evaluator'
+import Alpine from 'alpinejs'
+
+Alpine.interceptInit(el => {
+    // Alpine seeds an incoming morph's detached "to" tree by initializing a clone
+    // of it. Binding `x-for` there would render template contents into the
+    // incoming HTML itself, so only bind inside the live document...
+    if (! el.isConnected) return
+
+    for (let i = 0; i < el.attributes.length; i++) {
+        if (el.attributes[i].name.startsWith('wire:for')) {
+            let { name, value } = el.attributes[i]
+
+            if (el.tagName.toLowerCase() !== 'template') {
+                console.warn('Livewire: wire:for can only be used on a <template> tag', el)
+            }
+
+            let modifierString = name.split('wire:for')[1]
+
+            let expression = contextualizeForExpression(value.trim(), el)
+
+            // `x-for` reads its `:key` expression off `_x_keyExpression`, but Alpine
+            // stores that while processing the template's own attributes — after this
+            // early binding runs. Store it ahead of time so keyed lists work. Also
+            // accept `wire:key` as an alias since that's the Livewire convention...
+            let keyExpression = el.getAttribute(':key') || el.getAttribute('x-bind:key') || el.getAttribute('wire:key')
+
+            if (keyExpression && ! el._x_keyExpression) el._x_keyExpression = keyExpression
+
+            Alpine.bind(el, {
+                ['x-for' + modifierString]: expression,
+            })
+        }
+    }
+})
+
+// `x-for` parses its expression string directly ("item in items"), so it can't be
+// evaluated lazily behind a function like `wire:show`/`wire:if`. Instead, rewrite
+// only the items half to target `$wire` ("item in $wire.items") — the iterator
+// aliases on the left are declarations, not component property lookups...
+function contextualizeForExpression(expression, el) {
+    let match = expression.match(/([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/)
+
+    if (! match) return contextualizeExpression(expression, el)
+
+    let [, aliases, items] = match
+
+    return `${aliases} in ${contextualizeExpression(items, el)}`
+}

--- a/js/directives/wire-for.js
+++ b/js/directives/wire-for.js
@@ -2,43 +2,33 @@ import { contextualizeExpression } from '../evaluator'
 import Alpine from 'alpinejs'
 
 Alpine.interceptInit(el => {
-    // Alpine seeds an incoming morph's detached "to" tree by initializing a clone
-    // of it. Binding `x-for` there would render template contents into the
-    // incoming HTML itself, so only bind inside the live document...
+    if (! el.hasAttribute('wire:for')) return
+
+    // Morphing initializes the incoming "to" tree in Alpine's clone mode. Binding
+    // there would render template contents into the incoming HTML itself, so
+    // only bind inside the live document...
     if (! el.isConnected) return
 
-    for (let i = 0; i < el.attributes.length; i++) {
-        let { name, value } = el.attributes[i]
-
-        // Match precisely so `wire:for:key` isn't mistaken for the directive itself...
-        if (name !== 'wire:for' && ! name.startsWith('wire:for.')) continue
-
-        if (el.tagName.toLowerCase() !== 'template') {
-            console.warn('Livewire: wire:for can only be used on a <template> tag', el)
-        }
-
-        let modifierString = name.split('wire:for')[1]
-
-        let expression = contextualizeForExpression(value.trim(), el)
-
-        // `x-for` reads its `:key` expression off `_x_keyExpression`, but Alpine
-        // stores that while processing the template's own attributes — after this
-        // early binding runs. Store it ahead of time so keyed lists work...
-        let keyExpression = el.getAttribute('wire:for:key') || el.getAttribute(':key') || el.getAttribute('x-bind:key')
-
-        if (keyExpression && ! el._x_keyExpression) el._x_keyExpression = keyExpression
-
-        // `wire:key` holds a static string everywhere else, so it can't serve as
-        // the per-item key expression a template loop needs. Steer muscle memory
-        // toward the right attribute instead of silently falling back to index keys...
-        if (! keyExpression && el.hasAttribute('wire:key')) {
-            console.warn('Livewire: wire:key is not supported on wire:for templates. Use wire:for:key to key each item with a per-item expression (e.g. wire:for:key="item.id")', el)
-        }
-
-        Alpine.bind(el, {
-            ['x-for' + modifierString]: expression,
-        })
+    if (el.tagName.toLowerCase() !== 'template') {
+        console.warn('Livewire: wire:for can only be used on a <template> tag', el)
     }
+
+    let expression = contextualizeForExpression(el.getAttribute('wire:for').trim(), el)
+
+    // `x-for` reads its key expression off `_x_keyExpression`, but Alpine stores
+    // that while processing the template's own attributes — after this early
+    // binding runs. Store it ahead of time so keyed lists work...
+    let keyExpression = el.getAttribute('wire:for:key') || el.getAttribute(':key') || el.getAttribute('x-bind:key')
+
+    if (keyExpression) el._x_keyExpression = keyExpression
+
+    // `wire:key` holds a static string everywhere else in Livewire, so it can't
+    // serve as the per-item key expression a template loop needs...
+    if (! keyExpression && el.hasAttribute('wire:key')) {
+        console.warn('Livewire: wire:key is not supported on wire:for templates. Key each item with wire:for:key instead (e.g. wire:for:key="item.id")', el)
+    }
+
+    Alpine.bind(el, { 'x-for': expression })
 })
 
 // `x-for` parses its expression string directly ("item in items"), so it can't be

--- a/js/directives/wire-for.js
+++ b/js/directives/wire-for.js
@@ -8,29 +8,36 @@ Alpine.interceptInit(el => {
     if (! el.isConnected) return
 
     for (let i = 0; i < el.attributes.length; i++) {
-        if (el.attributes[i].name.startsWith('wire:for')) {
-            let { name, value } = el.attributes[i]
+        let { name, value } = el.attributes[i]
 
-            if (el.tagName.toLowerCase() !== 'template') {
-                console.warn('Livewire: wire:for can only be used on a <template> tag', el)
-            }
+        // Match precisely so `wire:for:key` isn't mistaken for the directive itself...
+        if (name !== 'wire:for' && ! name.startsWith('wire:for.')) continue
 
-            let modifierString = name.split('wire:for')[1]
-
-            let expression = contextualizeForExpression(value.trim(), el)
-
-            // `x-for` reads its `:key` expression off `_x_keyExpression`, but Alpine
-            // stores that while processing the template's own attributes — after this
-            // early binding runs. Store it ahead of time so keyed lists work. Also
-            // accept `wire:key` as an alias since that's the Livewire convention...
-            let keyExpression = el.getAttribute(':key') || el.getAttribute('x-bind:key') || el.getAttribute('wire:key')
-
-            if (keyExpression && ! el._x_keyExpression) el._x_keyExpression = keyExpression
-
-            Alpine.bind(el, {
-                ['x-for' + modifierString]: expression,
-            })
+        if (el.tagName.toLowerCase() !== 'template') {
+            console.warn('Livewire: wire:for can only be used on a <template> tag', el)
         }
+
+        let modifierString = name.split('wire:for')[1]
+
+        let expression = contextualizeForExpression(value.trim(), el)
+
+        // `x-for` reads its `:key` expression off `_x_keyExpression`, but Alpine
+        // stores that while processing the template's own attributes — after this
+        // early binding runs. Store it ahead of time so keyed lists work...
+        let keyExpression = el.getAttribute('wire:for:key') || el.getAttribute(':key') || el.getAttribute('x-bind:key')
+
+        if (keyExpression && ! el._x_keyExpression) el._x_keyExpression = keyExpression
+
+        // `wire:key` holds a static string everywhere else, so it can't serve as
+        // the per-item key expression a template loop needs. Steer muscle memory
+        // toward the right attribute instead of silently falling back to index keys...
+        if (! keyExpression && el.hasAttribute('wire:key')) {
+            console.warn('Livewire: wire:key is not supported on wire:for templates. Use wire:for:key to key each item with a per-item expression (e.g. wire:for:key="item.id")', el)
+        }
+
+        Alpine.bind(el, {
+            ['x-for' + modifierString]: expression,
+        })
     }
 })
 

--- a/js/directives/wire-for.js
+++ b/js/directives/wire-for.js
@@ -1,46 +1,46 @@
 import { contextualizeExpression } from '../evaluator'
 import Alpine from 'alpinejs'
 
-Alpine.interceptInit(el => {
-    if (! el.hasAttribute('wire:for')) return
+// Skipped during clone-mode init (morphing seeds incoming trees that way) —
+// rendering template contents there would leak stray elements into the page...
+Alpine.interceptInit(
+    Alpine.skipDuringClone(el => {
+        if (! el.hasAttribute('wire:for')) return
 
-    // Morphing initializes the incoming "to" tree in Alpine's clone mode. Binding
-    // there would render template contents into the incoming HTML itself, so
-    // only bind inside the live document...
-    if (! el.isConnected) return
+        if (el.tagName.toLowerCase() !== 'template') {
+            console.warn('Livewire: wire:for can only be used on a <template> tag', el)
 
-    if (el.tagName.toLowerCase() !== 'template') {
-        console.warn('Livewire: wire:for can only be used on a <template> tag', el)
-    }
+            return
+        }
 
-    let expression = contextualizeForExpression(el.getAttribute('wire:for').trim(), el)
+        let expression = contextualizeForExpression(el.getAttribute('wire:for').trim(), el)
 
-    // `x-for` reads its key expression off `_x_keyExpression`, but Alpine stores
-    // that while processing the template's own attributes — after this early
-    // binding runs. Store it ahead of time so keyed lists work...
-    let keyExpression = el.getAttribute('wire:for:key') || el.getAttribute(':key') || el.getAttribute('x-bind:key')
+        let keyExpression = el.getAttribute('wire:for:key') || el.getAttribute(':key') || el.getAttribute('x-bind:key')
 
-    if (keyExpression) el._x_keyExpression = keyExpression
+        // `wire:key` holds a static string everywhere else in Livewire, so it can't
+        // serve as the per-item key expression a template loop needs...
+        if (! keyExpression && el.hasAttribute('wire:key')) {
+            console.warn('Livewire: wire:key is not supported on wire:for templates. Key each item with wire:for:key instead (e.g. wire:for:key="item.id")', el)
+        }
 
-    // `wire:key` holds a static string everywhere else in Livewire, so it can't
-    // serve as the per-item key expression a template loop needs...
-    if (! keyExpression && el.hasAttribute('wire:key')) {
-        console.warn('Livewire: wire:key is not supported on wire:for templates. Key each item with wire:for:key instead (e.g. wire:for:key="item.id")', el)
-    }
+        Alpine.bind(el, {
+            // Alpine processes `bind` before `for`, storing the key expression
+            // where `x-for` reads per-item keys from...
+            ...(keyExpression ? { 'x-bind:key': keyExpression } : {}),
+            'x-for': expression,
+        })
+    })
+)
 
-    Alpine.bind(el, { 'x-for': expression })
-})
-
-// `x-for` parses its expression string directly ("item in items"), so it can't be
-// evaluated lazily behind a function like `wire:show`/`wire:if`. Instead, rewrite
-// only the items half to target `$wire` ("item in $wire.items") — the iterator
-// aliases on the left are declarations, not component property lookups...
+// Split on the same "aliases in items" grammar as Alpine's own x-for parser
+// (parseForExpression), then rewrite only the items half to target `$wire` —
+// the iterator aliases on the left are declarations, not property lookups...
 function contextualizeForExpression(expression, el) {
-    let match = expression.match(/([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/)
+    let match = expression.match(/([\s\S]*?)\s+(in|of)\s+([\s\S]*)/)
 
-    if (! match) return contextualizeExpression(expression, el)
+    if (! match) return expression
 
-    let [, aliases, items] = match
+    let [, aliases, keyword, items] = match
 
-    return `${aliases} in ${contextualizeExpression(items, el)}`
+    return `${aliases} ${keyword} ${contextualizeExpression(items, el)}`
 }

--- a/js/directives/wire-if.js
+++ b/js/directives/wire-if.js
@@ -1,0 +1,29 @@
+import { evaluateActionExpression } from '../evaluator'
+import Alpine from 'alpinejs'
+
+Alpine.interceptInit(el => {
+    // Alpine seeds an incoming morph's detached "to" tree by initializing a clone
+    // of it. Binding `x-if` there would render template contents into the
+    // incoming HTML itself, so only bind inside the live document...
+    if (! el.isConnected) return
+
+    for (let i = 0; i < el.attributes.length; i++) {
+        if (el.attributes[i].name.startsWith('wire:if')) {
+            let { name, value } = el.attributes[i]
+
+            if (el.tagName.toLowerCase() !== 'template') {
+                console.warn('Livewire: wire:if can only be used on a <template> tag', el)
+            }
+
+            let modifierString = name.split('wire:if')[1]
+
+            let expression = value.trim()
+
+            Alpine.bind(el, {
+                ['x-if' + modifierString]() {
+                    return evaluateActionExpression(el, expression)
+                }
+            })
+        }
+    }
+})

--- a/js/directives/wire-if.js
+++ b/js/directives/wire-if.js
@@ -2,28 +2,22 @@ import { evaluateActionExpression } from '../evaluator'
 import Alpine from 'alpinejs'
 
 Alpine.interceptInit(el => {
-    // Alpine seeds an incoming morph's detached "to" tree by initializing a clone
-    // of it. Binding `x-if` there would render template contents into the
-    // incoming HTML itself, so only bind inside the live document...
+    if (! el.hasAttribute('wire:if')) return
+
+    // Morphing initializes the incoming "to" tree in Alpine's clone mode. Binding
+    // there would render template contents into the incoming HTML itself, so
+    // only bind inside the live document...
     if (! el.isConnected) return
 
-    for (let i = 0; i < el.attributes.length; i++) {
-        if (el.attributes[i].name.startsWith('wire:if')) {
-            let { name, value } = el.attributes[i]
-
-            if (el.tagName.toLowerCase() !== 'template') {
-                console.warn('Livewire: wire:if can only be used on a <template> tag', el)
-            }
-
-            let modifierString = name.split('wire:if')[1]
-
-            let expression = value.trim()
-
-            Alpine.bind(el, {
-                ['x-if' + modifierString]() {
-                    return evaluateActionExpression(el, expression)
-                }
-            })
-        }
+    if (el.tagName.toLowerCase() !== 'template') {
+        console.warn('Livewire: wire:if can only be used on a <template> tag', el)
     }
+
+    let expression = el.getAttribute('wire:if').trim()
+
+    Alpine.bind(el, {
+        ['x-if']() {
+            return evaluateActionExpression(el, expression)
+        }
+    })
 })

--- a/js/directives/wire-if.js
+++ b/js/directives/wire-if.js
@@ -1,23 +1,24 @@
 import { evaluateActionExpression } from '../evaluator'
 import Alpine from 'alpinejs'
 
-Alpine.interceptInit(el => {
-    if (! el.hasAttribute('wire:if')) return
+// Skipped during clone-mode init (morphing seeds incoming trees that way) —
+// rendering template contents there would leak stray elements into the page...
+Alpine.interceptInit(
+    Alpine.skipDuringClone(el => {
+        if (! el.hasAttribute('wire:if')) return
 
-    // Morphing initializes the incoming "to" tree in Alpine's clone mode. Binding
-    // there would render template contents into the incoming HTML itself, so
-    // only bind inside the live document...
-    if (! el.isConnected) return
+        if (el.tagName.toLowerCase() !== 'template') {
+            console.warn('Livewire: wire:if can only be used on a <template> tag', el)
 
-    if (el.tagName.toLowerCase() !== 'template') {
-        console.warn('Livewire: wire:if can only be used on a <template> tag', el)
-    }
-
-    let expression = el.getAttribute('wire:if').trim()
-
-    Alpine.bind(el, {
-        ['x-if']() {
-            return evaluateActionExpression(el, expression)
+            return
         }
+
+        let expression = el.getAttribute('wire:if').trim()
+
+        Alpine.bind(el, {
+            ['x-if']() {
+                return evaluateActionExpression(el, expression)
+            }
+        })
     })
-})
+)

--- a/js/morph.js
+++ b/js/morph.js
@@ -138,13 +138,10 @@ function getMorphConfig(component) {
             if (isntElement(el)) return
 
             // Content rendered by `x-if`/`x-for` templates (`wire:if`/`wire:for`) is
-            // owned by Alpine, not the server, so morphing leaves it alone entirely.
-            // Skipping the template pair itself prevents morph's clone-seeding from
-            // rendering the incoming template's content into the "to" tree (stray
-            // clones that would get inserted as duplicate/ghost rows), and skipUntil
-            // hops over the live rendered content so it doesn't get diffed against
-            // unrelated incoming siblings. Alpine re-renders it reactively when
-            // `$wire` state lands after the morph...
+            // owned by Alpine, not the server, so morphing leaves it alone entirely:
+            // skipping the template pair prevents Alpine's clone-seeding from rendering
+            // stray content into the incoming tree, and skipUntil hops over the live
+            // rendered content. Alpine re-renders it reactively after the morph...
             if (isTemplateDirectiveEl(el)) {
                 let generated = templateGeneratedEls(el)
 
@@ -230,24 +227,15 @@ function isntElement(el) {
 function isTemplateDirectiveEl(el) {
     if (el.tagName !== 'TEMPLATE') return false
 
-    return Array.from(el.attributes).some(({ name }) =>
-        name === 'x-if' || name === 'x-for' || name.startsWith('wire:if') || name.startsWith('wire:for')
-    )
+    return ['x-if', 'x-for', 'wire:if', 'wire:for'].some(name => el.hasAttribute(name))
 }
 
-function templateGeneratedEls(el) {
-    if (! el || el.tagName !== 'TEMPLATE') return []
+function templateGeneratedEls(template) {
+    // `x-if` tracks its rendered element as `_x_currentIfEl`, and `x-for`
+    // tracks its rendered elements in the `_x_lookup` map...
+    if (template._x_currentIfEl) return [template._x_currentIfEl]
 
-    // `x-if` tracks its rendered element as `_x_currentIfEl`...
-    if (el._x_currentIfEl) return [el._x_currentIfEl]
-
-    // `x-for` tracks its rendered elements in a `_x_lookup` map
-    // (a plain object in older Alpine versions)...
-    if (el._x_lookup) {
-        return el._x_lookup instanceof Map
-            ? Array.from(el._x_lookup.values())
-            : Object.values(el._x_lookup)
-    }
+    if (template._x_lookup) return Array.from(template._x_lookup.values())
 
     return []
 }

--- a/js/morph.js
+++ b/js/morph.js
@@ -137,6 +137,16 @@ function getMorphConfig(component) {
 
             if (isntElement(el)) return
 
+            // Elements rendered by `x-if`/`x-for` templates (`wire:if`/`wire:for`) only
+            // exist on the client, so they aren't in the incoming server HTML. Skip
+            // over them on the "from" side so they don't get diffed against
+            // unrelated incoming siblings...
+            let templateGenerated = templateGeneratedEls(el)
+
+            if (templateGenerated.length > 0) {
+                skipUntil(node => ! templateGenerated.includes(node))
+            }
+
             trigger('morph.updating', { el, toEl, component, skip, childrenOnly, skipChildren, skipUntil })
 
             // bypass DOM diffing for children by overwriting the content
@@ -165,6 +175,11 @@ function getMorphConfig(component) {
 
         removing: (el, skip) => {
             if (isntElement(el)) return
+
+            // If the incoming HTML ends before reaching a template-generated element,
+            // it lands here instead of `skipUntil` above. Leave it alone — Alpine
+            // removes it itself when its template is removed or goes falsy...
+            if (isElGeneratedByTemplate(el)) return skip()
 
             trigger('morph.removing', { el, component, skip })
         },
@@ -202,6 +217,38 @@ function getMorphConfig(component) {
 
 function isntElement(el) {
     return typeof el.hasAttribute !== 'function'
+}
+
+function templateGeneratedEls(el) {
+    if (el.tagName !== 'TEMPLATE') return []
+
+    // `x-if` tracks its rendered element as `_x_currentIfEl`...
+    if (el._x_currentIfEl) return [el._x_currentIfEl]
+
+    // `x-for` tracks its rendered elements in a `_x_lookup` map
+    // (a plain object in older Alpine versions)...
+    if (el._x_lookup) {
+        return el._x_lookup instanceof Map
+            ? Array.from(el._x_lookup.values())
+            : Object.values(el._x_lookup)
+    }
+
+    return []
+}
+
+function isElGeneratedByTemplate(el) {
+    // Template-generated elements are always the contiguous siblings directly
+    // after their template, so the first template found walking backwards
+    // is the only candidate owner...
+    let prev = el.previousElementSibling
+
+    while (prev) {
+        if (prev.tagName === 'TEMPLATE') return templateGeneratedEls(prev).includes(el)
+
+        prev = prev.previousElementSibling
+    }
+
+    return false
 }
 
 function isComponentRootEl(el) {

--- a/js/morph.js
+++ b/js/morph.js
@@ -143,11 +143,9 @@ function getMorphConfig(component) {
             // stray content into the incoming tree, and skipUntil hops over the live
             // rendered content. Alpine re-renders it reactively after the morph...
             if (isTemplateDirectiveEl(el)) {
-                let generated = templateGeneratedEls(el)
+                let generated = new Set(templateGeneratedEls(el))
 
-                if (generated.length > 0) {
-                    skipUntil(node => ! generated.includes(node))
-                }
+                skipUntil(node => ! generated.has(node))
 
                 return skip()
             }
@@ -227,32 +225,43 @@ function isntElement(el) {
 function isTemplateDirectiveEl(el) {
     if (el.tagName !== 'TEMPLATE') return false
 
+    // Runtime markers catch templates whose directive was bound
+    // programmatically rather than via a literal attribute...
+    if (el._x_currentIfEl || el._x_lookup) return true
+
     return ['x-if', 'x-for', 'wire:if', 'wire:for'].some(name => el.hasAttribute(name))
 }
 
 function templateGeneratedEls(template) {
-    // `x-if` tracks its rendered element as `_x_currentIfEl`, and `x-for`
-    // tracks its rendered elements in the `_x_lookup` map...
+    // `x-if` tracks its rendered element as `_x_currentIfEl`...
     if (template._x_currentIfEl) return [template._x_currentIfEl]
 
-    if (template._x_lookup) return Array.from(template._x_lookup.values())
+    // `x-for` tracks its rendered elements in the `_x_lookup` map...
+    if (template._x_lookup) {
+        let els = []
+
+        template._x_lookup.forEach(el => {
+            els.push(el)
+
+            // An `x-for` item can itself be an `x-if` template whose rendered
+            // element is inserted alongside it as another sibling...
+            if (el._x_currentIfEl) els.push(el._x_currentIfEl)
+        })
+
+        return els
+    }
 
     return []
 }
 
 function isElGeneratedByTemplate(el) {
-    // Template-generated elements are always the contiguous siblings directly
-    // after their template, so the first template found walking backwards
-    // is the only candidate owner...
+    // `x-for` stamps every rendered element with a scope-refresh callback...
+    if (el._x_refreshXForScope) return true
+
+    // ...and `x-if` keeps its rendered element directly after its template...
     let prev = el.previousElementSibling
 
-    while (prev) {
-        if (prev.tagName === 'TEMPLATE') return templateGeneratedEls(prev).includes(el)
-
-        prev = prev.previousElementSibling
-    }
-
-    return false
+    return !! (prev && prev.tagName === 'TEMPLATE' && prev._x_currentIfEl === el)
 }
 
 function isComponentRootEl(el) {

--- a/js/morph.js
+++ b/js/morph.js
@@ -137,14 +137,22 @@ function getMorphConfig(component) {
 
             if (isntElement(el)) return
 
-            // Elements rendered by `x-if`/`x-for` templates (`wire:if`/`wire:for`) only
-            // exist on the client, so they aren't in the incoming server HTML. Skip
-            // over them on the "from" side so they don't get diffed against
-            // unrelated incoming siblings...
-            let templateGenerated = templateGeneratedEls(el)
+            // Content rendered by `x-if`/`x-for` templates (`wire:if`/`wire:for`) is
+            // owned by Alpine, not the server, so morphing leaves it alone entirely.
+            // Skipping the template pair itself prevents morph's clone-seeding from
+            // rendering the incoming template's content into the "to" tree (stray
+            // clones that would get inserted as duplicate/ghost rows), and skipUntil
+            // hops over the live rendered content so it doesn't get diffed against
+            // unrelated incoming siblings. Alpine re-renders it reactively when
+            // `$wire` state lands after the morph...
+            if (isTemplateDirectiveEl(el)) {
+                let generated = templateGeneratedEls(el)
 
-            if (templateGenerated.length > 0) {
-                skipUntil(node => ! templateGenerated.includes(node))
+                if (generated.length > 0) {
+                    skipUntil(node => ! generated.includes(node))
+                }
+
+                return skip()
             }
 
             trigger('morph.updating', { el, toEl, component, skip, childrenOnly, skipChildren, skipUntil })
@@ -219,8 +227,16 @@ function isntElement(el) {
     return typeof el.hasAttribute !== 'function'
 }
 
+function isTemplateDirectiveEl(el) {
+    if (el.tagName !== 'TEMPLATE') return false
+
+    return Array.from(el.attributes).some(({ name }) =>
+        name === 'x-if' || name === 'x-for' || name.startsWith('wire:if') || name.startsWith('wire:for')
+    )
+}
+
 function templateGeneratedEls(el) {
-    if (el.tagName !== 'TEMPLATE') return []
+    if (! el || el.tagName !== 'TEMPLATE') return []
 
     // `x-if` tracks its rendered element as `_x_currentIfEl`...
     if (el._x_currentIfEl) return [el._x_currentIfEl]

--- a/src/Features/SupportWireFor/BrowserTest.php
+++ b/src/Features/SupportWireFor/BrowserTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Livewire\Features\SupportWireFor;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    public function test_wire_for_renders_a_list_and_reacts_to_server_updates()
+    {
+        Livewire::visit(new class extends Component {
+            public $fruits = ['apple', 'banana'];
+
+            public function add() { $this->fruits[] = 'mango'; }
+
+            public function removeFirst() { array_shift($this->fruits); }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="add" dusk="add">Add</button>
+                    <button wire:click="removeFirst" dusk="remove">Remove</button>
+
+                    <ul dusk="list">
+                        <template wire:for="fruit in fruits">
+                            <li wire:text="fruit"></li>
+                        </template>
+                    </ul>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@list', 'apple')
+        ->assertSeeIn('@list', 'banana')
+        ->waitForLivewire()->click('@add')
+        ->assertSeeIn('@list', 'mango')
+        ->waitForLivewire()->click('@remove')
+        ->assertDontSeeIn('@list', 'apple')
+        ->assertSeeIn('@list', 'banana')
+        ->assertSeeIn('@list', 'mango');
+    }
+
+    public function test_wire_for_supports_an_index_alias()
+    {
+        Livewire::visit(new class extends Component {
+            public $fruits = ['apple', 'banana'];
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <ul dusk="list">
+                        <template wire:for="(fruit, index) in fruits">
+                            <li wire:text="index + ' - ' + fruit"></li>
+                        </template>
+                    </ul>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@list', '0 - apple')
+        ->assertSeeIn('@list', '1 - banana');
+    }
+
+    public function test_wire_for_reacts_to_client_side_state_changes_without_a_request()
+    {
+        Livewire::visit(new class extends Component {
+            public $fruits = ['apple'];
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button x-on:click="$wire.fruits.push('banana')" dusk="push">Push</button>
+
+                    <ul dusk="list">
+                        <template wire:for="fruit in fruits">
+                            <li wire:text="fruit"></li>
+                        </template>
+                    </ul>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@list', 'apple')
+        ->assertDontSeeIn('@list', 'banana')
+        ->click('@push')
+        ->assertSeeIn('@list', 'banana');
+    }
+
+    public function test_wire_for_items_survive_unrelated_livewire_updates()
+    {
+        Livewire::visit(new class extends Component {
+            public $fruits = ['apple', 'banana'];
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$refresh" dusk="refresh">Refresh</button>
+
+                    <ul dusk="list">
+                        <template wire:for="fruit in fruits" wire:key="fruit">
+                            <li><input type="text" dusk="input"></li>
+                        </template>
+                    </ul>
+
+                    <p dusk="after">After</p>
+                </div>
+                HTML;
+            }
+        })
+        ->assertPresent('@input')
+        ->type('@input', 'preserve me')
+        ->waitForLivewire()->click('@refresh')
+        // The generated list items aren't in the server-rendered HTML, so
+        // morphing must skip over them. The typed input value proves the
+        // first item wasn't torn down and recreated...
+        ->assertValue('@input', 'preserve me')
+        ->assertSeeIn('@after', 'After');
+    }
+
+    public function test_wire_for_actions_inside_the_loop_receive_the_iterated_item()
+    {
+        Livewire::visit(new class extends Component {
+            public $fruits = ['apple', 'banana'];
+
+            public function remove($fruit)
+            {
+                $this->fruits = array_values(array_diff($this->fruits, [$fruit]));
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <ul dusk="list">
+                        <template wire:for="fruit in fruits" wire:key="fruit">
+                            <li>
+                                <span wire:text="fruit"></span>
+                                <button wire:click="remove(fruit)" dusk="remove">Remove</button>
+                            </li>
+                        </template>
+                    </ul>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@list', 'apple')
+        ->waitForLivewire()->click('@remove')
+        ->assertDontSeeIn('@list', 'apple')
+        ->assertSeeIn('@list', 'banana');
+    }
+
+    public function test_wire_for_can_loop_over_a_nested_wire_for()
+    {
+        Livewire::visit(new class extends Component {
+            public $lists = [
+                ['name' => 'fruits', 'items' => ['apple', 'banana']],
+                ['name' => 'veggies', 'items' => ['carrot']],
+            ];
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <div dusk="lists">
+                        <template wire:for="list in lists" wire:key="list.name">
+                            <div>
+                                <h2 wire:text="list.name"></h2>
+
+                                <template wire:for="item in list.items" wire:key="item">
+                                    <p wire:text="item"></p>
+                                </template>
+                            </div>
+                        </template>
+                    </div>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@lists', 'fruits')
+        ->assertSeeIn('@lists', 'apple')
+        ->assertSeeIn('@lists', 'banana')
+        ->assertSeeIn('@lists', 'veggies')
+        ->assertSeeIn('@lists', 'carrot');
+    }
+}

--- a/src/Features/SupportWireFor/BrowserTest.php
+++ b/src/Features/SupportWireFor/BrowserTest.php
@@ -224,6 +224,42 @@ class BrowserTest extends BrowserTestCase
         ->assertScript("document.querySelector('[data-fruit=apple]').value", 'typed into apple');
     }
 
+    public function test_wire_for_items_that_are_themselves_conditional_templates_survive_updates()
+    {
+        Livewire::visit(new class extends Component {
+            public $fruits = ['apple', 'banana'];
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$refresh" dusk="refresh">Refresh</button>
+
+                    <ul dusk="list">
+                        <template wire:for="fruit in fruits">
+                            <template x-if="fruit !== 'banana'">
+                                <li x-text="fruit"></li>
+                            </template>
+                        </template>
+                    </ul>
+
+                    <p dusk="after">After</p>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@list', 'apple')
+        ->assertDontSeeIn('@list', 'banana')
+        // Each item is itself an `x-if` template whose rendered element is
+        // another sibling in the same flow — all of it must survive a morph
+        // without being diffed against the trailing paragraph...
+        ->waitForLivewire()->click('@refresh')
+        ->assertSeeIn('@list', 'apple')
+        ->assertDontSeeIn('@list', 'banana')
+        ->assertScript("document.querySelectorAll('[dusk=list] li').length", 1)
+        ->assertSeeIn('@after', 'After');
+    }
+
     public function test_plain_x_for_templates_survive_server_updates_without_ghost_rows()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportWireFor/BrowserTest.php
+++ b/src/Features/SupportWireFor/BrowserTest.php
@@ -189,6 +189,41 @@ class BrowserTest extends BrowserTestCase
         ->assertSeeIn('@lists', 'veggies')
         ->assertSeeIn('@lists', 'carrot');
     }
+
+    public function test_wire_for_keyed_items_keep_their_dom_state_when_reordered()
+    {
+        Livewire::visit(new class extends Component {
+            public $fruits = ['apple', 'banana'];
+
+            public function reverse() { $this->fruits = array_reverse($this->fruits); }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="reverse" dusk="reverse">Reverse</button>
+
+                    <ul dusk="list">
+                        <template wire:for="fruit in fruits" wire:for:key="fruit">
+                            <li>
+                                <span wire:text="fruit"></span>
+                                <input type="text" x-bind:data-fruit="fruit">
+                            </li>
+                        </template>
+                    </ul>
+                </div>
+                HTML;
+            }
+        })
+        ->assertScript("document.querySelector('[dusk=list] li:nth-of-type(1) input').dataset.fruit", 'apple')
+        ->tap(fn ($b) => $b->script("document.querySelector('[data-fruit=apple]').value = 'typed into apple'"))
+        ->waitForLivewire()->click('@reverse')
+        // With keyed items, reordering moves the existing elements instead of
+        // rewriting them in place — the input's typed value travels with its row...
+        ->assertScript("document.querySelector('[dusk=list] li:nth-of-type(1) input').dataset.fruit", 'banana')
+        ->assertScript("document.querySelector('[data-fruit=apple]').value", 'typed into apple');
+    }
+
     public function test_plain_x_for_templates_survive_server_updates_without_ghost_rows()
     {
         Livewire::visit(new class extends Component {
@@ -226,38 +261,5 @@ class BrowserTest extends BrowserTestCase
         ->assertSeeIn('@list', 'mango')
         ->assertScript("document.querySelectorAll('[dusk=list] li').length", 3)
         ->assertScript("[...document.querySelectorAll('[dusk=list] li')].every(li => li.innerText.trim() !== '')", true);
-    }
-    public function test_wire_for_keyed_items_keep_their_dom_state_when_reordered()
-    {
-        Livewire::visit(new class extends Component {
-            public $fruits = ['apple', 'banana'];
-
-            public function reverse() { $this->fruits = array_reverse($this->fruits); }
-
-            public function render()
-            {
-                return <<<'HTML'
-                <div>
-                    <button wire:click="reverse" dusk="reverse">Reverse</button>
-
-                    <ul dusk="list">
-                        <template wire:for="fruit in fruits" wire:for:key="fruit">
-                            <li>
-                                <span wire:text="fruit"></span>
-                                <input type="text" x-bind:data-fruit="fruit">
-                            </li>
-                        </template>
-                    </ul>
-                </div>
-                HTML;
-            }
-        })
-        ->assertScript("document.querySelector('[dusk=list] li:nth-of-type(1) input').dataset.fruit", 'apple')
-        ->tap(fn ($b) => $b->script("document.querySelector('[data-fruit=apple]').value = 'typed into apple'"))
-        ->waitForLivewire()->click('@reverse')
-        // With keyed items, reordering moves the existing elements instead of
-        // rewriting them in place — the input's typed value travels with its row...
-        ->assertScript("document.querySelector('[dusk=list] li:nth-of-type(1) input').dataset.fruit", 'banana')
-        ->assertScript("document.querySelector('[data-fruit=apple]').value", 'typed into apple');
     }
 }

--- a/src/Features/SupportWireFor/BrowserTest.php
+++ b/src/Features/SupportWireFor/BrowserTest.php
@@ -37,6 +37,7 @@ class BrowserTest extends BrowserTestCase
         ->assertSeeIn('@list', 'banana')
         ->waitForLivewire()->click('@add')
         ->assertSeeIn('@list', 'mango')
+        ->assertScript("document.querySelectorAll('[dusk=list] li').length", 3)
         ->waitForLivewire()->click('@remove')
         ->assertDontSeeIn('@list', 'apple')
         ->assertSeeIn('@list', 'banana')
@@ -103,7 +104,7 @@ class BrowserTest extends BrowserTestCase
                     <button wire:click="$refresh" dusk="refresh">Refresh</button>
 
                     <ul dusk="list">
-                        <template wire:for="fruit in fruits" wire:key="fruit">
+                        <template wire:for="fruit in fruits" wire:for:key="fruit">
                             <li><input type="text" dusk="input"></li>
                         </template>
                     </ul>
@@ -138,7 +139,7 @@ class BrowserTest extends BrowserTestCase
                 return <<<'HTML'
                 <div>
                     <ul dusk="list">
-                        <template wire:for="fruit in fruits" wire:key="fruit">
+                        <template wire:for="fruit in fruits" wire:for:key="fruit">
                             <li>
                                 <span wire:text="fruit"></span>
                                 <button wire:click="remove(fruit)" dusk="remove">Remove</button>
@@ -168,11 +169,11 @@ class BrowserTest extends BrowserTestCase
                 return <<<'HTML'
                 <div>
                     <div dusk="lists">
-                        <template wire:for="list in lists" wire:key="list.name">
+                        <template wire:for="list in lists" wire:for:key="list.name">
                             <div>
                                 <h2 wire:text="list.name"></h2>
 
-                                <template wire:for="item in list.items" wire:key="item">
+                                <template wire:for="item in list.items" :key="item">
                                     <p wire:text="item"></p>
                                 </template>
                             </div>
@@ -187,5 +188,76 @@ class BrowserTest extends BrowserTestCase
         ->assertSeeIn('@lists', 'banana')
         ->assertSeeIn('@lists', 'veggies')
         ->assertSeeIn('@lists', 'carrot');
+    }
+    public function test_plain_x_for_templates_survive_server_updates_without_ghost_rows()
+    {
+        Livewire::visit(new class extends Component {
+            public $fruits = ['apple', 'banana'];
+
+            public function add() { $this->fruits[] = 'mango'; }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="add" dusk="add">Add</button>
+                    <button wire:click="$refresh" dusk="refresh">Refresh</button>
+
+                    <ul dusk="list">
+                        <template x-for="fruit in $wire.fruits">
+                            <li x-text="fruit"></li>
+                        </template>
+                    </ul>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@list', 'apple')
+        ->assertScript("document.querySelectorAll('[dusk=list] li').length", 2)
+        // Growing the list on the server used to leave behind an extra empty
+        // row: morph would insert the raw clone that Alpine's seeding rendered
+        // into the incoming tree, alongside the real row the live `x-for`
+        // effect created...
+        ->waitForLivewire()->click('@add')
+        ->assertSeeIn('@list', 'mango')
+        ->assertScript("document.querySelectorAll('[dusk=list] li').length", 3)
+        ->waitForLivewire()->click('@refresh')
+        ->assertSeeIn('@list', 'apple')
+        ->assertSeeIn('@list', 'mango')
+        ->assertScript("document.querySelectorAll('[dusk=list] li').length", 3)
+        ->assertScript("[...document.querySelectorAll('[dusk=list] li')].every(li => li.innerText.trim() !== '')", true);
+    }
+    public function test_wire_for_keyed_items_keep_their_dom_state_when_reordered()
+    {
+        Livewire::visit(new class extends Component {
+            public $fruits = ['apple', 'banana'];
+
+            public function reverse() { $this->fruits = array_reverse($this->fruits); }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="reverse" dusk="reverse">Reverse</button>
+
+                    <ul dusk="list">
+                        <template wire:for="fruit in fruits" wire:for:key="fruit">
+                            <li>
+                                <span wire:text="fruit"></span>
+                                <input type="text" x-bind:data-fruit="fruit">
+                            </li>
+                        </template>
+                    </ul>
+                </div>
+                HTML;
+            }
+        })
+        ->assertScript("document.querySelector('[dusk=list] li:nth-of-type(1) input').dataset.fruit", 'apple')
+        ->tap(fn ($b) => $b->script("document.querySelector('[data-fruit=apple]').value = 'typed into apple'"))
+        ->waitForLivewire()->click('@reverse')
+        // With keyed items, reordering moves the existing elements instead of
+        // rewriting them in place — the input's typed value travels with its row...
+        ->assertScript("document.querySelector('[dusk=list] li:nth-of-type(1) input').dataset.fruit", 'banana')
+        ->assertScript("document.querySelector('[data-fruit=apple]').value", 'typed into apple');
     }
 }

--- a/src/Features/SupportWireIf/BrowserTest.php
+++ b/src/Features/SupportWireIf/BrowserTest.php
@@ -86,7 +86,7 @@ class BrowserTest extends BrowserTestCase
             {
                 return <<<'HTML'
                 <div>
-                    <button x-on:click="$wire.show = ! $wire.show" dusk="toggle">Toggle</button>
+                    <button wire:click="show = ! show" dusk="toggle">Toggle</button>
 
                     <template wire:if="show">
                         <div dusk="content">Hello</div>

--- a/src/Features/SupportWireIf/BrowserTest.php
+++ b/src/Features/SupportWireIf/BrowserTest.php
@@ -166,4 +166,36 @@ class BrowserTest extends BrowserTestCase
         ->waitForLivewire()->click('@increment')
         ->assertSeeIn('@count', '1');
     }
+    public function test_plain_x_if_templates_survive_server_updates()
+    {
+        Livewire::visit(new class extends Component {
+            public $show = true;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$refresh" dusk="refresh">Refresh</button>
+                    <button wire:click="$toggle('show')" dusk="toggle">Toggle</button>
+
+                    <div dusk="zone">
+                        <template x-if="$wire.show">
+                            <div>Hello</div>
+                        </template>
+                    </div>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@zone', 'Hello')
+        ->waitForLivewire()->click('@refresh')
+        ->assertSeeIn('@zone', 'Hello')
+        ->assertScript("document.querySelectorAll('[dusk=zone] div').length", 1)
+        ->waitForLivewire()->click('@toggle')
+        ->assertDontSeeIn('@zone', 'Hello')
+        ->assertScript("document.querySelectorAll('[dusk=zone] div').length", 0)
+        ->waitForLivewire()->click('@toggle')
+        ->assertSeeIn('@zone', 'Hello')
+        ->assertScript("document.querySelectorAll('[dusk=zone] div').length", 1);
+    }
 }

--- a/src/Features/SupportWireIf/BrowserTest.php
+++ b/src/Features/SupportWireIf/BrowserTest.php
@@ -166,6 +166,7 @@ class BrowserTest extends BrowserTestCase
         ->waitForLivewire()->click('@increment')
         ->assertSeeIn('@count', '1');
     }
+
     public function test_plain_x_if_templates_survive_server_updates()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportWireIf/BrowserTest.php
+++ b/src/Features/SupportWireIf/BrowserTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Livewire\Features\SupportWireIf;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    public function test_wire_if_toggles_content_in_and_out_of_the_dom()
+    {
+        Livewire::visit(new class extends Component {
+            public $show = false;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$toggle('show')" dusk="toggle">Toggle</button>
+
+                    <template wire:if="show">
+                        <div dusk="content">Hello</div>
+                    </template>
+                </div>
+                HTML;
+            }
+        })
+        ->assertNotPresent('@content')
+        ->assertDontSee('Hello')
+        ->waitForLivewire()->click('@toggle')
+        ->assertPresent('@content')
+        ->assertSee('Hello')
+        ->waitForLivewire()->click('@toggle')
+        ->assertNotPresent('@content')
+        ->assertDontSee('Hello');
+    }
+
+    public function test_wire_if_renders_content_on_page_load_when_property_is_initially_true()
+    {
+        Livewire::visit(new class extends Component {
+            public $show = true;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <template wire:if="show">
+                        <div dusk="content">Hello</div>
+                    </template>
+                </div>
+                HTML;
+            }
+        })
+        ->assertPresent('@content')
+        ->assertSee('Hello');
+    }
+
+    public function test_wire_if_supports_the_not_operator()
+    {
+        Livewire::visit(new class extends Component {
+            public $show = false;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$toggle('show')" dusk="toggle">Toggle</button>
+
+                    <template wire:if="! show">
+                        <div dusk="content">Hello</div>
+                    </template>
+                </div>
+                HTML;
+            }
+        })
+        ->assertPresent('@content')
+        ->waitForLivewire()->click('@toggle')
+        ->assertNotPresent('@content');
+    }
+
+    public function test_wire_if_reacts_to_client_side_state_changes_without_a_request()
+    {
+        Livewire::visit(new class extends Component {
+            public $show = false;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button x-on:click="$wire.show = ! $wire.show" dusk="toggle">Toggle</button>
+
+                    <template wire:if="show">
+                        <div dusk="content">Hello</div>
+                    </template>
+                </div>
+                HTML;
+            }
+        })
+        ->assertNotPresent('@content')
+        ->click('@toggle')
+        ->assertPresent('@content')
+        ->click('@toggle')
+        ->assertNotPresent('@content');
+    }
+
+    public function test_wire_if_content_survives_unrelated_livewire_updates()
+    {
+        Livewire::visit(new class extends Component {
+            public $show = true;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$refresh" dusk="refresh">Refresh</button>
+
+                    <template wire:if="show">
+                        <div dusk="content">
+                            <input type="text" dusk="input">
+                        </div>
+                    </template>
+
+                    <p dusk="after">After</p>
+                </div>
+                HTML;
+            }
+        })
+        ->assertPresent('@content')
+        ->type('@input', 'preserve me')
+        ->waitForLivewire()->click('@refresh')
+        // The generated content isn't in the server-rendered HTML, so morphing
+        // must skip over it instead of removing it or diffing it against the
+        // "After" paragraph. The typed input value proves the element also
+        // wasn't torn down and recreated...
+        ->assertPresent('@content')
+        ->assertValue('@input', 'preserve me')
+        ->assertSeeIn('@after', 'After');
+    }
+
+    public function test_wire_if_content_can_contain_livewire_directives()
+    {
+        Livewire::visit(new class extends Component {
+            public $show = true;
+
+            public $count = 0;
+
+            public function increment() { $this->count++; }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <template wire:if="show">
+                        <div>
+                            <button wire:click="increment" dusk="increment">Increment</button>
+
+                            <span wire:text="count" dusk="count"></span>
+                        </div>
+                    </template>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@count', '0')
+        ->waitForLivewire()->click('@increment')
+        ->assertSeeIn('@count', '1');
+    }
+}

--- a/src/Features/SupportWireIf/BrowserTest.php
+++ b/src/Features/SupportWireIf/BrowserTest.php
@@ -27,13 +27,11 @@ class BrowserTest extends BrowserTestCase
             }
         })
         ->assertNotPresent('@content')
-        ->assertDontSee('Hello')
         ->waitForLivewire()->click('@toggle')
         ->assertPresent('@content')
         ->assertSee('Hello')
         ->waitForLivewire()->click('@toggle')
-        ->assertNotPresent('@content')
-        ->assertDontSee('Hello');
+        ->assertNotPresent('@content');
     }
 
     public function test_wire_if_renders_content_on_page_load_when_property_is_initially_true()


### PR DESCRIPTION
## Summary

Adds `wire:if` and `wire:for` — the `x-if`/`x-for` counterparts to `wire:show`/`wire:text`. Both must be used on `<template>` tags (like their Alpine equivalents) and evaluate against component properties:

```blade
<template wire:if="confirmingDelete">
    <div>Are you sure?</div>
</template>

<template wire:for="task in tasks" wire:for:key="task.id">
    <li>
        <span wire:text="task.title"></span>
        <button wire:click="remove(task.id)">Remove</button>
    </li>
</template>
```

They react to both server updates and pure client-side mutations (`$wire.show = true`, `$wire.tasks.push(...)`) with no round-trip.

## Implementation notes

**`wire:if`** follows the exact `wire:show` pattern: `Alpine.bind` an `x-if` closure that evaluates through `evaluateActionExpression` (so bare identifiers get `$wire.`-prefixed, Alpine scope keys are left alone).

**`wire:for`** can't use that pattern — `x-for` regex-parses its expression *string* (`item in items`), so a function expression never works. Instead the items half of the expression is rewritten statically: `task in tasks` → `task in $wire.tasks`. Iterator aliases are left untouched, and nested loops work because inner expressions skip Alpine scope keys (`item in list.items` stays unprefixed when `list` comes from the outer loop).

**Keys** live on a dedicated `wire:for:key` attribute (following the `wire:sort:group` naming pattern), because `wire:key` holds a static Blade-rendered string everywhere else while a template loop needs a per-item client-side expression — overloading one attribute with two value languages felt like a trap. Alpine's `:key` also works; a plain `wire:key` on the template logs a console warning pointing at `wire:for:key`. The key expression is passed through `x-bind:key` in the same `Alpine.bind` object — Alpine processes `bind` before `for`, so it lands where `x-for` reads per-item keys from (binding `x-for` alone at `interceptInit` time would run before the template's own `:key` attribute is processed, silently index-keying every list).

## How this interacts with morphing

Alpine morph already has a mechanism for templates: as it patches each element pair it runs `Alpine.cloneNode(from, to)`, so the incoming (`to`) tree's `x-if`/`x-for` templates render their content *into the incoming tree*, and morph then pairs generated content 1:1 against the live content.

That mechanism has a race with `Alpine.transaction()` from #9882 (which correctly blocks reactive effects until after the morph): when a server update changes a list's length, the incoming template renders the **new** count while the live side is frozen at the **old** count — the leftover incoming rows get inserted as ghost/duplicate rows. Reproducible on `main` today with plain `x-for` bound to `$wire` state: growing a 2-item list produces 4 `<li>`s (one empty). This is the same family as #10144 (closed unmerged) and the navigate-cache duplicates fixed in #10336/#10339.

This PR takes the position that morph should not touch template-generated content at all — Alpine owns it on both sides:

1. When morph reaches an `x-if`/`x-for`/`wire:if`/`wire:for` template pair, it `skipUntil()`s past the live generated elements (same mechanism island fragment markers use) and `skip()`s the template pair itself. Skipping the pair prevents the per-element clone-seeding from ever rendering content into the incoming tree, which is what previously ghosted rows. State changes still land after the morph and Alpine re-renders reactively.
2. A guard in the `removing` hook protects generated elements when the incoming HTML ends before reaching them. Alpine still tears them down itself when the template is removed or its expression goes falsy.
3. `wire:if`/`wire:for` bindings are wrapped in `Alpine.skipDuringClone` (same as `wire:navigate`), so they never activate during clone-mode initialization.

Because 1–2 apply to plain Alpine templates too, this also fixes the existing ghost-row bug on `main` — covered by regression tests using plain `x-if`/`x-for` bound to `$wire`.

## Tests

15 browser tests across `SupportWireIf`/`SupportWireFor` covering: toggling in/out of the DOM, initial-true render, negation, client-side-only reactivity (`$wire.show = ...`, `$wire.fruits.push(...)`), server-driven add/remove with exact row counts, `(item, index)` aliases, actions receiving the iterated item, nested loops, keyed reorder preserving DOM state (typed input travels with its row through `array_reverse`), morph survival (typed input inside generated content persists across an unrelated `$refresh` with trailing siblings intact), and plain `x-if`/`x-for` ghost-row regressions.

Green regression sweeps: `SupportWireShow`/`SupportWireText`, `SupportIslands` (27 tests — heaviest consumer of the `skipUntil` machinery), `SupportMorphAwareBladeCompilation`, `AlpineMorphingBrowserTest` (the #9882 suite), and the JS unit suite (126).

Docs included for both directives (`docs/wire-if.md`, `docs/wire-for.md`) and registered in the nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

