### PR TITLE
[4.x] Fix authorize attribute bypass exception hook

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -20,14 +20,13 @@ use Livewire\Features\SupportRenderless\HandlesRenderless;
 use Livewire\Exceptions\PropertyNotFoundException;
 use Livewire\Concerns\InteractsWithProperties;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use BadMethodCallException;
+use Livewire\Features\SupportAuthorization\HandlesAuthorization;
 
 abstract class Component
 {
     use Macroable { __call as macroCall; }
 
-    use AuthorizesRequests;
     use InteractsWithProperties;
     use HandlesEvents;
     use HandlesIslands;
@@ -44,6 +43,7 @@ abstract class Component
     use HandlesSlots;
     use HandlesHtmlAttributeForwarding;
     use HandlesRenderless;
+    use HandlesAuthorization;
 
     protected $__id;
     protected $__name;

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -3,19 +3,16 @@
 namespace Livewire\Features\SupportAuthorization;
 
 use Attribute;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Arr;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\ImplicitlyBoundMethod;
 use UnitEnum;
 
-use function Illuminate\Support\enum_value;
+use function Livewire\wrap;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
 class BaseAuthorize extends LivewireAttribute
 {
-    use AuthorizesRequests;
-
     public function __construct(
         public UnitEnum|string $ability,
         public array|string|null $argument = null,
@@ -23,9 +20,11 @@ class BaseAuthorize extends LivewireAttribute
 
     public function call(array $parameters) : void
     {
+        $this->component->setAuthorizationMethod($this->getName());
+
         // Action that does not require a model or class...
         if (is_null($this->argument)) {
-            $this->authorize($this->ability);
+            wrap($this->component)->authorize($this->ability);
 
             return;
         }
@@ -45,16 +44,16 @@ class BaseAuthorize extends LivewireAttribute
         // Resolve each argument (prioritize method parameters first, then component properties)
         $resolved = [];
         foreach ($arguments as $arg) {
-            $resolved[] = $this->resolveArgument($arg, $parameters, $resolveMethodDependencies);
+            $resolved[] = $this->resolveArgument($arg, $resolveMethodDependencies);
         }
 
-        $this->authorize($this->ability, $resolved);
+        wrap($this->component)->authorize($this->ability, $resolved);
     }
 
     /**
      * Resolve a single argument.
      */
-    protected function resolveArgument(string $arg, array $parameters, \Closure $resolveMethodDependencies): mixed
+    protected function resolveArgument(string $arg, \Closure $resolveMethodDependencies): mixed
     {
         // Action that does not require a model, for example a 'create' action...
         if (class_exists($arg)) {
@@ -75,16 +74,5 @@ class BaseAuthorize extends LivewireAttribute
 
         // Fall back to component property
         return data_get($this->component, $arg);
-    }
-
-    protected function parseAbilityAndArguments($ability, $arguments)
-    {
-        $ability = enum_value($ability);
-
-        if (is_string($ability) && ! str_contains($ability, '\\')) {
-            return [$ability, $arguments];
-        }
-
-        return [$this->normalizeGuessedAbilityName($this->getName()), $ability];
     }
 }

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Livewire\Features\SupportAuthorization;
+
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
+use function Illuminate\Support\enum_value;
+
+trait HandlesAuthorization
+{
+    use AuthorizesRequests;
+
+    protected ?string $method = null;
+
+    public function setAuthorizationMethod($method = null): void
+    {
+        $this->method = $method;
+    }
+
+    protected function parseAbilityAndArguments($ability, $arguments): array
+    {
+        $ability = enum_value($ability);
+
+        if (is_string($ability) && ! str_contains($ability, '\\')) {
+            // Need to reset the properties in case attribute is used along with `$this->authorize()`
+            $this->setAuthorizationMethod();
+
+            return [$ability, $arguments];
+        }
+
+        // Because this method override the original method,
+        // we need to make sure it gets the right method name
+        // if its called from `$this->authorize()` inside component action
+        $method = $this->method ?? debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2]['function'];
+
+        // Need to reset the properties in case attribute is used along with `$this->authorize()`
+        $this->setAuthorizationMethod();
+
+        return [$this->normalizeGuessedAbilityName($method), $ability];
+    }
+}

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -2,7 +2,9 @@
 
 namespace Livewire\Features\SupportAuthorization;
 
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Auth\User as AuthUser;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Facades\Gate;
@@ -41,6 +43,29 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_defined_basic_gates_using_trait_method()
+    {
+        Gate::define('can-open-post', fn () : bool => true);
+        Gate::define('cannot-open-post', fn () : bool => false);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function canOpenPost()
+                {
+                    $this->authorize('can-open-post');
+                }
+
+                public function cannotOpenPost()
+                {
+                    $this->authorize('cannot-open-post');
+                }
+            })
+            ->call('canOpenPost')
+            ->assertOk()
+            ->call('cannotOpenPost')
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_defined_gates_without_arguments()
     {
         Gate::define('can-open-post', function (AuthorizationUser $user) : bool
@@ -65,6 +90,34 @@ class UnitTest extends TestCase
                 public function canOpenPost() : bool
                 {
                     return true;
+                }
+            })
+            ->call('canOpenPost')
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_defined_gates_without_arguments_using_trait_method()
+    {
+        Gate::define('can-open-post', function (AuthorizationUser $user) : bool
+        {
+            return (int) $user->id === 1;
+        });
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function canOpenPost()
+                {
+                    $this->authorize('can-open-post');
+                }
+            })
+            ->call('canOpenPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public function canOpenPost()
+                {
+                    $this->authorize('can-open-post');
                 }
             })
             ->call('canOpenPost')
@@ -115,6 +168,48 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_defined_gates_with_model_argument_using_trait_method()
+    {
+        Gate::define('can-open-post', function (AuthorizationUser $user, AuthorizationPost $post) : bool
+        {
+            return (int) $post->user_id === (int) $user->id;
+        });
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function canOpenPost()
+                {
+                    $this->authorize('can-open-post', $this->post);
+                }
+            })
+            ->call('canOpenPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function canOpenPost()
+                {
+                    $this->authorize('can-open-post', $this->post);
+                }
+            })
+            ->call('canOpenPost')
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_policy_with_class()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
@@ -136,6 +231,31 @@ class UnitTest extends TestCase
                 public function createPost() : bool
                 {
                     return true;
+                }
+            })
+            ->call('createPost')
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_policy_with_class_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function createPost()
+                {
+                    $this->authorize('create', AuthorizationPost::class);
+                }
+            })
+            ->call('createPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public function createPost()
+                {
+                    $this->authorize('create', AuthorizationPost::class);
                 }
             })
             ->call('createPost')
@@ -183,6 +303,45 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_policy_with_model_argument_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function editPost()
+                {
+                    $this->authorize('edit', $this->post);
+                }
+            })
+            ->call('editPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function editPost()
+                {
+                    $this->authorize('edit', $this->post);
+                }
+            })
+            ->call('editPost')
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_policy_with_positional_model_id_argument()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
@@ -204,6 +363,31 @@ class UnitTest extends TestCase
                 public function editPost(AuthorizationPost $post) : bool
                 {
                     return true;
+                }
+            })
+            ->call('editPost', 1)
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_policy_with_positional_model_id_argument_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function editPost(AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+                }
+            })
+            ->call('editPost', 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public function editPost(AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
                 }
             })
             ->call('editPost', 1)
@@ -237,6 +421,31 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_policy_with_model_id_argument_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function editPost(AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public function editPost(AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_policy_with_dependency_injection_and_positional_model_id_argument()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
@@ -264,6 +473,35 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_policy_with_dependency_injection_and_positional_model_id_argument_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function editPost(UrlGenerator $generator, AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+
+                    return $generator->to('/some-url') !== '';
+                }
+            })
+            ->call('editPost', 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public function editPost(UrlGenerator $generator, AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+
+                    return $generator->to('/some-url') !== '';
+                }
+            })
+            ->call('editPost', 1)
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_policy_with_dependency_injection_and_named_model_id_argument()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
@@ -284,6 +522,35 @@ class UnitTest extends TestCase
                 #[Authorize('edit', 'post')]
                 public function editPost(UrlGenerator $generator, AuthorizationPost $post) : bool
                 {
+                    return $generator->to('/some-url') !== '';
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_policy_with_dependency_injection_and_named_model_id_argument_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function editPost(UrlGenerator $generator, AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+
+                    return $generator->to('/some-url') !== '';
+                }
+            })
+            ->call('editPost', post: 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public function editPost(UrlGenerator $generator, AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+
                     return $generator->to('/some-url') !== '';
                 }
             })
@@ -394,6 +661,65 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_multiple_policies_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function createPost() 
+                {
+                    $this->authorize('create', AuthorizationPost::class);
+                    $this->authorize('edit', $this->post);
+                }
+            })
+            ->call('createPost')
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                public function createPost() 
+                {
+                    $this->authorize('create', AuthorizationPost::class);
+                    $this->authorize('edit', $this->post);
+                }
+            })
+            ->call('createPost')
+            ->assertForbidden();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                public function createPost() 
+                {
+                    $this->authorize('create', AuthorizationPost::class);
+                    $this->authorize('edit', $this->post);
+                }
+            })
+            ->call('createPost')
+            ->assertForbidden();
+    }
+
     public function test_it_does_not_perform_any_action_when_denied()
     {
         Gate::define('cannot-open-post', fn () => false);
@@ -405,6 +731,27 @@ class UnitTest extends TestCase
                 #[Authorize('cannot-open-post')]
                 public function cannotOpenPost() : void
                 {
+                    Session::put('should-never-be-set', true);
+                }
+            })
+            ->call('cannotOpenPost')
+            ->assertForbidden();
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
+    public function test_it_does_not_perform_any_action_when_denied_using_trait_method()
+    {
+        Gate::define('cannot-open-post', fn () => false);
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function cannotOpenPost() : void
+                {
+                    $this->authorize('cannot-open-post');
+
                     Session::put('should-never-be-set', true);
                 }
             })
@@ -433,6 +780,26 @@ class UnitTest extends TestCase
         $this->assertFalse(Session::has('should-never-be-set'));
     }
 
+    public function test_authorize_is_enforced_on_event_listeners_using_trait_method()
+    {
+        Gate::define('cannot-open-post', fn () => false);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[\Livewire\Attributes\On('some-event')]
+                public function handleEvent() : void
+                {
+                    $this->authorize('cannot-open-post');
+
+                    Session::put('should-never-be-set', true);
+                }
+            })
+            ->dispatch('some-event')
+            ->assertForbidden();
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
     public function test_authorize_allows_authorized_event_listeners()
     {
         Gate::define('can-open-post', fn () => true);
@@ -443,6 +810,26 @@ class UnitTest extends TestCase
                 #[Authorize('can-open-post')]
                 public function handleEvent() : void
                 {
+                    Session::put('event-was-handled', true);
+                }
+            })
+            ->dispatch('some-event')
+            ->assertOk();
+
+        $this->assertTrue(Session::has('event-was-handled'));
+    }
+
+    public function test_authorize_allows_authorized_event_listeners_using_trait_method()
+    {
+        Gate::define('can-open-post', fn () => true);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[\Livewire\Attributes\On('some-event')]
+                public function handleEvent() : void
+                {
+                    $this->authorize('can-open-post');
+
                     Session::put('event-was-handled', true);
                 }
             })
@@ -475,6 +862,33 @@ class UnitTest extends TestCase
                 public function editPost(AuthorizationPost $post) : bool
                 {
                     return true;
+                }
+            })
+            ->dispatch('edit-post', post: 1)
+            ->assertForbidden();
+    }
+
+    public function test_authorize_allows_authorized_event_listeners_with_named_argument_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[\Livewire\Attributes\On('edit-post')]
+                public function editPost(AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
+                }
+            })
+            ->dispatch('edit-post', post: 1)
+            ->assertOk();
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[\Livewire\Attributes\On('edit-post')]
+                public function editPost(AuthorizationPost $post)
+                {
+                    $this->authorize('edit', $post);
                 }
             })
             ->dispatch('edit-post', post: 1)
@@ -588,6 +1002,71 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_defined_gates_with_array_as_argument_using_trait_method()
+    {
+        Gate::define('create-comment', function (AuthorizationUser $user, string $commentClass, AuthorizationPost $post) {
+            return (int) $user->id === 1 && $post->id === 1;
+        });
+
+        // AssertOk using class name and method argument
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function createComment(AuthorizationPost $post)
+                {
+                    $this->authorize('create-comment', [AuthorizationComment::class, $post]);
+                }
+            })
+            ->call('createComment', post: 1)
+            ->assertOk();
+
+        // AssertOk using class name and component property
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function createComment()
+                {
+                    $this->authorize('create-comment', [AuthorizationComment::class, $this->post]);
+                }
+            })
+            ->call('createComment')
+            ->assertOk();
+
+        // AssertForbidden using class name and method argument
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function createComment(AuthorizationPost $post)
+                {
+                    $this->authorize('create-comment', [AuthorizationComment::class, $post]);
+                }
+            })
+            ->call('createComment', post: 2)
+            ->assertForbidden();
+
+        // AssertForbidden using class name and component property
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                public function createComment()
+                {
+                    $this->authorize('create-comment', [AuthorizationComment::class, $this->post]);
+                }
+            })
+            ->call('createComment')
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_policy_with_array_of_class_and_model()
     {
         Gate::policy(AuthorizationComment::class, AuthorizationCommentPolicy::class);
@@ -690,6 +1169,69 @@ class UnitTest extends TestCase
                 }
             })
             ->call('createComment', post: 2)
+            ->assertForbidden();
+    }
+
+    public function test_can_authorize_policy_with_array_of_class_and_model_using_trait_method()
+    {
+        Gate::policy(AuthorizationComment::class, AuthorizationCommentPolicy::class);
+
+        // AssertOk using class name and method argument
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function createComment(AuthorizationPost $post)
+                {
+                    $this->authorize('create', [AuthorizationComment::class, $post]);
+                }
+            })
+            ->call('createComment', post: 1)
+            ->assertOk();
+
+        // AssertOk using class name and component property
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function createComment()
+                {
+                    $this->authorize('create', [AuthorizationComment::class, $this->post]);
+                }
+            })
+            ->call('createComment')
+            ->assertOk();
+
+        // AssertForbidden using class name and method argument
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function createComment(AuthorizationPost $post)
+                {
+                    $this->authorize('create', [AuthorizationComment::class, $post]);
+                }
+            })
+            ->call('createComment', post: 2)
+            ->assertForbidden();
+
+        // AssertForbidden using class name and component property
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                public function createComment()
+                {
+                    $this->authorize('create', [AuthorizationComment::class, $this->post]);
+                }
+            })
+            ->call('createComment')
             ->assertForbidden();
     }
 
@@ -810,6 +1352,75 @@ class UnitTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_can_authorize_policy_with_array_of_models_using_trait_method()
+    {
+        Gate::policy(AuthorizationComment::class, AuthorizationCommentPolicy::class);
+
+        // AssertOk using method arguments
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function editComment(AuthorizationComment $comment, AuthorizationPost $post)
+                {
+                    $this->authorize('edit', [$comment, $post]);
+                }
+            })
+            ->call('editComment', comment: 1, post: 1)
+            ->assertOk();
+
+        // AssertOk using component properties
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationComment $comment;
+
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->comment = AuthorizationComment::find(1);
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                public function editComment()
+                {
+                    $this->authorize('edit', [$this->comment, $this->post]);
+                }
+            })
+            ->call('editComment')
+            ->assertOk();
+
+        // AssertForbidden using method arguments
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function editComment(AuthorizationComment $comment, AuthorizationPost $post)
+                {
+                    $this->authorize('edit', [$comment, $post]);
+                }
+            })
+            ->call('editComment', comment: 1, post: 2)
+            ->assertForbidden();
+
+        // AssertForbidden using component properties
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationComment $comment;
+
+                public AuthorizationPost $post;
+
+                public function mount(): void
+                {
+                    $this->comment = AuthorizationComment::find(1);
+                    $this->post = AuthorizationPost::find(2);
+                }
+
+                public function editComment()
+                {
+                    $this->authorize('edit', [$this->comment, $this->post]);
+                }
+            })
+            ->call('editComment')
+            ->assertForbidden();
+    }
+
     public function test_can_authorize_using_defined_gate_with_only_class_name_as_argument()
     {
         Gate::define('create', function (AuthorizationUser $user) : bool
@@ -823,6 +1434,24 @@ class UnitTest extends TestCase
                 public function create() : bool
                 {
                     return true;
+                }
+            })
+            ->call('create')
+            ->assertOk();
+    }
+
+    public function test_can_authorize_using_defined_gate_with_only_class_name_as_argument_using_trait_method()
+    {
+        Gate::define('create', function (AuthorizationUser $user) : bool
+        {
+            return (int) $user->id === 1;
+        });
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function create()
+                {
+                    $this->authorize(AuthorizationPost::class);
                 }
             })
             ->call('create')
@@ -845,6 +1474,21 @@ class UnitTest extends TestCase
             ->assertOk();
     }
 
+    public function test_can_authorize_using_policy_with_only_class_name_and_no_arguments_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function create()
+                {
+                    $this->authorize(AuthorizationPost::class);
+                }
+            })
+            ->call('create')
+            ->assertOk();
+    }
+
     public function test_can_authorize_using_policy_resource_ability_mapping_with_only_class_name()
     {
         Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
@@ -855,6 +1499,21 @@ class UnitTest extends TestCase
                 public function store() : bool
                 {
                     return true;
+                }
+            })
+            ->call('store')
+            ->assertOk();
+    }
+
+    public function test_can_authorize_using_policy_resource_ability_mapping_with_only_class_name_using_trait_method()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public function store()
+                {
+                    $this->authorize(AuthorizationPost::class);
                 }
             })
             ->call('store')
@@ -893,6 +1552,91 @@ class UnitTest extends TestCase
             })
             ->dispatch('some-event')
             ->assertForbidden();
+    }
+
+    public function test_authorize_attribute_trigger_exception_hook()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        $this->expectException(AuthorizationException::class);
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[BaseAuthorize(AuthorizationPost::class)]
+                public function store() : bool
+                {
+                    return true;
+                }
+
+                public function exception($e, $stopPropagation)
+                {
+                    $stopPropagation();
+
+                    Session::put('authorization-denied', $e->getMessage());
+                }
+            })
+            ->call('store')
+            ->assertOk();
+
+        $this->assertTrue(Session::has('authorization-denied'));
+        $this->assertSame('This action is unauthorized.', Session::pull('authorization-denied'));
+
+        $this->expectException(ModelNotFoundException::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[BaseAuthorize('edit', 'post')]
+                public function store(AuthorizationPost $post) : bool
+                {
+                    return true;
+                }
+
+                public function exception($e, $stopPropagation)
+                {
+                    $stopPropagation();
+
+                    Session::put('model-not-found', $e->getMessage());
+                }
+            })
+            ->call('store', post: 3)
+            ->assertOk();
+
+        $this->assertTrue(Session::has('model-not-found'));
+        $this->assertSame(
+            'No query results for model [Livewire\Features\SupportAuthorization\AuthorizationPost] 3', 
+            Session::pull('model-not-found')
+        );
+    }
+
+    public function test_can_authorize_using_attribute_and_trait_method_at_the_same_time()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                public AuthorizationPost $post;
+
+                public function mount() : void
+                {
+                    $this->post = AuthorizationPost::find(1);
+                }
+
+                #[Authorize('create', AuthorizationPost::class)]
+                public function createPost()
+                {
+                    $this->authorize('edit', $this->post);
+                }
+
+                #[Authorize('edit', 'post')]
+                public function anotherCreatePost()
+                {
+                    $this->authorize('create', AuthorizationPost::class);
+                }
+            })
+            ->call('createPost')
+            ->assertOk()
+            ->call('anotherCreatePost')
+            ->assertOk();
     }
 }
 


### PR DESCRIPTION
Based on https://github.com/livewire/livewire/pull/10422. This PR provide more simple fix rather than complex method override and trait aliasing.

> [!NOTE]
> Please give a little time to compare these 2 PR as both provide different approach. This PR doesnt cover `ModelNotFoundException` like the other PR does.
> If one the these PR is more suitable for the fix, feel free to open/close the PR, thanks!
> 
> I apologize for the unconvenience, best regards.

# Scenario
When using `#[Authorize]` attribute to perform authorization as pre-method execution. It doesnt trigger the component `exception()` hook.

```php
<?php

use App\Models\Post;
use Livewire\Component;

new class extends Component
{
    #[Authorize('edit', 'post')]
    public function save(Post $post)
    {
        //
    }

    public function exception($e, $stopPropagation)
    {
        $stopPropagation();

        dd($e->getMessage()); // not triggered
    }
}
```

# Problem
Attribute `call()` handled by `SupportAttributes::call()` which is running before the actual method get called so any exception thrown will not get handled by component exception hook.

# Solution
Back to use `$this->component->authorize()` with a wrapper. Now `HandlesAuthorization` trait only override `parseAbilityAndArguments()` to provide the right method name either from attribute or backtrace. This way, any exception thrown can be catched from component `exception()` hook.

# Files Changed
- New `HandlesAuthorization` trait
- Move `AuthorizesRequests` trait from `Component` to `HandlesAuthorization` trait
- Override `parseAbilityAndArguments()` but add fallback method name from backtrace to ensure it resolve the correct method name
- Added regression tests to make sure both works as expected either using `#[Authorize]` attribute or `$this->authorize()`

Fix: https://github.com/livewire/livewire/issues/10410