### PR TITLE
Fix #[Virtual] form objects by deriving attributes from the class shape

### DIFF
--- a/src/Features/SupportAttributes/Attribute.php
+++ b/src/Features/SupportAttributes/Attribute.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportAttributes;
 
 use Livewire\Component;
+use Livewire\Drawer\Utils;
 
 use function Livewire\store;
 
@@ -10,7 +11,11 @@ abstract class Attribute
 {
     protected Component $component;
 
-    protected $subTarget;
+    // An attribute addresses a PATH on the component ($levelName). When the
+    // path lives inside a form-typed member, $subTargetClass names that form
+    // class — a static fact. The live instance is never bound at boot time;
+    // anything that needs it resolves it on demand via getSubTarget()...
+    protected $subTargetClass;
 
     protected $subName;
 
@@ -18,11 +23,11 @@ abstract class Attribute
 
     protected $levelName;
 
-    function __boot($component, AttributeLevel $level, $name = null, $subName = null, $subTarget = null)
+    function __boot($component, AttributeLevel $level, $name = null, $subName = null, $subTargetClass = null)
     {
         $this->component = $component;
         $this->subName = $subName;
-        $this->subTarget = $subTarget;
+        $this->subTargetClass = $subTargetClass;
         $this->level = $level;
         $this->levelName = $name;
     }
@@ -32,9 +37,19 @@ abstract class Attribute
         return $this->component;
     }
 
+    function getSubTargetClass()
+    {
+        return $this->subTargetClass;
+    }
+
+    // Resolve the live sub-target instance on demand. Reading a virtual
+    // member materializes it — callers should only reach for the instance in
+    // phases where it's guaranteed to exist (updates, calls, dehydration)...
     function getSubTarget()
     {
-        return $this->subTarget;
+        if (! $this->subTargetClass || $this->levelName === null) return null;
+
+        return data_get($this->component, Utils::beforeFirstDot($this->levelName));
     }
 
     function getSubName()
@@ -58,7 +73,15 @@ abstract class Attribute
             throw new \Exception('Can\'t get the value of a non-property attribute.');
         }
 
-        return data_get($this->component->all(), $this->levelName);
+        // Never force an unmaterialized virtual property into being just to
+        // read a value — birth timing belongs to the component's lifecycle...
+        $root = Utils::beforeFirstDot($this->levelName);
+
+        if ($this->component->hasVirtualProperty($root) && ! $this->component->virtualPropertyIsMaterialized($root)) {
+            return null;
+        }
+
+        return data_get($this->component, $this->levelName);
     }
 
     function setValue($value, ?bool $nullable = false)
@@ -77,6 +100,17 @@ abstract class Attribute
             }
         }
 
+        // A write into a virtual property that hasn't materialized yet is
+        // staged and applied the moment the property is born — so the value
+        // lands identically no matter when first access happens...
+        $root = Utils::beforeFirstDot($this->levelName);
+
+        if ($this->component->hasVirtualProperty($root) && ! $this->component->virtualPropertyIsMaterialized($root)) {
+            $this->component->stageVirtualPropertyWrite($this->levelName, $value);
+
+            return;
+        }
+
         data_set($this->component, $this->levelName, $value);
     }
 
@@ -84,7 +118,7 @@ abstract class Attribute
     {
         if (! is_string($subject) && ! is_int($subject)) return;
 
-        $target = $this->subTarget ?? $this->component;
+        $target = $this->subTargetClass ?? $this->component;
 
         $name = $this->subName ?? $this->levelName;
 

--- a/src/Features/SupportAttributes/AttributeCollection.php
+++ b/src/Features/SupportAttributes/AttributeCollection.php
@@ -3,40 +3,110 @@
 namespace Livewire\Features\SupportAttributes;
 
 use Illuminate\Support\Collection;
+use Livewire\Features\SupportFormObjects\Form;
 use ReflectionAttribute;
-use ReflectionObject;
+use ReflectionClass;
+use ReflectionNamedType;
 
+// A component's attribute collection is a fact about its CLASS SHAPE, not a
+// runtime accumulation: the component's own attributes, plus — for every
+// form-typed member (a declared `public PostForm $form` property or a
+// #[Virtual] method with a Form return type) — that form class's attributes
+// under the member's path prefix. Because the full tree is derivable from
+// the class alone, it is complete before any lifecycle window runs and never
+// changes when instances are built, replaced, or reset. Discovery reflects
+// once per class per process; instantiation binds per component...
 class AttributeCollection extends Collection
 {
-    static function fromComponent($component, $subTarget = null, $propertyNamePrefix = '')
+    protected static array $discovered = [];
+
+    static function fromComponent($component)
     {
         $instance = new static;
 
-        $reflected = new ReflectionObject($subTarget ?? $component);
+        foreach (static::specs(get_class($component)) as [$attribute, $level, $name, $subName, $subTargetClass]) {
+            $instance->push(tap($attribute->newInstance(), function ($attr) use ($component, $level, $name, $subName, $subTargetClass) {
+                $attr->__boot($component, $level, $name, $subName, $subTargetClass);
+            }));
+        }
+
+        return $instance;
+    }
+
+    protected static function specs($class)
+    {
+        return static::$discovered[$class] ??= static::discover($class);
+    }
+
+    protected static function discover($class)
+    {
+        $specs = static::discoverClassShape(new ReflectionClass($class), null, '');
+
+        foreach (static::formMembers($class) as $name => $formClass) {
+            $specs = [
+                ...$specs,
+                ...static::discoverClassShape(new ReflectionClass($formClass), $formClass, $name . '.'),
+            ];
+        }
+
+        return $specs;
+    }
+
+    protected static function discoverClassShape(ReflectionClass $reflected, $subTargetClass, $prefix)
+    {
+        $specs = [];
 
         foreach (static::getClassAttributesRecursively($reflected) as $attribute) {
-            $instance->push(tap($attribute->newInstance(), function ($attribute) use ($component, $subTarget) {
-                $attribute->__boot($component, AttributeLevel::ROOT, null, null, $subTarget);
-            }));
+            // Form-level class attributes carry their member's path as a name
+            // so consumers can tell which member they belong to...
+            $rootName = $prefix === '' ? null : rtrim($prefix, '.');
+
+            $specs[] = [$attribute, AttributeLevel::ROOT, $rootName, null, $subTargetClass];
         }
 
         foreach ($reflected->getMethods() as $method) {
             foreach ($method->getAttributes(Attribute::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
-                $instance->push(tap($attribute->newInstance(), function ($attribute) use ($component, $method, $propertyNamePrefix, $subTarget) {
-                    $attribute->__boot($component, AttributeLevel::METHOD, $propertyNamePrefix . $method->getName(), $method->getName(), $subTarget);
-                }));
+                $specs[] = [$attribute, AttributeLevel::METHOD, $prefix . $method->getName(), $method->getName(), $subTargetClass];
             }
         }
 
         foreach ($reflected->getProperties() as $property) {
             foreach ($property->getAttributes(Attribute::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
-                $instance->push(tap($attribute->newInstance(), function ($attribute) use ($component, $property, $propertyNamePrefix, $subTarget) {
-                    $attribute->__boot($component, AttributeLevel::PROPERTY, $propertyNamePrefix . $property->getName(), $property->getName(), $subTarget);
-                }));
+                $specs[] = [$attribute, AttributeLevel::PROPERTY, $prefix . $property->getName(), $property->getName(), $subTargetClass];
             }
         }
 
-        return $instance;
+        return $specs;
+    }
+
+    // The form-typed members of a class: declared typed properties and
+    // #[Virtual] methods whose (statically enforced, concrete) return type
+    // is a Form. One level deep only — forms don't nest...
+    protected static function formMembers($class)
+    {
+        $members = [];
+
+        foreach ((new ReflectionClass($class))->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
+            if ($property->isStatic()) continue;
+
+            $type = $property->getType();
+
+            if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) continue;
+
+            if (is_a($type->getName(), Form::class, true)) {
+                $members[$property->getName()] = $type->getName();
+            }
+        }
+
+        if (method_exists($class, 'virtualPropertyTypes')) {
+            foreach ($class::virtualPropertyTypes() as $name => $type) {
+                if (is_a($type, Form::class, true)) {
+                    $members[$name] = $type;
+                }
+            }
+        }
+
+        return $members;
     }
 
     protected static function getClassAttributesRecursively($reflected) {

--- a/src/Features/SupportFormObjects/FormObjectSynth.php
+++ b/src/Features/SupportFormObjects/FormObjectSynth.php
@@ -3,9 +3,12 @@
 namespace Livewire\Features\SupportFormObjects;
 
 use Livewire\Drawer\Utils;
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
-use Livewire\Features\SupportAttributes\AttributeCollection;
+use ReflectionAttribute;
+use ReflectionClass;
 
+use function Livewire\store;
 use function Livewire\wrap;
 
 class FormObjectSynth extends Synth {
@@ -22,8 +25,8 @@ class FormObjectSynth extends Synth {
     }
 
     // A form can't be rebuilt from a raw value alone (it needs its
-    // component and booted attribute state), so typed updates without
-    // snapshot meta pass through untouched...
+    // component), so typed updates without snapshot meta pass through
+    // untouched...
     function hydrateFromType($type, $value)
     {
         return $value;
@@ -34,15 +37,11 @@ class FormObjectSynth extends Synth {
     // logic can reach the form through its component...
     function initialize($type, $assign)
     {
-        $component = $this->context->component;
-
-        $form = new $type($component, $this->path);
-
-        $callBootMethod = static::bootFormObject($component, $form, $this->path);
+        $form = new $type($this->context->component, $this->path);
 
         $assign($form);
 
-        $callBootMethod();
+        static::bootFormObject($form);
     }
 
     function dehydrate($target, $dehydrateChild)
@@ -65,8 +64,8 @@ class FormObjectSynth extends Synth {
 
         // If the form object already exists on the component (e.g. during a
         // consolidated property update where the entire form is sent as one
-        // update), reuse it. Creating a new instance would discard the booted
-        // #[Validate] attribute state that was set up during hydration.
+        // update), reuse it — it has already booted, and replacing it would
+        // discard any state the instance carries...
         $existing = data_get($this->context->component, $this->path);
 
         if ($existing instanceof Form && $existing instanceof $meta['class']) {
@@ -75,11 +74,9 @@ class FormObjectSynth extends Synth {
 
         $form = new $meta['class']($this->context->component, $this->path);
 
-        $callBootMethod = static::bootFormObject($this->context->component, $form, $this->path);
-
         $this->hydrateFormProperties($form, $data, $hydrateChild);
 
-        $callBootMethod();
+        static::bootFormObject($form);
 
         return $form;
     }
@@ -93,15 +90,83 @@ class FormObjectSynth extends Synth {
         }
     }
 
-    public static function bootFormObject($component, $form, $path)
+    // The single birth rite for form objects: boot() runs exactly once per
+    // instance per request, no matter which door the form came through
+    // (declared initialization, snapshot hydration, or virtual
+    // materialization). Attributes need no merging here — they're part of
+    // the component's statically-derived attribute tree already...
+    public static function bootFormObject($form)
     {
-        $component->mergeOutsideAttributes(
-            AttributeCollection::fromComponent($component, $form, $path . '.')
-        );
+        if (store($form)->get('formHasBooted', false)) return;
 
-        return function () use ($form) {
-            wrap($form)->boot();
-        };
+        store($form)->set('formHasBooted', true);
+
+        wrap($form)->boot();
+    }
+
+    // A form born from a #[Virtual] method was constructed by user code, so
+    // its coordinates are verified before it's welcomed: the path it was
+    // handed must be the property it lives under, and — because attributes
+    // are facts about the DECLARED class shape — a subclass instance may not
+    // smuggle in Livewire attributes the declared return type doesn't have...
+    public static function formObjectBorn($component, $name, $declaredType, Form $form)
+    {
+        if ($form->getPropertyName() !== $name) {
+            throw new \LogicException(
+                'Livewire: form object for virtual property ['.$name.'] was constructed with property name ['.$form->getPropertyName().'] — they must match: `new '.class_basename($form).'($this, \''.$name.'\')`.'
+            );
+        }
+
+        if ($form->getComponent() !== $component) {
+            throw new \LogicException(
+                'Livewire: form object for virtual property ['.$name.'] belongs to a different component — construct it with `new '.class_basename($form).'($this, \''.$name.'\')`.'
+            );
+        }
+
+        if (get_class($form) !== $declaredType) {
+            static::assertSubclassAddsNoAttributes($declaredType, get_class($form), $name);
+        }
+
+        static::bootFormObject($form);
+    }
+
+    // Cache the (declared, actual) verdict per class pair — the reflection
+    // walk runs once per process...
+    protected static array $subclassAttributeAudit = [];
+
+    protected static function assertSubclassAddsNoAttributes($declaredType, $actualClass, $name)
+    {
+        $violation = static::$subclassAttributeAudit["$declaredType|$actualClass"]
+            ??= static::findAttributeDeclaredBelow($declaredType, $actualClass);
+
+        if ($violation === false) return;
+
+        throw new \LogicException(
+            'Livewire: the form returned for virtual property ['.$name.'] declares ['.$violation.'] on a subclass of its declared return type ['.$declaredType.']. Attributes are read from the declared type — declare the form as a named class and use it as the return type.'
+        );
+    }
+
+    protected static function findAttributeDeclaredBelow($declaredType, $actualClass)
+    {
+        $reflected = new ReflectionClass($actualClass);
+
+        while ($reflected && $reflected->getName() !== $declaredType) {
+            foreach ($reflected->getAttributes(LivewireAttribute::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                return $attribute->getName();
+            }
+
+            foreach ([...$reflected->getMethods(), ...$reflected->getProperties()] as $member) {
+                if ($member->getDeclaringClass()->getName() !== $reflected->getName()) continue;
+
+                foreach ($member->getAttributes(LivewireAttribute::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                    return $attribute->getName();
+                }
+            }
+
+            $reflected = $reflected->getParentClass();
+        }
+
+        return false;
     }
 
     protected function hydrateFormProperties($form, $data, $hydrateChild)

--- a/src/Features/SupportFormObjects/VirtualFormObjectsUnitTest.php
+++ b/src/Features/SupportFormObjects/VirtualFormObjectsUnitTest.php
@@ -1,0 +1,631 @@
+<?php
+
+namespace Livewire\Features\SupportFormObjects;
+
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Url;
+use Livewire\Attributes\Validate;
+use Livewire\Attributes\Virtual;
+use Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException;
+use Livewire\Form;
+use Livewire\Livewire;
+use PHPUnit\Framework\Assert;
+use Tests\TestComponent;
+
+// A form born from a #[Virtual] method must behave exactly like a declared
+// one: same boot, same #[Validate]/#[Url]/#[Locked] powers, same consolidated
+// update handling. These tests pin every capability that used to silently
+// fall away on the virtual birth path...
+class VirtualFormObjectsUnitTest extends \Tests\TestCase
+{
+    function setUp(): void
+    {
+        parent::setUp();
+
+        VirtualDraftFormStub::$bootCount = 0;
+        VirtualDraftFormStub::$updatedHooks = [];
+    }
+
+    // --- form_boot -------------------------------------------------------
+
+    function test_virtual_form_boot_runs_on_mount()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): VirtualDraftFormStub
+            {
+                return new VirtualDraftFormStub($this, 'draft');
+            }
+        });
+
+        $this->assertSame(1, VirtualDraftFormStub::$bootCount);
+    }
+
+    function test_virtual_form_boot_runs_exactly_once_per_request_including_updates()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): VirtualDraftFormStub
+            {
+                return new VirtualDraftFormStub($this, 'draft');
+            }
+        })
+        ->call('$refresh');
+
+        // Once for the mount request, once for the update request...
+        $this->assertSame(2, VirtualDraftFormStub::$bootCount);
+    }
+
+    // --- validate_rules --------------------------------------------------
+
+    function test_virtual_form_validate_uses_attribute_rules()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): VirtualDraftFormStub
+            {
+                return new VirtualDraftFormStub($this, 'draft');
+            }
+
+            public function save()
+            {
+                $this->draft->validate();
+            }
+        })
+        ->call('save')
+        ->assertHasErrors('draft.title')
+        ->set('draft.title', 'A valid title')
+        ->call('save')
+        ->assertHasNoErrors('draft.title');
+    }
+
+    function test_virtual_form_rules_are_included_in_component_wide_validate()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): VirtualDraftFormStub
+            {
+                return new VirtualDraftFormStub($this, 'draft');
+            }
+
+            public function save()
+            {
+                $this->validate();
+            }
+        })
+        ->call('save')
+        ->assertHasErrors('draft.title');
+    }
+
+    function test_virtual_form_realtime_validation_runs_on_update()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): VirtualDraftFormStub
+            {
+                return new VirtualDraftFormStub($this, 'draft');
+            }
+        })
+        ->set('draft.title', '')
+        ->assertHasErrors('draft.title');
+    }
+
+    // --- url_read / url_readable_in_user_mount / url_push_effect ---------
+
+    function test_url_query_param_lands_in_virtual_form()
+    {
+        Livewire::withQueryParams(['q' => 'world'])
+            ->test(new class extends TestComponent {
+                #[Virtual]
+                public function draft(): VirtualDraftFormStub
+                {
+                    return new VirtualDraftFormStub($this, 'draft');
+                }
+            })
+            ->assertSetStrict('draft.q', 'world');
+    }
+
+    function test_url_value_is_readable_from_the_virtual_form_inside_mount()
+    {
+        Livewire::withQueryParams(['q' => 'world'])
+            ->test(new class extends TestComponent {
+                public $seenInMount = '';
+
+                public function mount()
+                {
+                    $this->seenInMount = $this->draft->q;
+                }
+
+                #[Virtual]
+                public function draft(): VirtualDraftFormStub
+                {
+                    return new VirtualDraftFormStub($this, 'draft');
+                }
+            })
+            ->assertSetStrict('seenInMount', 'world');
+    }
+
+    function test_url_values_on_plain_component_properties_are_still_readable_in_mount()
+    {
+        // The pre-existing ordering promise (attribute mount window before
+        // user mount) — previously unpinned by any shipped test...
+        Livewire::withQueryParams(['search' => 'bob'])
+            ->test(new class extends TestComponent {
+                #[Url]
+                public $search = '';
+
+                public $seenInMount = '';
+
+                public function mount()
+                {
+                    $this->seenInMount = $this->search;
+                }
+            })
+            ->assertSetStrict('seenInMount', 'bob');
+    }
+
+    function test_mount_writes_win_over_url_values_on_virtual_forms()
+    {
+        Livewire::withQueryParams(['q' => 'from-url'])
+            ->test(new class extends TestComponent {
+                public function mount()
+                {
+                    $this->draft->q = 'mount-wins';
+                }
+
+                #[Virtual]
+                public function draft(): VirtualDraftFormStub
+                {
+                    return new VirtualDraftFormStub($this, 'draft');
+                }
+            })
+            ->assertSetStrict('draft.q', 'mount-wins');
+    }
+
+    function test_url_effect_is_pushed_for_virtual_form_property()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): VirtualDraftFormStub
+            {
+                return new VirtualDraftFormStub($this, 'draft');
+            }
+        });
+
+        $this->assertTrue(isset($component->effects['url']));
+        $this->assertArrayHasKey('draft.q', $component->effects['url']);
+    }
+
+    // --- sibling_state_in_mount (the anti-timing test) --------------------
+
+    function test_virtual_form_method_reads_mount_set_sibling_state_even_when_a_query_param_is_present()
+    {
+        // The presence of a bound query param must NOT change when the
+        // method runs: it still runs after mount(), still sees mount-set
+        // sibling state, and the URL value still lands in the form...
+        Livewire::withQueryParams(['q' => 'from-url'])
+            ->test(new class extends TestComponent {
+                public $postId = null;
+
+                public function mount()
+                {
+                    $this->postId = 42;
+                }
+
+                #[Virtual]
+                public function draft(): VirtualDraftFormStub
+                {
+                    $form = new VirtualDraftFormStub($this, 'draft');
+
+                    $form->title = 'post-'.($this->postId ?? 'MISSING');
+
+                    return $form;
+                }
+            })
+            ->assertSetStrict('draft.title', 'post-42')
+            ->assertSetStrict('draft.q', 'from-url');
+    }
+
+    // --- locked_tamper ----------------------------------------------------
+
+    function test_locked_property_on_virtual_form_cannot_be_updated_from_the_client()
+    {
+        $this->expectException(CannotUpdateLockedPropertyException::class);
+
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): VirtualDraftFormStub
+            {
+                return new VirtualDraftFormStub($this, 'draft');
+            }
+        })
+        ->set('draft.id', 'hacked');
+    }
+
+    // --- consolidated_update ----------------------------------------------
+
+    function test_consolidated_virtual_form_update_expands_per_field()
+    {
+        // When every form field changes, the JS diff consolidates them into a
+        // single {draft: {...}} update. It must be re-expanded per-field so
+        // enum casting and update hooks run — same as a declared form...
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): VirtualDraftFormStub
+            {
+                return new VirtualDraftFormStub($this, 'draft');
+            }
+
+            public function check()
+            {
+                Assert::assertInstanceOf(VirtualFormEnumStub::class, $this->draft->status);
+                Assert::assertEquals(VirtualFormEnumStub::Active, $this->draft->status);
+            }
+        })
+        ->update(
+            calls: [['method' => 'check', 'params' => [], 'path' => '']],
+            updates: ['draft' => ['title' => 'A valid title', 'q' => 'hey', 'status' => 'active']],
+        )
+        ->assertHasNoErrors();
+
+        $this->assertContains('title', VirtualDraftFormStub::$updatedHooks);
+    }
+
+    // --- memoized_form_reset ----------------------------------------------
+
+    function test_reset_rebuilds_virtual_form_with_full_powers()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): VirtualDraftFormStub
+            {
+                return new VirtualDraftFormStub($this, 'draft');
+            }
+
+            public function resetDraft()
+            {
+                $this->reset('draft');
+            }
+
+            public function save()
+            {
+                $this->draft->validate();
+            }
+        })
+        ->set('draft.title', 'Something')
+        ->call('resetDraft')
+        ->assertSetStrict('draft.title', '');
+
+        // The replacement instance must be just as booted and validated as
+        // the original — attributes belong to the path, not the instance...
+        $component->call('save')->assertHasErrors('draft.title');
+
+        $this->expectException(CannotUpdateLockedPropertyException::class);
+
+        $component->set('draft.id', 'hacked');
+    }
+
+    function test_reset_boots_the_replacement_virtual_form()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): VirtualDraftFormStub
+            {
+                return new VirtualDraftFormStub($this, 'draft');
+            }
+
+            public function resetDraft()
+            {
+                $this->reset('draft');
+            }
+        })
+        ->call('resetDraft');
+
+        // Mount request boots once. The update request boots the hydrated
+        // instance once, then the reset-built replacement once more...
+        $this->assertSame(3, VirtualDraftFormStub::$bootCount);
+    }
+
+    // --- update_request_correctness ----------------------------------------
+
+    function test_granular_updates_on_virtual_forms_cast_enums_and_fire_hooks()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): VirtualDraftFormStub
+            {
+                return new VirtualDraftFormStub($this, 'draft');
+            }
+
+            public function check()
+            {
+                Assert::assertInstanceOf(VirtualFormEnumStub::class, $this->draft->status);
+            }
+        })
+        ->set('draft.status', 'active')
+        ->call('check');
+
+        $this->assertContains('status', VirtualDraftFormStub::$updatedHooks);
+    }
+
+    function test_virtual_form_state_survives_round_trips()
+    {
+        Livewire::withQueryParams(['q' => 'world'])
+            ->test(new class extends TestComponent {
+                #[Virtual]
+                public function draft(): VirtualDraftFormStub
+                {
+                    return new VirtualDraftFormStub($this, 'draft');
+                }
+            })
+            ->set('draft.title', 'kept')
+            ->call('$refresh')
+            ->assertSetStrict('draft.title', 'kept')
+            ->assertSetStrict('draft.q', 'world');
+    }
+
+    // --- guards ------------------------------------------------------------
+
+    function test_virtual_form_constructed_with_a_mismatched_path_fails_loudly()
+    {
+        $this->assertThrowsDeep(\LogicException::class, function () {
+            Livewire::test(new class extends TestComponent {
+                #[Virtual]
+                public function draft(): VirtualDraftFormStub
+                {
+                    return new VirtualDraftFormStub($this, 'wrongname');
+                }
+            });
+        });
+    }
+
+    function test_virtual_form_constructed_against_another_component_fails_loudly()
+    {
+        $this->assertThrowsDeep(\LogicException::class, function () {
+            Livewire::test(new class extends TestComponent {
+                #[Virtual]
+                public function draft(): VirtualDraftFormStub
+                {
+                    $other = new LazyVirtualFormComponent;
+
+                    return new VirtualDraftFormStub($other, 'draft');
+                }
+            });
+        });
+    }
+
+    function test_anonymous_form_subclass_carrying_attributes_fails_loudly()
+    {
+        // Attributes are read from the declared return type. A subclass that
+        // introduces its own Livewire attributes would silently lose them —
+        // fail loudly instead...
+        $this->assertThrowsDeep(\LogicException::class, function () {
+            Livewire::test(new class extends TestComponent {
+                #[Virtual]
+                public function draft(): Form
+                {
+                    return new class($this, 'draft') extends Form {
+                        #[Validate('required')]
+                        public $title = '';
+                    };
+                }
+            });
+        });
+    }
+
+    function test_anonymous_form_subclass_without_attributes_works()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): Form
+            {
+                return new class($this, 'draft') extends Form {
+                    public $title = '';
+
+                    public function rules()
+                    {
+                        return ['title' => 'required'];
+                    }
+                };
+            }
+
+            public function save()
+            {
+                $this->draft->validate();
+            }
+        })
+        ->call('save')
+        ->assertHasErrors('draft.title')
+        ->set('draft.title', 'ok')
+        ->call('save')
+        ->assertHasNoErrors('draft.title');
+    }
+
+    // --- adversarial corners ------------------------------------------------
+
+    function test_a_declared_and_a_virtual_form_of_the_same_class_dont_interfere()
+    {
+        Livewire::test(new class extends TestComponent {
+            public VirtualDraftFormStub $form;
+
+            #[Virtual]
+            public function draft(): VirtualDraftFormStub
+            {
+                return new VirtualDraftFormStub($this, 'draft');
+            }
+
+            public function save()
+            {
+                $this->validate();
+            }
+        })
+        ->set('form.title', 'declared is valid')
+        ->call('save')
+        ->assertHasNoErrors('form.title')
+        ->assertHasErrors('draft.title');
+    }
+
+    function test_a_locked_field_inside_a_consolidated_virtual_form_update_still_throws()
+    {
+        $this->expectException(CannotUpdateLockedPropertyException::class);
+
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): VirtualDraftFormStub
+            {
+                return new VirtualDraftFormStub($this, 'draft');
+            }
+        })
+        ->update(
+            calls: [],
+            updates: ['draft' => ['title' => 'x', 'q' => 'y', 'status' => 'active', 'id' => 'hacked']],
+        );
+    }
+
+    function test_attribute_rules_are_visible_inside_the_forms_own_boot()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Virtual]
+            public function draft(): BootRulesSpyFormStub
+            {
+                return new BootRulesSpyFormStub($this, 'draft');
+            }
+        });
+
+        $this->assertSame(['title' => 'required'], BootRulesSpyFormStub::$rulesSeenInBoot);
+    }
+
+    // --- lazy components ----------------------------------------------------
+
+    function test_url_deep_link_reaches_a_virtual_form_on_a_lazy_component()
+    {
+        // On the placeholder request user mount() is skipped but the
+        // attribute mount window runs: the #[Url] value is staged, lands
+        // when the virtual form materializes during dehydration, and rides
+        // the snapshot into the second request where mount() can read it...
+        $component = Livewire::withQueryParams(['q' => 'world'])
+            ->test(LazyVirtualFormComponent::class, ['lazy' => true]);
+
+        $this->assertSame('world', data_get($component->snapshot, 'data.draft.0.q'));
+
+        preg_match('/__lazyLoad\(&#039;(.*?)&#039;\)/', $component->html(), $matches);
+
+        $component->call('__lazyLoad', $matches[1])
+            ->assertSetStrict('seenInMount', 'world')
+            ->assertSetStrict('draft.q', 'world');
+    }
+
+    // Mount-time exceptions surface wrapped in a ViewException — walk the
+    // chain so we can assert on the real one...
+    protected function assertThrowsDeep($class, $callback)
+    {
+        try {
+            $callback();
+        } catch (\Throwable $e) {
+            while ($e) {
+                if ($e instanceof $class) {
+                    $this->assertInstanceOf($class, $e);
+
+                    return;
+                }
+
+                $e = $e->getPrevious();
+            }
+
+            Assert::fail('Exception thrown, but none in the chain was ['.$class.'].');
+        }
+
+        Assert::fail('Expected exception ['.$class.'] was not thrown.');
+    }
+
+    // --- declared forms: unchanged behavior guardrail ----------------------
+
+    function test_declared_forms_still_boot_and_validate_exactly_as_before()
+    {
+        Livewire::test(new class extends TestComponent {
+            public VirtualDraftFormStub $form;
+
+            public function save()
+            {
+                $this->form->validate();
+            }
+        })
+        ->call('save')
+        ->assertHasErrors('form.title');
+
+        $this->assertSame(2, VirtualDraftFormStub::$bootCount); // mount + update request
+    }
+}
+
+class LazyVirtualFormComponent extends \Livewire\Component
+{
+    public $seenInMount = '';
+
+    public function mount()
+    {
+        $this->seenInMount = $this->draft->q;
+    }
+
+    #[Virtual]
+    public function draft(): VirtualDraftFormStub
+    {
+        return new VirtualDraftFormStub($this, 'draft');
+    }
+
+    public function render()
+    {
+        return '<div>loaded</div>';
+    }
+}
+
+class VirtualDraftFormStub extends Form
+{
+    public static $bootCount = 0;
+
+    public static $updatedHooks = [];
+
+    #[Validate('required')]
+    public $title = '';
+
+    #[Url]
+    public $q = '';
+
+    #[Locked]
+    public $id = 1;
+
+    public VirtualFormEnumStub $status = VirtualFormEnumStub::Draft;
+
+    public function boot()
+    {
+        static::$bootCount++;
+    }
+
+    public function updatedTitle()
+    {
+        static::$updatedHooks[] = 'title';
+    }
+
+    public function updatedStatus()
+    {
+        static::$updatedHooks[] = 'status';
+    }
+}
+
+enum VirtualFormEnumStub: string
+{
+    case Draft = 'draft';
+    case Active = 'active';
+}
+
+class BootRulesSpyFormStub extends Form
+{
+    public static $rulesSeenInBoot = null;
+
+    #[Validate('required')]
+    public $title = '';
+
+    public function boot()
+    {
+        static::$rulesSeenInBoot = $this->getRules();
+    }
+}

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -39,7 +39,7 @@ class BaseUrl extends LivewireAttribute
         // It's nullable if they passed it in like: #[Url(nullable: true)]
         if ($this->nullable !== null) return $this->nullable;
 
-        $reflectionClass = new ReflectionClass($this->getSubTarget() ?? $this->getComponent());
+        $reflectionClass = new ReflectionClass($this->getSubTargetClass() ?? $this->getComponent());
 
         // It's nullable if there's a nullable typehint like: public ?string $foo;
         if ($this->getSubName() && $reflectionClass->hasProperty($this->getSubName())) {
@@ -139,9 +139,9 @@ class BaseUrl extends LivewireAttribute
 
     public function isOnFormObjectProperty()
     {
-        $subTarget = $this->getSubTarget();
+        $subTargetClass = $this->getSubTargetClass();
 
-        return $subTarget && is_subclass_of($subTarget, Form::class);
+        return $subTargetClass && is_subclass_of($subTargetClass, Form::class);
     }
 
     public function urlName()

--- a/src/Features/SupportValidation/BaseValidate.php
+++ b/src/Features/SupportValidation/BaseValidate.php
@@ -7,6 +7,10 @@ use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 
 use function Livewire\wrap;
 
+// #[Validate] is a declarative fact: the rules, messages, and validation
+// attributes it carries are derived on demand by whoever validates (the
+// component, or the form object the property lives on) — nothing is
+// registered at a lifecycle moment, so there is no window to miss...
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_ALL)]
 class BaseValidate extends LivewireAttribute
 {
@@ -19,17 +23,45 @@ class BaseValidate extends LivewireAttribute
         protected bool $translate = true
     ) {}
 
-    function boot()
+    // Whether this attribute belongs to the given validation target: the
+    // component itself, or a form object addressed by its property path...
+    function providesFor($target)
     {
-        // If this attribute is added to a "form object", we want to add the rules
-        // to the actual form object, not the base component...
-        $target = $this->subTarget ?: $this->component;
-        $name = $this->subTarget ? $this->getSubName() : $this->getName();
+        if ($target instanceof \Livewire\Component) {
+            return $this->getSubTargetClass() === null;
+        }
+
+        $path = $target->getPropertyName();
+
+        return $this->getSubTargetClass() !== null
+            && ($this->getName() === $path || str($this->getName() ?? '')->startsWith($path.'.'));
+    }
+
+    function rules()
+    {
+        return $this->provisions()['rules'];
+    }
+
+    function messages()
+    {
+        return $this->provisions()['messages'];
+    }
+
+    function validationAttributes()
+    {
+        return $this->provisions()['attributes'];
+    }
+
+    protected function provisions()
+    {
+        $name = $this->getSubTargetClass() ? $this->getSubName() : $this->getName();
 
         $rules = [];
+        $messages = [];
+        $validationAttributes = [];
 
         if (is_null($this->rule)) {
-            // Allow "Rule" to be used without a given validation rule. It's purpose is to instead
+            // Allow "Validate" to be used without a given validation rule. Its purpose is to instead
             // trigger validation on property updates...
         } elseif (is_array($this->rule) && count($this->rule) > 0 && ! is_numeric(array_keys($this->rule)[0])) {
             // Support setting rules by key-value for this and other properties:
@@ -41,10 +73,9 @@ class BaseValidate extends LivewireAttribute
 
         if ($this->attribute) {
             if (is_array($this->attribute)) {
-                $target = $this->subTarget ?? $this->component;
-                $target->addValidationAttributesFromOutside($this->attribute);
+                $validationAttributes = array_merge($validationAttributes, $this->attribute);
             } else {
-                $target->addValidationAttributesFromOutside([$name => $this->attribute]);
+                $validationAttributes[$name] = $this->attribute;
             }
         }
 
@@ -54,19 +85,18 @@ class BaseValidate extends LivewireAttribute
                     ? array_map(fn ($i) => trans($i), $this->as)
                     : $this->as;
 
-                $target->addValidationAttributesFromOutside($as);
+                $validationAttributes = array_merge($validationAttributes, $as);
             } else {
-                $target->addValidationAttributesFromOutside([$name => $this->translate ? trans($this->as) : $this->as]);
+                $validationAttributes[$name] = $this->translate ? trans($this->as) : $this->as;
             }
         }
 
         if ($this->message) {
             if (is_array($this->message)) {
-                $messages = $this->translate
+                $messages = array_merge($messages, $this->translate
                     ? array_map(fn ($i) => trans($i), $this->message)
-                    : $this->message;
-
-                $target->addMessagesFromOutside($messages);
+                    : $this->message
+                );
             } else {
                 // If a single message was provided, apply it to the first given rule.
                 // There should have only been one rule provided in this case anyways...
@@ -75,11 +105,11 @@ class BaseValidate extends LivewireAttribute
                 // In the case of "min:5" or something, we only want "min"...
                 $rule = (string) str($rule)->before(':');
 
-                $target->addMessagesFromOutside([$name.'.'.$rule => $this->translate ? trans($this->message) : $this->message]);
+                $messages[$name.'.'.$rule] = $this->translate ? trans($this->message) : $this->message;
             }
         }
 
-        $target->addRulesFromOutside($rules);
+        return ['rules' => $rules, 'messages' => $messages, 'attributes' => $validationAttributes];
     }
 
     function update($fullPath, $newValue)
@@ -88,13 +118,15 @@ class BaseValidate extends LivewireAttribute
 
         return function () use ($fullPath) {
             // If this attribute is added to a "form object", we want to run
-            // the validateOnly method on the form object, not the base component...
-            $target = $this->subTarget ?: $this->component;
+            // the validateOnly method on the form object, not the base
+            // component. The live instance resolves on demand — by update
+            // time it's guaranteed to exist...
+            $target = $this->getSubTarget() ?: $this->component;
 
             // Use the full path so that wildcard rules (e.g. 'items.*') are matched
             // when validating nested properties (e.g. 'items.0'). For form objects,
             // strip the form prefix to get the path relative to the form.
-            $name = $this->subTarget
+            $name = $this->getSubTargetClass()
                 ? $this->getSubName() . str($fullPath)->after($this->getName())
                 : $fullPath;
 

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -116,11 +116,39 @@ trait HandlesValidation
         $rulesFromOutside = array_merge_recursive(
             ...array_map(
                 fn($i) => value($i),
-                $this->rulesFromOutside
+                [...$this->validateAttributeProvisions('rules'), ...$this->rulesFromOutside]
             )
         );
 
         return array_merge($rulesFromComponent, $rulesFromOutside);
+    }
+
+    // #[Validate] attributes are facts read on demand, not registrations:
+    // the component reads its own; a form object reads the slice of its
+    // component's attribute tree that lives under its property path...
+    protected function validateAttributeProvisions($kind)
+    {
+        $provisions = store($this)->get('validateAttributeProvisions');
+
+        if ($provisions === null) {
+            $attributes = $this->isRootComponent() ? $this->getAttributes() : $this->getComponent()->getAttributes();
+
+            $provisions = ['rules' => [], 'messages' => [], 'attributes' => []];
+
+            foreach ($attributes as $attribute) {
+                if (! $attribute instanceof BaseValidate) continue;
+
+                if (! $attribute->providesFor($this)) continue;
+
+                $provisions['rules'][] = $attribute->rules();
+                $provisions['messages'][] = $attribute->messages();
+                $provisions['attributes'][] = $attribute->validationAttributes();
+            }
+
+            store($this)->set('validateAttributeProvisions', $provisions);
+        }
+
+        return $provisions[$kind];
     }
 
     protected function getMessages()
@@ -135,7 +163,7 @@ trait HandlesValidation
         $messagesFromOutside = array_merge(
             ...array_map(
                 fn($i) => value($i),
-                $this->messagesFromOutside
+                [...$this->validateAttributeProvisions('messages'), ...$this->messagesFromOutside]
             )
         );
 
@@ -154,7 +182,7 @@ trait HandlesValidation
         $validationAttributesFromOutside = array_merge(
             ...array_map(
                 fn($i) => value($i),
-                $this->validationAttributesFromOutside
+                [...$this->validateAttributeProvisions('attributes'), ...$this->validationAttributesFromOutside]
             )
         );
 

--- a/src/Features/SupportVirtualProperties/HandlesVirtualProperties.php
+++ b/src/Features/SupportVirtualProperties/HandlesVirtualProperties.php
@@ -2,6 +2,12 @@
 
 namespace Livewire\Features\SupportVirtualProperties;
 
+use Livewire\Drawer\Utils;
+use Livewire\Features\SupportFormObjects\Form;
+use Livewire\Features\SupportFormObjects\FormObjectSynth;
+
+use function Livewire\store;
+
 // A virtual property is a public method marked #[Virtual] that acts as a
 // property. The method is its constructor — it materializes on first access
 // (like #[Computed]) into a lookup on the component; there's no backing
@@ -16,7 +22,7 @@ trait HandlesVirtualProperties
     {
         foreach (static::virtualPropertyMethods() as $name => $method) {
             if (! array_key_exists($name, $this->__virtualProperties)) {
-                $this->__virtualProperties[$name] = $this->{$method['name']}();
+                $this->materializeVirtualProperty($name);
             }
         }
     }
@@ -35,6 +41,11 @@ trait HandlesVirtualProperties
         );
     }
 
+    function virtualPropertyIsMaterialized($name)
+    {
+        return array_key_exists((string) str($name)->camel(), $this->__virtualProperties);
+    }
+
     // The raw (non-camelCased) method names, for excluding them from the
     // callable-action list...
     function getVirtualPropertyMethodNames()
@@ -42,12 +53,20 @@ trait HandlesVirtualProperties
         return array_column(static::virtualPropertyMethods(), 'name');
     }
 
+    // The statically-declared return type of each virtual property, keyed by
+    // property name — the class-shape fact static attribute discovery and
+    // form-object detection are built on...
+    public static function virtualPropertyTypes()
+    {
+        return array_map(fn ($method) => $method['type'], static::virtualPropertyMethods());
+    }
+
     function getVirtualProperty($name)
     {
         $name = (string) str($name)->camel();
 
         if (! array_key_exists($name, $this->__virtualProperties)) {
-            $this->__virtualProperties[$name] = $this->{static::virtualPropertyMethods()[$name]['name']}();
+            $this->materializeVirtualProperty($name);
         }
 
         return $this->__virtualProperties[$name];
@@ -69,15 +88,91 @@ trait HandlesVirtualProperties
             );
         }
 
+        $isNewInstance = $value !== ($this->__virtualProperties[$name] ?? null);
+
         $this->__virtualProperties[$name] = $value;
+
+        // An explicitly assigned instance is a birth too (it needs the same
+        // rites, e.g. a form's boot()) — but the assigner's values are theirs:
+        // staged attribute writes only fill instances Livewire constructs...
+        if ($isNewInstance && $value !== null) {
+            $this->virtualPropertyWasBorn($name, $value, applyStagedWrites: false);
+        }
     }
 
-    // A virtual property has no empty state — unsetting reconstructs it...
+    // A virtual property has no empty state — unsetting reconstructs it.
+    // The replacement starts from the method's own defaults: staged
+    // attribute writes (e.g. #[Url] values) applied to a previous
+    // incarnation don't resurrect...
     function unsetVirtualProperty($name)
     {
         $name = (string) str($name)->camel();
 
-        $this->__virtualProperties[$name] = $this->{static::virtualPropertyMethods()[$name]['name']}();
+        $this->forgetStagedVirtualPropertyWrites($name);
+
+        $this->materializeVirtualProperty($name);
+    }
+
+    protected function materializeVirtualProperty($name)
+    {
+        $method = static::virtualPropertyMethods()[$name];
+
+        $value = $this->{$method['name']}();
+
+        $this->__virtualProperties[$name] = $value;
+
+        if ($value !== null) {
+            $this->virtualPropertyWasBorn($name, $value, applyStagedWrites: true);
+        }
+
+        return $value;
+    }
+
+    // The single birth rite for every way a virtual instance comes into
+    // being: form objects boot (idempotently) the moment they exist, and
+    // writes staged while the property didn't exist yet (e.g. #[Url] query
+    // string values) land on the newborn instance — so first-access timing
+    // never changes the outcome...
+    protected function virtualPropertyWasBorn($name, $value, $applyStagedWrites = true)
+    {
+        if ($value instanceof Form) {
+            FormObjectSynth::formObjectBorn($this, $name, static::virtualPropertyMethods()[$name]['type'], $value);
+        }
+
+        if ($applyStagedWrites) {
+            $this->applyStagedVirtualPropertyWrites($name, $value);
+        }
+    }
+
+    public function stageVirtualPropertyWrite($path, $value)
+    {
+        store($this)->push('stagedVirtualPropertyWrites', [$path, $value], $path);
+    }
+
+    protected function applyStagedVirtualPropertyWrites($name, $value)
+    {
+        $staged = store($this)->get('stagedVirtualPropertyWrites', []);
+
+        foreach ($staged as $path => [$fullPath, $stagedValue]) {
+            if (Utils::beforeFirstDot($fullPath) !== $name) continue;
+
+            // Write directly into the instance — never back through the
+            // component's magic __get, which is mid-materialization here...
+            data_set($value, Utils::afterFirstDot($fullPath), $stagedValue);
+
+            store($this)->unset('stagedVirtualPropertyWrites', $path);
+        }
+    }
+
+    protected function forgetStagedVirtualPropertyWrites($name)
+    {
+        $staged = store($this)->get('stagedVirtualPropertyWrites', []);
+
+        foreach ($staged as $path => $write) {
+            if (Utils::beforeFirstDot($path) === $name) {
+                store($this)->unset('stagedVirtualPropertyWrites', $path);
+            }
+        }
     }
 
     protected static function virtualPropertyMethods()

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -428,7 +428,7 @@ class HandleComponents extends Mechanism
         $expanded = [];
 
         foreach ($updates as $path => $value) {
-            if (is_array($value) && property_exists($component, $path) && $component->$path instanceof Form) {
+            if (is_array($value) && $this->pathIsAFormObject($component, $path)) {
                 foreach ($value as $key => $child) {
                     $expanded["{$path}.{$key}"] = $child;
                 }
@@ -438,6 +438,24 @@ class HandleComponents extends Mechanism
         }
 
         return $expanded;
+    }
+
+    // Whether a root path holds a form object — answered from the class
+    // shape (declared property or virtual return type), so virtual forms
+    // count without being forced into existence...
+    protected function pathIsAFormObject($component, $path)
+    {
+        if (property_exists($component, $path)) {
+            return $component->$path instanceof Form;
+        }
+
+        if ($component->hasVirtualProperty($path)) {
+            $type = $component::virtualPropertyTypes()[(string) str($path)->camel()] ?? null;
+
+            return $type && is_a($type, Form::class, true);
+        }
+
+        return false;
     }
 
     public function updateProperty($component, $path, $value, $context)

--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -257,7 +257,8 @@ class HandleSynths extends Mechanism
             $synth = new $synthClass(new ComponentContext($component), $property->getName());
 
             // The synth assigns through the callback so it controls ordering
-            // around the assignment (e.g. form objects boot afterwards)...
+            // around the assignment (e.g. a form's boot() runs after its
+            // property is assigned, so boot-time logic can reach it)...
             $synth->initialize($typeName, fn ($value) => $property->setValue($component, $value));
         }
 


### PR DESCRIPTION
## The bug

A `Form` returned from a `#[Virtual]` method never got booted. Its `#[Validate]`, `#[Url]`, and `#[Locked]` attributes were inert and its `boot()` never ran:

```php
public DeclaredForm $form;              // works completely

#[Virtual]
public function draft(): VirtualForm    // silently loses everything
{
    return new VirtualForm($this, 'draft');
}
```

The sharp edge is security: moving a form from a declared property to a virtual method **silently dropped its `#[Locked]` guard** — a hostile client could overwrite a locked form property and get HTTP 200.

## Why it happened

A form's powers come from merging its attributes onto the component under a `form.` path prefix, then calling `boot()`. That merge ran as instances came into being — from exactly two birth doors (declared initialization, snapshot hydration). A `#[Virtual]` method is a **third birth door** the merge never covered. The bug is fundamentally about *timing*: an attribute's effect depended on *when* its instance was built.

## The approach: attributes are a fact of the class, not an event at runtime

Instead of accumulating the attribute collection from instances, this derives it from the **class shape** — the component's own attributes, plus (for every form-typed member: a declared property type or a `#[Virtual]` return type, both statically known) that form class's attributes under the member's path prefix. Discovery runs once per class per process.

The tree is therefore complete *before any lifecycle window runs*, on every request, no matter when — or whether — an instance materializes. "Merged too late" stops being expressible, and **the `#[Locked]` hole closes as a side effect rather than a patch** — the tell of a structural fix. Virtual properties stay lazy (their constructors still read `mount()`-set siblings); only the *attributes* become eager, which is the whole insight.

## What changes

- **`AttributeCollection`** discovers from the class, cached per class per process (measured ~6× less per-request attribute reflection: 14.9µs → 2.5µs for a component with one 4-attribute form).
- **`#[Validate]` becomes a read, not a boot-time registration.** Rules/messages/attributes are derived on demand by whoever validates (the component, or the form the property lives on). This **deletes `BaseValidate::boot()`** and with it the class of "rules discarded after a form was rebuilt" bugs.
- **`Attribute`** binds a sub-target *class* (a static fact) rather than an instance; the live instance resolves lazily, only in phases where it's guaranteed to exist.
- **`FormObjectSynth::bootFormObject()`** shrinks to one idempotent `boot()` that every birth door funnels through — including the new virtual-materialization choke point.
- Attribute writes aimed at a not-yet-materialized virtual property (e.g. `#[Url]` values) are **staged and applied the moment it's born**, so first-access timing never changes the result and the `__get` recursion landmine is structurally unreachable.
- Consolidated whole-form updates now expand per field for virtual forms too, so enum casting, update hooks, validation, and `#[Locked]` all run on that path.

## Relationship to #10450

This is an alternative to #10450 that came out of a from-scratch structural exploration. Same bug, same security fix, same green suites — but it settles the timing problem by making it *unrepresentable* (attributes are class facts) rather than by replaying missed lifecycle windows. Net result is **three core moves instead of six cooperating mechanisms** (no adopt hook, no window recording/replay, no prune-and-remerge, no WeakMap), migration is byte-identical to `main` for every existing app, and it deletes real machinery (`BaseValidate::boot()`, `bootFormObject`'s attribute merge, the eager sub-target binding, the `$callBootMethod` closure dance). If this direction lands, #10450 can close.

There's a natural follow-up (not in this PR): promoting `Form` to a first-class internal component-extension concept, which would let a further round of `Form`-specific special-cases (the duplicated update-hook parser, the exception proxy) delete on top of this attribute work without re-opening it.

## Breaking changes (v4, unreleased-major; each intentional)

- A `#[Virtual]` method returning an **attribute-bearing anonymous subclass** now throws loudly (use a `rules()` method for anonymous forms) — previously it silently lost those attributes.
- A form constructed with a **mismatched property name or against a different component** now throws instead of silently mis-routing its errors and rules.
- `AttributeCollection::fromComponent()` loses its form-only `$subTarget`/`$propertyNamePrefix` params and `Attribute::__boot()`'s final argument is now a class string. Both are undocumented internals; the one core caller is updated. Third-party synths that copied `bootFormObject`'s pattern need a one-line change.

`getRules()` output and merge precedence are unchanged (247 validation/form/upload tests green); only direct introspection of `$rulesFromOutside` sees fewer entries.

## Verification

- **26 new feature tests** (`SupportFormObjects/VirtualFormObjectsUnitTest.php`), each written red-first (16/20 of the core set failed on `main`), driving the real wire lifecycle via `Livewire::test()` — boot-once, `#[Validate]` at rest and on update, `#[Locked]` on granular **and** consolidated paths, `#[Url]` read + push effect, lazy deep-link, memoized-form reset, declared-beside-virtual isolation.
- **Full unit suite green: 1440 tests, 0 failures.**
- **Grounded over real HTTP** against a playground app: on the virtual form, `boot()` runs once per request, `?vq=` lands in `draft.q` and registers its URL effect, validation errors surface, and the locked-property tamper is rejected (was HTTP 200 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
