### PR TITLE
Selection: accept arrays of keys in select/deselect/toggle, warn on unbound page methods

### DIFF
--- a/docs/selection.md
+++ b/docs/selection.md
@@ -105,6 +105,8 @@ This checkbox is fully wired up automatically:
 <button wire:click="selected.selectPage()">Select page</button>
 ```
 
+The page methods only see checkboxes bound with `wire:model` — if your interface doesn't use them, pass an array of keys to `select()` instead.
+
 ## Selecting all results
 
 Selecting the current page is often just the first step. When a user wants to select all 2,500 matching records, enumerating every key in the browser would be impractical. Instead, `selectAll()` flips the selection into *select-all* mode: the selection now represents every result, and tracks only the *exceptions* (rows that have been unchecked since).
@@ -258,9 +260,9 @@ Available on `Livewire\Selection` in PHP and on the bound property in directive 
 
 | Method | Description |
 |--------|-------------|
-| `select($key)` | Add a key to the selection |
-| `deselect($key)` | Remove a key from the selection |
-| `toggle($key)` | Select the key if unselected, deselect it otherwise |
+| `select($key)` | Add a key to the selection. Accepts a single key or an array of keys |
+| `deselect($key)` | Remove a key from the selection. Accepts a single key or an array of keys |
+| `toggle($key)` | Select the key if unselected, deselect it otherwise. Accepts a single key or an array — each key toggles independently |
 | `contains($key)` | Whether the key is selected |
 | `has($key)` | Alias of `contains($key)`, matching the `has()` on collections |
 | `count($total = null)` | Number of selected keys. In select-all mode a total is required: without one it throws in PHP and returns `null` in JavaScript |

--- a/js/features/supportSelection.js
+++ b/js/features/supportSelection.js
@@ -65,16 +65,24 @@ export class Selection extends Array {
     // same here, so whichever word users guess works...
     has(key) { return this.contains(key) }
 
+    // Each mutator accepts a single key or an array of keys — selecting
+    // straight from data is one call: select(files.map(f => f.id))...
     select(key) {
-        this.isAll() ? this.__removeKey(key) : this.__addKey(key)
+        for (let single of Array.isArray(key) ? key : [key]) {
+            this.isAll() ? this.__removeKey(single) : this.__addKey(single)
+        }
     }
 
     deselect(key) {
-        this.isAll() ? this.__addKey(key) : this.__removeKey(key)
+        for (let single of Array.isArray(key) ? key : [key]) {
+            this.isAll() ? this.__addKey(single) : this.__removeKey(single)
+        }
     }
 
     toggle(key) {
-        this.contains(key) ? this.deselect(key) : this.select(key)
+        for (let single of Array.isArray(key) ? key : [key]) {
+            this.contains(single) ? this.deselect(single) : this.select(single)
+        }
     }
 
     selectAll() {
@@ -86,10 +94,14 @@ export class Selection extends Array {
     // The current "page" is whatever is rendered: every bound checkbox
     // registered a value thunk in interceptWireModel()...
     selectPage() {
+        this.__warnIfPageIsUnbound('selectPage')
+
         this.__pageValues().forEach(value => this.select(value))
     }
 
     deselectPage() {
+        this.__warnIfPageIsUnbound('deselectPage')
+
         this.__pageValues().forEach(value => this.deselect(value))
     }
 
@@ -170,6 +182,15 @@ export class Selection extends Array {
         return [...this.__registry()]
             .map(value => value())
             .filter(value => value !== undefined && value !== null && value !== '')
+    }
+
+    // The page is defined by wire:model-bound checkboxes. A custom UI that
+    // never binds any has no page — surface that instead of silently
+    // doing nothing...
+    __warnIfPageIsUnbound(method) {
+        if (this.__registry().size > 0) return
+
+        console.warn('Livewire: ['+method+'] found no checkboxes bound to this selection with wire:model, so there is no page to operate on. In a custom UI, select from your data instead: selection.select(keys)')
     }
 
     // Value thunks live on the instance itself — merge() keeps the

--- a/src/Features/SupportSelection/BrowserTest.php
+++ b/src/Features/SupportSelection/BrowserTest.php
@@ -117,6 +117,39 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_an_array_of_keys_can_be_selected_from_a_directive_expression()
+    {
+        Livewire::visit(new class extends Component {
+            public Selection $selection;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="checkbox" dusk="one" wire:model="selection" value="1" />
+                    <input type="checkbox" dusk="two" wire:model="selection" value="2" />
+
+                    <button dusk="select-both" type="button" wire:click="selection.select(['1', '2'])">Select both</button>
+                    <button dusk="toggle-both" type="button" wire:click="selection.toggle(['2', '3'])">Toggle two and three</button>
+
+                    <button dusk="refresh" type="button" wire:click="$refresh">Refresh</button>
+
+                    <span dusk="server">{{ $selection->count() }}:{{ implode(',', $selection->keys()) }}</span>
+                </div>
+                HTML;
+            }
+        })
+        ->click('@select-both')
+        ->assertChecked('@one')
+        ->assertChecked('@two')
+        ->click('@toggle-both')
+        ->assertChecked('@one')
+        ->assertNotChecked('@two')
+        ->waitForLivewire()->click('@refresh')
+        ->assertSeeIn('@server', '2:1,3')
+        ;
+    }
+
     public function test_select_page_selects_every_bound_checkbox_on_the_page()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportSelection/Selection.php
+++ b/src/Features/SupportSelection/Selection.php
@@ -100,23 +100,31 @@ class Selection implements Arrayable, \Countable, \IteratorAggregate, \JsonSeria
         return $this->contains($key);
     }
 
+    // Each mutator accepts a single key or an array of keys — selecting
+    // straight from data is one call: select($rows->pluck('id')->all())...
     public function select($key): static
     {
-        $this->isAll() ? $this->removeKey($key) : $this->addKey($key);
+        foreach (is_array($key) ? $key : [$key] as $single) {
+            $this->isAll() ? $this->removeKey($single) : $this->addKey($single);
+        }
 
         return $this;
     }
 
     public function deselect($key): static
     {
-        $this->isAll() ? $this->addKey($key) : $this->removeKey($key);
+        foreach (is_array($key) ? $key : [$key] as $single) {
+            $this->isAll() ? $this->addKey($single) : $this->removeKey($single);
+        }
 
         return $this;
     }
 
     public function toggle($key): static
     {
-        $this->contains($key) ? $this->deselect($key) : $this->select($key);
+        foreach (is_array($key) ? $key : [$key] as $single) {
+            $this->contains($single) ? $this->deselect($single) : $this->select($single);
+        }
 
         return $this;
     }

--- a/src/Features/SupportSelection/UnitTest.php
+++ b/src/Features/SupportSelection/UnitTest.php
@@ -192,6 +192,41 @@ class UnitTest extends \Tests\TestCase
         Assert::assertFalse($selection->has(3));
     }
 
+    function test_select_deselect_and_toggle_accept_arrays_of_keys()
+    {
+        $selection = new Selection;
+
+        $selection->select([1, 2, 3]);
+
+        Assert::assertSame([1, 2, 3], $selection->keys());
+
+        $selection->deselect([1, 3]);
+
+        Assert::assertSame([2], $selection->keys());
+
+        // Each key in a toggled array flips independently...
+        $selection->toggle([2, 4]);
+
+        Assert::assertFalse($selection->contains(2));
+        Assert::assertTrue($selection->contains(4));
+    }
+
+    function test_arrays_of_keys_route_through_the_mode_branch_in_select_all_mode()
+    {
+        $selection = (new Selection)->selectAll();
+
+        // Deselecting in all-mode records exceptions...
+        $selection->deselect([1, 2]);
+
+        Assert::assertSame([1, 2], $selection->except());
+
+        // Re-selecting removes them...
+        $selection->select([1, 2]);
+
+        Assert::assertSame([], $selection->except());
+        Assert::assertTrue($selection->isAllSelected());
+    }
+
     function test_contains_uses_loose_comparison_for_checkbox_string_values()
     {
         $selection = new Selection([1, 2]);


### PR DESCRIPTION
## What

Two changes to the Selection primitive (#10423) for custom selection UIs that never use `wire:model` — e.g. a media-library grid where tiles use `wire:click="selected.toggle(index)"` and class bindings on `selected.contains(index)`:

1. **`select()`, `deselect()`, and `toggle()` accept arrays** — PHP and JS, strict parity. A single key behaves exactly as before; an array applies the operation to each key (`toggle` toggles each key independently). Each key routes through the existing single-key mode branch, so include and select-all modes behave identically to repeated calls. "Select all from data" becomes one expression:

    ```js
    selected.select(files.map((f, i) => i))
    ```

2. **`selectPage()`/`deselectPage()` warn on an empty registry** (JS only — the page is a client concept). In a custom UI with no `wire:model`-bound checkboxes, these methods used to silently do nothing. Now they `console.warn` that no bindings were found and point to selecting from data instead. The warning only fires when the registry has no entries — bindings whose values are currently empty-ish stay silent.

Docs: the select/deselect/toggle reference rows note array support, and the page section notes the page methods operate on wire:model-bound checkboxes with a pointer to selecting from data in custom UIs.

## Verification

- New unit tests: array select/deselect/toggle in include mode (independent toggling, key list state) and in select-all mode (exceptions recorded/removed, `isAllSelected()`) — full SupportSelection unit suite green (17 tests)
- New browser test driving `selection.select(['1', '2'])` and `selection.toggle(['2', '3'])` from directive expressions through real checkboxes + a server round-trip — full SupportSelection browser suite green (14 tests)
- Warning behavior verified with a scratch vitest spec (warns once on empty registry, silent when a binding exists even with an empty value) — not committed, since there is no existing spec file for this module
- `npm test` green (145 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)