### PR TITLE
[4.x] Add an opt-in delta update engine for large components

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -216,6 +216,33 @@ return [
 
     /*
     |---------------------------------------------------------------------------
+    | Update Engine
+    |---------------------------------------------------------------------------
+    |
+    | The default "morph" engine returns the component's full rendered HTML
+    | after each update. The "delta" engine caches eligible renders and sends
+    | only the bytes that changed, as long as the render is big enough and the
+    | saving is worth it. It verifies a SHA-256 hash on both ends and falls back
+    | to full HTML whenever a baseline can't be trusted.
+    |
+    */
+
+    'update_engine' => env('LIVEWIRE_UPDATE_ENGINE', 'morph'),
+
+    'delta' => [
+        'store' => env('LIVEWIRE_DELTA_STORE'),
+        'ttl' => env('LIVEWIRE_DELTA_TTL', 300),
+        'minimum_html_bytes' => env('LIVEWIRE_DELTA_MINIMUM_HTML_BYTES', 8192),
+        'minimum_savings' => env('LIVEWIRE_DELTA_MINIMUM_SAVINGS', 0.1),
+        'minimum_compressed_savings_bytes' => env(
+            'LIVEWIRE_DELTA_MINIMUM_COMPRESSED_SAVINGS_BYTES',
+            1024,
+        ),
+        'compression_aware' => env('LIVEWIRE_DELTA_COMPRESSION_AWARE', true),
+    ],
+
+    /*
+    |---------------------------------------------------------------------------
     | Smart Wire Keys
     |---------------------------------------------------------------------------
     |

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -220,10 +220,10 @@ return [
     |---------------------------------------------------------------------------
     |
     | The default "morph" engine returns the component's full rendered HTML
-    | after each update. The "delta" engine caches eligible renders and sends
-    | only the bytes that changed, as long as the render is big enough and the
-    | saving is worth it. It verifies a SHA-256 hash on both ends and falls back
-    | to full HTML whenever a baseline can't be trusted.
+    | after each update. The experimental "delta" transport negotiates exact,
+    | stateless chunk and explicit fragment updates, with an optional cache
+    | accelerator. Every reconstructed snapshot and render is verified with
+    | SHA-256 and falls back safely whenever optional state is unavailable.
     |
     */
 
@@ -232,6 +232,7 @@ return [
     'delta' => [
         'store' => env('LIVEWIRE_DELTA_STORE'),
         'ttl' => env('LIVEWIRE_DELTA_TTL', 300),
+        'cache_accelerator' => env('LIVEWIRE_DELTA_CACHE_ACCELERATOR', true),
         'minimum_html_bytes' => env('LIVEWIRE_DELTA_MINIMUM_HTML_BYTES', 8192),
         'minimum_savings' => env('LIVEWIRE_DELTA_MINIMUM_SAVINGS', 0.1),
         'minimum_compressed_savings_bytes' => env(
@@ -239,6 +240,22 @@ return [
             1024,
         ),
         'compression_aware' => env('LIVEWIRE_DELTA_COMPRESSION_AWARE', true),
+        // Stateful rollout-sensitive optimizations are off until explicitly enabled.
+        'request_compression' => env('LIVEWIRE_DELTA_REQUEST_COMPRESSION', false),
+        'request_compression_minimum_bytes' => env(
+            'LIVEWIRE_DELTA_REQUEST_COMPRESSION_MINIMUM_BYTES',
+            1024,
+        ),
+        'block_size' => env('LIVEWIRE_DELTA_BLOCK_SIZE', 2048),
+        'maximum_manifest_bytes' => env('LIVEWIRE_DELTA_MAXIMUM_MANIFEST_BYTES', 65536),
+        'maximum_fragments' => env('LIVEWIRE_DELTA_MAXIMUM_FRAGMENTS', 1024),
+        'maximum_html_bytes' => env('LIVEWIRE_DELTA_MAXIMUM_HTML_BYTES', 4 * 1024 * 1024),
+        'snapshot_delta' => env('LIVEWIRE_SNAPSHOT_DELTA', true),
+        'snapshot_references' => env('LIVEWIRE_SNAPSHOT_REFERENCES', false),
+        'maximum_snapshot_bytes' => env('LIVEWIRE_SNAPSHOT_MAXIMUM_BYTES', 4 * 1024 * 1024),
+        'snapshot_reference_minimum_bytes' => env('LIVEWIRE_SNAPSHOT_REFERENCE_MINIMUM_BYTES', 1024),
+        'snapshot_store' => env('LIVEWIRE_SNAPSHOT_STORE'),
+        'snapshot_reference_ttl' => env('LIVEWIRE_SNAPSHOT_REFERENCE_TTL', 300),
     ],
 
     /*

--- a/docs/__nav.md
+++ b/docs/__nav.md
@@ -80,6 +80,7 @@ Blade Directives:
     '@teleport': { uri: /docs/4.x/directive-teleport, file: /directive-teleport.md }
 Advanced:
     Morphing: { uri: /docs/4.x/morphing, file: /morph.md }
+    Delta Updates: { uri: /docs/4.x/delta-updates, file: /delta-updates.md }
     Hydration: { uri: /docs/4.x/hydration, file: /hydration.md }
     Nesting: { uri: /docs/4.x/understanding-nesting, file: /understanding-nesting.md }
     Troubleshooting: { uri: /docs/4.x/troubleshooting, file: /troubleshooting.md }

--- a/docs/delta-updates.md
+++ b/docs/delta-updates.md
@@ -1,0 +1,143 @@
+After every update, Livewire sends the component's full server-rendered HTML back to the browser inside `effects.html`. The morphing system then updates only the DOM nodes that actually changed. That's great for the DOM, but the whole HTML string still went over the wire to get there — even when a single character changed.
+
+The delta update engine trims that transport step. Instead of resending the entire render, the server diffs it against the component's previous render and sends only the bytes that changed. It's opt-in and global:
+
+```php
+// config/livewire.php
+
+'update_engine' => 'delta',
+```
+
+You don't touch your components or Blade templates. The browser rebuilds the exact HTML from the patches and hands it to the same morph pipeline, so `wire:key`, focus, nested components, and morph hooks all behave exactly as before.
+
+It's also hybrid: renders under 8 KiB skip the engine entirely and go through the normal morph transport. There's no point diffing a small component, so those updates never touch the render-state store or add any delta metadata to the response.
+
+## Example
+
+Here's a plain `counter`. Nothing about it is delta-aware:
+
+```php
+<?php // resources/views/components/⚡counter.blade.php
+
+use Livewire\Component;
+
+new class extends Component {
+    public int $count = 0;
+
+    public array $items = ['Alpha', 'Beta', 'Gamma'];
+
+    public function increment()
+    {
+        $this->count++;
+    }
+};
+?>
+
+<div>
+    <button wire:click="increment">Increment</button>
+
+    <span>{{ $count }}</span>
+
+    <ul>
+        @foreach ($items as $index => $item)
+            <li wire:key="item-{{ $index }}">{{ $item }}</li>
+        @endforeach
+    </ul>
+</div>
+```
+
+Once the browser holds an exact baseline, bumping the count sends something like this instead of the whole render:
+
+```json
+{
+    "htmlDelta": {
+        "base": "8aef...",
+        "patches": [
+            { "start": 82, "delete": 1, "insert": "Mg==" }
+        ]
+    },
+    "htmlHash": "b391..."
+}
+```
+
+`start` and `delete` are UTF-8 byte offsets into the previous render, and `insert` is base64 so the patch stays valid JSON even when it lands in the middle of a multi-byte character.
+
+The engine can also emit several patches at once. Moving a Kanban card is the usual example — you delete it from one column and insert it into another, and everything in between stays untouched. Every patch offset refers to the same original render, and the browser applies the whole list atomically or not at all.
+
+Anchor discovery is bounded. If a render is almost entirely new, or a diff would need too many operations, the engine stops looking for anchors and just compares one big replacement patch against sending full HTML. Worst-case diff work stays predictable.
+
+## Where the previous render lives
+
+To build a delta, the server needs the exact render the browser is currently showing. After the first full update establishes that baseline, the engine keeps one render per active component in a cache store:
+
+```php
+// config/livewire.php
+
+'delta' => [
+    'store' => 'redis',
+    'ttl' => 300,
+    'minimum_html_bytes' => 8192,
+    'minimum_savings' => 0.1,
+    'minimum_compressed_savings_bytes' => 1024,
+    'compression_aware' => true,
+],
+```
+
+Leave `store` as `null` to use your default cache. A file cache is fine on a single server; once updates for the same component can hit different servers, you'll want a shared store like Redis.
+
+Only the latest eligible render is kept, and anything under `minimum_html_bytes` never gets stored at all, which keeps cache usage in check for chatty components. If a request comes in against a render the server no longer has — say two updates raced — it just falls back to a full response rather than patching the wrong revision.
+
+## Integrity and security
+
+Delta updates change how HTML is shipped, not how requests are authorized. The browser never sends rendered HTML or patches for the server to apply — it only sends the hash of the render it currently has. The component ID and expected baseline hash live inside Livewire's checksum-protected snapshot, same as always.
+
+Action parameters and public properties are still untrusted input. Validate and authorize them exactly as you would without the delta engine. See [Security](/docs/4.x/security) for the details.
+
+The render gets verified at both ends before any delta is used:
+
+1. The server re-hashes the cached render before diffing. If it doesn't match the expected hash, the entry is dropped and full HTML goes out.
+2. The browser re-hashes the reconstructed HTML before morphing. If that doesn't match the server's target hash, it throws the baseline away and asks for a fresh render.
+
+Verification on the client uses the Web Crypto API. If SHA-256 isn't available there, the browser simply stops advertising a baseline and everything continues on full HTML.
+
+One thing worth keeping in mind: the cache holds raw rendered HTML, which can contain user-specific data. Keep the store on a private network, give it an app-specific prefix, lock it down with Redis ACLs and TLS where connections leave a trusted boundary, and don't set the TTL longer than the gap you'd expect between interactions.
+
+Each successful delta costs one SHA-256 pass over the previous HTML on the server and one over the reconstructed HTML in the browser. There's no extra round trip, and next to rendering and transferring a full component it's usually cheap — though it does grow with unusually large renders.
+
+## When it falls back to full HTML
+
+Livewire sends the whole render whenever a delta isn't safe or isn't worth it:
+
+- the browser doesn't have an exact baseline yet;
+- the cached render expired or lives on another server;
+- the cached render fails its integrity check, or the store is down;
+- the browser and server baseline hashes disagree;
+- the browser can't verify the result;
+- the render is smaller than `minimum_html_bytes`;
+- the delta wouldn't save enough — by default it has to clear the threshold twice, once on raw JSON and once on a quick gzip estimate, and beat `minimum_compressed_savings_bytes` after compression.
+
+That double check matters because a base64 delta can look smaller before compression yet lose to highly repetitive HTML once gzip gets to it. Set `compression_aware` to `false` if your responses aren't compressed and you'd rather skip the extra probe — that also disables the compressed-savings threshold, since there's no longer an estimate to compare against.
+
+Components can cross the size boundary in either direction. Grow past `minimum_html_bytes` and one full response re-establishes a baseline; shrink back under it and Livewire quietly returns to plain morphing and drops the client baseline.
+
+The very first update after a page load is always full HTML. Browsers normalize parsed markup, so a component's `outerHTML` won't reliably match the server's exact string — that first response is what pins down a byte-exact baseline for later.
+
+And if the client can't apply or verify a delta for any reason, it leaves the DOM as-is, discards its baseline, and requests a full render on its own.
+
+## What it doesn't change
+
+The delta engine only changes how a render reaches the browser, not how it's produced. PHP still renders your component on every normal update and the browser still morphs the DOM — you're just not resending the parts that didn't change. The snapshot travels in every request and response exactly as before.
+
+If an interaction doesn't need a server render at all, reach for Alpine state or a renderless action instead. The delta engine is for the case where you *do* need the server to render but most of the output stays put.
+
+## Configuration reference
+
+| Option | Default | Description |
+|---|---:|---|
+| `update_engine` | `morph` | Set to `delta` to enable JSON render deltas globally |
+| `delta.store` | Default cache store | Cache store used to hold the latest render |
+| `delta.ttl` | `300` | Seconds an inactive render survives before expiring |
+| `delta.minimum_html_bytes` | `8192` | Smallest render that's allowed to use the store at all |
+| `delta.minimum_savings` | `0.1` | Fractional byte reduction a delta must reach before it's sent |
+| `delta.minimum_compressed_savings_bytes` | `1024` | Absolute reduction required on the gzip estimate |
+| `delta.compression_aware` | `true` | Also require the saving to hold up under a fast gzip estimate |

--- a/js/component.js
+++ b/js/component.js
@@ -4,6 +4,7 @@ import { generateWireObject } from '@/$wire'
 import { findComponentByEl, findComponent, hasComponent } from '@/store'
 import { trigger } from '@/hooks'
 import { setNextActionOrigin } from '@/request'
+import { isSha256Hash, supportsHtmlDeltaVerification } from '@/htmlDelta'
 
 export class Component {
     constructor(el) {
@@ -31,6 +32,13 @@ export class Component {
 
         this.effects = JSON.parse(el.getAttribute('wire:effects'))
         this.originalEffects = deepClone(this.effects)
+
+        // The delta update engine needs the exact server-rendered string, not
+        // the browser-normalized DOM. A full update seeds this baseline before
+        // later requests can ask the server for deltas.
+        this.serverRenderedHtml = null
+        this.serverRenderedHtmlHash = null
+        this.htmlResyncPending = false
 
         // "canonical" data represents the last known server state.
         this.canonical = extractData(deepClone(this.snapshot.data), { component: this })
@@ -132,6 +140,44 @@ export class Component {
         let propertiesDiff = diffAndConsolidate(this.canonical, this.ephemeral)
 
         return this.mergeQueuedUpdates(propertiesDiff)
+    }
+
+    getRenderMetadata() {
+        if (! supportsHtmlDeltaVerification()
+            || this.serverRenderedHtml === null
+            || this.serverRenderedHtmlHash === null
+        ) return {}
+
+        return { htmlHash: this.serverRenderedHtmlHash }
+    }
+
+    rememberServerRenderedHtml(html, hash) {
+        if (typeof html !== 'string' || ! isSha256Hash(hash)) {
+            return this.forgetServerRenderedHtml()
+        }
+
+        this.serverRenderedHtml = html
+        this.serverRenderedHtmlHash = hash
+        this.htmlResyncPending = false
+    }
+
+    forgetServerRenderedHtml() {
+        this.serverRenderedHtml = null
+        this.serverRenderedHtmlHash = null
+    }
+
+    requestHtmlResync() {
+        this.forgetServerRenderedHtml()
+
+        if (this.htmlResyncPending) return
+
+        this.htmlResyncPending = true
+
+        queueMicrotask(() => {
+            this.$wire.$refresh().finally(() => {
+                this.htmlResyncPending = false
+            })
+        })
     }
 
     applyUpdates(object, updates) {

--- a/js/component.js
+++ b/js/component.js
@@ -5,6 +5,9 @@ import { findComponentByEl, findComponent, hasComponent } from '@/store'
 import { trigger } from '@/hooks'
 import { setNextActionOrigin } from '@/request'
 import { isSha256Hash, supportsHtmlDeltaVerification } from '@/htmlDelta'
+import { buildBlockManifest, buildFragmentManifest } from '@/renderTransport'
+
+let transportEncoder = new TextEncoder()
 
 export class Component {
     constructor(el) {
@@ -31,6 +34,10 @@ export class Component {
         this.name = this.snapshot.memo.name
 
         this.effects = JSON.parse(el.getAttribute('wire:effects'))
+        this.renderTransportConfig = normalizeRenderTransportConfig(
+            this.effects.renderTransport,
+        )
+        delete this.effects.renderTransport
         this.originalEffects = deepClone(this.effects)
 
         // The delta update engine needs the exact server-rendered string, not
@@ -38,7 +45,16 @@ export class Component {
         // later requests can ask the server for deltas.
         this.serverRenderedHtml = null
         this.serverRenderedHtmlHash = null
+        this.renderBaseline = null
+        this.renderRevision = 0
+        this.transportFullLosses = 0
+        this.transportManifestCooldown = 0
+        this.snapshotReference = null
+        this.snapshotReferenceSnapshot = null
+        this.snapshotReferenceCooldown = 0
+        this.requestCompressionMinimumBytes = null
         this.htmlResyncPending = false
+        this.htmlResyncPromise = null
 
         // "canonical" data represents the last known server state.
         this.canonical = extractData(deepClone(this.snapshot.data), { component: this })
@@ -142,42 +158,244 @@ export class Component {
         return this.mergeQueuedUpdates(propertiesDiff)
     }
 
-    getRenderMetadata() {
-        if (! supportsHtmlDeltaVerification()
-            || this.serverRenderedHtml === null
-            || this.serverRenderedHtmlHash === null
-        ) return {}
+    getRenderMetadata(baseline = this.captureRenderBaseline()) {
+        if (! supportsHtmlDeltaVerification()) return {}
 
-        return { htmlHash: this.serverRenderedHtmlHash }
+        let config = this.renderTransportConfig
+
+        // A page rendered by the original experimental delta server has no
+        // mount handshake. Keep speaking its htmlHash protocol during rolling
+        // deployments instead of sending v1 metadata it cannot understand.
+        if (! config) {
+            return baseline ? { htmlHash: baseline.hash } : {}
+        }
+
+        let capabilities = ['same']
+        let canSendPortableManifests = this.transportManifestCooldown === 0
+        let canUseSnapshotReferences = this.snapshotReferenceCooldown === 0
+
+        if (this.transportManifestCooldown > 0) this.transportManifestCooldown--
+        if (this.snapshotReferenceCooldown > 0) this.snapshotReferenceCooldown--
+
+        if (config.snapshotDelta) capabilities.push('snapshot-delta')
+        if (config.snapshotReferences && canUseSnapshotReferences) {
+            capabilities.push('snapshot-ref')
+        }
+
+        let metadata = {
+            v: 1,
+            capabilities,
+        }
+
+        if (! baseline) return metadata
+
+        if (baseline.portable && config.cacheAccelerator) {
+            capabilities.push('splice')
+        }
+
+        metadata.base = {
+            hash: baseline.hash,
+            bytes: baseline.bytes,
+            revision: baseline.revision,
+        }
+
+        if (canSendPortableManifests && baseline.chunks) {
+            capabilities.push('chunks')
+            metadata.chunks = baseline.chunks
+        }
+
+        if (canSendPortableManifests
+            && baseline.fragments
+            && baseline.fragments.nodes.length > 0
+        ) {
+            capabilities.push('fragments')
+            metadata.fragments = baseline.fragments
+        }
+
+        return metadata
     }
 
-    rememberServerRenderedHtml(html, hash) {
+    captureRenderBaseline() {
+        let baseline = this.renderBaseline
+
+        if (! baseline
+            || baseline.html !== this.serverRenderedHtml
+            || baseline.hash !== this.serverRenderedHtmlHash
+        ) return null
+
+        return baseline
+    }
+
+    captureSnapshotReference(allowed = true, snapshot = null) {
+        if (! allowed
+            || typeof this.snapshotReference !== 'string'
+            || ! /^[A-Za-z0-9_-]{24}$/.test(this.snapshotReference)
+            || typeof snapshot !== 'string'
+            || snapshot !== this.snapshotReferenceSnapshot
+        ) return null
+
+        return this.snapshotReference
+    }
+
+    rememberServerRenderedHtml(
+        html,
+        hash,
+        render = null,
+        requestBaseline = null,
+        attemptedPortable = false,
+    ) {
         if (typeof html !== 'string' || ! isSha256Hash(hash)) {
             return this.forgetServerRenderedHtml()
         }
 
+        if (render?.target && render.target !== hash) {
+            return this.forgetServerRenderedHtml()
+        }
+
+        let previous = this.captureRenderBaseline()
+
+        if (previous && previous.html === html && previous.hash === hash) {
+            this.htmlResyncPending = false
+            this.recordRenderTransportOutcome(render, requestBaseline, attemptedPortable)
+
+            return
+        }
+
+        let bytes = transportEncoder.encode(html).length
+        let chunks = null
+        let fragments = null
+        let config = this.renderTransportConfig
+        let portable = config !== null
+            && bytes >= config.minimumBytes
+            && bytes <= config.maximumBytes
+
+        if (portable) {
+            try {
+                chunks = buildBlockManifest(html, config.blockSize)
+
+                if (chunks.blocks.length > config.maximumManifestBytes) {
+                    chunks = null
+                }
+            } catch (error) {}
+
+            try {
+                fragments = buildFragmentManifest(html)
+
+                if (fragments.nodes.length > config.maximumFragments) {
+                    fragments = null
+                }
+            } catch (error) {}
+        }
+
+        let revision = ++this.renderRevision
+
         this.serverRenderedHtml = html
         this.serverRenderedHtmlHash = hash
+        this.renderBaseline = Object.freeze({
+            html,
+            hash,
+            bytes,
+            revision,
+            portable,
+            chunks,
+            fragments,
+        })
         this.htmlResyncPending = false
+
+        this.recordRenderTransportOutcome(render, requestBaseline, attemptedPortable)
     }
 
     forgetServerRenderedHtml() {
         this.serverRenderedHtml = null
         this.serverRenderedHtmlHash = null
+        this.renderBaseline = null
     }
 
-    requestHtmlResync() {
+    requestHtmlResync(start) {
+        if (this.htmlResyncPromise) return this.htmlResyncPromise
+
         this.forgetServerRenderedHtml()
-
-        if (this.htmlResyncPending) return
-
         this.htmlResyncPending = true
 
-        queueMicrotask(() => {
-            this.$wire.$refresh().finally(() => {
+        this.htmlResyncPromise = Promise.resolve()
+            .then(start)
+            .finally(() => {
                 this.htmlResyncPending = false
+                this.htmlResyncPromise = null
             })
-        })
+
+        return this.htmlResyncPromise
+    }
+
+    rememberSnapshotReference(reference, snapshot) {
+        this.snapshotReference = null
+        this.snapshotReferenceSnapshot = null
+
+        if (this.snapshotReferenceCooldown > 0
+            || typeof reference !== 'string'
+            || ! /^[A-Za-z0-9_-]{24}$/.test(reference)
+            || typeof snapshot !== 'string'
+        ) return
+
+        this.snapshotReference = reference
+        this.snapshotReferenceSnapshot = snapshot
+    }
+
+    rejectSnapshotReference(reference) {
+        if (reference === null || this.snapshotReference === reference) {
+            this.snapshotReference = null
+            this.snapshotReferenceSnapshot = null
+        }
+
+        this.snapshotReferenceCooldown = Math.max(this.snapshotReferenceCooldown, 5)
+    }
+
+    rememberRequestCompression(minimumBytes) {
+        if (minimumBytes === undefined || minimumBytes === null) {
+            this.requestCompressionMinimumBytes = null
+
+            return
+        }
+
+        if (! Number.isSafeInteger(minimumBytes)
+            || minimumBytes < 1
+            || minimumBytes > 16 * 1024 * 1024
+        ) return
+
+        this.requestCompressionMinimumBytes = minimumBytes
+    }
+
+    getRequestCompressionMinimumBytes() {
+        return this.requestCompressionMinimumBytes
+    }
+
+    getMaximumRequestBytes() {
+        return this.renderTransportConfig?.maximumRequestBytes ?? null
+    }
+
+    recordRenderTransportOutcome(render, requestBaseline, attemptedPortable) {
+        if (! render || render.v !== 1) return
+
+        let lost = render.mode === 'full'
+
+        if (Number.isSafeInteger(render.stats?.full)
+            && Number.isSafeInteger(render.stats?.selected)
+        ) {
+            lost = render.stats.selected >= render.stats.full
+        }
+
+        if (lost && requestBaseline && attemptedPortable) {
+            this.transportFullLosses++
+
+            if (this.transportFullLosses >= 3) {
+                this.transportFullLosses = 0
+                this.transportManifestCooldown = Math.max(this.transportManifestCooldown, 5)
+            }
+
+            return
+        }
+
+        if (! lost) this.transportFullLosses = 0
     }
 
     applyUpdates(object, updates) {
@@ -326,6 +544,12 @@ export class Component {
             effects.scripts = this.originalEffects.scripts;
         }
 
+        // Preserve the opt-in handshake when this DOM is stored in the
+        // wire:navigate back/forward cache and initialized again later.
+        if (this.renderTransportConfig) {
+            effects.renderTransport = this.renderTransportConfig
+        }
+
         el.setAttribute('wire:effects', JSON.stringify(effects))
 
         el.setAttribute('wire:key', this.key)
@@ -383,4 +607,48 @@ export class Component {
             this.cleanups.pop()()
         }
     }
+}
+
+function normalizeRenderTransportConfig(value) {
+    let maximumRequestBytes = value?.maximumRequestBytes ?? null
+
+    if (value === null
+        || typeof value !== 'object'
+        || Array.isArray(value)
+        || value.v !== 1
+        || ! Number.isSafeInteger(value.minimumBytes)
+        || value.minimumBytes < 0
+        || ! Number.isSafeInteger(value.maximumBytes)
+        || value.maximumBytes < value.minimumBytes
+        || value.maximumBytes > 64 * 1024 * 1024
+        || ! Number.isSafeInteger(value.blockSize)
+        || value.blockSize < 256
+        || value.blockSize > 65536
+        || ! Number.isSafeInteger(value.maximumManifestBytes)
+        || value.maximumManifestBytes < 0
+        || value.maximumManifestBytes > 65536
+        || ! Number.isSafeInteger(value.maximumFragments)
+        || value.maximumFragments < 0
+        || value.maximumFragments > 1024
+        || typeof value.cacheAccelerator !== 'boolean'
+        || typeof value.snapshotDelta !== 'boolean'
+        || typeof value.snapshotReferences !== 'boolean'
+        || (maximumRequestBytes !== null
+            && (! Number.isSafeInteger(maximumRequestBytes)
+                || maximumRequestBytes < 0
+                || maximumRequestBytes > 2147483647))
+    ) return null
+
+    return Object.freeze({
+        v: 1,
+        minimumBytes: value.minimumBytes,
+        maximumBytes: value.maximumBytes,
+        blockSize: value.blockSize,
+        maximumManifestBytes: value.maximumManifestBytes,
+        maximumFragments: value.maximumFragments,
+        cacheAccelerator: value.cacheAccelerator,
+        snapshotDelta: value.snapshotDelta,
+        snapshotReferences: value.snapshotReferences,
+        maximumRequestBytes,
+    })
 }

--- a/js/componentTransport.spec.js
+++ b/js/componentTransport.spec.js
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest'
+import { Component } from './component'
+import { hashHtml } from './htmlDelta'
+
+describe('component render transport state', () => {
+    it('does not advertise transport without a delta handshake or legacy hash', () => {
+        let component = transportComponent(false)
+
+        expect(component.getRenderMetadata()).toEqual({})
+    })
+
+    it('keeps the legacy htmlHash protocol during a rolling deployment', async () => {
+        let component = transportComponent(false)
+        let html = '<div>legacy baseline</div>'
+        let hash = await hashHtml(html)
+
+        component.rememberServerRenderedHtml(html, hash)
+
+        expect(component.getRenderMetadata()).toEqual({ htmlHash: hash })
+    })
+
+    it('advertises v1 without treating the parsed mount DOM as a baseline', () => {
+        let component = transportComponent()
+        let metadata = component.getRenderMetadata()
+
+        expect(metadata.v).toBe(1)
+        expect(metadata.base).toBeUndefined()
+        expect(metadata.capabilities).toContain('snapshot-delta')
+        expect(metadata.capabilities).toContain('snapshot-ref')
+    })
+
+    it('captures an immutable exact baseline and emits portable manifests', async () => {
+        let component = transportComponent()
+        let token = 'a'.repeat(16)
+        let marker = '<!--[if FRAGMENT:type=transport|name=row|token=' + token + ']><![endif]-->'
+        let end = '<!--[if ENDFRAGMENT:type=transport|name=row|token=' + token + ']><![endif]-->'
+        let html = '<div>' + marker + 'value'.repeat(2000) + end + '</div>'
+        let hash = await hashHtml(html)
+
+        component.rememberServerRenderedHtml(html, hash)
+
+        let baseline = component.captureRenderBaseline()
+        let metadata = component.getRenderMetadata(baseline)
+
+        expect(Object.isFrozen(baseline)).toBe(true)
+        expect(metadata.base).toEqual({
+            hash,
+            bytes: new TextEncoder().encode(html).length,
+            revision: 1,
+        })
+        expect(metadata.capabilities).toContain('chunks')
+        expect(metadata.capabilities).toContain('fragments')
+        expect(metadata.chunks.blocks).not.toBe('')
+        expect(metadata.fragments.nodes).toHaveLength(1)
+    })
+
+    it('does not expose a baseline after its legacy integrity aliases are changed', async () => {
+        let component = transportComponent()
+        let html = '<div>baseline</div>'
+
+        component.rememberServerRenderedHtml(html, await hashHtml(html))
+        component.serverRenderedHtmlHash = '0'.repeat(64)
+
+        expect(component.captureRenderBaseline()).toBeNull()
+    })
+
+    it('temporarily stops sending portable manifests after repeated full losses', async () => {
+        let component = transportComponent()
+        let html = '<div>' + 'large'.repeat(2000) + '</div>'
+        let hash = await hashHtml(html)
+
+        component.rememberServerRenderedHtml(html, hash)
+
+        for (let index = 0; index < 3; index++) {
+            let baseline = component.captureRenderBaseline()
+
+            component.rememberServerRenderedHtml(
+                html,
+                hash,
+                { v: 1, mode: 'full', target: hash },
+                baseline,
+                true,
+            )
+        }
+
+        let coolingDown = component.getRenderMetadata(component.captureRenderBaseline())
+
+        expect(coolingDown.capabilities).not.toContain('chunks')
+
+        for (let index = 0; index < 4; index++) {
+            component.getRenderMetadata(component.captureRenderBaseline())
+        }
+
+        let resumed = component.getRenderMetadata(component.captureRenderBaseline())
+
+        expect(resumed.capabilities).toContain('chunks')
+    })
+
+    it('keeps oversized render and fragment manifests out of request metadata', async () => {
+        let component = transportComponent()
+        let oversized = '<div>' + 'x'.repeat(4 * 1024 * 1024) + '</div>'
+        let oversizedHash = await hashHtml(oversized)
+
+        component.rememberServerRenderedHtml(oversized, oversizedHash)
+
+        let oversizedMetadata = component.getRenderMetadata(component.captureRenderBaseline())
+
+        expect(oversizedMetadata.capabilities).not.toContain('splice')
+        expect(oversizedMetadata.chunks).toBeUndefined()
+        expect(oversizedMetadata.fragments).toBeUndefined()
+
+        let fragments = ''
+
+        for (let index = 0; index < 1025; index++) {
+            let token = index.toString(16).padStart(16, '0')
+
+            fragments += '<!--[if FRAGMENT:type=transport|name=row|token=' + token + ']><![endif]-->'
+                + 'value'
+                + '<!--[if ENDFRAGMENT:type=transport|name=row|token=' + token + ']><![endif]-->'
+        }
+
+        let fragmented = '<div>' + fragments + '</div>'
+
+        component.rememberServerRenderedHtml(fragmented, await hashHtml(fragmented))
+
+        let fragmentedMetadata = component.getRenderMetadata(component.captureRenderBaseline())
+
+        expect(fragmentedMetadata.capabilities).toContain('chunks')
+        expect(fragmentedMetadata.capabilities).not.toContain('fragments')
+        expect(fragmentedMetadata.fragments).toBeUndefined()
+    })
+
+    it('only retains valid snapshot references outside the miss cooldown', () => {
+        let component = transportComponent()
+        let reference = 'a'.repeat(24)
+
+        component.rememberSnapshotReference(reference, 'snapshot')
+        expect(component.captureSnapshotReference(true, 'snapshot')).toBe(reference)
+        expect(component.captureSnapshotReference(true, 'changed snapshot')).toBeNull()
+
+        component.rejectSnapshotReference(reference)
+        component.rememberSnapshotReference('b'.repeat(24), 'snapshot')
+
+        expect(component.captureSnapshotReference(true, 'snapshot')).toBeNull()
+        expect(component.snapshotReferenceCooldown).toBe(5)
+    })
+
+    it('persists the delta handshake in navigate-cached DOM', () => {
+        let component = transportComponent()
+        let attributes = {}
+
+        component.el = {
+            setAttribute(name, value) {
+                attributes[name] = value
+            },
+        }
+        component.snapshotEncoded = '{"memo":{}}'
+        component.originalEffects = {}
+        component.key = null
+
+        component.inscribeSnapshotAndEffectsOnElement()
+
+        expect(JSON.parse(attributes['wire:effects']).renderTransport)
+            .toEqual(component.renderTransportConfig)
+    })
+
+    it('clears negotiated request compression when a v1 response disables it', () => {
+        let component = transportComponent()
+
+        component.rememberRequestCompression(1024)
+        expect(component.getRequestCompressionMinimumBytes()).toBe(1024)
+
+        component.rememberRequestCompression(undefined)
+        expect(component.getRequestCompressionMinimumBytes()).toBeNull()
+    })
+})
+
+function transportComponent(enabled = true) {
+    let component = Object.create(Component.prototype)
+
+    component.serverRenderedHtml = null
+    component.serverRenderedHtmlHash = null
+    component.renderBaseline = null
+    component.renderRevision = 0
+    component.transportFullLosses = 0
+    component.transportManifestCooldown = 0
+    component.snapshotReference = null
+    component.snapshotReferenceSnapshot = null
+    component.snapshotReferenceCooldown = 0
+    component.requestCompressionMinimumBytes = null
+    component.htmlResyncPending = false
+    component.htmlResyncPromise = null
+    component.renderTransportConfig = enabled
+        ? Object.freeze({
+            v: 1,
+            minimumBytes: 8192,
+            maximumBytes: 4 * 1024 * 1024,
+            blockSize: 2048,
+            maximumManifestBytes: 65536,
+            maximumFragments: 1024,
+            cacheAccelerator: true,
+            snapshotDelta: true,
+            snapshotReferences: true,
+            maximumRequestBytes: 1024 * 1024,
+        })
+        : null
+
+    return component
+}

--- a/js/features/supportMorphDom.js
+++ b/js/features/supportMorphDom.js
@@ -1,14 +1,47 @@
-import { morph } from "@/morph";
-import { interceptMessage } from "@/request";
+import { reconstructHtmlDelta } from '@/htmlDelta'
+import { interceptMessage } from '@/request'
+import { morph } from '@/morph'
 
 interceptMessage(({ message, onSuccess }) => {
     onSuccess(({ payload, onMorph }) => {
         onMorph(async () => {
             let html = payload.effects.html
+            let delta = payload.effects.htmlDelta
+            let hash = payload.effects.htmlHash
 
-            if (! html) return
+            if (typeof html === 'string') {
+                await morph(message.component, message.component.el, html)
+
+                message.component.rememberServerRenderedHtml(html, hash)
+
+                return
+            }
+
+            if (! delta) return
+
+            if (message.component.serverRenderedHtml === null
+                || message.component.serverRenderedHtmlHash !== delta.base
+            ) {
+                message.component.requestHtmlResync()
+
+                return
+            }
+
+            try {
+                html = await reconstructHtmlDelta(
+                    message.component.serverRenderedHtml,
+                    delta.patches ?? delta.patch,
+                    hash,
+                )
+            } catch (error) {
+                message.component.requestHtmlResync()
+
+                return
+            }
 
             await morph(message.component, message.component.el, html)
+
+            message.component.rememberServerRenderedHtml(html, hash)
         })
     })
 })

--- a/js/features/supportMorphDom.js
+++ b/js/features/supportMorphDom.js
@@ -1,47 +1,39 @@
-import { reconstructHtmlDelta } from '@/htmlDelta'
-import { interceptMessage } from '@/request'
+import { fireAction, interceptMessage } from '@/request'
 import { morph } from '@/morph'
 
 interceptMessage(({ message, onSuccess }) => {
     onSuccess(({ payload, onMorph }) => {
         onMorph(async () => {
             let html = payload.effects.html
-            let delta = payload.effects.htmlDelta
-            let hash = payload.effects.htmlHash
+            let render = payload.effects.render
+            let hash = render?.target || payload.effects.htmlHash
 
-            if (typeof html === 'string') {
+            if (payload.effects.renderRecovery) {
+                await message.component.requestHtmlResync(() => {
+                    return fireAction(
+                        message.component,
+                        '$refresh',
+                        [],
+                        { async: true, transportRecovery: true },
+                    )
+                })
+
+                return
+            }
+
+            if (typeof html !== 'string') return
+
+            if (message.component.serverRenderedHtmlHash !== hash) {
                 await morph(message.component, message.component.el, html)
-
-                message.component.rememberServerRenderedHtml(html, hash)
-
-                return
             }
 
-            if (! delta) return
-
-            if (message.component.serverRenderedHtml === null
-                || message.component.serverRenderedHtmlHash !== delta.base
-            ) {
-                message.component.requestHtmlResync()
-
-                return
-            }
-
-            try {
-                html = await reconstructHtmlDelta(
-                    message.component.serverRenderedHtml,
-                    delta.patches ?? delta.patch,
-                    hash,
-                )
-            } catch (error) {
-                message.component.requestHtmlResync()
-
-                return
-            }
-
-            await morph(message.component, message.component.el, html)
-
-            message.component.rememberServerRenderedHtml(html, hash)
+            message.component.rememberServerRenderedHtml(
+                html,
+                hash,
+                render,
+                message.renderBaseline,
+                message.renderAttemptedPortable,
+            )
         })
     })
 })

--- a/js/htmlDelta.js
+++ b/js/htmlDelta.js
@@ -1,0 +1,125 @@
+let encoder = new TextEncoder()
+let decoder = new TextDecoder('utf-8', { fatal: true })
+let verificationUnavailable = false
+
+export function supportsHtmlDeltaVerification() {
+    return ! verificationUnavailable
+        && typeof globalThis.crypto?.subtle?.digest === 'function'
+}
+
+export async function hashHtml(html) {
+    if (typeof html !== 'string' || ! supportsHtmlDeltaVerification()) {
+        throw new Error('Livewire HTML delta verification is unavailable')
+    }
+
+    let digest
+
+    try {
+        digest = await globalThis.crypto.subtle.digest('SHA-256', encoder.encode(html))
+    } catch (error) {
+        verificationUnavailable = true
+
+        throw error
+    }
+
+    return Array.from(
+        new Uint8Array(digest),
+        byte => byte.toString(16).padStart(2, '0'),
+    ).join('')
+}
+
+export async function reconstructHtmlDelta(html, patches, expectedHash) {
+    if (! isSha256Hash(expectedHash)) {
+        throw new Error('Invalid Livewire HTML delta hash')
+    }
+
+    let reconstructed = applyHtmlDelta(html, patches)
+    let actualHash = await hashHtml(reconstructed)
+
+    if (actualHash !== expectedHash) {
+        throw new Error('Livewire HTML delta integrity check failed')
+    }
+
+    return reconstructed
+}
+
+export function isSha256Hash(value) {
+    return typeof value === 'string' && /^[a-f0-9]{64}$/.test(value)
+}
+
+export function applyHtmlDelta(html, patches) {
+    let source = encoder.encode(html)
+
+    // Accept the original single-patch shape during rolling deployments.
+    if (! Array.isArray(patches)) patches = [patches]
+
+    let decoded = []
+    let sourceCursor = 0
+    let resultLength = source.length
+
+    patches.forEach(patch => {
+        if (! patch || typeof patch !== 'object') {
+            throw new Error('Invalid Livewire HTML delta patch')
+        }
+
+        let start = patch.start
+        let deleteLength = patch.delete
+        let insert = decodeBase64(patch.insert)
+
+        if (! Number.isInteger(start)
+            || ! Number.isInteger(deleteLength)
+            || start < sourceCursor
+            || deleteLength < 0
+            || start + deleteLength > source.length
+        ) {
+            throw new Error('Invalid Livewire HTML delta range')
+        }
+
+        resultLength += insert.length - deleteLength
+
+        if (! Number.isSafeInteger(resultLength) || resultLength < 0) {
+            throw new Error('Invalid Livewire HTML delta length')
+        }
+
+        decoded.push({ start, deleteLength, insert })
+        sourceCursor = start + deleteLength
+    })
+
+    let result = new Uint8Array(resultLength)
+    let resultCursor = 0
+
+    sourceCursor = 0
+
+    decoded.forEach(({ start, deleteLength, insert }) => {
+        let unchanged = source.subarray(sourceCursor, start)
+
+        result.set(unchanged, resultCursor)
+        resultCursor += unchanged.length
+
+        result.set(insert, resultCursor)
+        resultCursor += insert.length
+
+        sourceCursor = start + deleteLength
+    })
+
+    let suffix = source.subarray(sourceCursor)
+
+    result.set(suffix, resultCursor)
+
+    return decoder.decode(result)
+}
+
+function decodeBase64(value) {
+    if (typeof value !== 'string') {
+        throw new Error('Invalid Livewire HTML delta insert')
+    }
+
+    let binary = atob(value)
+    let bytes = new Uint8Array(binary.length)
+
+    for (let index = 0; index < binary.length; index++) {
+        bytes[index] = binary.charCodeAt(index)
+    }
+
+    return bytes
+}

--- a/js/htmlDelta.spec.js
+++ b/js/htmlDelta.spec.js
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { applyHtmlDelta, hashHtml, reconstructHtmlDelta } from './htmlDelta'
+
+describe('HTML deltas', () => {
+    it('applies a byte-range replacement', () => {
+        expect(applyHtmlDelta('<div>1</div>', {
+            start: 5,
+            delete: 1,
+            insert: encodeBase64('2'),
+        })).toBe('<div>2</div>')
+    })
+
+    it('applies inserts and deletes', () => {
+        expect(applyHtmlDelta('<div>old value</div>', {
+            start: 5,
+            delete: 9,
+            insert: encodeBase64('new'),
+        })).toBe('<div>new</div>')
+    })
+
+    it('uses UTF-8 byte offsets without corrupting unicode', () => {
+        let prefix = '<div>'
+        let from = `${prefix}foo 👋</div>`
+
+        expect(applyHtmlDelta(from, {
+            start: byteLength(prefix),
+            delete: byteLength('foo 👋'),
+            insert: encodeBase64('bar 🚀'),
+        })).toBe('<div>bar 🚀</div>')
+    })
+
+    it('applies multiple patches using offsets from the original HTML', () => {
+        let from = '<div><span>Todo card</span><main>Stable content</main><aside>Done</aside></div>'
+        let removedStart = byteLength('<div>')
+        let removedLength = byteLength('<span>Todo card</span>')
+        let insertionStart = byteLength('<div><span>Todo card</span><main>Stable content</main><aside>Done')
+
+        expect(applyHtmlDelta(from, [
+            {
+                start: removedStart,
+                delete: removedLength,
+                insert: '',
+            },
+            {
+                start: insertionStart,
+                delete: 0,
+                insert: encodeBase64('<span>Todo card</span>'),
+            },
+        ])).toBe('<div><main>Stable content</main><aside>Done<span>Todo card</span></aside></div>')
+    })
+
+    it('accepts an empty patch list', () => {
+        expect(applyHtmlDelta('<div>unchanged</div>', [])).toBe('<div>unchanged</div>')
+    })
+
+    it('rejects an out-of-bounds range', () => {
+        expect(() => applyHtmlDelta('<div></div>', {
+            start: 100,
+            delete: 0,
+            insert: '',
+        })).toThrow('Invalid Livewire HTML delta range')
+    })
+
+    it('rejects overlapping patches', () => {
+        expect(() => applyHtmlDelta('<div>content</div>', [
+            { start: 5, delete: 3, insert: '' },
+            { start: 6, delete: 1, insert: '' },
+        ])).toThrow('Invalid Livewire HTML delta range')
+    })
+
+    it('hashes the exact UTF-8 bytes used by the server', async () => {
+        expect(await hashHtml('<div>foo 🚀</div>'))
+            .toBe('fd5e37963f5a9f3bbfd8a5da40d73aa3c939b1866b2ef414302d89f2ed294e98')
+    })
+
+    it('verifies reconstructed HTML before returning it for morphing', async () => {
+        let from = '<div>Count: 1</div>'
+        let to = '<div>Count: 2</div>'
+        let patches = [{
+            start: byteLength('<div>Count: '),
+            delete: 1,
+            insert: encodeBase64('2'),
+        }]
+        let expectedHash = await hashHtml(to)
+
+        await expect(reconstructHtmlDelta(from, patches, expectedHash)).resolves.toBe(to)
+    })
+
+    it('rejects reconstructed HTML when a patch fails its integrity check', async () => {
+        let from = '<div>Count: 1</div>'
+        let expectedHash = await hashHtml('<div>Count: 2</div>')
+        let tamperedPatches = [{
+            start: byteLength('<div>Count: '),
+            delete: 1,
+            insert: encodeBase64('9'),
+        }]
+
+        await expect(reconstructHtmlDelta(from, tamperedPatches, expectedHash))
+            .rejects.toThrow('Livewire HTML delta integrity check failed')
+    })
+})
+
+function byteLength(value) {
+    return new TextEncoder().encode(value).length
+}
+
+function encodeBase64(value) {
+    let bytes = new TextEncoder().encode(value)
+    let binary = Array.from(bytes, byte => String.fromCharCode(byte)).join('')
+
+    return btoa(binary)
+}

--- a/js/htmlDelta.spec.js
+++ b/js/htmlDelta.spec.js
@@ -20,13 +20,13 @@ describe('HTML deltas', () => {
 
     it('uses UTF-8 byte offsets without corrupting unicode', () => {
         let prefix = '<div>'
-        let from = `${prefix}foo 👋</div>`
+        let from = `${prefix}д字 👋</div>`
 
         expect(applyHtmlDelta(from, {
             start: byteLength(prefix),
-            delete: byteLength('foo 👋'),
-            insert: encodeBase64('bar 🚀'),
-        })).toBe('<div>bar 🚀</div>')
+            delete: byteLength('д字 👋'),
+            insert: encodeBase64('ж世 🚀'),
+        })).toBe('<div>ж世 🚀</div>')
     })
 
     it('applies multiple patches using offsets from the original HTML', () => {
@@ -69,8 +69,8 @@ describe('HTML deltas', () => {
     })
 
     it('hashes the exact UTF-8 bytes used by the server', async () => {
-        expect(await hashHtml('<div>foo 🚀</div>'))
-            .toBe('fd5e37963f5a9f3bbfd8a5da40d73aa3c939b1866b2ef414302d89f2ed294e98')
+        expect(await hashHtml('<div>д字 🚀</div>'))
+            .toBe('aec6c9575dda2ec914dead7a34c741d7cfd1c305d0808fa88e85e95a0909029f')
     })
 
     it('verifies reconstructed HTML before returning it for morphing', async () => {

--- a/js/morph.js
+++ b/js/morph.js
@@ -29,6 +29,11 @@ export async function morph(component, el, html) {
     delete effects.html
     delete effects.htmlDelta
     delete effects.htmlHash
+    delete effects.render
+    delete effects.renderRecovery
+    if (component.renderTransportConfig) {
+        effects.renderTransport = component.renderTransportConfig
+    }
     to.setAttribute('wire:effects', JSON.stringify(effects))
 
     to.__livewire = component

--- a/js/morph.js
+++ b/js/morph.js
@@ -24,9 +24,11 @@ export async function morph(component, el, html) {
     // mismatch or problem the component will able to be re-initialized...
     to.setAttribute('wire:snapshot', component.snapshotEncoded)
 
-    // Remove the 'html' key from the effects as the html will be morphed...
+    // Remove transport-only render effects as the HTML will be morphed...
     let effects = { ...component.effects }
     delete effects.html
+    delete effects.htmlDelta
+    delete effects.htmlHash
     to.setAttribute('wire:effects', JSON.stringify(effects))
 
     to.__livewire = component

--- a/js/renderTransport.js
+++ b/js/renderTransport.js
@@ -1,0 +1,923 @@
+import { applyHtmlDelta, hashHtml, isSha256Hash } from './htmlDelta'
+
+let encoder = new TextEncoder()
+let decoder = new TextDecoder('utf-8', { fatal: true })
+let maximumOutputBytes = 128 * 1024 * 1024
+let maximumOperations = 65536
+let minimumBlockSize = 256
+let maximumBlockSize = 65536
+let crc32Table = buildCrc32Table()
+
+export function buildBlockManifest(html, blockSize = 2048) {
+    let source = encodeUtf8(html, 'render baseline')
+
+    validateBlockSize(blockSize)
+
+    let blockCount = Math.ceil(source.length / blockSize)
+
+    if (blockCount > maximumOperations) {
+        throw new Error('Livewire render block manifest is too large')
+    }
+
+    let packed = new Uint8Array(blockCount * 8)
+    let view = new DataView(packed.buffer)
+
+    for (let index = 0; index < blockCount; index++) {
+        let start = index * blockSize
+        let block = source.subarray(start, Math.min(start + blockSize, source.length))
+
+        view.setUint32(index * 8, rsyncWeakChecksum(block), false)
+        view.setUint32(index * 8 + 4, crc32(block), false)
+    }
+
+    return Object.freeze({
+        blockSize,
+        blocks: encodeBase64(packed),
+    })
+}
+
+export function applyChunkOps(baselineHtml, ops, expectedBytes = null) {
+    let source = encodeUtf8(baselineHtml, 'render baseline')
+
+    validateOperationList(ops, 'chunk')
+    validateOptionalByteLength(expectedBytes)
+
+    let decoded = []
+    let resultLength = 0
+
+    ops.forEach(op => {
+        if (! Array.isArray(op)) {
+            throw new Error('Invalid Livewire render chunk operation')
+        }
+
+        if (op[0] === 'c') {
+            if (op.length !== 3
+                || ! Number.isSafeInteger(op[1])
+                || ! Number.isSafeInteger(op[2])
+                || op[1] < 0
+                || op[2] <= 0
+                || ! Number.isSafeInteger(op[1] + op[2])
+                || op[1] + op[2] > source.length
+            ) {
+                throw new Error('Invalid Livewire render chunk copy range')
+            }
+
+            decoded.push({
+                bytes: source.subarray(op[1], op[1] + op[2]),
+            })
+
+            resultLength = addOutputLength(resultLength, op[2])
+
+            return
+        }
+
+        if (op[0] === 'a') {
+            if (op.length !== 2) {
+                throw new Error('Invalid Livewire render chunk add operation')
+            }
+
+            let bytes = decodeBase64(op[1], 'chunk add')
+
+            if (bytes.length === 0) {
+                throw new Error('Invalid Livewire render chunk add operation')
+            }
+
+            decoded.push({ bytes })
+            resultLength = addOutputLength(resultLength, bytes.length)
+
+            return
+        }
+
+        throw new Error('Invalid Livewire render chunk operation')
+    })
+
+    if (expectedBytes !== null && resultLength !== expectedBytes) {
+        throw new Error('Livewire render chunk length does not match its descriptor')
+    }
+
+    let result = new Uint8Array(resultLength)
+    let cursor = 0
+
+    decoded.forEach(part => {
+        result.set(part.bytes, cursor)
+        cursor += part.bytes.length
+    })
+
+    return decodeUtf8(result, 'chunk result')
+}
+
+export function parseTransportFragments(html) {
+    let source = encodeUtf8(html, 'fragment source')
+    let markerPattern = /<!--\[if (FRAGMENT|ENDFRAGMENT):([^\]]*)\]><!\[endif\]-->/g
+    let markerPrefixPattern = /<!--\[if (?:END)?FRAGMENT:/g
+    let markerPrefixCount = Array.from(html.matchAll(markerPrefixPattern)).length
+    let markerCount = 0
+    let stack = []
+    let drafts = []
+    let identities = new Set()
+    let match
+
+    while ((match = markerPattern.exec(html)) !== null) {
+        markerCount++
+
+        let markerType = match[1]
+        let encodedMetadata = match[2]
+        let metadata = parseFragmentMetadata(encodedMetadata)
+
+        if (markerType === 'FRAGMENT') {
+            let transport = metadata.type === 'transport'
+            let parentIndex = null
+
+            if (transport) {
+                for (let index = stack.length - 1; index >= 0; index--) {
+                    if (stack[index].transportIndex !== null) {
+                        parentIndex = stack[index].transportIndex
+
+                        break
+                    }
+                }
+            }
+
+            let transportIndex = null
+
+            if (transport) {
+                let token = transportFragmentToken(metadata)
+
+                if (identities.has(token)) {
+                    throw new Error('Duplicate Livewire transport fragment token')
+                }
+
+                identities.add(token)
+                transportIndex = drafts.length
+
+                drafts.push({
+                    index: transportIndex,
+                    token,
+                    metadata,
+                    parentIndex,
+                    depth: parentIndex === null ? 0 : drafts[parentIndex].depth + 1,
+                    startChar: match.index,
+                    contentStartChar: markerPattern.lastIndex,
+                    contentEndChar: null,
+                    endChar: null,
+                })
+            }
+
+            stack.push({
+                encodedMetadata,
+                transportIndex,
+            })
+
+            continue
+        }
+
+        if (stack.length === 0) {
+            throw new Error('Unmatched Livewire fragment end marker')
+        }
+
+        let opened = stack.pop()
+
+        if (opened.encodedMetadata !== encodedMetadata) {
+            throw new Error('Mismatched Livewire fragment markers')
+        }
+
+        if (opened.transportIndex !== null) {
+            drafts[opened.transportIndex].contentEndChar = match.index
+            drafts[opened.transportIndex].endChar = markerPattern.lastIndex
+        }
+    }
+
+    if (markerCount !== markerPrefixCount) {
+        throw new Error('Malformed Livewire fragment marker')
+    }
+
+    if (stack.length !== 0) {
+        throw new Error('Unclosed Livewire fragment marker')
+    }
+
+    let positions = [0, html.length]
+
+    drafts.forEach(fragment => {
+        positions.push(
+            fragment.startChar,
+            fragment.contentStartChar,
+            fragment.contentEndChar,
+            fragment.endChar,
+        )
+    })
+
+    let offsets = mapUtf8Offsets(html, positions)
+    let fragments = drafts.map(fragment => Object.freeze({
+        index: fragment.index,
+        token: fragment.token,
+        metadata: fragment.metadata,
+        parentIndex: fragment.parentIndex,
+        depth: fragment.depth,
+        start: offsets.get(fragment.startChar),
+        contentStart: offsets.get(fragment.contentStartChar),
+        contentEnd: offsets.get(fragment.contentEndChar),
+        end: offsets.get(fragment.endChar),
+        startChar: fragment.startChar,
+        contentStartChar: fragment.contentStartChar,
+        contentEndChar: fragment.contentEndChar,
+        endChar: fragment.endChar,
+    }))
+
+    if (offsets.get(html.length) !== source.length) {
+        throw new Error('Invalid Livewire fragment byte offsets')
+    }
+
+    return Object.freeze(fragments)
+}
+
+export function buildFragmentManifest(html) {
+    let source = encodeUtf8(html, 'fragment source')
+    let fragments = parseTransportFragments(html)
+    let children = new Map()
+
+    fragments.forEach(fragment => {
+        let parent = fragment.parentIndex === null ? -1 : fragment.parentIndex
+
+        if (! children.has(parent)) children.set(parent, [])
+
+        children.get(parent).push(fragment.index)
+    })
+
+    let rootSkeleton = buildSkeleton(
+        source,
+        0,
+        source.length,
+        fragments,
+        children.get(-1) || [],
+    )
+    let nodes = fragments.map(fragment => {
+        let content = source.subarray(fragment.contentStart, fragment.contentEnd)
+        let skeleton = buildSkeleton(
+            source,
+            fragment.contentStart,
+            fragment.contentEnd,
+            fragments,
+            children.get(fragment.index) || [],
+        )
+
+        return Object.freeze([
+            fragment.token,
+            contentDigest(content),
+            contentDigest(skeleton),
+        ])
+    })
+
+    return Object.freeze({
+        root: contentDigest(rootSkeleton),
+        nodes: Object.freeze(nodes),
+    })
+}
+
+export function applyFragmentOps(baselineHtml, ops, expectedBytes = null) {
+    let source = encodeUtf8(baselineHtml, 'render baseline')
+    let fragments = parseTransportFragments(baselineHtml)
+    let byToken = new Map(fragments.map(fragment => [fragment.token, fragment]))
+
+    validateOperationList(ops, 'fragment')
+    validateOptionalByteLength(expectedBytes)
+
+    let selected = new Set()
+    let replacements = []
+
+    ops.forEach(op => {
+        if (! Array.isArray(op)
+            || op.length !== 2
+            || typeof op[0] !== 'string'
+            || op[0].length === 0
+            || op[0].length > 256
+            || typeof op[1] !== 'string'
+        ) {
+            throw new Error('Invalid Livewire render fragment operation')
+        }
+
+        if (selected.has(op[0])) {
+            throw new Error('Duplicate Livewire render fragment operation')
+        }
+
+        let fragment = byToken.get(op[0])
+
+        if (! fragment) {
+            throw new Error('Unknown Livewire render fragment token')
+        }
+
+        let insert = encodeUtf8(op[1], 'fragment replacement')
+
+        selected.add(op[0])
+        replacements.push({
+            fragment,
+            start: fragment.contentStart,
+            end: fragment.contentEnd,
+            insert,
+        })
+    })
+
+    replacements.forEach(replacement => {
+        let parentIndex = replacement.fragment.parentIndex
+
+        while (parentIndex !== null) {
+            let parent = fragments[parentIndex]
+
+            if (selected.has(parent.token)) {
+                throw new Error('Overlapping Livewire render fragment operations')
+            }
+
+            parentIndex = parent.parentIndex
+        }
+    })
+
+    replacements.sort((left, right) => left.start - right.start)
+
+    for (let index = 1; index < replacements.length; index++) {
+        if (replacements[index].start < replacements[index - 1].end) {
+            throw new Error('Overlapping Livewire render fragment operations')
+        }
+    }
+
+    let result = applyByteReplacements(source, replacements)
+
+    if (expectedBytes !== null && result.length !== expectedBytes) {
+        throw new Error('Livewire render fragment length does not match its descriptor')
+    }
+
+    return decodeUtf8(result, 'fragment result')
+}
+
+export async function materializeRender(render, fullHtml = null, baseline = null) {
+    validateRenderDescriptor(render)
+
+    let mode = render.mode
+    let result
+
+    if (mode === 'full') {
+        if (typeof fullHtml !== 'string') {
+            throw new Error('Missing full Livewire render HTML')
+        }
+
+        if (hasOwn(render, 'base')
+            || hasOwn(render, 'patches')
+            || hasOwn(render, 'ops')
+        ) {
+            throw new Error('Invalid full Livewire render descriptor')
+        }
+
+        result = fullHtml
+    } else {
+        let captured = captureBaseline(baseline)
+
+        if (! isSha256Hash(render.base) || render.base !== captured.hash) {
+            throw new Error('Livewire render baseline does not match its descriptor')
+        }
+
+        let actualBaseHash = await hashHtml(captured.html)
+
+        if (actualBaseHash !== captured.hash) {
+            throw new Error('Livewire render baseline failed its integrity check')
+        }
+
+        if (mode === 'same') {
+            if (hasOwn(render, 'patches')
+                || hasOwn(render, 'ops')
+                || render.target !== render.base
+                || render.bytes !== captured.bytes
+            ) {
+                throw new Error('Invalid same Livewire render descriptor')
+            }
+
+            result = captured.html
+
+            // The baseline hash and byte length were verified above and same
+            // requires target === base, so a second full SHA-256 pass is redundant.
+            return result
+        } else if (mode === 'splice') {
+            if (! Array.isArray(render.patches) || hasOwn(render, 'ops')) {
+                throw new Error('Invalid splice Livewire render descriptor')
+            }
+
+            validateBytePatches(captured.html, render.patches, render.bytes)
+            result = applyHtmlDelta(captured.html, render.patches)
+        } else if (mode === 'chunks') {
+            if (! Array.isArray(render.ops) || hasOwn(render, 'patches')) {
+                throw new Error('Invalid chunks Livewire render descriptor')
+            }
+
+            result = applyChunkOps(captured.html, render.ops, render.bytes)
+        } else if (mode === 'fragments') {
+            if (! Array.isArray(render.ops) || hasOwn(render, 'patches')) {
+                throw new Error('Invalid fragments Livewire render descriptor')
+            }
+
+            result = applyFragmentOps(captured.html, render.ops, render.bytes)
+        }
+    }
+
+    await verifyMaterializedValue(result, render.target, render.bytes, 'render')
+
+    return result
+}
+
+export async function materializeSnapshotDelta(delta, baselineSnapshot) {
+    if (! isRecord(delta)
+        || delta.v !== 1
+        || ! isSha256Hash(delta.base)
+        || ! isSha256Hash(delta.target)
+        || ! isValidByteLength(delta.bytes)
+        || ! Array.isArray(delta.patches)
+        || typeof baselineSnapshot !== 'string'
+    ) {
+        throw new Error('Invalid Livewire snapshot delta')
+    }
+
+    let capturedSnapshot = baselineSnapshot
+    let actualBaseHash = await hashHtml(capturedSnapshot)
+
+    if (actualBaseHash !== delta.base) {
+        throw new Error('Livewire snapshot delta baseline failed its integrity check')
+    }
+
+    validateBytePatches(capturedSnapshot, delta.patches, delta.bytes)
+
+    if (delta.patches.length === 0 && delta.target === delta.base) {
+        return capturedSnapshot
+    }
+
+    let result = applyHtmlDelta(capturedSnapshot, delta.patches)
+
+    await verifyMaterializedValue(result, delta.target, delta.bytes, 'snapshot delta')
+
+    return result
+}
+
+export async function createGzipBody(value) {
+    if (typeof value !== 'string') {
+        throw new Error('Invalid Livewire request body')
+    }
+
+    let source = encodeUtf8(value, 'request body')
+
+    if (typeof globalThis.CompressionStream !== 'function'
+        || typeof globalThis.Response !== 'function'
+    ) {
+        return null
+    }
+
+    try {
+        let compression = new globalThis.CompressionStream('gzip')
+        let output = new globalThis.Response(compression.readable)
+            .arrayBuffer()
+            .catch(() => null)
+        let writer = compression.writable.getWriter()
+
+        await writer.write(source)
+        await writer.close()
+
+        let buffer = await output
+
+        if (buffer === null) return null
+
+        return new Uint8Array(buffer)
+    } catch (error) {
+        return null
+    }
+}
+
+export {
+    materializeRender as materializeRenderDescriptor,
+    materializeSnapshotDelta as reconstructSnapshotDelta,
+}
+
+function validateRenderDescriptor(render) {
+    let modes = ['full', 'same', 'splice', 'chunks', 'fragments']
+
+    if (! isRecord(render)
+        || render.v !== 1
+        || ! modes.includes(render.mode)
+        || ! isSha256Hash(render.target)
+        || ! isValidByteLength(render.bytes)
+        || hasOwn(render, 'html')
+    ) {
+        throw new Error('Invalid Livewire render descriptor')
+    }
+
+    if (render.mode !== 'full' && ! isSha256Hash(render.base)) {
+        throw new Error('Invalid Livewire render baseline hash')
+    }
+
+    if (hasOwn(render, 'requestGzip')
+        && (! Number.isSafeInteger(render.requestGzip)
+            || render.requestGzip < 1
+            || render.requestGzip > 16 * 1024 * 1024)
+    ) {
+        throw new Error('Invalid Livewire request compression threshold')
+    }
+
+    if (hasOwn(render, 'stats')) {
+        let stats = render.stats
+
+        if (! isRecord(stats)
+            || ! isValidByteLength(stats.full)
+            || ! isValidByteLength(stats.selected)
+        ) {
+            throw new Error('Invalid Livewire render statistics')
+        }
+    }
+}
+
+function captureBaseline(baseline) {
+    if (! isRecord(baseline)) {
+        throw new Error('Missing Livewire render baseline')
+    }
+
+    let html = baseline.html
+    let hash = baseline.hash
+    let bytes = baseline.bytes
+    let revision = baseline.revision
+
+    if (typeof html !== 'string'
+        || ! isSha256Hash(hash)
+        || ! isValidByteLength(bytes)
+        || (revision !== undefined
+            && (! Number.isSafeInteger(revision) || revision < 0))
+    ) {
+        throw new Error('Invalid Livewire render baseline')
+    }
+
+    if (encodeUtf8(html, 'render baseline').length !== bytes) {
+        throw new Error('Livewire render baseline byte length is invalid')
+    }
+
+    return Object.freeze({ html, hash, bytes })
+}
+
+function validateBytePatches(sourceValue, patches, expectedBytes) {
+    let source = encodeUtf8(sourceValue, 'delta baseline')
+
+    validateOperationList(patches, 'patch')
+    validateOptionalByteLength(expectedBytes)
+
+    let cursor = 0
+    let resultLength = source.length
+
+    patches.forEach(patch => {
+        if (! isRecord(patch)
+            || ! Number.isSafeInteger(patch.start)
+            || ! Number.isSafeInteger(patch.delete)
+            || patch.start < cursor
+            || patch.delete < 0
+            || ! Number.isSafeInteger(patch.start + patch.delete)
+            || patch.start + patch.delete > source.length
+        ) {
+            throw new Error('Invalid Livewire byte patch range')
+        }
+
+        let insert = decodeBase64(patch.insert, 'byte patch insert')
+
+        resultLength = addOutputLength(
+            resultLength - patch.delete,
+            insert.length,
+        )
+        cursor = patch.start + patch.delete
+    })
+
+    if (expectedBytes !== null && resultLength !== expectedBytes) {
+        throw new Error('Livewire byte patch length does not match its descriptor')
+    }
+}
+
+async function verifyMaterializedValue(value, expectedHash, expectedBytes, label) {
+    let bytes = encodeUtf8(value, label)
+
+    if (bytes.length !== expectedBytes) {
+        throw new Error('Livewire ' + label + ' byte length verification failed')
+    }
+
+    let actualHash = await hashHtml(value)
+
+    if (actualHash !== expectedHash) {
+        throw new Error('Livewire ' + label + ' integrity verification failed')
+    }
+}
+
+function applyByteReplacements(source, replacements) {
+    let resultLength = source.length
+
+    replacements.forEach(replacement => {
+        resultLength = addOutputLength(
+            resultLength - (replacement.end - replacement.start),
+            replacement.insert.length,
+        )
+    })
+
+    let result = new Uint8Array(resultLength)
+    let sourceCursor = 0
+    let resultCursor = 0
+
+    replacements.forEach(replacement => {
+        let unchanged = source.subarray(sourceCursor, replacement.start)
+
+        result.set(unchanged, resultCursor)
+        resultCursor += unchanged.length
+
+        result.set(replacement.insert, resultCursor)
+        resultCursor += replacement.insert.length
+        sourceCursor = replacement.end
+    })
+
+    result.set(source.subarray(sourceCursor), resultCursor)
+
+    return result
+}
+
+function buildSkeleton(source, start, end, fragments, childIndices) {
+    let children = childIndices
+        .map(index => fragments[index])
+        .sort((left, right) => left.contentStart - right.contentStart)
+    let length = end - start
+
+    children.forEach(child => {
+        if (child.contentStart < start
+            || child.contentEnd > end
+            || child.contentStart > child.contentEnd
+        ) {
+            throw new Error('Invalid Livewire transport fragment hierarchy')
+        }
+
+        length -= child.contentEnd - child.contentStart
+    })
+
+    let skeleton = new Uint8Array(length)
+    let sourceCursor = start
+    let resultCursor = 0
+
+    children.forEach(child => {
+        let unchanged = source.subarray(sourceCursor, child.contentStart)
+
+        skeleton.set(unchanged, resultCursor)
+        resultCursor += unchanged.length
+        sourceCursor = child.contentEnd
+    })
+
+    skeleton.set(source.subarray(sourceCursor, end), resultCursor)
+
+    return skeleton
+}
+
+function mapUtf8Offsets(value, positions) {
+    let sorted = Array.from(new Set(positions)).sort((left, right) => left - right)
+    let offsets = new Map()
+    let characterCursor = 0
+    let byteCursor = 0
+
+    sorted.forEach(position => {
+        if (! Number.isSafeInteger(position)
+            || position < characterCursor
+            || position > value.length
+        ) {
+            throw new Error('Invalid Livewire fragment character offset')
+        }
+
+        byteCursor += encoder.encode(value.slice(characterCursor, position)).length
+        characterCursor = position
+        offsets.set(position, byteCursor)
+    })
+
+    return offsets
+}
+
+function parseFragmentMetadata(encoded) {
+    if (typeof encoded !== 'string' || encoded.length === 0 || encoded.length > 4096) {
+        throw new Error('Invalid Livewire fragment metadata')
+    }
+
+    let metadata = Object.create(null)
+
+    encoded.split('|').forEach(pair => {
+        let separator = pair.indexOf('=')
+
+        if (separator <= 0
+            || separator === pair.length - 1
+            || hasOwn(metadata, pair.slice(0, separator))
+        ) {
+            throw new Error('Invalid Livewire fragment metadata')
+        }
+
+        let key = pair.slice(0, separator)
+        let value = pair.slice(separator + 1)
+
+        if (! /^[A-Za-z][A-Za-z0-9_-]*$/.test(key)
+            || value.includes('|')
+            || value.includes(']')
+        ) {
+            throw new Error('Invalid Livewire fragment metadata')
+        }
+
+        metadata[key] = value
+    })
+
+    return Object.freeze(metadata)
+}
+
+function transportFragmentToken(metadata) {
+    let candidates = ['token', 'id', 'name', 'key']
+
+    for (let index = 0; index < candidates.length; index++) {
+        let value = metadata[candidates[index]]
+
+        if (typeof value === 'string' && value.length > 0 && value.length <= 256) {
+            return value
+        }
+    }
+
+    throw new Error('Missing Livewire transport fragment token')
+}
+
+function contentDigest(bytes) {
+    return uint32Hex(crc32(bytes)) + uint32Hex(adler32(bytes))
+}
+
+function rsyncWeakChecksum(bytes) {
+    let a = 0
+    let b = 0
+
+    for (let index = 0; index < bytes.length; index++) {
+        a = (a + bytes[index]) & 0xffff
+        b = (b + (bytes.length - index) * bytes[index]) & 0xffff
+    }
+
+    return ((b << 16) | a) >>> 0
+}
+
+function crc32(bytes) {
+    let value = 0xffffffff
+
+    for (let index = 0; index < bytes.length; index++) {
+        value = crc32Table[(value ^ bytes[index]) & 0xff] ^ (value >>> 8)
+    }
+
+    return (value ^ 0xffffffff) >>> 0
+}
+
+function adler32(bytes) {
+    let a = 1
+    let b = 0
+
+    for (let index = 0; index < bytes.length; index++) {
+        a = (a + bytes[index]) % 65521
+        b = (b + a) % 65521
+    }
+
+    return ((b << 16) | a) >>> 0
+}
+
+function buildCrc32Table() {
+    let table = new Uint32Array(256)
+
+    for (let index = 0; index < table.length; index++) {
+        let value = index
+
+        for (let bit = 0; bit < 8; bit++) {
+            value = (value & 1) !== 0
+                ? 0xedb88320 ^ (value >>> 1)
+                : value >>> 1
+        }
+
+        table[index] = value >>> 0
+    }
+
+    return table
+}
+
+function uint32Hex(value) {
+    return (value >>> 0).toString(16).padStart(8, '0')
+}
+
+function encodeUtf8(value, label) {
+    if (typeof value !== 'string') {
+        throw new Error('Invalid Livewire ' + label)
+    }
+
+    let bytes = encoder.encode(value)
+
+    if (bytes.length > maximumOutputBytes) {
+        throw new Error('Livewire ' + label + ' is too large')
+    }
+
+    if (decoder.decode(bytes) !== value) {
+        throw new Error('Invalid UTF-8 in Livewire ' + label)
+    }
+
+    return bytes
+}
+
+function decodeUtf8(bytes, label) {
+    try {
+        return decoder.decode(bytes)
+    } catch (error) {
+        throw new Error('Invalid UTF-8 in Livewire ' + label)
+    }
+}
+
+function encodeBase64(bytes) {
+    let chunks = []
+    let chunkSize = 8192
+
+    for (let start = 0; start < bytes.length; start += chunkSize) {
+        let end = Math.min(start + chunkSize, bytes.length)
+        let binary = ''
+
+        for (let index = start; index < end; index++) {
+            binary += String.fromCharCode(bytes[index])
+        }
+
+        chunks.push(binary)
+    }
+
+    return btoa(chunks.join(''))
+}
+
+function decodeBase64(value, label) {
+    if (typeof value !== 'string'
+        || value.length > Math.ceil(maximumOutputBytes / 3) * 4
+        || ! /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)
+    ) {
+        throw new Error('Invalid base64 in Livewire ' + label)
+    }
+
+    let binary
+
+    try {
+        binary = atob(value)
+    } catch (error) {
+        throw new Error('Invalid base64 in Livewire ' + label)
+    }
+
+    let bytes = new Uint8Array(binary.length)
+
+    for (let index = 0; index < binary.length; index++) {
+        bytes[index] = binary.charCodeAt(index)
+    }
+
+    if (encodeBase64(bytes) !== value) {
+        throw new Error('Non-canonical base64 in Livewire ' + label)
+    }
+
+    return bytes
+}
+
+function validateBlockSize(blockSize) {
+    if (! Number.isSafeInteger(blockSize)
+        || blockSize < minimumBlockSize
+        || blockSize > maximumBlockSize
+    ) {
+        throw new Error('Invalid Livewire render block size')
+    }
+}
+
+function validateOperationList(ops, label) {
+    if (! Array.isArray(ops) || ops.length > maximumOperations) {
+        throw new Error('Invalid Livewire render ' + label + ' operations')
+    }
+}
+
+function validateOptionalByteLength(value) {
+    if (value !== null && ! isValidByteLength(value)) {
+        throw new Error('Invalid Livewire render byte length')
+    }
+}
+
+function isValidByteLength(value) {
+    return Number.isSafeInteger(value)
+        && value >= 0
+        && value <= maximumOutputBytes
+}
+
+function addOutputLength(current, addition) {
+    let result = current + addition
+
+    if (! Number.isSafeInteger(result)
+        || result < 0
+        || result > maximumOutputBytes
+    ) {
+        throw new Error('Invalid Livewire render output length')
+    }
+
+    return result
+}
+
+function isRecord(value) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+        return false
+    }
+
+    let prototype = Object.getPrototypeOf(value)
+
+    return prototype === Object.prototype || prototype === null
+}
+
+function hasOwn(value, key) {
+    return Object.prototype.hasOwnProperty.call(value, key)
+}

--- a/js/renderTransport.spec.js
+++ b/js/renderTransport.spec.js
@@ -37,10 +37,10 @@ describe('render transport chunk recipes', () => {
         let baseline = 'α--middle--ω'
         let prefix = 'α--'
         let suffix = '--ω'
-        let target = prefix + 'foo 🚀' + suffix
+        let target = prefix + 'д字 🚀' + suffix
         let ops = [
             ['c', 0, byteLength(prefix)],
-            ['a', encodeBase64('foo 🚀')],
+            ['a', encodeBase64('д字 🚀')],
             ['c', byteLength(prefix + 'middle'), byteLength(suffix)],
         ]
 
@@ -69,7 +69,7 @@ describe('render transport fragments', () => {
     it('parses nested transport markers and records UTF-8 byte ranges', () => {
         let outer = 'a'.repeat(64)
         let inner = 'b'.repeat(64)
-        let html = '<main>🚀' + fragment(outer, 'before' + fragment(inner, 'foo') + 'after') + '</main>'
+        let html = '<main>🚀' + fragment(outer, 'before' + fragment(inner, 'д字') + 'after') + '</main>'
         let fragments = parseTransportFragments(html)
 
         expect(fragments).toHaveLength(2)
@@ -84,7 +84,7 @@ describe('render transport fragments', () => {
             source.subarray(fragments[1].contentStart, fragments[1].contentEnd),
         )
 
-        expect(content).toBe('foo')
+        expect(content).toBe('д字')
     })
 
     it('builds content and skeleton digests that isolate nested changes', () => {
@@ -118,16 +118,16 @@ describe('render transport fragments', () => {
         let inner = 'b'.repeat(64)
         let baseline = '<main>' + fragment(
             outer,
-            'before' + fragment(inner, 'foo 👋') + 'after',
+            'before' + fragment(inner, 'д字 👋') + 'after',
         ) + '</main>'
         let target = '<main>' + fragment(
             outer,
-            'before' + fragment(inner, 'bar 🚀') + 'after',
+            'before' + fragment(inner, 'ж世 🚀') + 'after',
         ) + '</main>'
 
         expect(applyFragmentOps(
             baseline,
-            [[inner, 'bar 🚀']],
+            [[inner, 'ж世 🚀']],
             byteLength(target),
         )).toBe(target)
     })
@@ -154,7 +154,7 @@ describe('render transport fragments', () => {
 
 describe('render descriptor materialization', () => {
     it('verifies full HTML supplied separately from the descriptor', async () => {
-        let html = '<div>foo bar baz 🚀</div>'
+        let html = '<div>д字 ж世 з本 🚀</div>'
         let descriptor = {
             v: 1,
             mode: 'full',
@@ -189,8 +189,8 @@ describe('render descriptor materialization', () => {
     })
 
     it('materializes splice, chunk, and fragment modes', async () => {
-        let spliceBaseline = '<div>foo 👋</div>'
-        let spliceTarget = '<div>bar 🚀</div>'
+        let spliceBaseline = '<div>д字 👋</div>'
+        let spliceTarget = '<div>ж世 🚀</div>'
         let spliceState = await makeBaseline(spliceBaseline)
         let spliceDescriptor = {
             v: 1,
@@ -200,8 +200,8 @@ describe('render descriptor materialization', () => {
             bytes: byteLength(spliceTarget),
             patches: [{
                 start: byteLength('<div>'),
-                delete: byteLength('foo 👋'),
-                insert: encodeBase64('bar 🚀'),
+                delete: byteLength('д字 👋'),
+                insert: encodeBase64('ж世 🚀'),
             }],
         }
 
@@ -229,7 +229,7 @@ describe('render descriptor materialization', () => {
 
         let token = 'c'.repeat(64)
         let fragmentBaseline = '<div>' + fragment(token, 'old') + '</div>'
-        let fragmentTarget = '<div>' + fragment(token, 'baz') + '</div>'
+        let fragmentTarget = '<div>' + fragment(token, 'з本') + '</div>'
         let fragmentState = await makeBaseline(fragmentBaseline)
         let fragmentDescriptor = {
             v: 1,
@@ -237,7 +237,7 @@ describe('render descriptor materialization', () => {
             base: fragmentState.hash,
             target: await hashHtml(fragmentTarget),
             bytes: byteLength(fragmentTarget),
-            ops: [[token, 'baz']],
+            ops: [[token, 'з本']],
         }
 
         await expect(materializeRender(fragmentDescriptor, null, fragmentState))
@@ -296,16 +296,16 @@ describe('render descriptor materialization', () => {
 
 describe('snapshot deltas', () => {
     it('reconstructs and verifies a Unicode snapshot using byte patches', async () => {
-        let baseline = '{"memo":"foo 👋","count":1}'
-        let target = '{"memo":"bar 🚀","count":2}'
+        let baseline = '{"memo":"д字 👋","count":1}'
+        let target = '{"memo":"ж世 🚀","count":2}'
         let patches = [
             {
                 start: byteLength('{"memo":"'),
-                delete: byteLength('foo 👋'),
-                insert: encodeBase64('bar 🚀'),
+                delete: byteLength('д字 👋'),
+                insert: encodeBase64('ж世 🚀'),
             },
             {
-                start: byteLength('{"memo":"foo 👋","count":'),
+                start: byteLength('{"memo":"д字 👋","count":'),
                 delete: 1,
                 insert: encodeBase64('2'),
             },

--- a/js/renderTransport.spec.js
+++ b/js/renderTransport.spec.js
@@ -1,0 +1,418 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { hashHtml } from './htmlDelta'
+import {
+    applyChunkOps,
+    applyFragmentOps,
+    buildBlockManifest,
+    buildFragmentManifest,
+    createGzipBody,
+    materializeRender,
+    materializeSnapshotDelta,
+    parseTransportFragments,
+} from './renderTransport'
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+})
+
+describe('render transport block manifests', () => {
+    it('packs PHP-compatible rsync weak and CRC32 checksums', () => {
+        expect(buildBlockManifest('abc')).toEqual({
+            blockSize: 2048,
+            blocks: 'AkoBJjUkQcI=',
+        })
+    })
+
+    it('validates the fixed block size', () => {
+        expect(() => buildBlockManifest('abc', 32))
+            .toThrow('Invalid Livewire render block size')
+
+        expect(() => buildBlockManifest('abc', 65537))
+            .toThrow('Invalid Livewire render block size')
+    })
+})
+
+describe('render transport chunk recipes', () => {
+    it('reconstructs exact UTF-8 bytes using copy and add operations', () => {
+        let baseline = 'α--middle--ω'
+        let prefix = 'α--'
+        let suffix = '--ω'
+        let target = prefix + 'foo 🚀' + suffix
+        let ops = [
+            ['c', 0, byteLength(prefix)],
+            ['a', encodeBase64('foo 🚀')],
+            ['c', byteLength(prefix + 'middle'), byteLength(suffix)],
+        ]
+
+        expect(applyChunkOps(baseline, ops, byteLength(target))).toBe(target)
+    })
+
+    it('rejects malformed operations, ranges, base64, and UTF-8', () => {
+        expect(() => applyChunkOps('abc', [['c', 2, 2]]))
+            .toThrow('Invalid Livewire render chunk copy range')
+
+        expect(() => applyChunkOps('abc', [['c', 0, 0]]))
+            .toThrow('Invalid Livewire render chunk copy range')
+
+        expect(() => applyChunkOps('abc', [['a', 'YQ']]))
+            .toThrow('Invalid base64')
+
+        expect(() => applyChunkOps('abc', [['a', '/w==']]))
+            .toThrow('Invalid UTF-8')
+
+        expect(() => applyChunkOps('abc', [['unknown', 0, 1]]))
+            .toThrow('Invalid Livewire render chunk operation')
+    })
+})
+
+describe('render transport fragments', () => {
+    it('parses nested transport markers and records UTF-8 byte ranges', () => {
+        let outer = 'a'.repeat(64)
+        let inner = 'b'.repeat(64)
+        let html = '<main>🚀' + fragment(outer, 'before' + fragment(inner, 'foo') + 'after') + '</main>'
+        let fragments = parseTransportFragments(html)
+
+        expect(fragments).toHaveLength(2)
+        expect(fragments[0].token).toBe(outer)
+        expect(fragments[0].parentIndex).toBeNull()
+        expect(fragments[1].token).toBe(inner)
+        expect(fragments[1].parentIndex).toBe(0)
+        expect(fragments[1].depth).toBe(1)
+
+        let source = new TextEncoder().encode(html)
+        let content = new TextDecoder().decode(
+            source.subarray(fragments[1].contentStart, fragments[1].contentEnd),
+        )
+
+        expect(content).toBe('foo')
+    })
+
+    it('builds content and skeleton digests that isolate nested changes', () => {
+        let outer = 'a'.repeat(64)
+        let inner = 'b'.repeat(64)
+        let beforeHtml = '<main>' + fragment(
+            outer,
+            'before' + fragment(inner, 'one') + 'after',
+        ) + '</main>'
+        let afterHtml = '<main>' + fragment(
+            outer,
+            'before' + fragment(inner, 'two') + 'after',
+        ) + '</main>'
+        let before = buildFragmentManifest(beforeHtml)
+        let after = buildFragmentManifest(afterHtml)
+
+        expect(before.root).toMatch(/^[a-f0-9]{16}$/)
+        expect(before.root).toBe(after.root)
+        expect(before.nodes[0][1]).not.toBe(after.nodes[0][1])
+        expect(before.nodes[0][2]).toBe(after.nodes[0][2])
+        expect(before.nodes[1][1]).not.toBe(after.nodes[1][1])
+        expect(before.nodes[1][2]).not.toBe(after.nodes[1][2])
+
+        let leaf = buildFragmentManifest(fragment(inner, 'abc'))
+
+        expect(leaf.nodes[0][1]).toBe('352441c2024d0127')
+    })
+
+    it('applies non-overlapping inner HTML replacements atomically', () => {
+        let outer = 'a'.repeat(64)
+        let inner = 'b'.repeat(64)
+        let baseline = '<main>' + fragment(
+            outer,
+            'before' + fragment(inner, 'foo 👋') + 'after',
+        ) + '</main>'
+        let target = '<main>' + fragment(
+            outer,
+            'before' + fragment(inner, 'bar 🚀') + 'after',
+        ) + '</main>'
+
+        expect(applyFragmentOps(
+            baseline,
+            [[inner, 'bar 🚀']],
+            byteLength(target),
+        )).toBe(target)
+    })
+
+    it('rejects nested operations and malformed marker stacks', () => {
+        let outer = 'a'.repeat(64)
+        let inner = 'b'.repeat(64)
+        let baseline = fragment(outer, fragment(inner, 'value'))
+
+        expect(() => applyFragmentOps(baseline, [
+            [outer, 'outer'],
+            [inner, 'inner'],
+        ])).toThrow('Overlapping Livewire render fragment operations')
+
+        expect(() => parseTransportFragments(
+            startFragment(outer) + 'value' + endFragment(inner),
+        )).toThrow('Mismatched Livewire fragment markers')
+
+        expect(() => parseTransportFragments(
+            startFragment(outer) + 'value',
+        )).toThrow('Unclosed Livewire fragment marker')
+    })
+})
+
+describe('render descriptor materialization', () => {
+    it('verifies full HTML supplied separately from the descriptor', async () => {
+        let html = '<div>foo bar baz 🚀</div>'
+        let descriptor = {
+            v: 1,
+            mode: 'full',
+            target: await hashHtml(html),
+            bytes: byteLength(html),
+            stats: {
+                full: byteLength(html),
+                selected: byteLength(html),
+            },
+        }
+
+        await expect(materializeRender(descriptor, html)).resolves.toBe(html)
+        await expect(materializeRender(descriptor, '<div>tampered</div>'))
+            .rejects.toThrow('byte length verification failed')
+    })
+
+    it('returns the immutable message baseline for same renders', async () => {
+        let html = '<div>unchanged</div>'
+        let baseline = await makeBaseline(html)
+        let descriptor = Object.freeze({
+            v: 1,
+            mode: 'same',
+            base: baseline.hash,
+            target: baseline.hash,
+            bytes: baseline.bytes,
+        })
+
+        await expect(materializeRender(descriptor, null, baseline))
+            .resolves.toBe(html)
+        expect(Object.isFrozen(baseline)).toBe(true)
+        expect(baseline.html).toBe(html)
+    })
+
+    it('materializes splice, chunk, and fragment modes', async () => {
+        let spliceBaseline = '<div>foo 👋</div>'
+        let spliceTarget = '<div>bar 🚀</div>'
+        let spliceState = await makeBaseline(spliceBaseline)
+        let spliceDescriptor = {
+            v: 1,
+            mode: 'splice',
+            base: spliceState.hash,
+            target: await hashHtml(spliceTarget),
+            bytes: byteLength(spliceTarget),
+            patches: [{
+                start: byteLength('<div>'),
+                delete: byteLength('foo 👋'),
+                insert: encodeBase64('bar 🚀'),
+            }],
+        }
+
+        await expect(materializeRender(spliceDescriptor, null, spliceState))
+            .resolves.toBe(spliceTarget)
+
+        let chunkBaseline = 'left-old-right'
+        let chunkTarget = 'left-new-right'
+        let chunkState = await makeBaseline(chunkBaseline)
+        let chunkDescriptor = {
+            v: 1,
+            mode: 'chunks',
+            base: chunkState.hash,
+            target: await hashHtml(chunkTarget),
+            bytes: byteLength(chunkTarget),
+            ops: [
+                ['c', 0, byteLength('left-')],
+                ['a', encodeBase64('new')],
+                ['c', byteLength('left-old'), byteLength('-right')],
+            ],
+        }
+
+        await expect(materializeRender(chunkDescriptor, null, chunkState))
+            .resolves.toBe(chunkTarget)
+
+        let token = 'c'.repeat(64)
+        let fragmentBaseline = '<div>' + fragment(token, 'old') + '</div>'
+        let fragmentTarget = '<div>' + fragment(token, 'baz') + '</div>'
+        let fragmentState = await makeBaseline(fragmentBaseline)
+        let fragmentDescriptor = {
+            v: 1,
+            mode: 'fragments',
+            base: fragmentState.hash,
+            target: await hashHtml(fragmentTarget),
+            bytes: byteLength(fragmentTarget),
+            ops: [[token, 'baz']],
+        }
+
+        await expect(materializeRender(fragmentDescriptor, null, fragmentState))
+            .resolves.toBe(fragmentTarget)
+    })
+
+    it('rejects invalid modes, stale baselines, malformed patches, and tampering', async () => {
+        let baseline = await makeBaseline('<div>one</div>')
+        let target = '<div>two</div>'
+        let targetHash = await hashHtml(target)
+
+        await expect(materializeRender({
+            v: 1,
+            mode: 'unknown',
+            target: targetHash,
+            bytes: byteLength(target),
+        }, null, baseline)).rejects.toThrow('Invalid Livewire render descriptor')
+
+        await expect(materializeRender({
+            v: 1,
+            mode: 'same',
+            base: '0'.repeat(64),
+            target: '0'.repeat(64),
+            bytes: baseline.bytes,
+        }, null, baseline)).rejects.toThrow('baseline does not match')
+
+        await expect(materializeRender({
+            v: 1,
+            mode: 'splice',
+            base: baseline.hash,
+            target: targetHash,
+            bytes: byteLength(target),
+            patches: [{
+                start: 5,
+                delete: 3,
+                insert: 'dHdv=',
+            }],
+        }, null, baseline)).rejects.toThrow('Invalid base64')
+
+        await expect(materializeRender({
+            v: 1,
+            mode: 'full',
+            target: targetHash,
+            bytes: byteLength(target),
+        }, '<div>six</div>')).rejects.toThrow('integrity verification failed')
+
+        await expect(materializeRender({
+            v: 1,
+            mode: 'full',
+            target: targetHash,
+            bytes: byteLength(target),
+            requestGzip: 0,
+        }, target)).rejects.toThrow('Invalid Livewire request compression threshold')
+    })
+})
+
+describe('snapshot deltas', () => {
+    it('reconstructs and verifies a Unicode snapshot using byte patches', async () => {
+        let baseline = '{"memo":"foo 👋","count":1}'
+        let target = '{"memo":"bar 🚀","count":2}'
+        let patches = [
+            {
+                start: byteLength('{"memo":"'),
+                delete: byteLength('foo 👋'),
+                insert: encodeBase64('bar 🚀'),
+            },
+            {
+                start: byteLength('{"memo":"foo 👋","count":'),
+                delete: 1,
+                insert: encodeBase64('2'),
+            },
+        ]
+        let delta = {
+            v: 1,
+            base: await hashHtml(baseline),
+            target: await hashHtml(target),
+            bytes: byteLength(target),
+            patches,
+        }
+
+        await expect(materializeSnapshotDelta(delta, baseline)).resolves.toBe(target)
+    })
+
+    it('rejects snapshot tampering and accepts an empty same-snapshot patch list', async () => {
+        let baseline = '{"count":1}'
+        let hash = await hashHtml(baseline)
+        let same = {
+            v: 1,
+            base: hash,
+            target: hash,
+            bytes: byteLength(baseline),
+            patches: [],
+        }
+
+        await expect(materializeSnapshotDelta(same, baseline)).resolves.toBe(baseline)
+
+        await expect(materializeSnapshotDelta({
+            ...same,
+            target: '0'.repeat(64),
+        }, baseline)).rejects.toThrow('integrity verification failed')
+    })
+})
+
+describe('gzip request bodies', () => {
+    it('falls back to null when CompressionStream is unavailable', async () => {
+        vi.stubGlobal('CompressionStream', undefined)
+
+        await expect(createGzipBody('payload')).resolves.toBeNull()
+    })
+
+    it('falls back to null when compression fails', async () => {
+        vi.stubGlobal('CompressionStream', function () {
+            throw new Error('compression failed')
+        })
+
+        await expect(createGzipBody('payload')).resolves.toBeNull()
+    })
+
+    it('creates a valid gzip stream when the platform supports it', async () => {
+        if (typeof globalThis.CompressionStream !== 'function'
+            || typeof globalThis.DecompressionStream !== 'function'
+        ) {
+            return
+        }
+
+        let value = 'Livewire 🚀 '.repeat(100)
+        let compressed = await createGzipBody(value)
+        let decompression = new DecompressionStream('gzip')
+        let output = new Response(decompression.readable).text()
+        let writer = decompression.writable.getWriter()
+
+        await writer.write(compressed)
+        await writer.close()
+
+        let decompressed = await output
+
+        expect(compressed).toBeInstanceOf(Uint8Array)
+        expect(decompressed).toBe(value)
+    })
+})
+
+async function makeBaseline(html) {
+    return Object.freeze({
+        html,
+        hash: await hashHtml(html),
+        bytes: byteLength(html),
+        revision: 1,
+        chunks: null,
+        fragments: null,
+    })
+}
+
+function fragment(token, content) {
+    return startFragment(token) + content + endFragment(token)
+}
+
+function startFragment(token) {
+    return '<!--[if FRAGMENT:type=transport|name=fragment|token='
+        + token
+        + ']><![endif]-->'
+}
+
+function endFragment(token) {
+    return '<!--[if ENDFRAGMENT:type=transport|name=fragment|token='
+        + token
+        + ']><![endif]-->'
+}
+
+function byteLength(value) {
+    return new TextEncoder().encode(value).length
+}
+
+function encodeBase64(value) {
+    let bytes = new TextEncoder().encode(value)
+    let binary = Array.from(bytes, byte => String.fromCharCode(byte)).join('')
+
+    return btoa(binary)
+}

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -7,6 +7,12 @@ import { showHtmlModal } from '@/utils/modal.js'
 import { MessageBus, scopeSymbolFromMessage } from './messageBus.js'
 import Message from './message.js'
 import Action from './action.js'
+import { reconstructHtmlDelta } from '@/htmlDelta'
+import {
+    createGzipBody,
+    materializeRender,
+    materializeSnapshotDelta,
+} from '@/renderTransport'
 
 let outstandingActionOrigin = null
 let outstandingActionMetadata = {}
@@ -16,6 +22,7 @@ let messageBus = new MessageBus()
 let actionInterceptors = []
 let partitionInterceptors = []
 let sessionExpired = false
+let requestEncoder = new TextEncoder()
 
 export function sessionIsExpired() {
     return sessionExpired
@@ -266,6 +273,8 @@ function sendMessages() {
     requests.forEach(request => {
         request.messages.forEach(message => {
             message.snapshot = message.component.getEncodedSnapshotWithLatestChildrenMergedIn()
+            message.snapshotBaseline = message.snapshot
+            message.renderBaseline = message.component.captureRenderBaseline?.() || null
             message.updates = message.component.getUpdates()
             message.calls = Array.from(message.actions).map(i => ({
                 method: i.name,
@@ -273,7 +282,15 @@ function sendMessages() {
                 metadata: i.metadata,
             }))
 
-            let render = message.component.getRenderMetadata?.() || {}
+            let render = message.component.getRenderMetadata?.(message.renderBaseline) || {}
+            let allowsSnapshotReferences = render.capabilities?.includes('snapshot-ref') || false
+
+            message.renderAttemptedPortable = render.chunks !== undefined
+                || render.fragments !== undefined
+            message.snapshotReference = message.component.captureSnapshotReference?.(
+                allowsSnapshotReferences,
+                message.snapshot,
+            ) || null
 
             message.payload = {
                 snapshot: message.snapshot,
@@ -312,9 +329,10 @@ function sendMessages() {
 
                 cachedOptions = {
                     method: 'POST',
-                    body: JSON.stringify(request.payload),
+                    body: JSON.stringify(buildNetworkPayload(request)),
                     headers: {
                         'Content-type': 'application/json',
+                        'X-CSRF-TOKEN': getCsrfToken(),
                         'X-Livewire': '1', // This '1' value means nothing, but it stops Cloudflare from stripping the header...
                     },
                     signal: request.controller.signal,
@@ -415,74 +433,268 @@ function sendMessages() {
                 showHtmlModal(html)
             },
             success: async ({ response, responseBody, responseJson }) => {
+                await materializeResponseTransport(request, responseJson)
+
                 request.invokeOnSuccess({ response, body: responseBody, json: responseJson })
 
                 await triggerAsync('payload.intercept', responseJson)
 
                 let messageResponsePayloads = responseJson.components
+                let pendingMessages = []
 
                 request.messages.forEach(message => {
-                    messageResponsePayloads.forEach(payload => {
-                        if (message.isCancelled()) return
+                    if (message.isCancelled()) return
 
-                        // Server skipped this child (unchanged reactive props)...
-                        if (payload.skip) {
-                            if (payload.id === message.component.id) {
-                                message.responsePayload = payload
-                                message.markSkipped()
-                                message.invokeOnSkipped()
-                                message.resolveActionPromises([], [])
-                                message.invokeOnFinish()
-                            }
+                    let payload = findResponsePayload(message, messageResponsePayloads)
 
-                            return
-                        }
+                    if (! payload) return
 
-                        let { snapshot: snapshotEncoded, effects } = payload
-                        let snapshot = JSON.parse(snapshotEncoded)
+                    // Server skipped this child (unchanged reactive props)...
+                    if (payload.skip) {
+                        message.responsePayload = payload
+                        message.markSkipped()
+                        message.invokeOnSkipped()
+                        message.resolveActionPromises([], [])
+                        message.invokeOnFinish()
 
-                        if (snapshot.memo.id === message.component.id) {
-                            message.responsePayload = { snapshot, effects }
+                        return
+                    }
 
-                            message.invokeOnSuccess()
-                            if (message.isCancelled()) return
-
-                            // Use Alpine.transaction to batch data updates and DOM morphing
-                            // This prevents effects from firing before the morph cleanup runs
-                            Alpine.transaction(async () => {
-                                message.component.mergeNewSnapshot(snapshotEncoded, effects, message.updates)
-
-                                message.invokeOnSync()
-                                if (message.isCancelled()) return
-
-                                // Trigger any side effects from the payload like "morph" and "dispatch event"...
-                                message.component.processEffects(effects, request)
-
-                                message.invokeOnEffect()
-                                if (message.isCancelled()) return
-
-                                await message.invokeOnMorph()
-                            }).then(() => {
-                                // Resolve promises & finish AFTER morph completes
-                                if (! message.isCancelled()) {
-                                    message.resolveActionPromises(
-                                        message.pendingReturns,
-                                        message.pendingReturnsMeta
-                                    )
-                                    message.invokeOnFinish()
-                                }
-
-                                requestAnimationFrame(() => {
-                                    if (message.isCancelled()) return
-
-                                    message.invokeOnRender()
-                                })
-                            })
-                        }
-                    })
+                    pendingMessages.push(processMessageResponse(message, payload, request))
                 })
+
+                await Promise.all(pendingMessages)
             },
         })
+    })
+}
+
+function buildNetworkPayload(request, forceFullSnapshotIds = null) {
+    if (forceFullSnapshotIds === null) {
+        request.snapshotReferencesRetryable = snapshotReferenceFallbackFits(request)
+        request.usedSnapshotReferenceIds = new Set()
+    }
+
+    return {
+        _token: getCsrfToken(),
+        components: Array.from(request.messages, message => {
+            let payload = { ...message.payload }
+            let forceFullSnapshot = forceFullSnapshotIds?.has(
+                message.component.id,
+            ) || false
+
+            if (! forceFullSnapshot
+                && request.snapshotReferencesRetryable !== false
+                && message.snapshotReference !== null
+            ) {
+                delete payload.snapshot
+
+                payload.id = message.component.id
+                payload.snapshotRef = message.snapshotReference
+
+                if (forceFullSnapshotIds === null) {
+                    request.usedSnapshotReferenceIds.add(message.component.id)
+                }
+            }
+
+            return payload
+        }),
+    }
+}
+
+function snapshotReferenceFallbackFits(request) {
+    let referencedMessages = Array.from(request.messages).filter(message => {
+        return message.snapshotReference !== null
+    })
+
+    if (referencedMessages.length === 0) return true
+
+    let limits = referencedMessages
+        .map(message => message.component.getMaximumRequestBytes?.() ?? null)
+        .filter(limit => Number.isSafeInteger(limit) && limit >= 0)
+
+    if (limits.length === 0) return true
+
+    let fullPayload = {
+        _token: getCsrfToken(),
+        components: Array.from(request.messages, message => ({
+            ...message.payload,
+        })),
+    }
+    let fullBody = JSON.stringify(fullPayload)
+
+    return requestEncoder.encode(fullBody).length <= Math.min(...limits)
+}
+
+async function materializeResponseTransport(request, responseJson) {
+    if (! Array.isArray(responseJson.components)) {
+        throw new Error('Invalid Livewire response payload')
+    }
+
+    let hasResponseCompressionNegotiation = responseJson.transport?.v === 1
+
+    if (hasResponseCompressionNegotiation) {
+        request.messages.forEach(message => {
+            message.component.rememberRequestCompression?.(
+                responseJson.transport.requestGzip,
+            )
+        })
+    }
+
+    for (let payload of responseJson.components) {
+        if (payload.skip) continue
+
+        let message = findMessageForPayload(request, payload)
+
+        if (! message) continue
+
+        if (payload.snapshotDelta !== undefined) {
+            payload.snapshot = await materializeSnapshotDelta(
+                payload.snapshotDelta,
+                message.snapshotBaseline,
+            )
+
+            delete payload.snapshotDelta
+        }
+
+        let effects = payload.effects
+
+        if (! effects || typeof effects !== 'object') continue
+
+        if (effects.render !== undefined) {
+            try {
+                effects.html = await materializeRender(
+                    effects.render,
+                    effects.html ?? null,
+                    message.renderBaseline,
+                )
+
+                if (! hasResponseCompressionNegotiation) {
+                    message.component.rememberRequestCompression?.(
+                        effects.render.requestGzip,
+                    )
+                }
+            } catch (error) {
+                if (message.isTransportRecovery()) throw error
+
+                delete effects.html
+                delete effects.htmlDelta
+
+                effects.renderRecovery = true
+            }
+
+            continue
+        }
+
+        if (effects.htmlDelta !== undefined) {
+            try {
+                let baseline = message.renderBaseline
+                let delta = effects.htmlDelta
+
+                if (! baseline || baseline.hash !== delta.base) {
+                    throw new Error('Livewire render baseline does not match its legacy descriptor')
+                }
+
+                effects.html = await reconstructHtmlDelta(
+                    baseline.html,
+                    delta.patches ?? delta.patch,
+                    effects.htmlHash,
+                )
+
+                delete effects.htmlDelta
+            } catch (error) {
+                if (message.isTransportRecovery()) throw error
+
+                delete effects.html
+                delete effects.htmlDelta
+
+                effects.renderRecovery = true
+            }
+        }
+    }
+}
+
+function findMessageForPayload(request, payload) {
+    let componentId = payload.id
+
+    if (typeof componentId !== 'string' && typeof payload.snapshot === 'string') {
+        try {
+            componentId = JSON.parse(payload.snapshot).memo.id
+        } catch (error) {}
+    }
+
+    return Array.from(request.messages).find(message => {
+        return message.component.id === componentId
+    })
+}
+
+function findResponsePayload(message, payloads) {
+    return payloads.find(payload => {
+        if (payload.id === message.component.id) return true
+        if (typeof payload.snapshot !== 'string') return false
+
+        try {
+            return JSON.parse(payload.snapshot).memo.id === message.component.id
+        } catch (error) {
+            return false
+        }
+    })
+}
+
+async function processMessageResponse(message, payload, request) {
+    let { snapshot: snapshotEncoded, effects } = payload
+    let snapshot = JSON.parse(snapshotEncoded)
+
+    if (snapshot.memo.id !== message.component.id) return
+
+    message.responsePayload = { snapshot, effects }
+
+    message.invokeOnSuccess()
+    if (message.isCancelled()) return
+
+    try {
+        // Use Alpine.transaction to batch data updates and DOM morphing
+        // This prevents effects from firing before the morph cleanup runs
+        await Alpine.transaction(async () => {
+            message.component.mergeNewSnapshot(snapshotEncoded, effects, message.updates)
+            message.component.rememberSnapshotReference?.(payload.snapshotRef, snapshotEncoded)
+
+            message.invokeOnSync()
+            if (message.isCancelled()) return
+
+            // Trigger any side effects from the payload like "morph" and "dispatch event"...
+            message.component.processEffects(effects, request)
+
+            message.invokeOnEffect()
+            if (message.isCancelled()) return
+
+            if (! effects.renderRecovery) await message.invokeOnMorph()
+        })
+
+        if (effects.renderRecovery && ! message.isCancelled()) {
+            await message.invokeOnMorph()
+        }
+    } catch (error) {
+        console.error(error)
+
+        if (! message.isCancelled()) message.invokeOnFailure(error)
+
+        return
+    }
+
+    // Resolve promises & finish AFTER morph completes
+    if (! message.isCancelled()) {
+        message.resolveActionPromises(
+            message.pendingReturns,
+            message.pendingReturnsMeta
+        )
+        message.invokeOnFinish()
+    }
+
+    requestAnimationFrame(() => {
+        if (message.isCancelled()) return
+
+        message.invokeOnRender()
     })
 }
 
@@ -492,7 +704,7 @@ async function sendRequest(request, handlers) {
     try {
         if (request.isCancelled()) return
 
-        let responsePromise = fetch(request.uri, request.options)
+        let responsePromise = fetchWithSnapshotReferenceRetry(request)
 
         if (request.isCancelled()) return
         handlers.send({ responsePromise })
@@ -566,8 +778,93 @@ async function sendRequest(request, handlers) {
         return
     }
 
-    handlers.success({ response, responseBody, responseJson })
+    try {
+        await handlers.success({ response, responseBody, responseJson })
+    } catch (error) {
+        if (! request.isCancelled()) handlers.failure({ error })
+
+        handlers.finish()
+
+        return
+    }
+
     handlers.finish()
+}
+
+async function fetchWithSnapshotReferenceRetry(request) {
+    await prepareRequestOptions(request)
+
+    let response = await fetch(request.uri, request.options)
+    let messagesWithReferences = Array.from(request.messages).filter(message => {
+        return request.usedSnapshotReferenceIds?.has(message.component.id) || false
+    })
+
+    if (response.status !== 409
+        || response.headers.get('X-Livewire-Snapshot-Missing') !== '1'
+        || messagesWithReferences.length === 0
+    ) return response
+
+    let inspectionResponse = typeof response.clone === 'function'
+        ? response.clone()
+        : response
+    let responseBody = await inspectionResponse.text()
+    let missingIds = []
+
+    try {
+        let payload = JSON.parse(responseBody)
+
+        if (Array.isArray(payload.snapshotMissing)) missingIds = payload.snapshotMissing
+    } catch (error) {}
+
+    let retryableMessages = messagesWithReferences.filter(message => {
+        return missingIds.length === 0 || missingIds.includes(message.component.id)
+    })
+
+    if (retryableMessages.length === 0) return response
+
+    retryableMessages.forEach(message => {
+        message.component.rejectSnapshotReference?.(message.snapshotReference)
+    })
+
+    let referencedMessageIds = new Set(
+        messagesWithReferences.map(message => message.component.id),
+    )
+
+    await prepareRequestOptions(request, referencedMessageIds)
+
+    return await fetch(request.uri, request.options)
+}
+
+async function prepareRequestOptions(request, forceFullSnapshotIds = null) {
+    let options = request.options
+    let body = forceFullSnapshotIds !== null
+        ? JSON.stringify(buildNetworkPayload(request, forceFullSnapshotIds))
+        : options.body
+
+    delete options.headers['Content-Encoding']
+
+    options.body = body
+
+    if (typeof body !== 'string') return
+
+    let compressionThresholds = Array.from(request.messages, message => {
+        return message.component.getRequestCompressionMinimumBytes?.() ?? null
+    }).filter(value => Number.isSafeInteger(value) && value >= 0)
+
+    if (compressionThresholds.length === 0) return
+
+    let compressionThreshold = Math.min(...compressionThresholds)
+
+    let bodyBytes = requestEncoder.encode(body).length
+
+    if (bodyBytes < compressionThreshold) return
+
+    let compressed = await createGzipBody(body)
+
+    if (! compressed || compressed.length >= bodyBytes) return
+
+    options.body = compressed
+    options.headers['Content-Encoding'] = 'gzip'
 }
 
 async function interceptStreamAndReturnFinalResponse(response, callback) {

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -273,11 +273,15 @@ function sendMessages() {
                 metadata: i.metadata,
             }))
 
+            let render = message.component.getRenderMetadata?.() || {}
+
             message.payload = {
                 snapshot: message.snapshot,
                 updates: message.updates,
                 calls: message.calls,
             }
+
+            if (Object.keys(render).length > 0) message.payload.render = render
         })
     })
 

--- a/js/request/message.js
+++ b/js/request/message.js
@@ -3,6 +3,10 @@ import { MessageInterceptor } from "./interceptor"
 export default class Message {
     actions = new Set()
     snapshot = null
+    snapshotBaseline = null
+    snapshotReference = null
+    renderBaseline = null
+    renderAttemptedPortable = false
     updates = null
     calls = null
     payload = null
@@ -121,6 +125,10 @@ export default class Message {
 
     isAsync() {
         return Array.from(this.actions).every(action => action.isAsync())
+    }
+
+    isTransportRecovery() {
+        return Array.from(this.actions).some(action => action.metadata.transportRecovery)
     }
 
     /**

--- a/js/request/request.spec.js
+++ b/js/request/request.spec.js
@@ -1,64 +1,500 @@
-import { describe, it, vi, expect } from 'vitest'
-import { fireAction } from './index'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { hashHtml } from '../htmlDelta'
+import { fireAction, interceptMessage, interceptRequest } from './index'
+
+afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    document.head.innerHTML = ''
+    document.body.innerHTML = ''
+    delete window.livewireScriptConfig
+})
 
 describe('Request System', () => {
-    // Test is incomplete, so we'll skip it for now...
-    it.skip('should say hello world', async () => {
-        global.fetch = vi.fn(() =>
-            Promise.resolve({
-                json: () => Promise.resolve(JSON.stringify({
-                    components: [
-                        {
-                            snapshot: JSON.stringify({
-                                memo: { id: '1' },
-                            }),
-                        },
-                    ],
-                    assets: {},
-                })),
-            }),
-        )
+    it('retries a missing snapshot reference once with the full snapshot', async () => {
+        document.head.innerHTML = '<meta name="csrf-token" content="token">'
+        window.livewireScriptConfig = { uri: '/livewire/update' }
+        vi.stubGlobal('Alpine', {
+            transaction: async callback => await callback(),
+        })
+        vi.stubGlobal('requestAnimationFrame', callback => callback())
 
         let component = createComponent()
+        component.outboundSnapshotReference = 'a'.repeat(24)
+        component.outboundSnapshotReferenceSnapshot = component.initialSnapshot
+        let requests = []
+        let responseSnapshot = JSON.stringify({
+            data: { value: 'updated' },
+            memo: component.snapshot.memo,
+        })
 
-        let results = await fireAction(component, '$refresh')
+        vi.stubGlobal('fetch', vi.fn(async (uri, options) => {
+            requests.push({
+                body: options.body instanceof Uint8Array
+                    ? options.body.slice()
+                    : options.body,
+                headers: { ...options.headers },
+                uri,
+            })
 
-        expect(results).toBe('hello world')
+            if (requests.length === 1) {
+                return response(409, {
+                    snapshotMissing: [component.id],
+                }, {
+                    'X-Livewire-Snapshot-Missing': '1',
+                })
+            }
+
+            return response(200, {
+                components: [{
+                    id: component.id,
+                    snapshot: responseSnapshot,
+                    snapshotRef: 'b'.repeat(24),
+                    effects: { returns: [null] },
+                }],
+                assets: [],
+            })
+        }))
+
+        await fireAction(component, '$refresh')
+
+        expect(requests).toHaveLength(2)
+
+        let firstPayload = JSON.parse(requests[0].body)
+
+        expect(firstPayload.components[0].snapshot).toBeUndefined()
+        expect(firstPayload.components[0].snapshotRef).toBe('a'.repeat(24))
+        expect(component.rejectedSnapshotReference).toBe('a'.repeat(24))
+
+        let secondBody = await decodeRequestBody(requests[1])
+        let secondPayload = JSON.parse(secondBody)
+
+        expect(secondPayload.components[0].snapshot).toBe(component.initialSnapshot)
+        expect(secondPayload.components[0].snapshotRef).toBeUndefined()
+        expect(requests[1].headers['X-CSRF-TOKEN']).toBe('token')
+        expect(component.rememberedSnapshotReference).toBe('b'.repeat(24))
+    })
+
+    it('does not use a snapshot reference when its exact full fallback exceeds the server limit', async () => {
+        document.head.innerHTML = '<meta name="csrf-token" content="token">'
+        window.livewireScriptConfig = { uri: '/livewire/update' }
+        vi.stubGlobal('Alpine', {
+            transaction: async callback => await callback(),
+        })
+        vi.stubGlobal('requestAnimationFrame', callback => callback())
+
+        let component = createComponent()
+        component.outboundSnapshotReference = 'a'.repeat(24)
+        component.outboundSnapshotReferenceSnapshot = component.initialSnapshot
+        component.maximumRequestBytes = 100
+        let requests = []
+
+        vi.stubGlobal('fetch', vi.fn(async (uri, options) => {
+            requests.push({ body: options.body, uri })
+
+            return response(200, {
+                components: [{
+                    id: component.id,
+                    snapshot: component.initialSnapshot,
+                    effects: { returns: [null] },
+                }],
+                assets: [],
+            })
+        }))
+
+        await fireAction(component, '$refresh')
+
+        expect(requests).toHaveLength(1)
+
+        let payload = JSON.parse(requests[0].body)
+
+        expect(payload.components[0].snapshot).toBe(component.initialSnapshot)
+        expect(payload.components[0].snapshotRef).toBeUndefined()
+    })
+
+    it('retries a related bundled miss with full snapshots for every referenced message', async () => {
+        document.head.innerHTML = '<meta name="csrf-token" content="token">'
+        window.livewireScriptConfig = { uri: '/livewire/update' }
+        vi.stubGlobal('Alpine', {
+            transaction: async callback => await callback(),
+        })
+        vi.stubGlobal('requestAnimationFrame', callback => callback())
+
+        let missing = createComponent('missing-component')
+        let valid = createComponent('valid-component')
+        let requests = []
+
+        for (let component of [missing, valid]) {
+            component.outboundSnapshotReference = component.id[0].repeat(24)
+            component.outboundSnapshotReferenceSnapshot = component.initialSnapshot
+        }
+
+        vi.stubGlobal('fetch', vi.fn(async (uri, options) => {
+            requests.push({ body: options.body, uri })
+
+            if (requests.length === 1) {
+                return response(409, {
+                    snapshotMissing: [missing.id],
+                }, {
+                    'X-Livewire-Snapshot-Missing': '1',
+                })
+            }
+
+            return response(200, {
+                components: [missing, valid].map(component => ({
+                    id: component.id,
+                    snapshot: component.initialSnapshot,
+                    effects: { returns: [null] },
+                })),
+                assets: [],
+            })
+        }))
+
+        await Promise.all([
+            fireAction(missing, '$refresh'),
+            fireAction(valid, '$refresh'),
+        ])
+
+        expect(requests).toHaveLength(2)
+
+        let retry = JSON.parse(requests[1].body).components
+        let missingRetry = retry.find(component => {
+            return JSON.parse(component.snapshot).memo.id === missing.id
+        })
+        let validRetry = retry.find(component => {
+            return JSON.parse(component.snapshot).memo.id === valid.id
+        })
+
+        expect(missingRetry.snapshot).toBe(missing.initialSnapshot)
+        expect(missingRetry.snapshotRef).toBeUndefined()
+        expect(validRetry.snapshot).toBe(valid.initialSnapshot)
+        expect(validRetry.snapshotRef).toBeUndefined()
+    })
+
+    it('does not retry a snapshot missing response unrelated to the references it sent', async () => {
+        document.head.innerHTML = '<meta name="csrf-token" content="token">'
+        window.livewireScriptConfig = { uri: '/livewire/update' }
+        vi.stubGlobal('Alpine', {
+            transaction: async callback => await callback(),
+        })
+        vi.stubGlobal('requestAnimationFrame', callback => callback())
+
+        let component = createComponent()
+        component.outboundSnapshotReference = 'a'.repeat(24)
+        component.outboundSnapshotReferenceSnapshot = component.initialSnapshot
+        let requests = []
+        let removeInterceptor = interceptRequest(({ onError }) => {
+            onError(({ preventDefault }) => preventDefault())
+        })
+
+        vi.stubGlobal('fetch', vi.fn(async (uri, options) => {
+            requests.push({ body: options.body, uri })
+
+            return response(409, {
+                snapshotMissing: ['unrelated-component'],
+            }, {
+                'X-Livewire-Snapshot-Missing': '1',
+            })
+        }))
+
+        await expect(fireAction(component, '$refresh')).rejects.toBeTruthy()
+        removeInterceptor()
+
+        expect(requests).toHaveLength(1)
+    })
+
+    it('materializes snapshot and render deltas before public message hooks', async () => {
+        document.head.innerHTML = '<meta name="csrf-token" content="token">'
+        window.livewireScriptConfig = { uri: '/livewire/update' }
+        vi.stubGlobal('Alpine', {
+            transaction: async callback => await callback(),
+        })
+        vi.stubGlobal('requestAnimationFrame', callback => callback())
+
+        let component = createComponent()
+        let html = '<div>materialized</div>'
+        let snapshotHash = await hashHtml(component.initialSnapshot)
+        let observedPayload = null
+        let removeInterceptor = interceptMessage(({ message, onSuccess }) => {
+            if (message.component !== component) return
+
+            onSuccess(({ payload }) => observedPayload = payload)
+        })
+
+        vi.stubGlobal('fetch', vi.fn(async () => response(200, {
+            components: [{
+                id: component.id,
+                snapshotDelta: {
+                    v: 1,
+                    base: snapshotHash,
+                    target: snapshotHash,
+                    bytes: new TextEncoder().encode(component.initialSnapshot).length,
+                    patches: [],
+                },
+                effects: {
+                    render: {
+                        v: 1,
+                        mode: 'full',
+                        target: await hashHtml(html),
+                        bytes: new TextEncoder().encode(html).length,
+                    },
+                    html,
+                    returns: [null],
+                },
+            }],
+            assets: [],
+        })))
+
+        await fireAction(component, '$refresh')
+        removeInterceptor()
+
+        expect(observedPayload.snapshot).toEqual(JSON.parse(component.initialSnapshot))
+        expect(observedPayload.effects.html).toBe(html)
+        expect(component.processedEffects.html).toBe(html)
+    })
+
+    it('compresses requests only after the server negotiates gzip support', async () => {
+        if (typeof globalThis.CompressionStream !== 'function'
+            || typeof globalThis.DecompressionStream !== 'function'
+        ) {
+            return
+        }
+
+        document.head.innerHTML = '<meta name="csrf-token" content="token">'
+        window.livewireScriptConfig = { uri: '/livewire/update' }
+        vi.stubGlobal('Alpine', {
+            transaction: async callback => await callback(),
+        })
+        vi.stubGlobal('requestAnimationFrame', callback => callback())
+
+        let component = createComponent()
+        let requests = []
+        let html = '<div>gzip negotiation</div>'
+
+        vi.stubGlobal('fetch', vi.fn(async (uri, options) => {
+            requests.push({
+                body: options.body instanceof Uint8Array
+                    ? options.body.slice()
+                    : options.body,
+                headers: { ...options.headers },
+                uri,
+            })
+
+            let snapshot = JSON.stringify({
+                data: { value: 'updated-' + requests.length },
+                memo: component.snapshot.memo,
+            })
+
+            if (requests.length === 1) {
+                return response(200, {
+                    components: [{
+                        id: component.id,
+                        snapshot,
+                        effects: {
+                            html,
+                            render: {
+                                v: 1,
+                                mode: 'full',
+                                target: await hashHtml(html),
+                                bytes: new TextEncoder().encode(html).length,
+                                requestGzip: 1,
+                            },
+                            returns: [null],
+                        },
+                    }],
+                    assets: [],
+                })
+            }
+
+            return response(200, {
+                components: [{
+                    id: component.id,
+                    snapshot,
+                    effects: { returns: [null] },
+                }],
+                assets: [],
+            })
+        }))
+
+        await fireAction(component, '$refresh')
+        await fireAction(component, '$refresh')
+
+        expect(requests).toHaveLength(2)
+        expect(requests[0].body).toEqual(expect.any(String))
+        expect(requests[0].headers['Content-Encoding']).toBeUndefined()
+        expect(requests[1].body).toBeInstanceOf(Uint8Array)
+        expect(requests[1].headers['Content-Encoding']).toBe('gzip')
+
+        let secondPayload = JSON.parse(await decodeRequestBody(requests[1]))
+
+        expect(JSON.parse(secondPayload.components[0].snapshot).data.value)
+            .toBe('updated-1')
+    })
+
+    it('updates and clears gzip negotiation from top-level transport on renderless responses', async () => {
+        if (typeof globalThis.CompressionStream !== 'function'
+            || typeof globalThis.DecompressionStream !== 'function'
+        ) {
+            return
+        }
+
+        document.head.innerHTML = '<meta name="csrf-token" content="token">'
+        window.livewireScriptConfig = { uri: '/livewire/update' }
+        vi.stubGlobal('Alpine', {
+            transaction: async callback => await callback(),
+        })
+        vi.stubGlobal('requestAnimationFrame', callback => callback())
+
+        let component = createComponent()
+        let requests = []
+
+        vi.stubGlobal('fetch', vi.fn(async (uri, options) => {
+            requests.push({
+                body: options.body instanceof Uint8Array
+                    ? options.body.slice()
+                    : options.body,
+                headers: { ...options.headers },
+                uri,
+            })
+
+            let snapshot = JSON.stringify({
+                data: { value: 'updated-' + requests.length },
+                memo: component.snapshot.memo,
+            })
+
+            return response(200, {
+                transport: {
+                    v: 1,
+                    requestGzip: requests.length === 1 ? 1 : null,
+                },
+                components: [{
+                    id: component.id,
+                    snapshot,
+                    effects: { returns: [null] },
+                }],
+                assets: [],
+            })
+        }))
+
+        await fireAction(component, '$refresh')
+        await fireAction(component, '$refresh')
+        await fireAction(component, '$refresh')
+
+        expect(requests).toHaveLength(3)
+        expect(requests[0].body).toEqual(expect.any(String))
+        expect(requests[0].headers['Content-Encoding']).toBeUndefined()
+        expect(requests[1].body).toBeInstanceOf(Uint8Array)
+        expect(requests[1].headers['Content-Encoding']).toBe('gzip')
+        expect(requests[2].body).toEqual(expect.any(String))
+        expect(requests[2].headers['Content-Encoding']).toBeUndefined()
+        expect(component.requestCompressionMinimumBytes).toBeNull()
     })
 })
 
-function createComponent() {
+function createComponent(id = 'component-id') {
+    let snapshot = JSON.stringify({
+        data: { value: 'x'.repeat(5000) },
+        memo: {
+            async: [],
+            children: {},
+            id,
+            islands: {},
+            name: 'transport-test',
+        },
+    })
+
     return {
-        get el() {
-            throw new Error('el not implemented')
-        },
-
-        id: '1',
-
+        id,
         effects: {},
-
-        snapshot: {
-            memo: {
-                id: '1',
-            },
-        },
-
+        initialSnapshot: snapshot,
+        snapshotEncoded: snapshot,
+        snapshot: JSON.parse(snapshot),
         islands: {},
+        isIsolated: false,
+        isLazy: false,
+        hasBeenLazyLoaded: true,
+        isLazyIsolated: false,
 
-        getUpdates() {
-            //
+        captureRenderBaseline() {
+            return null
         },
+
+        captureSnapshotReference(allowed, snapshot) {
+            return allowed && snapshot === this.outboundSnapshotReferenceSnapshot
+                ? this.outboundSnapshotReference || null
+                : null
+        },
+
+        getDeepChildrenWithBindings() {},
 
         getEncodedSnapshotWithLatestChildrenMergedIn() {
-            //
+            return this.snapshotEncoded
         },
 
-        processEffects() {
-            //
+        getRenderMetadata() {
+            return {
+                v: 1,
+                capabilities: ['snapshot-delta', 'snapshot-ref'],
+            }
         },
 
-        mergeNewSnapshot() {
-            //
+        getUpdates() {
+            return {}
+        },
+
+        mergeNewSnapshot(snapshotEncoded, effects) {
+            this.snapshotEncoded = snapshotEncoded
+            this.snapshot = JSON.parse(snapshotEncoded)
+            this.effects = effects
+        },
+
+        processEffects(effects) {
+            this.processedEffects = effects
+        },
+
+        rejectSnapshotReference(reference) {
+            this.rejectedSnapshotReference = reference
+        },
+
+        rememberSnapshotReference(reference, snapshot) {
+            this.rememberedSnapshotReference = reference
+            this.rememberedSnapshotReferenceSnapshot = snapshot
+        },
+
+        rememberRequestCompression(minimumBytes) {
+            this.requestCompressionMinimumBytes = minimumBytes
+        },
+
+        getRequestCompressionMinimumBytes() {
+            return this.requestCompressionMinimumBytes ?? null
+        },
+
+        getMaximumRequestBytes() {
+            return this.maximumRequestBytes ?? 1024 * 1024
         },
     }
+}
+
+function response(status, payload, headers = {}) {
+    return {
+        aborted: false,
+        headers: new Headers(headers),
+        ok: status >= 200 && status < 300,
+        redirected: false,
+        status,
+        text: async () => JSON.stringify(payload),
+    }
+}
+
+async function decodeRequestBody(request) {
+    if (request.headers['Content-Encoding'] !== 'gzip') return request.body
+
+    let decompression = new DecompressionStream('gzip')
+    let output = new Response(decompression.readable).text()
+    let writer = decompression.writable.getWriter()
+
+    await writer.write(request.body)
+    await writer.close()
+
+    return await output
 }

--- a/src/Component.php
+++ b/src/Component.php
@@ -11,6 +11,7 @@ use Livewire\Features\SupportRedirects\HandlesRedirects;
 use Livewire\Features\SupportPageComponents\HandlesPageComponents;
 use Livewire\Features\SupportJsEvaluation\HandlesJsEvaluation;
 use Livewire\Features\SupportIslands\HandlesIslands;
+use Livewire\Features\SupportTransportFragments\HandlesTransportFragments;
 use Livewire\Features\SupportFormObjects\HandlesFormObjects;
 use Livewire\Features\SupportEvents\HandlesEvents;
 use Livewire\Features\SupportHtmlAttributeForwarding\HandlesHtmlAttributeForwarding;
@@ -31,6 +32,7 @@ abstract class Component
     use InteractsWithProperties;
     use HandlesEvents;
     use HandlesIslands;
+    use HandlesTransportFragments;
     use HandlesRedirects;
     use HandlesTransitions;
     use HandlesStreaming;

--- a/src/Features/SupportTesting/ComponentState.php
+++ b/src/Features/SupportTesting/ComponentState.php
@@ -13,6 +13,8 @@ class ComponentState
         protected $html,
         protected $snapshot,
         protected $effects,
+        protected $serverRenderedHtml = null,
+        protected $serverRenderedHtmlHash = null,
     ) {}
 
     function getComponent() {
@@ -32,6 +34,23 @@ class ComponentState
     function getEffects()
     {
         return $this->effects;
+    }
+
+    function getServerRenderedHtml()
+    {
+        return $this->serverRenderedHtml;
+    }
+
+    function getServerRenderedHtmlHash()
+    {
+        return $this->serverRenderedHtmlHash;
+    }
+
+    function getRenderMetadata()
+    {
+        if ($this->serverRenderedHtml === null || $this->serverRenderedHtmlHash === null) return [];
+
+        return ['htmlHash' => $this->serverRenderedHtmlHash];
     }
 
     function getView()

--- a/src/Features/SupportTesting/ComponentState.php
+++ b/src/Features/SupportTesting/ComponentState.php
@@ -3,6 +3,8 @@
 namespace Livewire\Features\SupportTesting;
 
 use Livewire\Drawer\Utils;
+use Livewire\Mechanisms\HandleComponents\UpdateEngines\RenderFragmentTree;
+use Livewire\Mechanisms\HandleComponents\UpdateEngines\StatelessHtmlChunks;
 
 class ComponentState
 {
@@ -15,6 +17,7 @@ class ComponentState
         protected $effects,
         protected $serverRenderedHtml = null,
         protected $serverRenderedHtmlHash = null,
+        protected int $renderRevision = 0,
     ) {}
 
     function getComponent() {
@@ -46,11 +49,100 @@ class ComponentState
         return $this->serverRenderedHtmlHash;
     }
 
+    function getRenderRevision()
+    {
+        return $this->renderRevision;
+    }
+
     function getRenderMetadata()
     {
-        if ($this->serverRenderedHtml === null || $this->serverRenderedHtmlHash === null) return [];
+        if (config('livewire.update_engine', 'morph') !== 'delta') return [];
 
-        return ['htmlHash' => $this->serverRenderedHtmlHash];
+        $blockSize = max(256, min(65536, (int) config('livewire.delta.block_size', 2048)));
+        $metadata = [
+            'v' => 1,
+            'capabilities' => ['same'],
+        ];
+
+        if (config('livewire.delta.snapshot_delta', true)) {
+            $metadata['capabilities'][] = 'snapshot-delta';
+        }
+
+        if (config('livewire.delta.snapshot_references', false)) {
+            $metadata['capabilities'][] = 'snapshot-ref';
+        }
+
+        if ($this->serverRenderedHtml === null || $this->serverRenderedHtmlHash === null) {
+            return $metadata;
+        }
+
+        $metadata['base'] = [
+            'hash' => $this->serverRenderedHtmlHash,
+            'bytes' => strlen($this->serverRenderedHtml),
+            'revision' => $this->renderRevision,
+        ];
+
+        $minimumBytes = min(
+            67108864,
+            max(0, (int) config('livewire.delta.minimum_html_bytes', 8192)),
+        );
+        $maximumBytes = min(
+            67108864,
+            max($minimumBytes, (int) config('livewire.delta.maximum_html_bytes', 4194304)),
+        );
+        $htmlBytes = strlen($this->serverRenderedHtml);
+
+        if ($htmlBytes < $minimumBytes || $htmlBytes > $maximumBytes) {
+            return $metadata;
+        }
+
+        if (config('livewire.delta.cache_accelerator', true)) {
+            $metadata['capabilities'][] = 'splice';
+        }
+
+        try {
+            $blocks = app(StatelessHtmlChunks::class)->manifest(
+                $this->serverRenderedHtml,
+                $blockSize,
+            );
+
+            $maximumManifestBytes = min(
+                65536,
+                max(0, (int) config('livewire.delta.maximum_manifest_bytes', 65536)),
+            );
+
+            if (strlen($blocks) <= $maximumManifestBytes) {
+                $metadata['chunks'] = [
+                    'blockSize' => $blockSize,
+                    'blocks' => $blocks,
+                ];
+                $metadata['capabilities'][] = 'chunks';
+            }
+        } catch (\InvalidArgumentException) {
+            // The testing client mirrors the browser by omitting manifests it cannot safely bound.
+        }
+
+        try {
+            $fragments = app(RenderFragmentTree::class)->manifest($this->serverRenderedHtml);
+
+            $maximumFragments = min(
+                1024,
+                max(0, (int) config('livewire.delta.maximum_fragments', 1024)),
+            );
+
+            if (count($fragments['nodes'] ?? []) > $maximumFragments) {
+                $fragments = null;
+            }
+        } catch (\InvalidArgumentException) {
+            $fragments = null;
+        }
+
+        if ($fragments !== null && ($fragments['nodes'] ?? []) !== []) {
+            $metadata['fragments'] = $fragments;
+            $metadata['capabilities'][] = 'fragments';
+        }
+
+        return $metadata;
     }
 
     function getView()

--- a/src/Features/SupportTesting/SubsequentRender.php
+++ b/src/Features/SupportTesting/SubsequentRender.php
@@ -2,6 +2,8 @@
 
 namespace Livewire\Features\SupportTesting;
 
+use Livewire\Mechanisms\HandleComponents\UpdateEngines\HtmlDelta;
+
 class SubsequentRender extends Render
 {
     function __construct(
@@ -27,6 +29,7 @@ class SubsequentRender extends Render
                     'snapshot' => $encodedSnapshot,
                     'calls' => $calls,
                     'updates' => $updates,
+                    'render' => $this->lastState->getRenderMetadata(),
                 ],
             ],
         ];
@@ -61,8 +64,7 @@ class SubsequentRender extends Render
 
         $effects = $componentResponsePayload['effects'];
 
-        // If no new HTML has been rendered, let's forward the last known HTML...
-        $html = $effects['html'] ?? $this->lastState->getHtml(stripInitialData: true);
+        [ $html, $serverRenderedHtml, $serverRenderedHtmlHash ] = $this->resolveRenderedHtml($effects);
         $view = $componentView ?? $this->lastState->getView();
 
         return new ComponentState(
@@ -72,6 +74,47 @@ class SubsequentRender extends Render
             $html,
             $snapshot,
             $effects,
+            $serverRenderedHtml,
+            $serverRenderedHtmlHash,
         );
+    }
+
+    protected function resolveRenderedHtml(array $effects): array
+    {
+        $previousHtml = $this->lastState->getServerRenderedHtml();
+        $previousHash = $this->lastState->getServerRenderedHtmlHash();
+
+        if (is_string($effects['html'] ?? null)) {
+            return [
+                $effects['html'],
+                $effects['html'],
+                is_string($effects['htmlHash'] ?? null) ? $effects['htmlHash'] : null,
+            ];
+        }
+
+        if (is_array($effects['htmlDelta'] ?? null)
+            && is_string($previousHtml)
+            && is_string($previousHash)
+            && is_string($effects['htmlDelta']['base'] ?? null)
+            && is_string($effects['htmlHash'] ?? null)
+            && hash_equals($previousHash, $effects['htmlDelta']['base'])
+        ) {
+            $serverRenderedHtml = app(HtmlDelta::class)->apply(
+                $previousHtml,
+                $effects['htmlDelta']['patches'] ?? $effects['htmlDelta']['patch'] ?? [],
+            );
+
+            return [
+                $serverRenderedHtml,
+                $serverRenderedHtml,
+                $effects['htmlHash'],
+            ];
+        }
+
+        return [
+            $this->lastState->getHtml(stripInitialData: true),
+            $previousHtml,
+            $previousHash,
+        ];
     }
 }

--- a/src/Features/SupportTesting/SubsequentRender.php
+++ b/src/Features/SupportTesting/SubsequentRender.php
@@ -3,6 +3,8 @@
 namespace Livewire\Features\SupportTesting;
 
 use Livewire\Mechanisms\HandleComponents\UpdateEngines\HtmlDelta;
+use Livewire\Mechanisms\HandleComponents\UpdateEngines\RenderFragmentTree;
+use Livewire\Mechanisms\HandleComponents\UpdateEngines\StatelessHtmlChunks;
 
 class SubsequentRender extends Render
 {
@@ -60,12 +62,19 @@ class SubsequentRender extends Render
 
         $componentResponsePayload = $json['components'][0];
 
-        $snapshot = json_decode($componentResponsePayload['snapshot'], true);
+        $snapshot = $this->resolveSnapshot($componentResponsePayload, $encodedSnapshot);
 
         $effects = $componentResponsePayload['effects'];
 
-        [ $html, $serverRenderedHtml, $serverRenderedHtmlHash ] = $this->resolveRenderedHtml($effects);
+        [ $html, $serverRenderedHtml, $serverRenderedHtmlHash, $effects ] = $this->resolveRenderedHtml($effects);
         $view = $componentView ?? $this->lastState->getView();
+        $renderRevision = $this->lastState->getRenderRevision();
+
+        if (is_string($serverRenderedHtmlHash)
+            && $serverRenderedHtmlHash !== $this->lastState->getServerRenderedHtmlHash()
+        ) {
+            $renderRevision++;
+        }
 
         return new ComponentState(
             $componentInstance,
@@ -76,6 +85,7 @@ class SubsequentRender extends Render
             $effects,
             $serverRenderedHtml,
             $serverRenderedHtmlHash,
+            $renderRevision,
         );
     }
 
@@ -85,10 +95,55 @@ class SubsequentRender extends Render
         $previousHash = $this->lastState->getServerRenderedHtmlHash();
 
         if (is_string($effects['html'] ?? null)) {
+            $hash = is_string($effects['render']['target'] ?? null)
+                ? $effects['render']['target']
+                : (is_string($effects['htmlHash'] ?? null)
+                    ? $effects['htmlHash']
+                    : hash('sha256', $effects['html']));
+
+            $this->assertTransportIntegrity($effects['html'], $hash, $effects['render']['bytes'] ?? null);
+
             return [
                 $effects['html'],
                 $effects['html'],
-                is_string($effects['htmlHash'] ?? null) ? $effects['htmlHash'] : null,
+                $hash,
+                $effects,
+            ];
+        }
+
+        if (is_array($effects['render'] ?? null)
+            && ($effects['render']['v'] ?? null) === 1
+            && is_string($previousHtml)
+            && is_string($previousHash)
+        ) {
+            $render = $effects['render'];
+            $mode = $render['mode'] ?? null;
+
+            if (! in_array($mode, ['same', 'splice', 'chunks', 'fragments'], true)
+                || ! is_string($render['base'] ?? null)
+                || ! hash_equals($previousHash, $render['base'])
+                || ! is_string($render['target'] ?? null)
+                || ! is_int($render['bytes'] ?? null)
+            ) {
+                throw new \InvalidArgumentException('Invalid render transport descriptor.');
+            }
+
+            $serverRenderedHtml = match ($mode) {
+                'same' => $previousHtml,
+                'splice' => app(HtmlDelta::class)->apply($previousHtml, $render['patches'] ?? []),
+                'chunks' => app(StatelessHtmlChunks::class)->apply($previousHtml, $render['ops'] ?? []),
+                'fragments' => app(RenderFragmentTree::class)->apply($previousHtml, $render['ops'] ?? []),
+            };
+
+            $this->assertTransportIntegrity($serverRenderedHtml, $render['target'], $render['bytes']);
+
+            $effects['html'] = $serverRenderedHtml;
+
+            return [
+                $serverRenderedHtml,
+                $serverRenderedHtml,
+                $render['target'],
+                $effects,
             ];
         }
 
@@ -108,6 +163,7 @@ class SubsequentRender extends Render
                 $serverRenderedHtml,
                 $serverRenderedHtml,
                 $effects['htmlHash'],
+                $effects + ['html' => $serverRenderedHtml],
             ];
         }
 
@@ -115,6 +171,43 @@ class SubsequentRender extends Render
             $this->lastState->getHtml(stripInitialData: true),
             $previousHtml,
             $previousHash,
+            $effects,
         ];
+    }
+
+    protected function resolveSnapshot(array $response, string $previousSnapshot): array
+    {
+        if (is_string($response['snapshot'] ?? null)) {
+            return json_decode($response['snapshot'], true, 512, JSON_THROW_ON_ERROR);
+        }
+
+        $delta = $response['snapshotDelta'] ?? null;
+
+        if (! is_array($delta)
+            || ($delta['v'] ?? null) !== 1
+            || ! is_string($delta['base'] ?? null)
+            || ! hash_equals(hash('sha256', $previousSnapshot), $delta['base'])
+            || ! is_string($delta['target'] ?? null)
+            || ! is_int($delta['bytes'] ?? null)
+            || ! is_array($delta['patches'] ?? null)
+        ) {
+            throw new \InvalidArgumentException('Invalid snapshot transport descriptor.');
+        }
+
+        $snapshot = app(HtmlDelta::class)->apply($previousSnapshot, $delta['patches']);
+
+        $this->assertTransportIntegrity($snapshot, $delta['target'], $delta['bytes']);
+
+        return json_decode($snapshot, true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    protected function assertTransportIntegrity(string $value, string $hash, ?int $bytes): void
+    {
+        if (preg_match('/^[a-f0-9]{64}$/', $hash) !== 1
+            || ($bytes !== null && $bytes !== strlen($value))
+            || ! hash_equals($hash, hash('sha256', $value))
+        ) {
+            throw new \InvalidArgumentException('Transport integrity check failed.');
+        }
     }
 }

--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -409,6 +409,8 @@ class Testable
                 $this->lastState->getHtml(),
                 $value,
                 $this->lastState->getEffects(),
+                $this->lastState->getServerRenderedHtml(),
+                $this->lastState->getServerRenderedHtmlHash(),
             );
             return;
         }

--- a/src/Features/SupportTesting/Testable.php
+++ b/src/Features/SupportTesting/Testable.php
@@ -411,6 +411,7 @@ class Testable
                 $this->lastState->getEffects(),
                 $this->lastState->getServerRenderedHtml(),
                 $this->lastState->getServerRenderedHtmlHash(),
+                $this->lastState->getRenderRevision(),
             );
             return;
         }

--- a/src/Features/SupportTransportFragments/HandlesTransportFragments.php
+++ b/src/Features/SupportTransportFragments/HandlesTransportFragments.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Livewire\Features\SupportTransportFragments;
+
+use LogicException;
+
+trait HandlesTransportFragments
+{
+    protected array $transportFragmentStack = [];
+
+    protected array $transportFragmentNames = [];
+
+    public function startTransportFragment(mixed $name): string
+    {
+        $name = $this->validateTransportFragmentName($name);
+        $metadata = null;
+        $marker = '';
+
+        if ($name !== null && ! isset($this->transportFragmentNames[$name])) {
+            $metadata = [
+                'type' => 'transport',
+                'name' => $name,
+                'token' => substr(hash('sha256', $name), 0, 16),
+                'mode' => 'morph',
+            ];
+
+            $this->transportFragmentNames[$name] = true;
+            $marker = $this->transportFragmentMarker('FRAGMENT', $metadata);
+        }
+
+        $this->transportFragmentStack[] = $metadata;
+
+        return $marker;
+    }
+
+    public function endTransportFragment(): string
+    {
+        if ($this->transportFragmentStack === []) {
+            return '';
+        }
+
+        $metadata = array_pop($this->transportFragmentStack);
+
+        if ($metadata === null) return '';
+
+        return $this->transportFragmentMarker('ENDFRAGMENT', $metadata);
+    }
+
+    public function resetTransportFragments(): void
+    {
+        $this->transportFragmentStack = [];
+        $this->transportFragmentNames = [];
+    }
+
+    public function ensureTransportFragmentsAreClosed(): void
+    {
+        $openTransportFragments = array_values(array_filter(
+            $this->transportFragmentStack,
+            fn ($metadata) => is_array($metadata),
+        ));
+
+        if ($openTransportFragments === []) {
+            $this->resetTransportFragments();
+
+            return;
+        }
+
+        $names = implode(', ', array_column($openTransportFragments, 'name'));
+
+        $this->resetTransportFragments();
+
+        throw new LogicException("Unclosed transport fragment stack: [{$names}].");
+    }
+
+    protected function validateTransportFragmentName(mixed $name): ?string
+    {
+        if (! is_string($name)
+            || strlen($name) > 256
+            || ! preg_match('/\A[A-Za-z0-9][A-Za-z0-9_.:-]*\z/', $name)
+        ) {
+            return null;
+        }
+
+        return $name;
+    }
+
+    protected function transportFragmentMarker(string $type, array $metadata): string
+    {
+        $encodedMetadata = [];
+
+        foreach ($metadata as $key => $value) {
+            $encodedMetadata[] = "{$key}={$value}";
+        }
+
+        return '<!--[if '.$type.':'.implode('|', $encodedMetadata).']><![endif]-->';
+    }
+}

--- a/src/Features/SupportTransportFragments/SupportTransportFragments.php
+++ b/src/Features/SupportTransportFragments/SupportTransportFragments.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Livewire\Features\SupportTransportFragments;
+
+use Illuminate\Support\Facades\Blade;
+use Livewire\ComponentHook;
+
+class SupportTransportFragments extends ComponentHook
+{
+    public static function provide(): void
+    {
+        Blade::directive('fragment', function ($expression) {
+            $expression = trim($expression) ?: 'null';
+
+            return "<?php \$__livewireTransportFragmentName = {$expression}; if (isset(\$__livewire) && config('livewire.update_engine') === 'delta') echo \$__livewire->startTransportFragment(\$__livewireTransportFragmentName); \$__env->startFragment(\$__livewireTransportFragmentName); unset(\$__livewireTransportFragmentName); ?>";
+        });
+
+        Blade::directive('endfragment', function () {
+            return "<?php \$__livewireTransportFragmentEnd = isset(\$__livewire) && config('livewire.update_engine') === 'delta' ? \$__livewire->endTransportFragment() : ''; echo \$__env->stopFragment(); echo \$__livewireTransportFragmentEnd; unset(\$__livewireTransportFragmentEnd); ?>";
+        });
+    }
+
+    public function render(): \Closure
+    {
+        $this->component->resetTransportFragments();
+
+        return function () {
+            $this->component->ensureTransportFragmentsAreClosed();
+        };
+    }
+}

--- a/src/Features/SupportTransportFragments/UnitTest.php
+++ b/src/Features/SupportTransportFragments/UnitTest.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Livewire\Features\SupportTransportFragments;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\View\ViewException;
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class UnitTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('livewire.update_engine', 'delta');
+    }
+
+    public function test_it_preserves_laravels_native_blade_fragment_capture()
+    {
+        $compiled = Blade::compileString(<<<'BLADE'
+            @fragment('native-panel')
+                <span>Native fragment content</span>
+            @endfragment
+        BLADE);
+        $html = Blade::render(<<<'BLADE'
+            @fragment('native-panel')
+                <span>Native fragment content</span>
+            @endfragment
+        BLADE);
+
+        $this->assertStringContainsString("\$__livewireTransportFragmentName = 'native-panel'", $compiled);
+        $this->assertStringContainsString(
+            '$__env->startFragment($__livewireTransportFragmentName)',
+            $compiled,
+        );
+        $this->assertStringContainsString('$__env->stopFragment()', $compiled);
+        $this->assertStringContainsString('<span>Native fragment content</span>', $html);
+        $this->assertStringNotContainsString('type=transport', $html);
+    }
+
+    public function test_native_fragments_do_not_add_transport_markers_for_the_default_engine()
+    {
+        config()->set('livewire.update_engine', 'morph');
+
+        $html = Livewire::test(new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @fragment('summary')
+                        <span>Native fragment content</span>
+                    @endfragment
+                </div>
+                HTML;
+            }
+        })->html();
+
+        $this->assertStringContainsString('<span>Native fragment content</span>', $html);
+        $this->assertStringNotContainsString('type=transport', $html);
+    }
+
+    public function test_fragment_markers_and_tokens_are_stable_across_renders()
+    {
+        $component = Livewire::test(new class extends Component {
+            public int $count = 0;
+
+            public function increment(): void
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @fragment('summary')
+                        <span>{{ $count }}</span>
+                    @endfragment
+                </div>
+                HTML;
+            }
+        });
+
+        $start = $this->marker('FRAGMENT', 'summary');
+        $end = $this->marker('ENDFRAGMENT', 'summary');
+
+        $this->assertStringContainsString($start, $component->html());
+        $this->assertStringContainsString($end, $component->html());
+
+        $component->call('increment');
+
+        $this->assertStringContainsString($start, $component->html());
+        $this->assertStringContainsString($end, $component->html());
+        $this->assertStringContainsString('<span>1</span>', $component->html());
+    }
+
+    public function test_dynamic_fragment_names_are_reflected_in_the_markers()
+    {
+        $component = Livewire::test(new class extends Component {
+            public string $fragmentName = 'panel-overview';
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @fragment($fragmentName)
+                        <span>{{ $fragmentName }}</span>
+                    @endfragment
+                </div>
+                HTML;
+            }
+        });
+
+        $this->assertStringContainsString($this->marker('FRAGMENT', 'panel-overview'), $component->html());
+
+        $component->set('fragmentName', 'panel-activity');
+
+        $this->assertStringContainsString($this->marker('FRAGMENT', 'panel-activity'), $component->html());
+        $this->assertStringNotContainsString($this->marker('FRAGMENT', 'panel-overview'), $component->html());
+    }
+
+    public function test_nested_fragments_emit_properly_nested_matching_markers()
+    {
+        $html = Livewire::test(new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @fragment('dashboard')
+                        <section>
+                            @fragment('dashboard-table')
+                                <table><tr><td>Row</td></tr></table>
+                            @endfragment
+                        </section>
+                    @endfragment
+                </div>
+                HTML;
+            }
+        })->html();
+
+        $outerStart = strpos($html, $this->marker('FRAGMENT', 'dashboard'));
+        $innerStart = strpos($html, $this->marker('FRAGMENT', 'dashboard-table'));
+        $innerEnd = strpos($html, $this->marker('ENDFRAGMENT', 'dashboard-table'));
+        $outerEnd = strpos($html, $this->marker('ENDFRAGMENT', 'dashboard'));
+
+        $this->assertIsInt($outerStart);
+        $this->assertIsInt($innerStart);
+        $this->assertIsInt($innerEnd);
+        $this->assertIsInt($outerEnd);
+        $this->assertTrue($outerStart < $innerStart);
+        $this->assertTrue($innerStart < $innerEnd);
+        $this->assertTrue($innerEnd < $outerEnd);
+    }
+
+    public function test_end_fragment_without_an_open_fragment_is_rejected()
+    {
+        $this->expectException(ViewException::class);
+
+        Livewire::test(new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @endfragment
+                </div>
+                HTML;
+            }
+        });
+    }
+
+    public function test_unclosed_fragment_stack_is_rejected_after_rendering()
+    {
+        $this->expectException(ViewException::class);
+        $this->expectExceptionMessage('Unclosed transport fragment stack: [dashboard, dashboard-table].');
+
+        Livewire::test(new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @fragment('dashboard')
+                        @fragment('dashboard-table')
+                            <span>Rows</span>
+                </div>
+                HTML;
+            }
+        });
+    }
+
+    public function test_native_fragment_names_that_are_unsafe_for_markers_fall_back_without_changing_output()
+    {
+        $html = Livewire::test(new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @fragment('unsafe|name')
+                        <span>Rows</span>
+                    @endfragment
+                </div>
+                HTML;
+            }
+        })->html();
+
+        $this->assertStringContainsString('<span>Rows</span>', $html);
+        $this->assertStringNotContainsString('type=transport|name=unsafe|name', $html);
+    }
+
+    public function test_duplicate_native_fragment_names_only_mark_the_first_occurrence()
+    {
+        $html = Livewire::test(new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @fragment('summary')
+                        <span>First</span>
+                    @endfragment
+
+                    @fragment('summary')
+                        <span>Second</span>
+                    @endfragment
+                </div>
+                HTML;
+            }
+        })->html();
+
+        $this->assertStringContainsString('<span>First</span>', $html);
+        $this->assertStringContainsString('<span>Second</span>', $html);
+        $this->assertSame(1, substr_count($html, $this->marker('FRAGMENT', 'summary')));
+        $this->assertSame(1, substr_count($html, $this->marker('ENDFRAGMENT', 'summary')));
+    }
+
+    public function test_fragment_expression_is_evaluated_only_once()
+    {
+        $instance = new class extends Component {
+            public static int $evaluations = 0;
+
+            public function fragmentName(): string
+            {
+                static::$evaluations++;
+
+                return 'summary';
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @fragment($this->fragmentName())
+                        <span>Summary</span>
+                    @endfragment
+                </div>
+                HTML;
+            }
+        };
+
+        $instance::$evaluations = 0;
+
+        Livewire::test($instance);
+
+        $this->assertSame(1, $instance::$evaluations);
+    }
+
+    protected function marker(string $type, string $name): string
+    {
+        $token = substr(hash('sha256', $name), 0, 16);
+
+        return "<!--[if {$type}:type=transport|name={$name}|token={$token}|mode=morph]><![endif]-->";
+    }
+}

--- a/src/LivewireManager.php
+++ b/src/LivewireManager.php
@@ -127,9 +127,9 @@ class LivewireManager
         return app(HandleSynths::class)->find($keyOrTarget, $component);
     }
 
-    function update($snapshot, $diff, $calls)
+    function update($snapshot, $diff, $calls, $renderMetadata = [])
     {
-        return app(HandleComponents::class)->update($snapshot, $diff, $calls);
+        return app(HandleComponents::class)->update($snapshot, $diff, $calls, $renderMetadata);
     }
 
     function updateProperty($component, $path, $value)

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -7,6 +7,8 @@ use Livewire\Compiler\Compiler;
 use Illuminate\Foundation\Console\AboutCommand;
 use Composer\InstalledVersions;
 use Livewire\Compiler\CacheManager;
+use Livewire\Mechanisms\HandleComponents\UpdateEngines\CacheRenderStateStore;
+use Livewire\Mechanisms\HandleComponents\UpdateEngines\RenderStateStore;
 
 class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
 {
@@ -29,6 +31,8 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $this->app->alias(LivewireManager::class, 'livewire');
         $this->app->singleton(LivewireManager::class);
+
+        $this->app->bind(RenderStateStore::class, CacheRenderStateStore::class);
 
         app('livewire')->setProvider($this);
 

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -7,6 +7,8 @@ use Livewire\Compiler\Compiler;
 use Illuminate\Foundation\Console\AboutCommand;
 use Composer\InstalledVersions;
 use Livewire\Compiler\CacheManager;
+use Livewire\Mechanisms\HandleRequests\CacheSnapshotStateStore;
+use Livewire\Mechanisms\HandleRequests\SnapshotStateStore;
 use Livewire\Mechanisms\HandleComponents\UpdateEngines\CacheRenderStateStore;
 use Livewire\Mechanisms\HandleComponents\UpdateEngines\RenderStateStore;
 
@@ -33,6 +35,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->app->singleton(LivewireManager::class);
 
         $this->app->bind(RenderStateStore::class, CacheRenderStateStore::class);
+        $this->app->bind(SnapshotStateStore::class, CacheSnapshotStateStore::class);
 
         app('livewire')->setProvider($this);
 
@@ -205,6 +208,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
             Features\SupportLocales\SupportLocales::class,
             Features\SupportTesting\SupportTesting::class,
             Features\SupportIslands\SupportIslands::class,
+            Features\SupportTransportFragments\SupportTransportFragments::class,
             Features\SupportModels\SupportModels::class,
             Features\SupportEvents\SupportEvents::class,
             Features\SupportSlots\SupportSlots::class,

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -5,6 +5,7 @@ namespace Livewire\Mechanisms\HandleComponents;
 use function Livewire\{on, store, trigger, wrap };
 use Livewire\Mechanisms\Mechanism;
 use Livewire\Mechanisms\HandleSynths\HandleSynths;
+use Livewire\Mechanisms\HandleComponents\UpdateEngines\UpdateEngineManager;
 use Livewire\Exceptions\PublicPropertyNotFoundException;
 use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Exceptions\MaxNestingDepthExceededException;
@@ -20,7 +21,10 @@ class HandleComponents extends Mechanism
     public static $renderStack = [];
     public static $componentStack = [];
 
-    public function __construct(protected HandleSynths $synths) {}
+    public function __construct(
+        protected HandleSynths $synths,
+        protected UpdateEngineManager $updateEngines,
+    ) {}
 
     public function boot()
     {
@@ -62,6 +66,8 @@ class HandleComponents extends Mechanism
             if (config('app.debug')) $start = microtime(true);
             $html = $this->render($component, '<div></div>');
             if (config('app.debug')) trigger('profile', 'render', $component->getId(), [$start, microtime(true)]);
+
+            $this->updateEngines->current()->mount($component, $html, $context);
 
             if (config('app.debug')) $start = microtime(true);
             trigger('dehydrate', $component, $context);
@@ -180,7 +186,7 @@ class HandleComponents extends Mechanism
         return $newHtml;
     }
 
-    public function update($snapshot, $updates, $calls)
+    public function update($snapshot, $updates, $calls, $renderMetadata = [])
     {
         if (! is_array($snapshot)
             || ! is_array($snapshot['data'] ?? null)
@@ -222,10 +228,11 @@ class HandleComponents extends Mechanism
             $this->callMethods($component, $calls, $context);
 
             if (config('app.debug')) $start = microtime(true);
-            if ($html = $this->render($component)) {
-                $context->addEffect('html', $html);
-                if (config('app.debug')) trigger('profile', 'render', $component->getId(), [$start, microtime(true)]);
-            }
+            $html = $this->render($component);
+
+            $this->updateEngines->current()->update($component, $html, $memo, $context, $renderMetadata);
+
+            if ($html && config('app.debug')) trigger('profile', 'render', $component->getId(), [$start, microtime(true)]);
 
             if (config('app.debug')) $start = microtime(true);
             trigger('dehydrate', $component, $context);

--- a/src/Mechanisms/HandleComponents/UpdateEngines/BrowserTest.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/BrowserTest.php
@@ -14,10 +14,11 @@ class BrowserTest extends \Tests\BrowserTestCase
             config()->set('livewire.delta.store', 'file');
             config()->set('livewire.delta.minimum_html_bytes', 0);
             config()->set('livewire.delta.minimum_compressed_savings_bytes', 0);
+            config()->set('livewire.delta.compression_aware', false);
         };
     }
 
-    public function test_global_delta_engine_updates_a_component_across_multiple_requests()
+    public function test_global_delta_engine_materializes_full_and_cached_splice_responses()
     {
         Livewire::visit(new class extends Component {
             public int $count = 0;
@@ -50,17 +51,21 @@ class BrowserTest extends \Tests\BrowserTestCase
             JS))
             ->waitForLivewire()->click('@increment')
             ->assertSeeIn('@count', '1')
+            ->assertScript("window.deltaRenderEffects[0].render.mode", 'full')
             ->assertScript("typeof window.deltaRenderEffects[0].html === 'string'", true)
+            ->assertScript("typeof window.deltaRenderEffects[0].htmlHash === 'undefined'", true)
             ->waitForLivewire()->click('@increment')
             ->assertSeeIn('@count', '2')
-            ->assertScript("typeof window.deltaRenderEffects[1].htmlDelta === 'object'", true)
-            ->assertScript("Array.isArray(window.deltaRenderEffects[1].htmlDelta.patches)", true)
-            ->assertScript("typeof window.deltaRenderEffects[1].html === 'undefined'", true)
+            ->assertScript("window.deltaRenderEffects[1].render.mode", 'splice')
+            ->assertScript("Array.isArray(window.deltaRenderEffects[1].render.patches)", true)
+            ->assertScript("typeof window.deltaRenderEffects[1].html === 'string'", true)
+            ->assertScript("window.deltaRenderEffects[1].render.stats.saved > 0", true)
             ->tap(fn ($browser) => $browser->script(
-                "Livewire.first().__instance.serverRenderedHtmlHash = 'tampered'"
+                'Livewire.first().__instance.forgetServerRenderedHtml()'
             ))
             ->waitForLivewire()->click('@increment')
             ->assertSeeIn('@count', '3')
+            ->assertScript("window.deltaRenderEffects[2].render.mode", 'full')
             ->assertScript("typeof window.deltaRenderEffects[2].html === 'string'", true)
         ;
     }
@@ -125,19 +130,25 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->waitForLivewire()->click('@move')
             ->assertDontSeeIn('@todo', 'Deploy application')
             ->assertSeeIn('@done', 'Deploy application')
-            ->assertScript("window.kanbanDeltaEffects[1].htmlDelta.patches.length >= 2", true)
-            ->assertScript("typeof window.kanbanDeltaEffects[1].html === 'undefined'", true)
+            ->assertScript("window.kanbanDeltaEffects[0].render.mode", 'full')
+            ->assertScript("typeof window.kanbanDeltaEffects[0].html === 'string'", true)
+            ->assertScript("window.kanbanDeltaEffects[1].render.mode", 'splice')
+            ->assertScript("window.kanbanDeltaEffects[1].render.patches.length >= 2", true)
+            ->assertScript("typeof window.kanbanDeltaEffects[1].html === 'string'", true)
         ;
     }
 
-    public function test_tampered_delta_is_rejected_before_morphing_and_triggers_a_full_resync()
+    public function test_corrupted_splice_triggers_full_resync_without_replaying_the_action()
     {
         Livewire::visit(new class extends Component {
             public int $count = 0;
 
+            public int $incrementCalls = 0;
+
             public function increment()
             {
                 $this->count++;
+                $this->incrementCalls++;
             }
 
             public function render()
@@ -146,6 +157,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 <div>
                     <button dusk="increment" wire:click="increment">Increment</button>
                     <span dusk="count">{{ $count }}</span>
+                    <span dusk="increment-calls">{{ $incrementCalls }}</span>
                     <p style="display: none">{{ str_repeat('stable-content-', 1000) }}</p>
                 </div>
                 HTML;
@@ -153,27 +165,70 @@ class BrowserTest extends \Tests\BrowserTestCase
         })
             ->tap(fn ($browser) => $browser->script(<<<'JS'
                 window.deltaIntegrityEffects = []
-                window.tamperNextDelta = false
+                window.tamperNextSplice = false
+                window.livewireOriginalFetch = window.fetch.bind(window)
+
+                window.fetch = async (input, options = {}) => {
+                    let response = await window.livewireOriginalFetch(input, options)
+
+                    if (! window.tamperNextSplice) return response
+
+                    let json
+
+                    try {
+                        json = await response.clone().json()
+                    } catch (error) {
+                        return response
+                    }
+
+                    let component = json.components?.[0]
+                    let render = component?.effects?.render
+
+                    if (render?.mode !== 'splice' || ! render.patches?.length) return response
+
+                    render.patches[0].insert = btoa('corrupted-render')
+                    window.tamperNextSplice = false
+
+                    let headers = new Headers(response.headers)
+                    headers.delete('content-length')
+                    headers.delete('content-encoding')
+
+                    return new Response(JSON.stringify(json), {
+                        status: response.status,
+                        statusText: response.statusText,
+                        headers,
+                    })
+                }
 
                 Livewire.interceptMessage(({ onSuccess }) => {
                     onSuccess(({ payload }) => {
-                        window.deltaIntegrityEffects.push(payload.effects)
-
-                        if (! window.tamperNextDelta || ! payload.effects.htmlDelta) return
-
-                        payload.effects.htmlDelta.patches[0].insert = btoa('tampered')
-                        window.tamperNextDelta = false
+                        window.deltaIntegrityEffects.push({
+                            mode: payload.effects.renderRecovery
+                                ? 'recovery'
+                                : payload.effects.render?.mode
+                                    || (typeof payload.effects.html === 'string' ? 'full' : null),
+                            renderMode: payload.effects.render?.mode,
+                            hasHtml: typeof payload.effects.html === 'string',
+                        })
                     })
                 })
             JS))
             ->waitForLivewire()->click('@increment')
             ->assertSeeIn('@count', '1')
-            ->tap(fn ($browser) => $browser->script('window.tamperNextDelta = true'))
+            ->assertSeeIn('@increment-calls', '1')
+            ->assertScript("window.deltaIntegrityEffects[0].mode", 'full')
+            ->tap(fn ($browser) => $browser->script('window.tamperNextSplice = true'))
             ->waitForLivewire()->click('@increment')
             ->waitForTextIn('@count', '2')
+            ->assertSeeIn('@increment-calls', '2')
             ->waitUntil('window.deltaIntegrityEffects.length >= 3')
-            ->assertScript("typeof window.deltaIntegrityEffects[1].htmlDelta === 'object'", true)
-            ->assertScript("typeof window.deltaIntegrityEffects[2].html === 'string'", true)
+            ->assertScript("window.deltaIntegrityEffects[1].mode", 'recovery')
+            ->assertScript("window.deltaIntegrityEffects[1].renderMode", 'splice')
+            ->assertScript("window.deltaIntegrityEffects[1].hasHtml", false)
+            ->assertScript("window.deltaIntegrityEffects[2].mode", 'full')
+            ->assertScript("window.deltaIntegrityEffects[2].hasHtml", true)
+            ->assertScript("Livewire.first().count", 2)
+            ->assertScript("Livewire.first().incrementCalls", 2)
         ;
     }
 }

--- a/src/Mechanisms/HandleComponents/UpdateEngines/BrowserTest.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/BrowserTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class BrowserTest extends \Tests\BrowserTestCase
+{
+    public static function tweakApplicationHook()
+    {
+        return function () {
+            config()->set('livewire.update_engine', 'delta');
+            config()->set('livewire.delta.store', 'file');
+            config()->set('livewire.delta.minimum_html_bytes', 0);
+            config()->set('livewire.delta.minimum_compressed_savings_bytes', 0);
+        };
+    }
+
+    public function test_global_delta_engine_updates_a_component_across_multiple_requests()
+    {
+        Livewire::visit(new class extends Component {
+            public int $count = 0;
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button dusk="increment" wire:click="increment">Increment</button>
+                    <span dusk="count">{{ $count }}</span>
+                    <p style="display: none">{{ str_repeat('stable-content-', 1000) }}</p>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@count', '0')
+            ->tap(fn ($browser) => $browser->script(<<<'JS'
+                window.deltaRenderEffects = []
+
+                Livewire.interceptMessage(({ onSuccess }) => {
+                    onSuccess(({ payload }) => {
+                        window.deltaRenderEffects.push(payload.effects)
+                    })
+                })
+            JS))
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '1')
+            ->assertScript("typeof window.deltaRenderEffects[0].html === 'string'", true)
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '2')
+            ->assertScript("typeof window.deltaRenderEffects[1].htmlDelta === 'object'", true)
+            ->assertScript("Array.isArray(window.deltaRenderEffects[1].htmlDelta.patches)", true)
+            ->assertScript("typeof window.deltaRenderEffects[1].html === 'undefined'", true)
+            ->tap(fn ($browser) => $browser->script(
+                "Livewire.first().__instance.serverRenderedHtmlHash = 'tampered'"
+            ))
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '3')
+            ->assertScript("typeof window.deltaRenderEffects[2].html === 'string'", true)
+        ;
+    }
+
+    public function test_multi_patch_delta_moves_a_kanban_card_between_columns()
+    {
+        Livewire::visit(new class extends Component {
+            public int $revision = 0;
+
+            public array $todo = ['Deploy application', 'Write documentation'];
+
+            public array $done = ['Create project'];
+
+            public function seedBaseline()
+            {
+                $this->revision++;
+            }
+
+            public function move()
+            {
+                $this->done[] = array_shift($this->todo);
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button dusk="seed" wire:click="seedBaseline">Seed {{ $revision }}</button>
+                    <button dusk="move" wire:click="move">Move</button>
+
+                    <section dusk="todo">
+                        @foreach ($todo as $card)
+                            <article wire:key="todo-{{ $card }}">{{ $card }}</article>
+                        @endforeach
+                    </section>
+
+                    <section style="display: none">
+                        @foreach (range(1, 200) as $index)
+                            <article>Unchanged middle card {{ $index }} in the doing column</article>
+                        @endforeach
+                    </section>
+
+                    <section dusk="done">
+                        @foreach ($done as $card)
+                            <article wire:key="done-{{ $card }}">{{ $card }}</article>
+                        @endforeach
+                    </section>
+                </div>
+                HTML;
+            }
+        })
+            ->tap(fn ($browser) => $browser->script(<<<'JS'
+                window.kanbanDeltaEffects = []
+
+                Livewire.interceptMessage(({ onSuccess }) => {
+                    onSuccess(({ payload }) => {
+                        window.kanbanDeltaEffects.push(payload.effects)
+                    })
+                })
+            JS))
+            ->waitForLivewire()->click('@seed')
+            ->waitForLivewire()->click('@move')
+            ->assertDontSeeIn('@todo', 'Deploy application')
+            ->assertSeeIn('@done', 'Deploy application')
+            ->assertScript("window.kanbanDeltaEffects[1].htmlDelta.patches.length >= 2", true)
+            ->assertScript("typeof window.kanbanDeltaEffects[1].html === 'undefined'", true)
+        ;
+    }
+
+    public function test_tampered_delta_is_rejected_before_morphing_and_triggers_a_full_resync()
+    {
+        Livewire::visit(new class extends Component {
+            public int $count = 0;
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button dusk="increment" wire:click="increment">Increment</button>
+                    <span dusk="count">{{ $count }}</span>
+                    <p style="display: none">{{ str_repeat('stable-content-', 1000) }}</p>
+                </div>
+                HTML;
+            }
+        })
+            ->tap(fn ($browser) => $browser->script(<<<'JS'
+                window.deltaIntegrityEffects = []
+                window.tamperNextDelta = false
+
+                Livewire.interceptMessage(({ onSuccess }) => {
+                    onSuccess(({ payload }) => {
+                        window.deltaIntegrityEffects.push(payload.effects)
+
+                        if (! window.tamperNextDelta || ! payload.effects.htmlDelta) return
+
+                        payload.effects.htmlDelta.patches[0].insert = btoa('tampered')
+                        window.tamperNextDelta = false
+                    })
+                })
+            JS))
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '1')
+            ->tap(fn ($browser) => $browser->script('window.tamperNextDelta = true'))
+            ->waitForLivewire()->click('@increment')
+            ->waitForTextIn('@count', '2')
+            ->waitUntil('window.deltaIntegrityEffects.length >= 3')
+            ->assertScript("typeof window.deltaIntegrityEffects[1].htmlDelta === 'object'", true)
+            ->assertScript("typeof window.deltaIntegrityEffects[2].html === 'string'", true)
+        ;
+    }
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/CacheRenderStateStore.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/CacheRenderStateStore.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\Repository;
+
+class CacheRenderStateStore implements RenderStateStore
+{
+    public function __construct(
+        protected CacheFactory $cache,
+        protected HtmlDelta $deltas,
+    ) {}
+
+    public function get(string $componentId, string $hash): ?string
+    {
+        $repository = $this->repository();
+        $key = $this->key($componentId);
+        $state = $repository->get($key);
+
+        if (! is_array($state)
+            || ! is_string($state['hash'] ?? null)
+            || ! is_string($state['html'] ?? null)
+            || ! hash_equals($state['hash'], $hash)
+        ) {
+            return null;
+        }
+
+        if (! hash_equals($hash, $this->deltas->hash($state['html']))) {
+            $repository->forget($key);
+
+            return null;
+        }
+
+        return $state['html'];
+    }
+
+    public function put(string $componentId, string $hash, string $html): void
+    {
+        $this->repository()->put(
+            $this->key($componentId),
+            ['hash' => $hash, 'html' => $html],
+            max(1, (int) config('livewire.delta.ttl', 300)),
+        );
+    }
+
+    protected function repository(): Repository
+    {
+        $store = config('livewire.delta.store');
+
+        return $store
+            ? $this->cache->store($store)
+            : $this->cache->store();
+    }
+
+    protected function key(string $componentId): string
+    {
+        return "livewire:delta:{$componentId}";
+    }
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/CacheRenderStateStore.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/CacheRenderStateStore.php
@@ -15,31 +15,57 @@ class CacheRenderStateStore implements RenderStateStore
     public function get(string $componentId, string $hash): ?string
     {
         $repository = $this->repository();
-        $key = $this->key($componentId);
+        $key = $this->key($componentId, $hash);
         $state = $repository->get($key);
+
+        if ($state === null) return null;
 
         if (! is_array($state)
             || ! is_string($state['hash'] ?? null)
-            || ! is_string($state['html'] ?? null)
+            || ! is_int($state['bytes'] ?? null)
+            || $state['bytes'] < 0
+            || $state['bytes'] > $this->maximumBytes()
+            || ! is_string($state['payload'] ?? null)
+            || ! is_string($state['encoding'] ?? null)
             || ! hash_equals($state['hash'], $hash)
         ) {
-            return null;
-        }
-
-        if (! hash_equals($hash, $this->deltas->hash($state['html']))) {
             $repository->forget($key);
 
             return null;
         }
 
-        return $state['html'];
+        $html = $this->decode($state['payload'], $state['encoding'], $state['bytes']);
+
+        if ($html === null
+            || $state['bytes'] !== strlen($html)
+            || ! hash_equals($hash, $this->deltas->hash($html))
+        ) {
+            $repository->forget($key);
+
+            return null;
+        }
+
+        return $html;
     }
 
     public function put(string $componentId, string $hash, string $html): void
     {
+        if (strlen($html) > $this->maximumBytes()
+            || ! hash_equals($hash, $this->deltas->hash($html))
+        ) {
+            throw new \InvalidArgumentException('Rendered HTML does not match its cache descriptor.');
+        }
+
+        [$payload, $encoding] = $this->encode($html);
+
         $this->repository()->put(
-            $this->key($componentId),
-            ['hash' => $hash, 'html' => $html],
+            $this->key($componentId, $hash),
+            [
+                'hash' => $hash,
+                'bytes' => strlen($html),
+                'encoding' => $encoding,
+                'payload' => $payload,
+            ],
             max(1, (int) config('livewire.delta.ttl', 300)),
         );
     }
@@ -53,8 +79,42 @@ class CacheRenderStateStore implements RenderStateStore
             : $this->cache->store();
     }
 
-    protected function key(string $componentId): string
+    protected function key(string $componentId, string $hash): string
     {
-        return "livewire:delta:{$componentId}";
+        return 'livewire:render:'.hash('sha256', $componentId."\0".$hash);
+    }
+
+    protected function encode(string $html): array
+    {
+        if (! function_exists('gzencode')) return [$html, 'identity'];
+
+        $compressed = gzencode($html, 1);
+
+        if (! is_string($compressed) || strlen($compressed) >= strlen($html)) {
+            return [$html, 'identity'];
+        }
+
+        return [$compressed, 'gzip'];
+    }
+
+    protected function decode(string $payload, string $encoding, int $bytes): ?string
+    {
+        if ($encoding === 'identity') return $payload;
+
+        if ($encoding !== 'gzip' || ! function_exists('gzdecode')) return null;
+
+        $html = @gzdecode($payload, $bytes + 1);
+
+        return is_string($html) ? $html : null;
+    }
+
+    protected function maximumBytes(): int
+    {
+        $minimumBytes = max(0, (int) config('livewire.delta.minimum_html_bytes', 8192));
+
+        return min(
+            134217728,
+            max($minimumBytes, (int) config('livewire.delta.maximum_html_bytes', 4194304)),
+        );
     }
 }

--- a/src/Mechanisms/HandleComponents/UpdateEngines/DeltaUpdateEngine.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/DeltaUpdateEngine.php
@@ -7,21 +7,14 @@ use Livewire\Mechanisms\HandleComponents\ComponentContext;
 
 class DeltaUpdateEngine implements UpdateEngine
 {
-    public function __construct(
-        protected RenderStateStore $states,
-        protected HtmlDelta $deltas,
-    ) {}
+    public function __construct(protected ResponseTransport $transport) {}
 
     public function mount(Component $component, string $html, ComponentContext $context): void
     {
-        if (! $this->shouldTrack($html)) return;
-
-        $hash = $this->deltas->hash($html);
-
-        $context->addMemo('delta', [
-            'revision' => 0,
-            'hash' => $hash,
-        ]);
+        // Advertise only a small protocol/configuration descriptor. The mount
+        // HTML is already in the page, but it cannot be used as an exact byte
+        // baseline after browser parsing, so the first update still sends full.
+        $context->addEffect('renderTransport', $this->transport->configuration());
     }
 
     public function update(
@@ -31,142 +24,11 @@ class DeltaUpdateEngine implements UpdateEngine
         ComponentContext $context,
         array $renderMetadata = [],
     ): void {
-        $previous = $memo['delta'] ?? null;
+        if ($html === null) return;
 
-        if ($html === null) {
-            if ($previous) {
-                $context->addMemo('delta', $previous);
-                $context->addEffect('htmlHash', $previous['hash']);
-            }
-
-            return;
-        }
-
-        if (! $this->shouldTrack($html)) {
-            $context->addEffect('html', $html);
-
-            return;
-        }
-
-        $hash = $this->deltas->hash($html);
-        $revision = ($previous['revision'] ?? -1) + 1;
-        $clientHash = $renderMetadata['htmlHash'] ?? null;
-        $previousHash = $previous['hash'] ?? null;
-        $previousHtml = null;
-
-        if (
-            is_string($clientHash)
-            && is_string($previousHash)
-            && hash_equals($previousHash, $clientHash)
-        ) {
-            $previousHtml = $this->getPreviousHtml($component->getId(), $previousHash);
-        }
-
-        if ($previousHtml !== null) {
-            $effect = [
-                'base' => $previousHash,
-                'patches' => $this->deltas->encode($previousHtml, $html),
-            ];
-
-            if ($this->shouldSendDelta($effect, $html, $hash)) {
-                $context->addEffect('htmlDelta', $effect);
-            } else {
-                $context->addEffect('html', $html);
-            }
-        } else {
-            $context->addEffect('html', $html);
-        }
-
-        $context->addEffect('htmlHash', $hash);
-        $context->addMemo('delta', [
-            'revision' => $revision,
-            'hash' => $hash,
-        ]);
-
-        $this->rememberHtml($component->getId(), $hash, $html);
-    }
-
-    protected function shouldSendDelta(array $effect, string $html, string $hash): bool
-    {
-        $minimumSavings = min(1, max(0, (float) config('livewire.delta.minimum_savings', 0.1)));
-        $deltaPayload = json_encode([
-            'htmlDelta' => $effect,
-            'htmlHash' => $hash,
-        ], JSON_THROW_ON_ERROR);
-        $fullHtmlPayload = json_encode([
-            'html' => $html,
-            'htmlHash' => $hash,
-        ], JSON_THROW_ON_ERROR);
-
-        if (! $this->savesEnough($deltaPayload, $fullHtmlPayload, $minimumSavings)) {
-            return false;
-        }
-
-        if (! config('livewire.delta.compression_aware', true)) {
-            return true;
-        }
-
-        $compressedDelta = $this->gzip($deltaPayload);
-        $compressedFullHtml = $this->gzip($fullHtmlPayload);
-
-        if ($compressedDelta === null || $compressedFullHtml === null) {
-            return true;
-        }
-
-        if (! $this->savesEnough($compressedDelta, $compressedFullHtml, $minimumSavings)) {
-            return false;
-        }
-
-        $minimumCompressedSavings = max(
-            0,
-            (int) config('livewire.delta.minimum_compressed_savings_bytes', 1024),
-        );
-
-        return strlen($compressedFullHtml) - strlen($compressedDelta)
-            >= $minimumCompressedSavings;
-    }
-
-    protected function savesEnough(string $delta, string $fullHtml, float $minimumSavings): bool
-    {
-        return strlen($delta) < strlen($fullHtml) * (1 - $minimumSavings);
-    }
-
-    protected function gzip(string $payload): ?string
-    {
-        if (! function_exists('gzencode')) return null;
-
-        $compressed = gzencode($payload, 1);
-
-        return is_string($compressed) ? $compressed : null;
-    }
-
-    protected function shouldTrack(string $html): bool
-    {
-        $minimumHtmlBytes = max(
-            0,
-            (int) config('livewire.delta.minimum_html_bytes', 8192),
-        );
-
-        return strlen($html) >= $minimumHtmlBytes;
-    }
-
-    protected function getPreviousHtml(string $componentId, string $hash): ?string
-    {
-        try {
-            return $this->states->get($componentId, $hash);
-        } catch (\Throwable $e) {
-            report($e);
-
-            return null;
-        }
-    }
-
-    protected function rememberHtml(string $componentId, string $hash, string $html): void
-    {
-        try {
-            $this->states->put($componentId, $hash, $html);
-        } catch (\Throwable $e) {
-            report($e);
-        }
+        // Keep canonical full HTML available through the entire component and
+        // response-hook lifecycle. HandleRequests performs the final transport
+        // encoding only after extensions have finished mutating the payload.
+        $context->addEffect('html', $html);
     }
 }

--- a/src/Mechanisms/HandleComponents/UpdateEngines/DeltaUpdateEngine.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/DeltaUpdateEngine.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+use Livewire\Component;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+
+class DeltaUpdateEngine implements UpdateEngine
+{
+    public function __construct(
+        protected RenderStateStore $states,
+        protected HtmlDelta $deltas,
+    ) {}
+
+    public function mount(Component $component, string $html, ComponentContext $context): void
+    {
+        if (! $this->shouldTrack($html)) return;
+
+        $hash = $this->deltas->hash($html);
+
+        $context->addMemo('delta', [
+            'revision' => 0,
+            'hash' => $hash,
+        ]);
+    }
+
+    public function update(
+        Component $component,
+        ?string $html,
+        array $memo,
+        ComponentContext $context,
+        array $renderMetadata = [],
+    ): void {
+        $previous = $memo['delta'] ?? null;
+
+        if ($html === null) {
+            if ($previous) {
+                $context->addMemo('delta', $previous);
+                $context->addEffect('htmlHash', $previous['hash']);
+            }
+
+            return;
+        }
+
+        if (! $this->shouldTrack($html)) {
+            $context->addEffect('html', $html);
+
+            return;
+        }
+
+        $hash = $this->deltas->hash($html);
+        $revision = ($previous['revision'] ?? -1) + 1;
+        $clientHash = $renderMetadata['htmlHash'] ?? null;
+        $previousHash = $previous['hash'] ?? null;
+        $previousHtml = null;
+
+        if (
+            is_string($clientHash)
+            && is_string($previousHash)
+            && hash_equals($previousHash, $clientHash)
+        ) {
+            $previousHtml = $this->getPreviousHtml($component->getId(), $previousHash);
+        }
+
+        if ($previousHtml !== null) {
+            $effect = [
+                'base' => $previousHash,
+                'patches' => $this->deltas->encode($previousHtml, $html),
+            ];
+
+            if ($this->shouldSendDelta($effect, $html, $hash)) {
+                $context->addEffect('htmlDelta', $effect);
+            } else {
+                $context->addEffect('html', $html);
+            }
+        } else {
+            $context->addEffect('html', $html);
+        }
+
+        $context->addEffect('htmlHash', $hash);
+        $context->addMemo('delta', [
+            'revision' => $revision,
+            'hash' => $hash,
+        ]);
+
+        $this->rememberHtml($component->getId(), $hash, $html);
+    }
+
+    protected function shouldSendDelta(array $effect, string $html, string $hash): bool
+    {
+        $minimumSavings = min(1, max(0, (float) config('livewire.delta.minimum_savings', 0.1)));
+        $deltaPayload = json_encode([
+            'htmlDelta' => $effect,
+            'htmlHash' => $hash,
+        ], JSON_THROW_ON_ERROR);
+        $fullHtmlPayload = json_encode([
+            'html' => $html,
+            'htmlHash' => $hash,
+        ], JSON_THROW_ON_ERROR);
+
+        if (! $this->savesEnough($deltaPayload, $fullHtmlPayload, $minimumSavings)) {
+            return false;
+        }
+
+        if (! config('livewire.delta.compression_aware', true)) {
+            return true;
+        }
+
+        $compressedDelta = $this->gzip($deltaPayload);
+        $compressedFullHtml = $this->gzip($fullHtmlPayload);
+
+        if ($compressedDelta === null || $compressedFullHtml === null) {
+            return true;
+        }
+
+        if (! $this->savesEnough($compressedDelta, $compressedFullHtml, $minimumSavings)) {
+            return false;
+        }
+
+        $minimumCompressedSavings = max(
+            0,
+            (int) config('livewire.delta.minimum_compressed_savings_bytes', 1024),
+        );
+
+        return strlen($compressedFullHtml) - strlen($compressedDelta)
+            >= $minimumCompressedSavings;
+    }
+
+    protected function savesEnough(string $delta, string $fullHtml, float $minimumSavings): bool
+    {
+        return strlen($delta) < strlen($fullHtml) * (1 - $minimumSavings);
+    }
+
+    protected function gzip(string $payload): ?string
+    {
+        if (! function_exists('gzencode')) return null;
+
+        $compressed = gzencode($payload, 1);
+
+        return is_string($compressed) ? $compressed : null;
+    }
+
+    protected function shouldTrack(string $html): bool
+    {
+        $minimumHtmlBytes = max(
+            0,
+            (int) config('livewire.delta.minimum_html_bytes', 8192),
+        );
+
+        return strlen($html) >= $minimumHtmlBytes;
+    }
+
+    protected function getPreviousHtml(string $componentId, string $hash): ?string
+    {
+        try {
+            return $this->states->get($componentId, $hash);
+        } catch (\Throwable $e) {
+            report($e);
+
+            return null;
+        }
+    }
+
+    protected function rememberHtml(string $componentId, string $hash, string $html): void
+    {
+        try {
+            $this->states->put($componentId, $hash, $html);
+        } catch (\Throwable $e) {
+            report($e);
+        }
+    }
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/HtmlDelta.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/HtmlDelta.php
@@ -1,0 +1,372 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+class HtmlDelta
+{
+    protected const BLOCK_SIZE = 32;
+
+    protected const MAX_PATCHES = 64;
+
+    protected const MAX_CANDIDATE_PATCHES = 256;
+
+    protected const MAX_SCAN_STEPS = 4096;
+
+    public function encode(string $from, string $to): array
+    {
+        if ($from === $to) return [];
+
+        $single = $this->singlePatch($from, $to);
+        $fromStart = $single['start'];
+        $fromEnd = $fromStart + $single['delete'];
+        $toStart = $fromStart;
+        $toEnd = $toStart + strlen($single['insert']);
+
+        if (
+            $fromEnd - $fromStart < self::BLOCK_SIZE
+            || $toEnd - $toStart < self::BLOCK_SIZE
+        ) {
+            return [$this->encodePatch($single)];
+        }
+
+        $patches = $this->findAnchoredPatches(
+            $from,
+            $to,
+            $fromStart,
+            $fromEnd,
+            $toStart,
+            $toEnd,
+        );
+
+        if ($patches === null) {
+            return [$this->encodePatch($single)];
+        }
+
+        $patches = $this->coalescePatches($from, $patches);
+
+        if (count($patches) > self::MAX_PATCHES) {
+            return [$this->encodePatch($single)];
+        }
+
+        return array_map($this->encodePatch(...), $patches);
+    }
+
+    public function apply(string $html, array $patches): string
+    {
+        // Accept the original single-patch shape so a cached test state or a
+        // rolling deployment can safely reconstruct an older delta.
+        if (isset($patches['start'])) $patches = [$patches];
+
+        $length = strlen($html);
+        $cursor = 0;
+        $result = '';
+
+        foreach ($patches as $patch) {
+            if (! is_array($patch)) {
+                throw new \InvalidArgumentException('Invalid HTML delta patch.');
+            }
+
+            $start = $patch['start'] ?? null;
+            $delete = $patch['delete'] ?? null;
+            $encodedInsert = $patch['insert'] ?? null;
+
+            if (
+                ! is_int($start)
+                || ! is_int($delete)
+                || ! is_string($encodedInsert)
+                || $start < $cursor
+                || $delete < 0
+                || $start + $delete > $length
+            ) {
+                throw new \InvalidArgumentException('Invalid HTML delta range.');
+            }
+
+            $insert = base64_decode($encodedInsert, strict: true);
+
+            if ($insert === false) {
+                throw new \InvalidArgumentException('Invalid base64 insert in HTML delta.');
+            }
+
+            $result .= substr($html, $cursor, $start - $cursor).$insert;
+            $cursor = $start + $delete;
+        }
+
+        return $result.substr($html, $cursor);
+    }
+
+    public function hash(string $html): string
+    {
+        return hash('sha256', $html);
+    }
+
+    protected function singlePatch(string $from, string $to): array
+    {
+        $prefix = $this->commonPrefixLength($from, $to);
+        $suffix = $this->commonSuffixLength($from, $to, $prefix);
+
+        return [
+            'start' => $prefix,
+            'delete' => strlen($from) - $prefix - $suffix,
+            'insert' => substr($to, $prefix, strlen($to) - $prefix - $suffix),
+        ];
+    }
+
+    protected function findAnchoredPatches(
+        string $from,
+        string $to,
+        int $fromStart,
+        int $fromEnd,
+        int $toStart,
+        int $toEnd,
+    ): ?array {
+        $index = $this->buildBlockIndex($from, $fromStart, $fromEnd);
+
+        if ($index === []) {
+            return [[
+                'start' => $fromStart,
+                'delete' => $fromEnd - $fromStart,
+                'insert' => substr($to, $toStart, $toEnd - $toStart),
+            ]];
+        }
+
+        $patches = [];
+        $fromCursor = $fromStart;
+        $toCursor = $toStart;
+        $scan = $toCursor;
+        $scanSteps = 0;
+
+        while (
+            $scan + self::BLOCK_SIZE <= $toEnd
+            && $fromCursor + self::BLOCK_SIZE <= $fromEnd
+        ) {
+            $block = substr($to, $scan, self::BLOCK_SIZE);
+            $candidates = $index[$this->blockHash($block)] ?? [];
+            $matchFrom = $this->findMatchingCandidate(
+                $from,
+                $block,
+                $candidates,
+                $fromCursor,
+            );
+
+            if ($matchFrom === null) {
+                $scan++;
+
+                if (++$scanSteps > self::MAX_SCAN_STEPS) return null;
+
+                continue;
+            }
+
+            $matchTo = $scan;
+
+            while (
+                $matchFrom > $fromCursor
+                && $matchTo > $toCursor
+                && $from[$matchFrom - 1] === $to[$matchTo - 1]
+            ) {
+                $matchFrom--;
+                $matchTo--;
+            }
+
+            if ($matchFrom > $fromCursor || $matchTo > $toCursor) {
+                $patches[] = [
+                    'start' => $fromCursor,
+                    'delete' => $matchFrom - $fromCursor,
+                    'insert' => substr($to, $toCursor, $matchTo - $toCursor),
+                ];
+
+                if (count($patches) > self::MAX_CANDIDATE_PATCHES) return null;
+            }
+
+            $matchLength = $this->commonRangeLength(
+                $from,
+                $matchFrom,
+                $fromEnd,
+                $to,
+                $matchTo,
+                $toEnd,
+            );
+
+            $fromCursor = $matchFrom + $matchLength;
+            $toCursor = $matchTo + $matchLength;
+            $scan = $toCursor;
+        }
+
+        if ($fromCursor < $fromEnd || $toCursor < $toEnd) {
+            $patches[] = [
+                'start' => $fromCursor,
+                'delete' => $fromEnd - $fromCursor,
+                'insert' => substr($to, $toCursor, $toEnd - $toCursor),
+            ];
+        }
+
+        return array_values(array_filter(
+            $patches,
+            fn ($patch) => $patch['delete'] !== 0 || $patch['insert'] !== '',
+        ));
+    }
+
+    protected function buildBlockIndex(string $html, int $start, int $end): array
+    {
+        $index = [];
+
+        for (
+            $offset = $start;
+            $offset + self::BLOCK_SIZE <= $end;
+            $offset += self::BLOCK_SIZE
+        ) {
+            $block = substr($html, $offset, self::BLOCK_SIZE);
+            $index[$this->blockHash($block)][] = $offset;
+        }
+
+        return $index;
+    }
+
+    protected function findMatchingCandidate(
+        string $html,
+        string $block,
+        array $candidates,
+        int $minimumOffset,
+    ): ?int {
+        $low = 0;
+        $high = count($candidates);
+
+        while ($low < $high) {
+            $middle = intdiv($low + $high, 2);
+
+            if ($candidates[$middle] < $minimumOffset) {
+                $low = $middle + 1;
+            } else {
+                $high = $middle;
+            }
+        }
+
+        for ($index = $low, $count = count($candidates); $index < $count; $index++) {
+            $candidate = $candidates[$index];
+
+            if (substr($html, $candidate, self::BLOCK_SIZE) === $block) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    protected function coalescePatches(string $from, array $patches): array
+    {
+        $result = [];
+
+        foreach ($patches as $patch) {
+            if ($result === []) {
+                $result[] = $patch;
+
+                continue;
+            }
+
+            $previousIndex = array_key_last($result);
+            $previous = $result[$previousIndex];
+            $previousEnd = $previous['start'] + $previous['delete'];
+            $gap = $patch['start'] - $previousEnd;
+
+            if ($gap < 0) {
+                throw new \LogicException('Generated HTML delta patches overlap.');
+            }
+
+            $combined = [
+                'start' => $previous['start'],
+                'delete' => $patch['start'] + $patch['delete'] - $previous['start'],
+                'insert' => $previous['insert']
+                    .substr($from, $previousEnd, $gap)
+                    .$patch['insert'],
+            ];
+
+            if (
+                $this->encodedPatchSize($combined)
+                <= $this->encodedPatchSize($previous) + $this->encodedPatchSize($patch) + 1
+            ) {
+                $result[$previousIndex] = $combined;
+            } else {
+                $result[] = $patch;
+            }
+        }
+
+        return $result;
+    }
+
+    protected function encodedPatchSize(array $patch): int
+    {
+        return strlen(json_encode($this->encodePatch($patch), JSON_THROW_ON_ERROR));
+    }
+
+    protected function encodePatch(array $patch): array
+    {
+        return [
+            'start' => $patch['start'],
+            'delete' => $patch['delete'],
+            'insert' => base64_encode($patch['insert']),
+        ];
+    }
+
+    protected function blockHash(string $block): string
+    {
+        return (string) crc32($block);
+    }
+
+    protected function commonPrefixLength(string $from, string $to): int
+    {
+        return $this->commonRangeLength($from, 0, strlen($from), $to, 0, strlen($to));
+    }
+
+    protected function commonSuffixLength(string $from, string $to, int $prefix): int
+    {
+        $fromLength = strlen($from);
+        $toLength = strlen($to);
+        $length = min($fromLength, $toLength) - $prefix;
+        $offset = 0;
+
+        while (
+            $offset + 64 <= $length
+            && substr($from, $fromLength - $offset - 64, 64)
+                === substr($to, $toLength - $offset - 64, 64)
+        ) {
+            $offset += 64;
+        }
+
+        while (
+            $offset < $length
+            && $from[$fromLength - $offset - 1] === $to[$toLength - $offset - 1]
+        ) {
+            $offset++;
+        }
+
+        return $offset;
+    }
+
+    protected function commonRangeLength(
+        string $from,
+        int $fromOffset,
+        int $fromEnd,
+        string $to,
+        int $toOffset,
+        int $toEnd,
+    ): int {
+        $length = min($fromEnd - $fromOffset, $toEnd - $toOffset);
+        $matched = 0;
+
+        while (
+            $matched + 64 <= $length
+            && substr($from, $fromOffset + $matched, 64)
+                === substr($to, $toOffset + $matched, 64)
+        ) {
+            $matched += 64;
+        }
+
+        while (
+            $matched < $length
+            && $from[$fromOffset + $matched] === $to[$toOffset + $matched]
+        ) {
+            $matched++;
+        }
+
+        return $matched;
+    }
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/LargeTransportDemoBrowserTest.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/LargeTransportDemoBrowserTest.php
@@ -62,8 +62,8 @@ class LargeTransportDemoBrowserTest extends \Tests\BrowserTestCase
             ->waitForLivewire()->click('@edit-middle')
             ->assertScript("window.largeTransportDemo.history[2].mode", 'fragments')
             ->assertSeeIn('@transport-mode', 'fragments')
-            ->assertScript("Livewire.first().rows.find(row => row.id === 200).name", 'foo 東京 — bar')
-            ->assertSeeIn('@row-name-200', 'foo 東京 — bar')
+            ->assertScript("Livewire.first().rows.find(row => row.id === 200).name", 'д字 東京 — ж世')
+            ->assertSeeIn('@row-name-200', 'д字 東京 — ж世')
             ->assertScript("window.largeTransportDemo.history[2].saved > 0", true)
 
             ->waitForLivewire()->click('@move-block')
@@ -114,7 +114,7 @@ class LargeTransportDemoComponent extends Component
     {
         $index = array_search(200, array_column($this->rows, 'id'), true);
 
-        $this->rows[$index]['name'] = 'foo 東京 — bar';
+        $this->rows[$index]['name'] = 'д字 東京 — ж世';
         $this->rows[$index]['status'] = 'unicode';
     }
 

--- a/src/Mechanisms/HandleComponents/UpdateEngines/LargeTransportDemoBrowserTest.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/LargeTransportDemoBrowserTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class LargeTransportDemoBrowserTest extends \Tests\BrowserTestCase
+{
+    public static function tweakApplicationHook()
+    {
+        return function () {
+            config()->set('livewire.update_engine', 'delta');
+            config()->set('livewire.delta.store', 'file');
+            config()->set('livewire.delta.cache_accelerator', false);
+            config()->set('livewire.delta.minimum_html_bytes', 0);
+            config()->set('livewire.delta.minimum_savings', 0.75);
+            config()->set('livewire.delta.minimum_compressed_savings_bytes', 0);
+            config()->set('livewire.delta.compression_aware', false);
+            config()->set('livewire.delta.request_compression', true);
+            config()->set('livewire.delta.request_compression_minimum_bytes', 256);
+            config()->set('livewire.delta.snapshot_references', true);
+        };
+    }
+
+    public function test_large_transport_demo_exercises_each_kind_of_render_change()
+    {
+        Livewire::visit(new LargeTransportDemoComponent)
+            ->waitForLivewireToLoad()
+            ->assertSeeIn('@row-count', '400')
+            ->assertSeeIn('@moved-row-position', '61')
+            ->assertSeeIn('@transport-mode', 'initial')
+
+            ->tap(fn ($browser) => $browser->script(<<<'JS'
+                window.largeTransportDemo.requestEncodings = []
+                window.largeTransportDemoOriginalFetch = window.fetch.bind(window)
+
+                window.fetch = async (input, options = {}) => {
+                    let headers = new Headers(options.headers || {})
+
+                    window.largeTransportDemo.requestEncodings.push(
+                        headers.get('Content-Encoding') || 'identity'
+                    )
+
+                    return await window.largeTransportDemoOriginalFetch(input, options)
+                }
+            JS))
+
+            ->waitForLivewire()->click('@noop')
+            ->assertScript('window.largeTransportDemo.responses', 1)
+            ->assertScript("window.largeTransportDemo.history[0].mode", 'full')
+            ->assertSeeIn('@transport-mode', 'full')
+            ->assertScript("window.largeTransportDemo.history[0].selected > 0", true)
+            ->assertScript("window.largeTransportDemo.history[0].saved", 0)
+
+            ->waitForLivewire()->click('@noop')
+            ->assertScript('window.largeTransportDemo.responses', 2)
+            ->assertScript("window.largeTransportDemo.history[1].mode", 'same')
+            ->assertSeeIn('@transport-mode', 'same')
+            ->assertScript("window.largeTransportDemo.history[1].saved > 0", true)
+
+            ->waitForLivewire()->click('@edit-middle')
+            ->assertScript("window.largeTransportDemo.history[2].mode", 'fragments')
+            ->assertSeeIn('@transport-mode', 'fragments')
+            ->assertScript("Livewire.first().rows.find(row => row.id === 200).name", 'foo 東京 — bar')
+            ->assertSeeIn('@row-name-200', 'foo 東京 — bar')
+            ->assertScript("window.largeTransportDemo.history[2].saved > 0", true)
+
+            ->waitForLivewire()->click('@move-block')
+            ->assertScript("window.largeTransportDemo.history[3].mode", 'chunks')
+            ->assertSeeIn('@transport-mode', 'chunks')
+            ->assertSeeIn('@moved-row-position', '301')
+            ->assertScript("window.largeTransportDemo.history[3].saved > 0", true)
+
+            ->waitForLivewire()->click('@replace-all')
+            ->assertScript("window.largeTransportDemo.history[4].mode", 'full')
+            ->assertSeeIn('@transport-mode', 'full')
+            ->assertSeeIn('@row-name-200', 'Replacement 200')
+            ->assertSeeIn('@row-count', '400')
+            ->assertScript('window.largeTransportDemo.responses', 5)
+            ->assertScript("window.largeTransportDemo.history[4].saved", 0)
+            ->assertScript("window.largeTransportDemo.history.every(item => Number.isInteger(item.full) && Number.isInteger(item.selected) && Number.isInteger(item.saved))", true)
+            ->assertScript("window.largeTransportDemo.requestEncodings[0]", 'identity')
+            ->assertScript("window.largeTransportDemo.requestEncodings[1]", 'gzip')
+            ->assertScript("window.largeTransportDemo.requestEncodings.slice(1).every(encoding => encoding === 'gzip')", true)
+        ;
+    }
+}
+
+class LargeTransportDemoComponent extends Component
+{
+    public array $rows = [];
+
+    public function mount(): void
+    {
+        foreach (range(1, 400) as $id) {
+            $fingerprint = hash('sha256', "transport-demo-row-{$id}");
+
+            $this->rows[] = [
+                'id' => $id,
+                'name' => "Customer {$id}",
+                'status' => $id % 3 === 0 ? 'queued' : 'ready',
+                'details' => "eu-central-{$id} / {$fingerprint} / {$fingerprint}",
+            ];
+        }
+    }
+
+    public function noop(): void
+    {
+        // Deliberately leave both the public state and HTML unchanged.
+    }
+
+    public function editMiddle(): void
+    {
+        $index = array_search(200, array_column($this->rows, 'id'), true);
+
+        $this->rows[$index]['name'] = 'foo 東京 — bar';
+        $this->rows[$index]['status'] = 'unicode';
+    }
+
+    public function moveBlock(): void
+    {
+        $block = array_splice($this->rows, 60, 40);
+
+        array_splice($this->rows, 300, 0, $block);
+    }
+
+    public function replaceAll(): void
+    {
+        foreach ($this->rows as &$row) {
+            $fingerprint = hash('sha256', "replacement-row-{$row['id']}");
+
+            $row['name'] = "Replacement {$row['id']}";
+            $row['status'] = 'replaced';
+            $row['details'] = "replacement / {$fingerprint} / {$fingerprint}";
+        }
+
+        unset($row);
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div
+            x-data="{ transport: { mode: 'initial', full: 0, selected: 0, saved: 0, responses: 0, history: [], requestEncodings: [] } }"
+            x-init="window.largeTransportDemo = transport"
+        >
+            @fragment('transport-dashboard')
+                <section>
+                    <button type="button" dusk="noop" wire:click="noop">No-op</button>
+                    <button type="button" dusk="edit-middle" wire:click="editMiddle">Unicode middle edit</button>
+                    <button type="button" dusk="move-block" wire:click="moveBlock">Move block</button>
+                    <button type="button" dusk="replace-all" wire:click="replaceAll">Replace all</button>
+
+                    <dl>
+                        <div>
+                            <dt>Rows</dt>
+                            <dd dusk="row-count">{{ count($rows) }}</dd>
+                        </div>
+                        <div>
+                            <dt>Moved row position</dt>
+                            <dd dusk="moved-row-position">{{ array_search(61, array_column($rows, 'id'), true) + 1 }}</dd>
+                        </div>
+                        <div>
+                            <dt>Transport mode</dt>
+                            <dd dusk="transport-mode" x-text="transport.mode">initial</dd>
+                        </div>
+                        <div>
+                            <dt>Full response bytes</dt>
+                            <dd dusk="transport-full-bytes" x-text="transport.full">0</dd>
+                        </div>
+                        <div>
+                            <dt>Selected response bytes</dt>
+                            <dd dusk="transport-selected-bytes" x-text="transport.selected">0</dd>
+                        </div>
+                        <div>
+                            <dt>Saved bytes</dt>
+                            <dd dusk="transport-saved-bytes" x-text="transport.saved">0</dd>
+                        </div>
+                    </dl>
+                </section>
+            @endfragment
+
+            <table>
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Customer</th>
+                        <th>Status</th>
+                        <th>Stable payload</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($rows as $row)
+                        @fragment('row-'.$row['id'])
+                            <tr wire:key="transport-row-{{ $row['id'] }}">
+                                <td>{{ $row['id'] }}</td>
+                                <td @if ($row['id'] === 200) dusk="row-name-200" @endif>{{ $row['name'] }}</td>
+                                <td>{{ $row['status'] }}</td>
+                                <td>{{ $row['details'] }}</td>
+                            </tr>
+                        @endfragment
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        @script
+        <script>
+            this.interceptMessage(({ onSuccess }) => {
+                onSuccess(({ payload }) => {
+                    let effects = payload.effects
+                    let render = effects.render
+                    let stats = window.largeTransportDemo
+
+                    if (! stats) return
+
+                    let item
+
+                    if (render?.stats) {
+                        item = {
+                            mode: render.mode,
+                            full: render.stats.full,
+                            selected: render.stats.selected,
+                            saved: render.stats.saved,
+                        }
+                    } else if (typeof effects.html === 'string') {
+                        let bytes = new TextEncoder().encode(JSON.stringify(effects)).byteLength
+
+                        item = {
+                            mode: 'full',
+                            full: bytes,
+                            selected: bytes,
+                            saved: 0,
+                        }
+                    } else {
+                        return
+                    }
+
+                    stats.mode = item.mode
+                    stats.full = item.full
+                    stats.selected = item.selected
+                    stats.saved = item.saved
+                    stats.responses++
+                    stats.history.push(item)
+                })
+            })
+        </script>
+        @endscript
+        HTML;
+    }
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/MorphUpdateEngine.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/MorphUpdateEngine.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+use Livewire\Component;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+
+class MorphUpdateEngine implements UpdateEngine
+{
+    public function mount(Component $component, string $html, ComponentContext $context): void
+    {
+        //
+    }
+
+    public function update(
+        Component $component,
+        ?string $html,
+        array $memo,
+        ComponentContext $context,
+        array $renderMetadata = [],
+    ): void {
+        if ($html === null) return;
+
+        $context->addEffect('html', $html);
+    }
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/RenderCandidateSelector.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/RenderCandidateSelector.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+class RenderCandidateSelector
+{
+    public function __construct(
+        protected float $minimumRelativeSavings = 0.2,
+        protected int $minimumAbsoluteSavingsBytes = 2048,
+        protected bool $compressionAware = true,
+    ) {
+        if ($minimumRelativeSavings < 0 || $minimumRelativeSavings >= 1) {
+            throw new \InvalidArgumentException('Relative render savings must be between zero and one.');
+        }
+
+        if ($minimumAbsoluteSavingsBytes < 0) {
+            throw new \InvalidArgumentException('Absolute render savings must not be negative.');
+        }
+    }
+
+    public function select(
+        array $full,
+        array $candidates,
+        int $requestManifestTax = 0,
+    ): array {
+        if ($requestManifestTax < 0) {
+            throw new \InvalidArgumentException('Render manifest tax must not be negative.');
+        }
+
+        $fullSize = $this->measure($full);
+        $selected = $full;
+        $selectedScore = $this->score($fullSize);
+
+        foreach ($candidates as $candidate) {
+            if (! is_array($candidate)) {
+                throw new \InvalidArgumentException('Render candidates must be arrays.');
+            }
+
+            $candidateSize = $this->measure($candidate);
+            $effectiveSize = [
+                'raw' => $candidateSize['raw'] + $requestManifestTax,
+                'gzip' => $candidateSize['gzip'] === null
+                    ? null
+                    : $candidateSize['gzip'] + $requestManifestTax,
+            ];
+
+            if (! $this->meetsThresholds($fullSize, $effectiveSize)) continue;
+
+            $score = $this->score($effectiveSize);
+
+            if ($score >= $selectedScore) continue;
+
+            $selected = $candidate;
+            $selectedScore = $score;
+        }
+
+        return $selected;
+    }
+
+    public function sizes(array $candidate): array
+    {
+        return $this->measure($candidate);
+    }
+
+    protected function measure(array $candidate): array
+    {
+        $json = json_encode($candidate, JSON_THROW_ON_ERROR);
+
+        return [
+            'raw' => strlen($json),
+            'gzip' => $this->gzipSize($json),
+        ];
+    }
+
+    protected function gzipSize(string $json): ?int
+    {
+        if (! $this->compressionAware || ! function_exists('gzencode')) return null;
+
+        $compressed = gzencode($json, 1);
+
+        return $compressed === false ? null : strlen($compressed);
+    }
+
+    protected function meetsThresholds(array $full, array $candidate): bool
+    {
+        if (! $this->dimensionMeetsThresholds($full['raw'], $candidate['raw'])) return false;
+
+        if ($full['gzip'] === null || $candidate['gzip'] === null) return true;
+
+        return $this->dimensionMeetsThresholds($full['gzip'], $candidate['gzip']);
+    }
+
+    protected function dimensionMeetsThresholds(int $full, int $candidate): bool
+    {
+        $savings = $full - $candidate;
+
+        return $savings >= $this->minimumAbsoluteSavingsBytes
+            && $candidate <= $full * (1 - $this->minimumRelativeSavings);
+    }
+
+    protected function score(array $size): int
+    {
+        return $size['gzip'] ?? $size['raw'];
+    }
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/RenderFragmentTree.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/RenderFragmentTree.php
@@ -1,0 +1,403 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+class RenderFragmentTree
+{
+    protected const MARKER_PATTERN = '/<!--\[if (FRAGMENT|ENDFRAGMENT):([^\]]*)\]><!\[endif\]-->/';
+
+    protected const MARKER_PREFIX_PATTERN = '/<!--\[if (?:FRAGMENT|ENDFRAGMENT):/';
+
+    protected const MAX_HTML_BYTES = 67108864;
+
+    protected const MAX_NODES = 4096;
+
+    protected const MAX_TOKEN_BYTES = 256;
+
+    protected const MAX_METADATA_BYTES = 4096;
+
+    public function manifest(string $html): ?array
+    {
+        $tree = $this->parse($html);
+
+        if ($tree === null) return null;
+
+        return [
+            'root' => $tree['root']['skeleton'],
+            'nodes' => array_map(
+                fn ($token) => [
+                    $token,
+                    $tree['nodes'][$token]['content'],
+                    $tree['nodes'][$token]['skeleton'],
+                ],
+                $tree['order'],
+            ),
+        ];
+    }
+
+    public function encode(string $html, array $manifest): ?array
+    {
+        $baseline = $this->decodeManifest($manifest);
+        $tree = $this->parse($html);
+
+        if ($tree === null) return null;
+
+        if ($tree['root']['skeleton'] !== $baseline['root']) return null;
+
+        $ops = [];
+
+        foreach ($tree['root']['children'] as $token) {
+            if (! $this->selectChangedNodes($html, $tree, $baseline, $token, $ops)) {
+                return null;
+            }
+        }
+
+        return $ops;
+    }
+
+    public function apply(string $html, array $ops): string
+    {
+        $tree = $this->parse($html);
+
+        if ($tree === null) {
+            throw new \InvalidArgumentException('Cannot apply fragment operations to malformed HTML.');
+        }
+
+        if (count($ops) > self::MAX_NODES) {
+            throw new \InvalidArgumentException('Too many render fragment operations.');
+        }
+
+        $replacements = [];
+        $seen = [];
+
+        foreach ($ops as $op) {
+            if (
+                ! is_array($op)
+                || ! array_is_list($op)
+                || count($op) !== 2
+                || ! is_string($op[0])
+                || ! is_string($op[1])
+                || ! isset($tree['nodes'][$op[0]])
+                || isset($seen[$op[0]])
+            ) {
+                throw new \InvalidArgumentException('Invalid render fragment operation.');
+            }
+
+            $seen[$op[0]] = true;
+            $node = $tree['nodes'][$op[0]];
+
+            $replacements[] = [
+                'start' => $node['contentStart'],
+                'end' => $node['contentEnd'],
+                'html' => $op[1],
+            ];
+        }
+
+        usort($replacements, fn ($left, $right) => $left['start'] <=> $right['start']);
+
+        $previousEnd = 0;
+        $resultLength = strlen($html);
+
+        foreach ($replacements as $replacement) {
+            if ($replacement['start'] < $previousEnd) {
+                throw new \InvalidArgumentException('Render fragment operations overlap.');
+            }
+
+            $previousEnd = $replacement['end'];
+            $resultLength += strlen($replacement['html'])
+                - ($replacement['end'] - $replacement['start']);
+
+            if ($resultLength > self::MAX_HTML_BYTES) {
+                throw new \InvalidArgumentException('Rendered fragment output is too large.');
+            }
+        }
+
+        $result = $html;
+
+        foreach (array_reverse($replacements) as $replacement) {
+            $result = substr($result, 0, $replacement['start'])
+                .$replacement['html']
+                .substr($result, $replacement['end']);
+        }
+
+        if ($this->parse($result) === null) {
+            throw new \InvalidArgumentException('Render fragment operations produced malformed HTML.');
+        }
+
+        return $result;
+    }
+
+    protected function selectChangedNodes(
+        string $html,
+        array $tree,
+        array $baseline,
+        string $token,
+        array &$ops,
+    ): bool {
+        $node = $tree['nodes'][$token];
+        $previous = $baseline['nodes'][$token] ?? null;
+
+        if ($previous === null) return false;
+
+        if ($node['content'] === $previous['content']) return true;
+
+        if ($node['skeleton'] !== $previous['skeleton']) {
+            $ops[] = [
+                $token,
+                substr($html, $node['contentStart'], $node['contentEnd'] - $node['contentStart']),
+            ];
+
+            return true;
+        }
+
+        foreach ($node['children'] as $childToken) {
+            if (! $this->selectChangedNodes($html, $tree, $baseline, $childToken, $ops)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function parse(string $html): ?array
+    {
+        if (strlen($html) > self::MAX_HTML_BYTES || preg_match('//u', $html) !== 1) return null;
+
+        $markerCount = preg_match_all(self::MARKER_PATTERN, $html, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE);
+        $prefixCount = preg_match_all(self::MARKER_PREFIX_PATTERN, $html);
+
+        if ($markerCount === false || $prefixCount === false || $markerCount !== $prefixCount) {
+            return null;
+        }
+
+        $nodes = [];
+        $order = [];
+        $rootChildren = [];
+        $stack = [];
+
+        foreach ($matches as $match) {
+            $marker = $match[0][0];
+            $offset = $match[0][1];
+            $kind = $match[1][0];
+            $encodedMetadata = $match[2][0];
+            $metadata = $this->parseMetadata($encodedMetadata);
+
+            if ($metadata === null) return null;
+
+            if ($kind === 'FRAGMENT') {
+                $token = null;
+
+                if (($metadata['type'] ?? null) === 'transport') {
+                    $token = $this->transportToken($metadata);
+
+                    if ($token === null) return null;
+
+                    if (isset($nodes[$token]) || count($nodes) >= self::MAX_NODES) return null;
+
+                    $parent = $this->closestTransportToken($stack);
+
+                    $nodes[$token] = [
+                        'token' => $token,
+                        'parent' => $parent,
+                        'children' => [],
+                        'start' => $offset,
+                        'contentStart' => $offset + strlen($marker),
+                    ];
+
+                    if ($parent === null) {
+                        $rootChildren[] = $token;
+                    } else {
+                        $nodes[$parent]['children'][] = $token;
+                    }
+
+                    $order[] = $token;
+                }
+
+                $stack[] = [
+                    'encoded' => $encodedMetadata,
+                    'token' => $token,
+                ];
+
+                continue;
+            }
+
+            if ($stack === []) return null;
+
+            $open = array_pop($stack);
+
+            if ($open['encoded'] !== $encodedMetadata) return null;
+
+            if ($open['token'] === null) continue;
+
+            $token = $this->transportToken($metadata);
+
+            if ($token !== $open['token']) return null;
+
+            $nodes[$token]['contentEnd'] = $offset;
+            $nodes[$token]['end'] = $offset + strlen($marker);
+        }
+
+        if ($stack !== []) return null;
+
+        foreach ($order as $token) {
+            if (! isset($nodes[$token]['contentEnd'], $nodes[$token]['end'])) return null;
+
+            $nodes[$token]['content'] = $this->digest(substr(
+                $html,
+                $nodes[$token]['contentStart'],
+                $nodes[$token]['contentEnd'] - $nodes[$token]['contentStart'],
+            ));
+            $nodes[$token]['skeleton'] = $this->digest($this->skeleton(
+                $html,
+                $nodes[$token]['contentStart'],
+                $nodes[$token]['contentEnd'],
+                $nodes[$token]['children'],
+                $nodes,
+            ));
+        }
+
+        return [
+            'root' => [
+                'children' => $rootChildren,
+                'skeleton' => $this->digest($this->skeleton(
+                    $html,
+                    0,
+                    strlen($html),
+                    $rootChildren,
+                    $nodes,
+                )),
+            ],
+            'nodes' => $nodes,
+            'order' => $order,
+        ];
+    }
+
+    protected function skeleton(
+        string $html,
+        int $start,
+        int $end,
+        array $children,
+        array $nodes,
+    ): string {
+        $skeleton = '';
+        $cursor = $start;
+
+        foreach ($children as $token) {
+            $child = $nodes[$token];
+
+            $skeleton .= substr($html, $cursor, $child['contentStart'] - $cursor);
+            $cursor = $child['contentEnd'];
+        }
+
+        return $skeleton.substr($html, $cursor, $end - $cursor);
+    }
+
+    protected function parseMetadata(string $encoded): ?array
+    {
+        if ($encoded === '' || strlen($encoded) > self::MAX_METADATA_BYTES) return null;
+
+        $metadata = [];
+
+        foreach (explode('|', $encoded) as $pair) {
+            $parts = explode('=', $pair, 2);
+
+            if (
+                count($parts) !== 2
+                || $parts[0] === ''
+                || $parts[1] === ''
+                || preg_match('/^[A-Za-z][A-Za-z0-9_-]*$/D', $parts[0]) !== 1
+                || array_key_exists($parts[0], $metadata)
+            ) {
+                return null;
+            }
+
+            $metadata[$parts[0]] = $parts[1];
+        }
+
+        ksort($metadata);
+
+        return $metadata;
+    }
+
+    protected function transportToken(array $metadata): ?string
+    {
+        foreach (['token', 'id', 'name', 'key'] as $key) {
+            $token = $metadata[$key] ?? null;
+
+            if (
+                is_string($token)
+                && $token !== ''
+                && strlen($token) <= self::MAX_TOKEN_BYTES
+            ) {
+                return $token;
+            }
+        }
+
+        return null;
+    }
+
+    protected function closestTransportToken(array $stack): ?string
+    {
+        for ($index = count($stack) - 1; $index >= 0; $index--) {
+            if ($stack[$index]['token'] !== null) return $stack[$index]['token'];
+        }
+
+        return null;
+    }
+
+    protected function decodeManifest(array $manifest): array
+    {
+        if (
+            count($manifest) !== 2
+            || ! array_key_exists('root', $manifest)
+            || ! array_key_exists('nodes', $manifest)
+            || ! is_string($manifest['root'])
+            || ! $this->isDigest($manifest['root'])
+            || ! is_array($manifest['nodes'])
+            || ! array_is_list($manifest['nodes'])
+            || count($manifest['nodes']) > self::MAX_NODES
+        ) {
+            throw new \InvalidArgumentException('Invalid render fragment manifest.');
+        }
+
+        $nodes = [];
+
+        foreach ($manifest['nodes'] as $entry) {
+            if (
+                ! is_array($entry)
+                || ! array_is_list($entry)
+                || count($entry) !== 3
+                || ! is_string($entry[0])
+                || $entry[0] === ''
+                || strlen($entry[0]) > self::MAX_TOKEN_BYTES
+                || ! is_string($entry[1])
+                || ! is_string($entry[2])
+                || ! $this->isDigest($entry[1])
+                || ! $this->isDigest($entry[2])
+                || isset($nodes[$entry[0]])
+            ) {
+                throw new \InvalidArgumentException('Invalid render fragment manifest node.');
+            }
+
+            $nodes[$entry[0]] = [
+                'content' => $entry[1],
+                'skeleton' => $entry[2],
+            ];
+        }
+
+        return [
+            'root' => $manifest['root'],
+            'nodes' => $nodes,
+        ];
+    }
+
+    protected function digest(string $value): string
+    {
+        return hash('crc32b', $value).hash('adler32', $value);
+    }
+
+    protected function isDigest(string $value): bool
+    {
+        return preg_match('/^[0-9a-f]{16}$/D', $value) === 1;
+    }
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/RenderStateStore.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/RenderStateStore.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+interface RenderStateStore
+{
+    public function get(string $componentId, string $hash): ?string;
+
+    public function put(string $componentId, string $hash, string $html): void;
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/ResponseTransport.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/ResponseTransport.php
@@ -1,0 +1,620 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+use Livewire\Mechanisms\HandleRequests\SnapshotStateStore;
+
+class ResponseTransport
+{
+    public function __construct(
+        protected HtmlDelta $deltas,
+        protected RenderStateStore $states,
+        protected StatelessHtmlChunks $chunks,
+        protected RenderFragmentTree $fragments,
+        protected SnapshotStateStore $snapshots,
+    ) {}
+
+    public function configuration(): array
+    {
+        [$minimumBytes, $maximumBytes] = $this->renderByteRange();
+        $maximumPortableBytes = min($maximumBytes, 67108864);
+
+        return [
+            'v' => 1,
+            'minimumBytes' => min($minimumBytes, $maximumPortableBytes),
+            'maximumBytes' => $maximumPortableBytes,
+            'blockSize' => min(
+                65536,
+                max(256, (int) config('livewire.delta.block_size', 2048)),
+            ),
+            'maximumManifestBytes' => min(
+                65536,
+                max(0, (int) config('livewire.delta.maximum_manifest_bytes', 65536)),
+            ),
+            'maximumFragments' => min(
+                1024,
+                max(0, (int) config('livewire.delta.maximum_fragments', 1024)),
+            ),
+            'cacheAccelerator' => (bool) config('livewire.delta.cache_accelerator', true),
+            'snapshotDelta' => (bool) config('livewire.delta.snapshot_delta', true),
+            'snapshotReferences' => (bool) config('livewire.delta.snapshot_references', false),
+            'maximumRequestBytes' => $this->maximumRequestBytes(),
+        ];
+    }
+
+    public function encode(mixed $payload, array $contexts): mixed
+    {
+        if (config('livewire.update_engine', 'morph') !== 'delta') {
+            return $payload;
+        }
+
+        if (! is_array($payload)) return $payload;
+
+        // This descriptor is deliberately top-level so renderless responses
+        // still renegotiate request transport. An explicit null tells clients
+        // to clear a threshold advertised by an older server/configuration.
+        $payload['transport'] = [
+            'v' => 1,
+            'requestGzip' => $this->requestGzipMinimumBytes(),
+        ];
+
+        if (! is_array($payload['components'] ?? null)) return $payload;
+
+        foreach ($payload['components'] as &$response) {
+            if (! is_array($response)) continue;
+
+            $componentId = $this->componentId($response);
+            $context = is_string($componentId)
+                ? $this->takeContext($contexts, $componentId)
+                : null;
+
+            if (! is_array($context)) continue;
+
+            $metadata = is_array($context['render'] ?? null) ? $context['render'] : [];
+
+            $this->encodeSnapshot($response, $context, $metadata, $componentId);
+            $this->encodeRender($response, $metadata, $componentId);
+        }
+
+        unset($response);
+
+        return $payload;
+    }
+
+    protected function encodeRender(array &$response, array $metadata, string $componentId): void
+    {
+        if (! is_array($response['effects'] ?? null)) return;
+
+        $html = $response['effects']['html'] ?? null;
+
+        if (! is_string($html)) return;
+
+        $targetHash = $this->deltas->hash($html);
+
+        if (isset($metadata['htmlHash'])) {
+            $this->encodeLegacyRender($response, $metadata['htmlHash'], $componentId, $html, $targetHash);
+            $this->rememberHtml($componentId, $targetHash, $html);
+
+            return;
+        }
+
+        if (($metadata['v'] ?? null) !== 1) {
+            // Seed the first experimental delta client during a rolling deploy.
+            // It sends no hash until it receives one alongside a full render.
+            $effects = $this->cleanRenderEffects($response['effects']);
+            $effects['html'] = $html;
+            $effects['htmlHash'] = $targetHash;
+            $response['effects'] = $effects;
+
+            $this->rememberHtml($componentId, $targetHash, $html);
+
+            return;
+        }
+
+        $targetBytes = strlen($html);
+        $capabilities = $metadata['capabilities'] ?? [];
+        $base = is_array($metadata['base'] ?? null) ? $metadata['base'] : null;
+        $manifestTax = $this->requestManifestTax($metadata);
+        $fullDescriptor = [
+            'v' => 1,
+            'mode' => 'full',
+            'target' => $targetHash,
+            'bytes' => $targetBytes,
+        ];
+        $fullEffects = $this->cleanRenderEffects($response['effects']);
+        $fullEffects['html'] = $html;
+        $fullEffects['render'] = $fullDescriptor;
+        $selectedEffects = $fullEffects;
+        $selectedTax = $manifestTax;
+
+        if ($this->hasCapability($capabilities, 'same')
+            && is_array($base)
+            && hash_equals($targetHash, $base['hash'])
+            && $targetBytes === $base['bytes']
+        ) {
+            $selectedEffects = $this->effectCandidate(
+                $response['effects'],
+                [
+                    'v' => 1,
+                    'mode' => 'same',
+                    'base' => $base['hash'],
+                    'target' => $targetHash,
+                    'bytes' => $targetBytes,
+                ],
+            );
+        } elseif ($this->canBuildPortableCandidates($html, $base)) {
+            $candidates = $this->renderCandidates(
+                $response['effects'],
+                $metadata,
+                $capabilities,
+                $base,
+                $componentId,
+                $html,
+                $targetHash,
+                $targetBytes,
+                $manifestTax,
+            );
+
+            [$selectedEffects, $selectedTax] = $this->selectRenderCandidate(
+                $fullEffects,
+                $candidates,
+                $manifestTax,
+            );
+        }
+
+        if ($minimumBytes = $this->requestGzipMinimumBytes()) {
+            $fullEffects['render']['requestGzip'] = $minimumBytes;
+            $selectedEffects['render']['requestGzip'] = $minimumBytes;
+        }
+
+        $selectedEffects['render']['stats'] = $this->renderStats(
+            $fullEffects,
+            $selectedEffects,
+            $selectedTax,
+        );
+
+        $response['effects'] = $selectedEffects;
+
+        $this->rememberHtml($componentId, $targetHash, $html);
+    }
+
+    protected function renderCandidates(
+        array $effects,
+        array $metadata,
+        array $capabilities,
+        array $base,
+        string $componentId,
+        string $html,
+        string $targetHash,
+        int $targetBytes,
+        int $manifestTax,
+    ): array {
+        $candidates = [];
+        $baseHash = $base['hash'];
+        $baseBytes = $base['bytes'];
+
+        if ($this->hasCapability($capabilities, 'splice')
+            && config('livewire.delta.cache_accelerator', true)
+        ) {
+            $previousHtml = $this->previousHtml($componentId, $baseHash);
+
+            if (is_string($previousHtml) && strlen($previousHtml) === $baseBytes) {
+                $candidates[] = [
+                    'effects' => $this->effectCandidate($effects, [
+                        'v' => 1,
+                        'mode' => 'splice',
+                        'base' => $baseHash,
+                        'target' => $targetHash,
+                        'bytes' => $targetBytes,
+                        'patches' => $this->deltas->encode($previousHtml, $html),
+                    ]),
+                    'tax' => $manifestTax,
+                ];
+            }
+        }
+
+        if ($this->hasCapability($capabilities, 'fragments')
+            && is_array($metadata['fragments'] ?? null)
+            && $this->fragmentManifestIsAllowed($metadata['fragments'])
+        ) {
+            try {
+                $ops = $this->fragments->encode($html, $metadata['fragments']);
+            } catch (\InvalidArgumentException) {
+                $ops = null;
+            } catch (\Throwable $e) {
+                report($e);
+
+                $ops = null;
+            }
+
+            if (is_array($ops) && $ops !== []) {
+                $candidates[] = [
+                    'effects' => $this->effectCandidate($effects, [
+                        'v' => 1,
+                        'mode' => 'fragments',
+                        'base' => $baseHash,
+                        'target' => $targetHash,
+                        'bytes' => $targetBytes,
+                        'ops' => $ops,
+                    ]),
+                    'tax' => $manifestTax,
+                ];
+            }
+        }
+
+        if ($this->hasCapability($capabilities, 'chunks')
+            && is_array($metadata['chunks'] ?? null)
+            && $this->chunkManifestIsAllowed($metadata['chunks'])
+        ) {
+            try {
+                $ops = $this->chunks->encode(
+                    $html,
+                    $metadata['chunks']['blocks'],
+                    $baseBytes,
+                    $metadata['chunks']['blockSize'],
+                );
+            } catch (\InvalidArgumentException) {
+                $ops = null;
+            } catch (\Throwable $e) {
+                report($e);
+
+                $ops = null;
+            }
+
+            if (is_array($ops)) {
+                $candidates[] = [
+                    'effects' => $this->effectCandidate($effects, [
+                        'v' => 1,
+                        'mode' => 'chunks',
+                        'base' => $baseHash,
+                        'target' => $targetHash,
+                        'bytes' => $targetBytes,
+                        'ops' => $ops,
+                    ]),
+                    'tax' => $manifestTax,
+                ];
+            }
+        }
+
+        return $candidates;
+    }
+
+    protected function selectRenderCandidate(
+        array $full,
+        array $candidates,
+        int $manifestTax,
+    ): array
+    {
+        $selector = $this->selector();
+        $selected = $full;
+        $selectedTax = $manifestTax;
+        $selectedScore = $this->score($selector->sizes($full));
+
+        foreach ($candidates as $candidate) {
+            $effects = $candidate['effects'];
+            $tax = $candidate['tax'];
+
+            if ($selector->select($full, [$effects], $tax) === $full) continue;
+
+            $score = $this->score($selector->sizes($effects)) + $tax;
+
+            if ($score >= $selectedScore) continue;
+
+            $selected = $effects;
+            $selectedTax = $tax;
+            $selectedScore = $score;
+        }
+
+        return [$selected, $selectedTax];
+    }
+
+    protected function encodeLegacyRender(
+        array &$response,
+        string $baseHash,
+        string $componentId,
+        string $html,
+        string $targetHash,
+    ): void {
+        $effects = $this->cleanRenderEffects($response['effects']);
+        $effects['html'] = $html;
+        $effects['htmlHash'] = $targetHash;
+        $previousHtml = config('livewire.delta.cache_accelerator', true)
+            ? $this->previousHtml($componentId, $baseHash)
+            : null;
+
+        if (! is_string($previousHtml)) {
+            $response['effects'] = $effects;
+
+            return;
+        }
+
+        $deltaEffects = $this->cleanRenderEffects($response['effects']);
+        $deltaEffects['htmlDelta'] = [
+            'base' => $baseHash,
+            'patches' => $this->deltas->encode($previousHtml, $html),
+        ];
+        $deltaEffects['htmlHash'] = $targetHash;
+
+        $response['effects'] = $this->selector()->select($effects, [$deltaEffects]);
+    }
+
+    protected function encodeSnapshot(
+        array &$response,
+        array $context,
+        array $metadata,
+        string $componentId,
+    ): void {
+        $snapshot = $response['snapshot'] ?? null;
+
+        if (! is_string($snapshot)) return;
+
+        $capabilities = $metadata['capabilities'] ?? [];
+
+        if (config('livewire.delta.snapshot_delta', true)
+            && $this->hasCapability($capabilities, 'snapshot-delta')
+            && is_string($context['snapshot'] ?? null)
+            && $this->snapshotsAreEligibleForDelta($context['snapshot'], $snapshot)
+        ) {
+            $previous = $context['snapshot'];
+            $descriptor = [
+                'v' => 1,
+                'base' => $this->deltas->hash($previous),
+                'target' => $this->deltas->hash($snapshot),
+                'bytes' => strlen($snapshot),
+                'patches' => $this->deltas->encode($previous, $snapshot),
+            ];
+            $full = ['snapshot' => $snapshot];
+            $delta = ['snapshotDelta' => $descriptor];
+            $selector = new RenderCandidateSelector(
+                minimumRelativeSavings: max(0, min(0.99, (float) config('livewire.delta.minimum_savings', 0.1))),
+                minimumAbsoluteSavingsBytes: 64,
+                compressionAware: (bool) config('livewire.delta.compression_aware', true),
+            );
+
+            if ($selector->select($full, [$delta]) === $delta) {
+                unset($response['snapshot']);
+                $response['snapshotDelta'] = $descriptor;
+            }
+        }
+
+        if (config('livewire.delta.snapshot_references', false)
+            && $this->hasCapability($capabilities, 'snapshot-ref')
+            && strlen($snapshot) >= max(
+                0,
+                (int) config('livewire.delta.snapshot_reference_minimum_bytes', 1024),
+            )
+            && strlen($snapshot) <= $this->maximumSnapshotReferenceBytes()
+        ) {
+            try {
+                $reference = $this->snapshots->put($componentId, $snapshot);
+            } catch (\Throwable $e) {
+                report($e);
+
+                $reference = null;
+            }
+
+            if (is_string($reference)) $response['snapshotRef'] = $reference;
+        }
+    }
+
+    protected function effectCandidate(array $effects, array $descriptor): array
+    {
+        $effects = $this->cleanRenderEffects($effects);
+        $effects['render'] = $descriptor;
+
+        return $effects;
+    }
+
+    protected function cleanRenderEffects(array $effects): array
+    {
+        unset(
+            $effects['html'],
+            $effects['htmlHash'],
+            $effects['htmlDelta'],
+            $effects['render'],
+            $effects['renderRecovery'],
+        );
+
+        return $effects;
+    }
+
+    protected function renderStats(array $full, array $selected, int $tax): array
+    {
+        $selector = $this->selector();
+        $fullBytes = $this->score($selector->sizes($full));
+        $selectedBytes = $this->score($selector->sizes($selected)) + $tax;
+
+        return [
+            'full' => $fullBytes,
+            'selected' => $selectedBytes,
+            'saved' => max(0, $fullBytes - $selectedBytes),
+        ];
+    }
+
+    protected function selector(): RenderCandidateSelector
+    {
+        return new RenderCandidateSelector(
+            minimumRelativeSavings: max(0, min(0.99, (float) config('livewire.delta.minimum_savings', 0.1))),
+            minimumAbsoluteSavingsBytes: max(
+                0,
+                (int) config('livewire.delta.minimum_compressed_savings_bytes', 1024),
+            ),
+            compressionAware: (bool) config('livewire.delta.compression_aware', true),
+        );
+    }
+
+    protected function score(array $sizes): int
+    {
+        return $sizes['gzip'] ?? $sizes['raw'];
+    }
+
+    protected function canBuildPortableCandidates(string $html, ?array $base): bool
+    {
+        if (! is_array($base)) return false;
+
+        [$minimumBytes, $maximumBytes] = $this->renderByteRange();
+
+        return strlen($html) >= $minimumBytes
+            && strlen($html) <= $maximumBytes;
+    }
+
+    protected function snapshotsAreEligibleForDelta(string $previous, string $snapshot): bool
+    {
+        $maximumBytes = $this->maximumSnapshotBytes();
+
+        return strlen($previous) <= $maximumBytes
+            && strlen($snapshot) <= $maximumBytes;
+    }
+
+    protected function maximumSnapshotBytes(): int
+    {
+        return min(
+            134217728,
+            max(0, (int) config('livewire.delta.maximum_snapshot_bytes', 4194304)),
+        );
+    }
+
+    protected function maximumSnapshotReferenceBytes(): int
+    {
+        $maximumBytes = $this->maximumSnapshotBytes();
+        $maximumPayloadBytes = config('livewire.payload.max_size');
+
+        if ($maximumPayloadBytes === null) return $maximumBytes;
+
+        // A cache miss retries with the full snapshot JSON-encoded inside the
+        // request envelope. Keep enough headroom for escaping, updates, calls,
+        // render metadata, and the rest of a bundled request.
+        return min($maximumBytes, intdiv(max(0, (int) $maximumPayloadBytes), 2));
+    }
+
+    protected function maximumRequestBytes(): ?int
+    {
+        $maximumBytes = config('livewire.payload.max_size');
+
+        if ($maximumBytes === null) return null;
+
+        return min(2147483647, max(0, (int) $maximumBytes));
+    }
+
+    protected function requestGzipMinimumBytes(): ?int
+    {
+        if (! config('livewire.delta.request_compression', false)) return null;
+
+        return min(
+            16777216,
+            max(1, (int) config('livewire.delta.request_compression_minimum_bytes', 1024)),
+        );
+    }
+
+    protected function requestManifestTax(array $metadata): int
+    {
+        $manifests = array_filter([
+            'chunks' => $metadata['chunks'] ?? null,
+            'fragments' => $metadata['fragments'] ?? null,
+        ], fn ($manifest) => is_array($manifest));
+
+        if ($manifests === []) return 0;
+
+        $json = json_encode($manifests, JSON_THROW_ON_ERROR);
+
+        if (request()->header('Content-Encoding') !== 'gzip'
+            || ! function_exists('gzencode')
+        ) return strlen($json);
+
+        $compressed = gzencode($json, 1);
+
+        return is_string($compressed) ? strlen($compressed) : strlen($json);
+    }
+
+    protected function chunkManifestIsAllowed(array $manifest): bool
+    {
+        $limit = max(0, (int) config('livewire.delta.maximum_manifest_bytes', 65536));
+
+        return is_string($manifest['blocks'] ?? null)
+            && strlen($manifest['blocks']) <= $limit;
+    }
+
+    protected function fragmentManifestIsAllowed(array $manifest): bool
+    {
+        $limit = max(0, (int) config('livewire.delta.maximum_fragments', 1024));
+
+        return is_array($manifest['nodes'] ?? null)
+            && count($manifest['nodes']) <= $limit;
+    }
+
+    protected function renderByteRange(): array
+    {
+        $minimumBytes = min(
+            134217728,
+            max(0, (int) config('livewire.delta.minimum_html_bytes', 8192)),
+        );
+        $maximumBytes = min(
+            134217728,
+            max($minimumBytes, (int) config('livewire.delta.maximum_html_bytes', 4194304)),
+        );
+
+        return [$minimumBytes, $maximumBytes];
+    }
+
+    protected function hasCapability(mixed $capabilities, string $capability): bool
+    {
+        return is_array($capabilities) && in_array($capability, $capabilities, true);
+    }
+
+    protected function componentId(array $response): ?string
+    {
+        if (is_string($response['id'] ?? null)) return $response['id'];
+
+        if (! is_string($response['snapshot'] ?? null)) return null;
+
+        $snapshot = json_decode($response['snapshot'], true);
+        $componentId = $snapshot['memo']['id'] ?? null;
+
+        return is_string($componentId) ? $componentId : null;
+    }
+
+    protected function previousHtml(string $componentId, string $hash): ?string
+    {
+        try {
+            return $this->states->get($componentId, $hash);
+        } catch (\Throwable $e) {
+            report($e);
+
+            return null;
+        }
+    }
+
+    protected function rememberHtml(string $componentId, string $hash, string $html): void
+    {
+        if (! config('livewire.delta.cache_accelerator', true)) return;
+
+        [$minimumBytes, $maximumBytes] = $this->renderByteRange();
+
+        if (strlen($html) < $minimumBytes || strlen($html) > $maximumBytes) return;
+
+        try {
+            $this->states->put($componentId, $hash, $html);
+        } catch (\Throwable $e) {
+            report($e);
+        }
+    }
+
+    protected function takeContext(array &$contexts, string $componentId): ?array
+    {
+        $context = $contexts[$componentId] ?? null;
+
+        if (! is_array($context)) return null;
+
+        // Multiple bundled payloads with the same component id are unusual,
+        // but keeping a queue preserves each response's immutable baseline.
+        if (array_is_list($context)) {
+            $next = array_shift($contexts[$componentId]);
+
+            return is_array($next) ? $next : null;
+        }
+
+        unset($contexts[$componentId]);
+
+        return $context;
+    }
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/StatelessHtmlChunks.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/StatelessHtmlChunks.php
@@ -1,0 +1,422 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+class StatelessHtmlChunks
+{
+    protected const MIN_BLOCK_SIZE = 256;
+
+    protected const MAX_BLOCK_SIZE = 65536;
+
+    protected const MAX_HTML_BYTES = 67108864;
+
+    protected const MAX_MANIFEST_BYTES = 524288;
+
+    protected const MAX_MANIFEST_BLOCKS = 65536;
+
+    protected const MAX_OPS = 65536;
+
+    protected const MAX_SCAN_STEPS = 65536;
+
+    protected const MAX_STRONG_CHECKSUM_BYTES = 8388608;
+
+    public function manifest(string $html, int $blockSize): string
+    {
+        $this->validateBlockSize($blockSize);
+        $this->validateHtml($html);
+
+        $blockCount = $html === ''
+            ? 0
+            : intdiv(strlen($html) + $blockSize - 1, $blockSize);
+
+        if ($blockCount > self::MAX_MANIFEST_BLOCKS) {
+            throw new \InvalidArgumentException('HTML chunk manifest is too large.');
+        }
+
+        $manifest = '';
+
+        for ($offset = 0, $length = strlen($html); $offset < $length; $offset += $blockSize) {
+            $block = substr($html, $offset, $blockSize);
+
+            $manifest .= pack('N2', $this->weakChecksum($block), $this->strongChecksum($block));
+        }
+
+        if (strlen($manifest) > self::MAX_MANIFEST_BYTES) {
+            throw new \InvalidArgumentException('HTML chunk manifest is too large.');
+        }
+
+        return base64_encode($manifest);
+    }
+
+    public function decodeManifest(
+        string $encodedManifest,
+        int $baseLength,
+        int $blockSize,
+    ): array {
+        $this->validateBlockSize($blockSize);
+        $this->validateHtmlLength($baseLength);
+
+        $expectedBlocks = $baseLength === 0
+            ? 0
+            : intdiv($baseLength + $blockSize - 1, $blockSize);
+
+        if (
+            $expectedBlocks > self::MAX_MANIFEST_BLOCKS
+            || strlen($encodedManifest) > 4 * intdiv(self::MAX_MANIFEST_BYTES + 2, 3)
+        ) {
+            throw new \InvalidArgumentException('HTML chunk manifest is too large.');
+        }
+
+        $manifest = base64_decode($encodedManifest, strict: true);
+
+        if (
+            $manifest === false
+            || $encodedManifest !== base64_encode($manifest)
+            || strlen($manifest) > self::MAX_MANIFEST_BYTES
+            || strlen($manifest) % 8 !== 0
+        ) {
+            throw new \InvalidArgumentException('Invalid HTML chunk manifest.');
+        }
+
+        if (strlen($manifest) !== $expectedBlocks * 8) {
+            throw new \InvalidArgumentException('HTML chunk manifest length does not match its baseline.');
+        }
+
+        $blocks = [];
+
+        for ($index = 0; $index < $expectedBlocks; $index++) {
+            $signature = unpack('Nweak/Nstrong', substr($manifest, $index * 8, 8));
+            $offset = $index * $blockSize;
+
+            $blocks[] = [
+                'offset' => $offset,
+                'length' => min($blockSize, $baseLength - $offset),
+                'weak' => $signature['weak'],
+                'strong' => $signature['strong'],
+            ];
+        }
+
+        return $blocks;
+    }
+
+    public function encode(
+        string $html,
+        string $encodedManifest,
+        int $baseLength,
+        int $blockSize,
+    ): array {
+        $this->validateHtml($html);
+
+        $blocks = $this->decodeManifest($encodedManifest, $baseLength, $blockSize);
+
+        if ($html === '') return [];
+
+        $index = [];
+
+        foreach ($blocks as $block) {
+            $length = $block['length'];
+            $weak = (string) $block['weak'];
+            $strong = (string) $block['strong'];
+
+            if (! isset($index[$length][$weak][$strong])) {
+                $index[$length][$weak][$strong] = [
+                    'first' => $block['offset'],
+                    'offsets' => [],
+                ];
+            }
+
+            $index[$length][$weak][$strong]['offsets'][$block['offset']] = true;
+        }
+
+        $windowLengths = array_keys($index);
+        rsort($windowLengths, SORT_NUMERIC);
+
+        $states = $this->initializeWindowStates($html, 0, $windowLengths);
+        $ops = [];
+        $add = '';
+        $offset = 0;
+        $scanSteps = 0;
+        $strongChecksumBytes = 0;
+        $htmlLength = strlen($html);
+
+        while ($offset < $htmlLength) {
+            $match = $this->findMatch(
+                $html,
+                $offset,
+                $states,
+                $windowLengths,
+                $index,
+                $add === '' ? $this->nextCopyOffset($ops) : null,
+                $strongChecksumBytes,
+            );
+
+            if ($match !== null) {
+                $this->flushAdd($ops, $add);
+                $this->appendCopy($ops, $match['offset'], $match['length']);
+
+                $offset += $match['length'];
+                $states = $this->initializeWindowStates($html, $offset, $windowLengths);
+
+                continue;
+            }
+
+            if (++$scanSteps > self::MAX_SCAN_STEPS) {
+                throw new \InvalidArgumentException('HTML chunk scan exceeded its work limit.');
+            }
+
+            $add .= $html[$offset];
+            $states = $this->rollWindowStates($html, $offset, $states, $windowLengths);
+            $offset++;
+        }
+
+        $this->flushAdd($ops, $add);
+
+        if (count($ops) > self::MAX_OPS) {
+            throw new \InvalidArgumentException('HTML chunk recipe contains too many operations.');
+        }
+
+        return $ops;
+    }
+
+    public function apply(string $base, array $ops): string
+    {
+        $this->validateHtml($base);
+
+        if (count($ops) > self::MAX_OPS) {
+            throw new \InvalidArgumentException('HTML chunk recipe contains too many operations.');
+        }
+
+        $result = '';
+
+        foreach ($ops as $op) {
+            if (! is_array($op) || ! array_is_list($op) || ! isset($op[0])) {
+                throw new \InvalidArgumentException('Invalid HTML chunk operation.');
+            }
+
+            if ($op[0] === 'c') {
+                if (
+                    count($op) !== 3
+                    || ! is_int($op[1])
+                    || ! is_int($op[2])
+                    || $op[1] < 0
+                    || $op[2] <= 0
+                    || $op[1] + $op[2] > strlen($base)
+                ) {
+                    throw new \InvalidArgumentException('Invalid HTML chunk copy range.');
+                }
+
+                $this->guardOutputLength(strlen($result), $op[2]);
+
+                $result .= substr($base, $op[1], $op[2]);
+
+                continue;
+            }
+
+            if ($op[0] === 'a') {
+                if (count($op) !== 2 || ! is_string($op[1])) {
+                    throw new \InvalidArgumentException('Invalid HTML chunk add operation.');
+                }
+
+                $addition = base64_decode($op[1], strict: true);
+
+                if (
+                    $addition === false
+                    || $addition === ''
+                    || $op[1] !== base64_encode($addition)
+                ) {
+                    throw new \InvalidArgumentException('Invalid base64 in HTML chunk operation.');
+                }
+
+                $this->guardOutputLength(strlen($result), strlen($addition));
+
+                $result .= $addition;
+
+                continue;
+            }
+
+            throw new \InvalidArgumentException('Unknown HTML chunk operation.');
+        }
+
+        $this->validateHtml($result);
+
+        return $result;
+    }
+
+    protected function findMatch(
+        string $html,
+        int $offset,
+        array $states,
+        array $windowLengths,
+        array $index,
+        ?int $preferredOffset,
+        int &$strongChecksumBytes,
+    ): ?array {
+        foreach ($windowLengths as $length) {
+            if (! isset($states[$length])) continue;
+
+            $weak = (string) $this->combineWeakChecksum($states[$length]);
+            $candidates = $index[$length][$weak] ?? null;
+
+            if ($candidates === null) continue;
+
+            if ($strongChecksumBytes + $length > self::MAX_STRONG_CHECKSUM_BYTES) {
+                throw new \InvalidArgumentException('HTML chunk checksum work exceeded its byte limit.');
+            }
+
+            $strongChecksumBytes += $length;
+
+            $strong = (string) $this->strongChecksum(substr($html, $offset, $length));
+            $matches = $candidates[$strong] ?? null;
+
+            if ($matches === null) continue;
+
+            $matchOffset = $preferredOffset !== null
+                && isset($matches['offsets'][$preferredOffset])
+                    ? $preferredOffset
+                    : $matches['first'];
+
+            return [
+                'offset' => $matchOffset,
+                'length' => $length,
+            ];
+        }
+
+        return null;
+    }
+
+    protected function initializeWindowStates(string $html, int $offset, array $windowLengths): array
+    {
+        $states = [];
+        $htmlLength = strlen($html);
+
+        foreach ($windowLengths as $length) {
+            if ($offset + $length > $htmlLength) continue;
+
+            $states[$length] = $this->weakChecksumParts(substr($html, $offset, $length));
+        }
+
+        return $states;
+    }
+
+    protected function rollWindowStates(
+        string $html,
+        int $offset,
+        array $states,
+        array $windowLengths,
+    ): array {
+        $htmlLength = strlen($html);
+
+        foreach ($windowLengths as $length) {
+            if (! isset($states[$length]) || $offset + $length >= $htmlLength) {
+                unset($states[$length]);
+
+                continue;
+            }
+
+            [$a, $b] = $states[$length];
+            $outgoing = ord($html[$offset]);
+            $incoming = ord($html[$offset + $length]);
+            $a = ($a - $outgoing + $incoming) & 0xffff;
+            $b = ($b - ($length * $outgoing) + $a) & 0xffff;
+
+            $states[$length] = [$a, $b];
+        }
+
+        return $states;
+    }
+
+    protected function weakChecksum(string $block): int
+    {
+        return $this->combineWeakChecksum($this->weakChecksumParts($block));
+    }
+
+    protected function weakChecksumParts(string $block): array
+    {
+        $a = 0;
+        $b = 0;
+        $length = strlen($block);
+
+        for ($index = 0; $index < $length; $index++) {
+            $byte = ord($block[$index]);
+            $a = ($a + $byte) & 0xffff;
+            $b = ($b + (($length - $index) * $byte)) & 0xffff;
+        }
+
+        return [$a, $b];
+    }
+
+    protected function combineWeakChecksum(array $parts): int
+    {
+        return (($parts[1] << 16) | $parts[0]) & 0xffffffff;
+    }
+
+    protected function strongChecksum(string $block): int
+    {
+        return unpack('Nchecksum', hash('crc32b', $block, true))['checksum'];
+    }
+
+    protected function nextCopyOffset(array $ops): ?int
+    {
+        if ($ops === []) return null;
+
+        $last = $ops[array_key_last($ops)];
+
+        if ($last[0] !== 'c') return null;
+
+        return $last[1] + $last[2];
+    }
+
+    protected function appendCopy(array &$ops, int $offset, int $length): void
+    {
+        if ($ops !== []) {
+            $lastIndex = array_key_last($ops);
+            $last = $ops[$lastIndex];
+
+            if ($last[0] === 'c' && $last[1] + $last[2] === $offset) {
+                $ops[$lastIndex][2] += $length;
+
+                return;
+            }
+        }
+
+        $ops[] = ['c', $offset, $length];
+    }
+
+    protected function flushAdd(array &$ops, string &$add): void
+    {
+        if ($add === '') return;
+
+        $ops[] = ['a', base64_encode($add)];
+        $add = '';
+    }
+
+    protected function validateBlockSize(int $blockSize): void
+    {
+        if ($blockSize < self::MIN_BLOCK_SIZE || $blockSize > self::MAX_BLOCK_SIZE) {
+            throw new \InvalidArgumentException('Invalid HTML chunk block size.');
+        }
+    }
+
+    protected function validateHtmlLength(int $length): void
+    {
+        if ($length < 0 || $length > self::MAX_HTML_BYTES) {
+            throw new \InvalidArgumentException('HTML chunk input is too large.');
+        }
+    }
+
+    protected function validateHtml(string $html): void
+    {
+        $this->validateHtmlLength(strlen($html));
+
+        if (preg_match('//u', $html) !== 1) {
+            throw new \InvalidArgumentException('HTML chunk input is not valid UTF-8.');
+        }
+    }
+
+    protected function guardOutputLength(int $current, int $addition): void
+    {
+        if ($addition < 0 || $current + $addition > self::MAX_HTML_BYTES) {
+            throw new \InvalidArgumentException('HTML chunk output is too large.');
+        }
+    }
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/TransportPrimitivesUnitTest.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/TransportPrimitivesUnitTest.php
@@ -22,12 +22,12 @@ class TransportPrimitivesUnitTest extends \Tests\TestCase
         $chunks = new StatelessHtmlChunks;
         $blockSize = 256;
         $base = '<main>'
-            .str_repeat('<p>foo 👋</p>', 20)
-            .'<p>bar baz</p>'
+            .str_repeat('<p>д字 👋</p>', 20)
+            .'<p>ж世 з本</p>'
             .str_repeat('<p>More stable content</p>', 20)
             .'</main>';
-        $target = '<main><h1>qux 🚀</h1>'
-            .str_repeat('<p>foo 👋</p>', 20)
+        $target = '<main><h1>ы語 🚀</h1>'
+            .str_repeat('<p>д字 👋</p>', 20)
             .str_repeat('<p>More stable content</p>', 20)
             .'</main>';
 

--- a/src/Mechanisms/HandleComponents/UpdateEngines/TransportPrimitivesUnitTest.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/TransportPrimitivesUnitTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+class TransportPrimitivesUnitTest extends \Tests\TestCase
+{
+    public function test_stateless_chunk_manifest_has_a_pinned_network_byte_order()
+    {
+        $chunks = new StatelessHtmlChunks;
+
+        $this->assertSame('DfgDJK7vKlA=', $chunks->manifest('abcdefgh', 256));
+        $this->assertSame([[
+            'offset' => 0,
+            'length' => 8,
+            'weak' => 0x0df80324,
+            'strong' => 0xaeef2a50,
+        ]], $chunks->decodeManifest('DfgDJK7vKlA=', 8, 256));
+    }
+
+    public function test_stateless_chunks_reconstruct_unicode_after_insertions_and_deletions()
+    {
+        $chunks = new StatelessHtmlChunks;
+        $blockSize = 256;
+        $base = '<main>'
+            .str_repeat('<p>foo 👋</p>', 20)
+            .'<p>bar baz</p>'
+            .str_repeat('<p>More stable content</p>', 20)
+            .'</main>';
+        $target = '<main><h1>qux 🚀</h1>'
+            .str_repeat('<p>foo 👋</p>', 20)
+            .str_repeat('<p>More stable content</p>', 20)
+            .'</main>';
+
+        $manifest = $chunks->manifest($base, $blockSize);
+        $ops = $chunks->encode($target, $manifest, strlen($base), $blockSize);
+
+        $this->assertSame($target, $chunks->apply($base, $ops));
+        $this->assertContains('c', array_column($ops, 0));
+        $this->assertContains('a', array_column($ops, 0));
+    }
+
+    public function test_stateless_chunks_reconstruct_reordered_and_duplicate_blocks()
+    {
+        $chunks = new StatelessHtmlChunks;
+        $blockSize = 256;
+        $a = str_repeat('A', $blockSize);
+        $b = str_repeat('B', $blockSize);
+        $c = str_repeat('C', $blockSize);
+        $tail = 'partial';
+        $base = $a.$b.$c.$b.$tail;
+        $target = $c.$b.$a.$b.$b.$tail;
+
+        $ops = $chunks->encode(
+            $target,
+            $chunks->manifest($base, $blockSize),
+            strlen($base),
+            $blockSize,
+        );
+
+        $this->assertSame($target, $chunks->apply($base, $ops));
+        $this->assertNotEmpty(array_filter($ops, fn ($op) => $op[0] === 'c'));
+    }
+
+    public function test_stateless_chunks_merge_adjacent_copy_operations()
+    {
+        $chunks = new StatelessHtmlChunks;
+        $blockSize = 256;
+        $base = str_repeat('0123456789abcdef', 8).'tail';
+
+        $ops = $chunks->encode(
+            $base,
+            $chunks->manifest($base, $blockSize),
+            strlen($base),
+            $blockSize,
+        );
+
+        $this->assertSame([['c', 0, strlen($base)]], $ops);
+    }
+
+    public function test_stateless_chunks_reject_malformed_manifests_and_recipe_bounds()
+    {
+        $chunks = new StatelessHtmlChunks;
+
+        try {
+            $chunks->decodeManifest('not canonical base64!', 512, 256);
+            $this->fail('The malformed manifest should have been rejected.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertSame('Invalid HTML chunk manifest.', $exception->getMessage());
+        }
+
+        try {
+            $chunks->decodeManifest(base64_encode(str_repeat("\0", 8)), 512, 256);
+            $this->fail('The truncated manifest should have been rejected.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertSame(
+                'HTML chunk manifest length does not match its baseline.',
+                $exception->getMessage(),
+            );
+        }
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $chunks->apply('short', [['c', 2, 20]]);
+    }
+
+    public function test_stateless_chunks_bound_work_for_adversarial_checksum_buckets()
+    {
+        $chunks = new StatelessHtmlChunks;
+        $blockSize = 65536;
+        $validSignature = base64_decode(
+            $chunks->manifest(str_repeat('A', $blockSize), $blockSize),
+            strict: true,
+        );
+        $wrongStrongChecksum = substr($validSignature, 0, 4).pack('N', 0);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('checksum work exceeded its byte limit');
+
+        $chunks->encode(
+            str_repeat('A', $blockSize + 256),
+            base64_encode($wrongStrongChecksum),
+            $blockSize,
+            $blockSize,
+        );
+    }
+
+    public function test_fragment_tree_selects_only_a_changed_nested_fragment()
+    {
+        $fragments = new RenderFragmentTree;
+        $base = '<main>before'
+            .$this->fragment('outer', '<p>outer</p>'.$this->fragment('inner', '<span>old</span>'))
+            .'after</main>';
+        $target = '<main>before'
+            .$this->fragment('outer', '<p>outer</p>'.$this->fragment('inner', '<span>new 🚀</span>'))
+            .'after</main>';
+
+        $manifest = $fragments->manifest($base);
+        $ops = $fragments->encode($target, $manifest);
+
+        $this->assertSame([['inner', '<span>new 🚀</span>']], $ops);
+        $this->assertSame($target, $fragments->apply($base, $ops));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{16}$/', $manifest['root']);
+        $this->assertSame(['outer', 'inner'], array_column($manifest['nodes'], 0));
+    }
+
+    public function test_fragment_tree_selects_a_parent_when_its_skeleton_changes()
+    {
+        $fragments = new RenderFragmentTree;
+        $baseInner = '<p>before</p>'.$this->fragment('inner', '<span>old</span>');
+        $targetInner = '<p>after</p>'.$this->fragment('inner', '<span>new</span>');
+        $base = '<main>'.$this->fragment('outer', $baseInner).'</main>';
+        $target = '<main>'.$this->fragment('outer', $targetInner).'</main>';
+
+        $ops = $fragments->encode($target, $fragments->manifest($base));
+
+        $this->assertSame([['outer', $targetInner]], $ops);
+        $this->assertSame($target, $fragments->apply($base, $ops));
+    }
+
+    public function test_fragment_tree_returns_null_when_content_outside_fragments_changes()
+    {
+        $fragments = new RenderFragmentTree;
+        $base = '<main>before'.$this->fragment('item', '<p>same</p>').'</main>';
+        $target = '<main>after'.$this->fragment('item', '<p>same</p>').'</main>';
+
+        $this->assertNull($fragments->encode($target, $fragments->manifest($base)));
+    }
+
+    public function test_fragment_tree_rejects_duplicate_and_unbalanced_transport_markers()
+    {
+        $fragments = new RenderFragmentTree;
+        $duplicate = $this->fragment('same', 'one').$this->fragment('same', 'two');
+        $unbalanced = $this->startFragment('open').'<p>never closed</p>';
+        $crossed = '<!--[if FRAGMENT:type=slot|token=slot]><![endif]-->'
+            .$this->startFragment('transport')
+            .'content'
+            .'<!--[if ENDFRAGMENT:type=slot|token=slot]><![endif]-->'
+            .$this->endFragment('transport');
+
+        $this->assertNull($fragments->manifest($duplicate));
+        $this->assertNull($fragments->manifest($unbalanced));
+        $this->assertNull($fragments->manifest($crossed));
+    }
+
+    public function test_fragment_tree_rejects_overlapping_operations()
+    {
+        $fragments = new RenderFragmentTree;
+        $base = '<main>'.$this->fragment(
+            'outer',
+            '<p>outer</p>'.$this->fragment('inner', '<p>inner</p>'),
+        ).'</main>';
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $fragments->apply($base, [
+            ['outer', '<p>changed outer</p>'],
+            ['inner', '<p>changed inner</p>'],
+        ]);
+    }
+
+    public function test_candidate_selector_chooses_a_smaller_candidate_after_manifest_tax()
+    {
+        $selector = new RenderCandidateSelector(
+            minimumRelativeSavings: 0.1,
+            minimumAbsoluteSavingsBytes: 20,
+            compressionAware: false,
+        );
+        $full = ['mode' => 'full', 'html' => str_repeat('stable-', 500)];
+        $chunks = ['mode' => 'chunks', 'ops' => [['c', 0, 3500]]];
+
+        $this->assertSame($chunks, $selector->select($full, [$chunks], requestManifestTax: 64));
+        $this->assertSame($full, $selector->select($full, [$chunks], requestManifestTax: 5000));
+    }
+
+    public function test_candidate_selector_falls_back_to_full_when_gzip_erases_raw_savings()
+    {
+        if (! function_exists('gzencode')) {
+            $this->markTestSkipped('The zlib extension is not available.');
+        }
+
+        $selector = new RenderCandidateSelector(
+            minimumRelativeSavings: 0.1,
+            minimumAbsoluteSavingsBytes: 0,
+            compressionAware: true,
+        );
+        $full = ['mode' => 'full', 'html' => str_repeat('A', 10000)];
+        $noise = implode('', array_map(
+            fn ($index) => hash('sha256', (string) $index),
+            range(1, 8),
+        ));
+        $chunks = ['mode' => 'chunks', 'ops' => [['a', base64_encode($noise)]]];
+
+        $this->assertLessThan($selector->sizes($full)['raw'], $selector->sizes($chunks)['raw']);
+        $this->assertGreaterThan($selector->sizes($full)['gzip'], $selector->sizes($chunks)['gzip']);
+        $this->assertSame($full, $selector->select($full, [$chunks]));
+    }
+
+    protected function fragment(string $token, string $html): string
+    {
+        return $this->startFragment($token).$html.$this->endFragment($token);
+    }
+
+    protected function startFragment(string $token): string
+    {
+        return "<!--[if FRAGMENT:type=transport|token={$token}]><![endif]-->";
+    }
+
+    protected function endFragment(string $token): string
+    {
+        return "<!--[if ENDFRAGMENT:type=transport|token={$token}]><![endif]-->";
+    }
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/UnitTest.php
@@ -1,0 +1,490 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+use Illuminate\Support\Facades\Cache;
+use Livewire\Component;
+use Livewire\Livewire;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+
+class UnitTest extends \Tests\TestCase
+{
+    public function test_it_encodes_replacements_as_reversible_byte_deltas()
+    {
+        $delta = new HtmlDelta;
+        $from = '<div>'.str_repeat('before-', 20).'old'.str_repeat('-after', 20).'</div>';
+        $to = '<div>'.str_repeat('before-', 20).'new'.str_repeat('-after', 20).'</div>';
+
+        $patches = $delta->encode($from, $to);
+        $patch = $patches[0];
+
+        $this->assertCount(1, $patches);
+        $this->assertSame($to, $delta->apply($from, $patches));
+        $this->assertSame(3, $patch['delete']);
+        $this->assertSame(base64_encode('new'), $patch['insert']);
+    }
+
+    public function test_it_preserves_unicode_when_a_delta_boundary_is_inside_a_multibyte_character()
+    {
+        $delta = new HtmlDelta;
+        $from = '<div>foo 👋 — bar</div>';
+        $to = '<div>foo 🚀 — baz</div>';
+
+        $patches = $delta->encode($from, $to);
+
+        $this->assertSame($to, $delta->apply($from, $patches));
+    }
+
+    public function test_it_encodes_distant_changes_as_multiple_patches()
+    {
+        $delta = new HtmlDelta;
+        $card = '<article wire:key="card-3">Deploy application</article>';
+        $middle = str_repeat('<article>Unchanged card content</article>', 100);
+        $from = '<div><section>'.$card.$middle.'</section><section>Done</section></div>';
+        $to = '<div><section>'.$middle.'</section><section>Done'.$card.'</section></div>';
+
+        $patches = $delta->encode($from, $to);
+
+        $this->assertGreaterThanOrEqual(2, count($patches));
+        $this->assertSame($to, $delta->apply($from, $patches));
+    }
+
+    public function test_it_rejects_overlapping_patches()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new HtmlDelta)->apply('<div>content</div>', [
+            ['start' => 5, 'delete' => 3, 'insert' => ''],
+            ['start' => 6, 'delete' => 1, 'insert' => ''],
+        ]);
+    }
+
+    public function test_it_bounds_anchor_scanning_for_completely_different_html()
+    {
+        $delta = new HtmlDelta;
+        $from = '<div>'.str_repeat('A', 10000).'</div>';
+        $to = '<div>'.str_repeat('B', 10000).'</div>';
+
+        $patches = $delta->encode($from, $to);
+
+        $this->assertCount(1, $patches);
+        $this->assertSame($to, $delta->apply($from, $patches));
+    }
+
+    public function test_delta_engine_seeds_with_full_html_then_sends_compact_json_deltas()
+    {
+        config()->set('livewire.update_engine', 'delta');
+        config()->set('livewire.delta.store', 'array');
+        config()->set('livewire.delta.minimum_savings', 0.1);
+        config()->set('livewire.delta.minimum_compressed_savings_bytes', 0);
+
+        $component = Livewire::test(new class extends Component {
+            public int $count = 0;
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="increment">Increment</button>
+                    <span>Count: {{ $count }}</span>
+                    <p>{{ str_repeat('stable-content-', 1000) }}</p>
+                </div>
+                HTML;
+            }
+        });
+
+        $component->call('increment')->assertSee('Count: 1');
+
+        $this->assertArrayHasKey('html', $component->effects);
+        $this->assertArrayNotHasKey('htmlDelta', $component->effects);
+
+        $fullHtmlSize = strlen($component->effects['html']);
+
+        $component->call('increment')->assertSee('Count: 2');
+
+        $this->assertArrayNotHasKey('html', $component->effects);
+        $this->assertArrayHasKey('htmlDelta', $component->effects);
+        $this->assertIsArray($component->effects['htmlDelta']['patches']);
+        $this->assertLessThan($fullHtmlSize / 10, strlen(json_encode($component->effects['htmlDelta'])));
+    }
+
+    public function test_delta_engine_rejects_a_delta_that_is_larger_after_gzip()
+    {
+        if (! function_exists('gzencode')) {
+            $this->markTestSkipped('The zlib extension is not available.');
+        }
+
+        config()->set('livewire.delta.minimum_savings', 0.1);
+        config()->set('livewire.delta.compression_aware', true);
+        config()->set('livewire.delta.minimum_compressed_savings_bytes', 0);
+
+        $deltas = new HtmlDelta;
+        $randomLooking = implode('', array_map(
+            fn ($index) => hash('sha256', (string) $index),
+            range(1, 16),
+        ));
+        $from = '<div>'.str_repeat('A', 5000).'</div>';
+        $to = '<div>'.str_repeat('A', 2000).$randomLooking.str_repeat('A', 1976).'</div>';
+        $hash = $deltas->hash($to);
+        $effect = [
+            'base' => $deltas->hash($from),
+            'patches' => $deltas->encode($from, $to),
+        ];
+        $deltaPayload = json_encode([
+            'htmlDelta' => $effect,
+            'htmlHash' => $hash,
+        ], JSON_THROW_ON_ERROR);
+        $fullPayload = json_encode([
+            'html' => $to,
+            'htmlHash' => $hash,
+        ], JSON_THROW_ON_ERROR);
+        $engine = new InspectableDeltaUpdateEngine(
+            new UnavailableRenderStateStore,
+            $deltas,
+        );
+
+        $this->assertLessThan(strlen($fullPayload) * 0.9, strlen($deltaPayload));
+        $this->assertGreaterThanOrEqual(strlen(gzencode($fullPayload, 1)) * 0.9, strlen(gzencode($deltaPayload, 1)));
+        $this->assertFalse($engine->canSendDelta($effect, $to, $hash));
+
+        config()->set('livewire.delta.compression_aware', false);
+
+        $this->assertTrue($engine->canSendDelta($effect, $to, $hash));
+    }
+
+    public function test_delta_engine_requires_minimum_absolute_compressed_savings()
+    {
+        if (! function_exists('gzencode')) {
+            $this->markTestSkipped('The zlib extension is not available.');
+        }
+
+        config()->set('livewire.delta.minimum_savings', 0.1);
+        config()->set('livewire.delta.compression_aware', true);
+
+        $deltas = new HtmlDelta;
+        $rows = implode('', array_map(
+            fn ($index) => '<tr><td>'.$index.'</td><td>'.hash('sha256', (string) $index).'</td></tr>',
+            range(1, 200),
+        ));
+        $from = '<table>'.$rows.'<tfoot><tr><td>pending</td></tr></tfoot></table>';
+        $to = '<table>'.$rows.'<tfoot><tr><td>running</td></tr></tfoot></table>';
+        $hash = $deltas->hash($to);
+        $effect = [
+            'base' => $deltas->hash($from),
+            'patches' => $deltas->encode($from, $to),
+        ];
+        $deltaPayload = json_encode([
+            'htmlDelta' => $effect,
+            'htmlHash' => $hash,
+        ], JSON_THROW_ON_ERROR);
+        $fullPayload = json_encode([
+            'html' => $to,
+            'htmlHash' => $hash,
+        ], JSON_THROW_ON_ERROR);
+        $compressedSavings = strlen(gzencode($fullPayload, 1))
+            - strlen(gzencode($deltaPayload, 1));
+        $engine = new InspectableDeltaUpdateEngine(
+            new UnavailableRenderStateStore,
+            $deltas,
+        );
+
+        $this->assertGreaterThan(0, $compressedSavings);
+
+        config()->set('livewire.delta.minimum_compressed_savings_bytes', $compressedSavings + 1);
+
+        $this->assertFalse($engine->canSendDelta($effect, $to, $hash));
+
+        config()->set('livewire.delta.minimum_compressed_savings_bytes', $compressedSavings);
+
+        $this->assertTrue($engine->canSendDelta($effect, $to, $hash));
+    }
+
+    public function test_small_renders_use_morph_without_touching_render_state()
+    {
+        config()->set('livewire.delta.minimum_html_bytes', 8192);
+
+        $states = new TrackingRenderStateStore;
+        $deltas = new HtmlDelta;
+        $engine = new DeltaUpdateEngine($states, $deltas);
+        $component = new DeltaCounter;
+        $component->setId('component-id');
+        $mountContext = new ComponentContext($component, mounting: true);
+        $previousHtml = '<div>Count: 1</div>';
+        $previousHash = $deltas->hash($previousHtml);
+
+        $engine->mount($component, $previousHtml, $mountContext);
+
+        $this->assertArrayNotHasKey('delta', $mountContext->memo);
+
+        $context = new ComponentContext($component);
+
+        $engine->update(
+            $component,
+            '<div>Count: 2</div>',
+            ['delta' => ['revision' => 1, 'hash' => $previousHash]],
+            $context,
+            ['htmlHash' => $previousHash],
+        );
+
+        $this->assertSame('<div>Count: 2</div>', $context->effects['html']);
+        $this->assertArrayNotHasKey('htmlHash', $context->effects);
+        $this->assertArrayNotHasKey('delta', $context->memo);
+        $this->assertSame(0, $states->getCalls);
+        $this->assertSame(0, $states->putCalls);
+    }
+
+    public function test_components_can_cross_the_hybrid_size_boundary()
+    {
+        config()->set('livewire.update_engine', 'delta');
+        config()->set('livewire.delta.store', 'array');
+        config()->set('livewire.delta.minimum_html_bytes', 1024);
+        config()->set('livewire.delta.minimum_compressed_savings_bytes', 0);
+
+        $component = Livewire::test(new class extends Component {
+            public int $count = 0;
+
+            public bool $large = false;
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function grow()
+            {
+                $this->large = true;
+            }
+
+            public function shrink()
+            {
+                $this->large = false;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <span>Count: {{ $count }}</span>
+                    @if ($large)
+                        <p>{{ str_repeat('stable-content-', 1000) }}</p>
+                    @endif
+                </div>
+                HTML;
+            }
+        });
+
+        $component->call('grow');
+
+        $this->assertArrayHasKey('html', $component->effects);
+        $this->assertArrayHasKey('htmlHash', $component->effects);
+
+        $component->call('increment')->assertSee('Count: 1');
+
+        $this->assertArrayHasKey('htmlDelta', $component->effects);
+
+        $component->call('shrink');
+
+        $this->assertArrayHasKey('html', $component->effects);
+        $this->assertArrayNotHasKey('htmlDelta', $component->effects);
+        $this->assertArrayNotHasKey('htmlHash', $component->effects);
+
+        $component->call('grow');
+
+        $this->assertArrayHasKey('html', $component->effects);
+        $this->assertArrayNotHasKey('htmlDelta', $component->effects);
+        $this->assertArrayHasKey('htmlHash', $component->effects);
+    }
+
+    public function test_delta_engine_falls_back_to_full_html_after_the_render_state_expires()
+    {
+        config()->set('livewire.update_engine', 'delta');
+        config()->set('livewire.delta.store', 'array');
+        config()->set('livewire.delta.minimum_html_bytes', 0);
+
+        $component = Livewire::test(DeltaCounter::class);
+
+        $component->call('increment');
+
+        Cache::store('array')->flush();
+
+        $component->call('increment')->assertSee('Count: 2');
+
+        $this->assertArrayHasKey('html', $component->effects);
+        $this->assertArrayNotHasKey('htmlDelta', $component->effects);
+    }
+
+    public function test_delta_engine_falls_back_to_full_html_when_the_cached_render_fails_integrity()
+    {
+        config()->set('livewire.update_engine', 'delta');
+        config()->set('livewire.delta.store', 'array');
+        config()->set('livewire.delta.minimum_html_bytes', 0);
+
+        $component = Livewire::test(DeltaCounter::class);
+
+        $component->call('increment');
+
+        Cache::store('array')->put(
+            'livewire:delta:'.$component->instance()->getId(),
+            [
+                'hash' => $component->effects['htmlHash'],
+                'html' => '<div>Tampered render</div>',
+            ],
+            300,
+        );
+
+        $component->call('increment')->assertSee('Count: 2');
+
+        $this->assertArrayHasKey('html', $component->effects);
+        $this->assertArrayNotHasKey('htmlDelta', $component->effects);
+    }
+
+    public function test_delta_engine_falls_back_to_full_html_when_the_store_is_unavailable()
+    {
+        config()->set('livewire.delta.minimum_html_bytes', 0);
+
+        $deltas = new HtmlDelta;
+        $engine = new DeltaUpdateEngine(new UnavailableRenderStateStore, $deltas);
+        $component = new DeltaCounter;
+        $component->setId('component-id');
+        $context = new ComponentContext($component);
+        $previousHtml = '<div>Count: 1</div>';
+        $previousHash = $deltas->hash($previousHtml);
+
+        $engine->update(
+            $component,
+            '<div>Count: 2</div>',
+            ['delta' => ['revision' => 1, 'hash' => $previousHash]],
+            $context,
+            ['htmlHash' => $previousHash],
+        );
+
+        $this->assertSame('<div>Count: 2</div>', $context->effects['html']);
+        $this->assertArrayNotHasKey('htmlDelta', $context->effects);
+    }
+
+    public function test_cache_store_only_retains_the_latest_render_for_a_component()
+    {
+        config()->set('livewire.delta.store', 'array');
+
+        $store = app(RenderStateStore::class);
+
+        $store->put('component-id', 'first-hash', '<div>First</div>');
+        $store->put('component-id', 'second-hash', '<div>Second</div>');
+
+        $this->assertNull($store->get('component-id', 'first-hash'));
+        $this->assertSame('<div>Second</div>', $store->get('component-id', 'second-hash'));
+    }
+
+    public function test_cache_store_rejects_rendered_html_that_does_not_match_its_hash()
+    {
+        config()->set('livewire.delta.store', 'array');
+
+        $html = '<div>Original render</div>';
+        $hash = app(HtmlDelta::class)->hash($html);
+        $key = 'livewire:delta:component-id';
+
+        Cache::store('array')->put($key, [
+            'hash' => $hash,
+            'html' => '<div>Tampered render</div>',
+        ], 300);
+
+        $this->assertNull(app(RenderStateStore::class)->get('component-id', $hash));
+        $this->assertFalse(Cache::store('array')->has($key));
+    }
+
+    public function test_renderless_updates_preserve_the_last_render_baseline()
+    {
+        config()->set('livewire.update_engine', 'delta');
+        config()->set('livewire.delta.store', 'array');
+        config()->set('livewire.delta.minimum_html_bytes', 0);
+        config()->set('livewire.delta.minimum_compressed_savings_bytes', 0);
+
+        $component = Livewire::test(DeltaCounter::class)
+            ->call('increment')
+            ->call('incrementRenderless')
+            ->assertSee('Count: 1');
+
+        $this->assertArrayNotHasKey('html', $component->effects);
+        $this->assertArrayNotHasKey('htmlDelta', $component->effects);
+
+        $component->call('increment')->assertSee('Count: 3');
+
+        $this->assertArrayHasKey('htmlDelta', $component->effects);
+    }
+
+    public function test_morph_remains_the_default_update_engine()
+    {
+        $component = Livewire::test(DeltaCounter::class)
+            ->call('increment')
+            ->call('increment');
+
+        $this->assertArrayHasKey('html', $component->effects);
+        $this->assertArrayNotHasKey('htmlDelta', $component->effects);
+    }
+}
+
+class DeltaCounter extends Component
+{
+    public int $count = 0;
+
+    public function increment()
+    {
+        $this->count++;
+    }
+
+    public function incrementRenderless()
+    {
+        $this->count++;
+        $this->skipRender();
+    }
+
+    public function render()
+    {
+        return '<div>Count: {{ $count }}'.str_repeat('<span>stable</span>', 100).'</div>';
+    }
+}
+
+class UnavailableRenderStateStore implements RenderStateStore
+{
+    public function get(string $componentId, string $hash): ?string
+    {
+        throw new \RuntimeException('Render state store unavailable.');
+    }
+
+    public function put(string $componentId, string $hash, string $html): void
+    {
+        throw new \RuntimeException('Render state store unavailable.');
+    }
+}
+
+class TrackingRenderStateStore implements RenderStateStore
+{
+    public int $getCalls = 0;
+
+    public int $putCalls = 0;
+
+    public function get(string $componentId, string $hash): ?string
+    {
+        $this->getCalls++;
+
+        return null;
+    }
+
+    public function put(string $componentId, string $hash, string $html): void
+    {
+        $this->putCalls++;
+    }
+}
+
+class InspectableDeltaUpdateEngine extends DeltaUpdateEngine
+{
+    public function canSendDelta(array $effect, string $html, string $hash): bool
+    {
+        return $this->shouldSendDelta($effect, $html, $hash);
+    }
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/UnitTest.php
@@ -5,10 +5,29 @@ namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Component;
 use Livewire\Livewire;
-use Livewire\Mechanisms\HandleComponents\ComponentContext;
+use Livewire\Mechanisms\HandleRequests\SnapshotStateStore;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UnitTest extends \Tests\TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('livewire.update_engine', 'delta');
+        config()->set('livewire.delta.store', 'array');
+        config()->set('livewire.delta.snapshot_store', 'array');
+        config()->set('livewire.delta.minimum_html_bytes', 0);
+        config()->set('livewire.delta.minimum_savings', 0);
+        config()->set('livewire.delta.minimum_compressed_savings_bytes', 0);
+        config()->set('livewire.delta.compression_aware', false);
+        config()->set('livewire.delta.request_compression', true);
+        config()->set('livewire.delta.request_compression_minimum_bytes', 1024);
+        config()->set('livewire.delta.snapshot_delta', true);
+        config()->set('livewire.delta.snapshot_references', true);
+        config()->set('livewire.delta.snapshot_reference_minimum_bytes', 0);
+    }
+
     public function test_it_encodes_replacements_as_reversible_byte_deltas()
     {
         $delta = new HtmlDelta;
@@ -71,360 +90,500 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame($to, $delta->apply($from, $patches));
     }
 
-    public function test_delta_engine_seeds_with_full_html_then_sends_compact_json_deltas()
+    public function test_response_transport_preserves_custom_non_array_responses()
     {
-        config()->set('livewire.update_engine', 'delta');
-        config()->set('livewire.delta.store', 'array');
-        config()->set('livewire.delta.minimum_savings', 0.1);
-        config()->set('livewire.delta.minimum_compressed_savings_bytes', 0);
-
-        $component = Livewire::test(new class extends Component {
-            public int $count = 0;
-
-            public function increment()
-            {
-                $this->count++;
-            }
-
-            public function render()
-            {
-                return <<<'HTML'
-                <div>
-                    <button wire:click="increment">Increment</button>
-                    <span>Count: {{ $count }}</span>
-                    <p>{{ str_repeat('stable-content-', 1000) }}</p>
-                </div>
-                HTML;
-            }
-        });
-
-        $component->call('increment')->assertSee('Count: 1');
-
-        $this->assertArrayHasKey('html', $component->effects);
-        $this->assertArrayNotHasKey('htmlDelta', $component->effects);
-
-        $fullHtmlSize = strlen($component->effects['html']);
-
-        $component->call('increment')->assertSee('Count: 2');
-
-        $this->assertArrayNotHasKey('html', $component->effects);
-        $this->assertArrayHasKey('htmlDelta', $component->effects);
-        $this->assertIsArray($component->effects['htmlDelta']['patches']);
-        $this->assertLessThan($fullHtmlSize / 10, strlen(json_encode($component->effects['htmlDelta'])));
-    }
-
-    public function test_delta_engine_rejects_a_delta_that_is_larger_after_gzip()
-    {
-        if (! function_exists('gzencode')) {
-            $this->markTestSkipped('The zlib extension is not available.');
-        }
-
-        config()->set('livewire.delta.minimum_savings', 0.1);
-        config()->set('livewire.delta.compression_aware', true);
-        config()->set('livewire.delta.minimum_compressed_savings_bytes', 0);
-
-        $deltas = new HtmlDelta;
-        $randomLooking = implode('', array_map(
-            fn ($index) => hash('sha256', (string) $index),
-            range(1, 16),
-        ));
-        $from = '<div>'.str_repeat('A', 5000).'</div>';
-        $to = '<div>'.str_repeat('A', 2000).$randomLooking.str_repeat('A', 1976).'</div>';
-        $hash = $deltas->hash($to);
-        $effect = [
-            'base' => $deltas->hash($from),
-            'patches' => $deltas->encode($from, $to),
-        ];
-        $deltaPayload = json_encode([
-            'htmlDelta' => $effect,
-            'htmlHash' => $hash,
-        ], JSON_THROW_ON_ERROR);
-        $fullPayload = json_encode([
-            'html' => $to,
-            'htmlHash' => $hash,
-        ], JSON_THROW_ON_ERROR);
-        $engine = new InspectableDeltaUpdateEngine(
-            new UnavailableRenderStateStore,
-            $deltas,
+        $this->assertSame(
+            'custom-response',
+            app(ResponseTransport::class)->encode('custom-response', []),
         );
-
-        $this->assertLessThan(strlen($fullPayload) * 0.9, strlen($deltaPayload));
-        $this->assertGreaterThanOrEqual(strlen(gzencode($fullPayload, 1)) * 0.9, strlen(gzencode($deltaPayload, 1)));
-        $this->assertFalse($engine->canSendDelta($effect, $to, $hash));
-
-        config()->set('livewire.delta.compression_aware', false);
-
-        $this->assertTrue($engine->canSendDelta($effect, $to, $hash));
     }
 
-    public function test_delta_engine_requires_minimum_absolute_compressed_savings()
+    public function test_renderless_responses_advertise_the_top_level_request_transport()
     {
-        if (! function_exists('gzencode')) {
-            $this->markTestSkipped('The zlib extension is not available.');
-        }
+        $payload = app(ResponseTransport::class)->encode([
+            'components' => [[
+                'id' => 'component-id',
+                'snapshot' => '{}',
+                'effects' => [],
+            ]],
+        ], [
+            'component-id' => [[
+                'snapshot' => '{}',
+                'render' => ['v' => 1, 'capabilities' => []],
+            ]],
+        ]);
 
-        config()->set('livewire.delta.minimum_savings', 0.1);
-        config()->set('livewire.delta.compression_aware', true);
-
-        $deltas = new HtmlDelta;
-        $rows = implode('', array_map(
-            fn ($index) => '<tr><td>'.$index.'</td><td>'.hash('sha256', (string) $index).'</td></tr>',
-            range(1, 200),
-        ));
-        $from = '<table>'.$rows.'<tfoot><tr><td>pending</td></tr></tfoot></table>';
-        $to = '<table>'.$rows.'<tfoot><tr><td>running</td></tr></tfoot></table>';
-        $hash = $deltas->hash($to);
-        $effect = [
-            'base' => $deltas->hash($from),
-            'patches' => $deltas->encode($from, $to),
-        ];
-        $deltaPayload = json_encode([
-            'htmlDelta' => $effect,
-            'htmlHash' => $hash,
-        ], JSON_THROW_ON_ERROR);
-        $fullPayload = json_encode([
-            'html' => $to,
-            'htmlHash' => $hash,
-        ], JSON_THROW_ON_ERROR);
-        $compressedSavings = strlen(gzencode($fullPayload, 1))
-            - strlen(gzencode($deltaPayload, 1));
-        $engine = new InspectableDeltaUpdateEngine(
-            new UnavailableRenderStateStore,
-            $deltas,
-        );
-
-        $this->assertGreaterThan(0, $compressedSavings);
-
-        config()->set('livewire.delta.minimum_compressed_savings_bytes', $compressedSavings + 1);
-
-        $this->assertFalse($engine->canSendDelta($effect, $to, $hash));
-
-        config()->set('livewire.delta.minimum_compressed_savings_bytes', $compressedSavings);
-
-        $this->assertTrue($engine->canSendDelta($effect, $to, $hash));
+        $this->assertSame([
+            'v' => 1,
+            'requestGzip' => 1024,
+        ], $payload['transport']);
+        $this->assertArrayNotHasKey('html', $payload['components'][0]['effects']);
     }
 
-    public function test_small_renders_use_morph_without_touching_render_state()
+    public function test_top_level_request_transport_explicitly_disables_gzip_negotiation()
     {
-        config()->set('livewire.delta.minimum_html_bytes', 8192);
+        config()->set('livewire.delta.request_compression', false);
 
-        $states = new TrackingRenderStateStore;
-        $deltas = new HtmlDelta;
-        $engine = new DeltaUpdateEngine($states, $deltas);
-        $component = new DeltaCounter;
-        $component->setId('component-id');
-        $mountContext = new ComponentContext($component, mounting: true);
-        $previousHtml = '<div>Count: 1</div>';
-        $previousHash = $deltas->hash($previousHtml);
+        $payload = app(ResponseTransport::class)->encode(['components' => []], []);
 
-        $engine->mount($component, $previousHtml, $mountContext);
-
-        $this->assertArrayNotHasKey('delta', $mountContext->memo);
-
-        $context = new ComponentContext($component);
-
-        $engine->update(
-            $component,
-            '<div>Count: 2</div>',
-            ['delta' => ['revision' => 1, 'hash' => $previousHash]],
-            $context,
-            ['htmlHash' => $previousHash],
-        );
-
-        $this->assertSame('<div>Count: 2</div>', $context->effects['html']);
-        $this->assertArrayNotHasKey('htmlHash', $context->effects);
-        $this->assertArrayNotHasKey('delta', $context->memo);
-        $this->assertSame(0, $states->getCalls);
-        $this->assertSame(0, $states->putCalls);
+        $this->assertSame([
+            'v' => 1,
+            'requestGzip' => null,
+        ], $payload['transport']);
     }
 
-    public function test_components_can_cross_the_hybrid_size_boundary()
+    public function test_delta_mount_advertises_bounded_client_transport_configuration()
     {
-        config()->set('livewire.update_engine', 'delta');
-        config()->set('livewire.delta.store', 'array');
-        config()->set('livewire.delta.minimum_html_bytes', 1024);
-        config()->set('livewire.delta.minimum_compressed_savings_bytes', 0);
-
-        $component = Livewire::test(new class extends Component {
-            public int $count = 0;
-
-            public bool $large = false;
-
-            public function increment()
-            {
-                $this->count++;
-            }
-
-            public function grow()
-            {
-                $this->large = true;
-            }
-
-            public function shrink()
-            {
-                $this->large = false;
-            }
-
-            public function render()
-            {
-                return <<<'HTML'
-                <div>
-                    <span>Count: {{ $count }}</span>
-                    @if ($large)
-                        <p>{{ str_repeat('stable-content-', 1000) }}</p>
-                    @endif
-                </div>
-                HTML;
-            }
-        });
-
-        $component->call('grow');
-
-        $this->assertArrayHasKey('html', $component->effects);
-        $this->assertArrayHasKey('htmlHash', $component->effects);
-
-        $component->call('increment')->assertSee('Count: 1');
-
-        $this->assertArrayHasKey('htmlDelta', $component->effects);
-
-        $component->call('shrink');
-
-        $this->assertArrayHasKey('html', $component->effects);
-        $this->assertArrayNotHasKey('htmlDelta', $component->effects);
-        $this->assertArrayNotHasKey('htmlHash', $component->effects);
-
-        $component->call('grow');
-
-        $this->assertArrayHasKey('html', $component->effects);
-        $this->assertArrayNotHasKey('htmlDelta', $component->effects);
-        $this->assertArrayHasKey('htmlHash', $component->effects);
-    }
-
-    public function test_delta_engine_falls_back_to_full_html_after_the_render_state_expires()
-    {
-        config()->set('livewire.update_engine', 'delta');
-        config()->set('livewire.delta.store', 'array');
-        config()->set('livewire.delta.minimum_html_bytes', 0);
+        config()->set('livewire.delta.block_size', 512);
+        config()->set('livewire.delta.maximum_manifest_bytes', 2048);
+        config()->set('livewire.delta.maximum_fragments', 10);
+        config()->set('livewire.delta.cache_accelerator', false);
+        config()->set('livewire.delta.snapshot_delta', false);
+        config()->set('livewire.delta.snapshot_references', false);
 
         $component = Livewire::test(DeltaCounter::class);
+        $transport = $component->effects['renderTransport'];
 
-        $component->call('increment');
-
-        Cache::store('array')->flush();
-
-        $component->call('increment')->assertSee('Count: 2');
-
-        $this->assertArrayHasKey('html', $component->effects);
-        $this->assertArrayNotHasKey('htmlDelta', $component->effects);
+        $this->assertSame(1, $transport['v']);
+        $this->assertSame(512, $transport['blockSize']);
+        $this->assertSame(2048, $transport['maximumManifestBytes']);
+        $this->assertSame(10, $transport['maximumFragments']);
+        $this->assertFalse($transport['cacheAccelerator']);
+        $this->assertFalse($transport['snapshotDelta']);
+        $this->assertFalse($transport['snapshotReferences']);
+        $this->assertSame(1024 * 1024, $transport['maximumRequestBytes']);
     }
 
-    public function test_delta_engine_falls_back_to_full_html_when_the_cached_render_fails_integrity()
+    public function test_v1_transport_sends_full_html_without_a_usable_baseline()
     {
-        config()->set('livewire.update_engine', 'delta');
-        config()->set('livewire.delta.store', 'array');
-        config()->set('livewire.delta.minimum_html_bytes', 0);
+        $html = '<div>'.str_repeat('full-', 1000).'</div>';
+        $response = $this->encodeRender($html, [
+            'v' => 1,
+            'capabilities' => [],
+        ]);
 
-        $component = Livewire::test(DeltaCounter::class);
+        $this->assertSame('full', $response['effects']['render']['mode']);
+        $this->assertSame($html, $response['effects']['html']);
+        $this->assertSame(strlen($html), $response['effects']['render']['bytes']);
+        $this->assertSame(hash('sha256', $html), $response['effects']['render']['target']);
+        $this->assertSame(1024, $response['effects']['render']['requestGzip']);
+    }
 
-        $component->call('increment');
+    public function test_v1_transport_can_disable_request_compression_negotiation()
+    {
+        config()->set('livewire.delta.request_compression', false);
 
-        Cache::store('array')->put(
-            'livewire:delta:'.$component->instance()->getId(),
-            [
-                'hash' => $component->effects['htmlHash'],
-                'html' => '<div>Tampered render</div>',
+        $response = $this->encodeRender('<div>full</div>', [
+            'v' => 1,
+            'capabilities' => [],
+        ]);
+
+        $this->assertArrayNotHasKey('requestGzip', $response['effects']['render']);
+    }
+
+    public function test_legacy_delta_client_is_seeded_when_it_has_no_render_hash_yet()
+    {
+        $html = '<div>'.str_repeat('legacy-', 1000).'</div>';
+        $hash = hash('sha256', $html);
+        $response = $this->encodeRender($html, []);
+
+        $this->assertSame($html, $response['effects']['html']);
+        $this->assertSame($hash, $response['effects']['htmlHash']);
+        $this->assertArrayNotHasKey('render', $response['effects']);
+        $this->assertSame(
+            $html,
+            app(RenderStateStore::class)->get('component-id', $hash),
+        );
+    }
+
+    public function test_v1_transport_sends_same_when_the_render_is_unchanged()
+    {
+        $html = '<div>'.str_repeat('same-', 1000).'</div>';
+        $response = $this->encodeRender($html, $this->metadata($html, ['same']));
+
+        $this->assertSame('same', $response['effects']['render']['mode']);
+        $this->assertArrayNotHasKey('html', $response['effects']);
+        $this->assertSame(hash('sha256', $html), $response['effects']['render']['base']);
+    }
+
+    public function test_v1_transport_uses_cached_splice_as_an_optional_accelerator()
+    {
+        $base = '<div>'.str_repeat('stable-content-', 2000).'<span>old</span></div>';
+        $target = str_replace('<span>old</span>', '<span>new</span>', $base);
+        $hash = hash('sha256', $base);
+
+        app(RenderStateStore::class)->put('component-id', $hash, $base);
+
+        $response = $this->encodeRender($target, $this->metadata($base, ['splice']));
+        $render = $response['effects']['render'];
+
+        $this->assertSame('splice', $render['mode']);
+        $this->assertArrayNotHasKey('html', $response['effects']);
+        $this->assertSame($target, app(HtmlDelta::class)->apply($base, $render['patches']));
+    }
+
+    public function test_v1_transport_builds_stateless_chunk_recipes_without_server_memory()
+    {
+        config()->set('livewire.delta.cache_accelerator', false);
+
+        $base = '<main>'.str_repeat('0123456789abcdef', 2000).'<b>old</b></main>';
+        $target = str_replace('<b>old</b>', '<b>new</b>', $base);
+        $blockSize = 256;
+        $metadata = $this->metadata($base, ['chunks']) + [
+            'chunks' => [
+                'blockSize' => $blockSize,
+                'blocks' => app(StatelessHtmlChunks::class)->manifest($base, $blockSize),
             ],
-            300,
-        );
+        ];
 
-        $component->call('increment')->assertSee('Count: 2');
+        $response = $this->encodeRender($target, $metadata);
+        $render = $response['effects']['render'];
 
-        $this->assertArrayHasKey('html', $component->effects);
-        $this->assertArrayNotHasKey('htmlDelta', $component->effects);
+        $this->assertSame('chunks', $render['mode']);
+        $this->assertSame($target, app(StatelessHtmlChunks::class)->apply($base, $render['ops']));
+        $this->assertSame(hash('sha256', $target), $render['target']);
     }
 
-    public function test_delta_engine_falls_back_to_full_html_when_the_store_is_unavailable()
+    public function test_v1_transport_replaces_explicit_fragments_without_server_memory()
     {
-        config()->set('livewire.delta.minimum_html_bytes', 0);
+        config()->set('livewire.delta.cache_accelerator', false);
 
-        $deltas = new HtmlDelta;
-        $engine = new DeltaUpdateEngine(new UnavailableRenderStateStore, $deltas);
-        $component = new DeltaCounter;
-        $component->setId('component-id');
-        $context = new ComponentContext($component);
-        $previousHtml = '<div>Count: 1</div>';
-        $previousHash = $deltas->hash($previousHtml);
+        $marker = 'type=transport|name=counter|token=0123456789abcdef|mode=morph';
+        $open = '<!--[if FRAGMENT:'.$marker.']><![endif]-->';
+        $close = '<!--[if ENDFRAGMENT:'.$marker.']><![endif]-->';
+        $stable = str_repeat('<p>stable-content</p>', 1000);
+        $base = '<main>'.$stable.$open.'old'.$close.$stable.'</main>';
+        $target = '<main>'.$stable.$open.'new'.$close.$stable.'</main>';
+        $manifest = app(RenderFragmentTree::class)->manifest($base);
 
-        $engine->update(
-            $component,
-            '<div>Count: 2</div>',
-            ['delta' => ['revision' => 1, 'hash' => $previousHash]],
-            $context,
-            ['htmlHash' => $previousHash],
-        );
+        $response = $this->encodeRender($target, $this->metadata($base, ['fragments']) + [
+            'fragments' => $manifest,
+        ]);
+        $render = $response['effects']['render'];
 
-        $this->assertSame('<div>Count: 2</div>', $context->effects['html']);
-        $this->assertArrayNotHasKey('htmlDelta', $context->effects);
+        $this->assertSame('fragments', $render['mode']);
+        $this->assertSame([['0123456789abcdef', 'new']], $render['ops']);
+        $this->assertSame($target, app(RenderFragmentTree::class)->apply($base, $render['ops']));
     }
 
-    public function test_cache_store_only_retains_the_latest_render_for_a_component()
+    public function test_configured_manifest_limits_silently_fall_back_to_full_html()
     {
-        config()->set('livewire.delta.store', 'array');
+        config()->set('livewire.delta.cache_accelerator', false);
 
+        $base = '<main>'.str_repeat('stable-content-', 1000).'<b>old</b></main>';
+        $target = str_replace('<b>old</b>', '<b>new</b>', $base);
+        $blockSize = 256;
+        $chunks = [
+            'blockSize' => $blockSize,
+            'blocks' => app(StatelessHtmlChunks::class)->manifest($base, $blockSize),
+        ];
+
+        config()->set('livewire.delta.maximum_manifest_bytes', 0);
+
+        $chunkResponse = $this->encodeRender(
+            $target,
+            $this->metadata($base, ['chunks']) + ['chunks' => $chunks],
+        );
+
+        $this->assertSame('full', $chunkResponse['effects']['render']['mode']);
+        $this->assertSame($target, $chunkResponse['effects']['html']);
+
+        $marker = 'type=transport|name=counter|token=0123456789abcdef|mode=morph';
+        $open = '<!--[if FRAGMENT:'.$marker.']><![endif]-->';
+        $close = '<!--[if ENDFRAGMENT:'.$marker.']><![endif]-->';
+        $fragmentBase = '<main>'.str_repeat('stable-', 1000).$open.'old'.$close.'</main>';
+        $fragmentTarget = str_replace('old', 'new', $fragmentBase);
+
+        config()->set('livewire.delta.maximum_fragments', 0);
+
+        $fragmentResponse = $this->encodeRender(
+            $fragmentTarget,
+            $this->metadata($fragmentBase, ['fragments']) + [
+                'fragments' => app(RenderFragmentTree::class)->manifest($fragmentBase),
+            ],
+        );
+
+        $this->assertSame('full', $fragmentResponse['effects']['render']['mode']);
+        $this->assertSame($fragmentTarget, $fragmentResponse['effects']['html']);
+    }
+
+    public function test_full_fallback_statistics_include_the_manifest_request_cost()
+    {
+        config()->set('livewire.delta.cache_accelerator', false);
+
+        $marker = 'type=transport|name=counter|token=0123456789abcdef|mode=morph';
+        $open = '<!--[if FRAGMENT:'.$marker.']><![endif]-->';
+        $close = '<!--[if ENDFRAGMENT:'.$marker.']><![endif]-->';
+        $base = '<main>'.str_repeat('stable-', 1000).$open.'old'.$close.'</main>';
+        $target = '<section>'.str_repeat('different-', 1000).$open.'new'.$close.'</section>';
+        $response = $this->encodeRender(
+            $target,
+            $this->metadata($base, ['fragments']) + [
+                'fragments' => app(RenderFragmentTree::class)->manifest($base),
+            ],
+        );
+        $render = $response['effects']['render'];
+
+        $this->assertSame('full', $render['mode']);
+        $this->assertGreaterThan($render['stats']['full'], $render['stats']['selected']);
+    }
+
+    public function test_snapshot_delta_is_verified_and_reversible()
+    {
+        config()->set('livewire.delta.snapshot_references', false);
+
+        $previous = json_encode(['data' => ['body' => str_repeat('stable-', 2000), 'count' => 1]], JSON_THROW_ON_ERROR);
+        $target = json_encode(['data' => ['body' => str_repeat('stable-', 2000), 'count' => 2]], JSON_THROW_ON_ERROR);
+        $response = $this->encodeRender('<div>ok</div>', [
+            'v' => 1,
+            'capabilities' => ['snapshot-delta'],
+        ], $previous, $target);
+
+        $this->assertArrayNotHasKey('snapshot', $response);
+        $this->assertSame(1, $response['snapshotDelta']['v']);
+        $this->assertSame(hash('sha256', $previous), $response['snapshotDelta']['base']);
+
+        $reconstructed = app(HtmlDelta::class)->apply($previous, $response['snapshotDelta']['patches']);
+
+        $this->assertSame($target, $reconstructed);
+        $this->assertSame(hash('sha256', $reconstructed), $response['snapshotDelta']['target']);
+        $this->assertSame(strlen($reconstructed), $response['snapshotDelta']['bytes']);
+    }
+
+    public function test_snapshot_references_keep_the_full_snapshot_as_a_client_fallback()
+    {
+        config()->set('livewire.delta.snapshot_delta', false);
+
+        $snapshot = json_encode(['data' => ['count' => 2]], JSON_THROW_ON_ERROR);
+        $response = $this->encodeRender('<div>ok</div>', [
+            'v' => 1,
+            'capabilities' => ['snapshot-ref'],
+        ], '{}', $snapshot);
+
+        $this->assertSame($snapshot, $response['snapshot']);
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9_-]{24}$/', $response['snapshotRef']);
+        $this->assertSame(
+            $snapshot,
+            app(SnapshotStateStore::class)->get($response['snapshotRef'], 'component-id'),
+        );
+    }
+
+    public function test_snapshot_references_are_not_issued_when_a_full_retry_would_exceed_the_safe_payload_budget()
+    {
+        config()->set('livewire.delta.snapshot_delta', false);
+        config()->set('livewire.payload.max_size', 1024);
+
+        $snapshot = json_encode([
+            'data' => str_repeat('A', 600),
+        ], JSON_THROW_ON_ERROR);
+        $response = $this->encodeRender('<div>ok</div>', [
+            'v' => 1,
+            'capabilities' => ['snapshot-ref'],
+        ], '{}', $snapshot);
+
+        $this->assertGreaterThan(512, strlen($snapshot));
+        $this->assertSame($snapshot, $response['snapshot']);
+        $this->assertArrayNotHasKey('snapshotRef', $response);
+    }
+
+    #[DataProvider('persistentCacheStores')]
+    public function test_render_and_snapshot_state_work_with_memory_and_file_cache_stores(string $storeName)
+    {
+        config()->set('livewire.delta.store', $storeName);
+        config()->set('livewire.delta.snapshot_store', $storeName);
+
+        $componentId = 'component-'.str()->random(12);
+        $html = '<div>'.str_repeat('cacheable-', 1000).'</div>';
+        $hash = hash('sha256', $html);
+        $snapshot = json_encode(['memo' => ['id' => $componentId], 'data' => ['value' => 1]], JSON_THROW_ON_ERROR);
+
+        app(RenderStateStore::class)->put($componentId, $hash, $html);
+        $reference = app(SnapshotStateStore::class)->put($componentId, $snapshot);
+
+        $this->assertSame($html, app(RenderStateStore::class)->get($componentId, $hash));
+        $this->assertSame($snapshot, app(SnapshotStateStore::class)->get($reference, $componentId));
+        $this->assertNull(app(SnapshotStateStore::class)->get($reference, 'another-component'));
+        $this->assertSame($snapshot, app(SnapshotStateStore::class)->get($reference, $componentId));
+    }
+
+    public static function persistentCacheStores(): array
+    {
+        return [
+            'memory' => ['array'],
+            'file' => ['file'],
+        ];
+    }
+
+    public function test_render_cache_preserves_concurrent_immutable_baselines()
+    {
         $store = app(RenderStateStore::class);
+        $first = '<div>First</div>';
+        $second = '<div>Second</div>';
+        $firstHash = hash('sha256', $first);
+        $secondHash = hash('sha256', $second);
 
-        $store->put('component-id', 'first-hash', '<div>First</div>');
-        $store->put('component-id', 'second-hash', '<div>Second</div>');
+        $store->put('component-id', $firstHash, $first);
+        $store->put('component-id', $secondHash, $second);
 
-        $this->assertNull($store->get('component-id', 'first-hash'));
-        $this->assertSame('<div>Second</div>', $store->get('component-id', 'second-hash'));
+        $this->assertSame($first, $store->get('component-id', $firstHash));
+        $this->assertSame($second, $store->get('component-id', $secondHash));
     }
 
-    public function test_cache_store_rejects_rendered_html_that_does_not_match_its_hash()
+    public function test_render_cache_rejects_and_forgets_tampered_content()
     {
-        config()->set('livewire.delta.store', 'array');
-
         $html = '<div>Original render</div>';
-        $hash = app(HtmlDelta::class)->hash($html);
-        $key = 'livewire:delta:component-id';
+        $hash = hash('sha256', $html);
+        $key = 'livewire:render:'.hash('sha256', 'component-id'."\0".$hash);
 
         Cache::store('array')->put($key, [
             'hash' => $hash,
-            'html' => '<div>Tampered render</div>',
+            'bytes' => strlen($html),
+            'encoding' => 'identity',
+            'payload' => '<div>Tampered render</div>',
         ], 300);
 
         $this->assertNull(app(RenderStateStore::class)->get('component-id', $hash));
         $this->assertFalse(Cache::store('array')->has($key));
     }
 
-    public function test_renderless_updates_preserve_the_last_render_baseline()
+    public function test_testable_livewire_materializes_same_and_snapshot_delta_responses()
     {
-        config()->set('livewire.update_engine', 'delta');
-        config()->set('livewire.delta.store', 'array');
-        config()->set('livewire.delta.minimum_html_bytes', 0);
-        config()->set('livewire.delta.minimum_compressed_savings_bytes', 0);
-
         $component = Livewire::test(DeltaCounter::class)
             ->call('increment')
-            ->call('incrementRenderless')
+            ->commit()
             ->assertSee('Count: 1');
+
+        $this->assertSame('same', $component->effects['render']['mode']);
+        $this->assertArrayHasKey('html', $component->effects);
+        $component->assertJsonPath('components.0.snapshotDelta.v', 1);
+        $this->assertSame(1, $component->get('count'));
+    }
+
+    public function test_testable_livewire_materializes_stateless_chunk_responses()
+    {
+        config()->set('livewire.delta.cache_accelerator', false);
+
+        $component = Livewire::test(new class extends Component {
+            public int $count = 0;
+
+            public function increment(): void
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return '<div><b>Count: {{ $count }}</b>'.str_repeat('<span>stable-content</span>', 2000).'</div>';
+            }
+        });
+
+        $component->call('increment');
+        $component->call('increment')->assertSee('Count: 2');
+
+        $this->assertSame('chunks', $component->effects['render']['mode']);
+        $this->assertArrayHasKey('html', $component->effects);
+        $this->assertSame(2, $component->get('count'));
+    }
+
+    public function test_testable_livewire_materializes_explicit_fragment_responses()
+    {
+        config()->set('livewire.delta.cache_accelerator', false);
+
+        $component = Livewire::test(new class extends Component {
+            public int $count = 0;
+
+            public function increment(): void
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <main>
+                    {{ str_repeat('stable-content-', 2000) }}
+                    @fragment('counter')
+                        <b>Count: {{ $count }}</b>
+                    @endfragment
+                </main>
+                HTML;
+            }
+        });
+
+        $component->call('increment');
+        $component->call('increment')->assertSee('Count: 2');
+
+        $this->assertSame('fragments', $component->effects['render']['mode']);
+        $this->assertArrayHasKey('html', $component->effects);
+    }
+
+    public function test_renderless_updates_preserve_the_last_render_baseline()
+    {
+        $component = Livewire::test(DeltaCounter::class)
+            ->call('increment')
+            ->call('increment')
+            ->call('incrementRenderless')
+            ->assertSee('Count: 2');
 
         $this->assertArrayNotHasKey('html', $component->effects);
         $this->assertArrayNotHasKey('htmlDelta', $component->effects);
 
-        $component->call('increment')->assertSee('Count: 3');
+        $component->call('increment')->assertSee('Count: 4');
 
-        $this->assertArrayHasKey('htmlDelta', $component->effects);
+        $this->assertArrayHasKey('render', $component->effects);
+        $this->assertSame('splice', $component->effects['render']['mode']);
     }
 
     public function test_morph_remains_the_default_update_engine()
     {
-        $component = Livewire::test(DeltaCounter::class)
+        config()->set('livewire.update_engine', 'morph');
+
+        $component = Livewire::test(DeltaCounter::class);
+
+        $this->assertArrayNotHasKey('renderTransport', $component->effects);
+
+        $component
             ->call('increment')
             ->call('increment');
 
         $this->assertArrayHasKey('html', $component->effects);
-        $this->assertArrayNotHasKey('htmlDelta', $component->effects);
+        $this->assertArrayNotHasKey('render', $component->effects);
+    }
+
+    protected function metadata(string $html, array $capabilities): array
+    {
+        return [
+            'v' => 1,
+            'capabilities' => $capabilities,
+            'base' => [
+                'hash' => hash('sha256', $html),
+                'bytes' => strlen($html),
+                'revision' => 1,
+            ],
+        ];
+    }
+
+    protected function encodeRender(
+        string $html,
+        array $metadata,
+        string $previousSnapshot = '{}',
+        string $snapshot = '{}',
+    ): array {
+        $payload = [
+            'components' => [[
+                'id' => 'component-id',
+                'snapshot' => $snapshot,
+                'effects' => ['html' => $html],
+            ]],
+        ];
+        $contexts = [
+            'component-id' => [
+                'snapshot' => $previousSnapshot,
+                'render' => $metadata,
+            ],
+        ];
+
+        return app(ResponseTransport::class)->encode($payload, $contexts)['components'][0];
     }
 }
 
@@ -446,45 +605,5 @@ class DeltaCounter extends Component
     public function render()
     {
         return '<div>Count: {{ $count }}'.str_repeat('<span>stable</span>', 100).'</div>';
-    }
-}
-
-class UnavailableRenderStateStore implements RenderStateStore
-{
-    public function get(string $componentId, string $hash): ?string
-    {
-        throw new \RuntimeException('Render state store unavailable.');
-    }
-
-    public function put(string $componentId, string $hash, string $html): void
-    {
-        throw new \RuntimeException('Render state store unavailable.');
-    }
-}
-
-class TrackingRenderStateStore implements RenderStateStore
-{
-    public int $getCalls = 0;
-
-    public int $putCalls = 0;
-
-    public function get(string $componentId, string $hash): ?string
-    {
-        $this->getCalls++;
-
-        return null;
-    }
-
-    public function put(string $componentId, string $hash, string $html): void
-    {
-        $this->putCalls++;
-    }
-}
-
-class InspectableDeltaUpdateEngine extends DeltaUpdateEngine
-{
-    public function canSendDelta(array $effect, string $html, string $hash): bool
-    {
-        return $this->shouldSendDelta($effect, $html, $hash);
     }
 }

--- a/src/Mechanisms/HandleComponents/UpdateEngines/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/UnitTest.php
@@ -46,8 +46,8 @@ class UnitTest extends \Tests\TestCase
     public function test_it_preserves_unicode_when_a_delta_boundary_is_inside_a_multibyte_character()
     {
         $delta = new HtmlDelta;
-        $from = '<div>foo 👋 — bar</div>';
-        $to = '<div>foo 🚀 — baz</div>';
+        $from = '<div>д字 👋 — ж世</div>';
+        $to = '<div>д字 🚀 — з本</div>';
 
         $patches = $delta->encode($from, $to);
 

--- a/src/Mechanisms/HandleComponents/UpdateEngines/UpdateEngine.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/UpdateEngine.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+use Livewire\Component;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+
+interface UpdateEngine
+{
+    public function mount(Component $component, string $html, ComponentContext $context): void;
+
+    public function update(
+        Component $component,
+        ?string $html,
+        array $memo,
+        ComponentContext $context,
+        array $renderMetadata = [],
+    ): void;
+}

--- a/src/Mechanisms/HandleComponents/UpdateEngines/UpdateEngineManager.php
+++ b/src/Mechanisms/HandleComponents/UpdateEngines/UpdateEngineManager.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\UpdateEngines;
+
+use Illuminate\Contracts\Container\Container;
+
+class UpdateEngineManager
+{
+    public function __construct(protected Container $container) {}
+
+    public function current(): UpdateEngine
+    {
+        return match (config('livewire.update_engine', 'morph')) {
+            'morph' => $this->container->make(MorphUpdateEngine::class),
+            'delta' => $this->container->make(DeltaUpdateEngine::class),
+            default => throw new \InvalidArgumentException(
+                'Invalid Livewire update engine. Supported engines: [morph], [delta].'
+            ),
+        };
+    }
+}

--- a/src/Mechanisms/HandleRequests/CacheSnapshotStateStore.php
+++ b/src/Mechanisms/HandleRequests/CacheSnapshotStateStore.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleRequests;
+
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\Repository;
+
+class CacheSnapshotStateStore implements SnapshotStateStore
+{
+    protected const MAX_SNAPSHOT_BYTES = 134217728;
+
+    public function __construct(protected CacheFactory $cache) {}
+
+    public function get(string $reference, string $componentId): ?string
+    {
+        if (! preg_match('/\A[A-Za-z0-9_-]{24}\z/', $reference)) return null;
+
+        $repository = $this->repository();
+        $key = $this->key($reference);
+        $state = $repository->get($key);
+
+        if ($state === null) return null;
+
+        if (! is_array($state)
+            || ! is_string($state['id'] ?? null)
+            || ! is_string($state['hash'] ?? null)
+        ) {
+            $repository->forget($key);
+
+            return null;
+        }
+
+        // A reference is scoped to its component, but a mismatched claimant
+        // must not be able to evict otherwise valid state.
+        if (! hash_equals($state['id'], $componentId)) return null;
+
+        // Accept references minted immediately before a rolling deployment of
+        // the compressed store format.
+        if (is_string($state['snapshot'] ?? null)) {
+            $snapshot = $state['snapshot'];
+        } elseif (is_int($state['bytes'] ?? null)
+            && $state['bytes'] >= 0
+            && $state['bytes'] <= $this->maximumBytes()
+            && is_string($state['payload'] ?? null)
+            && is_string($state['encoding'] ?? null)
+        ) {
+            $snapshot = $this->decode(
+                $state['payload'],
+                $state['encoding'],
+                $state['bytes'],
+            );
+        } else {
+            $snapshot = null;
+        }
+
+        if (! is_string($snapshot)
+            || strlen($snapshot) > $this->maximumBytes()
+            || (isset($state['bytes']) && $state['bytes'] !== strlen($snapshot))
+            || ! hash_equals($state['hash'], hash('sha256', $snapshot))
+        ) {
+            $repository->forget($key);
+
+            return null;
+        }
+
+        return $snapshot;
+    }
+
+    public function put(string $componentId, string $snapshot): ?string
+    {
+        $bytes = strlen($snapshot);
+
+        if ($bytes > $this->maximumBytes()) return null;
+
+        $reference = rtrim(strtr(base64_encode(random_bytes(18)), '+/', '-_'), '=');
+        [$payload, $encoding] = $this->encode($snapshot);
+
+        $stored = $this->repository()->put(
+            $this->key($reference),
+            [
+                'id' => $componentId,
+                'hash' => hash('sha256', $snapshot),
+                'bytes' => $bytes,
+                'encoding' => $encoding,
+                'payload' => $payload,
+            ],
+            max(1, (int) config('livewire.delta.snapshot_reference_ttl', 300)),
+        );
+
+        return $stored === false ? null : $reference;
+    }
+
+    protected function repository(): Repository
+    {
+        $store = config('livewire.delta.snapshot_store')
+            ?: config('livewire.delta.store');
+
+        return $store
+            ? $this->cache->store($store)
+            : $this->cache->store();
+    }
+
+    protected function key(string $reference): string
+    {
+        return "livewire:snapshot:{$reference}";
+    }
+
+    protected function encode(string $snapshot): array
+    {
+        if (! function_exists('gzencode')) return [$snapshot, 'identity'];
+
+        $compressed = gzencode($snapshot, 1);
+
+        if (! is_string($compressed) || strlen($compressed) >= strlen($snapshot)) {
+            return [$snapshot, 'identity'];
+        }
+
+        return [$compressed, 'gzip'];
+    }
+
+    protected function decode(string $payload, string $encoding, int $bytes): ?string
+    {
+        if ($encoding === 'identity') return $payload;
+
+        if ($encoding !== 'gzip' || ! function_exists('gzdecode')) return null;
+
+        $snapshot = @gzdecode($payload, $bytes + 1);
+
+        return is_string($snapshot) ? $snapshot : null;
+    }
+
+    protected function maximumBytes(): int
+    {
+        return min(
+            self::MAX_SNAPSHOT_BYTES,
+            max(0, (int) config('livewire.delta.maximum_snapshot_bytes', 4194304)),
+        );
+    }
+}

--- a/src/Mechanisms/HandleRequests/DecodeGzipRequests.php
+++ b/src/Mechanisms/HandleRequests/DecodeGzipRequests.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleRequests;
+
+use Closure;
+use Illuminate\Http\Request;
+use Livewire\Exceptions\PayloadTooLargeException;
+use Symfony\Component\HttpFoundation\InputBag;
+
+class DecodeGzipRequests
+{
+    public const PAYLOAD_ATTRIBUTE = '_livewire_gzip_payload';
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        // This middleware is registered globally and retained on the update
+        // route as a fallback. Only decode once when both registrations run.
+        if ($request->attributes->has(self::PAYLOAD_ATTRIBUTE)) {
+            return $next($request);
+        }
+
+        if (! $request->hasHeader('X-Livewire') || ! $request->isJson()) {
+            return $next($request);
+        }
+
+        $encoding = strtolower(trim((string) $request->header('Content-Encoding', '')));
+
+        if ($encoding === '' || $encoding === 'identity') return $next($request);
+
+        if ($encoding !== 'gzip') abort(415);
+
+        $payload = $this->decodePayload($request);
+
+        $request->attributes->set(self::PAYLOAD_ATTRIBUTE, true);
+        $request->setJson(new InputBag($payload));
+
+        return $next($request);
+    }
+
+    public function decodePayload(Request $request): array
+    {
+        if (! function_exists('gzdecode')) abort(415);
+
+        $maximumBytes = config('livewire.payload.max_size');
+        $maximumBytes = $maximumBytes === null
+            ? null
+            : max(0, (int) $maximumBytes);
+        $content = $request->getContent();
+        $actualContentLength = strlen($content);
+        $declaredContentLength = filter_var(
+            $request->header('Content-Length'),
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 0]],
+        );
+        $contentLength = max(
+            $actualContentLength,
+            $declaredContentLength === false ? 0 : $declaredContentLength,
+        );
+
+        if ($maximumBytes !== null && $contentLength > $maximumBytes) {
+            throw new PayloadTooLargeException($contentLength, $maximumBytes);
+        }
+
+        $declaredDecodedLength = $this->decodedLength($content);
+
+        if ($maximumBytes !== null
+            && $declaredDecodedLength !== null
+            && $declaredDecodedLength > $maximumBytes
+        ) {
+            throw new PayloadTooLargeException($declaredDecodedLength, $maximumBytes);
+        }
+
+        $decodeLimit = $maximumBytes === null || $maximumBytes === PHP_INT_MAX
+            ? 0
+            : $maximumBytes + 1;
+        $decoded = @gzdecode($content, $decodeLimit);
+
+        if (! is_string($decoded)) abort(400);
+
+        if ($maximumBytes !== null && strlen($decoded) > $maximumBytes) {
+            throw new PayloadTooLargeException(strlen($decoded), $maximumBytes);
+        }
+
+        try {
+            $payload = json_decode($decoded, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            abort(400);
+        }
+
+        if (! is_array($payload)) abort(400);
+
+        return $payload;
+    }
+
+    protected function decodedLength(string $content): ?int
+    {
+        // RFC 1952 stores the uncompressed size modulo 2^32 in the trailer.
+        if (strlen($content) < 18
+            || substr($content, 0, 2) !== "\x1f\x8b"
+            || ord($content[2]) !== 8
+        ) {
+            return null;
+        }
+
+        $trailer = unpack('Vlength', substr($content, -4));
+
+        return is_array($trailer) ? $trailer['length'] : null;
+    }
+}

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -167,6 +167,8 @@ class HandleRequests extends Mechanism
                 || ! is_string($component['snapshot'] ?? null)
                 || ! is_array($component['updates'] ?? null)
                 || ! is_array($component['calls'] ?? null)
+                || (array_key_exists('render', $component) && ! is_array($component['render']))
+                || (isset($component['render']['htmlHash']) && ! is_string($component['render']['htmlHash']))
             ) {
                 abort(404);
             }
@@ -189,6 +191,7 @@ class HandleRequests extends Mechanism
             $snapshot = json_decode($componentPayload['snapshot'], associative: true);
             $updates = $componentPayload['updates'];
             $calls = $componentPayload['calls'];
+            $renderMetadata = $componentPayload['render'] ?? [];
 
             // If this is a reactive child whose props didn't change,
             // skip its entire lifecycle (hydrate, render, dehydrate)...
@@ -202,7 +205,7 @@ class HandleRequests extends Mechanism
             }
 
             try {
-                [ $snapshot, $effects ] = app('livewire')->update($snapshot, $updates, $calls);
+                [ $snapshot, $effects ] = app('livewire')->update($snapshot, $updates, $calls, $renderMetadata);
             } catch (\TypeError $e) {
                 report($e);
 

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -3,12 +3,15 @@
 namespace Livewire\Mechanisms\HandleRequests;
 
 use Illuminate\Http\Response;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Support\Facades\Route;
 use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
 use Livewire\Features\SupportReactiveProps\SupportReactiveProps;
+use Livewire\Mechanisms\HandleComponents\UpdateEngines\ResponseTransport;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
 use Livewire\Exceptions\PayloadTooLargeException;
 use Livewire\Exceptions\TooManyComponentsException;
+use Symfony\Component\HttpFoundation\InputBag;
 
 use Livewire\Mechanisms\Mechanism;
 
@@ -20,12 +23,25 @@ class HandleRequests extends Mechanism
 
     function boot()
     {
+        // Compressed JSON has to be decoded before every other global
+        // middleware so auth, tenancy, logging, and user middleware can inspect
+        // the same request input that the Livewire controller will execute.
+        $kernel = app()->make(HttpKernel::class);
+
+        if (! $kernel->hasMiddleware(DecodeGzipRequests::class)) {
+            $kernel->prependMiddleware(DecodeGzipRequests::class);
+        }
+
         // Register the default route immediately (before routes files load)
         // so it's positioned before any catch-all routes.
         if (! $this->updateRoute && ! $this->updateRouteExists()) {
             app($this::class)->setUpdateRoute(function ($handle, $path) {
                 return Route::post($path, $handle)
-                    ->middleware(['web', RequireLivewireHeaders::class])
+                    ->middleware([
+                        DecodeGzipRequests::class,
+                        'web',
+                        RequireLivewireHeaders::class,
+                    ])
                     ->name('default-livewire.update');
             });
         }
@@ -92,6 +108,8 @@ class HandleRequests extends Mechanism
     {
         $route = $callback([self::class, 'handleUpdate'], EndpointResolver::updatePath());
 
+        $this->prependMiddleware($route, DecodeGzipRequests::class);
+
         // Ensure the route includes the `web` middleware group.
         // Without it, CSRF protection is lost entirely on the update endpoint.
         // Note: we use middleware() (not gatherMiddleware()) to avoid polluting
@@ -112,6 +130,18 @@ class HandleRequests extends Mechanism
         }
 
         $this->updateRoute = $route;
+    }
+
+    protected function prependMiddleware($route, string $middleware): void
+    {
+        $middlewareStack = $route->middleware();
+
+        if (in_array($middleware, $middlewareStack, true)) return;
+
+        $action = $route->getAction();
+        $action['middleware'] = [$middleware, ...$middlewareStack];
+        $route->setAction($action);
+        $route->computedMiddleware = null;
     }
 
     function isLivewireRequest()
@@ -145,41 +175,42 @@ class HandleRequests extends Mechanism
             abort(404);
         }
 
-        // Check payload size limit...
-        $maxSize = config('livewire.payload.max_size');
-
-        if ($maxSize !== null) {
-            $contentLength = request()->header('Content-Length', 0);
-
-            if ($contentLength > $maxSize) {
-                throw new PayloadTooLargeException($contentLength, $maxSize);
-            }
-        }
-
-        $requestPayload = request('components');
+        $requestPayload = $this->extractRequestPayload();
 
         if (! is_array($requestPayload) || empty($requestPayload)) {
             abort(404);
         }
 
-        foreach ($requestPayload as $component) {
-            if (! is_array($component)
-                || ! is_string($component['snapshot'] ?? null)
-                || ! is_array($component['updates'] ?? null)
-                || ! is_array($component['calls'] ?? null)
-                || (array_key_exists('render', $component) && ! is_array($component['render']))
-                || (isset($component['render']['htmlHash']) && ! is_string($component['render']['htmlHash']))
-            ) {
-                abort(404);
-            }
-        }
-
-        // Check max components limit...
+        // Reject oversized batches before validating individual components or
+        // touching optional external state stores.
         $maxComponents = config('livewire.payload.max_components');
 
         if ($maxComponents !== null && count($requestPayload) > $maxComponents) {
             throw new TooManyComponentsException(count($requestPayload), $maxComponents);
         }
+
+        foreach ($requestPayload as $component) {
+            if (! $this->isValidComponentPayload($component)) {
+                abort(404);
+            }
+        }
+
+        $missingSnapshots = $this->resolveSnapshotReferences($requestPayload);
+
+        if ($missingSnapshots) {
+            return response()->json(
+                ['snapshotMissing' => $missingSnapshots],
+                409,
+                ['X-Livewire-Snapshot-Missing' => '1'],
+            );
+        }
+
+        // Capture immutable wire baselines before request hooks can normalize
+        // or otherwise mutate the payload used by the component lifecycle.
+        $usesResponseTransport = $this->usesResponseTransport();
+        $transportContexts = $usesResponseTransport
+            ? $this->captureTransportContexts($requestPayload)
+            : [];
 
         $finish = trigger('request', $requestPayload);
 
@@ -188,7 +219,16 @@ class HandleRequests extends Mechanism
         $componentResponses = [];
 
         foreach ($requestPayload as $componentPayload) {
-            $snapshot = json_decode($componentPayload['snapshot'], associative: true);
+            try {
+                $snapshot = json_decode(
+                    $componentPayload['snapshot'],
+                    associative: true,
+                    flags: JSON_THROW_ON_ERROR,
+                );
+            } catch (\JsonException) {
+                abort(404);
+            }
+
             $updates = $componentPayload['updates'];
             $calls = $componentPayload['calls'];
             $renderMetadata = $componentPayload['render'] ?? [];
@@ -214,10 +254,16 @@ class HandleRequests extends Mechanism
                 abort(419);
             }
 
-            $componentResponses[] = [
+            $componentResponse = [
                 'snapshot' => json_encode($snapshot, JSON_THROW_ON_ERROR),
                 'effects' => $effects,
             ];
+
+            if ($usesResponseTransport) {
+                $componentResponse = ['id' => $snapshot['memo']['id']] + $componentResponse;
+            }
+
+            $componentResponses[] = $componentResponse;
         }
 
         $responsePayload = [
@@ -228,6 +274,10 @@ class HandleRequests extends Mechanism
         $finish = trigger('response', $responsePayload);
 
         $payload = $finish($responsePayload);
+
+        if ($usesResponseTransport) {
+            $payload = app(ResponseTransport::class)->encode($payload, $transportContexts);
+        }
 
         // When wire:stream is used, headers are sent early by SupportStreaming::ensureStreamResponseStarted().
         // The streaming content has already been output via echo/flush in SupportStreaming::streamContent().
@@ -245,5 +295,229 @@ class HandleRequests extends Mechanism
         }
 
         return $payload;
+    }
+
+    protected function extractRequestPayload(): mixed
+    {
+        if (request()->attributes->has(DecodeGzipRequests::PAYLOAD_ATTRIBUTE)) {
+            // Always read the current input bag. Middleware running after the
+            // decoder is allowed to merge or replace the component payload.
+            return request('components');
+        }
+
+        $configuredMaxSize = config('livewire.payload.max_size');
+        $maxSize = $configuredMaxSize === null
+            ? null
+            : max(0, (int) $configuredMaxSize);
+        $content = request()->getContent();
+        $actualContentLength = strlen($content);
+        $declaredContentLength = filter_var(
+            request()->header('Content-Length'),
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 0]],
+        );
+        $contentLength = max(
+            $actualContentLength,
+            $declaredContentLength === false ? 0 : $declaredContentLength,
+        );
+
+        if ($maxSize !== null && $contentLength > $maxSize) {
+            throw new PayloadTooLargeException($contentLength, $maxSize);
+        }
+
+        $encoding = strtolower(trim((string) request()->header('Content-Encoding', '')));
+
+        if ($encoding === '' || $encoding === 'identity') return request('components');
+
+        if ($encoding !== 'gzip') abort(415);
+
+        $payload = app(DecodeGzipRequests::class)->decodePayload(request());
+        request()->attributes->set(DecodeGzipRequests::PAYLOAD_ATTRIBUTE, true);
+        request()->setJson(new InputBag($payload));
+
+        return request('components');
+    }
+
+    protected function isValidComponentPayload(mixed $component): bool
+    {
+        if (! is_array($component)
+            || ! is_array($component['updates'] ?? null)
+            || ! is_array($component['calls'] ?? null)
+        ) {
+            return false;
+        }
+
+        $hasSnapshot = is_string($component['snapshot'] ?? null);
+        $hasSnapshotReference = is_string($component['snapshotRef'] ?? null)
+            && is_string($component['id'] ?? null)
+            && strlen($component['id']) >= 1
+            && strlen($component['id']) <= 255
+            && preg_match('/\A[A-Za-z0-9_-]{24}\z/', $component['snapshotRef']) === 1;
+
+        if (! $hasSnapshot && ! $hasSnapshotReference) return false;
+
+        if (! array_key_exists('render', $component)) return true;
+
+        return $this->isValidRenderMetadata($component['render']);
+    }
+
+    protected function isValidRenderMetadata(mixed $metadata): bool
+    {
+        if (! is_array($metadata)) return false;
+
+        if ($metadata === []) return true;
+
+        // Accept the first experimental client's legacy metadata during rolling upgrades.
+        if (array_key_exists('htmlHash', $metadata)) {
+            return is_string($metadata['htmlHash'])
+                && preg_match('/\A[a-f0-9]{64}\z/', $metadata['htmlHash']) === 1;
+        }
+
+        if (($metadata['v'] ?? null) !== 1) return false;
+
+        $capabilities = $metadata['capabilities'] ?? [];
+
+        if (! is_array($capabilities)
+            || ! array_is_list($capabilities)
+            || count($capabilities) > 12
+            || count($capabilities) !== count(array_unique($capabilities, SORT_REGULAR))
+        ) {
+            return false;
+        }
+
+        $allowed = ['same', 'splice', 'chunks', 'fragments', 'snapshot-delta', 'snapshot-ref'];
+
+        foreach ($capabilities as $capability) {
+            if (! is_string($capability) || ! in_array($capability, $allowed, true)) return false;
+        }
+
+        if (isset($metadata['base'])) {
+            $base = $metadata['base'];
+
+            if (! is_array($base)
+                || ! is_string($base['hash'] ?? null)
+                || preg_match('/\A[a-f0-9]{64}\z/', $base['hash']) !== 1
+                || ! is_int($base['bytes'] ?? null)
+                || $base['bytes'] < 0
+                || ! is_int($base['revision'] ?? null)
+                || $base['revision'] < 0
+            ) {
+                return false;
+            }
+        }
+
+        if (isset($metadata['chunks'])) {
+            $chunks = $metadata['chunks'];
+
+            if (! is_array($chunks)
+                || ! is_int($chunks['blockSize'] ?? null)
+                || $chunks['blockSize'] < 256
+                || $chunks['blockSize'] > 65536
+                || ! is_string($chunks['blocks'] ?? null)
+                || strlen($chunks['blocks']) > 65536
+            ) {
+                return false;
+            }
+        }
+
+        if (isset($metadata['fragments'])) {
+            $fragments = $metadata['fragments'];
+
+            if (! is_array($fragments)
+                || ! is_string($fragments['root'] ?? null)
+                || preg_match('/\A[a-f0-9]{16}\z/', $fragments['root']) !== 1
+                || ! is_array($fragments['nodes'] ?? null)
+                || count($fragments['nodes']) > 1024
+            ) {
+                return false;
+            }
+
+            foreach ($fragments['nodes'] as $node) {
+                if (! is_array($node)
+                    || count($node) !== 3
+                    || ! is_string($node[0] ?? null)
+                    || preg_match('/\A[a-f0-9]{16,64}\z/', $node[0]) !== 1
+                    || ! is_string($node[1] ?? null)
+                    || preg_match('/\A[a-f0-9]{16}\z/', $node[1]) !== 1
+                    || ! is_string($node[2] ?? null)
+                    || preg_match('/\A[a-f0-9]{16}\z/', $node[2]) !== 1
+                ) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    protected function resolveSnapshotReferences(array &$components): array
+    {
+        $missing = [];
+
+        foreach ($components as &$component) {
+            if (is_string($component['snapshot'] ?? null)) continue;
+
+            $reference = $component['snapshotRef'];
+            $componentId = $component['id'];
+
+            try {
+                $snapshot = app(SnapshotStateStore::class)->get($reference, $componentId);
+            } catch (\Throwable $e) {
+                report($e);
+
+                $snapshot = null;
+            }
+
+            if ($snapshot === null) {
+                $missing[] = $componentId;
+
+                continue;
+            }
+
+            $component['snapshot'] = $snapshot;
+        }
+
+        unset($component);
+
+        return $missing;
+    }
+
+    protected function captureTransportContexts(array $components): array
+    {
+        $contexts = [];
+
+        foreach ($components as $component) {
+            $snapshotEncoded = $component['snapshot'] ?? null;
+
+            if (! is_string($snapshotEncoded)) continue;
+
+            try {
+                $snapshot = json_decode(
+                    $snapshotEncoded,
+                    associative: true,
+                    flags: JSON_THROW_ON_ERROR,
+                );
+            } catch (\JsonException) {
+                continue;
+            }
+
+            $componentId = $snapshot['memo']['id'] ?? null;
+
+            if (! is_string($componentId)) continue;
+
+            $contexts[$componentId][] = [
+                'snapshot' => $snapshotEncoded,
+                'render' => is_array($component['render'] ?? null)
+                    ? $component['render']
+                    : [],
+            ];
+        }
+
+        return $contexts;
+    }
+
+    protected function usesResponseTransport(): bool
+    {
+        return config('livewire.update_engine', 'morph') === 'delta';
     }
 }

--- a/src/Mechanisms/HandleRequests/SnapshotStateStore.php
+++ b/src/Mechanisms/HandleRequests/SnapshotStateStore.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleRequests;
+
+interface SnapshotStateStore
+{
+    public function get(string $reference, string $componentId): ?string;
+
+    public function put(string $componentId, string $snapshot): ?string;
+}

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -1,12 +1,17 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Livewire\Livewire;
+use Livewire\Exceptions\PayloadTooLargeException;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
+use Livewire\Mechanisms\HandleRequests\DecodeGzipRequests;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
 use Livewire\Mechanisms\HandleRequests\RequireLivewireHeaders;
+use Livewire\Mechanisms\HandleRequests\SnapshotStateStore;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tests\TestComponent;
@@ -252,6 +257,10 @@ class UnitTest extends TestCase
 
         $this->assertCount(1, $livewireUpdateRoutes);
         $this->assertEquals(ltrim(EndpointResolver::updatePath(), '/'), $livewireUpdateRoutes->first()->uri());
+        $this->assertSame(
+            DecodeGzipRequests::class,
+            $livewireUpdateRoutes->first()->middleware()[0],
+        );
     }
 
     public function test_duplicate_route_is_not_registered_when_livewire_update_route_already_exists(): void
@@ -433,5 +442,467 @@ class UnitTest extends TestCase
         $uri = $handleRequests->getUpdateUri();
 
         $this->assertEquals(EndpointResolver::updatePath(), $uri);
+    }
+
+    public function test_update_endpoint_accepts_a_gzipped_json_request_body(): void
+    {
+        if (! function_exists('gzencode')) {
+            $this->markTestSkipped('The zlib extension is not available.');
+        }
+
+        $testable = Livewire::test(new class extends TestComponent {
+            public int $count = 0;
+
+            public function increment(): void
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return '<div>Count: {{ $count }}</div>';
+            }
+        });
+        $body = json_encode([
+            'components' => [[
+                'snapshot' => json_encode($testable->snapshot, JSON_THROW_ON_ERROR),
+                'updates' => [],
+                'calls' => [[
+                    'method' => 'increment',
+                    'params' => [],
+                    'metadata' => [],
+                ]],
+            ]],
+        ], JSON_THROW_ON_ERROR);
+        $route = collect(Route::getRoutes()->getRoutes())
+            ->first(fn ($route) => $route->getName() === 'default-livewire.update');
+
+        GzipPayloadProbe::$snapshot = null;
+        GlobalGzipPayloadProbe::$snapshot = null;
+        app(HttpKernel::class)->pushMiddleware(GlobalGzipPayloadProbe::class);
+        $route->middleware(GzipPayloadProbe::class);
+        $route->computedMiddleware = null;
+
+        $response = $this->call(
+            'POST',
+            EndpointResolver::updatePath(),
+            [],
+            [],
+            [],
+            $this->livewireJsonServerHeaders(['HTTP_CONTENT_ENCODING' => 'gzip']),
+            gzencode($body, 1),
+        );
+
+        $response->assertOk();
+        $this->assertSame(
+            json_encode($testable->snapshot, JSON_THROW_ON_ERROR),
+            GzipPayloadProbe::$snapshot,
+        );
+        $this->assertSame(
+            json_encode($testable->snapshot, JSON_THROW_ON_ERROR),
+            GlobalGzipPayloadProbe::$snapshot,
+        );
+        $this->assertStringContainsString('Count: 1', $response->json('components.0.effects.html'));
+    }
+
+    public function test_gzip_decoder_is_the_first_global_middleware(): void
+    {
+        $middleware = new ReflectionProperty(
+            \Illuminate\Foundation\Http\Kernel::class,
+            'middleware',
+        );
+
+        $this->assertSame(
+            DecodeGzipRequests::class,
+            $middleware->getValue(app(HttpKernel::class))[0] ?? null,
+        );
+    }
+
+    public function test_middleware_can_mutate_a_decoded_payload_before_execution(): void
+    {
+        if (! function_exists('gzencode')) {
+            $this->markTestSkipped('The zlib extension is not available.');
+        }
+
+        $testable = Livewire::test(new class extends TestComponent {
+            public int $count = 0;
+
+            public function original(): void
+            {
+                $this->count++;
+            }
+
+            public function mutated(): void
+            {
+                $this->count += 10;
+            }
+
+            public function render()
+            {
+                return '<div>Count: {{ $count }}</div>';
+            }
+        });
+        $body = json_encode([
+            'components' => [[
+                'snapshot' => json_encode($testable->snapshot, JSON_THROW_ON_ERROR),
+                'updates' => [],
+                'calls' => [[
+                    'method' => 'original',
+                    'params' => [],
+                    'metadata' => [],
+                ]],
+            ]],
+        ], JSON_THROW_ON_ERROR);
+        $route = collect(Route::getRoutes()->getRoutes())
+            ->first(fn ($route) => $route->getName() === 'default-livewire.update');
+
+        $route->middleware(GzipPayloadMutator::class);
+        $route->computedMiddleware = null;
+
+        $response = $this->call(
+            'POST',
+            EndpointResolver::updatePath(),
+            [],
+            [],
+            [],
+            $this->livewireJsonServerHeaders(['HTTP_CONTENT_ENCODING' => 'gzip']),
+            gzencode($body, 1),
+        );
+
+        $response->assertOk();
+        $this->assertStringContainsString('Count: 10', $response->json('components.0.effects.html'));
+    }
+
+    public function test_gzip_cannot_bypass_the_decompressed_payload_limit(): void
+    {
+        if (! function_exists('gzencode')) {
+            $this->markTestSkipped('The zlib extension is not available.');
+        }
+
+        config()->set('livewire.payload.max_size', 1024);
+
+        $testable = Livewire::test(new class extends TestComponent {});
+        $body = json_encode([
+            'components' => [[
+                'snapshot' => json_encode($testable->snapshot, JSON_THROW_ON_ERROR),
+                'updates' => [],
+                'calls' => [[
+                    'method' => 'unused',
+                    'params' => [str_repeat('A', 10000)],
+                    'metadata' => [],
+                ]],
+            ]],
+        ], JSON_THROW_ON_ERROR);
+        $compressed = gzencode($body, 1);
+
+        $this->assertLessThan(1024, strlen($compressed));
+        $this->assertGreaterThan(1024, strlen($body));
+        $this->expectException(PayloadTooLargeException::class);
+
+        $this->withoutExceptionHandling()->call(
+            'POST',
+            EndpointResolver::updatePath(),
+            [],
+            [],
+            [],
+            $this->livewireJsonServerHeaders(['HTTP_CONTENT_ENCODING' => 'gzip']),
+            $compressed,
+        );
+    }
+
+    public function test_update_endpoint_rejects_unknown_content_encoding(): void
+    {
+        $response = $this->call(
+            'POST',
+            EndpointResolver::updatePath(),
+            [],
+            [],
+            [],
+            $this->livewireJsonServerHeaders(['HTTP_CONTENT_ENCODING' => 'br']),
+            '{"components":[]}',
+        );
+
+        $response->assertStatus(415);
+    }
+
+    public function test_delta_renderless_response_includes_the_top_level_transport_descriptor(): void
+    {
+        config()->set('livewire.update_engine', 'delta');
+        config()->set('livewire.delta.request_compression', true);
+        config()->set('livewire.delta.request_compression_minimum_bytes', 2048);
+
+        $testable = Livewire::test(new class extends TestComponent {
+            public function saveWithoutRendering(): void
+            {
+                $this->skipRender();
+            }
+        });
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [[
+                'snapshot' => json_encode($testable->snapshot, JSON_THROW_ON_ERROR),
+                'updates' => [],
+                'calls' => [[
+                    'method' => 'saveWithoutRendering',
+                    'params' => [],
+                    'metadata' => [],
+                ]],
+            ]]]);
+
+        $response->assertOk();
+        $response->assertJsonPath('transport.v', 1);
+        $response->assertJsonPath('transport.requestGzip', 2048);
+        $this->assertArrayNotHasKey('html', $response->json('components.0.effects'));
+    }
+
+    public function test_update_endpoint_rejects_malformed_v1_render_metadata(): void
+    {
+        config()->set('app.debug', false);
+
+        $testable = Livewire::test(new class extends TestComponent {});
+        $snapshot = json_encode($testable->snapshot, JSON_THROW_ON_ERROR);
+        $invalidMetadata = [
+            'non-array' => 'bad',
+            'unknown version' => ['v' => 2, 'capabilities' => []],
+            'unknown capability' => ['v' => 1, 'capabilities' => ['execute-code']],
+            'malformed base hash' => [
+                'v' => 1,
+                'capabilities' => ['same'],
+                'base' => ['hash' => 'not-a-hash', 'bytes' => 1, 'revision' => 1],
+            ],
+            'negative base bytes' => [
+                'v' => 1,
+                'capabilities' => ['same'],
+                'base' => ['hash' => str_repeat('a', 64), 'bytes' => -1, 'revision' => 1],
+            ],
+            'unsafe chunk size' => [
+                'v' => 1,
+                'capabilities' => ['chunks'],
+                'chunks' => ['blockSize' => 64, 'blocks' => ''],
+            ],
+            'malformed fragment token' => [
+                'v' => 1,
+                'capabilities' => ['fragments'],
+                'fragments' => [
+                    'root' => str_repeat('a', 16),
+                    'nodes' => [['unsafe-token', str_repeat('b', 16), str_repeat('c', 16)]],
+                ],
+            ],
+        ];
+
+        foreach ($invalidMetadata as $name => $render) {
+            $response = $this->withHeaders(['X-Livewire' => 'true'])
+                ->postJson(EndpointResolver::updatePath(), ['components' => [[
+                    'snapshot' => $snapshot,
+                    'updates' => [],
+                    'calls' => [],
+                    'render' => $render,
+                ]]]);
+
+            $this->assertSame(404, $response->status(), $name);
+        }
+    }
+
+    public function test_protocol_safe_manifests_are_accepted_above_custom_candidate_limits(): void
+    {
+        config()->set('app.debug', false);
+        config()->set('livewire.delta.maximum_manifest_bytes', 1);
+        config()->set('livewire.delta.maximum_fragments', 0);
+
+        $testable = Livewire::test(new class extends TestComponent {});
+        $snapshot = json_encode($testable->snapshot, JSON_THROW_ON_ERROR);
+        $render = [
+            'v' => 1,
+            'capabilities' => ['chunks', 'fragments'],
+            'chunks' => [
+                'blockSize' => 256,
+                'blocks' => 'AAAA',
+            ],
+            'fragments' => [
+                'root' => str_repeat('a', 16),
+                'nodes' => [[
+                    str_repeat('b', 16),
+                    str_repeat('c', 16),
+                    str_repeat('d', 16),
+                ]],
+            ],
+        ];
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [[
+                'snapshot' => $snapshot,
+                'updates' => [],
+                'calls' => [],
+                'render' => $render,
+            ]]]);
+
+        $response->assertOk();
+    }
+
+    public function test_snapshot_reference_is_resolved_before_component_actions_run(): void
+    {
+        config()->set('livewire.delta.snapshot_store', 'array');
+
+        $testable = Livewire::test(new class extends TestComponent {
+            public int $count = 0;
+
+            public function increment(): void
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return '<div>Count: {{ $count }}</div>';
+            }
+        });
+        $snapshot = json_encode($testable->snapshot, JSON_THROW_ON_ERROR);
+        $componentId = $testable->snapshot['memo']['id'];
+        $reference = app(SnapshotStateStore::class)->put($componentId, $snapshot);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [[
+                'id' => $componentId,
+                'snapshotRef' => $reference,
+                'updates' => [],
+                'calls' => [[
+                    'method' => 'increment',
+                    'params' => [],
+                    'metadata' => [],
+                ]],
+            ]]]);
+
+        $response->assertOk();
+        $this->assertStringContainsString('Count: 1', $response->json('components.0.effects.html'));
+    }
+
+    public function test_missing_snapshot_reference_returns_a_retryable_conflict(): void
+    {
+        config()->set('livewire.delta.snapshot_store', 'array');
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [[
+                'id' => 'missing-component',
+                'snapshotRef' => str_repeat('a', 24),
+                'updates' => [],
+                'calls' => [[
+                    'method' => 'must-not-run',
+                    'params' => [],
+                    'metadata' => [],
+                ]],
+            ]]]);
+
+        $response->assertStatus(409);
+        $response->assertHeader('X-Livewire-Snapshot-Missing', '1');
+        $response->assertJson(['snapshotMissing' => ['missing-component']]);
+    }
+
+    public function test_one_missing_snapshot_reference_prevents_every_action_in_the_batch(): void
+    {
+        config()->set('livewire.delta.snapshot_store', 'array');
+
+        $component = new class extends TestComponent {
+            public static int $runs = 0;
+
+            public function run(): void
+            {
+                static::$runs++;
+            }
+        };
+        $testable = Livewire::test($component);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                [
+                    'snapshot' => json_encode($testable->snapshot, JSON_THROW_ON_ERROR),
+                    'updates' => [],
+                    'calls' => [[
+                        'method' => 'run',
+                        'params' => [],
+                        'metadata' => [],
+                    ]],
+                ],
+                [
+                    'id' => 'missing-component',
+                    'snapshotRef' => str_repeat('b', 24),
+                    'updates' => [],
+                    'calls' => [],
+                ],
+            ]]);
+
+        $response->assertStatus(409);
+        $this->assertSame(0, $component::$runs);
+    }
+
+    public function test_tampered_snapshot_reference_is_treated_as_a_cache_miss(): void
+    {
+        config()->set('livewire.delta.snapshot_store', 'array');
+
+        $testable = Livewire::test(new class extends TestComponent {});
+        $snapshot = json_encode($testable->snapshot, JSON_THROW_ON_ERROR);
+        $componentId = $testable->snapshot['memo']['id'];
+        $reference = app(SnapshotStateStore::class)->put($componentId, $snapshot);
+
+        Cache::store('array')->put('livewire:snapshot:'.$reference, [
+            'id' => $componentId,
+            'hash' => hash('sha256', $snapshot),
+            'snapshot' => $snapshot.'tampered',
+        ], 300);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [[
+                'id' => $componentId,
+                'snapshotRef' => $reference,
+                'updates' => [],
+                'calls' => [],
+            ]]]);
+
+        $response->assertStatus(409);
+        $response->assertJson(['snapshotMissing' => [$componentId]]);
+    }
+
+    protected function livewireJsonServerHeaders(array $headers = []): array
+    {
+        return $headers + [
+            'HTTP_X_LIVEWIRE' => 'true',
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'application/json',
+        ];
+    }
+}
+
+class GzipPayloadProbe
+{
+    public static ?string $snapshot = null;
+
+    public function handle($request, \Closure $next)
+    {
+        static::$snapshot = $request->input('components.0.snapshot');
+
+        return $next($request);
+    }
+}
+
+class GlobalGzipPayloadProbe
+{
+    public static ?string $snapshot = null;
+
+    public function handle($request, \Closure $next)
+    {
+        static::$snapshot = $request->input('components.0.snapshot');
+
+        return $next($request);
+    }
+}
+
+class GzipPayloadMutator
+{
+    public function handle($request, \Closure $next)
+    {
+        $components = $request->input('components');
+        $components[0]['calls'][0]['method'] = 'mutated';
+        $request->merge(['components' => $components]);
+
+        return $next($request);
     }
 }


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
Opening as a draft for feedback — take a look and let's see what makes sense to do with it @calebporzio @joshhanley 

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
`feature/stateful-delta-engine`

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No. It's one feature, plus its tests and docs.

4️⃣ Does it include tests? (Required)
Yes — PHP unit tests, a browser test, and JS tests covering the diff/patch round-trip, integrity checks, the fallback paths, and the size thresholds.


## The idea

Morphing already does the smart thing on the client: it only touches the DOM nodes that actually changed. But to get there, the browser still downloads the component's *entire* rendered HTML on every update. On a 200-row table where a single status cell flips, that's the whole table crossing the wire to deliver a few bytes of real change.

This PR adds a `delta` update engine that closes that gap. The server hangs on to the previous render, diffs the new one against it, and sends only the bytes that changed as a short list of byte-offset patches. The browser reconstructs the exact HTML and feeds it to the same morph pipeline it already uses. PHP still renders the component every time — the only thing that changes is how much of the result crosses the wire.

It's opt-in and off by default:

```php
// config/livewire.php

'update_engine' => 'delta', // default: 'morph'
```

Existing components and Blade templates don't change, and with the default `morph` setting nothing about Livewire's behavior moves at all.

## How it works

The first eligible update sends full HTML and establishes an exact, byte-for-byte baseline:

```json
{ "html": "<div>...</div>", "htmlHash": "8aef..." }
```

A later update can come back as patches instead:

```json
{
    "htmlDelta": {
        "base": "8aef...",
        "patches": [
            { "start": 13842, "delete": 7, "insert": "cnVubmluZw==" }
        ]
    },
    "htmlHash": "b391..."
}
```

On the browser side it checks that `base` matches the render it's currently showing, applies the patches by byte offset, hashes the result with SHA-256, and only morphs once that hash matches `htmlHash`. Because the reconstructed HTML flows through the normal morph, `wire:key`, focus handling, nested components, and morph hooks all keep working untouched. If anything doesn't line up, it throws the baseline away and quietly asks for a full render.

## It only kicks in when it's worth it

The engine doesn't try to delta everything — that would just add overhead to small components. Anything under 8 KiB stays on plain morph and never touches the render store or adds delta metadata to the response.

Above that, a delta actually has to earn its place: it needs to save at least 10% of the payload, and — because responses are usually gzipped on the wire — it has to still win after a fast gzip estimate and clear a 1 KiB absolute floor. Otherwise Livewire just sends full HTML. The defaults:

```php
'delta' => [
    'store' => null,   // your default cache store
    'ttl' => 300,
    'minimum_html_bytes' => 8192,
    'minimum_savings' => 0.1,
    'minimum_compressed_savings_bytes' => 1024,
    'compression_aware' => true,
],
```

Components can cross that line either way. Grow past the threshold and one full response re-seeds a baseline; shrink back under it and things drop back to plain morph.

## More than one patch at a time

A single prefix/suffix diff falls apart the moment two far-apart regions change — think of moving a Kanban card, where you delete it from one column and insert it into another. So `HtmlDelta` can emit several non-overlapping patches that all reference the same original render and apply atomically:

```json
"patches": [
    { "start": 120,  "delete": 86, "insert": "" },
    { "start": 2980, "delete": 0,  "insert": "PGFydGljbGU+..." }
]
```

Anchor discovery has fixed limits on scan steps and patch count. If a diff stops being productive, the encoder falls back to a single replacement patch and lets the normal size checks decide whether full HTML is the better deal anyway — so worst-case work stays bounded.

## Where the previous render lives

To build a delta the server needs the render the browser is currently showing, so after the first update it keeps one render per active component in Laravel's cache:

```php
'delta' => [
    'store' => 'redis',
    'ttl' => 300,
],
```

A file cache is fine on a single server. Once updates for the same component can land on different servers you'll want a shared store like Redis. Only the latest eligible render is kept, and expiry, a missing entry, a raced revision, or an unavailable store all just fall back to full HTML.

## Integrity and security

Delta updates change how HTML is shipped, not how requests are authorized. The browser never sends rendered HTML or patches for the server to apply — only the hash of the render it currently holds, and that's only trusted when it matches the hash inside Livewire's checksum-protected snapshot. The render gets SHA-256-verified on both ends: the server re-hashes the cached copy before diffing, and the browser re-hashes the reconstructed HTML before morphing. A tampered or corrupted patch never reaches the DOM — it triggers a full resync instead.

> **Worth calling out:** the cache holds raw rendered HTML, which can contain user-specific data. The docs cover this — keep the store on a private network with an app-specific prefix, use Redis ACLs and TLS across trust boundaries, and keep the TTL short.

## Benchmarks

These cover the render effect only — the snapshot is identical on both transports, so it's excluded.

### Payload size

| Scenario | Rendered | Morph raw | Delta raw | Morph gzip | Delta gzip | Gzip saved |
|---|---:|---:|---:|---:|---:|---:|
| Todo toggle | 415 B | 460 B | 273 B | 232 B | 240 B | −3.4% |
| Kanban move | 3,616 B | 3,866 B | 440 B | 599 B | 341 B | 43.1% |
| 200-row table status | 35,828 B | 38,444 B | 235 B | 3,410 B | 205 B | 94.0% |

With the default thresholds the Todo and the 3.6 KiB Kanban components both stay on morph — the win is too small to bother with — and only the 35.8 KiB table actually uses a delta. That's the whole point of the size gate: don't spend cache and hashing time chasing savings that don't matter.

### Server cost (file cache)

| Scenario | Morph p50 | Delta + file p50 | Extra |
|---|---:|---:|---:|
| Todo, forced delta | 0.004 ms | 0.611 ms | +0.607 ms |
| Kanban, forced delta | 0.018 ms | 0.826 ms | +0.808 ms |
| 200-row table | 0.165 ms | 1.901 ms | +1.736 ms |

For the table, the delta cuts about 3.2 KB off the gzipped response — roughly 5 ms of transfer on a 5 Mbps link, so after the server and client overhead it comes out about 2.9 ms ahead in this local run. At high throughput the CPU can cost more than the transfer it saves, which is exactly why this is opt-in, hybrid, and compression-aware rather than the default.

> **On the numbers:** the byte measurements are deterministic and I'd stand behind them. The CPU timings were taken with PHP 8.4 WASM under Node against the host filesystem (warm cache, `LOCK_EX` writes, no `fsync`), so treat them as directional — they should really be rerun on native PHP-FPM/Octane with production storage and real components.

## Compatibility and rollback

No component changes are needed, and everything you'd expect keeps working: actions, Blade rendering, validation and authorization, redirects and events, renderless actions, nested components, `wire:key`, the existing morph, and the normal snapshot/hydration model. The reconstruction path also accepts the original single-patch shape, so cached test state and rolling deployments stay safe.

To turn it off, flip the setting back:

```php
'update_engine' => 'morph',
```

There's no migration and no persistent application state to unwind. If an interaction doesn't need a server render at all, Alpine state or a renderless action is still the right tool — the delta engine is for when you *do* need to render but most of the output stays put.

