### PR TITLE
[4.x] Rename internal `WithFileUploads` trait to `HandlesFileUploads`

### DIFF
--- a/src/Features/SupportFileUploads/HandlesFileUploads.php
+++ b/src/Features/SupportFileUploads/HandlesFileUploads.php
@@ -7,7 +7,7 @@ use Illuminate\Http\UploadedFile;
 use Livewire\Attributes\Renderless;
 use Livewire\Facades\GenerateSignedUploadUrlFacade;
 
-trait WithFileUploads
+trait HandlesFileUploads
 {
     #[Renderless]
     function _startUpload($name, $fileInfo, $isMultiple)

--- a/src/WithFileUploads.php
+++ b/src/WithFileUploads.php
@@ -2,9 +2,9 @@
 
 namespace Livewire;
 
-use Livewire\Features\SupportFileUploads\WithFileUploads as BaseWithFileUploads;
+use Livewire\Features\SupportFileUploads\HandlesFileUploads;
 
 trait WithFileUploads
 {
-   use BaseWithFileUploads;
+   use HandlesFileUploads;
 }


### PR DESCRIPTION
# Why
`WithFileUploads` trait exists in two different directory
- `src\Features\SupportFileUploads\WithFileUploads.php`
- `src\WithFileUploads.php`

This can be confusing from IDE perpective when importing the trait (See image below)

<img width="620" height="88" alt="image" src="https://github.com/user-attachments/assets/7753e5fc-0323-4190-b342-63eccf444306" />

Yes, its well documented but I think its a good to be explicitly use different name so I rename it to `HandlesFileUploads`. This is internal change so there is no bc at all.

However, it still has some concern that some people already use this internal trait but we already agreed that internal class, trait etc should be strictly not used as public API.

<img width="623" height="51" alt="image" src="https://github.com/user-attachments/assets/9140d60d-96b5-4c39-af33-7f130715cb8e" />

# Whats Changed
- Rename `src\Features\SupportFileUploads\WithFileUploads.php` to `src\Features\SupportFileUploads\HandlesFileUploads.php`
- Change the imported trait in `src\WithFileUploads.php` to use this new namespace.

