### PR TITLE
[4.x] Make `wire:drop` general-purpose and add the `.file` listener modifier

### DIFF
--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -256,7 +256,7 @@ Livewire supports all of these through a single action: `$upload`. Use it inside
 ```blade
 <textarea wire:paste="$upload('photos')"></textarea>
 
-<div wire:drop="$upload('photos')">Drop files here</div>
+<div wire:drop.file="$upload('photos')">Drop files here</div>
 
 <button type="button" wire:click="$upload('photos')">Attach files</button>
 ```
@@ -266,6 +266,10 @@ Livewire supports all of these through a single action: `$upload`. Use it inside
 * When the triggering event carries files — pasted screenshots, dropped files — those files upload into the property
 * When the event *can* carry files but doesn't — a plain text paste — nothing happens, and the browser's default behavior proceeds untouched
 * When the event *can't* carry files — a click — the browser's file picker opens and the user's selection uploads instead
+
+Because `$upload` filters for itself, the listeners stay ordinary events you can use however you like. The `.file` modifier on `wire:drop` above is a listener-level filter — like `wire:keydown.enter` — that additionally scopes the *dropzone* to drags carrying files, so dragging selected text over it never engages it. More on that in the [`wire:drop` documentation](/docs/wire-drop).
+
+`.file` works on any event listener carrying files — `wire:paste.file="handlePastedFiles"` only fires for pastes whose clipboard contains files, which is handy for custom handlers that would otherwise need their own guard.
 
 Uploads started this way are ordinary Livewire uploads: they flow through the same temporary-upload pipeline as `wire:model` file inputs, respect your validation rules, and hydrate into [rich upload objects](#rich-upload-objects-in-javascript) for instant previews and progress.
 
@@ -294,7 +298,7 @@ new class extends Component {
 ```
 
 ```blade
-<div class="relative" wire:drop.window="$upload('attachments')">
+<div class="relative" wire:drop.file.window="$upload('attachments')">
     {{-- A full-screen overlay, shown while files are dragged over the page... --}}
     <div class="hidden in-data-dragging:grid fixed inset-0 place-items-center bg-black/50 text-white">
         Drop files to attach
@@ -330,7 +334,8 @@ new class extends Component {
 A few things worth noticing:
 
 * `wire:paste` sits on elements — paste events bubble, so placing it on the `<form>` would cover every input inside it
-* `wire:drop.window` accepts drops anywhere on the page, and the `data-dragging` attribute it applies powers the overlay with plain CSS — no JavaScript required
+* `wire:drop`'s `.file` modifier scopes the dropzone to drags carrying files — dragging selected text across the page never flashes the overlay
+* `.window` accepts drops anywhere on the page, and the `data-dragging` attribute it applies powers the overlay with plain CSS — no JavaScript required
 * The "Add photos & files" button is a real `<button>`, so keyboards and screen readers work for free — no hidden `<input type="file">` hacks
 
 ### Options

--- a/docs/wire-drop.md
+++ b/docs/wire-drop.md
@@ -1,11 +1,11 @@
 
-`wire:drop` turns any element into a dropzone. It listens for files being dragged over the element, reflects the drag state so you can style an overlay, and evaluates its expression when files are dropped.
+`wire:drop` turns any element into a dropzone. It listens for things being dragged over the element, reflects the drag state so you can style an overlay, and evaluates its expression when something is dropped.
 
-Unlike a plain `drop` event listener — which the browser never fires unless `dragover` is cancelled by hand — `wire:drop` manages the entire drag lifecycle for you. It also only engages with drags that carry files: dragging selected text across the element does nothing.
+Unlike a plain `drop` event listener — which the browser never fires unless `dragover` is cancelled by hand — `wire:drop` manages the entire drag lifecycle for you.
 
 ## Basic usage
 
-The most common expression is the [`$upload` action](/docs/uploads#uploading-beyond-file-inputs), which uploads the dropped files into a component property:
+The most common dropzone accepts files, using the `.file` modifier together with the [`$upload` action](/docs/uploads#uploading-beyond-file-inputs) to upload the dropped files into a component property:
 
 ```php
 <?php // resources/views/components/⚡photo-gallery.blade.php
@@ -23,27 +23,19 @@ new class extends Component {
 ```
 
 ```blade
-<div wire:drop="$upload('photos')">
+<div wire:drop.file="$upload('photos')">
     Drop photos here
 </div>
 ```
 
-Dropped files flow through Livewire's standard [file upload pipeline](/docs/uploads) — temporary uploads, validation, previews, and [rich upload objects](/docs/uploads#rich-upload-objects-in-javascript) all work exactly as if the files came from a file input.
-
-The expression is an ordinary action expression, so you can also call your own JavaScript with the drop event available as `$event`:
-
-```blade
-<div wire:drop="handleDrop($event.dataTransfer.files)">
-    Drop files here
-</div>
-```
+The `.file` modifier scopes the dropzone to drags carrying files — dragging selected text across the element does nothing. Dropped files flow through Livewire's standard [file upload pipeline](/docs/uploads): temporary uploads, validation, previews, and [rich upload objects](/docs/uploads#rich-upload-objects-in-javascript) all work exactly as if the files came from a file input.
 
 ## Styling the drag state
 
-While files are dragged over the dropzone, Livewire applies a `data-dragging` attribute to the element. Style it with plain CSS — no JavaScript required:
+While something is dragged over the dropzone, Livewire applies a `data-dragging` attribute to the element. Style it with plain CSS — no JavaScript required:
 
 ```blade
-<div wire:drop="$upload('photos')" class="border-dashed data-dragging:border-blue-500">
+<div wire:drop.file="$upload('photos')" class="border-dashed data-dragging:border-blue-500">
     Drop photos here
 </div>
 ```
@@ -51,19 +43,21 @@ While files are dragged over the dropzone, Livewire applies a `data-dragging` at
 Or target it from a descendant using Tailwind's `in-*` variants:
 
 ```blade
-<div wire:drop="$upload('photos')">
+<div wire:drop.file="$upload('photos')">
     <div class="opacity-0 in-data-dragging:opacity-100">
         Release to upload
     </div>
 </div>
 ```
 
+With `.file`, the attribute only appears for drags carrying files, so overlays never flash while a user drags text around the page.
+
 ## Accepting drops anywhere on the page
 
 Chat and editor interfaces often accept drops anywhere in the window rather than on one specific region. Add the `.window` modifier to listen at the window level:
 
 ```blade
-<div wire:drop.window="$upload('attachments')">
+<div wire:drop.file.window="$upload('attachments')">
     {{-- A full-screen overlay, shown while files are dragged over the page... --}}
     <div class="hidden in-data-dragging:grid fixed inset-0 place-items-center bg-black/50 text-white">
         Drop files to attach
@@ -75,6 +69,24 @@ Chat and editor interfaces often accept drops anywhere in the window rather than
 
 The `data-dragging` attribute is still applied to the element carrying the directive, so overlays always have a styling anchor.
 
+## General dropzones
+
+Without `.file`, `wire:drop` is a general dropzone: any drag engages it, and any drop evaluates the expression — with the drop event available as `$event`. Use this for drops that aren't files, like text, links, or images dragged in from another tab:
+
+```blade
+<div wire:drop="importFromUrl($event.dataTransfer.getData('text/uri-list'))">
+    Drop a link here
+</div>
+```
+
+Two defaults worth knowing:
+
+* Drops carrying files always have their browser default cancelled — nobody drops a file onto an app wanting the browser to navigate away and open it
+* All other drops keep their default behavior (dropping text into an input still inserts it), unless your expression calls `$event.preventDefault()`
+
+> [!tip] Uploading from a general dropzone still works
+> `$upload` filters for itself — on a bare `wire:drop="$upload('photos')"` it uploads file drops and silently ignores everything else. Reach for `.file` when you want the *dropzone itself* scoped to files, so `data-dragging` (and your overlay) only engage for file drags.
+
 ## Reference
 
 ```blade
@@ -83,4 +95,5 @@ wire:drop="expression"
 
 Modifier | Description
 --- | ---
+`.file` | Scope the dropzone to drags carrying files: only file drags show `data-dragging`, and only file drops evaluate the expression
 `.window` | Accept drops anywhere on the page instead of only on this element

--- a/js/directives/wire-drop.js
+++ b/js/directives/wire-drop.js
@@ -2,13 +2,19 @@ import { callAndClearComponentDebounces } from '@/debounce'
 import { evaluateActionExpression } from '@/evaluator'
 import { setNextActionOrigin } from '@/request'
 import { directive } from '@/directives'
+import { filesFromEvent } from '@/utils'
 
 // A first-class dropzone. A plain `drop` listener never fires unless
 // `dragover` is cancelled, so this directive owns the full drag lifecycle:
-// it only engages for drags carrying files (dragging selected text over
-// the element does nothing), reflects the drag state as a `data-dragging`
-// attribute for styling, and evaluates the expression on drop...
+// it reflects the drag state as a `data-dragging` attribute for styling
+// and evaluates the expression on drop.
+//
+// The `.file` modifier scopes the whole directive to drags carrying files:
+// only file drags show `data-dragging`, and only file drops evaluate —
+// dragging selected text over the element does nothing...
 directive('drop', ({ el, directive, component, cleanup }) => {
+    let fileOnly = directive.modifiers.includes('file')
+
     // The `.window` modifier accepts drops anywhere on the page —
     // `data-dragging` still lands on this element so overlays have
     // a styling anchor...
@@ -18,12 +24,16 @@ directive('drop', ({ el, directive, component, cleanup }) => {
     // track depth and only clear the attribute when the drag truly leaves...
     let depth = 0
 
-    let hasFiles = e => e.dataTransfer && Array.from(e.dataTransfer.types || []).includes('Files')
+    let engages = e => {
+        if (! e.dataTransfer) return false
+
+        return fileOnly ? Array.from(e.dataTransfer.types || []).includes('Files') : true
+    }
 
     let clearDragging = () => { depth = 0; el.removeAttribute('data-dragging') }
 
     let onDragenter = e => {
-        if (! hasFiles(e)) return
+        if (! engages(e)) return
 
         e.preventDefault()
 
@@ -34,13 +44,13 @@ directive('drop', ({ el, directive, component, cleanup }) => {
 
     // Cancelling dragover is what makes the element a valid drop target...
     let onDragover = e => {
-        if (! hasFiles(e)) return
+        if (! engages(e)) return
 
         e.preventDefault()
     }
 
     let onDragleave = e => {
-        if (! hasFiles(e)) return
+        if (! engages(e)) return
 
         depth = Math.max(0, depth - 1)
 
@@ -50,9 +60,12 @@ directive('drop', ({ el, directive, component, cleanup }) => {
     let onDrop = e => {
         clearDragging()
 
-        if (! hasFiles(e)) return
+        if (! engages(e)) return
 
-        e.preventDefault()
+        // A dropped file's default is "navigate away and open it" — always
+        // cancel that. Other drops keep their default (text drops into
+        // inputs, for example) unless the expression prevents it...
+        if (filesFromEvent(e)?.length > 0) e.preventDefault()
 
         directive.eventContext = e
         directive.wire = component.$wire

--- a/js/directives/wire-wildcard.js
+++ b/js/directives/wire-wildcard.js
@@ -1,5 +1,6 @@
 import { callAndClearComponentDebounces } from '@/debounce'
 import { customDirectiveHasBeenRegistered } from '@/directives'
+import { filesFromEvent } from '@/utils'
 import { on } from '@/hooks'
 import { setNextActionOrigin, setNextActionInterceptor } from '@/request'
 import Alpine from 'alpinejs'
@@ -36,8 +37,17 @@ on('directive.init', ({ el, directive, cleanup, component }) => {
         attribute = attribute.replace('.append', '')
     }
 
+    // Strip .file from Alpine expression because it only concerns Livewire and trips up Alpine...
+    if (directive.modifiers.includes('file')) {
+        attribute = attribute.replace('.file', '')
+    }
+
     let cleanupBinding = Alpine.bind(el, {
         [attribute](e) {
+            // The .file modifier filters the listener to events carrying
+            // files — a plain text paste on wire:paste.file does nothing...
+            if (directive.modifiers.includes('file') && ! filesFromEvent(e)?.length) return
+
             directive.eventContext = e
             directive.wire = component.$wire
 

--- a/js/features/supportFileUploads/action.js
+++ b/js/features/supportFileUploads/action.js
@@ -1,5 +1,5 @@
 import { getUploadManager } from './manager'
-import { dataGet } from '@/utils'
+import { dataGet, filesFromEvent } from '@/utils'
 
 // The smart `$upload` action behind `$wire.$upload()` and template
 // expressions like `wire:paste="$upload('photos')"`. Files are acquired
@@ -83,21 +83,6 @@ function parseArguments(args) {
     callbacks.cancelled ??= () => {}
 
     return { files, event, options, callbacks }
-}
-
-// Pull files out of a paste, drop, or file-input change event. Returns
-// null for events that can't carry files (like clicks), so callers can
-// fall back to opening the file picker...
-function filesFromEvent(event) {
-    if (! event) return null
-
-    let source = event.clipboardData || event.dataTransfer || (event.target?.files ? event.target : null)
-
-    if (! source) return null
-
-    let files = Array.from(source.files || [])
-
-    return files
 }
 
 function uploadFiles(component, name, files, options, callbacks) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -52,6 +52,19 @@ export function listen(target, name, handler) {
     return () => target.removeEventListener(name, handler)
 }
 
+// Pull files out of a paste, drop, or file-input change event. Returns
+// null for events that can't carry files (like clicks), so callers can
+// distinguish "no files attached" from "not a file-capable event"...
+export function filesFromEvent(event) {
+    if (! event) return null
+
+    let source = event.clipboardData || event.dataTransfer || (event.target?.files ? event.target : null)
+
+    if (! source) return null
+
+    return Array.from(source.files || [])
+}
+
 /**
  * Type-checking in JS is weird and annoying, these are better.
  */

--- a/src/Features/SupportFileUploads/UploadActionBrowserTest.php
+++ b/src/Features/SupportFileUploads/UploadActionBrowserTest.php
@@ -84,7 +84,7 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
 
             function render() { return <<<'HTML'
             <div>
-                <div dusk="zone" wire:drop="$upload('photos')" style="width: 300px; height: 100px">Drop files here</div>
+                <div dusk="zone" wire:drop.file="$upload('photos')" style="width: 300px; height: 100px">Drop files here</div>
 
                 <div dusk="elsewhere" style="width: 300px; height: 100px">Somewhere else</div>
 
@@ -108,7 +108,7 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
-    public function test_text_drags_are_ignored_by_dropzones()
+    public function test_file_modifier_scopes_dropzones_to_file_drags()
     {
         Storage::persistentFake('tmp-for-tests');
 
@@ -119,7 +119,7 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
 
             function render() { return <<<'HTML'
             <div>
-                <div dusk="zone" wire:drop="$upload('photos')" style="width: 300px; height: 100px">Drop files here</div>
+                <div dusk="zone" wire:drop.file="$upload('photos')" style="width: 300px; height: 100px">Drop files here</div>
 
                 <span dusk="count" x-text="$wire.photos.length"></span>
             </div>
@@ -130,6 +130,70 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
         ->pause(300)
         ->assertAttributeMissing('@zone', 'data-dragging')
         ->assertSeeIn('@count', '0')
+        ;
+    }
+
+    public function test_bare_dropzones_are_general_and_evaluate_any_drop()
+    {
+        Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $dropped = '';
+
+            function handleDrop($text)
+            {
+                $this->dropped = $text;
+            }
+
+            function render() { return <<<'HTML'
+            <div>
+                <div dusk="zone" wire:drop="handleDrop($event.dataTransfer.getData('text/plain'))" style="width: 300px; height: 100px">Drop anything here</div>
+
+                <span dusk="dropped">{{ $dropped }}</span>
+            </div>
+            HTML; }
+        })
+        // Without .file, any drag engages the zone...
+        ->tap(fn ($b) => $this->dispatchDrag($b, 'dragEnter', '@zone', [], [['mimeType' => 'text/plain', 'data' => 'dragged text']]))
+        ->waitUntil('document.querySelector(\'[dusk="zone"]\').hasAttribute(\'data-dragging\')')
+        // ...and any drop evaluates the expression, with $event in scope...
+        ->tap(fn ($b) => $this->dispatchDrag($b, 'drop', '@zone', [], [['mimeType' => 'text/plain', 'data' => 'dragged text']]))
+        ->waitForTextIn('@dropped', 'dragged text')
+        ->waitUntil('! document.querySelector(\'[dusk="zone"]\').hasAttribute(\'data-dragging\')')
+        ;
+    }
+
+    public function test_file_modifier_filters_pastes_to_files()
+    {
+        Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $body = '';
+            public $pastes = 0;
+
+            function render() { return <<<'HTML'
+            <div>
+                <textarea dusk="box" wire:model="body" wire:paste.file="$set('pastes', pastes + 1)"></textarea>
+
+                <span dusk="pastes" x-text="$wire.pastes"></span>
+            </div>
+            HTML; }
+        })
+        // A real text paste doesn't trigger the filtered listener...
+        ->tap(fn ($b) => $this->putTextOnClipboard($b, 'just some text'))
+        ->click('@box')
+        ->keys('@box', [$this->pasteChord(), 'v'])
+        ->waitUntil('document.querySelector(\'[dusk="box"]\').value === "just some text"')
+        ->assertSeeIn('@pastes', '0')
+        // A real file paste does...
+        ->tap(fn ($b) => $this->putImageOnClipboard($b))
+        ->click('@box')
+        ->keys('@box', [$this->pasteChord(), 'v'])
+        ->waitForTextIn('@pastes', '1')
         ;
     }
 
@@ -144,7 +208,7 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
 
             function render() { return <<<'HTML'
             <div>
-                <div dusk="overlay" wire:drop.window="$upload('photos')">Drop anywhere</div>
+                <div dusk="overlay" wire:drop.file.window="$upload('photos')">Drop anywhere</div>
 
                 <p dusk="outside" style="margin-top: 100px">Somewhere else entirely on the page</p>
 


### PR DESCRIPTION
## The problem with what shipped in #10408

`wire:drop` baked "drops mean files" into the listener itself: non-file drops never evaluated the expression, locking the word away from native-style uses (dropping a link or image from another tab, custom drag data). That put the file decision at the wrong layer.

The right layering — already true for `wire:paste` — is that **the listener stays a plain event and `$upload` filters for itself** (silent no-op when the event carries no files).

## What this changes

**Bare `wire:drop` is now a general dropzone.** It still owns the mandatory drag ceremony (a plain `drop` listener never fires unless `dragover` is cancelled), but any drag engages it and any drop evaluates the expression, with `$event` in scope:

```blade
<div wire:drop="importFromUrl($event.dataTransfer.getData('text/uri-list'))">
    Drop a link here
</div>
```

**The `.file` modifier scopes the whole dropzone to file drags** — the grammar of `wire:keydown.enter`: an event word plus a modifier filtering when it fires. Only file drags show `data-dragging` (so overlays never flash while someone drags selected text around), and only file drops evaluate:

```blade
<div wire:drop.file.window="$upload('attachments')">
```

Docs now push `wire:drop.file="$upload(...)"` as the canonical upload spelling.

**`.file` works on any wildcard event listener too** — implemented via the established `.async`/`.renderless` strip-and-handle pattern:

```blade
<textarea wire:paste.file="handlePastedFiles"></textarea>
```

**Two defaults that don't change with the modifier:**
- Drops carrying files always get `preventDefault` — the browser's default for a dropped file is "navigate away and open it"
- All other drops keep their default (text dropped into an input still inserts), unless the expression prevents it — important for `.window` zones wrapping forms

`$upload` itself is untouched: bare `wire:drop="$upload('photos')"` still uploads file drops and ignores the rest.

## Verification

- Updated browser tests: file-gated behaviors (drag-state lifecycle, text-drag ignore, `.window` overlay anchor) now exercise `.file`; the `accept`/single-property tests stay on bare `wire:drop` to cover the `$upload`-filters-for-itself path
- New tests: bare `wire:drop` evaluates a text drop (server receives the dragged text via `$event.dataTransfer`) and shows `data-dragging` for any drag; `wire:paste.file` verified with a real clipboard — a real text paste doesn't fire it (and still lands in the textarea), a real image paste does
- All 12 upload-action tests green, full uploads suite (29), events/magic-actions/request-interactions suites (37), JS specs (128)
- Re-verified the Upload Lab chat page end-to-end with Playwright (12/12) on `wire:drop.file.window`, plus a live check that a text drag over the window shows no overlay while a file drag does

🤖 Generated with [Claude Code](https://claude.com/claude-code)