### PR TITLE
[4.x] Handle empty successful responses

### DIFF
--- a/js/request/index.js
+++ b/js/request/index.js
@@ -388,6 +388,12 @@ function sendMessages() {
                     return
                 }
 
+                if (response.ok && responseBody.trim() === '') {
+                    confirm('The server’s response was lost, refresh?') && window.location.reload()
+
+                    return
+                }
+
                 if (response.aborted) return
 
                 showHtmlModal(responseBody)
@@ -527,6 +533,13 @@ async function sendRequest(request, handlers) {
 
     if (response.redirected) {
         handlers.redirect(response.url)
+        handlers.finish()
+
+        return
+    }
+
+    if (responseBody.trim() === '') {
+        handlers.error({ response, responseBody })
         handlers.finish()
 
         return

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -389,7 +389,9 @@ function sendMessages() {
                 }
 
                 if (response.ok && responseBody.trim() === '') {
-                    confirm('The server’s response was lost, refresh?') && window.location.reload()
+                    confirm(
+                        'The server returned an empty response.\nWould you like to refresh the page?'
+                    ) && window.location.reload()
 
                     return
                 }

--- a/src/Features/SupportErrorResponses/BrowserTest.php
+++ b/src/Features/SupportErrorResponses/BrowserTest.php
@@ -74,7 +74,7 @@ class BrowserTest extends \Tests\BrowserTestCase
         Livewire::visit(Component::class)
             ->click('@refresh')
             ->waitForDialog()
-            ->assertDialogOpened('The server’s response was lost, refresh?')
+            ->assertDialogOpened("The server returned an empty response.\nWould you like to refresh the page?")
             ->dismissDialog()
             ->pause(100)
             ->assertMissing('#livewire-error')

--- a/src/Features/SupportErrorResponses/BrowserTest.php
+++ b/src/Features/SupportErrorResponses/BrowserTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportErrorResponses;
 
+use Illuminate\Support\Facades\Route;
 use Livewire\Component as BaseComponent;
 use Livewire\Livewire;
 
@@ -65,16 +66,54 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertMissing('#livewire-error')
         ;
     }
+
+    public function test_it_shows_a_refresh_dialog_when_the_server_returns_an_empty_successful_response(): void
+    {
+        $this->returnEmptyUpdateResponses();
+
+        Livewire::visit(Component::class)
+            ->click('@refresh')
+            ->waitForDialog()
+            ->assertDialogOpened('The server’s response was lost, refresh?')
+            ->dismissDialog()
+            ->pause(100)
+            ->assertMissing('#livewire-error')
+        ;
+    }
+
+    public function test_it_allows_the_empty_response_dialog_to_be_customised_using_the_error_response_hook(): void
+    {
+        $this->returnEmptyUpdateResponses();
+
+        Livewire::withQueryParams(['useCustomEmptyResponseHook' => true])
+            ->visit(Component::class)
+            ->click('@refresh')
+            ->waitForDialog()
+            ->assertDialogOpened('Empty Response - Custom Error Response')
+            ->dismissDialog()
+            ->pause(100)
+            ->assertMissing('#livewire-error')
+        ;
+    }
+
+    protected function returnEmptyUpdateResponses(): void
+    {
+        Livewire::setUpdateRoute(function ($handle, $path) {
+            return Route::post($path, fn () => response('', 200, ['Content-Type' => 'application/json']));
+        });
+    }
 }
 
 class Component extends BaseComponent
 {
     public $useCustomPageExpiredHook = false;
     public $useCustomErrorResponseHook = false;
+    public bool $useCustomEmptyResponseHook = false;
 
     protected $queryString = [
         'useCustomPageExpiredHook' => ['except' => false],
         'useCustomErrorResponseHook' => ['except' => false],
+        'useCustomEmptyResponseHook' => ['except' => false],
     ];
 
     public function regenerateSession()
@@ -96,6 +135,22 @@ class Component extends BaseComponent
                 fail(({ status }) => {
                     if (status === 419) {
                         confirm('Page Expired - Error Response')
+
+                        preventDefault()
+                    }
+                })
+            })
+        })
+    </script>
+    @endif
+
+    @if($useCustomEmptyResponseHook)
+    <script>
+        document.addEventListener('livewire:init', () => {
+            Livewire.hook('request', ({ fail }) => {
+                fail(({ status, content, preventDefault }) => {
+                    if (status === 200 && content === '') {
+                        confirm('Empty Response - Custom Error Response')
 
                         preventDefault()
                     }

--- a/src/Features/SupportErrorResponses/BrowserTest.php
+++ b/src/Features/SupportErrorResponses/BrowserTest.php
@@ -81,11 +81,11 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
-    public function test_it_allows_the_empty_response_dialog_to_be_customised_using_the_error_response_hook(): void
+    public function test_it_allows_the_empty_response_dialog_to_be_customised_using_a_request_interceptor(): void
     {
         $this->returnEmptyUpdateResponses();
 
-        Livewire::withQueryParams(['useCustomEmptyResponseHook' => true])
+        Livewire::withQueryParams(['useCustomEmptyResponseInterceptor' => true])
             ->visit(Component::class)
             ->click('@refresh')
             ->waitForDialog()
@@ -108,12 +108,12 @@ class Component extends BaseComponent
 {
     public $useCustomPageExpiredHook = false;
     public $useCustomErrorResponseHook = false;
-    public bool $useCustomEmptyResponseHook = false;
+    public bool $useCustomEmptyResponseInterceptor = false;
 
     protected $queryString = [
         'useCustomPageExpiredHook' => ['except' => false],
         'useCustomErrorResponseHook' => ['except' => false],
-        'useCustomEmptyResponseHook' => ['except' => false],
+        'useCustomEmptyResponseInterceptor' => ['except' => false],
     ];
 
     public function regenerateSession()
@@ -144,12 +144,12 @@ class Component extends BaseComponent
     </script>
     @endif
 
-    @if($useCustomEmptyResponseHook)
+    @if($useCustomEmptyResponseInterceptor)
     <script>
         document.addEventListener('livewire:init', () => {
-            Livewire.hook('request', ({ fail }) => {
-                fail(({ status, content, preventDefault }) => {
-                    if (status === 200 && content === '') {
+            Livewire.interceptRequest(({ onError }) => {
+                onError(({ response, body, preventDefault }) => {
+                    if (response.ok && body === '') {
                         confirm('Empty Response - Custom Error Response')
 
                         preventDefault()


### PR DESCRIPTION
# The Scenario

Sometimes when Safari resumes after being suspended, a Livewire update request can resolve with a successful status but an empty response body. The action then appears to fail, and Livewire displays a completely blank error modal.

This can affect any Livewire action, including ordinary `wire:click` interactions.

<img width="800" height="567" alt="CleanShot 2026-07-27 at 21 18 03" src="https://github.com/user-attachments/assets/ab1f0fa2-1673-4512-9eb5-d08c0944e1ea" />

```blade
<?php

use Livewire\Component;

new class extends Component {
    public int $count = 0;

    public function increment(): void
    {
        $this->count++;
    }
};
?>

<div>
    <p>{{ $count }}</p>

    <button wire:click="increment">Increment</button>
</div>
```

# The Problem

Livewire treats the response as successful because its HTTP status is `200`, then attempts to parse the empty body as JSON.

When parsing fails, the response is passed to the normal HTML error handler. Because the body is empty, `showHtmlModal()` renders a blank full-screen dialog with no useful information or recovery path.

Automatically retrying the request is unsafe because Livewire cannot determine whether the action reached the server before its response was lost.

# The Solution

The solution is to detect an empty successful response before attempting to parse it as JSON and route it through Livewire's existing error-response handling.

The default handling displays a concise confirmation (similar to 419) asking the user whether they want to refresh the page. Refreshing restores the latest server state without repeating an action that may already have completed.

<img width="800" height="567" alt="CleanShot 2026-07-27 at 21 15 55" src="https://github.com/user-attachments/assets/7f0558e7-f5b7-44bc-b413-287d2015f9f9" />

Request interceptors receive the response first and can call `preventDefault()` to suppress or replace the default confirmation.

Fixes #10424
