### PR TITLE
[4.x] Fix script modules not loading after back/forward navigation

### DIFF
--- a/js/component.js
+++ b/js/component.js
@@ -280,6 +280,12 @@ export class Component {
             effects.scripts = this.originalEffects.scripts;
         }
 
+        // We need to re-load the component's script module, otherwise its $js
+        // actions are gone after a back/forward navigation...
+        if (this.originalEffects.scriptModule) {
+            effects.scriptModule = this.originalEffects.scriptModule
+        }
+
         el.setAttribute('wire:effects', JSON.stringify(effects))
 
         el.setAttribute('wire:key', this.key)

--- a/src/Features/SupportJsModules/BrowserTest.php
+++ b/src/Features/SupportJsModules/BrowserTest.php
@@ -68,4 +68,37 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->pause(100)
             ->assertSeeIn('@target', 'js-import-loaded');
     }
+
+    public function test_script_module_survives_a_back_navigation()
+    {
+        // The `scriptModule` effect is only sent while mounting, so navigating
+        // away has to carry it over onto the element: inscribeSnapshotAndEffectsOnElement()
+        // rewrites wire:effects and navigate caches that markup for the back button.
+        // When the effect is dropped there, the restored component never imports its
+        // module and all of its $js actions are gone.
+        //
+        // Note the assertion is a $js action *call* after coming back, not text the
+        // module wrote before navigating away: navigate caches the mutated HTML, so
+        // that text is restored either way and would pass without the module loading.
+        Livewire::visit('testns::back-forward')
+            ->waitForLivewireToLoad()
+            ->pause(100)
+            ->assertSeeIn('@loaded', 'js-loaded')
+            ->waitForNavigate()->click('@link')
+            ->waitForText('On second page')
+            ->back()
+            ->waitForText('Mark')
+            ->pause(100)
+            ->click('@mark')
+            ->assertSeeIn('@target', 'js-action-called')
+            // And it has to survive doing all of that again, so the restored
+            // component carries the effect for the next navigation as well...
+            ->waitForNavigate()->click('@link')
+            ->waitForText('On second page')
+            ->back()
+            ->waitForText('Mark')
+            ->pause(100)
+            ->click('@mark-again')
+            ->assertSeeIn('@target', 'js-action-called-again');
+    }
 }

--- a/src/Features/SupportJsModules/fixtures/back-forward-second.blade.php
+++ b/src/Features/SupportJsModules/fixtures/back-forward-second.blade.php
@@ -1,0 +1,10 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <div dusk="second-page">On second page</div>
+</div>

--- a/src/Features/SupportJsModules/fixtures/back-forward/back-forward.blade.php
+++ b/src/Features/SupportJsModules/fixtures/back-forward/back-forward.blade.php
@@ -1,0 +1,9 @@
+<div>
+    <div dusk="loaded">waiting</div>
+    <div dusk="target">waiting</div>
+
+    <button type="button" wire:click="$js.mark" dusk="mark">Mark</button>
+    <button type="button" wire:click="$js.markAgain" dusk="mark-again">Mark again</button>
+
+    <a href="/livewire-dusk/testns::back-forward-second" wire:navigate dusk="link">Go to second page</a>
+</div>

--- a/src/Features/SupportJsModules/fixtures/back-forward/back-forward.js
+++ b/src/Features/SupportJsModules/fixtures/back-forward/back-forward.js
@@ -1,0 +1,9 @@
+this.$el.querySelector('[dusk="loaded"]').textContent = 'js-loaded'
+
+let write = (text) => {
+    this.$el.querySelector('[dusk="target"]').textContent = text
+}
+
+$js('mark', () => write('js-action-called'))
+
+$js('markAgain', () => write('js-action-called-again'))

--- a/src/Features/SupportJsModules/fixtures/back-forward/back-forward.php
+++ b/src/Features/SupportJsModules/fixtures/back-forward/back-forward.php
@@ -1,0 +1,7 @@
+<?php
+
+new class extends \Livewire\Component
+{
+    //
+};
+?>


### PR DESCRIPTION
## Problem

A component's colocated JS (`<name>.js`, and the compiled `<script>` block of an SFC) is loaded exclusively from the `scriptModule` effect. After a browser **back/forward** navigation that module is never imported, so every `$js` action the component defines is gone:

```
Uncaught TypeError: $wire.$js.calculateTotal is not a function
```

Direct visits and regular `wire:navigate` links are fine — it only breaks on back/forward.

What makes this easy to miss in an app: server-rendered markup is still there, only the client-driven parts silently fail. In our case `x-text="$wire.$js.format($wire.$js.calculateTotal())"` rendered an empty string and an `x-show` row stayed hidden behind `x-cloak`, so the page looked *almost* right. It also takes down anything else registered from that module — for us a `$wire.intercept` that collects form state on save, which makes it data-loss shaped rather than cosmetic.

## Cause

1. `SupportJsModules::dehydrate()` only adds the `scriptModule` effect while mounting (or when a lazy component hydrates).
2. `js/features/supportJsModules.js` imports the module from that effect via the `effect` hook.
3. On navigating away, the `alpine:navigating` listener in `js/directives/wire-navigate.js` calls `Component.inscribeSnapshotAndEffectsOnElement()`, which rewrites `wire:effects` from an allowlist — `listeners`, `url`, `scripts`. **`scriptModule` is not on it and is dropped.**
4. `updateCurrentPageHtmlInSnapshotCacheForLaterBackButtonClicks()` then caches `document.documentElement.outerHTML`, i.e. the DOM without the effect.
5. On back/forward the restored component reads `wire:effects` off the element in its constructor and calls `processEffects()` — no `scriptModule`, so the `import()` never runs.

The older `@script` channel (`scripts`) *is* on the allowlist, and `SupportNavigate\BrowserTest::test_navigate_back_reevaluates_scripts` covers exactly this for it. It looks like only the newer module channel was missed when it was added.

## Fix

Carry `scriptModule` across the same way the other effects are carried:

```javascript
// We need to re-load the component's script module, otherwise its $js
// actions are gone after a back/forward navigation...
if (this.originalEffects.scriptModule) {
    effects.scriptModule = this.originalEffects.scriptModule
}
```

`originalEffects` is set once in the constructor and left untouched by `mergeNewSnapshot()`, so the hash is still available at that point. Restoring the effect lets the existing loader do its job, and the restored component carries the effect in its own `originalEffects` again, so repeated back/forward navigations keep working. Module imports are cached by URL in the browser, so this reuses the already-loaded module rather than refetching it.

## Test

`SupportJsModules\BrowserTest::test_script_module_survives_a_back_navigation`, with an MFC fixture that has a colocated `.js` file — the `scriptModule` effect only exists when the compiler injects `scriptModuleSrc()`, so an inline component using `@script` would exercise the wrong (already working) channel.

The assertion deliberately **calls** a `$js` action after coming back rather than checking text the module wrote before navigating away: navigate caches the mutated `outerHTML`, so that text is restored either way and such a test would pass without the module ever loading.

## Verification

Run against this branch's base (`main`, `9c14507`), Chrome 150, PHP 8.5:

| | |
|---|---|
| `test:browser --filter="script_module_survives"`, fix reverted | **fails** — `Did not see expected text [js-action-called] within element [body [dusk="target"]]` |
| same test, fix applied | **passes** (1 test, 3 assertions) |
| `--filter="SupportJsModules"` | 5 tests pass |
| `--filter="SupportNavigate"` | 55 tests, 372 assertions pass |
| `--filter="SupportScriptsAndAssets"` | 14 tests pass |
| `--filter="SupportJsEvaluation"` | 16 tests pass |
| `--filter="SupportSingleAndMultiFileComponents"` | 2 tests pass |
| `composer test:unit` | 1414 tests, 4046 assertions pass |
| `npm run test:run` | 145 tests pass |

Originally found on 4.3.3 in a production app, reproduced on current `main` by the test above.