### PR TITLE
[4.x] Consolidate Livewire attributes getter into Component Hook

### DIFF
--- a/src/ComponentHook.php
+++ b/src/ComponentHook.php
@@ -11,6 +11,13 @@ abstract class ComponentHook
         $this->component = $component;
     }
 
+    function getLivewireAttributes()
+    {
+        return $this->component
+            ->getAttributes()
+            ->whereInstanceOf(LivewireAttribute::class);
+    }
+
     function callBoot(...$params) {
         if (method_exists($this, 'boot')) $this->boot(...$params);
     }

--- a/src/ComponentHook.php
+++ b/src/ComponentHook.php
@@ -2,6 +2,8 @@
 
 namespace Livewire;
 
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
 abstract class ComponentHook
 {
     protected $component;

--- a/src/Features/SupportAttributes/SupportAttributes.php
+++ b/src/Features/SupportAttributes/SupportAttributes.php
@@ -2,7 +2,6 @@
 
 namespace Livewire\Features\SupportAttributes;
 
-use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\ComponentHook;
 
 class SupportAttributes extends ComponentHook
@@ -114,12 +113,5 @@ class SupportAttributes extends ComponentHook
                 $attribute->exception(...$params);
             }
         });
-    }
-
-    protected function getLivewireAttributes()
-    {
-        return $this->component
-            ->getAttributes()
-            ->whereInstanceOf(LivewireAttribute::class);
     }
 }

--- a/src/Features/SupportEvents/SupportEvents.php
+++ b/src/Features/SupportEvents/SupportEvents.php
@@ -29,7 +29,7 @@ class SupportEvents extends ComponentHook
             // Run any authorization checks on the listener method since
             // its normal "call" hook doesn't get run when the method
             // is called as an event listener...
-            $this->component->getAttributes()
+            $this->getLivewireAttributes()
                 ->filter(fn ($i) => $i instanceof BaseAuthorize)
                 ->filter(fn ($i) => $i->getName() === $method)
                 ->filter(fn ($i) => $i->getLevel() === AttributeLevel::METHOD)
@@ -42,7 +42,7 @@ class SupportEvents extends ComponentHook
             // Here we have to manually check to see if the event listener method
             // is "renderless" as it's normal "call" hook doesn't get run when
             // the method is called as an event listener...
-            $isRenderless = $this->component->getAttributes()
+            $isRenderless = $this->getLivewireAttributes()
                 ->filter(fn ($i) => $i instanceof BaseRenderless)
                 ->filter(fn ($i) => $i->getName() === $method)
                 ->filter(fn ($i) => $i->getLevel() === AttributeLevel::METHOD)

--- a/src/Features/SupportIsolating/SupportIsolating.php
+++ b/src/Features/SupportIsolating/SupportIsolating.php
@@ -15,7 +15,7 @@ class SupportIsolating extends ComponentHook
 
     public function shouldIsolate()
     {
-        return $this->component->getAttributes()
+        return $this->getLivewireAttributes()
             ->filter(fn ($i) => is_subclass_of($i, BaseIsolate::class))
             ->count() > 0;
     }

--- a/src/Features/SupportIsolating/SupportIsolating.php
+++ b/src/Features/SupportIsolating/SupportIsolating.php
@@ -16,7 +16,7 @@ class SupportIsolating extends ComponentHook
     public function shouldIsolate()
     {
         return $this->getLivewireAttributes()
-            ->filter(fn ($i) => is_subclass_of($i, BaseIsolate::class))
+            ->filter(fn ($i) => $i instanceof BaseIsolate)
             ->count() > 0;
     }
 }


### PR DESCRIPTION
# Motivation
Currently, there are 3 component hooks that retrieve Livewire attributes using
```php
$this->component->getAttributes()
```
### `SupportAttributes`
```php
protected function getLivewireAttributes()
{
    return $this->component
        ->getAttributes()
        ->whereInstanceOf(LivewireAttribute::class);
}
```
### `SupportEvents`
```php
function call($method, $params, $returnEarly)
{
    ...
    $this->component->getAttributes()
        ->filter(fn ($i) => $i instanceof BaseAuthorize)
        ->filter(fn ($i) => $i->getName() === $method)
        ->filter(fn ($i) => $i->getLevel() === AttributeLevel::METHOD)
        ->each(fn ($i) => $i->call($params));

    $isRenderless = $this->component->getAttributes()
        ->filter(fn ($i) => $i instanceof BaseRenderless)
        ->filter(fn ($i) => $i->getName() === $method)
        ->filter(fn ($i) => $i->getLevel() === AttributeLevel::METHOD)
        ->count() > 0;
    ...
}
```
### `SupportIsolating`
```php
public function shouldIsolate()
{
    return $this->component->getAttributes()
        ->filter(fn ($i) => is_subclass_of($i, BaseIsolate::class))
        ->count() > 0;
}
```
This means there is a high chance that the new component hook might be using it as well. Currently, only `SupportAttributes` has this getter.

# What's Changed
- Move Livewire attributes getter into `ComponentHook` class so all component hooks have access to this getter
- All component hooks now can use `$this->getLivewireAttributes()` to retrieve Livewire attributes
- In addition, change `is_subclass_of` to `instanceof` in **SupportIsolating**