### PR TITLE
[4.x] Add the `$upload` action and `wire:drop` — paste, drop, and file-picker uploads

### DIFF
--- a/docs/__nav.md
+++ b/docs/__nav.md
@@ -33,6 +33,7 @@ HTML Directives:
     wire:click: { uri: /docs/4.x/wire-click, file: /wire-click.md }
     wire:submit: { uri: /docs/4.x/wire-submit, file: /wire-submit.md }
     wire:model: { uri: /docs/4.x/wire-model, file: /wire-model.md }
+    wire:drop: { uri: /docs/4.x/wire-drop, file: /wire-drop.md }
     wire:loading: { uri: /docs/4.x/wire-loading, file: /wire-loading.md }
     wire:navigate: { uri: /docs/4.x/wire-navigate, file: /wire-navigate.md }
     wire:current: { uri: /docs/4.x/wire-current, file: /wire-current.md }

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -294,23 +294,23 @@ new class extends Component {
 ```
 
 ```blade
-<div class="group relative" wire:drop.window="$upload('attachments')">
+<div class="relative" wire:drop.window="$upload('attachments')">
     {{-- A full-screen overlay, shown while files are dragged over the page... --}}
-    <div class="hidden group-data-dragging:grid fixed inset-0 place-items-center bg-black/50 text-white">
+    <div class="hidden in-data-dragging:grid fixed inset-0 place-items-center bg-black/50 text-white">
         Drop files to attach
     </div>
 
     <form wire:submit="send">
         {{-- Pending and finished attachments, powered by rich upload objects... --}}
-        <template x-for="file in $wire.attachments" :key="file.name">
+        <template wire:for="file in attachments" wire:for:key="file.name">
             <div>
-                <img x-show="file.isPreviewable" x-bind:src="file.previewUrl">
+                <img wire:show="file.isPreviewable" wire:bind:src="file.previewUrl">
 
-                <span x-text="file.name"></span>
+                <span wire:text="file.name"></span>
 
-                <progress x-show="file.isUploading" x-bind:value="file.progress" max="100"></progress>
+                <progress wire:show="file.isUploading" wire:bind:value="file.progress" max="100"></progress>
 
-                <button type="button" x-on:click="file.remove()">&times;</button>
+                <button type="button" wire:click="file.remove()">&times;</button>
             </div>
         </template>
 
@@ -320,7 +320,7 @@ new class extends Component {
             Add photos & files
         </button>
 
-        <button type="submit" x-bind:disabled="$wire.attachments.some(file => file.isUploading)">
+        <button type="submit" wire:bind:disabled="attachments.some(file => file.isUploading)">
             Send
         </button>
     </form>
@@ -693,7 +693,15 @@ These functions exist on a JavaScript component object, which can be accessed us
 </script>
 ```
 
-`$wire.$upload()` returns a promise that resolves when the upload finishes (or with `null` if the picker is dismissed or the upload is cancelled) and rejects if it fails. For upload state while in flight — progress, previews — read the property's [rich upload objects](#rich-upload-objects-in-javascript) reactively.
+`$wire.$upload()` returns a promise that resolves with the [rich upload object](#rich-upload-objects-in-javascript) now living on the property — or an array of them when uploading multiple files (just the files from this upload, not the property's previously uploaded ones). If the picker is dismissed or the upload is cancelled it resolves with `null`, and if the upload fails it rejects:
+
+```blade
+<script>
+    let photo = await $wire.$upload('photo')
+
+    photo.previewUrl // Instant local preview...
+</script>
+```
 
 The legacy callback signature from earlier versions of Livewire continues to work:
 

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -247,6 +247,119 @@ Properties holding multiple uploads hydrate into arrays of rich objects, so each
 
 Rich upload objects are powered by [JavaScript synthesizers](/docs/synthesizers#javascript-synthesizers). When sent back to the server or stringified via `JSON.stringify()`, they degrade to their raw wire value automatically.
 
+## Uploading beyond file inputs
+
+Modern interfaces accept files from more than a file input: users paste screenshots into a message box, drag files onto the page, and click "Attach" buttons that open the system's file picker.
+
+Livewire supports all of these through a single action: `$upload`. Use it inside any event listener — most commonly `wire:paste`, [`wire:drop`](/docs/wire-drop), and `wire:click`:
+
+```blade
+<textarea wire:paste="$upload('photos')"></textarea>
+
+<div wire:drop="$upload('photos')">Drop files here</div>
+
+<button type="button" wire:click="$upload('photos')">Attach files</button>
+```
+
+`$upload` follows one rule: **it takes files from the argument, else from the event, else from the user.**
+
+* When the triggering event carries files — pasted screenshots, dropped files — those files upload into the property
+* When the event *can* carry files but doesn't — a plain text paste — nothing happens, and the browser's default behavior proceeds untouched
+* When the event *can't* carry files — a click — the browser's file picker opens and the user's selection uploads instead
+
+Uploads started this way are ordinary Livewire uploads: they flow through the same temporary-upload pipeline as `wire:model` file inputs, respect your validation rules, and hydrate into [rich upload objects](#rich-upload-objects-in-javascript) for instant previews and progress.
+
+Here's a complete chat-style message box that accepts attachments from all three gestures:
+
+```php
+<?php // resources/views/components/⚡message-box.blade.php
+
+use Livewire\Attributes\Validate;
+use Livewire\WithFileUploads;
+use Livewire\Component;
+
+new class extends Component {
+    use WithFileUploads;
+
+    public $message = '';
+
+    #[Validate(['attachments.*' => 'file|max:10240'])]
+    public $attachments = [];
+
+    public function send()
+    {
+        // ...
+    }
+};
+```
+
+```blade
+<div class="group relative" wire:drop.window="$upload('attachments')">
+    {{-- A full-screen overlay, shown while files are dragged over the page... --}}
+    <div class="hidden group-data-dragging:grid fixed inset-0 place-items-center bg-black/50 text-white">
+        Drop files to attach
+    </div>
+
+    <form wire:submit="send">
+        {{-- Pending and finished attachments, powered by rich upload objects... --}}
+        <template x-for="file in $wire.attachments" :key="file.name">
+            <div>
+                <img x-show="file.isPreviewable" x-bind:src="file.previewUrl">
+
+                <span x-text="file.name"></span>
+
+                <progress x-show="file.isUploading" x-bind:value="file.progress" max="100"></progress>
+
+                <button type="button" x-on:click="file.remove()">&times;</button>
+            </div>
+        </template>
+
+        <textarea wire:model="message" wire:paste="$upload('attachments')"></textarea>
+
+        <button type="button" wire:click="$upload('attachments', { accept: 'image/*,.pdf' })">
+            Add photos & files
+        </button>
+
+        <button type="submit" x-bind:disabled="$wire.attachments.some(file => file.isUploading)">
+            Send
+        </button>
+    </form>
+</div>
+```
+
+A few things worth noticing:
+
+* `wire:paste` sits on elements — paste events bubble, so placing it on the `<form>` would cover every input inside it
+* `wire:drop.window` accepts drops anywhere on the page, and the `data-dragging` attribute it applies powers the overlay with plain CSS — no JavaScript required
+* The "Add photos & files" button is a real `<button>`, so keyboards and screen readers work for free — no hidden `<input type="file">` hacks
+
+### Options
+
+`$upload` accepts an options object as its final argument:
+
+```blade
+<button type="button" wire:click="$upload('attachments', { accept: 'image/*', multiple: true })">
+    Add photos
+</button>
+```
+
+Option | Description
+--- | ---
+`accept` | Filter incoming files like a native file input's `accept` attribute — comma-separated mime types (with wildcards) or extensions. Applies to pasted and dropped files as well as the file picker
+`multiple` | Whether to accept multiple files. Defaults to `true` when the property currently holds an array, `false` otherwise
+`append` | Whether multiple uploads append to the property's existing files (`true`, the default) or replace them
+
+> [!warning] Client-side filtering is a convenience, not a guard
+> Like a native file input's `accept` attribute, `$upload`'s filtering only improves the experience for honest users. Always enforce file rules with [server-side validation](#file-validation).
+
+### Explicit files and events
+
+`$upload` also accepts files — or an event to pull files from — as its second argument, for when you're wiring things up manually:
+
+```blade
+<textarea x-on:paste="$wire.$upload('photos', $event)"></textarea>
+```
+
 ## Testing file uploads
 
 You can use Laravel's existing file upload testing helpers to test file uploads.
@@ -560,10 +673,33 @@ These functions exist on a JavaScript component object, which can be accessed us
 
 ```blade
 <script>
-    let file = $wire.el.querySelector('input[type="file"]').files[0]
+    // Open the file picker and upload the user's selection...
+    await $wire.$upload('photos')
 
-    // Upload a file...
-    $wire.upload('photo', file, (uploadedFilename) => {
+    // Upload specific File objects (or a FileList, or an array of Files)...
+    await $wire.$upload('photos', files)
+
+    // Pull files out of a paste, drop, or change event...
+    await $wire.$upload('photos', event)
+
+    // Pass picker and filtering options...
+    await $wire.$upload('photos', { accept: 'image/*', multiple: true })
+
+    // Remove single file from multiple uploaded files...
+    $wire.$removeUpload('photos', uploadedFilename)
+
+    // Cancel an upload...
+    $wire.$cancelUpload('photos')
+</script>
+```
+
+`$wire.$upload()` returns a promise that resolves when the upload finishes (or with `null` if the picker is dismissed or the upload is cancelled) and rejects if it fails. For upload state while in flight — progress, previews — read the property's [rich upload objects](#rich-upload-objects-in-javascript) reactively.
+
+The legacy callback signature from earlier versions of Livewire continues to work:
+
+```blade
+<script>
+    $wire.$upload('photo', file, (uploadedFilename) => {
         // Success callback...
     }, () => {
         // Error callback...
@@ -575,13 +711,7 @@ These functions exist on a JavaScript component object, which can be accessed us
     })
 
     // Upload multiple files...
-    $wire.uploadMultiple('photos', [file], successCallback, errorCallback, progressCallback, cancelledCallback)
-
-    // Remove single file from multiple uploaded files...
-    $wire.removeUpload('photos', uploadedFilename, successCallback)
-
-    // Cancel an upload...
-    $wire.cancelUpload('photos')
+    $wire.$uploadMultiple('photos', [file], successCallback, errorCallback, progressCallback, cancelledCallback)
 </script>
 ```
 

--- a/docs/wire-drop.md
+++ b/docs/wire-drop.md
@@ -48,11 +48,11 @@ While files are dragged over the dropzone, Livewire applies a `data-dragging` at
 </div>
 ```
 
-Or target it from a parent using Tailwind's `group` utilities:
+Or target it from a descendant using Tailwind's `in-*` variants:
 
 ```blade
-<div class="group" wire:drop="$upload('photos')">
-    <div class="opacity-0 group-data-dragging:opacity-100">
+<div wire:drop="$upload('photos')">
+    <div class="opacity-0 in-data-dragging:opacity-100">
         Release to upload
     </div>
 </div>
@@ -63,9 +63,9 @@ Or target it from a parent using Tailwind's `group` utilities:
 Chat and editor interfaces often accept drops anywhere in the window rather than on one specific region. Add the `.window` modifier to listen at the window level:
 
 ```blade
-<div class="group" wire:drop.window="$upload('attachments')">
+<div wire:drop.window="$upload('attachments')">
     {{-- A full-screen overlay, shown while files are dragged over the page... --}}
-    <div class="hidden group-data-dragging:grid fixed inset-0 place-items-center bg-black/50 text-white">
+    <div class="hidden in-data-dragging:grid fixed inset-0 place-items-center bg-black/50 text-white">
         Drop files to attach
     </div>
 

--- a/docs/wire-drop.md
+++ b/docs/wire-drop.md
@@ -1,0 +1,86 @@
+
+`wire:drop` turns any element into a dropzone. It listens for files being dragged over the element, reflects the drag state so you can style an overlay, and evaluates its expression when files are dropped.
+
+Unlike a plain `drop` event listener — which the browser never fires unless `dragover` is cancelled by hand — `wire:drop` manages the entire drag lifecycle for you. It also only engages with drags that carry files: dragging selected text across the element does nothing.
+
+## Basic usage
+
+The most common expression is the [`$upload` action](/docs/uploads#uploading-beyond-file-inputs), which uploads the dropped files into a component property:
+
+```php
+<?php // resources/views/components/⚡photo-gallery.blade.php
+
+use Livewire\Attributes\Validate;
+use Livewire\WithFileUploads;
+use Livewire\Component;
+
+new class extends Component {
+    use WithFileUploads;
+
+    #[Validate(['photos.*' => 'image|max:10240'])]
+    public $photos = [];
+};
+```
+
+```blade
+<div wire:drop="$upload('photos')">
+    Drop photos here
+</div>
+```
+
+Dropped files flow through Livewire's standard [file upload pipeline](/docs/uploads) — temporary uploads, validation, previews, and [rich upload objects](/docs/uploads#rich-upload-objects-in-javascript) all work exactly as if the files came from a file input.
+
+The expression is an ordinary action expression, so you can also call your own JavaScript with the drop event available as `$event`:
+
+```blade
+<div wire:drop="handleDrop($event.dataTransfer.files)">
+    Drop files here
+</div>
+```
+
+## Styling the drag state
+
+While files are dragged over the dropzone, Livewire applies a `data-dragging` attribute to the element. Style it with plain CSS — no JavaScript required:
+
+```blade
+<div wire:drop="$upload('photos')" class="border-dashed data-dragging:border-blue-500">
+    Drop photos here
+</div>
+```
+
+Or target it from a parent using Tailwind's `group` utilities:
+
+```blade
+<div class="group" wire:drop="$upload('photos')">
+    <div class="opacity-0 group-data-dragging:opacity-100">
+        Release to upload
+    </div>
+</div>
+```
+
+## Accepting drops anywhere on the page
+
+Chat and editor interfaces often accept drops anywhere in the window rather than on one specific region. Add the `.window` modifier to listen at the window level:
+
+```blade
+<div class="group" wire:drop.window="$upload('attachments')">
+    {{-- A full-screen overlay, shown while files are dragged over the page... --}}
+    <div class="hidden group-data-dragging:grid fixed inset-0 place-items-center bg-black/50 text-white">
+        Drop files to attach
+    </div>
+
+    {{-- ... --}}
+</div>
+```
+
+The `data-dragging` attribute is still applied to the element carrying the directive, so overlays always have a styling anchor.
+
+## Reference
+
+```blade
+wire:drop="expression"
+```
+
+Modifier | Description
+--- | ---
+`.window` | Accept drops anywhere on the page instead of only on this element

--- a/js/$wire.js
+++ b/js/$wire.js
@@ -1,4 +1,4 @@
-import { cancelUpload, removeUpload, upload, uploadMultiple } from './features/supportFileUploads'
+import { cancelUpload, removeUpload, uploadAction, uploadMultiple } from './features/supportFileUploads'
 import { dispatch, dispatchEl, dispatchRef, dispatchSelf, dispatchTo, listen } from '@/events'
 import { generateEntangleFunction } from '@/features/supportEntangle'
 import { findComponentByEl } from '@/store'
@@ -328,7 +328,7 @@ wireProperty('$dispatchSelf', (component) => (...params) => dispatchSelf(compone
 wireProperty('$dispatchTo', () => (...params) => dispatchTo(...params))
 wireProperty('$dispatchEl', (component) => (...params) => dispatchEl(component, ...params))
 wireProperty('$dispatchRef', (component) => (...params) => dispatchRef(component, ...params))
-wireProperty('$upload', (component) => (...params) => upload(component, ...params))
+wireProperty('$upload', (component) => (...params) => uploadAction(component, ...params))
 wireProperty('$uploadMultiple', (component) => (...params) => uploadMultiple(component, ...params))
 wireProperty('$removeUpload', (component) => (...params) => removeUpload(component, ...params))
 wireProperty('$cancelUpload', (component) => (...params) => cancelUpload(component, ...params))

--- a/js/directives/index.js
+++ b/js/directives/index.js
@@ -11,6 +11,7 @@ import './wire-ignore';
 import './wire-cloak';
 import './wire-dirty';
 import './wire-model';
+import './wire-drop';
 import './wire-init';
 import './wire-poll';
 import './wire-show';

--- a/js/directives/wire-drop.js
+++ b/js/directives/wire-drop.js
@@ -1,0 +1,78 @@
+import { callAndClearComponentDebounces } from '@/debounce'
+import { evaluateActionExpression } from '@/evaluator'
+import { setNextActionOrigin } from '@/request'
+import { directive } from '@/directives'
+
+// A first-class dropzone. A plain `drop` listener never fires unless
+// `dragover` is cancelled, so this directive owns the full drag lifecycle:
+// it only engages for drags carrying files (dragging selected text over
+// the element does nothing), reflects the drag state as a `data-dragging`
+// attribute for styling, and evaluates the expression on drop...
+directive('drop', ({ el, directive, component, cleanup }) => {
+    // The `.window` modifier accepts drops anywhere on the page —
+    // `data-dragging` still lands on this element so overlays have
+    // a styling anchor...
+    let target = directive.modifiers.includes('window') ? window : el
+
+    // Drags fire enter/leave pairs for every child element crossed, so
+    // track depth and only clear the attribute when the drag truly leaves...
+    let depth = 0
+
+    let hasFiles = e => e.dataTransfer && Array.from(e.dataTransfer.types || []).includes('Files')
+
+    let clearDragging = () => { depth = 0; el.removeAttribute('data-dragging') }
+
+    let onDragenter = e => {
+        if (! hasFiles(e)) return
+
+        e.preventDefault()
+
+        depth++
+
+        el.setAttribute('data-dragging', '')
+    }
+
+    // Cancelling dragover is what makes the element a valid drop target...
+    let onDragover = e => {
+        if (! hasFiles(e)) return
+
+        e.preventDefault()
+    }
+
+    let onDragleave = e => {
+        if (! hasFiles(e)) return
+
+        depth = Math.max(0, depth - 1)
+
+        if (depth === 0) el.removeAttribute('data-dragging')
+    }
+
+    let onDrop = e => {
+        clearDragging()
+
+        if (! hasFiles(e)) return
+
+        e.preventDefault()
+
+        directive.eventContext = e
+        directive.wire = component.$wire
+
+        callAndClearComponentDebounces(component, () => {
+            setNextActionOrigin({ el, directive })
+
+            evaluateActionExpression(el, directive.expression, { scope: { $event: e } })
+        })
+    }
+
+    target.addEventListener('dragenter', onDragenter)
+    target.addEventListener('dragover', onDragover)
+    target.addEventListener('dragleave', onDragleave)
+    target.addEventListener('drop', onDrop)
+
+    cleanup(() => {
+        target.removeEventListener('dragenter', onDragenter)
+        target.removeEventListener('dragover', onDragover)
+        target.removeEventListener('dragleave', onDragleave)
+        target.removeEventListener('drop', onDrop)
+    })
+})

--- a/js/evaluator.js
+++ b/js/evaluator.js
@@ -78,6 +78,16 @@ export function contextualizeExpression(expression, el) {
         return `___${strings.length - 1}___`
     })
 
+    // 1.5. Skip arrow-function parameters ('file' in 'files.some(file => ...)')
+    //      so they don't get prefixed with $wire...
+    for (let match of result.matchAll(/(\(([^()]*)\)|[a-zA-Z_$][\w$]*)\s*=>/g)) {
+        for (let param of (match[2] ?? match[1]).split(',')) {
+            let name = param.replace(/[{}\[\]]/g, '').trim().split(/[=:\s]/)[0]
+
+            if (name && ! SKIP.includes(name)) SKIP.push(name)
+        }
+    }
+
     // 2. Prefix identifiers not after a dot (skip placeholders from step 1)
     //    Also skip object keys (identifiers immediately followed by colon)
     result = result.replace(/(^|[^.\w$])(\$?[a-zA-Z_]\w*)/g, (m, pre, ident, offset) => {

--- a/js/evaluator.spec.js
+++ b/js/evaluator.spec.js
@@ -39,6 +39,13 @@ describe('Contextualize expressions', () => {
         expect(contextualizeExpression("{ fooBar: foo }")).toBe('{ fooBar: $wire.foo }')
     })
 
+    it('arrow function parameters', () => {
+        expect(contextualizeExpression('files.some(file => file.isUploading)')).toBe('$wire.files.some(file => file.isUploading)')
+        expect(contextualizeExpression('files.map((file, index) => file.name + index)')).toBe('$wire.files.map((file, index) => file.name + index)')
+        expect(contextualizeExpression('files.filter(file => file.size > threshold)')).toBe('$wire.files.filter(file => file.size > $wire.threshold)')
+        expect(contextualizeExpression('items.map(({ id }) => id)')).toBe('$wire.items.map(({ id }) => id)')
+    })
+
     it('alpine scope variables are skipped', () => {
         let mockEl = {
             _x_dataStack: [{ user: {}, index: 0 }],

--- a/js/features/supportFileUploads/action.js
+++ b/js/features/supportFileUploads/action.js
@@ -114,7 +114,7 @@ function uploadFiles(component, name, files, options, callbacks) {
     if (! multiple) files = files.slice(0, 1)
 
     return new Promise((resolve, reject) => {
-        let finish = result => { callbacks.finish(result); resolve(result) }
+        let finish = result => { callbacks.finish(result); resolve(uploadedObjects(component, name, multiple, result)) }
         let error = () => { callbacks.error(); reject(new Error(`Livewire upload to [${name}] failed`)) }
         let cancelled = () => { callbacks.cancelled(); resolve(null) }
 
@@ -124,6 +124,20 @@ function uploadFiles(component, name, files, options, callbacks) {
             manager.upload(name, files[0], finish, error, callbacks.progress, cancelled)
         }
     })
+}
+
+// Resolve the promise with the reactive rich upload object(s) now living
+// on the property, mirroring the upload's shape: a single upload resolves
+// one object, a multiple upload resolves an array holding just this
+// batch (not the property's previously uploaded files)...
+function uploadedObjects(component, name, multiple, tmpFilenames) {
+    let value = dataGet(component.reactive, name)
+
+    if (! multiple) return value
+
+    let filenames = Array.isArray(tmpFilenames) ? tmpFilenames : [tmpFilenames]
+
+    return (value || []).filter(upload => filenames.includes(upload?.filename))
 }
 
 // Open the browser's file picker and resolve with the chosen files

--- a/js/features/supportFileUploads/action.js
+++ b/js/features/supportFileUploads/action.js
@@ -1,0 +1,187 @@
+import { getUploadManager } from './manager'
+import { dataGet } from '@/utils'
+
+// The smart `$upload` action behind `$wire.$upload()` and template
+// expressions like `wire:paste="$upload('photos')"`. Files are acquired
+// from the first available source:
+//
+//   1. An explicit argument (a File, FileList, array of Files, or an Event)
+//   2. The DOM event currently being dispatched (pasted files, dropped
+//      files, or a file input's selection)
+//   3. The user — via the browser's file picker
+//
+// A file-capable event that carries no files (a plain text paste, a text
+// drag) is a no-op, so it never hijacks the browser's default behavior...
+export function uploadAction(component, name, ...args) {
+    let { files, event, options, callbacks } = parseArguments(args)
+
+    let promise
+
+    if (! files && ! event) {
+        // No explicit source — inherit the event currently being
+        // dispatched, if there is one...
+        event = window.event
+
+        files = filesFromEvent(event)
+    }
+
+    if (files) {
+        // Suppress the event's default behavior only when we're actually
+        // consuming its files — a text paste must proceed untouched...
+        if (event && files.length > 0) event.preventDefault()
+
+        promise = uploadFiles(component, name, files, options, callbacks)
+    } else {
+        promise = openFilePicker(component, name, options).then(pickedFiles => {
+            if (pickedFiles.length === 0) {
+                callbacks.cancelled()
+
+                return null
+            }
+
+            return uploadFiles(component, name, pickedFiles, options, callbacks)
+        })
+    }
+
+    return markAsAction(promise)
+}
+
+function parseArguments(args) {
+    let files = null
+    let event = null
+    let options = {}
+    let callbacks = {}
+
+    let [second, ...rest] = args
+
+    if (second instanceof Event) {
+        event = second
+
+        files = filesFromEvent(second) || []
+    } else if (typeof File !== 'undefined' && second instanceof File) {
+        files = [second]
+    } else if (typeof FileList !== 'undefined' && second instanceof FileList) {
+        files = Array.from(second)
+    } else if (Array.isArray(second)) {
+        files = second
+    } else if (isPlainObject(second)) {
+        options = second
+    }
+
+    // Legacy signature: $upload(name, file, finish, error, progress, cancelled)...
+    if (typeof rest[0] === 'function') {
+        let [finish, error, progress, cancelled] = rest
+
+        callbacks = { finish, error, progress, cancelled }
+    } else if (isPlainObject(rest[0])) {
+        options = rest[0]
+    }
+
+    callbacks.finish ??= () => {}
+    callbacks.error ??= () => {}
+    callbacks.progress ??= () => {}
+    callbacks.cancelled ??= () => {}
+
+    return { files, event, options, callbacks }
+}
+
+// Pull files out of a paste, drop, or file-input change event. Returns
+// null for events that can't carry files (like clicks), so callers can
+// fall back to opening the file picker...
+function filesFromEvent(event) {
+    if (! event) return null
+
+    let source = event.clipboardData || event.dataTransfer || (event.target?.files ? event.target : null)
+
+    if (! source) return null
+
+    let files = Array.from(source.files || [])
+
+    return files
+}
+
+function uploadFiles(component, name, files, options, callbacks) {
+    let manager = getUploadManager(component)
+
+    let multiple = options.multiple ?? Array.isArray(dataGet(component.ephemeral, name))
+
+    if (options.accept) {
+        files = files.filter(file => matchesAccept(file, options.accept))
+    }
+
+    if (files.length === 0) return Promise.resolve(null)
+
+    if (! multiple) files = files.slice(0, 1)
+
+    return new Promise((resolve, reject) => {
+        let finish = result => { callbacks.finish(result); resolve(result) }
+        let error = () => { callbacks.error(); reject(new Error(`Livewire upload to [${name}] failed`)) }
+        let cancelled = () => { callbacks.cancelled(); resolve(null) }
+
+        if (multiple) {
+            manager.uploadMultiple(name, files, finish, error, callbacks.progress, cancelled, options.append ?? true)
+        } else {
+            manager.upload(name, files[0], finish, error, callbacks.progress, cancelled)
+        }
+    })
+}
+
+// Open the browser's file picker and resolve with the chosen files
+// (or an empty array if the dialog is dismissed)...
+function openFilePicker(component, name, options) {
+    return new Promise(resolve => {
+        let input = document.createElement('input')
+
+        input.type = 'file'
+        input.style.display = 'none'
+        input.setAttribute('data-livewire-picker', name)
+
+        if (options.accept) input.accept = options.accept
+        if (options.multiple ?? Array.isArray(dataGet(component.ephemeral, name))) input.multiple = true
+
+        let settle = files => { input.remove(); resolve(files) }
+
+        input.addEventListener('change', () => settle(Array.from(input.files)))
+        input.addEventListener('cancel', () => settle([]))
+
+        // Some browsers require the input to be in the document for the
+        // picker to open...
+        document.body.appendChild(input)
+
+        input.click()
+    })
+}
+
+// Match a file against an `accept` string the same way a native file
+// input does: comma-separated mime types (with wildcards) or extensions...
+function matchesAccept(file, accept) {
+    let patterns = accept.split(',').map(pattern => pattern.trim().toLowerCase()).filter(Boolean)
+
+    if (patterns.length === 0) return true
+
+    let type = (file.type || '').toLowerCase()
+    let extension = '.' + file.name.split('.').pop().toLowerCase()
+
+    return patterns.some(pattern => {
+        if (pattern.startsWith('.')) return extension === pattern
+
+        if (pattern.endsWith('/*')) return type.startsWith(pattern.slice(0, -1))
+
+        return type === pattern
+    })
+}
+
+function isPlainObject(value) {
+    return typeof value === 'object' && value !== null && value.constructor === Object
+}
+
+// Flag the promise so action expressions silence rejections (upload
+// failures surface as validation errors on the component), while JS
+// callers who await the promise still get them...
+function markAsAction(promise) {
+    promise._livewireAction = true
+
+    promise.catch(() => {})
+
+    return promise
+}

--- a/js/features/supportFileUploads/index.js
+++ b/js/features/supportFileUploads/index.js
@@ -1,6 +1,8 @@
 import { getUploadManager, MessageBag } from './manager'
 import './synth'
 
+export { uploadAction } from './action'
+
 export function handleFileUpload(el, property, component, cleanup) {
     let manager = getUploadManager(component)
 
@@ -73,27 +75,6 @@ export function handleFileUpload(el, property, component, cleanup) {
 }
 
 export default MessageBag
-
-export function upload(
-    component,
-    name,
-    file,
-    finishCallback = () => { },
-    errorCallback = () => { },
-    progressCallback = () => { },
-    cancelledCallback = () => { },
-) {
-    let uploadManager = getUploadManager(component)
-
-    uploadManager.upload(
-        name,
-        file,
-        finishCallback,
-        errorCallback,
-        progressCallback,
-        cancelledCallback,
-    )
-}
 
 export function uploadMultiple(
     component,

--- a/src/Features/SupportFileUploads/UploadActionBrowserTest.php
+++ b/src/Features/SupportFileUploads/UploadActionBrowserTest.php
@@ -1,0 +1,329 @@
+<?php
+
+namespace Livewire\Features\SupportFileUploads;
+
+use Livewire\WithFileUploads;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class UploadActionBrowserTest extends \Tests\BrowserTestCase
+{
+    public function test_paste_uploads_files_from_the_clipboard()
+    {
+        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $body = '';
+            public $photos = [];
+
+            function render() { return <<<'HTML'
+            <div>
+                <textarea dusk="box" wire:model="body" wire:paste="$upload('photos')"></textarea>
+
+                <span dusk="name" x-text="$wire.photos[0]?.name"></span>
+                <span dusk="status" x-text="$wire.photos[0] ? ($wire.photos[0].isUploading ? 'uploading' : 'finished') : 'empty'"></span>
+            </div>
+            HTML; }
+        })
+        ->assertSeeIn('@status', 'empty')
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            let data = new DataTransfer()
+            data.items.add(new File(['fake-image-content'], 'pasted.png', { type: 'image/png' }))
+
+            document.querySelector('[dusk="box"]').dispatchEvent(
+                new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true })
+            )
+        JS))
+        ->waitForTextIn('@name', 'pasted.png')
+        ->waitForTextIn('@status', 'finished')
+        ;
+    }
+
+    public function test_text_pastes_are_left_alone()
+    {
+        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $body = '';
+            public $photos = [];
+
+            function render() { return <<<'HTML'
+            <div>
+                <textarea dusk="box" wire:model="body" wire:paste="$upload('photos')"></textarea>
+
+                <span dusk="count" x-text="$wire.photos.length"></span>
+            </div>
+            HTML; }
+        })
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            let data = new DataTransfer()
+            data.setData('text/plain', 'just some text')
+
+            let event = new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true })
+
+            document.querySelector('[dusk="box"]').dispatchEvent(event)
+
+            window.__pasteDefaultPrevented = event.defaultPrevented
+        JS))
+        ->pause(300)
+        ->assertSeeIn('@count', '0')
+        // A text paste must never be hijacked from the browser...
+        ->waitUntil('window.__pasteDefaultPrevented === false')
+        ;
+    }
+
+    public function test_drop_uploads_dropped_files_and_tracks_drag_state()
+    {
+        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photos = [];
+
+            function render() { return <<<'HTML'
+            <div>
+                <div dusk="zone" wire:drop="$upload('photos')">Drop files here</div>
+
+                <span dusk="name" x-text="$wire.photos[0]?.name"></span>
+                <span dusk="status" x-text="$wire.photos[0] ? ($wire.photos[0].isUploading ? 'uploading' : 'finished') : 'empty'"></span>
+            </div>
+            HTML; }
+        })
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            window.__zone = document.querySelector('[dusk="zone"]')
+
+            window.__fileDrag = type => {
+                let data = new DataTransfer()
+                data.items.add(new File(['fake-image-content'], 'dropped.png', { type: 'image/png' }))
+
+                return new DragEvent(type, { dataTransfer: data, bubbles: true, cancelable: true })
+            }
+
+            window.__zone.dispatchEvent(window.__fileDrag('dragenter'))
+        JS))
+        // A file drag over the zone reflects as data-dragging...
+        ->waitUntil('document.querySelector(\'[dusk="zone"]\').hasAttribute(\'data-dragging\')')
+        ->tap(fn ($b) => $b->script('window.__zone.dispatchEvent(window.__fileDrag("dragleave"))'))
+        ->waitUntil('! document.querySelector(\'[dusk="zone"]\').hasAttribute(\'data-dragging\')')
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            window.__zone.dispatchEvent(window.__fileDrag('dragenter'))
+            window.__zone.dispatchEvent(window.__fileDrag('drop'))
+        JS))
+        ->waitUntil('! document.querySelector(\'[dusk="zone"]\').hasAttribute(\'data-dragging\')')
+        ->waitForTextIn('@name', 'dropped.png')
+        ->waitForTextIn('@status', 'finished')
+        ;
+    }
+
+    public function test_text_drags_are_ignored_by_dropzones()
+    {
+        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photos = [];
+
+            function render() { return <<<'HTML'
+            <div>
+                <div dusk="zone" wire:drop="$upload('photos')">Drop files here</div>
+
+                <span dusk="count" x-text="$wire.photos.length"></span>
+            </div>
+            HTML; }
+        })
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            let data = new DataTransfer()
+            data.setData('text/plain', 'dragged text')
+
+            document.querySelector('[dusk="zone"]').dispatchEvent(
+                new DragEvent('dragenter', { dataTransfer: data, bubbles: true, cancelable: true })
+            )
+        JS))
+        ->pause(300)
+        ->assertAttributeMissing('@zone', 'data-dragging')
+        ->assertSeeIn('@count', '0')
+        ;
+    }
+
+    public function test_window_modifier_accepts_drops_anywhere_on_the_page()
+    {
+        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photos = [];
+
+            function render() { return <<<'HTML'
+            <div>
+                <div dusk="overlay" wire:drop.window="$upload('photos')">Drop anywhere</div>
+
+                <p dusk="outside">Somewhere else entirely on the page</p>
+
+                <span dusk="name" x-text="$wire.photos[0]?.name"></span>
+            </div>
+            HTML; }
+        })
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            let data = new DataTransfer()
+            data.items.add(new File(['fake-image-content'], 'window-dropped.png', { type: 'image/png' }))
+
+            let outside = document.querySelector('[dusk="outside"]')
+
+            outside.dispatchEvent(new DragEvent('dragenter', { dataTransfer: data, bubbles: true, cancelable: true }))
+
+            window.__draggingDuringDrag = document.querySelector('[dusk="overlay"]').hasAttribute('data-dragging')
+
+            outside.dispatchEvent(new DragEvent('drop', { dataTransfer: data, bubbles: true, cancelable: true }))
+        JS))
+        // The drag state lands on the directive's element, not the drop target...
+        ->waitUntil('window.__draggingDuringDrag === true')
+        ->waitForTextIn('@name', 'window-dropped.png')
+        ;
+    }
+
+    public function test_click_opens_the_file_picker_and_uploads_the_selection()
+    {
+        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photos = [];
+
+            function render() { return <<<'HTML'
+            <div>
+                <button dusk="add" type="button" wire:click="$upload('photos')">Add files</button>
+
+                <span dusk="name" x-text="$wire.photos[0]?.name"></span>
+            </div>
+            HTML; }
+        })
+        // Headless Chrome auto-dismisses file choosers (firing `cancel`, which
+        // cleans the picker input up before we can reach it) — intercept the
+        // chooser so the input stays put and we can deliver a selection the
+        // way the OS dialog would...
+        ->tap(fn ($b) => $b->driver->executeCustomCommand(
+            '/session/:sessionId/goog/cdp/execute',
+            'POST',
+            ['cmd' => 'Page.setInterceptFileChooserDialog', 'params' => ['enabled' => true]],
+        ))
+        ->click('@add')
+        ->waitUntil('document.querySelector(\'input[data-livewire-picker="photos"]\') !== null')
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            let input = document.querySelector('input[data-livewire-picker="photos"]')
+
+            window.__pickerWasMultiple = input.multiple
+
+            let data = new DataTransfer()
+            data.items.add(new File(['fake-image-content'], 'picked.png', { type: 'image/png' }))
+
+            input.files = data.files
+
+            input.dispatchEvent(new Event('change'))
+        JS))
+        ->waitForTextIn('@name', 'picked.png')
+        // An array property implies a multiple-file picker...
+        ->waitUntil('window.__pickerWasMultiple === true')
+        // The picker input cleans up after itself...
+        ->waitUntil('document.querySelector(\'input[data-livewire-picker]\') === null')
+        ;
+    }
+
+    public function test_accept_option_filters_incoming_files()
+    {
+        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photos = [];
+
+            function render() { return <<<'HTML'
+            <div>
+                <div dusk="zone" wire:drop="$upload('photos', { accept: 'image/*' })">Drop images here</div>
+
+                <span dusk="count" x-text="$wire.photos.length"></span>
+                <span dusk="name" x-text="$wire.photos[0]?.name"></span>
+            </div>
+            HTML; }
+        })
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            let data = new DataTransfer()
+            data.items.add(new File(['not-an-image'], 'notes.txt', { type: 'text/plain' }))
+            data.items.add(new File(['fake-image-content'], 'photo.png', { type: 'image/png' }))
+
+            document.querySelector('[dusk="zone"]').dispatchEvent(
+                new DragEvent('drop', { dataTransfer: data, bubbles: true, cancelable: true })
+            )
+        JS))
+        ->waitForTextIn('@name', 'photo.png')
+        ->waitUntil('document.querySelector(\'[dusk="count"]\').textContent === "1"')
+        ;
+    }
+
+    public function test_single_file_property_takes_only_the_first_file()
+    {
+        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photo;
+
+            function render() { return <<<'HTML'
+            <div>
+                <div dusk="zone" wire:drop="$upload('photo')">Drop a file here</div>
+
+                <span dusk="name" x-text="$wire.photo?.name"></span>
+            </div>
+            HTML; }
+        })
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            let data = new DataTransfer()
+            data.items.add(new File(['fake-image-content'], 'first.png', { type: 'image/png' }))
+            data.items.add(new File(['fake-image-content'], 'second.png', { type: 'image/png' }))
+
+            document.querySelector('[dusk="zone"]').dispatchEvent(
+                new DragEvent('drop', { dataTransfer: data, bubbles: true, cancelable: true })
+            )
+        JS))
+        ->waitForTextIn('@name', 'first.png')
+        ;
+    }
+
+    public function test_legacy_upload_callback_signature_still_works()
+    {
+        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photo;
+
+            function render() { return <<<'HTML'
+            <div>
+                <span dusk="name" x-text="$wire.photo?.name"></span>
+            </div>
+            HTML; }
+        })
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            let component = window.Livewire.all()[0]
+
+            component.$wire.$upload(
+                'photo',
+                new File(['fake-image-content'], 'legacy.png', { type: 'image/png' }),
+                () => window.__legacyFinished = true
+            )
+        JS))
+        ->waitForTextIn('@name', 'legacy.png')
+        ->waitUntil('window.__legacyFinished === true')
+        ;
+    }
+}

--- a/src/Features/SupportFileUploads/UploadActionBrowserTest.php
+++ b/src/Features/SupportFileUploads/UploadActionBrowserTest.php
@@ -2,15 +2,24 @@
 
 namespace Livewire\Features\SupportFileUploads;
 
+use Illuminate\Support\Facades\Storage;
+use Facebook\WebDriver\WebDriverKeys;
 use Livewire\WithFileUploads;
 use Livewire\Component;
 use Livewire\Livewire;
 
+/**
+ * These tests drive real browser input wherever the platform allows it:
+ * real clipboard contents delivered by real paste keystrokes, browser-
+ * generated drag events carrying real files from disk (via CDP), and a
+ * real click opening a real file chooser. The JS-door tests construct
+ * File objects directly because that IS how the JS API is used.
+ */
 class UploadActionBrowserTest extends \Tests\BrowserTestCase
 {
     public function test_paste_uploads_files_from_the_clipboard()
     {
-        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+        Storage::persistentFake('tmp-for-tests');
 
         Livewire::visit(new class extends Component {
             use WithFileUploads;
@@ -28,22 +37,18 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
             HTML; }
         })
         ->assertSeeIn('@status', 'empty')
-        ->tap(fn ($b) => $b->script(<<<'JS'
-            let data = new DataTransfer()
-            data.items.add(new File(['fake-image-content'], 'pasted.png', { type: 'image/png' }))
-
-            document.querySelector('[dusk="box"]').dispatchEvent(
-                new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true })
-            )
-        JS))
-        ->waitForTextIn('@name', 'pasted.png')
+        ->tap(fn ($b) => $this->putImageOnClipboard($b))
+        ->click('@box')
+        ->keys('@box', [$this->pasteChord(), 'v'])
+        // Chrome names pasted image data "image.png"...
+        ->waitForTextIn('@name', 'image.png')
         ->waitForTextIn('@status', 'finished')
         ;
     }
 
     public function test_text_pastes_are_left_alone()
     {
-        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+        Storage::persistentFake('tmp-for-tests');
 
         Livewire::visit(new class extends Component {
             use WithFileUploads;
@@ -59,26 +64,18 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
             </div>
             HTML; }
         })
-        ->tap(fn ($b) => $b->script(<<<'JS'
-            let data = new DataTransfer()
-            data.setData('text/plain', 'just some text')
-
-            let event = new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true })
-
-            document.querySelector('[dusk="box"]').dispatchEvent(event)
-
-            window.__pasteDefaultPrevented = event.defaultPrevented
-        JS))
-        ->pause(300)
+        ->tap(fn ($b) => $this->putTextOnClipboard($b, 'just some text'))
+        ->click('@box')
+        ->keys('@box', [$this->pasteChord(), 'v'])
+        // The browser's default paste must actually happen...
+        ->waitUntil('document.querySelector(\'[dusk="box"]\').value === "just some text"')
         ->assertSeeIn('@count', '0')
-        // A text paste must never be hijacked from the browser...
-        ->waitUntil('window.__pasteDefaultPrevented === false')
         ;
     }
 
     public function test_drop_uploads_dropped_files_and_tracks_drag_state()
     {
-        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+        Storage::persistentFake('tmp-for-tests');
 
         Livewire::visit(new class extends Component {
             use WithFileUploads;
@@ -87,42 +84,33 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
 
             function render() { return <<<'HTML'
             <div>
-                <div dusk="zone" wire:drop="$upload('photos')">Drop files here</div>
+                <div dusk="zone" wire:drop="$upload('photos')" style="width: 300px; height: 100px">Drop files here</div>
+
+                <div dusk="elsewhere" style="width: 300px; height: 100px">Somewhere else</div>
 
                 <span dusk="name" x-text="$wire.photos[0]?.name"></span>
                 <span dusk="status" x-text="$wire.photos[0] ? ($wire.photos[0].isUploading ? 'uploading' : 'finished') : 'empty'"></span>
             </div>
             HTML; }
         })
-        ->tap(fn ($b) => $b->script(<<<'JS'
-            window.__zone = document.querySelector('[dusk="zone"]')
-
-            window.__fileDrag = type => {
-                let data = new DataTransfer()
-                data.items.add(new File(['fake-image-content'], 'dropped.png', { type: 'image/png' }))
-
-                return new DragEvent(type, { dataTransfer: data, bubbles: true, cancelable: true })
-            }
-
-            window.__zone.dispatchEvent(window.__fileDrag('dragenter'))
-        JS))
-        // A file drag over the zone reflects as data-dragging...
+        // Drag a real file over the zone...
+        ->tap(fn ($b) => $this->dragFileOver($b, '@zone', [__DIR__.'/browser_test_image.png']))
         ->waitUntil('document.querySelector(\'[dusk="zone"]\').hasAttribute(\'data-dragging\')')
-        ->tap(fn ($b) => $b->script('window.__zone.dispatchEvent(window.__fileDrag("dragleave"))'))
+        // Drag it away — the browser generates the real dragleave...
+        ->tap(fn ($b) => $this->dragFileOver($b, '@elsewhere', [__DIR__.'/browser_test_image.png']))
         ->waitUntil('! document.querySelector(\'[dusk="zone"]\').hasAttribute(\'data-dragging\')')
-        ->tap(fn ($b) => $b->script(<<<'JS'
-            window.__zone.dispatchEvent(window.__fileDrag('dragenter'))
-            window.__zone.dispatchEvent(window.__fileDrag('drop'))
-        JS))
+        // Drag back and drop...
+        ->tap(fn ($b) => $this->dragFileOver($b, '@zone', [__DIR__.'/browser_test_image.png']))
+        ->tap(fn ($b) => $this->dropFiles($b, '@zone', [__DIR__.'/browser_test_image.png']))
         ->waitUntil('! document.querySelector(\'[dusk="zone"]\').hasAttribute(\'data-dragging\')')
-        ->waitForTextIn('@name', 'dropped.png')
+        ->waitForTextIn('@name', 'browser_test_image.png')
         ->waitForTextIn('@status', 'finished')
         ;
     }
 
     public function test_text_drags_are_ignored_by_dropzones()
     {
-        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+        Storage::persistentFake('tmp-for-tests');
 
         Livewire::visit(new class extends Component {
             use WithFileUploads;
@@ -131,20 +119,14 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
 
             function render() { return <<<'HTML'
             <div>
-                <div dusk="zone" wire:drop="$upload('photos')">Drop files here</div>
+                <div dusk="zone" wire:drop="$upload('photos')" style="width: 300px; height: 100px">Drop files here</div>
 
                 <span dusk="count" x-text="$wire.photos.length"></span>
             </div>
             HTML; }
         })
-        ->tap(fn ($b) => $b->script(<<<'JS'
-            let data = new DataTransfer()
-            data.setData('text/plain', 'dragged text')
-
-            document.querySelector('[dusk="zone"]').dispatchEvent(
-                new DragEvent('dragenter', { dataTransfer: data, bubbles: true, cancelable: true })
-            )
-        JS))
+        // A drag carrying only text (no files) over the zone...
+        ->tap(fn ($b) => $this->dispatchDrag($b, 'dragEnter', '@zone', [], [['mimeType' => 'text/plain', 'data' => 'dragged text']]))
         ->pause(300)
         ->assertAttributeMissing('@zone', 'data-dragging')
         ->assertSeeIn('@count', '0')
@@ -153,7 +135,7 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
 
     public function test_window_modifier_accepts_drops_anywhere_on_the_page()
     {
-        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+        Storage::persistentFake('tmp-for-tests');
 
         Livewire::visit(new class extends Component {
             use WithFileUploads;
@@ -164,33 +146,24 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
             <div>
                 <div dusk="overlay" wire:drop.window="$upload('photos')">Drop anywhere</div>
 
-                <p dusk="outside">Somewhere else entirely on the page</p>
+                <p dusk="outside" style="margin-top: 100px">Somewhere else entirely on the page</p>
 
                 <span dusk="name" x-text="$wire.photos[0]?.name"></span>
             </div>
             HTML; }
         })
-        ->tap(fn ($b) => $b->script(<<<'JS'
-            let data = new DataTransfer()
-            data.items.add(new File(['fake-image-content'], 'window-dropped.png', { type: 'image/png' }))
-
-            let outside = document.querySelector('[dusk="outside"]')
-
-            outside.dispatchEvent(new DragEvent('dragenter', { dataTransfer: data, bubbles: true, cancelable: true }))
-
-            window.__draggingDuringDrag = document.querySelector('[dusk="overlay"]').hasAttribute('data-dragging')
-
-            outside.dispatchEvent(new DragEvent('drop', { dataTransfer: data, bubbles: true, cancelable: true }))
-        JS))
-        // The drag state lands on the directive's element, not the drop target...
-        ->waitUntil('window.__draggingDuringDrag === true')
-        ->waitForTextIn('@name', 'window-dropped.png')
+        // Drag over an element that is NOT the directive's element...
+        ->tap(fn ($b) => $this->dragFileOver($b, '@outside', [__DIR__.'/browser_test_image.png']))
+        // The drag state lands on the directive's element...
+        ->waitUntil('document.querySelector(\'[dusk="overlay"]\').hasAttribute(\'data-dragging\')')
+        ->tap(fn ($b) => $this->dropFiles($b, '@outside', [__DIR__.'/browser_test_image.png']))
+        ->waitForTextIn('@name', 'browser_test_image.png')
         ;
     }
 
     public function test_click_opens_the_file_picker_and_uploads_the_selection()
     {
-        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+        Storage::persistentFake('tmp-for-tests');
 
         Livewire::visit(new class extends Component {
             use WithFileUploads;
@@ -206,30 +179,17 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
             HTML; }
         })
         // Headless Chrome auto-dismisses file choosers (firing `cancel`, which
-        // cleans the picker input up before we can reach it) — intercept the
-        // chooser so the input stays put and we can deliver a selection the
-        // way the OS dialog would...
-        ->tap(fn ($b) => $b->driver->executeCustomCommand(
-            '/session/:sessionId/goog/cdp/execute',
-            'POST',
-            ['cmd' => 'Page.setInterceptFileChooserDialog', 'params' => ['enabled' => true]],
-        ))
+        // cleans the picker input up before a selection can happen) — intercept
+        // the chooser so the dialog stays "open"...
+        ->tap(fn ($b) => $this->cdp($b, 'Page.setInterceptFileChooserDialog', ['enabled' => true]))
         ->click('@add')
         ->waitUntil('document.querySelector(\'input[data-livewire-picker="photos"]\') !== null')
-        ->tap(fn ($b) => $b->script(<<<'JS'
-            let input = document.querySelector('input[data-livewire-picker="photos"]')
-
-            window.__pickerWasMultiple = input.multiple
-
-            let data = new DataTransfer()
-            data.items.add(new File(['fake-image-content'], 'picked.png', { type: 'image/png' }))
-
-            input.files = data.files
-
-            input.dispatchEvent(new Event('change'))
-        JS))
-        ->waitForTextIn('@name', 'picked.png')
         // An array property implies a multiple-file picker...
+        ->tap(fn ($b) => $b->script('window.__pickerWasMultiple = document.querySelector(\'input[data-livewire-picker]\').multiple'))
+        // Deliver the selection the way Chrome's own automation does — a real
+        // file from disk, with the browser firing the trusted change event...
+        ->tap(fn ($b) => $this->chooseFilesInPicker($b, [__DIR__.'/browser_test_image.png']))
+        ->waitForTextIn('@name', 'browser_test_image.png')
         ->waitUntil('window.__pickerWasMultiple === true')
         // The picker input cleans up after itself...
         ->waitUntil('document.querySelector(\'input[data-livewire-picker]\') === null')
@@ -238,7 +198,7 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
 
     public function test_accept_option_filters_incoming_files()
     {
-        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+        Storage::persistentFake('tmp-for-tests');
 
         Livewire::visit(new class extends Component {
             use WithFileUploads;
@@ -247,30 +207,25 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
 
             function render() { return <<<'HTML'
             <div>
-                <div dusk="zone" wire:drop="$upload('photos', { accept: 'image/*' })">Drop images here</div>
+                <div dusk="zone" wire:drop="$upload('photos', { accept: 'image/*' })" style="width: 300px; height: 100px">Drop images here</div>
 
                 <span dusk="count" x-text="$wire.photos.length"></span>
                 <span dusk="name" x-text="$wire.photos[0]?.name"></span>
             </div>
             HTML; }
         })
-        ->tap(fn ($b) => $b->script(<<<'JS'
-            let data = new DataTransfer()
-            data.items.add(new File(['not-an-image'], 'notes.txt', { type: 'text/plain' }))
-            data.items.add(new File(['fake-image-content'], 'photo.png', { type: 'image/png' }))
-
-            document.querySelector('[dusk="zone"]').dispatchEvent(
-                new DragEvent('drop', { dataTransfer: data, bubbles: true, cancelable: true })
-            )
-        JS))
-        ->waitForTextIn('@name', 'photo.png')
+        ->tap(fn ($b) => $this->dropFiles($b, '@zone', [
+            __DIR__.'/browser_test_document.txt',
+            __DIR__.'/browser_test_image.png',
+        ]))
+        ->waitForTextIn('@name', 'browser_test_image.png')
         ->waitUntil('document.querySelector(\'[dusk="count"]\').textContent === "1"')
         ;
     }
 
     public function test_single_file_property_takes_only_the_first_file()
     {
-        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+        Storage::persistentFake('tmp-for-tests');
 
         Livewire::visit(new class extends Component {
             use WithFileUploads;
@@ -279,28 +234,68 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
 
             function render() { return <<<'HTML'
             <div>
-                <div dusk="zone" wire:drop="$upload('photo')">Drop a file here</div>
+                <div dusk="zone" wire:drop="$upload('photo')" style="width: 300px; height: 100px">Drop a file here</div>
 
                 <span dusk="name" x-text="$wire.photo?.name"></span>
             </div>
             HTML; }
         })
-        ->tap(fn ($b) => $b->script(<<<'JS'
-            let data = new DataTransfer()
-            data.items.add(new File(['fake-image-content'], 'first.png', { type: 'image/png' }))
-            data.items.add(new File(['fake-image-content'], 'second.png', { type: 'image/png' }))
+        ->tap(fn ($b) => $this->dropFiles($b, '@zone', [
+            __DIR__.'/browser_test_image.png',
+            __DIR__.'/browser_test_image2.png',
+        ]))
+        ->waitForTextIn('@name', 'browser_test_image.png')
+        ;
+    }
 
-            document.querySelector('[dusk="zone"]').dispatchEvent(
-                new DragEvent('drop', { dataTransfer: data, bubbles: true, cancelable: true })
-            )
+    public function test_upload_promise_resolves_with_rich_upload_objects()
+    {
+        Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photo;
+            public $photos = [];
+
+            function render() { return <<<'HTML'
+            <div>
+                <span dusk="name" x-text="$wire.photo?.name"></span>
+            </div>
+            HTML; }
+        })
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            (async () => {
+                let $wire = window.Livewire.all()[0].$wire
+
+                // A real 1x1 PNG, so the server's mime-sniffing marks it previewable...
+                let png = () => Uint8Array.from(atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='), c => c.charCodeAt(0))
+
+                // A single upload resolves the property's rich upload object...
+                let photo = await $wire.$upload('photo', new File([png()], 'awaited.png', { type: 'image/png' }))
+
+                // A multiple upload resolves an array holding just this batch...
+                let batch = await $wire.$upload('photos', [
+                    new File([png()], 'one.png', { type: 'image/png' }),
+                    new File([png()], 'two.png', { type: 'image/png' }),
+                ])
+
+                window.__resolved = {
+                    single: { name: photo.name, isUploading: photo.isUploading, previewable: photo.isPreviewable },
+                    batch: batch.map(upload => upload.name),
+                }
+            })()
         JS))
-        ->waitForTextIn('@name', 'first.png')
+        ->waitUntil('window.__resolved !== undefined')
+        ->waitUntil('window.__resolved.single.name === "awaited.png" && window.__resolved.single.isUploading === false')
+        ->waitUntil('JSON.stringify(window.__resolved.batch) === \'["one.png","two.png"]\'')
+        ->assertScript('window.__resolved.single.previewable', true)
         ;
     }
 
     public function test_legacy_upload_callback_signature_still_works()
     {
-        \Illuminate\Support\Facades\Storage::persistentFake('tmp-for-tests');
+        Storage::persistentFake('tmp-for-tests');
 
         Livewire::visit(new class extends Component {
             use WithFileUploads;
@@ -325,5 +320,107 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
         ->waitForTextIn('@name', 'legacy.png')
         ->waitUntil('window.__legacyFinished === true')
         ;
+    }
+
+    // ─── Real-input helpers ─────────────────────────────────────────────
+
+    protected function cdp($browser, $command, $params = [])
+    {
+        return $browser->driver->executeCustomCommand(
+            '/session/:sessionId/goog/cdp/execute',
+            'POST',
+            ['cmd' => $command, 'params' => (object) $params],
+        );
+    }
+
+    protected function pasteChord()
+    {
+        return PHP_OS_FAMILY === 'Darwin' ? WebDriverKeys::COMMAND : WebDriverKeys::CONTROL;
+    }
+
+    // Write a real PNG to the browser's actual clipboard so a real paste
+    // keystroke delivers it as a trusted event...
+    protected function putImageOnClipboard($browser)
+    {
+        $this->cdp($browser, 'Browser.grantPermissions', ['permissions' => ['clipboardReadWrite', 'clipboardSanitizedWrite']]);
+
+        $browser->script(<<<'JS'
+            (async () => {
+                let canvas = document.createElement('canvas')
+                canvas.width = canvas.height = 8
+                let context = canvas.getContext('2d')
+                context.fillStyle = 'red'
+                context.fillRect(0, 0, 8, 8)
+
+                let blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'))
+
+                await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])
+
+                window.__clipboardReady = true
+            })()
+        JS);
+
+        $browser->waitUntil('window.__clipboardReady === true');
+    }
+
+    protected function putTextOnClipboard($browser, $text)
+    {
+        $this->cdp($browser, 'Browser.grantPermissions', ['permissions' => ['clipboardReadWrite', 'clipboardSanitizedWrite']]);
+
+        $browser->script("(async () => { await navigator.clipboard.writeText('{$text}'); window.__clipboardReady = true })()");
+
+        $browser->waitUntil('window.__clipboardReady === true');
+    }
+
+    // Dispatch browser-generated drag events (via CDP) carrying real files
+    // from disk — the browser derives the trusted dragenter/dragover/dragleave
+    // stream from the pointer position, exactly like an OS file drag...
+    protected function dispatchDrag($browser, $type, $selector, $files = [], $items = [])
+    {
+        [$x, $y] = $this->centerOf($browser, $selector);
+
+        $this->cdp($browser, 'Input.dispatchDragEvent', [
+            'type' => $type,
+            'x' => $x,
+            'y' => $y,
+            'data' => ['items' => $items, 'files' => $files, 'dragOperationsMask' => 1],
+        ]);
+    }
+
+    protected function dragFileOver($browser, $selector, $files)
+    {
+        $this->dispatchDrag($browser, 'dragEnter', $selector, $files);
+        $this->dispatchDrag($browser, 'dragOver', $selector, $files);
+    }
+
+    protected function dropFiles($browser, $selector, $files)
+    {
+        $this->dragFileOver($browser, $selector, $files);
+        $this->dispatchDrag($browser, 'drop', $selector, $files);
+    }
+
+    protected function centerOf($browser, $selector)
+    {
+        $selector = str_starts_with($selector, '@') ? '[dusk="'.substr($selector, 1).'"]' : $selector;
+
+        return $browser->script("let rect = document.querySelector('{$selector}').getBoundingClientRect(); return [rect.x + rect.width / 2, rect.y + rect.height / 2]")[0];
+    }
+
+    // Deliver a picker selection the way Chrome's own automation does:
+    // DOM.setFileInputFiles sets real files from disk on the input and the
+    // browser fires the trusted change event...
+    protected function chooseFilesInPicker($browser, $files)
+    {
+        $document = $this->cdp($browser, 'DOM.getDocument');
+
+        $input = $this->cdp($browser, 'DOM.querySelector', [
+            'nodeId' => $document['root']['nodeId'],
+            'selector' => 'input[data-livewire-picker]',
+        ]);
+
+        $this->cdp($browser, 'DOM.setFileInputFiles', [
+            'files' => $files,
+            'nodeId' => $input['nodeId'],
+        ]);
     }
 }


### PR DESCRIPTION
## The problem

Building a ChatGPT-style prompt box — paste a screenshot while typing, drag a file anywhere on the page, click "Attach" to open the OS picker — currently requires hand-rolling all three gestures on top of a hidden `<input type="file">`: manual `dragover` cancellation, dragenter/dragleave counters to avoid overlay flicker, clipboard inspection, and `$refs.fileInput.click()` hacks.

`<input type="file" wire:model="...">` has been Livewire's only template-level entrance for files. This PR adds the rest.

## The API

One new magic action, usable inside any event listener:

```blade
<textarea wire:paste="$upload('photos')"></textarea>

<div wire:drop="$upload('photos')">Drop files here</div>

<button type="button" wire:click="$upload('photos')">Attach files</button>
```

`$upload` follows one rule: **it takes files from the argument, else from the event, else from the user.**

- A paste or drop that carries files → those files upload into the property
- A file-capable event *without* files (a plain text paste) → no-op; the browser's default proceeds untouched
- An event that *can't* carry files (a click) → the OS file picker opens

And one new directive, `wire:drop`, because a bare `drop` listener never fires unless `dragover` is cancelled — a plain wildcard listener physically can't power a dropzone. `wire:drop` owns the whole drag lifecycle:

- Only engages with drags carrying files (`DataTransfer.types` includes `Files`) — dragging selected text does nothing
- Applies `data-dragging` to the element while files are dragged over it, so overlays are pure CSS (same move as `data-loading`)
- Handles the dragenter/dragleave depth-counting so the attribute doesn't flicker over child elements
- `.window` accepts drops anywhere on the page (Alpine's `.window` semantics), with `data-dragging` still landing on the directive's element as a styling anchor

A complete ChatGPT-style prompt box needs zero custom JavaScript and no hidden inputs:

```blade
<div class="group" wire:drop.window="$upload('attachments')">
    <div class="hidden group-data-dragging:grid fixed inset-0 place-items-center bg-black/50">
        Drop files to attach
    </div>

    <form wire:submit="send">
        <template x-for="file in $wire.attachments" :key="file.name">
            <div>
                <img x-show="file.isPreviewable" :src="file.previewUrl">
                <progress x-show="file.isUploading" :value="file.progress" max="100"></progress>
                <button type="button" x-on:click="file.remove()">&times;</button>
            </div>
        </template>

        <textarea wire:model="message" wire:paste="$upload('attachments')"></textarea>

        <button type="button" wire:click="$upload('attachments', { accept: 'image/*,.pdf' })">
            Add photos & files
        </button>

        <button type="submit" x-bind:disabled="$wire.attachments.some(f => f.isUploading)">Send</button>
    </form>
</div>
```

### Options

`$upload(property, filesOrEvent?, { accept, multiple, append })`

- `accept` — filters pasted/dropped files and constrains the picker, matching native `accept` semantics (client-side convenience only; server validation remains the gate)
- `multiple` — defaults to whether the property currently holds an array
- `append` — multiple uploads append (default) or replace

### JS door

`$wire.$upload()` is modernized to return a promise (resolves on finish, `null` on cancel/dismiss, rejects on failure) and accepts a File/FileList/array, an Event to pull files from, or an options object. **The v3 callback signature still works unchanged** — detected by a function in the third argument.

## Design notes

Walked through `api-design.md`:

- **No new vocabulary was minted for the gestures.** `wire:paste` and `wire:click` are the existing wildcard/event directives; `$upload` joins the existing magic-action family (`$set`, `$toggle`, `$dispatch`) and mirrors the existing `$wire.$upload()` — the word "upload" already belongs to this capability through every door (`WithFileUploads`, `livewire-upload-*` events, the docs page).
- **`wire:drop` is claimed from the wildcard** because the wildcard version was inert (no `dragover` cancellation → the browser never fires `drop`). Anyone with an existing `wire:drop="handler"` gets a strict upgrade: their handler now actually fires for file drops, with `$event` in scope, plus `data-dragging` for free.
- **Event inheritance** uses `window.event`, which the DOM spec sets synchronously during any dispatch — so `$upload` works identically inside `wire:paste`, `x-on:paste`, and any addEventListener callback, with no evaluator or wildcard changes. (Consequence: an async wrapper like `.debounce` loses the event context and falls through to the picker — documented trade-off, and not a meaningful combination for paste/drop anyway.)
- **Zero new server surface.** Every gesture funnels into the existing upload manager, so signed URLs, throttling, chunked/resumable transport, S3 multipart, validation, `wire:loading` targeting, and the rich upload synth objects all compose with no new threat model.

## Verification

- **9 new browser tests** (`UploadActionBrowserTest`) covering: paste upload, text-paste non-hijack (asserts `defaultPrevented === false`), drop upload + `data-dragging` lifecycle, text-drag ignore, `.window` drops landing state on the directive element, picker flow (CDP file-chooser interception; asserts the input is removed after selection), `accept` filtering, single-property first-file semantics, and the legacy callback signature.
- Full `SupportFileUploads` browser suite (26 tests), upload unit suite (99 tests), and JS specs (126) all green.
- Exercised end-to-end in a real Laravel app: a ChatGPT-style chat page driven by Playwright through real Chrome — synthetic clipboard/drag events, a **real trusted click opening a real file chooser**, chip previews from blob URLs, optimistic remove, and send round-trip with server-side original filenames. 12/12 scenarios passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)