### PR TITLE
[3.x] Backport Octane computed property listener leak fix

### DIFF
--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -3,8 +3,6 @@
 namespace Livewire\Features\SupportComputed;
 
 use function Livewire\invade;
-use function Livewire\on;
-use function Livewire\off;
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
@@ -22,15 +20,6 @@ class BaseComputed extends Attribute
         public $tags = null,
     ) {}
 
-    function boot()
-    {
-        off('__get', $this->handleMagicGet(...));
-        on('__get', $this->handleMagicGet(...));
-
-        off('__unset', $this->handleMagicUnset(...));
-        on('__unset', $this->handleMagicUnset(...));
-    }
-
     function call()
     {
         throw new CannotCallComputedDirectlyException(
@@ -39,11 +28,8 @@ class BaseComputed extends Attribute
         );
     }
 
-    protected function handleMagicGet($target, $property, $returnValue)
+    public function handleMagicGet($returnValue)
     {
-        if ($target !== $this->component) return;
-        if ($this->generatePropertyName($property) !== $this->getName()) return;
-
         if ($this->persist) {
             $returnValue($this->handlePersistedGet());
 
@@ -61,11 +47,8 @@ class BaseComputed extends Attribute
         );
     }
 
-    protected function handleMagicUnset($target, $property)
+    public function handleMagicUnset()
     {
-        if ($target !== $this->component) return;
-        if ($property !== $this->getName()) return;
-
         if ($this->persist) {
             $this->handlePersistedUnset();
 

--- a/src/Features/SupportComputed/SupportLegacyComputedPropertySyntax.php
+++ b/src/Features/SupportComputed/SupportLegacyComputedPropertySyntax.php
@@ -14,34 +14,34 @@ class SupportLegacyComputedPropertySyntax extends ComponentHook
     static function provide()
     {
         on('__get', function ($target, $property, $returnValue) {
-            // Handle legacy computed properties (getXxxProperty pattern)...
-            if (static::hasComputedProperty($target, $property)) {
-                $returnValue(static::getComputedProperty($target, $property));
-
-                return;
-            }
-
-            // Handle #[Computed] attribute properties...
+            // Handle #[Computed] attribute properties (takes priority over legacy)...
             $attribute = static::findComputedAttribute($target, $property);
 
             if ($attribute) {
                 $attribute->handleMagicGet($returnValue);
-            }
-        });
-
-        on('__unset', function ($target, $property) {
-            // Handle legacy computed properties (getXxxProperty pattern)...
-            if (static::hasComputedProperty($target, $property)) {
-                store($target)->unset('computedProperties', $property);
 
                 return;
             }
 
-            // Handle #[Computed] attribute properties...
+            // Handle legacy computed properties (getXxxProperty pattern)...
+            if (static::hasComputedProperty($target, $property)) {
+                $returnValue(static::getComputedProperty($target, $property));
+            }
+        });
+
+        on('__unset', function ($target, $property) {
+            // Handle #[Computed] attribute properties (takes priority over legacy)...
             $attribute = static::findComputedAttribute($target, $property);
 
             if ($attribute) {
                 $attribute->handleMagicUnset();
+
+                return;
+            }
+
+            // Handle legacy computed properties (getXxxProperty pattern)...
+            if (static::hasComputedProperty($target, $property)) {
+                store($target)->unset('computedProperties', $property);
             }
         });
     }

--- a/src/Features/SupportComputed/SupportLegacyComputedPropertySyntax.php
+++ b/src/Features/SupportComputed/SupportLegacyComputedPropertySyntax.php
@@ -14,16 +14,45 @@ class SupportLegacyComputedPropertySyntax extends ComponentHook
     static function provide()
     {
         on('__get', function ($target, $property, $returnValue) {
+            // Handle legacy computed properties (getXxxProperty pattern)...
             if (static::hasComputedProperty($target, $property)) {
                 $returnValue(static::getComputedProperty($target, $property));
+
+                return;
+            }
+
+            // Handle #[Computed] attribute properties...
+            $attribute = static::findComputedAttribute($target, $property);
+
+            if ($attribute) {
+                $attribute->handleMagicGet($returnValue);
             }
         });
 
         on('__unset', function ($target, $property) {
+            // Handle legacy computed properties (getXxxProperty pattern)...
             if (static::hasComputedProperty($target, $property)) {
                 store($target)->unset('computedProperties', $property);
+
+                return;
+            }
+
+            // Handle #[Computed] attribute properties...
+            $attribute = static::findComputedAttribute($target, $property);
+
+            if ($attribute) {
+                $attribute->handleMagicUnset();
             }
         });
+    }
+
+    public static function findComputedAttribute($target, $property)
+    {
+        $propertyName = (string) str($property)->camel();
+
+        return $target->getAttributes()
+            ->whereInstanceOf(BaseComputed::class)
+            ->first(fn ($attr) => $attr->getName() === $propertyName);
     }
 
     public static function getComputedProperties($target)

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportComputed;
 use Illuminate\Support\Facades\Cache;
 use Tests\TestComponent;
 use Tests\TestCase;
+use Livewire\EventBus;
 use Livewire\Livewire;
 use Livewire\Component;
 use Livewire\Attributes\Computed;
@@ -385,6 +386,38 @@ class UnitTest extends TestCase
             ->assertSetStrict('foo', 'computed');
     }
 
+    public function test_computed_attributes_do_not_accumulate_event_bus_listeners()
+    {
+        $countListeners = function () {
+            $eventBus = app(EventBus::class);
+            $reflection = new \ReflectionClass($eventBus);
+            $total = 0;
+
+            foreach (['listeners', 'listenersAfter', 'listenersBefore'] as $propertyName) {
+                $property = $reflection->getProperty($propertyName);
+                $property->setAccessible(true);
+
+                foreach ($property->getValue($eventBus) as $listeners) {
+                    $total += count($listeners);
+                }
+            }
+
+            return $total;
+        };
+
+        Livewire::test(ComputedAttributeMemoryLeakStub::class);
+        Livewire::flushState();
+
+        $baselineListeners = $countListeners();
+
+        for ($i = 0; $i < 20; $i++) {
+            Livewire::test(ComputedAttributeMemoryLeakStub::class);
+            Livewire::flushState();
+        }
+
+        $this->assertEquals($baselineListeners, $countListeners());
+    }
+
     public function test_it_supports_legacy_computed_properties()
     {
         Livewire::test(new class extends TestComponent {
@@ -548,6 +581,26 @@ trait HasLegacyComputedProperty
     public function getFooProperty(): string
     {
         return 'legacy';
+    }
+}
+
+class ComputedAttributeMemoryLeakStub extends Component
+{
+    #[Computed]
+    public function items(): array
+    {
+        return ['a', 'b', 'c'];
+    }
+
+    #[Computed]
+    public function total(): int
+    {
+        return count($this->items);
+    }
+
+    public function render()
+    {
+        return '<div>{{ $this->total }}</div>';
     }
 }
 

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -371,6 +371,20 @@ class UnitTest extends TestCase
             ->assertSee('false');
     }
 
+    public function test_computed_attribute_takes_priority_over_legacy_get_property_syntax()
+    {
+        Livewire::test(new class extends TestComponent {
+            use HasLegacyComputedProperty;
+
+            #[Computed]
+            public function foo(): string
+            {
+                return 'computed';
+            }
+        })
+            ->assertSetStrict('foo', 'computed');
+    }
+
     public function test_it_supports_legacy_computed_properties()
     {
         Livewire::test(new class extends TestComponent {
@@ -526,6 +540,14 @@ class FalseIssetComputedPropertyStub extends Component{
             {{ var_dump(isset($this->foo)) }}
         </div>
         HTML;
+    }
+}
+
+trait HasLegacyComputedProperty
+{
+    public function getFooProperty(): string
+    {
+        return 'legacy';
     }
 }
 


### PR DESCRIPTION
This backports the computed-property portion of #10022 and the precedence correction from #10215 to Livewire 3.x.

# The Scenario

When rendering components with `#[Computed]` properties under Laravel Octane, memory usage grows across requests until the worker exhausts PHP's memory limit.

Large computed results, such as paginated Eloquent models with eager-loaded relationships, make the growth occur more quickly.

```php
#[Computed]
public function orders()
{
    return Order::with([
        'customer',
        'items.product.category',
        'items.product.tags',
        'items.product.reviews.customer',
    ])->paginate(20);
}
```

# The Problem

Each `#[Computed]` attribute registers global `__get` and `__unset` EventBus listeners when its component boots.

Those listeners are not removed when the component is destroyed, so they accumulate across requests in long-running Octane workers. They retain the computed attribute, component, and evaluated computed value.

# The Solution

Computed attribute access is handled through the existing permanent computed-property EventBus listeners instead of registering listeners for every attribute instance.

Computed attributes are resolved before legacy `getXxxProperty()` methods, preserving their existing priority when both syntaxes define the same property.

Fixes #10411