### PR TITLE
Add reset() and has() aliases to Selection

### DIFF
--- a/docs/selection.md
+++ b/docs/selection.md
@@ -272,6 +272,7 @@ Available on `Livewire\Selection` in PHP and on the bound property in directive 
 | `except()` | The exception keys while in select-all mode |
 | `total()` | The stored total, or `null` if one was never set |
 | `clear()` | Deselect everything and leave select-all mode |
+| `reset()` | Alias of `clear()`, matching the `reset()` on form objects |
 
 Keys are compared loosely, since checkbox values arrive as strings while database keys are often integers, so `'1'` and `1` refer to the same row.
 

--- a/docs/selection.md
+++ b/docs/selection.md
@@ -262,6 +262,7 @@ Available on `Livewire\Selection` in PHP and on the bound property in directive 
 | `deselect($key)` | Remove a key from the selection |
 | `toggle($key)` | Select the key if unselected, deselect it otherwise |
 | `contains($key)` | Whether the key is selected |
+| `has($key)` | Alias of `contains($key)`, matching the `has()` on collections |
 | `count($total = null)` | Number of selected keys. In select-all mode a total is required: without one it throws in PHP and returns `null` in JavaScript |
 | `any()` | Whether anything is selected |
 | `isEmpty()` | Whether nothing is selected |

--- a/js/features/supportSelection.js
+++ b/js/features/supportSelection.js
@@ -101,6 +101,12 @@ export class Selection extends Array {
         this.__mode = 'include'
     }
 
+    // Form objects call this operation reset() — same word here so either
+    // primitive answers to the vocabulary users already know...
+    reset() {
+        this.clear()
+    }
+
     // A dedicated "select all" checkbox — the one at the top of a column —
     // binds to this facet: wire:model="selection.page". Checked models
     // "the whole page is selected", indeterminate marks a partial page,

--- a/js/features/supportSelection.js
+++ b/js/features/supportSelection.js
@@ -61,6 +61,10 @@ export class Selection extends Array {
         return this.isAll() ? ! has : has
     }
 
+    // Collections answer membership checks as both has() and contains() —
+    // same here, so whichever word users guess works...
+    has(key) { return this.contains(key) }
+
     select(key) {
         this.isAll() ? this.__removeKey(key) : this.__addKey(key)
     }

--- a/src/Features/SupportSelection/BrowserTest.php
+++ b/src/Features/SupportSelection/BrowserTest.php
@@ -89,6 +89,34 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_reset_clears_the_selection_from_a_directive_expression()
+    {
+        Livewire::visit(new class extends Component {
+            public Selection $selection;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="checkbox" dusk="one" wire:model="selection" value="1" />
+
+                    <button dusk="reset" type="button" wire:click="selection.reset()">Reset selection</button>
+
+                    <button dusk="refresh" type="button" wire:click="$refresh">Refresh</button>
+
+                    <span dusk="server">{{ $selection->count() }}</span>
+                </div>
+                HTML;
+            }
+        })
+        ->check('@one')
+        ->click('@reset')
+        ->assertNotChecked('@one')
+        ->waitForLivewire()->click('@refresh')
+        ->assertSeeIn('@server', '0')
+        ;
+    }
+
     public function test_select_page_selects_every_bound_checkbox_on_the_page()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportSelection/Selection.php
+++ b/src/Features/SupportSelection/Selection.php
@@ -130,6 +130,13 @@ class Selection implements Arrayable, \Countable, \IteratorAggregate, \JsonSeria
         return $this;
     }
 
+    // Form objects call this operation reset() — same word here so either
+    // primitive answers to the vocabulary users already know...
+    public function reset(): static
+    {
+        return $this->clear();
+    }
+
     public function toArray(): array
     {
         $this->ensureIncludeMode(__FUNCTION__);

--- a/src/Features/SupportSelection/Selection.php
+++ b/src/Features/SupportSelection/Selection.php
@@ -93,6 +93,13 @@ class Selection implements Arrayable, \Countable, \IteratorAggregate, \JsonSeria
         return $this->isAll() ? ! $has : $has;
     }
 
+    // Collections answer membership checks as both has() and contains() —
+    // same here, so whichever word users guess works...
+    public function has($key): bool
+    {
+        return $this->contains($key);
+    }
+
     public function select($key): static
     {
         $this->isAll() ? $this->removeKey($key) : $this->addKey($key);

--- a/src/Features/SupportSelection/UnitTest.php
+++ b/src/Features/SupportSelection/UnitTest.php
@@ -116,6 +116,20 @@ class UnitTest extends \Tests\TestCase
         Assert::assertSame([], $selection->keys());
     }
 
+    function test_reset_returns_to_an_empty_include_mode_selection_like_clear()
+    {
+        $selection = new Selection([1, 2]);
+
+        $selection->selectAll();
+        $selection->deselect(3);
+
+        $selection->reset();
+
+        Assert::assertFalse($selection->isAll());
+        Assert::assertFalse($selection->any());
+        Assert::assertSame([], $selection->keys());
+    }
+
     function test_enumerating_an_all_mode_selection_fails_loudly()
     {
         $selection = (new Selection)->selectAll();

--- a/src/Features/SupportSelection/UnitTest.php
+++ b/src/Features/SupportSelection/UnitTest.php
@@ -177,6 +177,21 @@ class UnitTest extends \Tests\TestCase
         Assert::assertTrue($selection->contains(2));
     }
 
+    function test_has_answers_membership_like_contains_in_both_modes()
+    {
+        $selection = new Selection([1, 2]);
+
+        Assert::assertTrue($selection->has(2));
+        Assert::assertTrue($selection->has('2'));
+        Assert::assertFalse($selection->has(3));
+
+        $selection->selectAll();
+        $selection->deselect(3);
+
+        Assert::assertTrue($selection->has(999));
+        Assert::assertFalse($selection->has(3));
+    }
+
     function test_contains_uses_loose_comparison_for_checkbox_string_values()
     {
         $selection = new Selection([1, 2]);


### PR DESCRIPTION
## What

Adds two aliases to the Selection primitive (#10423), on both sides of the wire. Nothing is removed — purely additive:

- `reset()` — alias of `clear()`: deselect everything and return to an empty include-mode selection. PHP `Selection::reset()` (returns `$this->clear()`), JS `Selection.reset()`.
- `has($key)` — alias of `contains($key)`: same loose comparison, same select-all inversion. PHP `Selection::has($key)`, JS `Selection.has(key)`.
- Docs: both added to the method reference table in `docs/selection.md`.

## Why

Vocabulary users already know: Form objects use `reset()` for "back to the initial state", and collections answer membership checks as both `has()` and `contains()`. Selection now responds to whichever word users guess first.

## Verification

- New unit tests in `SupportSelection/UnitTest.php`: reset from all-mode with an exception → empty include-mode; has() membership in include-mode (loose comparison) and except-mode — full `--filter=SupportSelection` unit suite green (17 tests)
- New browser test exercising `wire:click="selection.reset()"` through a real checkbox + server round-trip — full SupportSelection browser suite green (14 tests)
- `npm test` green (145 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)