### PR TITLE
[4.x] Fix `$js` actions not being able to call each other inside component scripts

### DIFF
--- a/js/$wire.js
+++ b/js/$wire.js
@@ -167,6 +167,15 @@ wireProperty('$js', (component) => {
             return true
         },
         get(target, property) {
+            // Actions are stored on the component, not on this proxy's target.
+            // The target is only a snapshot from when this proxy was created,
+            // so always prefer the live action registry — otherwise a $js
+            // function can't see actions registered after the proxy was made
+            // (like a script's $js functions calling each other)...
+            if (component.hasJsAction(property)) {
+                return component.getJsAction(property)
+            }
+
             // Scripts in view-based components are imported dynamically,
             // which means they run asynchronously. This causes issues with
             // things like wire:text="$js.foo()" not being available on page load.

--- a/src/Features/SupportJsModules/BrowserTest.php
+++ b/src/Features/SupportJsModules/BrowserTest.php
@@ -44,6 +44,19 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertSeeIn('@target', 'js-import-loaded');
     }
 
+    public function test_js_actions_can_call_other_js_actions()
+    {
+        // The $js object passed into a component's script module is created
+        // before the script's own $js functions are registered. Reads must
+        // consult the component's live action registry so that one $js
+        // function can call another (e.g. $js.outer() calling $js.inner()).
+        // Regression test for $js actions not seeing each other in SFC scripts.
+        Livewire::visit('testns::sfc-with-js-actions')
+            ->waitForLivewireToLoad()
+            ->pause(100)
+            ->assertSeeIn('@target', 'js-actions-composed');
+    }
+
     public function test_multi_file_component_js_supports_es_imports()
     {
         // This tests that ES module import statements work in multi-file

--- a/src/Features/SupportJsModules/fixtures/sfc-with-js-actions.blade.php
+++ b/src/Features/SupportJsModules/fixtures/sfc-with-js-actions.blade.php
@@ -1,0 +1,16 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <div dusk="target" wire:text="$js.outer()">waiting</div>
+</div>
+
+<script>
+$js.inner = () => 'js-actions-composed'
+
+$js.outer = () => $js.inner()
+</script>


### PR DESCRIPTION
## The bug

Given an SFC (or MFC) script that defines two `$js` actions where one calls the other:

```html
<script>
$js.isImage = (file) => ['png', 'jpg'].includes((file?.name ?? '').split('.').pop())

$js.matchesFilters = (file) => {
    if (this.filter === 'images') return $js.isImage(file)

    return true
}
</script>
```

Calling `$js.matchesFilters(file)` from the template (e.g. `wire:show="$js.matchesFilters(file)"`) throws:

```
Livewire Expression Error: $js.isImage is not a function
```

## Why

Every access of `$wire.$js` builds a fresh proxy whose target is a **snapshot** of the actions registered at that moment. The `set` trap registers new actions on the component — never on the snapshot — while the `get` trap reads from the snapshot.

The `$js` object passed into a script module's `run()` wrapper is created *before* the script's own assignments execute, so its snapshot is empty forever. Template expressions work (each evaluation gets a fresh proxy with the actions copied on), but any `$js.foo` reference *inside* a `$js` function resolves against the script's stale, empty proxy → `undefined`.

## The fix

The proxy's `get` trap now consults the component's live action registry (`component.getJsAction()`) before falling back to the snapshot. Every `$js` reference — no matter when its proxy was created — sees the same, current set of actions. Actions keep being bound to `$wire`, so `this.foo` inside them works unchanged.

This check runs before the pending-module promise shim, which also means a `$js` action that's already registered is returned directly instead of being wrapped in a deferred promise.

## Verification

Added a browser test (`test_js_actions_can_call_other_js_actions`) with an SFC fixture where `$js.outer()` calls `$js.inner()` via `wire:text`. It fails with `waiting` (the error above in console) before the fix and passes after. Existing `SupportJsModules` and `SupportJsEvaluation` browser suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)