### PR TITLE
[4.x] Surface `TypeErrors` thrown during Livewire tests

### DIFF
--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -560,6 +560,28 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             ->assertReturned(fn ($data) => $data === 'bar');
     }
 
+    function test_type_errors_thrown_from_component_actions_are_rethrown()
+    {
+        config()->set('app.debug', false);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('array_merge(): Argument #1 must be of type array, Illuminate\Support\Collection given');
+
+        Livewire::test(ComponentWithActionThatThrowsTypeError::class)
+            ->call('save');
+    }
+
+    function test_type_errors_thrown_while_binding_component_action_parameters_are_rethrown()
+    {
+        config()->set('app.debug', false);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('must be of type array, string given');
+
+        Livewire::test(ComponentWithActionThatThrowsTypeError::class)
+            ->call('saveItems', 'not-an-array');
+    }
+
     public function test_can_set_cookies_for_use_with_testing()
     {
         // Test both the `withCookies` and `withCookie` methods that Laravel normally provides
@@ -804,6 +826,18 @@ class ComponentWithMethodThatReturnsData extends TestComponent
     function foo()
     {
         return 'bar';
+    }
+}
+
+class ComponentWithActionThatThrowsTypeError extends TestComponent
+{
+    function save()
+    {
+        array_merge(collect(), []);
+    }
+
+    function saveItems(array $items)
+    {
     }
 }
 

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -2,6 +2,8 @@
 
 namespace Livewire\Mechanisms\HandleRequests;
 
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Foundation\Testing\Concerns\WithoutExceptionHandlingHandler;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
 use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
@@ -206,7 +208,7 @@ class HandleRequests extends Mechanism
             } catch (\TypeError $e) {
                 report($e);
 
-                if (config('app.debug')) throw $e;
+                if (config('app.debug') || app(ExceptionHandler::class) instanceof WithoutExceptionHandlingHandler) throw $e;
 
                 abort(419);
             }


### PR DESCRIPTION
# The Scenario

When a component action throws a `TypeError`, calling it through `Livewire::test()` silently absorbs the exception. The following assertion fails without exposing the original exception or stack trace:

```php
<?php

use Livewire\Component;
use Livewire\Livewire;

new class extends Component
{
    public function save(): void
    {
        array_merge(collect(), []);
    }
};

Livewire::test(EditMessage::class)
    ->call('save')
    ->assertHasErrors();
```

# The Problem

Livewire catches `TypeError`s thrown during an update request so production requests can report the exception and return a 419 response.

`Livewire::test()` disables Laravel's exception handling, but the caught `TypeError` is converted into a 419 before Laravel's testing handler has an opportunity to rethrow it. The test harness receives the response and creates an empty component state instead, hiding the original exception.

The same behaviour affects `TypeError`s thrown while binding component action parameters.

# The Solution

The solution is to detect Laravel's `WithoutExceptionHandlingHandler` when handling a caught `TypeError` and rethrow the original exception, matching the behaviour expected when exception handling has been disabled.

Production HTTP behaviour remains unchanged. With normal exception handling and debug mode disabled, Livewire continues to report the exception and return 419.

Fixes #10385
