### PR TITLE
[4.x] Refactor `SupportIsolating` to use `instanceof` instead `is_subclass_of`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "test": "phpunit --configuration phpunit.xml.dist",
     "test:unit": "phpunit --configuration phpunit.xml.dist --testsuite Unit",
     "test:browser": "phpunit --configuration phpunit.xml.dist --testsuite Browser",
-    "test:browser:headed": "DUSK_HEADLESS_DISABLED=true phpunit --configuration phpunit.xml.dist --testsuite Browser"
+    "test:browser:headed": "set DUSK_HEADLESS_DISABLED=true&&phpunit --configuration phpunit.xml.dist --testsuite Browser"
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "test": "phpunit --configuration phpunit.xml.dist",
     "test:unit": "phpunit --configuration phpunit.xml.dist --testsuite Unit",
     "test:browser": "phpunit --configuration phpunit.xml.dist --testsuite Browser",
-    "test:browser:headed": "set DUSK_HEADLESS_DISABLED=true&&phpunit --configuration phpunit.xml.dist --testsuite Browser"
+    "test:browser:headed": "DUSK_HEADLESS_DISABLED=true phpunit --configuration phpunit.xml.dist --testsuite Browser"
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/src/Features/SupportIsolating/BrowserTest.php
+++ b/src/Features/SupportIsolating/BrowserTest.php
@@ -10,6 +10,59 @@ use Livewire\Attributes\Isolate;
 
 class BrowserTest extends BrowserTestCase
 {
+    public function test_components_can_be_marked_as_isolated_using_base_isolate()
+    {
+        Livewire::visit([new class extends Component {
+            public function render() { return <<<HTML
+            <div>
+                <livewire:child num="1" />
+                <livewire:child num="2" />
+                <livewire:child num="3" />
+
+                <button wire:click="\$dispatch('trigger')" dusk="trigger">Dispatch trigger</button>
+            </div>
+            HTML; }
+        }, 'child' => new #[BaseIsolate] class extends Component {
+            public $num;
+            public $time;
+            public function mount() {
+                $this->time = LARAVEL_START;
+            }
+            #[On('trigger')]
+            public function react() {
+                $this->time = LARAVEL_START;
+            }
+            public function render() { return <<<'HTML'
+            <div id="child">
+                Child {{ $num }}
+
+                <span dusk="time-{{ $num }}">{{ $time }}</span>
+            </div>
+            HTML; }
+        }])
+        ->waitForText('Child 1')
+        ->waitForText('Child 2')
+        ->waitForText('Child 3')
+        ->tap(function ($b) {
+            $time1 = (float) $b->text('@time-1');
+            $time2 = (float) $b->text('@time-2');
+            $time3 = (float) $b->text('@time-3');
+
+            $this->assertEquals($time1, $time2);
+            $this->assertEquals($time2, $time3);
+        })
+        ->waitForLivewire()->click('@trigger')
+        ->tap(function ($b) {
+            $time1 = (float) $b->waitFor('@time-1')->text('@time-1');
+            $time2 = (float) $b->waitFor('@time-2')->text('@time-2');
+            $time3 = (float) $b->waitFor('@time-3')->text('@time-3');
+
+            $this->assertNotEquals($time1, $time2);
+            $this->assertNotEquals($time2, $time3);
+        })
+        ;
+    }
+
     public function test_components_can_be_marked_as_isolated()
     {
         Livewire::visit([new class extends Component {

--- a/src/Features/SupportIsolating/SupportIsolating.php
+++ b/src/Features/SupportIsolating/SupportIsolating.php
@@ -16,7 +16,7 @@ class SupportIsolating extends ComponentHook
     public function shouldIsolate()
     {
         return $this->component->getAttributes()
-            ->filter(fn ($i) => is_subclass_of($i, BaseIsolate::class))
+            ->filter(fn ($i) => $i instanceof BaseIsolate)
             ->count() > 0;
     }
 }


### PR DESCRIPTION
Inside `SupportIsolating::shouldIsolate()` still using `is_subclass_of` instead `instanceof`. All `Base*` attribute are strictly for internal uses, however there is a chance future contributors not aware of this and creating browser test using base attribute.

This is to ensure that both from public API use case and tests align without any error that some people not aware of

# Whats Changed
- Change `is_subclass_of` to `instanceof`
- Added regression browser test
