### PR TITLE
Recover from failed server responses by reverting rejected updates

### DIFF
--- a/js/$wire.js
+++ b/js/$wire.js
@@ -194,7 +194,10 @@ wireProperty('$js', (component) => {
     })
 })
 
-wireProperty('$set', (component) => async (property, value, live = true) => {
+// These return the action's own promise (instead of wrapping it in an async
+// function) so fire-and-forget callers don't create an extra promise chain
+// that surfaces server errors as unhandled rejections...
+wireProperty('$set', (component) => (property, value, live = true) => {
     dataSet(component.reactive, property, value)
 
     // If "live", send a request, queueing the property update to happen first

--- a/js/component.js
+++ b/js/component.js
@@ -1,4 +1,4 @@
-import { dataSet, deepClone, diff, diffAndConsolidate, diffAndPatchRecursive, extractData} from '@/utils'
+import { dataDelete, dataGet, dataSet, deepClone, diff, diffAndConsolidate, diffAndPatchRecursive, extractData} from '@/utils'
 import { generateWireObject } from '@/$wire'
 import { findComponentByEl, findComponent, hasComponent } from '@/store'
 import { trigger } from '@/hooks'
@@ -126,6 +126,31 @@ export class Component {
         let propertiesDiff = diffAndConsolidate(this.canonical, this.ephemeral)
 
         return this.mergeQueuedUpdates(propertiesDiff)
+    }
+
+    revertUpdates(updates) {
+        // Updates the server rejected would otherwise linger in the diff between
+        // canonical and ephemeral state and be re-sent with every subsequent
+        // request, repeating the same server error and wedging the component...
+        Object.entries(updates).forEach(([path, sentValue]) => {
+            let currentValue = dataGet(this.ephemeral, path)
+
+            // Leave properties alone if the user has changed them again since
+            // the failed request was sent...
+            let stillMatchesSentValue = sentValue === '__rm__'
+                ? currentValue === undefined
+                : JSON.stringify(currentValue) === JSON.stringify(sentValue)
+
+            if (! stillMatchesSentValue) return
+
+            let canonicalValue = dataGet(this.canonical, path)
+
+            if (canonicalValue === undefined) {
+                dataDelete(this.reactive, path)
+            } else {
+                dataSet(this.reactive, path, deepClone(canonicalValue))
+            }
+        })
     }
 
     applyUpdates(object, updates) {

--- a/js/request/action.js
+++ b/js/request/action.js
@@ -30,6 +30,11 @@ export default class Action {
             this.promiseResolution = { resolve, reject }
         })
 
+        // Fire-and-forget actions (wire:click, wire:model.live, etc.) never await
+        // this promise, so attach a no-op handler to keep rejections from
+        // surfacing as unhandled. Callers that do await still receive them...
+        this.promise.catch(() => {})
+
         this.promise._livewireAction = this
     }
 

--- a/js/request/message.js
+++ b/js/request/message.js
@@ -175,6 +175,10 @@ export default class Message {
         // Invoke action-level onError callbacks
         Array.from(this.actions).forEach(action => action.invokeOnError({ response, body, preventDefault }))
 
+        // The server rejected this message's property updates, so revert them
+        // to keep them from being re-sent on every subsequent request...
+        if (! this.isCancelled()) this.component.revertUpdates(this.updates ?? {})
+
         // Try to parse body as JSON for the rejection payload
         let json = null
         try { json = JSON.parse(body) } catch (e) {}

--- a/src/Features/SupportErrorResponses/BrowserTest.php
+++ b/src/Features/SupportErrorResponses/BrowserTest.php
@@ -49,6 +49,53 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_component_stays_interactive_after_a_server_error_by_reverting_the_failed_updates()
+    {
+        Livewire::visit(new class extends BaseComponent {
+            public $count = 0;
+
+            public $name = '';
+
+            public function updatedName()
+            {
+                abort(500);
+            }
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input dusk="name" wire:model.live="name" />
+
+                    <button dusk="increment" wire:click="increment">Increment</button>
+
+                    <span dusk="count">{{ $count }}</span>
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '1')
+            // Trigger a server error from the updated hook...
+            ->type('@name', 'x')
+            ->waitFor('#livewire-error')
+            ->keys('#livewire-error', '{escape}')
+            ->waitUntilMissing('#livewire-error')
+            // The rejected update is reverted so it isn't re-sent with every
+            // subsequent request, which would repeat the error forever...
+            ->assertValue('@name', '')
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '2')
+            ->pause(100)
+            ->assertMissing('#livewire-error')
+        ;
+    }
+
     public function test_it_does_not_show_html_modal_after_session_expired_dialog()
     {
         if (app()->version() >= '13') {


### PR DESCRIPTION
### The bug

Put a `dd()` (or anything that throws / aborts) inside an `updated` hook:

```php
public $name = '';

public function updatedName($value)
{
    dd($value);
}
```

Type into a `wire:model.live` input → the request 500s and the error modal appears. Dismiss the modal, and the component is now **permanently broken**: every subsequent interaction (e.g. an unrelated `wire:click`) fails with the same error and re-opens the modal.

### Why

The failed property update lives in the diff between `canonical` and `ephemeral` state. Since the server never accepted it, `getUpdates()` keeps producing the same diff, so **every subsequent message replays the failing update** — the server hits the `dd()` while applying updates, before it ever reaches the action being called. The component is wedged until a full page refresh.

On top of that, the rejected action promise (which nothing awaits for fire-and-forget actions like `wire:model.live` / `wire:click`) surfaced in the console as an unhandled promise rejection.

### The fix

- **`Message.invokeOnError`** now reverts the message's rejected updates via a new `Component.revertUpdates()` — each failed path is rolled back to its last server-accepted (canonical) value, so it's no longer re-sent on every request. A path is left alone if the user changed it again while the request was in flight. Network failures are untouched — offline changes still retry as before.
- **`Action`** attaches an internal no-op rejection handler to its promise so fire-and-forget actions don't produce unhandled rejections (callers that `await` still receive them).
- **`$set` / `$commit` / `$refresh`** no longer wrap the action promise in an `async` function — the wrapper promise re-wrapped the rejection and leaked it as unhandled even with the handler above.

After the fix: dismiss the error modal → the input reverts to its last synced value → the component is fully interactive again, and typing again re-triggers the hook normally.

### Testing

Added a browser test in `SupportErrorResponses` that triggers a 500 from an `updated` hook, dismisses the error dialog, asserts the failed update was reverted, and asserts an unrelated action works afterwards. Verified it fails against the previous build and passes with the fix. Also verified end-to-end in a real app with Playwright (dd modal → Escape → component alive, zero unhandled rejections), and ran the `SupportDataBinding`, `SupportRequestInteractions`, `SupportMagicActions`, and `SupportInterceptors` browser suites plus the JS unit specs — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)