### PR TITLE
[4.x] Refactor component hooks to use existing helper method from `ComponentHook` class

### DIFF
--- a/src/ComponentHook.php
+++ b/src/ComponentHook.php
@@ -108,6 +108,11 @@ abstract class ComponentHook
         return store($this->component)->get($key, $default);
     }
 
+    function storeFind($key, $iKey = null, $default = null)
+    {
+        return store($this->component)->find($key, $iKey, $default);
+    }
+
     function storeHas($key)
     {
         return store($this->component)->has($key);

--- a/src/Features/SupportEvents/SupportEvents.php
+++ b/src/Features/SupportEvents/SupportEvents.php
@@ -55,9 +55,9 @@ class SupportEvents extends ComponentHook
     function dehydrate($context)
     {
         // Don't register listeners until a lazy component has fully mounted...
-        if (store($this->component)->get('isLazyLoadMounting') === true) return;
+        if ($this->storeGet('isLazyLoadMounting') === true) return;
 
-        if ($context->isMounting() || store($this->component)->get('isLazyLoadHydrating') === true) {
+        if ($context->isMounting() || $this->storeGet('isLazyLoadHydrating') === true) {
             $listeners = static::getListenerEventNames($this->component);
 
             $listeners && $context->addEffect('listeners', $listeners);

--- a/src/Features/SupportJsEvaluation/SupportJsEvaluation.php
+++ b/src/Features/SupportJsEvaluation/SupportJsEvaluation.php
@@ -2,16 +2,14 @@
 
 namespace Livewire\Features\SupportJsEvaluation;
 
-use function Livewire\store;
-
 use Livewire\ComponentHook;
 
 class SupportJsEvaluation extends ComponentHook
 {
     function dehydrate($context)
     {
-        if (! store($this->component)->has('js')) return;
+        if (! $this->storeHas('js')) return;
 
-        $context->addEffect('xjs', store($this->component)->get('js'));
+        $context->addEffect('xjs', $this->storeGet('js'));
     }
 }

--- a/src/Features/SupportJsModules/SupportJsModules.php
+++ b/src/Features/SupportJsModules/SupportJsModules.php
@@ -7,8 +7,6 @@ use Livewire\ComponentHook;
 use Livewire\Drawer\Utils;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
 
-use function Livewire\store;
-
 class SupportJsModules extends ComponentHook
 {
     static function provide()
@@ -47,13 +45,13 @@ class SupportJsModules extends ComponentHook
         // Don't add scriptModule effect during lazy-loading placeholder mount.
         // The component's view isn't rendered yet, so @assets won't have run.
         // The scriptModule will be added when __lazyLoad triggers the real mount.
-        if (store($this->component)->get('isLazyLoadMounting') === true) return;
+        if ($this->storeGet('isLazyLoadMounting') === true) return;
 
         // Add scriptModule effect during:
         // 1. Normal component mounting ($context->isMounting())
         // 2. Lazy-loaded component hydration (when __lazyLoad runs)
         $isNormalMount = $context->isMounting();
-        $isLazyLoadHydration = store($this->component)->get('isLazyLoadHydrating') === true;
+        $isLazyLoadHydration = $this->storeGet('isLazyLoadHydrating') === true;
 
         if (! $isNormalMount && ! $isLazyLoadHydration) return;
 

--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -5,7 +5,7 @@ namespace Livewire\Features\SupportLazyLoading;
 use Livewire\Features\SupportLifecycleHooks\SupportLifecycleHooks;
 use Livewire\Mechanisms\HandleComponents\ComponentContext;
 use Livewire\Mechanisms\HandleComponents\ViewContext;
-use function Livewire\{ on, store, trigger, wrap };
+use function Livewire\{ on, trigger, wrap };
 use Illuminate\Routing\Route;
 use Livewire\ComponentHook;
 use Livewire\Drawer\Utils;
@@ -96,8 +96,8 @@ class SupportLazyLoading extends ComponentHook
 
         $this->component->skipMount();
 
-        store($this->component)->set('isLazyLoadMounting', true);
-        store($this->component)->set('isLazyIsolated', $isolate);
+        $this->storeSet('isLazyLoadMounting', true);
+        $this->storeSet('isLazyIsolated', $isolate);
 
         $this->component->skipRender(
             $this->generatePlaceholderHtml($params, $isDeferred)
@@ -111,15 +111,15 @@ class SupportLazyLoading extends ComponentHook
 
         $this->component->skipHydrate();
 
-        store($this->component)->set('isLazyLoadHydrating', true);
+        $this->storeSet('isLazyLoadHydrating', true);
     }
 
     function dehydrate($context)
     {
-        if (store($this->component)->get('isLazyLoadMounting') === true) {
+        if ($this->storeGet('isLazyLoadMounting') === true) {
             $context->addMemo('lazyLoaded', false);
-            $context->addMemo('lazyIsolated', store($this->component)->get('isLazyIsolated'));
-        } elseif (store($this->component)->get('isLazyLoadHydrating') === true) {
+            $context->addMemo('lazyIsolated', $this->storeGet('isLazyIsolated'));
+        } elseif ($this->storeGet('isLazyLoadHydrating') === true) {
             $context->addMemo('lazyLoaded', true);
         }
     }

--- a/src/Features/SupportNestedComponentListeners/SupportNestedComponentListeners.php
+++ b/src/Features/SupportNestedComponentListeners/SupportNestedComponentListeners.php
@@ -2,7 +2,6 @@
 
 namespace Livewire\Features\SupportNestedComponentListeners;
 
-use function Livewire\store;
 use Livewire\Drawer\Utils;
 use Livewire\ComponentHook;
 
@@ -25,7 +24,7 @@ class SupportNestedComponentListeners extends ComponentHook
                 $attributeKey = 'x-on:'.$fullEvent;
                 $attributeValue = "\$wire.\$parent.".$value;
 
-                store($this->component)->push('generatedAttributes', $attributeValue, $attributeKey);
+                $this->storePush('generatedAttributes', $attributeValue, $attributeKey);
             }
         }
     }
@@ -33,7 +32,7 @@ class SupportNestedComponentListeners extends ComponentHook
     public function render($view, $data)
     {
         return function ($html, $replaceHtml) {
-            $attributes = store($this->component)->get('generatedAttributes', false);
+            $attributes = $this->storeGet('generatedAttributes', false);
 
             if (! $attributes) return;
 
@@ -43,7 +42,7 @@ class SupportNestedComponentListeners extends ComponentHook
 
     public function dehydrate($context)
     {
-        $attributes = store($this->component)->get('generatedAttributes', false);
+        $attributes = $this->storeGet('generatedAttributes', false);
 
         if (! $attributes) return;
 
@@ -57,6 +56,6 @@ class SupportNestedComponentListeners extends ComponentHook
         $attributes = $memo['generatedAttributes'];
 
         // Store the attributes for later dehydration...
-        store($this->component)->set('generatedAttributes', $attributes);
+        $this->storeSet('generatedAttributes', $attributes);
     }
 }

--- a/src/Features/SupportScriptsAndAssets/SupportScriptsAndAssets.php
+++ b/src/Features/SupportScriptsAndAssets/SupportScriptsAndAssets.php
@@ -2,7 +2,6 @@
 
 namespace Livewire\Features\SupportScriptsAndAssets;
 
-use function Livewire\store;
 use Livewire\ComponentHook;
 
 use function Livewire\on;
@@ -129,20 +128,20 @@ class SupportScriptsAndAssets extends ComponentHook
     function hydrate($memo) {
         // Store the "scripts" and "assets" memos so they can be re-added later (persisted between requests)...
         if (isset($memo['scripts'])) {
-            store($this->component)->set('forwardScriptsToDehydrateMemo', $memo['scripts']);
+            $this->storeSet('forwardScriptsToDehydrateMemo', $memo['scripts']);
         }
 
         if (isset($memo['assets'])) {
-            store($this->component)->set('forwardAssetsToDehydrateMemo', $memo['assets']);
+            $this->storeSet('forwardAssetsToDehydrateMemo', $memo['assets']);
         }
     }
 
     function dehydrate($context)
     {
-        $alreadyRunScriptKeys = store($this->component)->get('forwardScriptsToDehydrateMemo', []);
+        $alreadyRunScriptKeys = $this->storeGet('forwardScriptsToDehydrateMemo', []);
 
         // Add any scripts to the payload that haven't been run yet for this component....
-        foreach (store($this->component)->get('scripts', []) as $key => $script) {
+        foreach ($this->storeGet('scripts', []) as $key => $script) {
             if (! in_array($key, $alreadyRunScriptKeys)) {
                 $context->pushEffect('scripts', $script, $key);
                 $alreadyRunScriptKeys[] = $key;
@@ -153,9 +152,9 @@ class SupportScriptsAndAssets extends ComponentHook
 
         // Add any assets to the payload that haven't been run yet for the entire page...
 
-        $alreadyRunAssetKeys = store($this->component)->get('forwardAssetsToDehydrateMemo', []);
+        $alreadyRunAssetKeys = $this->storeGet('forwardAssetsToDehydrateMemo', []);
 
-        foreach (store($this->component)->get('assets', []) as $key => $assets) {
+        foreach ($this->storeGet('assets', []) as $key => $assets) {
             if (! in_array($key, $alreadyRunAssetKeys)) {
 
                 // These will either get injected into the HTML if it's an initial page load

--- a/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
+++ b/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
@@ -6,7 +6,6 @@ use Livewire\ComponentHook;
 use Livewire\Drawer\Utils;
 use Livewire\Exceptions\ModelableRootHasWireModelException;
 use function Livewire\on;
-use function Livewire\store;
 
 class SupportWireModelingNestedComponents extends ComponentHook
 {
@@ -39,8 +38,8 @@ class SupportWireModelingNestedComponents extends ComponentHook
         $directives = $memo['bindingsDirectives'];
 
         // Store the bindings for later dehydration...
-        store($this->component)->set('bindings', $bindings);
-        store($this->component)->set('bindings-directives', $directives);
+        $this->storeSet('bindings', $bindings);
+        $this->storeSet('bindings-directives', $directives);
 
         // If this child's parent already rendered its stub, retrieve
         // the memo'd value and set it.
@@ -49,7 +48,7 @@ class SupportWireModelingNestedComponents extends ComponentHook
         $outers = static::$outersByComponentId[$memo['id']];
 
         foreach ($bindings as $outer => $inner) {
-            store($this->component)->set('hasBeenSeeded', true);
+            $this->storeSet('hasBeenSeeded', true);
 
             $this->component->$inner = $outers[$outer];
         }
@@ -58,8 +57,8 @@ class SupportWireModelingNestedComponents extends ComponentHook
     public function render($view, $data)
     {
         return function ($html, $replaceHtml) {
-            $bindings = store($this->component)->get('bindings', false);
-            $directives = store($this->component)->get('bindings-directives', false);
+            $bindings = $this->storeGet('bindings', false);
+            $directives = $this->storeGet('bindings-directives', false);
 
             if (! $bindings) return;
 
@@ -94,11 +93,11 @@ class SupportWireModelingNestedComponents extends ComponentHook
 
     public function dehydrate($context)
     {
-        $bindings = store($this->component)->get('bindings', false);
+        $bindings = $this->storeGet('bindings', false);
 
         if (! $bindings) return;
 
-        $directives = store($this->component)->get('bindings-directives');
+        $directives = $this->storeGet('bindings-directives');
 
         // Add the bindings metadata to the paylad for later reference...
         $context->addMemo('bindings', $bindings);


### PR DESCRIPTION
# Motivation
Inside `ComponentHook` class, there are already data store helper methods that can be used from component hooks. However, currently there are many component hooks that still using `store` function instead those helper methods

- `SupportEvents`
- `SupportJsEvaluation`
- `SupportJsModules`
- `SupportLazyLoading`
- `SupportNestedComponentListeners`
- `SupportScriptsAndAssets`
- `SupportWireModelingNestedComponents`

# What's Changed
- Change all `store()` to existing helper methods from `ComponentHook` class
- In addition, adds `$this->storeFind()` to `ComponentHook` class