### PR TITLE
[4.x] Fix `wire:loading.delay` remaining visible after concurrent requests

### DIFF
--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -48,11 +48,16 @@ function applyDelay(directive) {
         }
     })
 
+    let active = 0
     let timeout
     let started = false
 
     return [
         (callback) => { // Initiate delay...
+            active++
+
+            if (active > 1) return
+
             timeout = setTimeout(() => {
                 callback()
 
@@ -60,6 +65,12 @@ function applyDelay(directive) {
             }, duration)
         },
         async (callback) => { // Execute or abort...
+            if (active === 0) return
+
+            active--
+
+            if (active > 0) return
+
             if (started) {
                 await callback()
                 started = false

--- a/src/Features/SupportWireLoading/BrowserTest.php
+++ b/src/Features/SupportWireLoading/BrowserTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportWireLoading;
 
+use Livewire\Attributes\Async;
 use Livewire\Component;
 use Livewire\Form;
 use Livewire\Livewire;
@@ -182,6 +183,32 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertDontSee('Loading...')
         ->type('@input', 'Bye Caleb')
         ->pause(500) // wait for the loader to show when it shouldn't (second request is fast)
+        ->assertDontSee('Loading...')
+        ;
+    }
+
+    function test_wire_loading_delay_is_removed_after_concurrent_requests()
+    {
+        Livewire::visit(new class extends Component {
+            #[Async]
+            public function doSomething() {}
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <button x-on:click="$wire.doSomething(); $wire.doSomething()" dusk="button">Run</button>
+
+                        <div wire:loading.delay.longest wire:target="doSomething">
+                            Loading...
+                        </div>
+                    </div>
+                HTML;
+            }
+        })
+        ->assertDontSee('Loading...')
+        ->click('@button')
+        ->pause(1200)
         ->assertDontSee('Loading...')
         ;
     }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes. I did not open a discussion because this is a small bug fix.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

4️⃣ Does it include tests? (Required)

Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

When concurrent requests share the same delayed loading state, each request creates a timeout, but only the latest timeout can be cleared. An earlier timeout may still run after both requests finish, leaving the loading element visible.

This keeps track of the active requests so the timeout is started once and cleared after the last request finishes.





https://github.com/user-attachments/assets/aa305c79-71c9-4fa6-9ac4-47d7451034f1





https://github.com/user-attachments/assets/dffa956d-6e41-455a-8a7c-60fd35eda922
