### PR TITLE
[4.x] Fix for the temporary file upload rules given in the livewire config is causing livewire.js syntax error

### DIFF
--- a/src/Features/SupportFileUploads/FileUploadController.php
+++ b/src/Features/SupportFileUploads/FileUploadController.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportFileUploads;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Controllers\Middleware;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 
 class FileUploadController implements HasMiddleware
 {
@@ -37,9 +38,13 @@ class FileUploadController implements HasMiddleware
 
     public function validateAndStore($files, $disk)
     {
-        Validator::make(['files' => $files], [
-            'files.*' => FileUploadConfiguration::rules()
-        ])->validate();
+        try {
+            Validator::make(['files' => $files], [
+                'files.*' => FileUploadConfiguration::rules()
+            ])->validate();
+        } catch (ValidationException $e) {
+            abort(response()->json(['errors' => $e->errors()], 422));
+        }
 
         $fileHashPaths = collect($files)->map(function ($file) use ($disk) {
             return FileUploadConfiguration::storeTemporaryFile($file, $disk);


### PR DESCRIPTION
# The Scenario
Fixes #10430
When a file uploaded against the `livewire.temporary_file_upload.rules` rules given in the livewire config file or the default rules that are set (['required', 'file', 'max:12288']), it will cause this error in the browser console.
```text
Uncaught SyntaxError: JSON.parse: unexpected character at line 4 column 9 of the JSON data in livewire.js:809:62
```
<img width="1291" height="54" alt="image" src="https://github.com/user-attachments/assets/4eab3735-a7b5-41b9-bf11-7f1caaa3ff2c" />

### Code snippets to reproduce the issue
```php
<?php

use Livewire\Component;
use Livewire\WithFileUploads;
use Illuminate\Validation\ValidationException;

new class extends Component
{
    use WithFileUploads;

    public $image;

    public function upload(){
        $this->image->store(path: 'images');
    }
};
?>

<div>
    <form wire:submit="upload">
        <h3>Upload a file bigger than 12 MB</h3>
        <input type="file" wire:model="image">
        <button type="submit">Upload</button>
    </form>
</div>
```
# The Problem
When a file that is not valid with the rules given in `livewire.temporary_file_upload.rules`, Livewire should show the validation errors in the form. But currently it is having `Uncaught SyntaxError` in the JavaScript. This is due to the validation check done in the file `src\Features\SupportFileUploads\FileUploadController.php` is like this:
```php
public function validateAndStore($files, $disk)
{
    Validator::make(['files' => $files], [
        'files.*' => FileUploadConfiguration::rules()
    ])->validate();
....

```
Where the validation is done by the Laravel and return a 302 response which will cause the `livewire.js` to redirect and load the form page. `livewire.js` expects 422 status code for validation error.
```js
request.addEventListener("load", () => {
  if ((request.status + "")[0] === "2") {
    let paths = retrievePaths(request.response && JSON.parse(request.response));
    this.component.$wire.call("_finishUpload", name, paths, this.uploadBag.first(name).multiple, this.uploadBag.first(name).append);
    return;
  }
  let errors = null;
  if (request.status === 422) {
    errors = request.response;
  }
  this.component.$wire.call("_uploadErrored", name, errors, this.uploadBag.first(name).multiple);
});
```
# The Solution
Fix is done in `FileUploadController.php`, so that it will return the validation errors as a 422 status code response.
```php
try {
    Validator::make(['files' => $files], [
        'files.*' => FileUploadConfiguration::rules()
    ])->validate();
} catch (ValidationException $e) {
    abort(response()->json(['errors' => $e->errors()], 422));
}
....
```