### PR TITLE
Detect temporary upload mime type from actual file contents

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -78,7 +78,7 @@ class TemporaryUploadedFile extends UploadedFile
             }
         }
 
-        $mimeType = $this->storage->mimeType($this->path);
+        $mimeType = $this->detectMimeTypeFromContents() ?? $this->storage->mimeType($this->path);
 
         // Flysystem V2.0+ removed guess mimeType from extension support, so it has been re-added back
         // in here to ensure the correct mimeType is returned when using faked files in tests
@@ -89,6 +89,29 @@ class TemporaryUploadedFile extends UploadedFile
         }
 
         return $mimeType;
+    }
+
+    protected function detectMimeTypeFromContents()
+    {
+        try {
+            $stream = $this->storage->readStream($this->path);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        if (! is_resource($stream)) {
+            return null;
+        }
+
+        $contents = stream_get_contents($stream, 65536);
+
+        fclose($stream);
+
+        if ($contents === false || $contents === '') {
+            return null;
+        }
+
+        return (new FinfoMimeTypeDetector())->detectMimeTypeFromBuffer($contents) ?: null;
     }
 
     public function getFilename(): string

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -1216,6 +1216,33 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertInstanceOf(TemporaryUploadedFile::class, $test->viewData('photo'));
     }
+
+    public function test_mime_type_is_detected_from_file_contents_and_not_from_the_mime_type_stored_on_the_disk()
+    {
+        config()->set('livewire.temporary_file_upload.disk', 'tmp-for-tests');
+
+        $adapter = new \League\Flysystem\Local\LocalFilesystemAdapter(
+            $root = storage_path('framework/testing/disks/tmp-for-tests'),
+            null,
+            LOCK_EX,
+            \League\Flysystem\Local\LocalFilesystemAdapter::DISALLOW_LINKS,
+            // Like S3, this detector reports a mime type based on the file's name
+            // rather than sniffing the actual bytes...
+            new \League\MimeTypeDetection\ExtensionMimeTypeDetector()
+        );
+
+        $disk = new FilesystemAdapter(new \League\Flysystem\Filesystem($adapter), $adapter, ['root' => $root]);
+
+        Storage::set('tmp-for-tests', $disk);
+
+        $disk->put('livewire-tmp/png-disguised-as.webp', file_get_contents(__DIR__.'/browser_test_image.png'));
+
+        $this->assertEquals('image/webp', $disk->mimeType('livewire-tmp/png-disguised-as.webp'));
+
+        $file = TemporaryUploadedFile::createFromLivewire('png-disguised-as.webp');
+
+        $this->assertEquals('image/png', $file->getMimeType());
+    }
 }
 
 class FileUploadWithValidateAttributeComponent extends TestComponent


### PR DESCRIPTION
Same fix as #10440, ported to v4