### PR TITLE
Fix _removeUpload for Collection properties

### DIFF
--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -165,6 +165,30 @@ class UnitTest extends \Tests\TestCase
         $this->assertCount(1, $tmpFiles);
     }
 
+    public function test_can_remove_a_file_from_a_collection_of_files_property()
+    {
+        $file1 = UploadedFile::fake()->image('avatar1.jpg');
+        $file2 = UploadedFile::fake()->image('avatar2.jpg');
+
+        $component = Livewire::test(FileUploadComponent::class)
+            ->set('photos', [$file1, $file2]);
+
+        $tmpFiles = $component->viewData('photos');
+
+        // Convert the photos property into a Collection of TemporaryUploadedFile instances
+        $component->set('photos', collect($tmpFiles));
+
+        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $component->viewData('photos'));
+
+        $component->call('_removeUpload', 'photos', $tmpFiles[1]->getFilename())
+            ->assertDispatched('upload:removed', name: 'photos', tmpFilename: $tmpFiles[1]->getFilename());
+
+        $remainingFiles = $component->call('$refresh')->viewData('photos');
+
+        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $remainingFiles);
+        $this->assertCount(1, $remainingFiles);
+    }
+
     public function test_if_the_file_property_is_an_array_the_uploaded_file_will_append_to_the_array()
     {
         Storage::fake('avatars');

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -134,17 +134,25 @@ trait WithFileUploads
     {
         $uploads = $this->getPropertyValue($name);
 
-        if (is_array($uploads) && isset($uploads[0]) && $uploads[0] instanceof TemporaryUploadedFile) {
-            $this->dispatch('upload:removed', name: $name, tmpFilename: $tmpFilename)->self();
+        $isCollection = $uploads instanceof \Illuminate\Support\Collection;
 
-            app('livewire')->updateProperty($this, $name, array_values(array_filter($uploads, function ($upload) use ($tmpFilename) {
-                if ($upload->getFilename() === $tmpFilename) {
-                    $upload->delete();
-                    return false;
-                }
+        if (is_array($uploads) || $isCollection) {
+            $items = $isCollection ? $uploads->all() : $uploads;
 
-                return true;
-            })));
+            if (isset($items[0]) && $items[0] instanceof TemporaryUploadedFile) {
+                $this->dispatch('upload:removed', name: $name, tmpFilename: $tmpFilename)->self();
+
+                $filtered = array_values(array_filter($items, function ($upload) use ($tmpFilename) {
+                    if ($upload->getFilename() === $tmpFilename) {
+                        $upload->delete();
+                        return false;
+                    }
+
+                    return true;
+                }));
+
+                app('livewire')->updateProperty($this, $name, $isCollection ? collect($filtered) : $filtered);
+            }
         } elseif ($uploads instanceof TemporaryUploadedFile && $uploads->getFilename() === $tmpFilename) {
             $uploads->delete();
 

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -136,23 +136,21 @@ trait WithFileUploads
 
         $isCollection = $uploads instanceof \Illuminate\Support\Collection;
 
-        if (is_array($uploads) || $isCollection) {
-            $items = $isCollection ? $uploads->all() : $uploads;
+        $items = $isCollection ? $uploads->all() : $uploads;
 
-            if (isset($items[0]) && $items[0] instanceof TemporaryUploadedFile) {
-                $this->dispatch('upload:removed', name: $name, tmpFilename: $tmpFilename)->self();
+        if (is_array($items) && isset($items[0]) && $items[0] instanceof TemporaryUploadedFile) {
+            $this->dispatch('upload:removed', name: $name, tmpFilename: $tmpFilename)->self();
 
-                $filtered = array_values(array_filter($items, function ($upload) use ($tmpFilename) {
-                    if ($upload->getFilename() === $tmpFilename) {
-                        $upload->delete();
-                        return false;
-                    }
+            $filtered = array_values(array_filter($items, function ($upload) use ($tmpFilename) {
+                if ($upload->getFilename() === $tmpFilename) {
+                    $upload->delete();
+                    return false;
+                }
 
-                    return true;
-                }));
+                return true;
+            }));
 
-                app('livewire')->updateProperty($this, $name, $isCollection ? collect($filtered) : $filtered);
-            }
+            app('livewire')->updateProperty($this, $name, $isCollection ? collect($filtered) : $filtered);
         } elseif ($uploads instanceof TemporaryUploadedFile && $uploads->getFilename() === $tmpFilename) {
             $uploads->delete();
 


### PR DESCRIPTION
Fixes #10459

### Summary

When storing multiple file uploads in a `Collection` property (e.g. `public Collection $photos`), calling `_removeUpload` would fail silently because it only checked `is_array($uploads)`.

`_finishUpload` and `validateIncomingUpload` both support `Collection` instances, but `_removeUpload` was missing it.

### Changes

- Added `Collection` support to `_removeUpload` in `WithFileUploads.php` while preserving the property's original `Collection` type when updated.
- Added a unit test to verify removing temporary uploads from a `Collection` property.