### PR TITLE
Support template literal interpolation in directive expressions

### DIFF
--- a/js/evaluator.js
+++ b/js/evaluator.js
@@ -61,8 +61,8 @@ export function evaluateActionExpression(el, expression, options = {}) {
     }
 }
 
-export function contextualizeExpression(expression, el) {
-    let SKIP = ['JSON', 'true', 'false', 'null', 'undefined', 'this', '$wire', '$event']
+export function contextualizeExpression(expression, el, extraSkip = []) {
+    let SKIP = ['JSON', 'true', 'false', 'null', 'undefined', 'this', '$wire', '$event', ...extraSkip]
 
     // If an element is provided, collect Alpine scope keys between
     // this element and the Livewire component root so they don't
@@ -88,6 +88,12 @@ export function contextualizeExpression(expression, el) {
         }
     }
 
+    // 1.75. Contextualize interpolations inside template literals so
+    //       `${count} selected` becomes `${$wire.count} selected`...
+    strings = strings.map(string => {
+        return string.startsWith('`') ? contextualizeTemplateLiteral(string, el, SKIP) : string
+    })
+
     // 2. Prefix identifiers not after a dot (skip placeholders from step 1)
     //    Also skip object keys (identifiers immediately followed by colon)
     result = result.replace(/(^|[^.\w$])(\$?[a-zA-Z_]\w*)/g, (m, pre, ident, offset) => {
@@ -98,4 +104,51 @@ export function contextualizeExpression(expression, el) {
 
     // 3. Restore strings
     return result.replace(/___(\d+)___/g, (m, i) => strings[i])
+}
+
+function contextualizeTemplateLiteral(literal, el, skip) {
+    let result = ''
+    let i = 0
+
+    while (i < literal.length) {
+        if (literal[i] === '\\') {
+            result += literal[i] + (literal[i + 1] ?? '')
+            i += 2
+        } else if (literal[i] === '$' && literal[i + 1] === '{') {
+            // Find the interpolation's closing brace, balancing nested
+            // braces and skipping over nested string literals...
+            let start = i + 2
+            let j = start
+            let depth = 1
+
+            while (j < literal.length) {
+                let char = literal[j]
+
+                if (char === '\\') {
+                    j++
+                } else if (char === '"' || char === "'" || char === '`') {
+                    j++
+                    while (j < literal.length && literal[j] !== char) {
+                        if (literal[j] === '\\') j++
+                        j++
+                    }
+                } else if (char === '{') {
+                    depth++
+                } else if (char === '}') {
+                    depth--
+                    if (depth === 0) break
+                }
+
+                j++
+            }
+
+            result += '${' + contextualizeExpression(literal.slice(start, j), el, skip) + '}'
+            i = j + 1
+        } else {
+            result += literal[i]
+            i++
+        }
+    }
+
+    return result
 }

--- a/js/evaluator.spec.js
+++ b/js/evaluator.spec.js
@@ -46,6 +46,33 @@ describe('Contextualize expressions', () => {
         expect(contextualizeExpression('items.map(({ id }) => id)')).toBe('$wire.items.map(({ id }) => id)')
     })
 
+    it('template literal interpolations', () => {
+        expect(contextualizeExpression('`${count} selected`')).toBe('`${$wire.count} selected`')
+        expect(contextualizeExpression('`${selection.count()} selected`')).toBe('`${$wire.selection.count()} selected`')
+        expect(contextualizeExpression('`${first} of ${total}`')).toBe('`${$wire.first} of ${$wire.total}`')
+        expect(contextualizeExpression("`${foo ? 'yes' : 'no'}`")).toBe("`${$wire.foo ? 'yes' : 'no'}`")
+        expect(contextualizeExpression("`${foo ? '}' : name}`")).toBe("`${$wire.foo ? '}' : $wire.name}`")
+        expect(contextualizeExpression('`${JSON.stringify({ foo: foo })}`')).toBe('`${JSON.stringify({ foo: $wire.foo })}`')
+        expect(contextualizeExpression('`${files.filter(file => file.size > threshold).length} big`')).toBe('`${$wire.files.filter(file => file.size > $wire.threshold).length} big`')
+        expect(contextualizeExpression('`no interpolation`')).toBe('`no interpolation`')
+        expect(contextualizeExpression('`\\${count} escaped`')).toBe('`\\${count} escaped`')
+        expect(contextualizeExpression('save(`${name}`)')).toBe('$wire.save(`${$wire.name}`)')
+    })
+
+    it('template literal interpolations respect arrow function parameters', () => {
+        expect(contextualizeExpression('files.map(file => `${file.name}`)')).toBe('$wire.files.map(file => `${file.name}`)')
+    })
+
+    it('template literal interpolations respect alpine scope variables', () => {
+        let mockEl = {
+            _x_dataStack: [{ user: {} }],
+            hasAttribute: () => false,
+            parentElement: null,
+        }
+
+        expect(contextualizeExpression('`${user.name} and ${other}`', mockEl)).toBe('`${user.name} and ${$wire.other}`')
+    })
+
     it('alpine scope variables are skipped', () => {
         let mockEl = {
             _x_dataStack: [{ user: {}, index: 0 }],

--- a/src/Features/SupportWireText/BrowserTest.php
+++ b/src/Features/SupportWireText/BrowserTest.php
@@ -25,6 +25,31 @@ class BrowserTest extends BrowserTestCase
         ->assertSeeIn('@label', 'foo');
     }
 
+    public function test_wire_text_supports_template_literal_interpolation()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <div wire:text="`${count} selected`" dusk="label"></div>
+                    <button wire:click="increment" dusk="increment">Increment</button>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@label', '0 selected')
+        ->waitForLivewire()->click('@increment')
+        ->assertSeeIn('@label', '1 selected');
+    }
+
     public function test_wire_text_updates_when_property_changes()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
## The bug

Using a template literal in a directive expression fails with a \`ReferenceError\`:

```blade
<flux:text wire:text="`${selection.count()} selected`"></flux:text>
```

```
Livewire Expression Error: selection is not defined
Expression: "`${selection.count()} selected`"
```

## Why

`contextualizeExpression()` in `js/evaluator.js` yanks out all string literals before prefixing identifiers with `$wire.` — and backtick template literals are stashed whole, interpolations included. So `count` inside `${count}` is never rewritten to `$wire.count`, and the raw identifier blows up at evaluation time.

## The fix

After string literals are stashed (and arrow-function params are collected into the skip list), template literals get one extra pass: each `${...}` interpolation is recursively run through `contextualizeExpression()` with the current skip list threaded through. The scanner balances nested braces and skips nested string literals, so things like `${JSON.stringify({ foo: foo })}` and `${foo ? '}' : name}` contextualize correctly.

Threading the skip list means the existing scoping rules keep working inside interpolations:

- `files.map(file => `${file.name}`)` — arrow params stay bare
- `` `${user.name} and ${other}` `` — Alpine scope vars stay bare, everything else gets `$wire.`
- `` `\${count} escaped` `` — escaped interpolations are left alone

Since the fix is in the shared evaluator, it applies to every directive that takes an action expression (`wire:text`, `wire:show`, `wire:if`, …), not just `wire:text`.

## Tests

- 3 new unit test groups in `js/evaluator.spec.js` covering interpolation prefixing, nested braces/strings, escaped `${`, arrow params, and Alpine scope
- New browser test in `SupportWireText/BrowserTest.php`: `wire:text="`${count} selected`"` renders `0 selected` and updates to `1 selected` after a real click (passing locally)
- Full JS suite passes (137 tests); verified end-to-end in a real Laravel app with the repro above

🤖 Generated with [Claude Code](https://claude.com/claude-code)