### PR TITLE
[4.x] Dedicated data store helper methods for base `Attribute` class

### DIFF
--- a/src/Features/SupportAttributes/Attribute.php
+++ b/src/Features/SupportAttributes/Attribute.php
@@ -4,6 +4,8 @@ namespace Livewire\Features\SupportAttributes;
 
 use Livewire\Component;
 
+use function Livewire\store;
+
 abstract class Attribute
 {
     protected Component $component;
@@ -103,5 +105,30 @@ abstract class Attribute
         }
 
         return false;
+    }
+
+    function storeSet($key, $value)
+    {
+        store($this->component)->set($key, $value);
+    }
+
+    function storePush($key, $value, $iKey = null)
+    {
+        store($this->component)->push($key, $value, $iKey);
+    }
+
+    function storeGet($key, $default = null)
+    {
+        return store($this->component)->get($key, $default);
+    }
+
+    function storeFind($key, $iKey = null, $default = null)
+    {
+        return store($this->component)->find($key, $iKey, $default);
+    }
+
+    function storeHas($key)
+    {
+        return store($this->component)->has($key);
     }
 }

--- a/src/Features/SupportEvents/BaseOn.php
+++ b/src/Features/SupportEvents/BaseOn.php
@@ -6,8 +6,6 @@ use Attribute;
 use Illuminate\Support\Arr;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
-use function Livewire\store;
-
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 class BaseOn extends LivewireAttribute
 {
@@ -16,7 +14,7 @@ class BaseOn extends LivewireAttribute
     public function boot()
     {
         foreach (Arr::wrap($this->event) as $event) {
-            store($this->component)->push(
+            $this->storePush(
                 'listenersFromAttributes',
                 $this->getName() ?? '$refresh',
                 $event,

--- a/src/Features/SupportReactiveProps/BaseReactive.php
+++ b/src/Features/SupportReactiveProps/BaseReactive.php
@@ -3,7 +3,6 @@
 namespace Livewire\Features\SupportReactiveProps;
 
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
-use function Livewire\store;
 
 #[\Attribute]
 class BaseReactive extends LivewireAttribute
@@ -16,7 +15,7 @@ class BaseReactive extends LivewireAttribute
     {
         $property = $this->getName();
 
-        store($this->component)->push('reactiveProps', $property);
+        $this->storePush('reactiveProps', $property);
 
         $this->originalValueHash = crc32(json_encode($this->getValue()));
     }

--- a/src/Features/SupportRenderless/BaseRenderless.php
+++ b/src/Features/SupportRenderless/BaseRenderless.php
@@ -4,14 +4,12 @@ namespace Livewire\Features\SupportRenderless;
 
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
-use function Livewire\store;
-
 #[\Attribute]
 class BaseRenderless extends LivewireAttribute
 {
     function call()
     {
-        store($this->component)->set('skipIslandsRender', true);
+        $this->storeSet('skipIslandsRender', true);
 
         $this->component->skipRender();
     }

--- a/src/Features/SupportTransitions/BaseTransitionAttribute.php
+++ b/src/Features/SupportTransitions/BaseTransitionAttribute.php
@@ -4,8 +4,6 @@ namespace Livewire\Features\SupportTransitions;
 
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
-use function Livewire\store;
-
 #[\Attribute(\Attribute::TARGET_METHOD)]
 class BaseTransitionAttribute extends LivewireAttribute
 {
@@ -17,11 +15,11 @@ class BaseTransitionAttribute extends LivewireAttribute
     function call()
     {
         if ($this->type) {
-            store($this->component)->set('transitionType', $this->type);
+            $this->storeSet('transitionType', $this->type);
         }
 
         if ($this->skip) {
-            store($this->component)->set('transitionSkip', true);
+            $this->storeSet('transitionSkip', true);
         }
     }
 }

--- a/src/Features/SupportWireModelingNestedComponents/BaseModelable.php
+++ b/src/Features/SupportWireModelingNestedComponents/BaseModelable.php
@@ -2,7 +2,6 @@
 
 namespace Livewire\Features\SupportWireModelingNestedComponents;
 
-use function Livewire\store;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
 #[\Attribute]
@@ -17,7 +16,7 @@ class BaseModelable extends LivewireAttribute
         foreach ($attributes as $key => $value) {
             if (str($key)->startsWith('wire:model')) {
                 $outer = $value;
-                store($this->component)->push('bindings-directives', $key, $value);
+                $this->storePush('bindings-directives', $key, $value);
                 break;
             }
         }
@@ -26,7 +25,7 @@ class BaseModelable extends LivewireAttribute
 
         $inner = $this->getName();
 
-        store($this->component)->push('bindings', $inner, $outer);
+        $this->storePush('bindings', $inner, $outer);
 
         $this->setValue(data_get($parent, $outer));
     }
@@ -44,7 +43,7 @@ class BaseModelable extends LivewireAttribute
     // final value for the child's request...
     function update($fullPath, $newValue)
     {
-        if (store($this->component)->get('hasBeenSeeded', false)) {
+        if ($this->storeGet('hasBeenSeeded', false)) {
             $oldValue = $this->getValue();
 
             return function () use ($oldValue) {


### PR DESCRIPTION
# Motivation
Following how `ComponentHook` class using data store helper methods, this PR adds dedicated data store helper methods in base `Attribute` class that can be used from Livewire attribute. Currently, these are `Base*` attribute that still using `store()`
- `src/Features/SupportEvents/BaseOn.php`
- `src/Features/SupportReactiveProps/BaseReactive.php`
- `src/Features/SupportRenderless/BaseRenderless.php`
- `src/Features/SupportTransitions/BaseTransitionAttribute.php`
- `src/Features/SupportWireModelingNestedComponents/BaseModelable.php`

# What's Changed
- Adds dedicated data store helper methods in base `Attribute` class
- Change all `Base*` attribute that using `store()` to those helper methods