### PR TITLE
[4.x] Add failing test for wire:loading ending before navigate redirects complete

### DIFF
--- a/src/Features/SupportRedirects/BrowserTest.php
+++ b/src/Features/SupportRedirects/BrowserTest.php
@@ -54,6 +54,39 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_wire_loading_remains_active_while_a_navigate_redirect_is_in_progress()
+    {
+        Route::get('/slow-redirect-destination', function () {
+            sleep(1);
+
+            return response(<<<'HTML'
+                <!DOCTYPE html>
+                <html>
+                    <body>
+                        <h1 dusk="destination">Slow redirect destination</h1>
+                    </body>
+                </html>
+                HTML);
+        })->middleware('web');
+
+        Livewire::visit([new class extends Component {
+            public function save()
+            {
+                $this->redirect('/slow-redirect-destination', navigate: true);
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button type="button" dusk="save" wire:click="save" wire:loading.attr="disabled">Save</button>
+            </div>
+            HTML; }
+        }])
+            ->waitForLivewire()->click('@save')
+            ->assertAttribute('@save', 'disabled', 'true')
+            ->waitFor('@destination', 6)
+        ;
+    }
+
     public function test_session_flash_persists_when_redirecting_from_request_with_multiple_components_in_the_same_request()
     {
         config()->set('session.driver', 'file');


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

This seems related to the loading-state behavior discussed in #8165 and https://github.com/livewire/livewire/discussions/7578.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

4️⃣ Does it include tests? (Required)

Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

This adds a failing browser test for an action that redirects using `wire:navigate`.

Currently, `wire:loading.attr="disabled"` is removed after the Livewire request finishes, while the navigation is still in progress.

The test expects the button to remain disabled until the navigation completes.

No fix is included.