### PR TITLE
Offer rejected query string values to the property's synthesizer

### DIFF
--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -5,6 +5,8 @@ namespace Livewire\Features\SupportQueryString;
 use Illuminate\Support\Arr;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\Features\SupportFormObjects\Form;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+use Livewire\Mechanisms\HandleSynths\HandleSynths;
 use ReflectionClass;
 
 #[\Attribute]
@@ -90,8 +92,21 @@ class BaseUrl extends LivewireAttribute
         try {
             $this->setValue($value, $this->nullable);
         } catch (\TypeError $e) {
-            // Silently ignore invalid query string types and keep the default.
-            return;
+            // A synth-typed property (Selection, Sort, ...) can't accept the
+            // raw query string value directly — offer it to the property's
+            // synthesizer, the same conversion wire updates receive...
+            $hydrated = app(HandleSynths::class)->hydrateForUpdate(
+                null, $this->getName(), $value, new ComponentContext($this->getComponent())
+            );
+
+            if ($hydrated === $value) return;
+
+            try {
+                $this->setValue($hydrated, $this->nullable);
+            } catch (\TypeError) {
+                // Silently ignore invalid query string types and keep the default.
+                return;
+            }
         }
     }
 

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -227,6 +227,36 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame(['foo'], $component->instance()->test);
     }
 
+    function test_query_string_value_for_synth_typed_property_hydrates_through_its_synthesizer()
+    {
+        $component = Livewire::withQueryParams([
+            'selected' => ['5', '7'],
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public \Livewire\Selection $selected;
+        });
+
+        $component->assertStatus(200);
+        $this->assertInstanceOf(\Livewire\Selection::class, $component->instance()->selected);
+        $this->assertTrue($component->instance()->selected->contains(5));
+        $this->assertTrue($component->instance()->selected->contains(7));
+        $this->assertSame(2, $component->instance()->selected->count());
+    }
+
+    function test_garbage_query_string_value_for_synth_typed_property_keeps_a_valid_value()
+    {
+        $component = Livewire::withQueryParams([
+            'selected' => 'garbage',
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public \Livewire\Selection $selected;
+        });
+
+        $component->assertStatus(200);
+        $this->assertInstanceOf(\Livewire\Selection::class, $component->instance()->selected);
+        $this->assertTrue($component->instance()->selected->isEmpty());
+    }
+
     function test_valid_string_value_for_string_property_still_works()
     {
         $component = Livewire::withQueryParams([


### PR DESCRIPTION
## The bug

`BaseUrl` catches the `TypeError` when a query string value can't be assigned to a typed property and silently keeps the default. That's the right instinct for garbage input, but it also locks every synth-typed property out of URL binding entirely — `#[Url] public Selection $selected` could never receive a value from the query string, because the raw array always fails the typed assignment.

## The fix

A rejected value is now offered to the property's synthesizer via `HandleSynths::hydrateForUpdate` — the exact conversion wire updates already receive — before falling back to keeping the default. If no synth claims the property (plain `string`/`int` props with garbage input), behavior is unchanged: the value comes back untouched and the default wins.

This lets any synth-typed property — `Selection`, userland synths — participate in URL binding, with each synth's `hydrateFromType` deciding what the query string value means.

## Verification

- Two new tests in `SupportQueryString/UnitTest.php`: `?selected[]=5&selected[]=7` hydrates into a real `Selection` containing both keys; garbage input still lands on a valid empty `Selection`
- `SupportQueryString` unit tests: 20 tests, 37 assertions, green — including all the existing silently-ignore tests for plain typed properties
- Full `Unit` testsuite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)