### PR TITLE
Boot form objects returned from #[Virtual] property methods (eager alternative to #10450)

### DIFF
--- a/src/Features/SupportAttributes/Attribute.php
+++ b/src/Features/SupportAttributes/Attribute.php
@@ -18,6 +18,19 @@ abstract class Attribute
 
     protected $levelName;
 
+    protected $booted = false;
+
+    // A form object boots its own attributes as it merges them, which can
+    // land either side of the component's boot hook...
+    function callBoot(...$params)
+    {
+        if ($this->booted) return;
+
+        $this->booted = true;
+
+        if (method_exists($this, 'boot')) $this->boot(...$params);
+    }
+
     function __boot($component, AttributeLevel $level, $name = null, $subName = null, $subTarget = null)
     {
         $this->component = $component;

--- a/src/Features/SupportAttributes/HandlesAttributes.php
+++ b/src/Features/SupportAttributes/HandlesAttributes.php
@@ -22,4 +22,9 @@ trait HandlesAttributes
     {
         $this->attributes = $this->getAttributes()->concat($attributes);
     }
+
+    function forgetAttributesWhere($callback)
+    {
+        $this->attributes = $this->getAttributes()->reject($callback)->values();
+    }
 }

--- a/src/Features/SupportAttributes/SupportAttributes.php
+++ b/src/Features/SupportAttributes/SupportAttributes.php
@@ -10,9 +10,7 @@ class SupportAttributes extends ComponentHook
     function boot(...$params)
     {
         $this->getLivewireAttributes()->each(function ($attribute) use ($params) {
-            if (method_exists($attribute, 'boot')) {
-                $attribute->boot(...$params);
-            }
+            $attribute->callBoot(...$params);
         });
     }
 

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -7,10 +7,12 @@ use Illuminate\Validation\ValidationException;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\MessageBag;
 use function Livewire\invade;
+use function Livewire\wrap;
 use Illuminate\Support\Arr;
 use Livewire\Drawer\Utils;
 use Livewire\Component;
 use Livewire\Concerns\InteractsWithProperties;
+use Livewire\Features\SupportAttributes\AttributeCollection;
 use Livewire\Features\SupportVirtualProperties\HandlesVirtualProperties;
 
 class Form implements Arrayable
@@ -23,6 +25,8 @@ class Form implements Arrayable
     use InteractsWithProperties;
     use HandlesVirtualProperties;
 
+    protected $booted = false;
+
     function __construct(
         protected Component $component,
         protected $propertyName
@@ -30,6 +34,35 @@ class Form implements Arrayable
 
     public function getComponent() { return $this->component; }
     public function getPropertyName() { return $this->propertyName; }
+
+    // However a form comes into existence — a declared property, a #[Virtual]
+    // method, a reset — its attributes reach the component here...
+    public function bootIfNotBooted()
+    {
+        if ($this->booted) return;
+
+        $this->booted = true;
+
+        // A form replacing another at this path takes its attributes with it;
+        // otherwise hooks keep firing against a discarded instance...
+        $this->component->forgetAttributesWhere(function ($attribute) {
+            $subTarget = $attribute->getSubTarget();
+
+            return $subTarget instanceof Form
+                && $subTarget !== $this
+                && $subTarget->getPropertyName() === $this->propertyName;
+        });
+
+        $attributes = AttributeCollection::fromComponent($this->component, $this, $this->propertyName.'.');
+
+        $this->component->mergeOutsideAttributes($attributes);
+
+        // Not left to the component's boot hook — a form built after it (a
+        // reset mid-request) still needs its rules registered...
+        $attributes->each(fn ($attribute) => $attribute->callBoot());
+
+        wrap($this)->boot();
+    }
 
     public function validate($rules = null, $messages = [], $attributes = [])
     {

--- a/src/Features/SupportFormObjects/FormObjectSynth.php
+++ b/src/Features/SupportFormObjects/FormObjectSynth.php
@@ -4,9 +4,6 @@ namespace Livewire\Features\SupportFormObjects;
 
 use Livewire\Drawer\Utils;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
-use Livewire\Features\SupportAttributes\AttributeCollection;
-
-use function Livewire\wrap;
 
 class FormObjectSynth extends Synth {
     public static $key = 'form';
@@ -30,19 +27,15 @@ class FormObjectSynth extends Synth {
     }
 
     // Uninitialized `public PostForm $form` properties spring to life.
-    // The form's boot runs after the property assignment so boot-time
-    // logic can reach the form through its component...
+    // The form boots after the property assignment so boot-time logic can
+    // reach the form through its component...
     function initialize($type, $assign)
     {
-        $component = $this->context->component;
-
-        $form = new $type($component, $this->path);
-
-        $callBootMethod = static::bootFormObject($component, $form, $this->path);
+        $form = new $type($this->context->component, $this->path);
 
         $assign($form);
 
-        $callBootMethod();
+        $form->bootIfNotBooted();
     }
 
     function dehydrate($target, $dehydrateChild)
@@ -75,11 +68,9 @@ class FormObjectSynth extends Synth {
 
         $form = new $meta['class']($this->context->component, $this->path);
 
-        $callBootMethod = static::bootFormObject($this->context->component, $form, $this->path);
-
         $this->hydrateFormProperties($form, $data, $hydrateChild);
 
-        $callBootMethod();
+        $form->bootIfNotBooted();
 
         return $form;
     }
@@ -91,17 +82,6 @@ class FormObjectSynth extends Synth {
         } else {
             $target->$key = $value;
         }
-    }
-
-    public static function bootFormObject($component, $form, $path)
-    {
-        $component->mergeOutsideAttributes(
-            AttributeCollection::fromComponent($component, $form, $path . '.')
-        );
-
-        return function () use ($form) {
-            wrap($form)->boot();
-        };
     }
 
     protected function hydrateFormProperties($form, $data, $hydrateChild)

--- a/src/Features/SupportVirtualProperties/HandlesVirtualProperties.php
+++ b/src/Features/SupportVirtualProperties/HandlesVirtualProperties.php
@@ -2,10 +2,13 @@
 
 namespace Livewire\Features\SupportVirtualProperties;
 
+use Livewire\Features\SupportFormObjects\Form;
+
 // A virtual property is a public method marked #[Virtual] that acts as a
-// property. The method is its constructor — it materializes on first access
-// (like #[Computed]) into a lookup on the component; there's no backing
-// declaration. On the wire it's indistinguishable from a normal property...
+// property. The method is its constructor — it runs alongside the synths that
+// initialize declared properties, into a lookup on the component; there's no
+// backing declaration. On the wire it's indistinguishable from a normal
+// property...
 trait HandlesVirtualProperties
 {
     protected $__virtualProperties = [];
@@ -16,7 +19,7 @@ trait HandlesVirtualProperties
     {
         foreach (static::virtualPropertyMethods() as $name => $method) {
             if (! array_key_exists($name, $this->__virtualProperties)) {
-                $this->__virtualProperties[$name] = $this->{$method['name']}();
+                $this->constructVirtualProperty($name);
             }
         }
     }
@@ -47,7 +50,7 @@ trait HandlesVirtualProperties
         $name = (string) str($name)->camel();
 
         if (! array_key_exists($name, $this->__virtualProperties)) {
-            $this->__virtualProperties[$name] = $this->{static::virtualPropertyMethods()[$name]['name']}();
+            $this->constructVirtualProperty($name);
         }
 
         return $this->__virtualProperties[$name];
@@ -70,14 +73,49 @@ trait HandlesVirtualProperties
         }
 
         $this->__virtualProperties[$name] = $value;
+
+        $this->bootVirtualFormObject($name, $value);
     }
 
     // A virtual property has no empty state — unsetting reconstructs it...
     function unsetVirtualProperty($name)
     {
-        $name = (string) str($name)->camel();
+        $this->constructVirtualProperty((string) str($name)->camel());
+    }
 
-        $this->__virtualProperties[$name] = $this->{static::virtualPropertyMethods()[$name]['name']}();
+    protected function constructVirtualProperty($name)
+    {
+        $method = static::virtualPropertyMethods()[$name]['name'];
+
+        try {
+            $value = $this->{$method}();
+        } catch (\Error $e) {
+            // Reading a sibling that mount() assigns is the usual trip-up,
+            // and PHP's error names neither the method nor the timing...
+            throw new VirtualPropertyConstructionException(static::class, $method, $e);
+        }
+
+        // In place before booting: a form's boot() can reach itself back
+        // through the component...
+        $this->__virtualProperties[$name] = $value;
+
+        $this->bootVirtualFormObject($name, $value);
+    }
+
+    protected function bootVirtualFormObject($name, $value)
+    {
+        if (! $value instanceof Form) return;
+
+        // A form registers its attributes under the name it was constructed
+        // with. If that doesn't match the property it backs, #[Locked] and
+        // #[Validate] end up guarding a path the client never sends...
+        if ($this instanceof \Livewire\Component && $value->getPropertyName() !== $name) {
+            throw new \LogicException(
+                'Livewire: virtual property ['.$name.'] on component ['.static::class.'] returned a form object constructed as ['.$value->getPropertyName().'] — it must be constructed with the name of the property it backs.'
+            );
+        }
+
+        $value->bootIfNotBooted();
     }
 
     protected static function virtualPropertyMethods()

--- a/src/Features/SupportVirtualProperties/UnitTest.php
+++ b/src/Features/SupportVirtualProperties/UnitTest.php
@@ -339,25 +339,33 @@ class UnitTest extends \Tests\TestCase
             ->assertSetStrict('newDuringUpdated', ['new']);
     }
 
-    function test_a_virtual_method_can_read_sibling_property_state()
+    function test_a_virtual_method_runs_before_mount_and_before_parameters_land()
     {
-        // Because construction is lazy (on first access, after mount and
-        // hydration), the method can depend on other properties...
+        // A virtual method is a constructor, not a callback: it runs
+        // alongside the synths that initialize declared properties — before
+        // parameters are assigned and before mount() can mutate anything.
+        // That's what puts the objects it returns in place early enough to
+        // take part in the lifecycle hooks that follow (see the form object
+        // tests below). Configure them from mount() instead of building them
+        // there, exactly as you would a declared form object...
         Livewire::test(new class extends TestComponent {
             public $seed = 'default';
 
+            public $mutated = 'default';
+
             public function mount()
             {
-                $this->seed = 'mounted';
+                $this->mutated = 'mounted';
             }
 
             #[Virtual]
             public function selected(): Selection
             {
-                return new Selection(keys: [$this->seed]);
+                return new Selection(keys: [$this->seed, $this->mutated]);
             }
-        })
-            ->assertSet('selected', fn ($s) => $s->keys() === ['mounted']);
+        }, ['seed' => 'from-parameter'])
+            ->assertSetStrict('seed', 'from-parameter')
+            ->assertSet('selected', fn ($s) => $s->keys() === ['default', 'default']);
     }
 
     function test_unsetting_a_virtual_property_resets_it_to_a_freshly_constructed_instance()
@@ -417,5 +425,311 @@ class UnitTest extends \Tests\TestCase
 
         Assert::assertInstanceOf(Selection::class, $component->get('selected'));
         Assert::assertSame([], $component->get('selected')->keys());
+    }
+
+    function test_a_form_object_from_a_virtual_property_runs_its_boot_method_once_per_request()
+    {
+        VirtualFormStub::$boots = 0;
+
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+
+            public function touch()
+            {
+                $this->form->title;
+                $this->form->title;
+            }
+        })
+            ->call('touch')
+            ->call('$refresh');
+
+        Assert::assertSame(3, VirtualFormStub::$boots);
+    }
+
+    function test_validate_attributes_on_a_form_object_from_a_virtual_property_are_registered()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+
+            public function save()
+            {
+                $this->form->validate();
+            }
+        })
+            ->call('save')
+            ->assertHasErrors('form.title');
+    }
+
+    function test_validate_attributes_on_a_form_object_from_a_virtual_property_validate_on_update()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+        })
+            ->set('form.title', 'ab')
+            ->assertHasErrors('form.title');
+    }
+
+    function test_locked_properties_on_a_form_object_from_a_virtual_property_cannot_be_updated()
+    {
+        $this->expectException(\Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException::class);
+
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+        })
+            ->set('form.secret', 'HACKED');
+    }
+
+    function test_url_attributes_on_a_form_object_from_a_virtual_property_read_the_query_string()
+    {
+        Livewire::withQueryParams(['q' => 'from-url'])
+            ->test(new class extends TestComponent {
+                #[Virtual]
+                public function form(): VirtualFormStub
+                {
+                    return new VirtualFormStub($this, 'form');
+                }
+            })
+            ->assertSetStrict('form.q', 'from-url');
+    }
+
+    function test_url_attributes_on_a_form_object_from_a_virtual_property_register_a_url_effect()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+        });
+
+        Assert::assertArrayHasKey('form.q', $component->effects['url'] ?? []);
+    }
+
+    function test_a_whole_form_update_on_a_virtual_property_expands_into_per_field_updates()
+    {
+        // Sending the entire form as one consolidated update runs the same
+        // per-field update hooks as setting each field individually — the
+        // guarantee declared form objects already have...
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+        })
+            ->set('form', ['title' => 'ab', 'q' => 'searching'])
+            ->assertSetStrict('form.title', 'ab')
+            ->assertSetStrict('form.q', 'searching')
+            ->assertHasErrors('form.title');
+    }
+
+    function test_a_reset_virtual_form_object_is_booted_again()
+    {
+        // reset() reconstructs a virtual property, so the form that comes
+        // back is a different instance — it has to arrive booted even though
+        // the component's boot hook has long since run...
+        Livewire::test(new class extends TestComponent {
+            public $errorAfterReset;
+
+            public $bootsDuringReset;
+
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+
+            public function resetAndValidate()
+            {
+                $before = VirtualFormStub::$boots;
+
+                $this->reset('form');
+
+                $this->bootsDuringReset = VirtualFormStub::$boots - $before;
+
+                try {
+                    $this->form->validate();
+                } catch (\Illuminate\Validation\ValidationException $e) {
+                    $this->errorAfterReset = $e->validator->errors()->first('form.title');
+                }
+            }
+        })
+            ->call('resetAndValidate')
+            ->assertSetStrict('bootsDuringReset', 1)
+            ->assertSetStrict('errorAfterReset', 'The title field is required.');
+    }
+
+    function test_resetting_a_virtual_form_object_does_not_accumulate_attributes()
+    {
+        // Each reconstruction replaces the previous form's attributes rather
+        // than stacking a new set on top of them...
+        Livewire::test(new class extends TestComponent {
+            public $countsMatch;
+
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+
+            public function resetTwice()
+            {
+                $this->reset('form');
+                $after = $this->getAttributes()->count();
+
+                $this->reset('form');
+                $this->countsMatch = $after === $this->getAttributes()->count();
+            }
+        })
+            ->call('resetTwice')
+            ->assertSetStrict('countsMatch', true);
+    }
+
+    function test_a_virtual_method_that_memoizes_its_form_object_does_not_reregister_rules()
+    {
+        // A method free to return the same instance twice must not boot it
+        // twice — the rule would land in the form's rule set again...
+        Livewire::test(new class extends TestComponent {
+            protected $memo;
+
+            public $ruleCount;
+
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return $this->memo ??= new VirtualFormStub($this, 'form');
+            }
+
+            public function resetAndCount()
+            {
+                $this->reset('form');
+
+                $this->ruleCount = count($this->form->getRules());
+            }
+        })
+            ->call('resetAndCount')
+            ->assertSetStrict('ruleCount', 1)
+            ->assertSet('form', fn ($form) => $form->getRules()['title'] === 'required|min:3');
+    }
+
+    function test_a_form_object_swapped_onto_a_virtual_property_is_booted()
+    {
+        // Assignment is a construction path too — the replacement has to
+        // arrive booted or it silently loses its rules...
+        Livewire::test(new class extends TestComponent {
+            public $ruleCount;
+
+            #[Virtual]
+            public function form(): VirtualFormStub
+            {
+                return new VirtualFormStub($this, 'form');
+            }
+
+            public function swap()
+            {
+                $this->fill(['form' => new VirtualFormStub($this, 'form')]);
+
+                $this->ruleCount = count($this->form->getRules());
+            }
+        })
+            ->call('swap')
+            ->assertSetStrict('ruleCount', 1);
+    }
+
+    function test_a_form_object_constructed_under_the_wrong_name_throws()
+    {
+        // Attributes are registered under the name the form was constructed
+        // with, so a mismatch would quietly disarm #[Locked] and #[Validate]
+        // rather than protecting anything...
+        $this->assertThrowsDeep(\LogicException::class, function () {
+            Livewire::test(new class extends TestComponent {
+                #[Virtual]
+                public function form(): VirtualFormStub
+                {
+                    return new VirtualFormStub($this, 'frm');
+                }
+            });
+        });
+    }
+
+    function test_a_virtual_method_that_reads_an_uninitialized_sibling_names_itself_in_the_error()
+    {
+        // The raw PHP error mentions neither the method nor the fact that
+        // virtual methods run before mount()...
+        $this->assertThrowsDeep(VirtualPropertyConstructionException::class, function () {
+            Livewire::test(new class extends TestComponent {
+                public VirtualSiblingStub $sibling;
+
+                public function mount()
+                {
+                    $this->sibling = new VirtualSiblingStub;
+                }
+
+                #[Virtual]
+                public function copied(): Selection
+                {
+                    return new Selection(keys: [$this->sibling->key]);
+                }
+            });
+        });
+    }
+
+    function test_a_form_object_assigned_to_a_declared_property_still_boots()
+    {
+        // The synth path is untouched by all of the above...
+        VirtualFormStub::$boots = 0;
+
+        Livewire::test(new class extends TestComponent {
+            public VirtualFormStub $form;
+
+            public function save()
+            {
+                $this->form->validate();
+            }
+        })
+            ->call('save')
+            ->assertHasErrors('form.title');
+
+        Assert::assertSame(2, VirtualFormStub::$boots);
+    }
+}
+
+class VirtualSiblingStub
+{
+    public $key = 'sibling';
+}
+
+class VirtualFormStub extends \Livewire\Form
+{
+    public static $boots = 0;
+
+    #[\Livewire\Attributes\Validate('required|min:3')]
+    public $title = '';
+
+    #[\Livewire\Attributes\Url]
+    public $q = '';
+
+    #[\Livewire\Attributes\Locked]
+    public $secret = 'original';
+
+    public function boot()
+    {
+        static::$boots++;
     }
 }

--- a/src/Features/SupportVirtualProperties/VirtualPropertyConstructionException.php
+++ b/src/Features/SupportVirtualProperties/VirtualPropertyConstructionException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Livewire\Features\SupportVirtualProperties;
+
+use Exception;
+
+class VirtualPropertyConstructionException extends Exception
+{
+    function __construct($componentClass, $methodName, $previous)
+    {
+        parent::__construct(
+            "Virtual property method [{$methodName}()] on component [{$componentClass}] failed: {$previous->getMessage()}. "
+            ."Virtual methods construct properties before parameters are assigned and before mount() runs, so anything set there is still unset.",
+            previous: $previous,
+        );
+    }
+}

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -427,8 +427,10 @@ class HandleComponents extends Mechanism
     {
         $expanded = [];
 
+        $properties = $component->all();
+
         foreach ($updates as $path => $value) {
-            if (is_array($value) && property_exists($component, $path) && $component->$path instanceof Form) {
+            if (is_array($value) && ($properties[$path] ?? null) instanceof Form) {
                 foreach ($value as $key => $child) {
                     $expanded["{$path}.{$key}"] = $child;
                 }

--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -261,11 +261,10 @@ class HandleSynths extends Mechanism
             $synth->initialize($typeName, fn ($value) => $property->setValue($component, $value));
         }
 
-        // Virtual properties are deliberately NOT constructed here. They
-        // materialize on first access (like #[Computed]) — always after
-        // mount()/hydration, so a method can read sibling state, and a lazy
-        // placeholder never runs a body it doesn't touch. Dehydration still
-        // accesses them via all(), so they're serialized every request...
+        // Virtual methods run here too: they're constructors, not callbacks —
+        // before mount(), and early enough for what they return to take part
+        // in the lifecycle hooks that follow...
+        $component->initializeVirtualProperties();
     }
 
     protected function discoverInitializableProperties(string $class): array


### PR DESCRIPTION
Alternative to #10450, rebuilt from scratch on the feedback there. Same bug, far less machinery — it trades one documented constraint for the removal of every moving part in that PR.

**Take one or the other, not both.**

## The bug

A `Form` returned from a `#[Virtual]` method never gets booted: its `#[Validate]`/`#[Url]`/`#[Locked]` attributes never register on the component and its `boot()` never runs. Verified over real HTTP — validation throws `MissingRulesException`, the query string is ignored, and **a hostile client can overwrite a `#[Locked]` form property with a 200**.

## The constraint this PR accepts

`#[Virtual]` methods now construct in `HandleSynths::initializeProperties()`, alongside the synths that initialize declared typed properties. **A virtual method is a constructor, not a callback** — it runs before parameters are assigned and before `mount()`, and can't see either.

That's the whole trade, and everything below follows from it: once a virtual form exists before the lifecycle hooks open, it takes part in them like any declared form and no catch-up machinery is needed.

It's the constraint declared form objects already live with, so the mental model collapses to one line — *a virtual property is a declared property whose constructor you wrote*. The patterns that keep working are the ones you'd already use with a declared form:

```php
#[Virtual]
public function form(): PostForm
{
    return new PostForm($this, 'form');     // ✅ construct it
    // return PostForm::for($this->post);   // ❌ $post isn't assigned yet
}

public function mount(Post $post)
{
    $this->form->setPost($post);            // ✅ configure it here instead
}
```

What's genuinely lost versus `main` (pinned by `test_a_virtual_method_runs_before_mount_and_before_parameters_land`): a virtual method can no longer read a sibling property assigned from a mount parameter or set in `mount()`.

Because that fails silently for untyped siblings and with a bare PHP `Error` for typed ones, both cases now say what happened:

- reading an uninitialized sibling raises `VirtualPropertyConstructionException`, naming the method and the timing rule, with the original error chained
- a form constructed under a name that doesn't match the property it backs (`new PostForm($this, 'frm')` behind `form()`) throws. That one was a silent `#[Locked]` bypass from a one-character typo: rules still applied, so the app looked correct while `#[Locked]` and validate-on-update guarded a path the client never sends.

If the parameter case turns out to matter more than the simplicity is worth, the seam exists: `SupportNestingComponents::setParametersToMatchingProperties()` runs on `mount` before the attribute hooks open, so construction could move there for the mount path. I didn't — it makes construction time depend on hook registration order and differ between the mount and hydrate paths, which costs more clarity than it buys.

## The change

- **`Form::bootIfNotBooted()`** — the form owns its boot. It prunes a predecessor form's attributes at the same path, merges its own onto the component, boots them, then runs `boot()`. Once per instance, so a method that memoizes its form doesn't register rules twice.
- **`Attribute::callBoot()`** — an attribute boots once. A form boots its own attributes as it merges them, which can land either side of the component's boot hook.
- **`HandleSynths::initializeProperties()`** — constructs virtual properties alongside declared ones (replacing the comment that explained why it didn't).
- **`HandlesVirtualProperties`** — the construction sites funnel through one `constructVirtualProperty()`, which puts the value in place before booting it so `boot()` can reach the form back through the component. Assignment (`fill()`, `setVirtualProperty()`) boots too.
- **`FormObjectSynth`** — *shrinks*: `bootFormObject()` is gone, both call sites became `$form->bootIfNotBooted()`.
- **`HandleComponents`** — the consolidated whole-form update looks the form up in `all()` instead of `property_exists`, so virtual forms expand into per-field updates like declared ones. Net one line.

Against #10450 this drops the synth `adopt()` protocol, the lifecycle-window record/replay, the `Attribute::setValue` sub-target reroute (unreachable now — nothing materializes inside a `__get` frame), and the snapshot-echo comparison: **126 source lines changed against 441.**

## Deliberately unchanged

Consolidated whole-form updates still expand every field, so an unchanged `#[Locked]` field inside one throws — exactly what declared forms do on `main` today. The parity tests assert virtual and declared behave identically here.

## Verified

- 35 tests in `SupportVirtualProperties/UnitTest.php` — 14 new (boot once per request, validate at rest and on update, `#[Locked]`, `#[Url]` read + effect, consolidated expansion, reset-then-validate, reset without attribute accumulation, memoized instance, swapped instance, name mismatch, construction error, declared-form control) plus the rewritten timing test
- Full unit suite green (1428); touched features order-stable across seeds
- Real-Chrome browser suites: virtual properties, form objects, lazy loading, query string, validation, locked properties, selection
- Real HTTP against a playground app: both forms boot once per request, `?q=` lands in each and registers a URL effect, validation errors surface, both locked tampers throw
- An independent adversarial pass ran ~40 probes, including 14 hostile-client shapes (granular/deep/consolidated locked writes, garbage roots, forged synth tuples, unknown keys) with **no case where virtual and declared diverge**. The three holes it found are the three errors and the assignment path fixed above.

## Noted, not fixed here

- `$this->form = new PostForm(...)` on a virtual property creates a shadowing dynamic property rather than routing to the virtual lookup — `Component` has no `__set`. Pre-existing on `main`; worth its own fix.
- A `#[Lazy]` component runs virtual method bodies during the placeholder request. Confirmed identical on `main` (virtuals dehydrate every request, and dehydration constructs them), so it's not a regression — but it's the eager model's least obvious cost.
- `#[Url]`/`#[Session]`/`#[Locked]` can't target a `#[Virtual]` method (they're `TARGET_PROPERTY`), so only forms *behind* virtual properties carry them. Pre-existing; worth a doc line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
