### PR TITLE
[3.x] Detect temporary upload MIME type from file contents

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -13,6 +13,7 @@ class TemporaryUploadedFile extends UploadedFile
     protected $disk;
     protected $storage;
     protected $path;
+    protected $detectedMimeType;
 
     public function __construct($path, $disk)
     {
@@ -62,17 +63,30 @@ class TemporaryUploadedFile extends UploadedFile
             return (string) $escapedMimeType->replace('_', '/');
         }
 
-        $mimeType = $this->storage->mimeType($this->path);
+        return $this->detectedMimeType ??= $this->detectMimeTypeFromContents();
+    }
 
-        // Flysystem V2.0+ removed guess mimeType from extension support, so it has been re-added back
-        // in here to ensure the correct mimeType is returned when using faked files in tests
-        if (in_array($mimeType, ['application/octet-stream', 'inode/x-empty', 'application/x-empty'])) {
-            $detector = new FinfoMimeTypeDetector();
+    protected function detectMimeTypeFromContents(): string
+    {
+        $stream = $this->storage->readStream($this->path);
 
-            $mimeType = $detector->detectMimeTypeFromPath($this->path) ?: 'text/plain';
+        if (! is_resource($stream)) {
+            return 'application/octet-stream';
         }
 
-        return $mimeType;
+        try {
+            // Avoid downloading the entire object when the temporary disk is remote...
+            $contents = stream_get_contents($stream, 64 * 1024);
+        } finally {
+            fclose($stream);
+        }
+
+        if ($contents === false || $contents === '') {
+            return 'application/octet-stream';
+        }
+
+        return (new FinfoMimeTypeDetector())->detectMimeTypeFromBuffer($contents)
+            ?: 'application/octet-stream';
     }
 
     public function getFilename(): string

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -857,6 +857,47 @@ class UnitTest extends \Tests\TestCase
             ]);
     }
 
+    public function test_temporary_upload_validation_uses_file_contents_instead_of_storage_metadata()
+    {
+        $disk = $this->useS3LikeTemporaryUploadDisk();
+
+        $disk->put('livewire-tmp/png-disguised-as.webp', file_get_contents(__DIR__.'/browser_test_image.png'));
+
+        $this->assertSame('image/webp', $disk->mimeType('livewire-tmp/png-disguised-as.webp'));
+
+        $file = TemporaryUploadedFile::createFromLivewire('png-disguised-as.webp');
+
+        $this->assertSame('image/png', $file->getMimeType());
+        $this->assertTrue(validator(['file' => $file], ['file' => 'mimes:png|mimetypes:image/png'])->passes());
+        $this->assertFalse(validator(['file' => $file], ['file' => 'mimes:webp|mimetypes:image/webp'])->passes());
+        $this->assertSame(1, $disk->readStreamCalls);
+    }
+
+    public function test_temporary_upload_mime_type_does_not_fall_back_to_storage_metadata_for_empty_files()
+    {
+        $disk = $this->useS3LikeTemporaryUploadDisk();
+
+        $disk->put('livewire-tmp/empty.webp', '');
+
+        $this->assertSame('image/webp', $disk->mimeType('livewire-tmp/empty.webp'));
+
+        $file = TemporaryUploadedFile::createFromLivewire('empty.webp');
+
+        $this->assertSame('application/octet-stream', $file->getMimeType());
+    }
+
+    public function test_temporary_upload_mime_type_is_unknown_when_the_file_cannot_be_read()
+    {
+        $disk = $this->useS3LikeTemporaryUploadDisk();
+
+        $disk->put('livewire-tmp/unreadable.webp', file_get_contents(__DIR__.'/browser_test_image.png'));
+        $disk->canRead = false;
+
+        $file = TemporaryUploadedFile::createFromLivewire('unreadable.webp');
+
+        $this->assertSame('application/octet-stream', $file->getMimeType());
+    }
+
     public function test_the_default_file_upload_controller_middleware_overwritten()
     {
         config()->set('livewire.temporary_file_upload.middleware', ['throttle:60,1']);
@@ -910,6 +951,36 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertInstanceOf(TemporaryUploadedFile::class, $rows['one']['image']);
         $this->assertEquals(['image' => null, 'caption' => 'New row'], $rows['three']);
+    }
+
+    protected function useS3LikeTemporaryUploadDisk()
+    {
+        config()->set('livewire.temporary_file_upload.disk', 'tmp-for-tests');
+
+        // Simulate a remote disk returning stored upload metadata instead of inspecting the file...
+        $adapter = new \League\Flysystem\Local\LocalFilesystemAdapter(
+            $root = storage_path('framework/testing/disks/tmp-for-tests'),
+            null,
+            LOCK_EX,
+            \League\Flysystem\Local\LocalFilesystemAdapter::DISALLOW_LINKS,
+            new \League\MimeTypeDetection\ExtensionMimeTypeDetector(),
+        );
+
+        $disk = new class(new \League\Flysystem\Filesystem($adapter), $adapter, ['root' => $root]) extends FilesystemAdapter {
+            public $canRead = true;
+            public $readStreamCalls = 0;
+
+            public function readStream($path)
+            {
+                $this->readStreamCalls++;
+
+                return $this->canRead ? parent::readStream($path) : null;
+            }
+        };
+
+        Storage::set('tmp-for-tests', $disk);
+
+        return $disk;
     }
 }
 


### PR DESCRIPTION
## What changed

`TemporaryUploadedFile::getMimeType()` now detects the MIME type from a bounded sample of the temporary file's contents instead of trusting the MIME metadata reported by its storage disk.

The detected value is cached for the lifetime of the `TemporaryUploadedFile`, so repeated validation does not repeat the remote read. If the file cannot be read or identified, it is treated as `application/octet-stream` rather than falling back to potentially client-controlled metadata.

## Why

Remote storage adapters such as S3 return the object's stored `Content-Type`. For direct temporary uploads, that metadata can originate from the browser and can reflect the filename rather than the bytes. A file renamed from `.png` to `.webp`, for example, can therefore be reported as `image/webp` even though its contents are still PNG.

Laravel's `mimes` and `mimetypes` rules expect `UploadedFile::getMimeType()` to represent a server-derived type. Returning storage metadata here could allow mislabeled files through those rules and defer the failure to later image or media processing.

This change reads at most 64 KiB, detects the type with Fileinfo, and always closes the stream. The bounded, cached read keeps the behavior practical for remote temporary disks.

## Tests

The tests use an extension-based local adapter to reproduce S3-style metadata without requiring an S3 connection, and verify that:

- PNG bytes stored under a `.webp` name validate as PNG and not WebP
- repeated MIME checks only read the remote object once
- empty and unreadable files resolve to `application/octet-stream` instead of storage metadata

Validation run locally:

- `vendor/bin/phpunit src/Features/SupportFileUploads/UnitTest.php` — 56 tests, 131 assertions, 1 skipped
- `vendor/bin/phpunit --testsuite Unit` — 930 tests, 2,982 assertions, 17 skipped, 3 incomplete
