### PR TITLE
[4.x] Support minute durations for `wire:poll`

### DIFF
--- a/docs/polling.md
+++ b/docs/polling.md
@@ -49,6 +49,8 @@ The best way to reduce requests in this scenario is simply to make the polling i
 You can manually control how often the component will poll by appending the desired duration to `wire:poll` like so:
 
 ```blade
+<div wire:poll.1m> <!-- In minutes... -->
+
 <div wire:poll.15s> <!-- In seconds... -->
 
 <div wire:poll.15000ms> <!-- In milliseconds... -->

--- a/docs/wire-poll.md
+++ b/docs/wire-poll.md
@@ -52,6 +52,8 @@ The best way to reduce requests in this scenario is simply to make the polling i
 You can manually control how often the component will poll by appending the desired duration to `wire:poll` like so:
 
 ```blade
+<div wire:poll.1m> <!-- In minutes... -->
+
 <div wire:poll.15s> <!-- In seconds... -->
 
 <div wire:poll.15000ms> <!-- In milliseconds... -->
@@ -88,6 +90,7 @@ wire:poll="action"
 
 | Modifier | Description |
 |----------|-------------|
+| `.[number]m` | Poll interval in minutes (e.g., `.1m`) |
 | `.[number]s` | Poll interval in seconds (e.g., `.15s`) |
 | `.[number]ms` | Poll interval in milliseconds (e.g., `.15000ms`) |
 | `.keep-alive` | Continue polling even when the tab is in the background |

--- a/js/directives/wire-poll.js
+++ b/js/directives/wire-poll.js
@@ -128,11 +128,14 @@ export function extractDurationFrom(modifiers, defaultDuration) {
     let durationInMilliSeconds
     let durationInMilliSecondsString = modifiers.find(mod => mod.match(/([0-9]+)ms/))
     let durationInSecondsString = modifiers.find(mod => mod.match(/([0-9]+)s/))
+    let durationInMinutesString = modifiers.find(mod => mod.match(/([0-9]+)m/))
 
     if (durationInMilliSecondsString) {
         durationInMilliSeconds = Number(durationInMilliSecondsString.replace('ms', ''))
     } else if (durationInSecondsString) {
         durationInMilliSeconds = Number(durationInSecondsString.replace('s', '')) * 1000
+    } else if (durationInMinutesString) {
+        durationInMilliSeconds = Number(durationInMinutesString.replace('m', '')) * 60 * 1000
     }
 
     return durationInMilliSeconds || defaultDuration

--- a/src/Features/SupportPolling/BrowserTest.php
+++ b/src/Features/SupportPolling/BrowserTest.php
@@ -8,6 +8,48 @@ use Livewire\Component;
 
 class BrowserTest extends BrowserTestCase
 {
+    public function test_poll_duration_can_be_in_minutes()
+    {
+        Livewire::visit(new class extends Component {
+            public $pollCount = 0;
+            public $polling = false;
+
+            public function startPolling()
+            {
+                $this->polling = true;
+            }
+
+            public function poll()
+            {
+                $this->pollCount++;
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button wire:click="startPolling" dusk="start-polling">Start polling</button>
+                <span dusk="poll-count">{{ $pollCount }}</span>
+
+                @if ($polling)
+                    <div wire:poll.1m="poll"></div>
+                @endif
+            </div>
+            HTML; }
+        })
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            window.originalSetInterval = window.setInterval
+            window.setInterval = (callback, duration) => {
+                window.pollDuration = duration
+                window.setInterval = window.originalSetInterval
+
+                return window.setTimeout(callback)
+            }
+            JS))
+        ->waitForLivewire()->click('@start-polling')
+        ->assertScript('window.pollDuration', 60000)
+        ->waitForTextIn('@poll-count', '1')
+        ;
+    }
+
     public function test_polling_requests_are_batched_by_default()
     {
         Livewire::visit([new class extends Component {

--- a/src/Features/SupportPolling/BrowserTest.php
+++ b/src/Features/SupportPolling/BrowserTest.php
@@ -27,6 +27,48 @@ class BrowserTest extends BrowserTestCase
             ;
     }
 
+    public function test_poll_duration_can_be_in_minutes()
+    {
+        Livewire::visit(new class extends Component {
+            public $pollCount = 0;
+            public $polling = false;
+
+            public function startPolling()
+            {
+                $this->polling = true;
+            }
+
+            public function poll()
+            {
+                $this->pollCount++;
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button wire:click="startPolling" dusk="start-polling">Start polling</button>
+                <span dusk="poll-count">{{ $pollCount }}</span>
+
+                @if ($polling)
+                    <div wire:poll.1m="poll"></div>
+                @endif
+            </div>
+            HTML; }
+        })
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            window.originalSetInterval = window.setInterval
+            window.setInterval = (callback, duration) => {
+                window.pollDuration = duration
+                window.setInterval = window.originalSetInterval
+
+                return window.setTimeout(callback)
+            }
+            JS))
+        ->waitForLivewire()->click('@start-polling')
+        ->assertScript('window.pollDuration', 60000)
+        ->waitForTextIn('@poll-count', '1')
+        ;
+    }
+
     public function test_polling_requests_are_batched_by_default()
     {
         Livewire::visit([new class extends Component {


### PR DESCRIPTION
This PR is a companion to PR https://github.com/livewire/livewire/pull/10426 which adds a warning for unsupported durations.

# The Scenario

When using `wire:poll` for dashboard widgets that only need occasional updates, a duration such as `wire:poll.10m` appears to represent ten minutes but instead polls every two seconds.

```blade
<div wire:poll.10m>
    ...
</div>
```

# The Problem

The `wire:poll` duration parser only recognises milliseconds and seconds. A duration using `m` is not parsed, so Livewire falls back to the default two-second interval.

# The Solution

The solution is to support minutes as a polling duration.

```blade
<div wire:poll.10m>
    ...
</div>
```

Fixes #10419
