### PR TITLE
[4.x] Fix `#[Authorize]` attribute doesnt trigger component exception hook

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -20,14 +20,13 @@ use Livewire\Features\SupportRenderless\HandlesRenderless;
 use Livewire\Exceptions\PropertyNotFoundException;
 use Livewire\Concerns\InteractsWithProperties;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use BadMethodCallException;
+use Livewire\Features\SupportAuthorization\HandlesAuthorization;
 
 abstract class Component
 {
     use Macroable { __call as macroCall; }
 
-    use AuthorizesRequests;
     use InteractsWithProperties;
     use HandlesEvents;
     use HandlesIslands;
@@ -44,6 +43,7 @@ abstract class Component
     use HandlesSlots;
     use HandlesHtmlAttributeForwarding;
     use HandlesRenderless;
+    use HandlesAuthorization;
 
     protected $__id;
     protected $__name;

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -35,6 +35,7 @@ class BaseAuthorize extends LivewireAttribute
         // Action that does not require a model or class...
         if (is_null($this->argument)) {
             $this->authorize($this->ability);
+
             return;
         }
 
@@ -77,6 +78,7 @@ class BaseAuthorize extends LivewireAttribute
 
         if ($methodArgument instanceof \ReflectionParameter) {
             $methodDependencies = $resolveMethodDependencies();
+
             return $methodDependencies['named'][$arg];
         }
 
@@ -95,7 +97,7 @@ class BaseAuthorize extends LivewireAttribute
         return [$this->normalizeGuessedAbilityName($this->getName()), $ability];
     }
 
-    protected function withExceptionHandling(Closure $operation): void
+    protected function withExceptionHandling(Closure $operation)
     {
         $handler = $this->exceptionHandler ??= function (Closure $expression) {
             try {

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportAuthorization;
 
 use Attribute;
+use Closure;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Arr;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
@@ -10,23 +11,30 @@ use Livewire\ImplicitlyBoundMethod;
 use UnitEnum;
 
 use function Illuminate\Support\enum_value;
+use function Livewire\trigger;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
 class BaseAuthorize extends LivewireAttribute
 {
     use AuthorizesRequests;
 
+    private ?Closure $exceptionHandler = null;
+
     public function __construct(
         public UnitEnum|string $ability,
         public array|string|null $argument = null,
     ) {}
 
-    public function call(array $parameters) : void
+    public function call(array $parameters): void
+    {
+        $this->withExceptionHandling(fn () => $this->handleAuthorization($parameters));
+    }
+
+    protected function handleAuthorization(array $parameters): void
     {
         // Action that does not require a model or class...
         if (is_null($this->argument)) {
             $this->authorize($this->ability);
-
             return;
         }
 
@@ -54,7 +62,7 @@ class BaseAuthorize extends LivewireAttribute
     /**
      * Resolve a single argument.
      */
-    protected function resolveArgument(string $arg, array $parameters, \Closure $resolveMethodDependencies): mixed
+    protected function resolveArgument(string $arg, array $parameters, Closure $resolveMethodDependencies): mixed
     {
         // Action that does not require a model, for example a 'create' action...
         if (class_exists($arg)) {
@@ -64,12 +72,11 @@ class BaseAuthorize extends LivewireAttribute
         // Try method parameter first (prioritized per rules)
         $methodArgument = Arr::first(
             (new \ReflectionObject($this->component))->getMethod($this->getName())->getParameters(),
-            fn (\ReflectionParameter $parameter) : bool => $parameter->getName() === $arg,
+            fn (\ReflectionParameter $parameter): bool => $parameter->getName() === $arg,
         );
 
         if ($methodArgument instanceof \ReflectionParameter) {
             $methodDependencies = $resolveMethodDependencies();
-
             return $methodDependencies['named'][$arg];
         }
 
@@ -86,5 +93,28 @@ class BaseAuthorize extends LivewireAttribute
         }
 
         return [$this->normalizeGuessedAbilityName($this->getName()), $ability];
+    }
+
+    protected function withExceptionHandling(Closure $operation): void
+    {
+        $handler = $this->exceptionHandler ??= function (Closure $expression) {
+            try {
+                return $expression();
+            } catch (\Throwable $e) {
+                $shouldPropagate = true;
+
+                $stopPropagation = function () use (&$shouldPropagate) {
+                    $shouldPropagate = false;
+                };
+
+                trigger('exception', $this->component, $e, $stopPropagation);
+
+                if ($shouldPropagate) {
+                    throw $e;
+                }
+            }
+        };
+
+        $handler($operation);
     }
 }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -3,120 +3,26 @@
 namespace Livewire\Features\SupportAuthorization;
 
 use Attribute;
-use Closure;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use Illuminate\Support\Arr;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
-use Livewire\ImplicitlyBoundMethod;
 use UnitEnum;
 
-use function Illuminate\Support\enum_value;
-use function Livewire\trigger;
+use function Livewire\wrap;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
 class BaseAuthorize extends LivewireAttribute
 {
-    use AuthorizesRequests;
-
-    private ?Closure $exceptionHandler = null;
-
     public function __construct(
         public UnitEnum|string $ability,
         public array|string|null $argument = null,
     ) {}
 
-    public function call(array $parameters): void
+    public function call(array $parameters)
     {
-        $this->withExceptionHandling(fn () => $this->handleAuthorization($parameters));
-    }
-
-    protected function handleAuthorization(array $parameters): void
-    {
-        // Action that does not require a model or class...
-        if (is_null($this->argument)) {
-            $this->authorize($this->ability);
-
-            return;
-        }
-
-        $arguments = Arr::wrap($this->argument);
-
-        // Resolve method dependencies lazily, then reuse them for multi-argument authorization checks...
-        $methodDependencies = null;
-        $resolveMethodDependencies = function () use (&$methodDependencies, $parameters): array {
-            return $methodDependencies ??= ImplicitlyBoundMethod::resolveMethodDependencies(
-                app(),
-                [$this->component, $this->getName()],
-                $parameters,
-            );
-        };
-
-        // Resolve each argument (prioritize method parameters first, then component properties)
-        $resolved = [];
-        foreach ($arguments as $arg) {
-            $resolved[] = $this->resolveArgument($arg, $parameters, $resolveMethodDependencies);
-        }
-
-        $this->authorize($this->ability, $resolved);
-    }
-
-    /**
-     * Resolve a single argument.
-     */
-    protected function resolveArgument(string $arg, array $parameters, Closure $resolveMethodDependencies): mixed
-    {
-        // Action that does not require a model, for example a 'create' action...
-        if (class_exists($arg)) {
-            return $arg;
-        }
-
-        // Try method parameter first (prioritized per rules)
-        $methodArgument = Arr::first(
-            (new \ReflectionObject($this->component))->getMethod($this->getName())->getParameters(),
-            fn (\ReflectionParameter $parameter): bool => $parameter->getName() === $arg,
+        wrap($this->component)->handleAuthorization(
+            $this->getName(),
+            $parameters,
+            $this->ability,
+            $this->argument
         );
-
-        if ($methodArgument instanceof \ReflectionParameter) {
-            $methodDependencies = $resolveMethodDependencies();
-
-            return $methodDependencies['named'][$arg];
-        }
-
-        // Fall back to component property
-        return data_get($this->component, $arg);
-    }
-
-    protected function parseAbilityAndArguments($ability, $arguments)
-    {
-        $ability = enum_value($ability);
-
-        if (is_string($ability) && ! str_contains($ability, '\\')) {
-            return [$ability, $arguments];
-        }
-
-        return [$this->normalizeGuessedAbilityName($this->getName()), $ability];
-    }
-
-    protected function withExceptionHandling(Closure $operation)
-    {
-        $handler = $this->exceptionHandler ??= function (Closure $expression) {
-            try {
-                return $expression();
-            } catch (\Throwable $e) {
-                $shouldPropagate = true;
-
-                $stopPropagation = function () use (&$shouldPropagate) {
-                    $shouldPropagate = false;
-                };
-
-                trigger('exception', $this->component, $e, $stopPropagation);
-
-                if ($shouldPropagate) {
-                    throw $e;
-                }
-            }
-        };
-
-        $handler($operation);
     }
 }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -18,11 +18,8 @@ class BaseAuthorize extends LivewireAttribute
 
     public function call(array $parameters)
     {
-        wrap($this->component)->handleAuthorization(
-            $this->getName(),
-            $parameters,
-            $this->ability,
-            $this->argument
-        );
+        $this->component->setMethodAndParameters($this->getName(), $parameters);
+
+        wrap($this->component)->handleAuthorization($this->ability, $this->argument);
     }
 }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -20,6 +20,6 @@ class BaseAuthorize extends LivewireAttribute
     {
         $this->component->setMethodAndParameters($this->getName(), $parameters);
 
-        wrap($this->component)->handleAuthorization($this->ability, $this->argument);
+        wrap($this->component)->authorize($this->ability, $this->argument);
     }
 }

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -20,6 +20,6 @@ class BaseAuthorize extends LivewireAttribute
     {
         $this->component->setMethodAndParameters($this->getName(), $parameters);
 
-        wrap($this->component)->authorize($this->ability, $this->argument);
+        wrap($this->component)->handleAuthorization($this->ability, $this->argument);
     }
 }

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -10,9 +10,7 @@ use function Illuminate\Support\enum_value;
 
 trait HandlesAuthorization
 {
-    use AuthorizesRequests {
-        authorize as public baseAuthorize;
-    }
+    use AuthorizesRequests;
 
     protected ?string $method = null;
     protected ?array $parameters = null;
@@ -23,27 +21,16 @@ trait HandlesAuthorization
         $this->parameters = $parameters;
     }
 
-    /**
-     * Authorize a given action for the current user.
-     *
-     * @param  mixed  $ability
-     * @param  mixed  $arguments
-     * @return \Illuminate\Auth\Access\Response
-     *
-     * @throws \Illuminate\Auth\Access\AuthorizationException
-     */
-    public function authorize($ability, $arguments = [])
+    public function handleAuthorization($ability, $argument)
     {
-        if (is_null($this->method ) || is_null($this->parameters)) {
-            return $this->baseAuthorize($ability, $arguments);
-        }
+        if (is_null($this->method) || is_null($this->parameters)) return;
 
         // Action that does not require a model or class...
-        if (is_null($arguments)) {
-            return $this->baseAuthorize($ability);
+        if (is_null($argument)) {
+            return $this->authorize($ability);
         }
 
-        $arguments = Arr::wrap($arguments);
+        $arguments = Arr::wrap($argument);
 
         // Resolve method dependencies lazily, then reuse them for multi-argument authorization checks...
         $methodDependencies = null;
@@ -61,7 +48,7 @@ trait HandlesAuthorization
             $resolved[] = $this->resolveArgument($arg, $resolveMethodDependencies);
         }
 
-        return $this->baseAuthorize($ability, $resolved);
+        return $this->authorize($ability, $resolved);
     }
 
     protected function resolveArgument(string $arg, \Closure $resolveMethodDependencies): mixed
@@ -94,6 +81,11 @@ trait HandlesAuthorization
         if (is_string($ability) && ! str_contains($ability, '\\')) {
             return [$ability, $arguments];
         }
+
+        // Because this method override the original method,
+        // we need to make sure it gets the right method name
+        // if its called from `$this->authorize()` inside component action
+        $this->method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2]['function'];
 
         return [$this->normalizeGuessedAbilityName($this->method), $ability];
     }

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -11,38 +11,49 @@ use function Illuminate\Support\enum_value;
 trait HandlesAuthorization
 {
     use AuthorizesRequests;
+    
+    protected ?string $method = null;
+    protected ?array $parameters = null;
 
-    public function handleAuthorization($method, $parameters, $ability, $argument)
+    public function setMethodAndParameters($method, $parameters)
     {
+        $this->method = $method;
+        $this->parameters = $parameters;
+    }
+
+    public function handleAuthorization($ability, $argument)
+    {
+        if (! $this->method && ! $this->parameters) {
+            return $this->authorize($ability, $argument);
+        }
+
         // Action that does not require a model or class...
         if (is_null($argument)) {
-            [$ability, $arguments] = $this->resolveAbilityAndArgument($method, $ability, $argument);
-            
-            return $this->authorize($ability, $arguments);
+            return $this->authorize($ability);
         }
 
         $arguments = Arr::wrap($argument);
 
         // Resolve method dependencies lazily, then reuse them for multi-argument authorization checks...
         $methodDependencies = null;
-        $resolveMethodDependencies = function () use (&$methodDependencies, $method, $parameters): array {
+        $resolveMethodDependencies = function () use (&$methodDependencies): array {
             return $methodDependencies ??= ImplicitlyBoundMethod::resolveMethodDependencies(
                 app(),
-                [$this, $method],
-                $parameters,
+                [$this, $this->method],
+                $this->parameters,
             );
         };
 
         // Resolve each argument (prioritize method parameters first, then component properties)
         $resolved = [];
         foreach ($arguments as $arg) {
-            $resolved[] = $this->resolveArgument($arg, $method, $parameters, $resolveMethodDependencies);
+            $resolved[] = $this->resolveArgument($arg, $resolveMethodDependencies);
         }
 
         return $this->authorize($ability, $resolved);
     }
 
-    protected function resolveArgument(string $arg, string $method, array $parameters, \Closure $resolveMethodDependencies): mixed
+    protected function resolveArgument(string $arg, \Closure $resolveMethodDependencies): mixed
     {
         // Action that does not require a model, for example a 'create' action...
         if (class_exists($arg)) {
@@ -51,7 +62,7 @@ trait HandlesAuthorization
 
         // Try method parameter first (prioritized per rules)
         $methodArgument = Arr::first(
-            (new \ReflectionObject($this))->getMethod($method)->getParameters(),
+            (new \ReflectionObject($this))->getMethod($this->method)->getParameters(),
             fn (\ReflectionParameter $parameter): bool => $parameter->getName() === $arg,
         );
 
@@ -65,7 +76,7 @@ trait HandlesAuthorization
         return data_get($this, $arg);
     }
 
-    protected function resolveAbilityAndArgument($method, $ability, $arguments)
+    protected function parseAbilityAndArguments($ability, $arguments)
     {
         $ability = enum_value($ability);
 
@@ -73,6 +84,6 @@ trait HandlesAuthorization
             return [$ability, $arguments];
         }
 
-        return [$this->normalizeGuessedAbilityName($method), $ability];
+        return [$this->normalizeGuessedAbilityName($this->method), $ability];
     }
 }

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -34,13 +34,8 @@ trait HandlesAuthorization
      */
     public function authorize($ability, $arguments = [])
     {
-        if (is_null($this->method) || is_null($this->parameters)) {
+        if (is_null($this->method) || is_null($this->parameters) || is_null($arguments)) {
             return $this->baseAuthorize($ability, $arguments);
-        }
-
-        // Action that does not require a model or class...
-        if (is_null($arguments)) {
-            return $this->baseAuthorize($ability);
         }
 
         $arguments = Arr::wrap($arguments);
@@ -102,13 +97,11 @@ trait HandlesAuthorization
         // we need to make sure it gets the right method name
         // if its called from `$this->authorize()` inside component action where the 4 stacks comes from
         // [3]action -> [2]authorize() -> [1]baseAuthorize() -> [0]parseAbilityAndArguments
-        $this->method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4)[3]['function'];
-
-        $methodAndAbility = [$this->normalizeGuessedAbilityName($this->method), $ability];
+        $method = $this->method ?? debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4)[3]['function'];
 
         // Need to reset the properties in case attribute is used along with `$this->authorize()`
         $this->setMethodAndParameters(null, null);
 
-        return $methodAndAbility;
+        return [$this->normalizeGuessedAbilityName($method), $ability];
     }
 }

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -2,7 +2,6 @@
 
 namespace Livewire\Features\SupportAuthorization;
 
-use Illuminate\Auth\Access\Response;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Arr;
 use Livewire\ImplicitlyBoundMethod;
@@ -11,7 +10,9 @@ use function Illuminate\Support\enum_value;
 
 trait HandlesAuthorization
 {
-    use AuthorizesRequests;
+    use AuthorizesRequests {
+        authorize as public baseAuthorize;
+    }
 
     protected ?string $method = null;
     protected ?array $parameters = null;
@@ -22,18 +23,27 @@ trait HandlesAuthorization
         $this->parameters = $parameters;
     }
 
-    public function handleAuthorization($ability, $argument): Response
+    /**
+     * Authorize a given action for the current user.
+     *
+     * @param  mixed  $ability
+     * @param  mixed  $arguments
+     * @return \Illuminate\Auth\Access\Response
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function authorize($ability, $arguments = [])
     {
         if (! $this->method && ! $this->parameters) {
-            return $this->authorize($ability, $argument);
+            return $this->baseAuthorize($ability, $arguments);
         }
 
         // Action that does not require a model or class...
-        if (is_null($argument)) {
-            return $this->authorize($ability);
+        if (is_null($arguments)) {
+            return $this->baseAuthorize($ability);
         }
 
-        $arguments = Arr::wrap($argument);
+        $arguments = Arr::wrap($arguments);
 
         // Resolve method dependencies lazily, then reuse them for multi-argument authorization checks...
         $methodDependencies = null;
@@ -51,7 +61,7 @@ trait HandlesAuthorization
             $resolved[] = $this->resolveArgument($arg, $resolveMethodDependencies);
         }
 
-        return $this->authorize($ability, $resolved);
+        return $this->baseAuthorize($ability, $resolved);
     }
 
     protected function resolveArgument(string $arg, \Closure $resolveMethodDependencies): mixed

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -34,7 +34,7 @@ trait HandlesAuthorization
      */
     public function authorize($ability, $arguments = [])
     {
-        if (! $this->method && ! $this->parameters) {
+        if (is_null($this->method ) || is_null($this->parameters)) {
             return $this->baseAuthorize($ability, $arguments);
         }
 

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -10,7 +10,9 @@ use function Illuminate\Support\enum_value;
 
 trait HandlesAuthorization
 {
-    use AuthorizesRequests;
+    use AuthorizesRequests {
+        authorize as baseAuthorize;
+    }
 
     protected ?string $method = null;
     protected ?array $parameters = null;
@@ -21,16 +23,27 @@ trait HandlesAuthorization
         $this->parameters = $parameters;
     }
 
-    public function handleAuthorization($ability, $argument)
+    /**
+     * Authorize a given action for the current user.
+     *
+     * @param  mixed  $ability
+     * @param  mixed  $arguments
+     * @return \Illuminate\Auth\Access\Response
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function authorize($ability, $arguments = [])
     {
-        if (is_null($this->method) || is_null($this->parameters)) return;
-
-        // Action that does not require a model or class...
-        if (is_null($argument)) {
-            return $this->authorize($ability);
+        if (is_null($this->method) || is_null($this->parameters)) {
+            return $this->baseAuthorize($ability, $arguments);
         }
 
-        $arguments = Arr::wrap($argument);
+        // Action that does not require a model or class...
+        if (is_null($arguments)) {
+            return $this->baseAuthorize($ability);
+        }
+
+        $arguments = Arr::wrap($arguments);
 
         // Resolve method dependencies lazily, then reuse them for multi-argument authorization checks...
         $methodDependencies = null;
@@ -48,7 +61,7 @@ trait HandlesAuthorization
             $resolved[] = $this->resolveArgument($arg, $resolveMethodDependencies);
         }
 
-        return $this->authorize($ability, $resolved);
+        return $this->baseAuthorize($ability, $resolved);
     }
 
     protected function resolveArgument(string $arg, \Closure $resolveMethodDependencies): mixed
@@ -84,8 +97,9 @@ trait HandlesAuthorization
 
         // Because this method override the original method,
         // we need to make sure it gets the right method name
-        // if its called from `$this->authorize()` inside component action
-        $this->method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2]['function'];
+        // if its called from `$this->authorize()` inside component action where the 4 stacks comes from
+        // [3]action -> [2]authorize() -> [1]baseAuthorize() -> [0]parseAbilityAndArguments
+        $this->method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4)[3]['function'];
 
         return [$this->normalizeGuessedAbilityName($this->method), $ability];
     }

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -92,6 +92,9 @@ trait HandlesAuthorization
         $ability = enum_value($ability);
 
         if (is_string($ability) && ! str_contains($ability, '\\')) {
+            // Need to reset the properties in case attribute is used along with `$this->authorize()`
+            $this->setMethodAndParameters(null, null);
+
             return [$ability, $arguments];
         }
 
@@ -101,6 +104,11 @@ trait HandlesAuthorization
         // [3]action -> [2]authorize() -> [1]baseAuthorize() -> [0]parseAbilityAndArguments
         $this->method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4)[3]['function'];
 
-        return [$this->normalizeGuessedAbilityName($this->method), $ability];
+        $methodAndAbility = [$this->normalizeGuessedAbilityName($this->method), $ability];
+
+        // Need to reset the properties in case attribute is used along with `$this->authorize()`
+        $this->setMethodAndParameters(null, null);
+
+        return $methodAndAbility;
     }
 }

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -65,14 +65,14 @@ trait HandlesAuthorization
         return data_get($this, $arg);
     }
 
-protected function resolveAbilityAndArgument($method, $ability, $arguments)
-{
-    $ability = enum_value($ability);
+    protected function resolveAbilityAndArgument($method, $ability, $arguments)
+    {
+        $ability = enum_value($ability);
 
-    if (is_string($ability) && ! str_contains($ability, '\\')) {
-        return [$ability, $arguments];
+        if (is_string($ability) && ! str_contains($ability, '\\')) {
+            return [$ability, $arguments];
+        }
+
+        return [$this->normalizeGuessedAbilityName($method), $ability];
     }
-
-    return [$this->normalizeGuessedAbilityName($method), $ability];
-}
 }

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Livewire\Features\SupportAuthorization;
+
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Arr;
+use Livewire\ImplicitlyBoundMethod;
+
+use function Illuminate\Support\enum_value;
+
+trait HandlesAuthorization
+{
+    use AuthorizesRequests;
+
+    public function handleAuthorization($method, $parameters, $ability, $argument)
+    {
+        // Action that does not require a model or class...
+        if (is_null($argument)) {
+            [$ability, $arguments] = $this->resolveAbilityAndArgument($method, $ability, $argument);
+            
+            return $this->authorize($ability, $arguments);
+        }
+
+        $arguments = Arr::wrap($argument);
+
+        // Resolve method dependencies lazily, then reuse them for multi-argument authorization checks...
+        $methodDependencies = null;
+        $resolveMethodDependencies = function () use (&$methodDependencies, $method, $parameters): array {
+            return $methodDependencies ??= ImplicitlyBoundMethod::resolveMethodDependencies(
+                app(),
+                [$this, $method],
+                $parameters,
+            );
+        };
+
+        // Resolve each argument (prioritize method parameters first, then component properties)
+        $resolved = [];
+        foreach ($arguments as $arg) {
+            $resolved[] = $this->resolveArgument($arg, $method, $parameters, $resolveMethodDependencies);
+        }
+
+        return $this->authorize($ability, $resolved);
+    }
+
+    protected function resolveArgument(string $arg, string $method, array $parameters, \Closure $resolveMethodDependencies): mixed
+    {
+        // Action that does not require a model, for example a 'create' action...
+        if (class_exists($arg)) {
+            return $arg;
+        }
+
+        // Try method parameter first (prioritized per rules)
+        $methodArgument = Arr::first(
+            (new \ReflectionObject($this))->getMethod($method)->getParameters(),
+            fn (\ReflectionParameter $parameter): bool => $parameter->getName() === $arg,
+        );
+
+        if ($methodArgument instanceof \ReflectionParameter) {
+            $methodDependencies = $resolveMethodDependencies();
+
+            return $methodDependencies['named'][$arg];
+        }
+
+        // Fall back to component property
+        return data_get($this, $arg);
+    }
+
+protected function resolveAbilityAndArgument($method, $ability, $arguments)
+{
+    $ability = enum_value($ability);
+
+    if (is_string($ability) && ! str_contains($ability, '\\')) {
+        return [$ability, $arguments];
+    }
+
+    return [$this->normalizeGuessedAbilityName($method), $ability];
+}
+}

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -11,7 +11,7 @@ use function Illuminate\Support\enum_value;
 trait HandlesAuthorization
 {
     use AuthorizesRequests {
-        authorize as baseAuthorize;
+        authorize as private baseAuthorize;
     }
 
     protected ?string $method = null;

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportAuthorization;
 
+use Illuminate\Auth\Access\Response;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Arr;
 use Livewire\ImplicitlyBoundMethod;
@@ -11,17 +12,17 @@ use function Illuminate\Support\enum_value;
 trait HandlesAuthorization
 {
     use AuthorizesRequests;
-    
+
     protected ?string $method = null;
     protected ?array $parameters = null;
 
-    public function setMethodAndParameters($method, $parameters)
+    public function setMethodAndParameters($method, $parameters): void
     {
         $this->method = $method;
         $this->parameters = $parameters;
     }
 
-    public function handleAuthorization($ability, $argument)
+    public function handleAuthorization($ability, $argument): Response
     {
         if (! $this->method && ! $this->parameters) {
             return $this->authorize($ability, $argument);
@@ -76,7 +77,7 @@ trait HandlesAuthorization
         return data_get($this, $arg);
     }
 
-    protected function parseAbilityAndArguments($ability, $arguments)
+    protected function parseAbilityAndArguments($ability, $arguments): array
     {
         $ability = enum_value($ability);
 

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportAuthorization;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Auth\User as AuthUser;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Facades\Gate;
@@ -893,6 +894,56 @@ class UnitTest extends TestCase
             })
             ->dispatch('some-event')
             ->assertForbidden();
+    }
+
+    public function test_authorize_attribute_trigger_exception_hook()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[BaseAuthorize(AuthorizationPost::class)]
+                public function store() : bool
+                {
+                    return true;
+                }
+
+                public function exception($e, $stopPropagation)
+                {
+                    $stopPropagation();
+
+                    Session::put('authorization-denied', $e->getMessage());
+                }
+            })
+            ->call('store')
+            ->assertOk();
+
+        $this->assertTrue(Session::has('authorization-denied'));
+        $this->assertSame('This action is unauthorized.', Session::pull('authorization-denied'));
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[BaseAuthorize('edit', 'post')]
+                public function store(AuthorizationPost $post) : bool
+                {
+                    return true;
+                }
+
+                public function exception($e, $stopPropagation)
+                {
+                    $stopPropagation();
+
+                    Session::put('model-not-found', $e->getMessage());
+                }
+            })
+            ->call('store', post: 3)
+            ->assertOk();
+
+        $this->assertTrue(Session::has('model-not-found'));
+        $this->assertSame(
+            'No query results for model [Livewire\Features\SupportAuthorization\AuthorizationPost] 3', 
+            Session::pull('model-not-found')
+        );
     }
 }
 

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -41,6 +41,29 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_defined_basic_gates_using_trait_method()
+    {
+        Gate::define('can-open-post', fn () : bool => true);
+        Gate::define('cannot-open-post', fn () : bool => false);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function canOpenPost()
+                {
+                    $this->authorize('can-open-post');
+                }
+
+                public function cannotOpenPost()
+                {
+                    $this->authorize('cannot-open-post');
+                }
+            })
+            ->call('canOpenPost')
+            ->assertOk()
+            ->call('cannotOpenPost')
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_defined_gates_without_arguments()
     {
         Gate::define('can-open-post', function (AuthorizationUser $user) : bool
@@ -65,6 +88,34 @@ class UnitTest extends TestCase
                 public function canOpenPost() : bool
                 {
                     return true;
+                }
+            })
+            ->call('canOpenPost')
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_defined_gates_without_arguments_using_trait_method()
+    {
+        Gate::define('can-open-post', function (AuthorizationUser $user) : bool
+        {
+            return (int) $user->id === 1;
+        });
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function canOpenPost()
+                {
+                    $this->authorize('can-open-post');
+                }
+            })
+            ->call('canOpenPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public function canOpenPost()
+                {
+                    $this->authorize('can-open-post');
                 }
             })
             ->call('canOpenPost')
@@ -115,6 +166,48 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_defined_gates_with_model_argument_using_trait_method()
+    {
+        Gate::define('can-open-post', function (AuthorizationUser $user, AuthorizationPost $post) : bool
+        {
+            return (int) $post->user_id === (int) $user->id;
+        });
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function canOpenPost()
+                {
+                    $this->authorize('can-open-post', $this->post);
+                }
+            })
+            ->call('canOpenPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function canOpenPost()
+                {
+                    $this->authorize('can-open-post', $this->post);
+                }
+            })
+            ->call('canOpenPost')
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_policy_with_class()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
@@ -136,6 +229,31 @@ class UnitTest extends TestCase
                 public function createPost() : bool
                 {
                     return true;
+                }
+            })
+            ->call('createPost')
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_policy_with_class_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function createPost()
+                {
+                    $this->authorize('create', AuthorizationPost::class);
+                }
+            })
+            ->call('createPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public function createPost()
+                {
+                    $this->authorize('create', AuthorizationPost::class);
                 }
             })
             ->call('createPost')
@@ -183,6 +301,45 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_policy_with_model_argument_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function editPost()
+                {
+                    $this->authorize('edit', $this->post);
+                }
+            })
+            ->call('editPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function editPost()
+                {
+                    $this->authorize('edit', $this->post);
+                }
+            })
+            ->call('editPost')
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_policy_with_positional_model_id_argument()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
@@ -204,6 +361,31 @@ class UnitTest extends TestCase
                 public function editPost(AuthorizationPost $post) : bool
                 {
                     return true;
+                }
+            })
+            ->call('editPost', 1)
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_policy_with_positional_model_id_argument_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function editPost(AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+                }
+            })
+            ->call('editPost', 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public function editPost(AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
                 }
             })
             ->call('editPost', 1)
@@ -237,6 +419,31 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_policy_with_model_id_argument_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function editPost(AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public function editPost(AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_policy_with_dependency_injection_and_positional_model_id_argument()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
@@ -264,6 +471,35 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_policy_with_dependency_injection_and_positional_model_id_argument_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function editPost(UrlGenerator $generator, AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+
+                    return $generator->to('/some-url') !== '';
+                }
+            })
+            ->call('editPost', 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public function editPost(UrlGenerator $generator, AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+
+                    return $generator->to('/some-url') !== '';
+                }
+            })
+            ->call('editPost', 1)
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_policy_with_dependency_injection_and_named_model_id_argument()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
@@ -284,6 +520,35 @@ class UnitTest extends TestCase
                 #[Authorize('edit', 'post')]
                 public function editPost(UrlGenerator $generator, AuthorizationPost $post) : bool
                 {
+                    return $generator->to('/some-url') !== '';
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_policy_with_dependency_injection_and_named_model_id_argument_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function editPost(UrlGenerator $generator, AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+
+                    return $generator->to('/some-url') !== '';
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public function editPost(UrlGenerator $generator, AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+
                     return $generator->to('/some-url') !== '';
                 }
             })
@@ -394,6 +659,65 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_multiple_policies_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function createPost() 
+                {
+                    $this->authorize('create', AuthorizationPost::class);
+                    $this->authorize('edit', $this->post);
+                }
+            })
+            ->call('createPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                public function createPost() 
+                {
+                    $this->authorize('create', AuthorizationPost::class);
+                    $this->authorize('edit', $this->post);
+                }
+            })
+            ->call('createPost')
+            ->assertForbidden();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                public function createPost() 
+                {
+                    $this->authorize('create', AuthorizationPost::class);
+                    $this->authorize('edit', $this->post);
+                }
+            })
+            ->call('createPost')
+            ->assertForbidden();
+    }
+
     public function test_it_does_not_perform_any_action_when_denied()
     {
         Gate::define('cannot-open-post', fn () => false);
@@ -405,6 +729,27 @@ class UnitTest extends TestCase
                 #[Authorize('cannot-open-post')]
                 public function cannotOpenPost() : void
                 {
+                    Session::put('should-never-be-set', true);
+                }
+            })
+            ->call('cannotOpenPost')
+            ->assertForbidden();
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
+    public function test_it_does_not_perform_any_action_when_denied_using_trait_method()
+    {
+        Gate::define('cannot-open-post', fn () => false);
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function cannotOpenPost() : void
+                {
+                    $this->authorize('cannot-open-post');
+
                     Session::put('should-never-be-set', true);
                 }
             })
@@ -433,6 +778,26 @@ class UnitTest extends TestCase
         $this->assertFalse(Session::has('should-never-be-set'));
     }
 
+    public function test_authorize_is_enforced_on_event_listeners_using_trait_method()
+    {
+        Gate::define('cannot-open-post', fn () => false);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[\Livewire\Attributes\On('some-event')]
+                public function handleEvent() : void
+                {
+                    $this->authorize('cannot-open-post');
+
+                    Session::put('should-never-be-set', true);
+                }
+            })
+            ->dispatch('some-event')
+            ->assertForbidden();
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
     public function test_authorize_allows_authorized_event_listeners()
     {
         Gate::define('can-open-post', fn () => true);
@@ -443,6 +808,26 @@ class UnitTest extends TestCase
                 #[Authorize('can-open-post')]
                 public function handleEvent() : void
                 {
+                    Session::put('event-was-handled', true);
+                }
+            })
+            ->dispatch('some-event')
+            ->assertOk();
+
+        $this->assertTrue(Session::has('event-was-handled'));
+    }
+
+    public function test_authorize_allows_authorized_event_listeners_using_trait_method()
+    {
+        Gate::define('can-open-post', fn () => true);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[\Livewire\Attributes\On('some-event')]
+                public function handleEvent() : void
+                {
+                    $this->authorize('can-open-post');
+
                     Session::put('event-was-handled', true);
                 }
             })
@@ -475,6 +860,33 @@ class UnitTest extends TestCase
                 public function editPost(AuthorizationPost $post) : bool
                 {
                     return true;
+                }
+            })
+            ->dispatch('edit-post', post: 1)
+            ->assertForbidden();
+    }
+
+    public function test_authorize_allows_authorized_event_listeners_with_named_argument_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[\Livewire\Attributes\On('edit-post')]
+                public function editPost(AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+                }
+            })
+            ->dispatch('edit-post', post: 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[\Livewire\Attributes\On('edit-post')]
+                public function editPost(AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
                 }
             })
             ->dispatch('edit-post', post: 1)
@@ -588,6 +1000,71 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_defined_gates_with_array_as_argument_using_trait_method()
+    {
+        Gate::define('create-comment', function (AuthorizationUser $user, string $commentClass, AuthorizationPost $post) {
+            return (int) $user->id === 1 && $post->id === 1;
+        });
+
+        // AssertOk using class name and method argument
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function createComment(AuthorizationPost $post)
+                {
+                    $this->authorize('create-comment', [AuthorizationComment::class, $post]);
+                }
+            })
+            ->call('createComment', post: 1)
+            ->assertOk();
+
+        // AssertOk using class name and component property
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function createComment()
+                {
+                    $this->authorize('create-comment', [AuthorizationComment::class, $this->post]);
+                }
+            })
+            ->call('createComment')
+            ->assertOk();
+
+        // AssertForbidden using class name and method argument
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function createComment(AuthorizationPost $post)
+                {
+                    $this->authorize('create-comment', [AuthorizationComment::class, $post]);
+                }
+            })
+            ->call('createComment', post: 2)
+            ->assertForbidden();
+
+        // AssertForbidden using class name and component property
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                public function createComment()
+                {
+                    $this->authorize('create-comment', [AuthorizationComment::class, $this->post]);
+                }
+            })
+            ->call('createComment')
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_policy_with_array_of_class_and_model()
     {
         Gate::policy(AuthorizationComment::class, AuthorizationCommentPolicy::class);
@@ -690,6 +1167,69 @@ class UnitTest extends TestCase
                 }
             })
             ->call('createComment', post: 2)
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_policy_with_array_of_class_and_model_using_trait_method()
+    {
+        Gate::policy(AuthorizationComment::class, AuthorizationCommentPolicy::class);
+
+        // AssertOk using class name and method argument
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function createComment(AuthorizationPost $post)
+                {
+                    $this->authorize('create', [AuthorizationComment::class, $post]);
+                }
+            })
+            ->call('createComment', post: 1)
+            ->assertOk();
+
+        // AssertOk using class name and component property
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function createComment()
+                {
+                    $this->authorize('create', [AuthorizationComment::class, $this->post]);
+                }
+            })
+            ->call('createComment')
+            ->assertOk();
+
+        // AssertForbidden using class name and method argument
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function createComment(AuthorizationPost $post)
+                {
+                    $this->authorize('create', [AuthorizationComment::class, $post]);
+                }
+            })
+            ->call('createComment', post: 2)
+            ->assertForbidden();
+
+        // AssertForbidden using class name and component property
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                public function createComment()
+                {
+                    $this->authorize('create', [AuthorizationComment::class, $this->post]);
+                }
+            })
+            ->call('createComment')
             ->assertForbidden();
     }
 
@@ -810,6 +1350,75 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_policy_with_array_of_models_using_trait_method()
+    {
+        Gate::policy(AuthorizationComment::class, AuthorizationCommentPolicy::class);
+
+        // AssertOk using method arguments
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function editComment(AuthorizationComment $comment, AuthorizationPost $post)
+                {
+                    $this->authorize('edit', [$comment, $post]);
+                }
+            })
+            ->call('editComment', comment: 1, post: 1)
+            ->assertOk();
+
+        // AssertOk using component properties
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationComment $comment;
+
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->comment = AuthorizationComment::find(1);
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function editComment()
+                {
+                    $this->authorize('edit', [$this->comment, $this->post]);
+                }
+            })
+            ->call('editComment')
+            ->assertOk();
+
+        // AssertForbidden using method arguments
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function editComment(AuthorizationComment $comment, AuthorizationPost $post)
+                {
+                    $this->authorize('edit', [$comment, $post]);
+                }
+            })
+            ->call('editComment', comment: 1, post: 2)
+            ->assertForbidden();
+
+        // AssertForbidden using component properties
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationComment $comment;
+
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->comment = AuthorizationComment::find(1);
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                public function editComment()
+                {
+                    $this->authorize('edit', [$this->comment, $this->post]);
+                }
+            })
+            ->call('editComment')
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_using_defined_gate_with_only_class_name_as_argument()
     {
         Gate::define('create', function (AuthorizationUser $user) : bool
@@ -823,6 +1432,24 @@ class UnitTest extends TestCase
                 public function create() : bool
                 {
                     return true;
+                }
+            })
+            ->call('create')
+            ->assertOk();
+    }
+
+    public function test_can_authorize_using_defined_gate_with_only_class_name_as_argument_using_trait_method()
+    {
+        Gate::define('create', function (AuthorizationUser $user) : bool
+        {
+            return (int) $user->id === 1;
+        });
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function create()
+                {
+                    $this->authorize(AuthorizationPost::class);
                 }
             })
             ->call('create')
@@ -845,6 +1472,21 @@ class UnitTest extends TestCase
             ->assertOk();
     }
 
+    public function test_can_authorize_using_policy_with_only_class_name_and_no_arguments_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function create()
+                {
+                    $this->authorize(AuthorizationPost::class);
+                }
+            })
+            ->call('create')
+            ->assertOk();
+    }
+
     public function test_can_authorize_using_policy_resource_ability_mapping_with_only_class_name()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
@@ -855,6 +1497,21 @@ class UnitTest extends TestCase
                 public function store() : bool
                 {
                     return true;
+                }
+            })
+            ->call('store')
+            ->assertOk();
+    }
+
+    public function test_can_authorize_using_policy_resource_ability_mapping_with_only_class_name_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function store()
+                {
+                    $this->authorize(AuthorizationPost::class);
                 }
             })
             ->call('store')

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -1601,6 +1601,37 @@ class UnitTest extends TestCase
             Session::pull('model-not-found')
         );
     }
+
+    public function test_can_authorize_using_attribute_and_trait_method_at_the_same_time()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('create', AuthorizationPost::class)]
+                public function createPost()
+                {
+                    $this->authorize('edit', $this->post);
+                }
+
+                #[Authorize('edit', 'post')]
+                public function anotherCreatePost()
+                {
+                    $this->authorize('create', AuthorizationPost::class);
+                }
+            })
+            ->call('createPost')
+            ->assertOk()
+            ->call('anotherCreatePost')
+            ->assertOk();
+    }
 }
 
 class AuthorizationUser extends AuthUser

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -3,7 +3,6 @@
 namespace Livewire\Features\SupportAuthorization;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Auth\User as AuthUser;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Facades\Gate;


### PR DESCRIPTION
# Scenario
When using `#[Authorize]` attribute to perform authorization as pre-method execution. It doesnt trigger the component `exception()` hook.

```php
<?php

use App\Models\Post;
use Livewire\Component;

new class extends Component
{
    #[Authorize('edit', 'post')]
    public function save(Post $post)
    {
        //
    }

    public function exception($e, $stopPropagation)
    {
        $stopPropagation();

        dd($e->getMessage()); // not triggered
    }
}
```

# Problem
Attribute `call()` handled by `SupportAttributes::call()` which is running before the actual method get called so any exception thrown will not get handled by component exception hook.

Using `$this->component->authorize()` could fix this regression but comes with another issue where `AuthorizesRequests` trait resolve wrong method name from backtrace. Also, `ModelNotFoundException` from method dependency resolver will be ignored.

# Solution
Delegate authorization to `HandlesAuthorization` trait and inside `BaseAuthorize::call()`, wrap the component before performing the authorization from that trait. This way, any exception thrown can be catched from component `exception()` hook. All method parameters resolution handled just like before.

Another option is to keep `AuthorizesRequests` trait at `Component` and use `Gate` facade inside `HandlesAuthorization`. But I think its good to group it as one as it handles the same feature.

# Files Changed
- New `HandlesAuthorization` trait
- Move `AuthorizesRequests` trait from `Component` to `HandlesAuthorization` trait
- Override `parseAbilityAndArguments()` but add fallback method name from backtrace to ensure it resolve the correct method name
- Added regression tests to make sure both works as expected either using `#[Authorize]` attribute or `$this->authorize()`

Fix: https://github.com/livewire/livewire/issues/10410