### PR TITLE
Warn with a corrected expression when `wire:for` is given Blade-style `as` syntax

### DIFF
--- a/js/directives/wire-for.js
+++ b/js/directives/wire-for.js
@@ -13,7 +13,17 @@ Alpine.interceptInit(
             return
         }
 
-        let expression = contextualizeForExpression(el.getAttribute('wire:for').trim(), el)
+        let expression = el.getAttribute('wire:for').trim()
+
+        let contextualized = contextualizeForExpression(expression, el)
+
+        // Bail before an unparseable expression reaches Alpine, where it would
+        // surface as an opaque TypeError from deep inside x-for...
+        if (! contextualized) {
+            warnUnparseableForExpression(expression, el)
+
+            return
+        }
 
         let keyExpression = el.getAttribute('wire:for:key') || el.getAttribute(':key') || el.getAttribute('x-bind:key')
 
@@ -27,10 +37,33 @@ Alpine.interceptInit(
             // Alpine processes `bind` before `for`, storing the key expression
             // where `x-for` reads per-item keys from...
             ...(keyExpression ? { 'x-bind:key': keyExpression } : {}),
-            'x-for': expression,
+            'x-for': contextualized,
         })
     })
 )
+
+// The expression is JavaScript, so it follows x-for's "item in items" grammar —
+// but Blade muscle memory produces "items as item", so when that shape is
+// detected, hand back the exact corrected expression...
+function warnUnparseableForExpression(expression, el) {
+    let asMatch = expression.match(/^([\s\S]+?)\s+as\s+([\s\S]+)$/)
+
+    if (! asMatch) {
+        console.warn(`Livewire: wire:for expects an "item in items" expression (like x-for) and couldn't parse "${expression}"`, el)
+
+        return
+    }
+
+    let [, items, alias] = asMatch
+
+    let keyed = alias.match(/^([\s\S]+?)\s*=>\s*([\s\S]+)$/)
+
+    let suggestion = keyed
+        ? `(${keyed[2].trim()}, ${keyed[1].trim()}) in ${items.trim()}`
+        : `${alias.trim()} in ${items.trim()}`
+
+    console.warn(`Livewire: wire:for expressions use JavaScript's "item in items" syntax (like x-for), not Blade's "items as item". Change "${expression}" to "${suggestion}"`, el)
+}
 
 // Split on the same "aliases in items" grammar as Alpine's own x-for parser
 // (parseForExpression), then rewrite only the items half to target `$wire` —
@@ -38,7 +71,7 @@ Alpine.interceptInit(
 function contextualizeForExpression(expression, el) {
     let match = expression.match(/([\s\S]*?)\s+(in|of)\s+([\s\S]*)/)
 
-    if (! match) return expression
+    if (! match) return null
 
     let [, aliases, keyword, items] = match
 

--- a/src/Features/SupportWireFor/BrowserTest.php
+++ b/src/Features/SupportWireFor/BrowserTest.php
@@ -298,4 +298,68 @@ class BrowserTest extends BrowserTestCase
         ->assertScript("document.querySelectorAll('[dusk=list] li').length", 3)
         ->assertScript("[...document.querySelectorAll('[dusk=list] li')].every(li => li.innerText.trim() !== '')", true);
     }
+
+    public function test_wire_for_warns_with_a_corrected_expression_when_given_blade_style_as_syntax()
+    {
+        Livewire::visit(new class extends Component {
+            public $fruits = ['apple', 'banana'];
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <ul dusk="list">
+                        <template wire:for="fruits as fruit">
+                            <li wire:text="fruit"></li>
+                        </template>
+                    </ul>
+                </div>
+                HTML;
+            }
+        })
+        ->assertConsoleLogHasWarning('Change \"fruits as fruit\" to \"fruit in fruits\"')
+        ->assertScript("document.querySelectorAll('[dusk=list] li').length", 0);
+    }
+
+    public function test_wire_for_warns_with_a_corrected_expression_when_given_blade_style_keyed_as_syntax()
+    {
+        Livewire::visit(new class extends Component {
+            public $fruits = ['apple', 'banana'];
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <ul dusk="list">
+                        <template wire:for="fruits as index => fruit">
+                            <li wire:text="fruit"></li>
+                        </template>
+                    </ul>
+                </div>
+                HTML;
+            }
+        })
+        ->assertConsoleLogHasWarning('Change \"fruits as index => fruit\" to \"(fruit, index) in fruits\"');
+    }
+
+    public function test_wire_for_warns_when_given_an_unparseable_expression()
+    {
+        Livewire::visit(new class extends Component {
+            public $fruits = ['apple', 'banana'];
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <ul dusk="list">
+                        <template wire:for="fruits">
+                            <li wire:text="fruit"></li>
+                        </template>
+                    </ul>
+                </div>
+                HTML;
+            }
+        })
+        ->assertConsoleLogHasWarning('couldn\'t parse \"fruits\"');
+    }
 }


### PR DESCRIPTION
## The problem

`wire:for` follows `x-for`/`v-for` grammar: `item in items`. But Blade muscle memory produces the PHP-style spelling:

```blade
<template wire:for="files as file">
```

Today that expression sails through Livewire's contextualizer (which only matches `in`/`of`), lands in Alpine's `x-for`, and dies as an opaque `TypeError: Cannot read properties of undefined (reading 'items')` from deep inside Alpine internals — zero hint that the loop syntax is the problem.

## The fix

When the expression doesn't parse, `wire:for` now bails before binding `x-for` (so the console shows one clear message instead of a crash) and warns. When the Blade `as` shape is detected — which is unambiguous, since `as` is not a JavaScript expression keyword — the warning hands back the exact corrected expression:

```
Livewire: wire:for expressions use JavaScript's "item in items" syntax (like x-for), not Blade's "items as item". Change "files as file" to "file in files"
```

Blade's keyed form is translated too: `files as index => file` suggests `(file, index) in files`.

Any other unparseable expression gets a generic warning:

```
Livewire: wire:for expects an "item in items" expression (like x-for) and couldn't parse "files"
```

Deliberately *not* supporting `as` as an alias: the mistake is a symptom of thinking the expression is PHP (the rest of it must be JavaScript — `file.name`, not `$file['name']`), and `wire:for` inherits `x-for`'s grammar wholesale — accepting `as` here would train a habit that breaks one layer down in plain Alpine.

## Verification

Three new browser tests in `SupportWireFor/BrowserTest.php` assert the console warnings (plain, keyed, and generic-unparseable cases) and that no rows render. All 12 wire:for browser tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)