### PR TITLE
Boot form objects returned from #[Virtual] property methods

### DIFF
--- a/src/Features/SupportAttributes/Attribute.php
+++ b/src/Features/SupportAttributes/Attribute.php
@@ -77,7 +77,16 @@ abstract class Attribute
             }
         }
 
-        data_set($this->component, $this->levelName, $value);
+        // Write straight onto the sub-target when there is one. Routing
+        // through the component would re-enter Component::__get mid-write —
+        // and if the property is a #[Virtual] being materialized right now,
+        // PHP's magic-method recursion guard bypasses __get entirely and
+        // data_set would shadow it with a plain array property...
+        if ($this->subTarget) {
+            data_set($this->subTarget, $this->subName, $value);
+        } else {
+            data_set($this->component, $this->levelName, $value);
+        }
     }
 
     protected function tryingToSetStringOrIntegerToEnum($subject)

--- a/src/Features/SupportAttributes/HandlesAttributes.php
+++ b/src/Features/SupportAttributes/HandlesAttributes.php
@@ -2,6 +2,8 @@
 
 namespace Livewire\Features\SupportAttributes;
 
+use function Livewire\store;
+
 trait HandlesAttributes
 {
     protected AttributeCollection $attributes;
@@ -21,5 +23,24 @@ trait HandlesAttributes
     function mergeOutsideAttributes(AttributeCollection $attributes)
     {
         $this->attributes = $this->getAttributes()->concat($attributes);
+
+        // Attributes can arrive after a one-shot lifecycle window has
+        // already run (a #[Virtual] form object materializing mid-request).
+        // Replay the missed windows on just the late arrivals so arrival
+        // time never changes behavior...
+        $arrivals = $attributes->whereInstanceOf(Attribute::class);
+
+        foreach (store($this)->get('attributeWindows', []) as [$window, $params]) {
+            $arrivals->each(function ($attribute) use ($window, $params) {
+                if (method_exists($attribute, $window)) {
+                    $attribute->$window(...$params);
+                }
+            });
+        }
+    }
+
+    function forgetAttributesWhere($callback)
+    {
+        $this->attributes = $this->getAttributes()->reject($callback)->values();
     }
 }

--- a/src/Features/SupportAttributes/SupportAttributes.php
+++ b/src/Features/SupportAttributes/SupportAttributes.php
@@ -9,6 +9,8 @@ class SupportAttributes extends ComponentHook
 {
     function boot(...$params)
     {
+        $this->recordWindow('boot', $params);
+
         $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
             if (method_exists($attribute, 'boot')) {
                 $attribute->boot(...$params);
@@ -18,6 +20,8 @@ class SupportAttributes extends ComponentHook
 
     function mount(...$params)
     {
+        $this->recordWindow('mount', $params);
+
         $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
             if (method_exists($attribute, 'mount')) {
                 $attribute->mount(...$params);
@@ -27,11 +31,24 @@ class SupportAttributes extends ComponentHook
 
     function hydrate(...$params)
     {
+        $this->recordWindow('hydrate', $params);
+
         $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
             if (method_exists($attribute, 'hydrate')) {
                 $attribute->hydrate(...$params);
             }
         });
+    }
+
+    // Each one-shot lifecycle window records itself (BEFORE iterating, so
+    // attributes merged mid-window replay it without double-running — the
+    // iteration above reads a snapshot of the collection that doesn't
+    // include them). Attributes that arrive after a window has passed —
+    // a #[Virtual] form materializing mid-request — replay the missed
+    // windows in mergeOutsideAttributes()...
+    protected function recordWindow($window, $params)
+    {
+        $this->storePush('attributeWindows', [$window, $params]);
     }
 
     function update($propertyName, $fullPath, $newValue)
@@ -91,6 +108,8 @@ class SupportAttributes extends ComponentHook
 
     function dehydrate(...$params)
     {
+        $this->recordWindow('dehydrate', $params);
+
         $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
             if (method_exists($attribute, 'dehydrate')) {
                 $attribute->dehydrate(...$params);

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -31,6 +31,13 @@ class Form implements Arrayable
     public function getComponent() { return $this->component; }
     public function getPropertyName() { return $this->propertyName; }
 
+    // A virtual property on a form adopts against the owning component,
+    // under the form's own path...
+    protected function virtualPropertyOwner()
+    {
+        return [$this->component, $this->propertyName.'.'];
+    }
+
     public function validate($rules = null, $messages = [], $attributes = [])
     {
         try {

--- a/src/Features/SupportFormObjects/FormObjectSynth.php
+++ b/src/Features/SupportFormObjects/FormObjectSynth.php
@@ -4,6 +4,7 @@ namespace Livewire\Features\SupportFormObjects;
 
 use Livewire\Drawer\Utils;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+use Livewire\Features\SupportAttributes\Attribute;
 use Livewire\Features\SupportAttributes\AttributeCollection;
 
 use function Livewire\wrap;
@@ -84,6 +85,16 @@ class FormObjectSynth extends Synth {
         return $form;
     }
 
+    // A form constructed outside the synth — returned from a #[Virtual]
+    // property method — still boots exactly like one constructed by
+    // initialize() or hydrate()...
+    function adopt($form)
+    {
+        $callBootMethod = static::bootFormObject($this->context->component, $form, $this->path);
+
+        $callBootMethod();
+    }
+
     function set(&$target, $key, $value)
     {
         if ($value === null && Utils::propertyIsTyped($target, $key) && ! Utils::getProperty($target, $key)->getType()->allowsNull()) {
@@ -93,8 +104,31 @@ class FormObjectSynth extends Synth {
         }
     }
 
+    // Booting is per-instance, not per-call: the same form can be presented
+    // for booting more than once (a #[Virtual] method that memoizes its
+    // instance, then a reset()). Doing it twice would register its
+    // attributes — and so its validation rules — twice...
+    protected static ?\WeakMap $booted = null;
+
     public static function bootFormObject($component, $form, $path)
     {
+        static::$booted ??= new \WeakMap;
+
+        if (isset(static::$booted[$form])) return fn () => null;
+
+        static::$booted[$form] = true;
+
+        // A reconstructed form at this path (reset/unset of a #[Virtual]
+        // property) REPLACES its predecessor's attributes — accumulating
+        // both sets would duplicate validation rules and leave attributes
+        // bound to a discarded instance...
+        $component->forgetAttributesWhere(function ($attribute) use ($form, $path) {
+            return $attribute instanceof Attribute
+                && ($subTarget = $attribute->getSubTarget()) instanceof Form
+                && $subTarget !== $form
+                && $subTarget->getPropertyName() === $path;
+        });
+
         $component->mergeOutsideAttributes(
             AttributeCollection::fromComponent($component, $form, $path . '.')
         );

--- a/src/Features/SupportVirtualProperties/HandlesVirtualProperties.php
+++ b/src/Features/SupportVirtualProperties/HandlesVirtualProperties.php
@@ -2,6 +2,8 @@
 
 namespace Livewire\Features\SupportVirtualProperties;
 
+use Livewire\Mechanisms\HandleSynths\HandleSynths;
+
 // A virtual property is a public method marked #[Virtual] that acts as a
 // property. The method is its constructor — it materializes on first access
 // (like #[Computed]) into a lookup on the component; there's no backing
@@ -16,7 +18,7 @@ trait HandlesVirtualProperties
     {
         foreach (static::virtualPropertyMethods() as $name => $method) {
             if (! array_key_exists($name, $this->__virtualProperties)) {
-                $this->__virtualProperties[$name] = $this->{$method['name']}();
+                $this->constructVirtualProperty($name);
             }
         }
     }
@@ -47,7 +49,7 @@ trait HandlesVirtualProperties
         $name = (string) str($name)->camel();
 
         if (! array_key_exists($name, $this->__virtualProperties)) {
-            $this->__virtualProperties[$name] = $this->{static::virtualPropertyMethods()[$name]['name']}();
+            $this->constructVirtualProperty($name);
         }
 
         return $this->__virtualProperties[$name];
@@ -77,7 +79,32 @@ trait HandlesVirtualProperties
     {
         $name = (string) str($name)->camel();
 
-        $this->__virtualProperties[$name] = $this->{static::virtualPropertyMethods()[$name]['name']}();
+        $this->constructVirtualProperty($name);
+    }
+
+    // Every construction runs through here: call the method, store the value
+    // (stored BEFORE adoption so re-entrant reads during adoption hit the
+    // lookup instead of re-running the method), then let the value's
+    // synthesizer finish construction — see HandleSynths::adopt()...
+    protected function constructVirtualProperty($name)
+    {
+        $value = $this->{static::virtualPropertyMethods()[$name]['name']}();
+
+        $this->__virtualProperties[$name] = $value;
+
+        if ($owner = $this->virtualPropertyOwner()) {
+            [$component, $prefix] = $owner;
+
+            app(HandleSynths::class)->adopt($component, $prefix.$name, $value);
+        }
+    }
+
+    // Adoption binds against a component. On a component that's $this; on a
+    // sub-object hosting its own virtuals it's the owning component, with
+    // the sub-object's path as a prefix — see Form's override...
+    protected function virtualPropertyOwner()
+    {
+        return $this instanceof \Livewire\Component ? [$this, ''] : null;
     }
 
     protected static function virtualPropertyMethods()

--- a/src/Features/SupportVirtualProperties/UnitTest.php
+++ b/src/Features/SupportVirtualProperties/UnitTest.php
@@ -418,4 +418,261 @@ class UnitTest extends \Tests\TestCase
         Assert::assertInstanceOf(Selection::class, $component->get('selected'));
         Assert::assertSame([], $component->get('selected')->keys());
     }
+
+    function test_a_form_object_from_a_virtual_property_runs_its_boot_method()
+    {
+        VirtualFormStub::$bootLog = [];
+
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+        });
+
+        Assert::assertSame(['booted'], VirtualFormStub::$bootLog);
+    }
+
+    function test_a_form_object_from_a_virtual_property_runs_its_boot_method_on_subsequent_requests()
+    {
+        VirtualFormStub::$bootLog = [];
+
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+        })->call('$refresh');
+
+        Assert::assertSame(['booted', 'booted'], VirtualFormStub::$bootLog);
+    }
+
+    function test_validate_attributes_on_a_form_object_from_a_virtual_property_are_registered()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+
+            public function save()
+            {
+                $this->form->validate();
+            }
+        })
+            ->call('save')
+            ->assertHasErrors('form.title');
+    }
+
+    function test_validate_attributes_on_a_form_object_from_a_virtual_property_validate_on_update()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+        })
+            ->set('form.title', 'ab')
+            ->assertHasErrors('form.title');
+    }
+
+    function test_locked_properties_on_a_form_object_from_a_virtual_property_cannot_be_updated()
+    {
+        $this->expectException(\Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException::class);
+
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+        })
+            ->set('form.secret', 'HACKED');
+    }
+
+    function test_url_attributes_on_a_form_object_from_a_virtual_property_read_the_query_string()
+    {
+        Livewire::withQueryParams(['q' => 'from-url'])
+            ->test(new class extends TestComponent {
+                #[Virtual]
+                public function form(): VirtualFormStub
+                {
+                    return new VirtualFormStub($this, 'form');
+                }
+            })
+            ->assertSetStrict('form.q', 'from-url');
+    }
+
+    function test_url_attributes_on_a_form_object_from_a_virtual_property_register_a_url_effect()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+        });
+
+        Assert::assertArrayHasKey('form.q', $component->effects['url'] ?? []);
+    }
+
+    function test_a_virtual_form_object_first_accessed_inside_mount_gets_url_and_rules()
+    {
+        // First access happens INSIDE the user's mount() — i.e. inside an
+        // open Component::__get() frame. PHP's magic-method recursion guard
+        // bypasses __get on nested access, so any attribute replay that
+        // writes through the component would shadow the virtual property
+        // with a plain array. The write must land on the form directly...
+        Livewire::withQueryParams(['q' => 'from-url'])
+            ->test(new class extends TestComponent {
+                public $titleAtMount;
+
+                public function mount()
+                {
+                    $this->titleAtMount = $this->form->title;
+                }
+
+                #[Virtual]
+                public function form(): VirtualFormStub
+                {
+                    return new VirtualFormStub($this, 'form');
+                }
+            })
+            ->assertSetStrict('titleAtMount', '')
+            ->assertSet('form', fn ($form) => $form instanceof VirtualFormStub)
+            ->assertSetStrict('form.q', 'from-url');
+    }
+
+    function test_a_whole_form_update_on_a_virtual_property_expands_into_per_field_updates()
+    {
+        // Sending the entire form as one consolidated update should behave
+        // exactly like setting each field individually (running per-field
+        // update hooks) — the same guarantee declared form objects have...
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+        })
+            ->set('form', ['title' => 'ab', 'q' => '', 'secret' => 'original'])
+            ->assertSetStrict('form.title', 'ab')
+            ->assertHasErrors('form.title');
+    }
+
+    function test_a_changed_locked_value_inside_a_whole_form_update_still_throws()
+    {
+        $this->expectException(\Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException::class);
+
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+        })
+            ->set('form', ['title' => 'ab', 'q' => '', 'secret' => 'HACKED']);
+    }
+
+    function test_an_unchanged_echo_of_a_json_lossy_locked_field_does_not_trip_the_lock()
+    {
+        // The browser can't express 1.0-as-float — a JSON number round-trips
+        // back as the int 1. An echoed, unchanged locked float must compare
+        // equal to its snapshot value, not trip #[Locked]...
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormWithFloatStub
+            {
+                return new VirtualFormWithFloatStub($this, 'form');
+            }
+        })
+            ->set('form', ['title' => 'changed', 'price' => 1])
+            ->assertSetStrict('form.title', 'changed')
+            ->assertSetStrict('form.price', 1.0);
+    }
+
+    function test_a_memoized_virtual_form_does_not_reregister_its_rules_when_reconstructed()
+    {
+        // A method free to memoize its instance hands back the SAME form on
+        // reconstruction. Booting it again would merge its attributes a
+        // second time — doubling every rule it registered...
+        Livewire::test(new class extends TestComponent {
+            protected $memo;
+
+            public $ruleCount;
+
+            public $attributeCountsMatch;
+
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return $this->memo ??= new VirtualFormStub($this, 'form');
+            }
+
+            public function resetTwice()
+            {
+                $this->reset('form');
+                $before = $this->getAttributes()->count();
+
+                $this->reset('form');
+                $after = $this->getAttributes()->count();
+
+                $this->ruleCount = count($this->form->getRules());
+                $this->attributeCountsMatch = $before === $after;
+            }
+        })
+            ->call('resetTwice')
+            ->assertSetStrict('ruleCount', 1)
+            // A doubled merge turns the rule string into an array via
+            // array_merge_recursive — assert the shape survived too...
+            ->assertSet('form', fn ($form) => $form->getRules()['title'] === 'required|min:3')
+            ->assertSetStrict('attributeCountsMatch', true);
+    }
+
+    function test_an_aliased_path_does_not_resolve_a_virtual_form_object()
+    {
+        // hasVirtualProperty() camelCases its input — the consolidated-update
+        // expansion must not let [Form] reach the virtual [form]...
+        $this->expectException(\Livewire\Exceptions\PublicPropertyNotFoundException::class);
+
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+        })
+            ->set('Form', ['secret' => 'original']);
+    }
+}
+
+class VirtualFormWithFloatStub extends \Livewire\Form
+{
+    public $title = '';
+
+    #[\Livewire\Attributes\Locked]
+    public float $price = 1.0;
+}
+
+class VirtualFormStub extends \Livewire\Form
+{
+    public static $bootLog = [];
+
+    #[\Livewire\Attributes\Validate('required|min:3')]
+    public $title = '';
+
+    #[\Livewire\Attributes\Url]
+    public $q = '';
+
+    #[\Livewire\Attributes\Locked]
+    public $secret = 'original';
+
+    public function boot()
+    {
+        static::$bootLog[] = 'booted';
+    }
 }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -405,7 +405,7 @@ class HandleComponents extends Mechanism
         // Form objects are special — they should never be fully replaced. Instead, decompose
         // the consolidated update into individual property updates so each goes through
         // the normal hydration path (which handles type casting for enums, etc.)...
-        $updates = $this->expandConsolidatedFormObjectUpdates($component, $updates);
+        $updates = $this->expandConsolidatedFormObjectUpdates($component, $updates, $data);
 
         $finishes = [];
 
@@ -423,13 +423,24 @@ class HandleComponents extends Mechanism
         }
     }
 
-    protected function expandConsolidatedFormObjectUpdates($component, $updates)
+    protected function expandConsolidatedFormObjectUpdates($component, $updates, $data)
     {
         $expanded = [];
 
         foreach ($updates as $path => $value) {
-            if (is_array($value) && property_exists($component, $path) && $component->$path instanceof Form) {
+            $form = is_array($value) ? $this->resolveFormObject($component, $path) : null;
+
+            if ($form) {
+                // A consolidated update echoes every field. The snapshot
+                // holds exactly what the client was given, so a field echoed
+                // back unchanged carries no information — expanding it would
+                // run update hooks (and trip #[Locked]) for a write that
+                // isn't one...
+                $snapshotFields = Utils::isSyntheticTuple($data[$path] ?? null) ? $data[$path][0] : [];
+
                 foreach ($value as $key => $child) {
+                    if (array_key_exists($key, $snapshotFields) && $this->wireValuesMatch($snapshotFields[$key], $child)) continue;
+
                     $expanded["{$path}.{$key}"] = $child;
                 }
             } else {
@@ -438,6 +449,40 @@ class HandleComponents extends Mechanism
         }
 
         return $expanded;
+    }
+
+    protected function resolveFormObject($component, $path)
+    {
+        // Exact key match only — hasVirtualProperty() camelCases its input,
+        // which would let an aliased path ([Form]) resolve the virtual [form]
+        // instead of failing as an unknown property...
+        $value = $component->all()[$path] ?? null;
+
+        return $value instanceof Form ? $value : null;
+    }
+
+    // Equality as the client sees it. The snapshot side carries synth tuples
+    // and one number type per value; the browser echoes back plain data and
+    // can't tell 1.0 from 1, or hold integer-like keys in order...
+    protected function wireValuesMatch($a, $b)
+    {
+        if (Utils::isSyntheticTuple($a)) $a = $a[0];
+
+        if (is_array($a) && is_array($b)) {
+            if (count($a) !== count($b)) return false;
+
+            foreach ($a as $key => $value) {
+                if (! array_key_exists($key, $b)) return false;
+
+                if (! $this->wireValuesMatch($value, $b[$key])) return false;
+            }
+
+            return true;
+        }
+
+        if ((is_int($a) || is_float($a)) && (is_int($b) || is_float($b))) return $a == $b;
+
+        return $a === $b;
     }
 
     public function updateProperty($component, $path, $value, $context)

--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -130,6 +130,21 @@ class HandleSynths extends Mechanism
         });
     }
 
+    // Declared properties get initialize(); a #[Virtual] property's method
+    // is a second birth path the synth never sees. adopt() closes that gap:
+    // when a virtual value materializes, its synthesizer may finish
+    // construction the way initialize() would have (booting a form object,
+    // for example). Synths opt in by defining adopt($value) — the same
+    // protocol shape as hydrateInto()...
+    public function adopt($component, $path, $value)
+    {
+        if (Utils::isAPrimitive($value)) return;
+
+        $synth = $this->resolve($value, new ComponentContext($component), $path);
+
+        if (method_exists($synth, 'adopt')) $synth->adopt($value);
+    }
+
     public function hydrateForUpdate($raw, $path, $value, $context)
     {
         $meta = $this->getMetaForPath($raw, $path);


### PR DESCRIPTION
## The bug

A `Form` object returned from a `#[Virtual]` method never gets booted. Its `#[Validate]`, `#[Url]`, and `#[Locked]` attributes are never registered on the component, and its `boot()` never runs.

```php
public DeclaredForm $form;              // works

#[Virtual]
public function draft(): VirtualForm    // silently broken
{
    return new VirtualForm($this, 'draft');
}
```

Verified over real HTTP against a playground app — the declared form behaves, the virtual one doesn't:

| Behavior | Declared | Virtual (before) |
|---|---|---|
| `boot()` | runs | never runs |
| `#[Validate]` on `validate()` | errors | `MissingRulesException` |
| Validate-on-update | fires | silent |
| `#[Url]` read + effect | both | both dead |
| `#[Locked]` vs. hostile write | throws | **overwritten, HTTP 200** |
| Consolidated whole-form update | expands per-field | not expanded |

The `#[Locked]` bypass is the sharp edge: moving a form from a declared property to a virtual one silently dropped a security contract.

## Why

**A birth path the synth never sees.** `FormObjectSynth::bootFormObject()` — which merges the form's attributes onto the component and runs its `boot()` — is only reachable from `initialize()` and `hydrate()`'s fresh-construction branch. A `#[Virtual]` method is a third way a form comes into existence, and on later requests `hydrate()` finds the just-materialized instance and takes the *reuse* branch, which skips boot.

**Attributes live in one-shot windows.** `SupportAttributes` iterates the collection at `trigger('mount')`/`trigger('hydrate')` and calls each attribute's lifecycle hook. Anything merged after that window silently gets none. Virtual properties materialize lazily — by design, so a method can read sibling state set in `mount()` — which on the initial request is always after the window has closed.

## The fix

- **`HandleSynths::adopt()`** — a synth may finish constructing a value born in user code, opting in via `method_exists` exactly like `hydrateInto()`. `FormObjectSynth::adopt()` runs the existing boot flow. All virtual construction funnels through one `constructVirtualProperty()` that stores the value *before* adopting, so re-entrant reads don't reconstruct.
- **Lifecycle-window catch-up** — `SupportAttributes` records each one-shot window (before iterating, so a mid-window merge doesn't double-run); `mergeOutsideAttributes()` replays missed windows on late arrivals only. Arrival time stops changing behavior — here and for every future late merge (`setPropertyAttribute()` mid-action, SupportPagination's hand-patched query-string call).
- **`Attribute::setValue` writes through its sub-target** — routing through the component would re-enter `__get` mid-write, where PHP's magic-method recursion guard bypasses `__get` and `data_set` shadows the materializing virtual with a plain array. Reachable today via `#[Url]` + a query param, so client-influenceable.
- **Consolidated updates** resolve virtual forms (exact key match — `hasVirtualProperty()` camelCases, which would let `Form` alias onto `form`) and skip fields echoed back identical to their *snapshot* value, compared as the client sees them (one number type, synth tuples unwrapped) so filler never trips `#[Locked]` while every real change still expands and gets gated.
- **Boot is per-instance** — a method that memoizes its form plus a `reset()` would otherwise merge its attributes twice and double its rules; a reconstructed form at the same path replaces its predecessor's attributes rather than accumulating them.

Deliberately *not* added: `FormObjectSynth::hydrateInto()`. Forms are identity-stable by design ("form objects should never be fully replaced") — a clone-and-replace root update would orphan every merged attribute's sub-target binding.

No new user-facing API. A virtual form simply behaves like a declared one.

## Verified

- 13 new tests in `SupportVirtualProperties/UnitTest.php`, each written red first (boot-once, `#[Validate]` at rest and on update, `#[Locked]` on granular and consolidated paths, `#[Url]` read + effect, first-access-inside-`mount()` recursion-guard corruption, memoized-instance reset, JSON-lossy locked float echo, aliased-path resolution)
- Full unit suite green (1427), and the touched feature suites are order-stable across several random seeds
- Real-Chrome browser suites for virtual properties, form objects, query string, validation, locked properties, selection, pagination, lazy loading
- Real HTTP wire requests against a playground app: `boot()` runs exactly once per request, `?vq=` lands in the form and registers its URL effect, validation errors surface, and the locked-property tamper now throws instead of returning 200
- ~70 adversarial probes from independent reviewers (hostile client, lifecycle, integration), including a pre-fix baseline build confirming the `#[Locked]` bypass was live before and closed after

## Follow-ups (not in this PR)

- Pre-existing `FormObjectSynth` 500s, declared forms included: a consolidated update with an unknown key set to `null` hits a `ReflectionException` in `propertyIsTyped()`; root `set('form', null)`/`''` hits a `foreach` TypeError in `hydrateFormProperties()`. Two small guards would make these clean rejections.
- `SupportPagination`'s manual `setPropertyFromQueryString()` call exists to paper over the missed mount window that catch-up now heals generally — deletable, best with its own browser-test pass.
- `Form::toArray()` uses reflection-only `getPublicProperties()`, so a `#[Virtual]` property *on a form* dehydrates nowhere. Half-wired today; worth a deliberate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)