### PR TITLE
[4.x] Warn when `wire:poll` uses an unsupported duration

### DIFF
--- a/js/directives/wire-poll.js
+++ b/js/directives/wire-poll.js
@@ -3,7 +3,7 @@ import { setNextActionMetadata, setNextActionOrigin, sessionIsExpired } from '@/
 import { evaluateActionExpression } from '../evaluator'
 
 directive('poll', ({ el, directive, component }) => {
-    let interval = extractDurationFrom(el, directive, 2000)
+    let interval = extractDurationFrom(directive.modifiers, 2000)
 
     let { start, pauseWhile, throttleWhile, stopWhen } = poll(() => {
         triggerComponentRequest(el, directive, component)
@@ -124,8 +124,7 @@ export function theElementIsDisconnected(el) {
     return el.isConnected === false
 }
 
-export function extractDurationFrom(el, directive, defaultDuration) {
-    let modifiers = directive.modifiers
+export function extractDurationFrom(modifiers, defaultDuration) {
     let durationInMilliSeconds
     let durationInMilliSecondsString = modifiers.find(mod => mod.match(/([0-9]+)ms/))
     let durationInSecondsString = modifiers.find(mod => mod.match(/([0-9]+)s/))
@@ -140,10 +139,7 @@ export function extractDurationFrom(el, directive, defaultDuration) {
         let unsupportedDuration = modifiers.find(mod => mod.match(/^[0-9]+[a-z]+$/))
 
         if (unsupportedDuration) {
-            console.warn(
-                `Livewire: [${directive.rawName}] uses an unsupported duration. Supported units are "ms" and "s". The default 2-second interval will be used.`,
-                el,
-            )
+            console.warn(`Livewire: [wire:poll.${unsupportedDuration}] uses an unsupported duration. Supported units are "ms" and "s". The default 2-second interval will be used.`)
         }
 
         return defaultDuration

--- a/js/directives/wire-poll.js
+++ b/js/directives/wire-poll.js
@@ -3,9 +3,7 @@ import { setNextActionMetadata, setNextActionOrigin, sessionIsExpired } from '@/
 import { evaluateActionExpression } from '../evaluator'
 
 directive('poll', ({ el, directive, component }) => {
-    warnIfPollDurationIsUnsupported(el, directive)
-
-    let interval = extractDurationFrom(directive.modifiers, 2000)
+    let interval = extractDurationFrom(el, directive, 2000)
 
     let { start, pauseWhile, throttleWhile, stopWhen } = poll(() => {
         triggerComponentRequest(el, directive, component)
@@ -126,10 +124,11 @@ export function theElementIsDisconnected(el) {
     return el.isConnected === false
 }
 
-export function extractDurationFrom(modifiers, defaultDuration) {
+export function extractDurationFrom(el, directive, defaultDuration) {
+    let modifiers = directive.modifiers
     let durationInMilliSeconds
-    let durationInMilliSecondsString = modifiers.find(mod => mod.match(/^([0-9]+)ms$/))
-    let durationInSecondsString = modifiers.find(mod => mod.match(/^([0-9]+)s$/))
+    let durationInMilliSecondsString = modifiers.find(mod => mod.match(/([0-9]+)ms/))
+    let durationInSecondsString = modifiers.find(mod => mod.match(/([0-9]+)s/))
 
     if (durationInMilliSecondsString) {
         durationInMilliSeconds = Number(durationInMilliSecondsString.replace('ms', ''))
@@ -137,18 +136,18 @@ export function extractDurationFrom(modifiers, defaultDuration) {
         durationInMilliSeconds = Number(durationInSecondsString.replace('s', '')) * 1000
     }
 
-    return durationInMilliSeconds || defaultDuration
-}
+    if (! durationInMilliSeconds) {
+        let unsupportedDuration = modifiers.find(mod => mod.match(/^[0-9]+[a-z]+$/))
 
-function warnIfPollDurationIsUnsupported(el, directive) {
-    let unsupportedDuration = directive.modifiers.find(mod => {
-        return mod.match(/^[0-9]+[a-z]+$/) && ! mod.match(/^([0-9]+)(ms|s)$/)
-    })
+        if (unsupportedDuration) {
+            console.warn(
+                `Livewire: [${directive.rawName}] uses an unsupported duration. Supported units are "ms" and "s". The default 2-second interval will be used.`,
+                el,
+            )
+        }
 
-    if (! unsupportedDuration) return
+        return defaultDuration
+    }
 
-    console.warn(
-        `Livewire: [${directive.rawName}] uses an unsupported duration. Supported units are "ms" and "s". The default 2-second interval will be used.`,
-        el,
-    )
+    return durationInMilliSeconds
 }

--- a/js/directives/wire-poll.js
+++ b/js/directives/wire-poll.js
@@ -3,6 +3,8 @@ import { setNextActionMetadata, setNextActionOrigin, sessionIsExpired } from '@/
 import { evaluateActionExpression } from '../evaluator'
 
 directive('poll', ({ el, directive, component }) => {
+    warnIfPollDurationIsUnsupported(el, directive)
+
     let interval = extractDurationFrom(directive.modifiers, 2000)
 
     let { start, pauseWhile, throttleWhile, stopWhen } = poll(() => {
@@ -126,8 +128,8 @@ export function theElementIsDisconnected(el) {
 
 export function extractDurationFrom(modifiers, defaultDuration) {
     let durationInMilliSeconds
-    let durationInMilliSecondsString = modifiers.find(mod => mod.match(/([0-9]+)ms/))
-    let durationInSecondsString = modifiers.find(mod => mod.match(/([0-9]+)s/))
+    let durationInMilliSecondsString = modifiers.find(mod => mod.match(/^([0-9]+)ms$/))
+    let durationInSecondsString = modifiers.find(mod => mod.match(/^([0-9]+)s$/))
 
     if (durationInMilliSecondsString) {
         durationInMilliSeconds = Number(durationInMilliSecondsString.replace('ms', ''))
@@ -136,4 +138,17 @@ export function extractDurationFrom(modifiers, defaultDuration) {
     }
 
     return durationInMilliSeconds || defaultDuration
+}
+
+function warnIfPollDurationIsUnsupported(el, directive) {
+    let unsupportedDuration = directive.modifiers.find(mod => {
+        return mod.match(/^[0-9]+[a-z]+$/) && ! mod.match(/^([0-9]+)(ms|s)$/)
+    })
+
+    if (! unsupportedDuration) return
+
+    console.warn(
+        `Livewire: [${directive.rawName}] uses an unsupported duration. Supported units are "ms" and "s". The default 2-second interval will be used.`,
+        el,
+    )
 }

--- a/src/Features/SupportPolling/BrowserTest.php
+++ b/src/Features/SupportPolling/BrowserTest.php
@@ -8,6 +8,19 @@ use Livewire\Component;
 
 class BrowserTest extends BrowserTestCase
 {
+    public function test_warns_when_a_poll_duration_uses_an_unsupported_unit()
+    {
+        Livewire::visit(new class extends Component {
+            public function render() { return <<<'HTML'
+            <div wire:poll.10m>
+                Polling
+            </div>
+            HTML; }
+        })
+        ->assertConsoleLogHasWarning('Livewire: [wire:poll.10m] uses an unsupported duration. Supported units are \"ms\" and \"s\". The default 2-second interval will be used.')
+        ;
+    }
+
     public function test_polling_requests_are_batched_by_default()
     {
         Livewire::visit([new class extends Component {


### PR DESCRIPTION
This PR is a companion to PR https://github.com/livewire/livewire/pull/10427 which adds support for minute durations.

# The Scenario

When using a duration such as `wire:poll.10m`, Livewire silently ignores the unsupported unit and falls back to polling every two seconds.

This can cause a page intended to poll every ten minutes to send 300 times more requests than expected without any visible indication that the duration was not recognised.

```blade
<div wire:poll.10m>
    ...
</div>
```

# The Problem

The `wire:poll` duration parser only recognises modifiers ending in `ms` or `s`. Duration-shaped modifiers using any other unit fall through to the default two-second interval without warning.

# The Solution

The solution is to show a warning when `wire:poll` uses an unsupported duration:

```text
Livewire: [wire:poll.10m] uses an unsupported duration. Supported units are "ms" and "s". The default 2-second interval will be used.
```

This matches existing directive warnings:

```text
Livewire: [wire:model] is missing a value.
Livewire: [wire:model="foo"] property does not exist on component: [example]
```

Fixes #10419
