### PR TITLE
Support #[Virtual] methods that return a Form

### DIFF
--- a/src/Features/SupportAttributes/HandlesAttributes.php
+++ b/src/Features/SupportAttributes/HandlesAttributes.php
@@ -6,6 +6,10 @@ trait HandlesAttributes
 {
     protected AttributeCollection $attributes;
 
+    // Lifecycle phases that have already run for this component, so attributes
+    // registered later can catch up on the ones they missed...
+    protected array $elapsedAttributePhases = [];
+
     function getAttributes()
     {
         return $this->attributes ??= AttributeCollection::fromComponent($this);
@@ -21,5 +25,31 @@ trait HandlesAttributes
     function mergeOutsideAttributes(AttributeCollection $attributes)
     {
         $this->attributes = $this->getAttributes()->concat($attributes);
+
+        // Attributes can arrive after the lifecycle has moved on — a virtual
+        // property is built by its own method, so a form object's attributes
+        // only exist once that method has run. Replay the phases they missed
+        // instead of letting them silently do nothing...
+        foreach ($this->elapsedAttributePhases as [$phase, $params]) {
+            foreach ($attributes as $attribute) {
+                if (! $attribute instanceof Attribute) continue;
+
+                if (method_exists($attribute, $phase)) $attribute->{$phase}(...$params);
+            }
+        }
+    }
+
+    // Drop every attribute registered on behalf of a sub-target (a form object
+    // being replaced, say) so its rules and effects don't pile up...
+    function forgetOutsideAttributes($subTarget)
+    {
+        $this->attributes = $this->getAttributes()->reject(
+            fn ($attribute) => $attribute instanceof Attribute && $attribute->getSubTarget() === $subTarget
+        )->values();
+    }
+
+    function markAttributePhaseAsElapsed($phase, $params = [])
+    {
+        $this->elapsedAttributePhases[] = [$phase, $params];
     }
 }

--- a/src/Features/SupportAttributes/SupportAttributes.php
+++ b/src/Features/SupportAttributes/SupportAttributes.php
@@ -9,27 +9,32 @@ class SupportAttributes extends ComponentHook
 {
     function boot(...$params)
     {
-        $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
-            if (method_exists($attribute, 'boot')) {
-                $attribute->boot(...$params);
-            }
-        });
+        $this->runSetupPhase('boot', $params);
     }
 
     function mount(...$params)
     {
-        $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
-            if (method_exists($attribute, 'mount')) {
-                $attribute->mount(...$params);
-            }
-        });
+        $this->runSetupPhase('mount', $params);
     }
 
     function hydrate(...$params)
     {
-        $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
-            if (method_exists($attribute, 'hydrate')) {
-                $attribute->hydrate(...$params);
+        $this->runSetupPhase('hydrate', $params);
+    }
+
+    // The phases that wire an attribute up (as opposed to render/dehydrate,
+    // which report on it). Marking the phase before running it means an
+    // attribute registered from inside one of these hooks — or any time
+    // later — is caught up by mergeOutsideAttributes() exactly once...
+    protected function runSetupPhase($phase, $params)
+    {
+        $attributes = $this->getLivewireAttributes();
+
+        $this->component->markAttributePhaseAsElapsed($phase, $params);
+
+        $attributes->each(function ($attribute) use ($phase, $params) {
+            if (method_exists($attribute, $phase)) {
+                $attribute->{$phase}(...$params);
             }
         });
     }

--- a/src/Features/SupportFormObjects/FormObjectSynth.php
+++ b/src/Features/SupportFormObjects/FormObjectSynth.php
@@ -30,19 +30,33 @@ class FormObjectSynth extends Synth {
     }
 
     // Uninitialized `public PostForm $form` properties spring to life.
-    // The form's boot runs after the property assignment so boot-time
-    // logic can reach the form through its component...
+    // Adoption runs after the property assignment so boot-time logic can
+    // reach the form through its component...
     function initialize($type, $assign)
+    {
+        $assign($form = new $type($this->context->component, $this->path));
+
+        $this->adopt($form);
+    }
+
+    // A form built somewhere other than this synth — a #[Virtual] method
+    // returning a Form — still needs its attributes registered on the
+    // component and its boot() run. This is initialize() minus the
+    // construction, for instances that arrive already made...
+    function adopt($target, $previous = null)
     {
         $component = $this->context->component;
 
-        $form = new $type($component, $this->path);
+        // Replacing an earlier instance (an unset or a reset): its attributes
+        // still point at the old form, so drop them before registering the
+        // new ones. Otherwise rules and query-string effects double up...
+        if ($previous !== null) $component->forgetOutsideAttributes($previous);
 
-        $callBootMethod = static::bootFormObject($component, $form, $this->path);
+        $component->mergeOutsideAttributes(
+            AttributeCollection::fromComponent($component, $target, $this->path . '.')
+        );
 
-        $assign($form);
-
-        $callBootMethod();
+        wrap($target)->boot();
     }
 
     function dehydrate($target, $dehydrateChild)
@@ -63,10 +77,10 @@ class FormObjectSynth extends Synth {
             throw new \Exception('Livewire: Invalid form object class.');
         }
 
-        // If the form object already exists on the component (e.g. during a
-        // consolidated property update where the entire form is sent as one
-        // update), reuse it. Creating a new instance would discard the booted
-        // #[Validate] attribute state that was set up during hydration.
+        // The form object usually already exists by now — initialize() built
+        // declared ones, and a #[Virtual] method built its own. Reuse it:
+        // building a second instance would discard the booted #[Validate]
+        // state and leave the first one registered but orphaned...
         $existing = data_get($this->context->component, $this->path);
 
         if ($existing instanceof Form && $existing instanceof $meta['class']) {
@@ -75,11 +89,9 @@ class FormObjectSynth extends Synth {
 
         $form = new $meta['class']($this->context->component, $this->path);
 
-        $callBootMethod = static::bootFormObject($this->context->component, $form, $this->path);
-
         $this->hydrateFormProperties($form, $data, $hydrateChild);
 
-        $callBootMethod();
+        $this->adopt($form);
 
         return $form;
     }
@@ -91,17 +103,6 @@ class FormObjectSynth extends Synth {
         } else {
             $target->$key = $value;
         }
-    }
-
-    public static function bootFormObject($component, $form, $path)
-    {
-        $component->mergeOutsideAttributes(
-            AttributeCollection::fromComponent($component, $form, $path . '.')
-        );
-
-        return function () use ($form) {
-            wrap($form)->boot();
-        };
     }
 
     protected function hydrateFormProperties($form, $data, $hydrateChild)

--- a/src/Features/SupportVirtualProperties/BrowserTest.php
+++ b/src/Features/SupportVirtualProperties/BrowserTest.php
@@ -135,4 +135,59 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertSeeIn('@server', '2,1')
         ;
     }
+
+    public function test_a_virtual_form_object_validates_and_binds_like_a_declared_one()
+    {
+        Livewire::visit(new class extends Component {
+            #[Virtual]
+            public function form(): BrowserVirtualForm
+            {
+                return new BrowserVirtualForm($this, 'form');
+            }
+
+            public function save()
+            {
+                $this->form->validate();
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <input dusk="title" wire:model.live="form.title" />
+
+                    <button dusk="save" type="button" wire:click="save">Save</button>
+
+                    <span dusk="booted">{{ $form->booted ? 'booted' : 'not booted' }}</span>
+                    <span dusk="error">@error('form.title') {{ $message }} @enderror</span>
+                    <span dusk="server">{{ $form->title }}</span>
+                </div>
+                HTML;
+            }
+        })
+        // boot() ran on the method-built form...
+        ->assertSeeIn('@booted', 'booted')
+        // #[Validate] rules registered, so saving an empty form errors...
+        ->waitForLivewire()->click('@save')
+        ->assertSeeIn('@error', 'The title field is required.')
+        // wire:model binds through to the form and clears the error...
+        ->waitForLivewire()->type('@title', 'Real title')
+        ->assertSeeIn('@server', 'Real title')
+        ->waitForLivewire()->click('@save')
+        ->assertSeeNothingIn('@error')
+        ;
+    }
+}
+
+class BrowserVirtualForm extends \Livewire\Form
+{
+    #[\Livewire\Attributes\Validate('required')]
+    public $title = '';
+
+    public $booted = false;
+
+    public function boot()
+    {
+        $this->booted = true;
+    }
 }

--- a/src/Features/SupportVirtualProperties/FormObjectUnitTest.php
+++ b/src/Features/SupportVirtualProperties/FormObjectUnitTest.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Livewire\Features\SupportVirtualProperties;
+
+use Livewire\Attributes\Url;
+use Livewire\Attributes\Validate;
+use Livewire\Attributes\Virtual;
+use Livewire\Form;
+use Livewire\Livewire;
+use Tests\TestComponent;
+
+class FormObjectUnitTest extends \Tests\TestCase
+{
+    function test_a_virtual_form_object_is_booted()
+    {
+        Livewire::test(VirtualFormComponent::class)
+            ->assertSetStrict('form.bootCount', 1);
+    }
+
+    function test_a_virtual_form_object_is_booted_exactly_once_per_request()
+    {
+        // The snapshot carries bootCount, so it can't tell one boot from two —
+        // count them out of band. Hydration reuses the materialized instance,
+        // and a second boot would mean a second set of registered attributes...
+        VirtualForm::$boots = 0;
+
+        Livewire::test(VirtualFormComponent::class);
+        $this->assertSame(1, VirtualForm::$boots);
+
+        VirtualForm::$boots = 0;
+
+        Livewire::test(VirtualFormComponent::class)->set('form.title', 'Something');
+        $this->assertSame(2, VirtualForm::$boots); // one for the mount, one for the update
+    }
+
+    function test_a_virtual_form_object_honors_validate_attributes()
+    {
+        Livewire::test(VirtualFormComponent::class)
+            ->call('save')
+            ->assertHasErrors(['form.title' => 'required']);
+    }
+
+    function test_a_virtual_form_object_validates_on_update()
+    {
+        Livewire::test(VirtualFormComponent::class)
+            ->set('form.title', '')
+            ->assertHasErrors(['form.title' => 'required'])
+            ->set('form.title', 'Filled in')
+            ->assertHasNoErrors();
+    }
+
+    function test_a_virtual_form_object_reads_url_attributes_from_the_query_string()
+    {
+        Livewire::withQueryParams(['title' => 'from-url'])
+            ->test(VirtualFormComponent::class)
+            ->assertSetStrict('form.title', 'from-url');
+    }
+
+    function test_a_virtual_form_object_pushes_the_same_query_string_effect_as_a_declared_one()
+    {
+        $virtual = Livewire::withQueryParams([])
+            ->test(VirtualFormComponent::class)
+            ->effects;
+
+        $declared = Livewire::withQueryParams([])
+            ->test(new class extends TestComponent {
+                public VirtualForm $form;
+            })
+            ->effects;
+
+        $this->assertSame(['form.title'], array_keys($virtual['url']));
+        $this->assertSame($declared['url'], $virtual['url']);
+    }
+
+    function test_a_virtual_form_object_round_trips_its_state()
+    {
+        Livewire::test(VirtualFormComponent::class)
+            ->set('form.title', 'Kept')
+            ->call('$refresh')
+            ->assertSetStrict('form.title', 'Kept');
+    }
+
+    function test_a_virtual_form_object_keeps_configuration_that_does_not_serialize()
+    {
+        // The method — not the snapshot — is the source of the closure, so it
+        // has to survive a round trip the way a declared form's boot would...
+        Livewire::test(VirtualFormComponent::class)
+            ->set('form.title', 'shout')
+            ->call('applyDecorator')
+            ->assertSetStrict('form.title', 'SHOUT');
+    }
+
+    function test_a_virtual_form_object_runs_its_updated_hooks()
+    {
+        Livewire::test(VirtualFormComponent::class)
+            ->set('form.title', 'Hooked')
+            ->assertSetStrict('form.updatedPaths', ['title']);
+    }
+
+    function test_a_consolidated_update_to_a_virtual_form_is_decomposed_into_property_updates()
+    {
+        // The JS diff sends the whole form as one update when every property
+        // changed. Each one still has to go through the normal update path...
+        Livewire::test(VirtualFormComponent::class)
+            ->set('form', ['title' => 'Whole', 'status' => 'draft'])
+            ->assertSetStrict('form.title', 'Whole')
+            ->assertSetStrict('form.updatedPaths', ['title', 'status']);
+    }
+
+    function test_a_virtual_form_object_can_be_reset()
+    {
+        Livewire::test(VirtualFormComponent::class)
+            ->set('form.title', 'Filled in')
+            ->call('startOver')
+            ->assertSetStrict('form.title', '')
+            ->call('save')
+            ->assertHasErrors(['form.title' => 'required']);
+    }
+
+    function test_replacing_a_virtual_form_object_detaches_the_old_instance()
+    {
+        // Rebuilding the instance re-registers the form's attributes. If the
+        // abandoned one stays registered too, it keeps validating its own
+        // stale data and reports errors for a form nobody can see...
+        Livewire::test(ResettingVirtualFormComponent::class)
+            ->set('form.title', 'Filled in')
+            ->assertHasNoErrors()
+            ->assertSetStrict('form.title', 'Filled in');
+    }
+
+    function test_a_virtual_form_object_can_be_an_anonymous_class()
+    {
+        // The payoff: a bespoke one-off form has no name to typehint, so it
+        // can't be expressed as a declared property at all...
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): Form
+            {
+                return new class ($this, 'form') extends Form {
+                    #[Validate('required')]
+                    public $name = '';
+                };
+            }
+
+            public function save() { $this->form->validate(); }
+        })
+            ->call('save')
+            ->assertHasErrors(['form.name' => 'required'])
+            ->set('form.name', 'Caleb')
+            ->call('save')
+            ->assertHasNoErrors();
+    }
+}
+
+class VirtualFormComponent extends TestComponent
+{
+    public function save()
+    {
+        $this->form->validate();
+    }
+
+    public function startOver()
+    {
+        $this->reset('form');
+    }
+
+    public function applyDecorator()
+    {
+        $this->form->decorate();
+    }
+
+    #[Virtual]
+    public function form(): VirtualForm
+    {
+        return new VirtualForm($this, 'form', decorate: fn ($value) => strtoupper($value));
+    }
+}
+
+class ResettingVirtualFormComponent extends VirtualFormComponent
+{
+    public function boot()
+    {
+        // Empty the instance out, then throw it away for a fresh one...
+        $this->form->title = '';
+
+        $this->reset('form');
+    }
+}
+
+class VirtualForm extends Form
+{
+    #[Validate('required')]
+    #[Url]
+    public $title = '';
+
+    public $status = '';
+
+    public $bootCount = 0;
+
+    public $updatedPaths = [];
+
+    // Boots counted out of band, where the snapshot can't paper over them...
+    public static $boots = 0;
+
+    // Protected, so it never crosses the wire — the virtual method rebuilds
+    // it from code on every request...
+    protected $decorator;
+
+    public function __construct($component, $propertyName, $decorate = null)
+    {
+        parent::__construct($component, $propertyName);
+
+        $this->decorator = $decorate;
+    }
+
+    public function decorate()
+    {
+        $this->title = ($this->decorator)($this->title);
+    }
+
+    public function boot()
+    {
+        $this->bootCount++;
+
+        static::$boots++;
+    }
+
+    public function updated($path)
+    {
+        $this->updatedPaths[] = $path;
+    }
+}

--- a/src/Features/SupportVirtualProperties/HandlesVirtualProperties.php
+++ b/src/Features/SupportVirtualProperties/HandlesVirtualProperties.php
@@ -2,10 +2,16 @@
 
 namespace Livewire\Features\SupportVirtualProperties;
 
+use function Livewire\trigger;
+
 // A virtual property is a public method marked #[Virtual] that acts as a
 // property. The method is its constructor — it materializes on first access
 // (like #[Computed]) into a lookup on the component; there's no backing
-// declaration. On the wire it's indistinguishable from a normal property...
+// declaration. On the wire it's indistinguishable from a normal property.
+//
+// Materializing announces itself (see materializeVirtualProperty) so the
+// instance's synthesizer can do the wire-up it would have done had it built
+// the instance itself — registering a form object's attributes, say...
 trait HandlesVirtualProperties
 {
     protected $__virtualProperties = [];
@@ -16,7 +22,7 @@ trait HandlesVirtualProperties
     {
         foreach (static::virtualPropertyMethods() as $name => $method) {
             if (! array_key_exists($name, $this->__virtualProperties)) {
-                $this->__virtualProperties[$name] = $this->{$method['name']}();
+                $this->materializeVirtualProperty($name);
             }
         }
     }
@@ -47,7 +53,7 @@ trait HandlesVirtualProperties
         $name = (string) str($name)->camel();
 
         if (! array_key_exists($name, $this->__virtualProperties)) {
-            $this->__virtualProperties[$name] = $this->{static::virtualPropertyMethods()[$name]['name']}();
+            return $this->materializeVirtualProperty($name);
         }
 
         return $this->__virtualProperties[$name];
@@ -75,9 +81,21 @@ trait HandlesVirtualProperties
     // A virtual property has no empty state — unsetting reconstructs it...
     function unsetVirtualProperty($name)
     {
-        $name = (string) str($name)->camel();
+        $this->materializeVirtualProperty((string) str($name)->camel());
+    }
 
-        $this->__virtualProperties[$name] = $this->{static::virtualPropertyMethods()[$name]['name']}();
+    // The one place a virtual property comes into being. The instance is
+    // stored before it's announced so anything the synth triggers (a form
+    // object's boot(), say) can already reach it as a property...
+    protected function materializeVirtualProperty($name)
+    {
+        $previous = $this->__virtualProperties[$name] ?? null;
+
+        $this->__virtualProperties[$name] = $instance = $this->{static::virtualPropertyMethods()[$name]['name']}();
+
+        trigger('virtual-property', $this, $name, $instance, $previous);
+
+        return $instance;
     }
 
     protected static function virtualPropertyMethods()

--- a/src/Features/SupportVirtualProperties/SupportVirtualProperties.php
+++ b/src/Features/SupportVirtualProperties/SupportVirtualProperties.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Livewire\Features\SupportVirtualProperties;
+
+use Livewire\Component;
+use Livewire\ComponentHook;
+use Livewire\Mechanisms\HandleSynths\HandleSynths;
+
+use function Livewire\on;
+
+class SupportVirtualProperties extends ComponentHook
+{
+    public static function provide()
+    {
+        on('virtual-property', function ($target, $name, $instance, $previous) {
+            // Virtual properties on form objects aren't wire-addressable on
+            // their own, so there's nothing to wire up for them...
+            if (! $target instanceof Component) return;
+
+            app(HandleSynths::class)->adopt($target, $name, $instance, $previous);
+        });
+    }
+
+    // Construction stays lazy so a method can read state that mount() set, but
+    // it can't be allowed to drift past the lifecycle: an instance that
+    // registers attributes (a form object) would miss every hook it needs.
+    // Materializing here — last hook of the phase — is late enough to see
+    // sibling state and early enough that adoption still catches up...
+    public function mount()
+    {
+        $this->component->initializeVirtualProperties();
+    }
+
+    // Hydration builds virtuals as it pours the snapshot into them, so this is
+    // usually a no-op. It only bites for a property the snapshot predates —
+    // a virtual method deployed between requests...
+    public function hydrate()
+    {
+        $this->component->initializeVirtualProperties();
+    }
+}

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -211,6 +211,10 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
             Features\SupportLifecycleHooks\SupportLifecycleHooks::class,
             Features\SupportLegacyModels\SupportLegacyModels::class,
             Features\SupportWireables\SupportWireables::class,
+
+            // Virtual properties materialize after every other hook has run,
+            // so their methods can read whatever mount() set...
+            Features\SupportVirtualProperties\SupportVirtualProperties::class,
         ] as $feature) {
             app('livewire')->componentHook($feature);
         }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -428,7 +428,12 @@ class HandleComponents extends Mechanism
         $expanded = [];
 
         foreach ($updates as $path => $value) {
-            if (is_array($value) && property_exists($component, $path) && $component->$path instanceof Form) {
+            // A #[Virtual] method can return a form too, and it has no backing
+            // declaration for property_exists() to find...
+            $isRootProperty = ! str_contains($path, '.')
+                && (property_exists($component, $path) || $component->hasVirtualProperty($path));
+
+            if (is_array($value) && $isRootProperty && $component->$path instanceof Form) {
                 foreach ($value as $key => $child) {
                     $expanded["{$path}.{$key}"] = $child;
                 }

--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -130,6 +130,29 @@ class HandleSynths extends Mechanism
         });
     }
 
+    // A virtual property's instance comes from the user's method, so the synth
+    // never gets asked to build it and never runs the wire-up initialize()
+    // would have done. Offer the instance to its synth after the fact —
+    // synths opt in by defining adopt($target, $previous)...
+    public function adopt($component, $path, $instance, $previous = null)
+    {
+        if (! is_object($instance)) return;
+
+        $context = new ComponentContext($component);
+
+        // An unsupported type throws at dehydration with a better message than
+        // we could give here, so stay quiet and let it get that far...
+        try {
+            $synth = $this->resolve($instance, $context, $path);
+        } catch (\Exception) {
+            return;
+        }
+
+        if (! method_exists($synth, 'adopt')) return;
+
+        $synth->adopt($instance, $previous);
+    }
+
     public function hydrateForUpdate($raw, $path, $value, $context)
     {
         $meta = $this->getMetaForPath($raw, $path);
@@ -262,10 +285,11 @@ class HandleSynths extends Mechanism
         }
 
         // Virtual properties are deliberately NOT constructed here. They
-        // materialize on first access (like #[Computed]) — always after
-        // mount()/hydration, so a method can read sibling state, and a lazy
-        // placeholder never runs a body it doesn't touch. Dehydration still
-        // accesses them via all(), so they're serialized every request...
+        // materialize on first access (like #[Computed]) so a method can read
+        // sibling state set in mount(). SupportVirtualProperties then forces
+        // any that nothing touched, at the end of the mount/hydrate phase —
+        // late enough for that, early enough for a form object's attributes
+        // to still catch the lifecycle...
     }
 
     protected function discoverInitializableProperties(string $class): array


### PR DESCRIPTION
Follow-up to #10443. A `#[Virtual]` method returning a `Form` was never booted, so form-object attributes and `boot()` silently did nothing.

```php
#[Virtual]
public function form(): PostForm
{
    return new PostForm($this, 'form');
}
```

| | declared form | virtual form (before) | virtual form (after) |
|---|---|---|---|
| wire state round trip | ✅ | ✅ | ✅ |
| `Form::boot()` runs | ✅ | ❌ never | ✅ |
| `#[Validate]` rules | ✅ | ❌ `MissingRulesException` | ✅ |
| `#[Url]` reads query string | ✅ | ❌ | ✅ |

Not a regression — declared forms are untouched and virtual properties didn't exist before #10443. But it failed *silently* for `boot()`; you only found out when you leaned on `#[Validate]`.

## Why it happened

Declared forms get wired up by `FormObjectSynth::initialize()`. A virtual property is built by the *user's method*, so the synth is never asked to build it and nothing registers the form's attributes.

## The tension, and why it isn't forced

Two things were conflated:

1. **When the instance is built** — wants to be *late*, so the method can read state `mount()` set.
2. **When its attributes are registered** — wants to be *early*, so their `boot()`/`mount()` hooks still fire.

Going eager looks like the fix but costs more than it seems: on an *update* request `initializeProperties()` runs before `hydrateProperties()`, so an eagerly-built method would see **default** property values rather than hydrated ones. Config derived from component state would silently capture the wrong values on every request after the first.

So construction stays lazy and registration catches up instead. Virtual methods can still read sibling property state.

## What's in here

- **Late-registered attributes catch up.** `mergeOutsideAttributes()` appended to the collection and did nothing else, so an attribute registered after `SupportAttributes::boot` silently never booted. It now replays the setup phases that already elapsed, marking the phase *before* running it so anything registered from inside one of those hooks is caught up exactly once. `setPropertyAttribute()` had the same latent hole.
- **`FormObjectSynth::adopt($target, $previous)`** registers the form's attributes and runs `boot()`. `initialize()` and `hydrate()` both route through it, so this is a *sibling* of `initialize()` (construction aside), not a third synth contract — `bootFormObject()` folds away.
- **Virtual properties announce themselves as they materialize**, so a synth can wire up an instance it didn't build.
- **`SupportVirtualProperties`** forces any untouched virtual at the end of the mount/hydrate phase. Without it a virtual form materialized during `dehydrateProperties()` — *after* `trigger('dehydrate')` — so `#[Url]` never pushed its query-string effect.
- **Replacing an instance** (`unset`/`reset`) drops the old one's attribute registrations. Left registered, the abandoned form kept validating its own stale data and reported errors for a form nobody could see.
- **`expandConsolidatedFormObjectUpdates()`** gated on `property_exists()`, false for a virtual property, so a whole-form update skipped every per-property `updated` hook and the enum casting that rides along with them.

## Payoff: anonymous class form objects

A one-off form has no name to typehint, so it can't be a declared property at all:

```php
#[Virtual]
public function form(): Form
{
    return new class ($this, 'form') extends Form {
        #[Validate('required')]
        public $name = '';
    };
}
```

## Verification

- Unit: **1427 tests, 4074 assertions, 0 failures** (1414 on `main` + 13 added here; skipped/incomplete unchanged at 13/3).
- Browser: **79 tests, 699 assertions, 0 failures** across `SupportVirtualProperties`, `SupportQueryString`, `SupportValidation`, `SupportAttributes`, `SupportPagination`, `SupportLazyLoading` — the suites most exposed to the attribute-phase change.
- New browser test drives real Chrome: `wire:model.live` into a virtual form, `boot()` visible in the rendered output, `#[Validate]` erroring and clearing.
- Virtual and declared forms now emit **byte-identical** `url` effects (asserted).
- Each guard was confirmed load-bearing by reverting it and watching the matching test fail.

## Note for reviewers

`FormObjectSynth::bootFormObject()` was `public static` and is **removed**, folded into `adopt()`. Nothing in the repo called it from outside the synth, but it was a public symbol.

No JS changes, so no `dist/` rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)