### PR TITLE
[4.x] Support `wire:transition` behind open dialogs

### DIFF
--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -41,6 +41,7 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
         return callback()
     }
 
+    // Capture native modal dialogs that are already open before the transition starts...
     let dialogs = Array.from(document.querySelectorAll('dialog:modal'))
     let transitionRoot = document
 
@@ -109,6 +110,8 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
     // and skips the transition before the browser paints a frame...
     let skipOnDialog = (transition) => {
         let observer = new MutationObserver(() => {
+            // Ignore dialogs that were open when the transition started and
+            // only skip when a new dialog opens during the transition...
             let uncapturedDialogOpened = Array.from(document.querySelectorAll('dialog:modal'))
                 .some(dialog => ! dialogs.includes(dialog))
 

--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -41,10 +41,17 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
         return callback()
     }
 
-    // Skip entirely if a modal dialog is already open (transitions behind
-    // a dialog are invisible to the user and the ::view-transition pseudo-
-    // elements would paint above the dialog during animation)...
-    if (document.querySelector('dialog:modal')) return callback()
+    let dialogs = Array.from(document.querySelectorAll('dialog:modal'))
+    let transitionRoot = document
+
+    // A document-scoped transition paints above the browser's top layer. When
+    // supported, scope the transition to the component so open dialogs remain
+    // in the top layer above the transition. Otherwise, skip the transition...
+    if (dialogs.length > 0) {
+        if (typeof fromEl.startViewTransition !== 'function') return callback()
+
+        transitionRoot = fromEl
+    }
 
     // Set transition names right before the transition starts (not permanently)...
     setTransitionNames(fromEl, options)
@@ -102,7 +109,10 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
     // and skips the transition before the browser paints a frame...
     let skipOnDialog = (transition) => {
         let observer = new MutationObserver(() => {
-            if (document.querySelector('dialog:modal')) {
+            let uncapturedDialogOpened = Array.from(document.querySelectorAll('dialog:modal'))
+                .some(dialog => ! dialogs.includes(dialog))
+
+            if (uncapturedDialogOpened) {
                 transition.skipTransition()
                 observer.disconnect()
             }
@@ -118,7 +128,7 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
     }
 
     try {
-        let transition = document.startViewTransition(transitionConfig)
+        let transition = transitionRoot.startViewTransition(transitionConfig)
 
         skipOnDialog(transition)
 
@@ -127,7 +137,7 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
         await transition.updateCallbackDone
     } catch (e) {
         // Firefox 144+ supports View Transitions but only with a callback, not a config object (no transition types support)
-        let transition = document.startViewTransition(update)
+        let transition = transitionRoot.startViewTransition(update)
 
         skipOnDialog(transition)
 

--- a/src/Features/SupportTransitions/BrowserTest.php
+++ b/src/Features/SupportTransitions/BrowserTest.php
@@ -210,6 +210,56 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_can_transition_an_element_behind_an_open_dialog()
+    {
+        $animationsRunning = 'document.getAnimations().some(a => a.playState === "running")';
+
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $items = ['Item A', 'Item B'];
+
+                public function removeItem()
+                {
+                    array_shift($this->items);
+                }
+
+                public function render() { return <<<'HTML'
+                <div dusk="root">
+                    <style>
+                        ::view-transition-old(*) { animation: 1s ease-out fade-out; }
+                        ::view-transition-new(*) { animation: 1s ease-in fade-in; }
+                        @keyframes fade-out { to { opacity: 0; } }
+                        @keyframes fade-in { from { opacity: 0; } }
+                    </style>
+
+                    @foreach ($items as $index => $item)
+                        <div
+                            wire:transition="card-{{ $index }}"
+                            wire:key="item-{{ $item }}"
+                            dusk="card-{{ $index }}"
+                        >
+                            {{ $item }}
+                        </div>
+                    @endforeach
+
+                    <dialog wire:ignore.self x-init="$el.showModal()" dusk="dialog">
+                        <p>Modal Content</p>
+                        <button wire:click="removeItem" dusk="remove">Remove item</button>
+                    </dialog>
+                </div>
+                HTML; }
+            }
+        )
+        ->waitFor('dialog[open]')
+        ->waitForLivewire()->click('@remove')
+        ->waitUntil($animationsRunning)
+        ->assertMissing('@card-1')
+        ->assertScript("document.querySelector('[dusk=dialog]').matches(':modal')", true)
+        ->assertScript("getComputedStyle(document.querySelector('[dusk=root]')).viewTransitionScope", 'all')
+        ->waitUntil("!$animationsRunning")
+        ;
+    }
+
     public function test_can_transition_dynamic_component_swap()
     {
         $animationsRunning = 'document.getAnimations().some(a => a.playState === "running")';


### PR DESCRIPTION
# The Scenario

If we have a list of items using `wire:transition`, removing an item directly from the list animates it out as expected.

However, if we use a Flux modal as a confirmation dialog before removing the item, the item disappears immediately without its exit animation.

<img width="800" height="662" alt="CleanShot 2026-07-13 at 13 05 41" src="https://github.com/user-attachments/assets/c68931a7-c038-4503-89c7-98b7ffc43700" />

```blade
<?php

use Livewire\Component;

new class extends Component {
    public array $sources = [
        ['id' => 1, 'name' => 'Production API'],
        ['id' => 2, 'name' => 'Analytics warehouse'],
    ];

    public function remove(int $sourceId): void
    {
        $this->sources = array_values(array_filter(
            $this->sources,
            fn (array $source): bool => $source['id'] !== $sourceId,
        ));
    }
}; ?>

<div>
    @foreach ($sources as $source)
        <div wire:transition wire:key="source-{{ $source['id'] }}">
            <span>{{ $source['name'] }}</span>

            <flux:modal.trigger name="remove-source-{{ $source['id'] }}">
                <flux:button icon="trash" />
            </flux:modal.trigger>

            <flux:modal name="remove-source-{{ $source['id'] }}">
                <flux:heading>Delete source?</flux:heading>

                <flux:button
                    wire:click="remove({{ $source['id'] }})"
                    variant="danger"
                >
                    Delete
                </flux:button>
            </flux:modal>
        </div>
    @endforeach
</div>
```

# The Problem

Livewire intentionally skips document-scoped view transitions when a native modal dialog is open.

This prevents the document’s view transition layer from painting transitioning elements above the browser’s top layer, where native dialogs are rendered. However, it also prevents transitions that could safely run behind an existing dialog.

# The Solution

The solution is to use an [element-scoped view transition](https://developer.chrome.com/docs/css-ui/view-transitions/element-scoped-view-transitions) on the Livewire component when a native dialog is already open.

Unlike a document-scoped transition, the scoped transition layer remains within the component. This allows the browser’s top-layer dialog to stay above the transitioning content.

Livewire now uses one of three paths:

- If no dialog is open, Livewire uses the existing document-scoped transition. If a dialog opens during that transition, Livewire skips the animation to prevent transitioning content from appearing above it.
- If a dialog is already open and the browser supports element-scoped transitions, Livewire scopes the transition to the component so the animation can run behind the dialog.
- If a dialog is already open but the browser does not support element-scoped transitions, Livewire retains the existing safe fallback and applies the DOM update without animation.

According to [Can I Use](https://caniuse.com/wf-view-transitions-element-scoped), element-scoped transitions are currently supported in Chromium-based browsers from Chrome and Edge 147. Firefox and Safari do not yet support them, so they continue to use the safe fallback until support becomes available.

<img width="800" height="662" alt="CleanShot 2026-07-13 at 13 04 19" src="https://github.com/user-attachments/assets/df837705-2208-42ff-a12a-382d840ad665" />

Fixes livewire/flux#2679
