### PR TITLE
Give rich upload objects `size` and a `sizeForHumans` display string

### DIFF
--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -216,6 +216,8 @@ Property | Description
 --- | ---
 `name` | The original filename from the user's machine
 `extension` | The file extension, derived from `name`
+`size` | The file's size in bytes
+`sizeForHumans` | The size as a display string ("1.5 KB", "2 MB") — also available in PHP as `$file->sizeForHumans()`
 `kind` | The coarse category of the file: `'image'`, `'audio'`, `'video'`, or `'file'` — from the browser's MIME type while uploading, the filename's extension after
 `isImage` / `isAudio` / `isVideo` | Shorthand predicates over `kind`, e.g. `wire:show="photo.isImage"`
 `filename` | The hashed temporary filename on the server (`null` while uploading)

--- a/js/features/supportFileUploads/size.js
+++ b/js/features/supportFileUploads/size.js
@@ -1,0 +1,16 @@
+// Format a byte count the way Laravel's Number::fileSize() does — same units,
+// same base-1024 divisor, and the same "promote at 0.9" threshold so a size
+// never displays as an awkward near-miss like "1010 KB"...
+export function sizeForHumans(bytes) {
+    let units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+    let i = 0
+
+    while (bytes / 1024 > 0.9 && i < units.length - 1) {
+        bytes /= 1024
+
+        i++
+    }
+
+    return `${Math.round(bytes * 10) / 10} ${units[i]}`
+}

--- a/js/features/supportFileUploads/size.spec.js
+++ b/js/features/supportFileUploads/size.spec.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { sizeForHumans } from './size'
+import { TemporaryUpload } from './synth'
+
+describe('sizeForHumans', () => {
+    it('formats byte counts into the nearest sensible unit', () => {
+        expect(sizeForHumans(0)).toBe('0 B')
+        expect(sizeForHumans(512)).toBe('512 B')
+        expect(sizeForHumans(1024)).toBe('1 KB')
+        expect(sizeForHumans(1536)).toBe('1.5 KB')
+        expect(sizeForHumans(15 * 1024)).toBe('15 KB')
+        expect(sizeForHumans(1024 * 1024)).toBe('1 MB')
+        expect(sizeForHumans(2.5 * 1024 * 1024)).toBe('2.5 MB')
+        expect(sizeForHumans(3.4 * 1024 ** 3)).toBe('3.4 GB')
+    })
+
+    it('rounds to at most one decimal place', () => {
+        expect(sizeForHumans(1234567)).toBe('1.2 MB')
+        expect(sizeForHumans(1024 * 1024 - 1)).toBe('1 MB')
+    })
+
+    it('promotes near-miss sizes to the next unit instead of showing "1010 KB"', () => {
+        expect(sizeForHumans(1000)).toBe('1 KB')
+        expect(sizeForHumans(1010 * 1024)).toBe('1 MB')
+    })
+})
+
+describe('TemporaryUpload size', () => {
+    it('reads bytes from the native File object while the upload is pending', () => {
+        let pending = TemporaryUpload.pending({ name: 'photo.png', size: 1536 })
+
+        expect(pending.size).toBe(1536)
+        expect(pending.sizeForHumans).toBe('1.5 KB')
+    })
+
+    it('reads bytes from the server meta after hydration', () => {
+        let hydrated = new TemporaryUpload('livewire-file:abc123.png', { size: 2.5 * 1024 * 1024 })
+
+        expect(hydrated.size).toBe(2.5 * 1024 * 1024)
+        expect(hydrated.sizeForHumans).toBe('2.5 MB')
+    })
+
+    it('returns null when the byte count is unknown', () => {
+        let hydrated = new TemporaryUpload('livewire-file:abc123.png', {})
+
+        expect(hydrated.size).toBe(null)
+        expect(hydrated.sizeForHumans).toBe(null)
+    })
+})

--- a/js/features/supportFileUploads/synth.js
+++ b/js/features/supportFileUploads/synth.js
@@ -1,6 +1,7 @@
 import { registerSynth } from '@/synths'
 import { getUploadManager } from './manager'
 import { kindFromMime, kindFromName } from './kind'
+import { sizeForHumans } from './size'
 
 // Client-side blob URLs for uploaded files, keyed by their temporary server
 // filename. Lets previews keep using the local file after the upload
@@ -58,6 +59,14 @@ export class TemporaryUpload {
     get filename() { return this.serialized === null ? null : this.serialized.replace('livewire-file:', '') }
 
     get extension() { return this.name?.split('.').pop() }
+
+    // The file's size in bytes — from the native File object while it's
+    // around, from the server-provided meta after hydration...
+    get size() { return this.file?.size ?? this.meta.size ?? null }
+
+    // The size as a display string ("1.5 KB", "2 MB"), formatted the same
+    // way as PHP's $file->sizeForHumans()...
+    get sizeForHumans() { return this.size === null ? null : sizeForHumans(this.size) }
 
     // The coarse category of the file — 'image', 'audio', 'video', or 'file'.
     // While the native File object is around, its MIME type is the authority;

--- a/src/Features/SupportFileUploads/BrowserTest.php
+++ b/src/Features/SupportFileUploads/BrowserTest.php
@@ -124,6 +124,43 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertMissing('@document-is-image');
     }
 
+    public function test_rich_upload_objects_expose_size_in_bytes_and_a_display_version()
+    {
+        Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $photo;
+
+            function render() { return <<<'HTML'
+            <div>
+                <input type="file" wire:model="photo" dusk="upload">
+
+                <button wire:click="$refresh" dusk="refresh">Refresh</button>
+
+                <span dusk="size" wire:text="photo?.size"></span>
+                <span dusk="size-for-humans" wire:text="photo?.sizeForHumans"></span>
+
+                @if ($photo)
+                    <span dusk="php-size-for-humans">{{ $photo->sizeForHumans() }}</span>
+                @endif
+            </div>
+            HTML; }
+        })
+        ->attach('@upload', __DIR__ . '/browser_test_image.png')
+        // The pending upload answers from the native File object immediately...
+        ->waitForTextIn('@size-for-humans', '2.7 KB')
+        ->assertSeeIn('@size', '2749')
+        // The PHP door renders the identical string once the upload lands...
+        ->waitForTextIn('@php-size-for-humans', '2.7 KB')
+        // A round trip rebuilds the rich object from snapshot meta — the byte
+        // count must survive without the native File object...
+        ->waitForLivewire()->click('@refresh')
+        ->assertSeeIn('@size', '2749')
+        ->assertSeeIn('@size-for-humans', '2.7 KB');
+    }
+
     public function test_rich_upload_objects_expose_reactive_progress_state_and_client_side_previews()
     {
         Storage::persistentFake('tmp-for-tests');

--- a/src/Features/SupportFileUploads/FileUploadSynth.php
+++ b/src/Features/SupportFileUploads/FileUploadSynth.php
@@ -35,6 +35,15 @@ class FileUploadSynth extends Synth {
         }
 
         try {
+            // Carry the byte count so the frontend's rich upload object can
+            // answer file.size and file.sizeForHumans without the native File
+            // object (which is gone once the upload finishes)...
+            $meta['size'] = $file->getSize();
+        } catch (\Throwable $e) {
+            //
+        }
+
+        try {
             // Sign a preview URL eagerly so the frontend's rich upload object
             // can preview the file without a Blade render ever asking for it...
             $meta['url'] = $file->temporaryUrl();

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportFileUploads;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Number;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Storage;
@@ -59,6 +60,11 @@ class TemporaryUploadedFile extends UploadedFile
         }
 
         return (int) $this->storage->size($this->path);
+    }
+
+    public function sizeForHumans(): string
+    {
+        return Number::fileSize($this->getSize(), maxPrecision: 1);
     }
 
     public function getMimeType(): string


### PR DESCRIPTION
## The problem

Showing a file's size next to an upload tile means hand-rolling byte math in every template — `file.size` (when you can even reach it) is raw bytes, and everyone writes the same divide-by-1024 helper to get "1.5 KB".

Worse: the rich upload object had no `size` at all after a round trip. The native `File` object's byte count is gone once the upload finishes, and nothing carried it through the snapshot.

## The fix

The rich upload object now answers both questions itself:

```js
file.size           // bytes: 2749
file.sizeForHumans  // display string: "2.7 KB"
```

```blade
<span wire:text="photo.sizeForHumans"></span>
```

- **Pending uploads** read bytes straight off the native `File` object — the size renders the instant a file is picked, before any bytes reach the server.
- **After hydration** the byte count rides the snapshot meta (alongside the existing `name`/`url`), so it survives round trips.
- **The PHP door** is `$file->sizeForHumans()`, named after Carbon's `diffForHumans()` and delegating to Laravel's `Number::fileSize(..., maxPrecision: 1)`.

The JS formatter mirrors `Number::fileSize()`'s exact semantics — base 1024, max one decimal, and its promote-at-0.9 threshold (so you never see "1010 KB") — verified value-for-value against the PHP output so both doors render the identical string.

Considered and rejected: the `Intl.NumberFormat` compact-byte trick (`style: 'unit', unit: 'byte', notation: 'compact'`) — it renders gigabytes as "3.4BB" (compact-notation billion-bytes) and German as "2,5 Mio. B". There's no real platform digital-size formatter, so a 10-line util matching Laravel's convention wins.

## Verification

- Vitest specs for the formatter and the `size`/`sizeForHumans` getters (pending, hydrated, and unknown-size paths).
- A browser test uploads a real file through a real file input and asserts the display string at all three stages: while pending (native `File` source), server-rendered via the Blade `$file->sizeForHumans()` door, and after a `$refresh` round trip (snapshot-meta source).
- Full JS suite (151), upload unit tests (99), and neighboring upload browser tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)