### PR TITLE
[4.x] Extract payload & structure validation into dedicated `PayloadGuards` class

### DIFF
--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -8,10 +8,10 @@ use Livewire\Mechanisms\HandleSynths\HandleSynths;
 use Livewire\Exceptions\PublicPropertyNotFoundException;
 use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Exceptions\MaxNestingDepthExceededException;
-use Livewire\Exceptions\TooManyCallsException;
 use Livewire\Drawer\Utils;
 use Livewire\Features\SupportFormObjects\Form;
 use Illuminate\Support\Facades\View;
+use Livewire\Mechanisms\HandleRequests\PayloadGuards;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -182,28 +182,9 @@ class HandleComponents extends Mechanism
 
     public function update($snapshot, $updates, $calls)
     {
-        if (! is_array($snapshot)
-            || ! is_array($snapshot['data'] ?? null)
-            || ! is_array($snapshot['memo'] ?? null)
-            || ! is_string($snapshot['checksum'] ?? null)
-            || ! is_string($snapshot['memo']['id'] ?? null)
-            || ! is_string($snapshot['memo']['name'] ?? null)
-        ) {
-            if (config('app.debug')) throw new \InvalidArgumentException('Invalid Livewire snapshot structure: expected [data], [memo], [checksum], [memo.id], and [memo.name].');
+        PayloadGuards::verifySnapshotStructure($snapshot);
 
-            abort(404);
-        }
-
-        foreach ($calls as $call) {
-            if (! is_array($call)
-                || ! is_string($call['method'] ?? null)
-                || ! is_array($call['params'] ?? null)
-            ) {
-                if (config('app.debug')) throw new \InvalidArgumentException('Invalid Livewire call structure: each call must contain [method] (string) and [params] (array).');
-
-                abort(404);
-            }
-        }
+        PayloadGuards::verifyCallsStructure($calls);
 
         $data = $snapshot['data'];
         $memo = $snapshot['memo'];
@@ -523,11 +504,7 @@ class HandleComponents extends Mechanism
 
     protected function callMethods($root, $calls, $componentContext)
     {
-        $maxCalls = config('livewire.payload.max_calls');
-
-        if ($maxCalls !== null && count($calls) > $maxCalls) {
-            throw new TooManyCallsException(count($calls), $maxCalls);
-        }
+        PayloadGuards::verifyPayloadMaxCalls($calls);
 
         $returns = [];
 

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -2,13 +2,10 @@
 
 namespace Livewire\Mechanisms\HandleRequests;
 
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
 use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
 use Livewire\Features\SupportReactiveProps\SupportReactiveProps;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
-use Livewire\Exceptions\PayloadTooLargeException;
-use Livewire\Exceptions\TooManyComponentsException;
 
 use Livewire\Mechanisms\Mechanism;
 
@@ -145,39 +142,7 @@ class HandleRequests extends Mechanism
             abort(404);
         }
 
-        // Check payload size limit...
-        $maxSize = config('livewire.payload.max_size');
-
-        if ($maxSize !== null) {
-            $contentLength = request()->header('Content-Length', 0);
-
-            if ($contentLength > $maxSize) {
-                throw new PayloadTooLargeException($contentLength, $maxSize);
-            }
-        }
-
-        $requestPayload = request('components');
-
-        if (! is_array($requestPayload) || empty($requestPayload)) {
-            abort(404);
-        }
-
-        foreach ($requestPayload as $component) {
-            if (! is_array($component)
-                || ! is_string($component['snapshot'] ?? null)
-                || ! is_array($component['updates'] ?? null)
-                || ! is_array($component['calls'] ?? null)
-            ) {
-                abort(404);
-            }
-        }
-
-        // Check max components limit...
-        $maxComponents = config('livewire.payload.max_components');
-
-        if ($maxComponents !== null && count($requestPayload) > $maxComponents) {
-            throw new TooManyComponentsException(count($requestPayload), $maxComponents);
-        }
+        $requestPayload = PayloadGuards::verify();
 
         $finish = trigger('request', $requestPayload);
 

--- a/src/Mechanisms/HandleRequests/PayloadGuards.php
+++ b/src/Mechanisms/HandleRequests/PayloadGuards.php
@@ -3,6 +3,7 @@
 namespace Livewire\Mechanisms\HandleRequests;
 
 use Livewire\Exceptions\PayloadTooLargeException;
+use Livewire\Exceptions\TooManyCallsException;
 use Livewire\Exceptions\TooManyComponentsException;
 
 class PayloadGuards
@@ -44,5 +45,43 @@ class PayloadGuards
         }
 
         return $requestPayload;
+    }
+
+    public static function verifyPayloadMaxCalls($calls)
+    {
+        $maxCalls = config('livewire.payload.max_calls');
+
+        if ($maxCalls !== null && count($calls) > $maxCalls) {
+            throw new TooManyCallsException(count($calls), $maxCalls);
+        }
+    }
+
+    public static function verifySnapshotStructure($snapshot)
+    {
+        if (! is_array($snapshot)
+            || ! is_array($snapshot['data'] ?? null)
+            || ! is_array($snapshot['memo'] ?? null)
+            || ! is_string($snapshot['checksum'] ?? null)
+            || ! is_string($snapshot['memo']['id'] ?? null)
+            || ! is_string($snapshot['memo']['name'] ?? null)
+        ) {
+            if (config('app.debug')) throw new \InvalidArgumentException('Invalid Livewire snapshot structure: expected [data], [memo], [checksum], [memo.id], and [memo.name].');
+
+            abort(404);
+        }
+    }
+
+    public static function verifyCallsStructure($calls)
+    {
+        foreach ($calls as $call) {
+            if (! is_array($call)
+                || ! is_string($call['method'] ?? null)
+                || ! is_array($call['params'] ?? null)
+            ) {
+                if (config('app.debug')) throw new \InvalidArgumentException('Invalid Livewire call structure: each call must contain [method] (string) and [params] (array).');
+
+                abort(404);
+            }
+        }
     }
 }

--- a/src/Mechanisms/HandleRequests/PayloadGuards.php
+++ b/src/Mechanisms/HandleRequests/PayloadGuards.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleRequests;
+
+use Livewire\Exceptions\PayloadTooLargeException;
+use Livewire\Exceptions\TooManyComponentsException;
+
+class PayloadGuards
+{
+    public static function verify()
+    {
+        // Check payload size limit...
+        $maxSize = config('livewire.payload.max_size');
+
+        if ($maxSize !== null) {
+            $contentLength = request()->header('Content-Length', 0);
+
+            if ($contentLength > $maxSize) {
+                throw new PayloadTooLargeException($contentLength, $maxSize);
+            }
+        }
+
+        $requestPayload = request('components');
+
+        if (! is_array($requestPayload) || empty($requestPayload)) {
+            abort(404);
+        }
+
+        foreach ($requestPayload as $component) {
+            if (! is_array($component)
+                || ! is_string($component['snapshot'] ?? null)
+                || ! is_array($component['updates'] ?? null)
+                || ! is_array($component['calls'] ?? null)
+            ) {
+                abort(404);
+            }
+        }
+
+        // Check max components limit...
+        $maxComponents = config('livewire.payload.max_components');
+
+        if ($maxComponents !== null && count($requestPayload) > $maxComponents) {
+            throw new TooManyComponentsException(count($requestPayload), $maxComponents);
+        }
+
+        return $requestPayload;
+    }
+}


### PR DESCRIPTION
## Motivation

The validation blocks were becoming noisy and mixed concerns with the core request/component handling logic. Moving pure guard logic into a dedicated class keeps the happy path clean while preserving identical behavior (same exceptions, same abort codes, same config keys).

## Summary

Extracts all request-payload and component-update validation/guard logic into a dedicated `PayloadGuards` class.

Previously this logic was scattered across `HandleRequests::handleUpdate()` and `HandleComponents::update()` / `callMethods()`. Centralizing it improves readability of the main request & component handling flow.

## Changes

### Added
- `src/Mechanisms/HandleRequests/PayloadGuards.php`
  - `verify()` – payload size limit, components array structure, max components limit
  - `verifyPayloadMaxCalls()` – max calls limit
  - `verifySnapshotStructure()` – snapshot shape validation
  - `verifyCallsStructure()` – calls shape validation

### Updated
- `HandleRequests.php` – replaced the large inline validation block with `PayloadGuards::verify()`
- `HandleComponents.php` – delegated snapshot structure, calls structure, and max-calls checks to `PayloadGuards`

## Notes

- Pure refactor – no intentional behavior changes.
- All existing config keys (`livewire.payload.max_size`, `max_components`, `max_calls`) and exception classes remain unchanged.