### PR TITLE
[4.x] Fix unhandled rejections from cancelled polls

### DIFF
--- a/js/$wire.js
+++ b/js/$wire.js
@@ -298,12 +298,20 @@ wireProperty('$effect', (component) => (callback) => {
     return effect
 })
 
-wireProperty('$refresh', (component) => async () => {
-    return fireAction(component, '$refresh')
+wireProperty('$refresh', (component) => () => {
+    try {
+        return fireAction(component, '$refresh')
+    } catch (error) {
+        return Promise.reject(error)
+    }
 })
 
-wireProperty('$commit', (component) => async () => {
-    return fireAction(component, '$commit')
+wireProperty('$commit', (component) => () => {
+    try {
+        return fireAction(component, '$commit')
+    } catch (error) {
+        return Promise.reject(error)
+    }
 })
 
 wireProperty('$on', (component) => (...params) => listen(component, ...params))

--- a/js/$wire.js
+++ b/js/$wire.js
@@ -299,6 +299,7 @@ wireProperty('$effect', (component) => (callback) => {
 })
 
 wireProperty('$refresh', (component) => () => {
+    // Keep the original action promise, but return synchronous errors as rejected promises...
     try {
         return fireAction(component, '$refresh')
     } catch (error) {
@@ -307,6 +308,7 @@ wireProperty('$refresh', (component) => () => {
 })
 
 wireProperty('$commit', (component) => () => {
+    // Keep the original action promise, but return synchronous errors as rejected promises...
     try {
         return fireAction(component, '$commit')
     } catch (error) {

--- a/src/Features/SupportPolling/BrowserTest.php
+++ b/src/Features/SupportPolling/BrowserTest.php
@@ -8,6 +8,25 @@ use Livewire\Component;
 
 class BrowserTest extends BrowserTestCase
 {
+    public function test_cancelled_poll_does_not_trigger_an_unhandled_promise_rejection()
+    {
+        Livewire::visit(new class extends Component {
+            public function render() {
+                usleep(3 * 1000 * 1000);
+
+                return <<<'HTML'
+                <div wire:poll>
+                    Polling
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->pause(4500)
+            ->assertConsoleLogHasNoErrors()
+            ;
+    }
+
     public function test_polling_requests_are_batched_by_default()
     {
         Livewire::visit([new class extends Component {


### PR DESCRIPTION
# The Scenario

When a component using `wire:poll` takes longer to respond than the polling interval, cancelled polls produce an error in the browser console:

```text
Uncaught (in promise) {status: null, body: null, json: null, errors: null}
```

```blade
<div wire:poll>
    ...
</div>
```

# The Problem

Livewire marks action promises with `_livewireAction` so expected request rejections can be handled by the action evaluator.

The `$refresh` and `$commit` helpers return `fireAction()` through an `async` function. The `async` function creates a new promise that adopts the action promise’s result but does not retain its `_livewireAction` marker.

When Livewire cancels an overlapping poll, the wrapper promise therefore rejects without the evaluator attaching its request rejection handler.

# The Solution

Return the original action promise directly from `$refresh` and `$commit` so the `_livewireAction` marker is preserved.

Synchronous errors from `fireAction()` are caught and returned as rejected promises, preserving the previous behaviour of the `async` functions.

Fixes #10420
