### PR TITLE
[4.x] Add the `$empty` magic for checking property emptiness in expressions

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -775,6 +775,10 @@ let $wire = {
     // Usage: $wire.$get('count')
     $get(name) { ... },
 
+    // Determine if a property is empty — mirrors PHP's empty()...
+    // Usage: $wire.$empty('items'), wire:show="$empty('items')"
+    $empty(name) { ... },
+
     // Set a property on the component by name...
     // Usage: $wire.$set('count', 5)
     $set(name, value, live = true) { ... },

--- a/docs/wire-show.md
+++ b/docs/wire-show.md
@@ -44,6 +44,22 @@ class CreatePost extends Component
 
 When the "Create New Post" button is clicked, the modal appears without a server roundtrip. After successfully saving the post, the modal is hidden and the form is reset.
 
+## Checking for emptiness
+
+Rather than writing out emptiness checks like `items.length === 0` by hand, you can use the `$empty` magic. It mirrors PHP's `empty()`, so a property reads the same on both sides of the wire:
+
+```blade
+<div wire:show="$empty('items')">
+    No items yet — add your first one!
+</div>
+
+<div wire:show="! $empty('items')">
+    <!-- ... -->
+</div>
+```
+
+`$empty` is reactive — the element toggles as the property changes, even for client-side mutations that haven't reached the server yet.
+
 ## Using transitions
 
 You can combine `wire:show` with Alpine.js transitions to create smooth show/hide animations. Since `wire:show` only toggles the CSS `display` property, Alpine's `x-transition` directives work perfectly with it:

--- a/js/$wire.js
+++ b/js/$wire.js
@@ -2,7 +2,7 @@ import { cancelUpload, removeUpload, uploadAction, uploadMultiple } from './feat
 import { dispatch, dispatchEl, dispatchRef, dispatchSelf, dispatchTo, listen } from '@/events'
 import { generateEntangleFunction } from '@/features/supportEntangle'
 import { findComponentByEl } from '@/store'
-import { dataGet, dataSet } from '@/utils'
+import { dataGet, dataSet, isEmpty } from '@/utils'
 import Alpine from 'alpinejs'
 import { on as hook } from './hooks'
 import { fireAction, setNextActionMetadata, interceptComponentAction, interceptComponentMessage, interceptComponentRequest } from '@/request'
@@ -142,6 +142,10 @@ Alpine.magic('wire', (el, { cleanup }) => {
 wireProperty('__instance', (component) => component)
 
 wireProperty('$get', (component) => (property, reactive = true) => dataGet(reactive ? component.reactive : component.ephemeral, property))
+
+// Reads through the reactive proxy so expressions like wire:show="$empty('items')"
+// re-evaluate as the property changes — including client-side-only mutations...
+wireProperty('$empty', (component) => (property) => isEmpty(dataGet(component.reactive, property)))
 
 wireProperty('$el', (component) => {
     return component.el

--- a/js/utils.js
+++ b/js/utils.js
@@ -75,6 +75,21 @@ export function isFunction(subject) { return typeof subject === 'function' }
 export function isPrimitive(subject) { return typeof subject !== 'object' || subject === null }
 
 /**
+ * Determine if a value is "empty" — mirroring PHP's empty() so component
+ * properties feel the same on both sides of the wire: null, undefined,
+ * false, 0, '', '0', empty arrays, and key-less objects (how empty PHP
+ * associative arrays arrive on the client) are all empty.
+ */
+export function isEmpty(subject) {
+    if (subject === null || subject === undefined) return true
+    if (subject === false || subject === 0 || subject === '' || subject === '0') return true
+    if (isArray(subject)) return subject.length === 0
+    if (isObject(subject)) return Object.keys(subject).length === 0
+
+    return false
+}
+
+/**
  * Clone an object deeply to wipe out any shared references.
  */
 export function deepClone(obj) { return JSON.parse(JSON.stringify(obj)) }

--- a/js/utils.spec.js
+++ b/js/utils.spec.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { isEmpty } from './utils'
+
+describe('isEmpty', () => {
+    it('mirrors PHP empty() for scalars', () => {
+        expect(isEmpty(null)).toBe(true)
+        expect(isEmpty(undefined)).toBe(true)
+        expect(isEmpty(false)).toBe(true)
+        expect(isEmpty(0)).toBe(true)
+        expect(isEmpty('')).toBe(true)
+        expect(isEmpty('0')).toBe(true)
+
+        expect(isEmpty(true)).toBe(false)
+        expect(isEmpty(1)).toBe(false)
+        expect(isEmpty(-1)).toBe(false)
+        expect(isEmpty('a')).toBe(false)
+        expect(isEmpty(' ')).toBe(false)
+        expect(isEmpty('0.0')).toBe(false)
+        expect(isEmpty('false')).toBe(false)
+    })
+
+    it('treats arrays without items as empty', () => {
+        expect(isEmpty([])).toBe(true)
+
+        expect(isEmpty([0])).toBe(false)
+        expect(isEmpty([null])).toBe(false)
+        expect(isEmpty(['a'])).toBe(false)
+    })
+
+    it('treats objects without keys as empty (empty PHP associative arrays)', () => {
+        expect(isEmpty({})).toBe(true)
+
+        expect(isEmpty({ a: 1 })).toBe(false)
+        expect(isEmpty({ a: null })).toBe(false)
+    })
+})

--- a/src/Features/SupportMagicEmpty/BrowserTest.php
+++ b/src/Features/SupportMagicEmpty/BrowserTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Livewire\Features\SupportMagicEmpty;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    public function test_empty_magic_tracks_property_emptiness_across_server_roundtrips()
+    {
+        Livewire::visit(new class extends Component {
+            public $items = [];
+
+            public function add() { $this->items[] = 'item'; }
+
+            public function clear() { $this->items = []; }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="add" dusk="add">Add</button>
+                    <button wire:click="clear" dusk="clear">Clear</button>
+
+                    <div wire:show="$empty('items')" dusk="empty-state">No items yet</div>
+                    <div wire:show="! $empty('items')" dusk="list">Has items</div>
+                </div>
+                HTML;
+            }
+        })
+        ->assertVisible('@empty-state')
+        ->assertMissing('@list')
+        ->waitForLivewire()->click('@add')
+        ->assertMissing('@empty-state')
+        ->assertVisible('@list')
+        ->waitForLivewire()->click('@clear')
+        ->assertVisible('@empty-state')
+        ->assertMissing('@list');
+    }
+
+    public function test_empty_magic_is_reactive_to_client_side_only_mutations()
+    {
+        Livewire::visit(new class extends Component {
+            public $items = ['item'];
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button x-on:click="$wire.items = []" dusk="clear-client">Clear client-side</button>
+
+                    <div wire:show="$empty('items')" dusk="empty-state">No items yet</div>
+                </div>
+                HTML;
+            }
+        })
+        ->assertMissing('@empty-state')
+        ->click('@clear-client')
+        ->waitFor('@empty-state')
+        ->assertVisible('@empty-state');
+    }
+
+    public function test_empty_magic_mirrors_php_empty_semantics()
+    {
+        Livewire::visit(new class extends Component {
+            public $nothing = null;
+            public $falsy = false;
+            public $zero = 0;
+            public $zeroString = '0';
+            public $blank = '';
+            public $list = [];
+            public $name = 'Caleb';
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <span dusk="results"
+                        x-text="[
+                            $wire.$empty('nothing'),
+                            $wire.$empty('falsy'),
+                            $wire.$empty('zero'),
+                            $wire.$empty('zeroString'),
+                            $wire.$empty('blank'),
+                            $wire.$empty('list'),
+                            $wire.$empty('name'),
+                        ].join()"
+                    ></span>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@results', 'true,true,true,true,true,true,false');
+    }
+}


### PR DESCRIPTION
## What

Adds a `$empty('property')` magic to the `$wire` object, usable anywhere Livewire expressions run:

```blade
<div wire:show="$empty('files')">
    No media yet — drop files anywhere to get started
</div>
```

Because the expression contextualizer already prefixes `$`-identifiers onto `$wire`, the magic works in `wire:show` / `wire:text` / `wire:if` out of the box, plus Alpine and scripts via `$wire.$empty('items')`.

## Semantics

Mirrors PHP's `empty()` so a property reads the same on both sides of the wire: `null`, `false`, `0`, `''`, `'0'`, empty arrays, and key-less objects (how empty PHP associative arrays arrive on the client) are all empty. Implemented as an `isEmpty()` util in `js/utils.js`.

## Reactivity

Reads go through `component.reactive`, so bound expressions re-evaluate on any change — including client-side-only mutations (`$wire.items = []`) that haven't reached the server yet.

## Tests

- `js/utils.spec.js` — `isEmpty()` unit coverage across the PHP `empty()` matrix (vitest ✅)
- `src/Features/SupportMagicEmpty/BrowserTest.php` — three Dusk tests: toggling across server roundtrips, reactivity to client-side-only mutations, and PHP-semantics parity (✅ locally)

Docs added to the `$wire` reference in `javascript.md` and a "Checking for emptiness" section in `wire-show.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)