### PR TITLE
Keep rich synth values out of consolidated diffs

### DIFF
--- a/js/synths.spec.js
+++ b/js/synths.spec.js
@@ -240,17 +240,30 @@ describe('diffing rich values', () => {
         expect(diffAndConsolidate(left, right)).toEqual({ price: { amount: 200, currency: 'USD' } })
     })
 
-    it('dehydrates rich values nested inside consolidated diffs', () => {
+    it('keeps rich values granular in their dehydrated wire format when an array grows', () => {
         registerDateSynth()
 
         let left = { dates: [new Date('2021-01-01T00:00:00Z')] }
         let right = { dates: [new Date('2021-01-01T00:00:00Z'), new Date('2022-02-02T00:00:00Z')] }
 
-        // The array grew, so the diff consolidates to the parent level and
-        // must contain wire-format values, not rich ones...
+        // Rich values veto consolidation to the parent level — the server
+        // resolves each one's synthesizer from meta stored at its own path,
+        // so a consolidated parent update would strip their type. The diff
+        // stays granular, in wire format...
         expect(diffAndConsolidate(left, right)).toEqual({
-            dates: ['2021-01-01T00:00:00.000Z', '2022-02-02T00:00:00.000Z'],
+            'dates.1': '2022-02-02T00:00:00.000Z',
         })
+    })
+
+    it('emits explicit removal markers when an array holding rich values shrinks', () => {
+        registerDateSynth()
+
+        let left = { dates: [new Date('2021-01-01T00:00:00Z'), new Date('2022-02-02T00:00:00Z')] }
+        let right = { dates: [new Date('2021-01-01T00:00:00Z')] }
+
+        // Removals normally ride along inside a consolidated parent update —
+        // with consolidation vetoed they surface as explicit markers instead...
+        expect(diffAndConsolidate(left, right)).toEqual({ 'dates.1': '__rm__' })
     })
 })
 
@@ -413,6 +426,8 @@ describe('values that dehydrate to undefined (no wire representation)', () => {
         let left = { things: [new PendingThing('a')] }
         let right = { things: [new PendingThing('b'), new PendingThing()] }
 
-        expect(diffAndConsolidate(left, right)).toEqual({ things: ['b'] })
+        // Granular because rich values veto consolidation: the settled value
+        // syncs at its own path while the pending one stays off the wire...
+        expect(diffAndConsolidate(left, right)).toEqual({ 'things.0': 'b' })
     })
 })

--- a/js/utils.js
+++ b/js/utils.js
@@ -259,6 +259,17 @@ export function diffAndConsolidate(left, right) {
     return diffs
 }
 
+// Whether a value tree holds any rich synth value. Used to veto diff
+// consolidation: rich values must stay at their own dot-notated paths
+// because that's where the server finds their synth meta...
+function containsSynthValue(value) {
+    if (typeof value !== 'object' || value === null) return false
+
+    if (findSynthByValue(value)) return true
+
+    return Object.values(value).some(containsSynthValue)
+}
+
 function diffRecursive(left, right, path, diffs, rootLeft, rootRight) {
     // Are they the same?
     if (left === right) return { changed: false, consolidated: false }
@@ -331,10 +342,17 @@ function diffRecursive(left, right, path, diffs, rootLeft, rootRight) {
     let leftKeys = Object.keys(left)
     let rightKeys = Object.keys(right)
 
+    // Consolidation is off the table anywhere the subtree holds rich synth values:
+    // the server resolves each rich value's synthesizer from the snapshot meta stored
+    // at its OWN path, so a consolidated parent update would hydrate them as plain
+    // data and silently strip their type. Fall through to granular child diffs
+    // instead (with explicit removals, which consolidation used to imply)...
+    let hasRichValues = hasSynths() && (containsSynthValue(left) || containsSynthValue(right))
+
     // If the size changed, consolidate at this level
     // BUT if we converted to object, don't consolidate - we're adding new items
     // and should produce granular diffs for query string handling
-    if (leftKeys.length !== rightKeys.length && !convertedToObject) {
+    if (leftKeys.length !== rightKeys.length && !convertedToObject && !hasRichValues) {
         // For root level, we can't consolidate to a single key, so diff each root property
         if (path === '') {
             Object.keys(right).forEach(key => {
@@ -349,7 +367,7 @@ function diffRecursive(left, right, path, diffs, rootLeft, rootRight) {
     }
 
     // Did the key order change?
-    if (isObject(left) && leftKeys.length === rightKeys.length && leftKeys.some((key, i) => key !== rightKeys[i])) {
+    if (isObject(left) && leftKeys.length === rightKeys.length && leftKeys.some((key, i) => key !== rightKeys[i]) && !hasRichValues) {
         if (path !== '') {
             diffs[path] = dataGet(rootRight, path)
             return { changed: true, consolidated: true }
@@ -359,7 +377,7 @@ function diffRecursive(left, right, path, diffs, rootLeft, rootRight) {
     // Check if all keys are the same (no additions/removals)
     let keysMatch = leftKeys.every(k => rightKeys.includes(k))
 
-    if (!keysMatch && !convertedToObject) {
+    if (!keysMatch && !convertedToObject && !hasRichValues) {
         // Keys differ (some added, some removed) - consolidate
         if (path !== '') {
             diffs[path] = dataGet(rootRight, path)
@@ -385,7 +403,7 @@ function diffRecursive(left, right, path, diffs, rootLeft, rootRight) {
     // ALSO skip consolidation if we converted to object - we're adding new items, not replacing
     // Only consolidate if there are MULTIPLE children - single property changes should remain granular
     // for wire:target to work correctly (e.g., wire:target="form.text" needs "form.text" not "form")
-    if (path !== '' && totalChildren > 1 && changedCount === totalChildren && consolidatedCount === 0 && !convertedToObject) {
+    if (path !== '' && totalChildren > 1 && changedCount === totalChildren && consolidatedCount === 0 && !convertedToObject && !hasRichValues) {
         diffs[path] = dataGet(rootRight, path)
         return { changed: true, consolidated: true }
     }
@@ -393,10 +411,23 @@ function diffRecursive(left, right, path, diffs, rootLeft, rootRight) {
     // Otherwise, add individual child diffs
     Object.assign(diffs, childDiffs)
 
+    // Removed keys normally ride along inside a consolidated parent update - when rich
+    // values vetoed consolidation, they need explicit removal markers instead...
+    let removedCount = 0
+
+    if (hasRichValues) {
+        leftKeys.filter(key => !rightKeys.includes(key)).forEach(key => {
+            let childPath = path === '' ? key : `${path}.${key}`
+            if (diffs[childPath] === undefined) diffs[childPath] = '__rm__'
+            removedCount++
+        })
+    }
+
     // If any child was consolidated, bubble that up to prevent further consolidation
     // Also bubble up convertedToObject to prevent parent consolidation from
     // JSON-serializing arrays with non-numeric keys (which JSON.stringify ignores)
-    return { changed: changedCount > 0, consolidated: consolidatedCount > 0 || convertedToObject }
+    // Rich-value subtrees report consolidated so ancestors never re-swallow them
+    return { changed: changedCount > 0 || removedCount > 0, consolidated: consolidatedCount > 0 || convertedToObject || hasRichValues }
 }
 
 /**


### PR DESCRIPTION
## The bug

The client's `diffAndConsolidate` collapses child updates into a single parent-path update whenever an array/object changes shape (size change, key order, added/removed keys) or when every child changed. But the server resolves each rich synth value's synthesizer from snapshot meta stored at the value's **own dot-notated path** — so a consolidated parent update hydrates rich values as plain data and silently strips their type.

Concretely, on main today: put a `Selection` (or any synth value) inside an array property, then grow or shrink that array — the next request degrades the Selection to a plain array server-side. The long-standing Form-object special case in the diff code is a scar from this same problem; this fixes the class of bug rather than the instance.

## The fix

Rich values veto consolidation anywhere in their subtree, falling back to granular child diffs. Removals that consolidation used to imply now surface as explicit `__rm__` markers — a wire format the server already handles.

Two existing specs asserted the old consolidated wire *shape*; they now assert the granular equivalent (same server-side outcome), plus a new spec covering the removal-marker path.

## Verification

- `npm test` (vitest): 142 passed, including the rewritten and new diff specs
- `composer test:browser -- --filter='SupportSelection|SupportJsSynthesizers'`: 25 tests, 91 assertions, green against the built bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)