### PR TITLE
[4.x] Adds `#[Debounce]` attribute for property-level `wire:model` debounce timing

### DIFF
--- a/docs/attribute-debounce.md
+++ b/docs/attribute-debounce.md
@@ -1,0 +1,116 @@
+The `#[Debounce]` attribute allows you to define a property's `wire:model` debounce timing directly on your Livewire component. This lets you configure debounce behavior once and reuse the property without adding `.debounce.Xms` modifiers to every `wire:model` binding.
+
+## Basic usage
+
+Apply the `#[Debounce]` attribute to a public property. Pass the debounce duration in milliseconds:
+
+```php
+<?php // resources/views/components/⚡search-box.blade.php
+
+use Livewire\Attributes\Debounce;
+use Livewire\Component;
+
+new class extends Component {
+    #[Debounce(250)] // [tl! highlight]
+    public string $search = '';
+};
+```
+
+```blade
+<input wire:model.live="search">
+```
+
+When the user types into the input, Livewire waits `250ms` after the last change before sending the update request.
+
+Without the attribute, you would need to define the debounce duration directly in your Blade template:
+
+```blade
+<input wire:model.live.debounce.250ms="search">
+```
+
+The `#[Debounce]` attribute allows you to keep this configuration alongside the property it affects.
+
+## Default debounce duration
+
+You may omit the duration to use Livewire's default debounce timing:
+
+```php
+#[Debounce]
+public string $search = '';
+```
+
+This is equivalent to:
+
+```blade
+<input wire:model.live.debounce.150ms="search">
+```
+
+## Overriding the attribute
+
+A `wire:model` modifier in your Blade template takes precedence over the property attribute. This allows you to define a sensible default while still overriding it when needed:
+
+```php
+#[Debounce(250)]
+public string $search = '';
+```
+
+```blade
+<input wire:model.live.debounce.500ms="search">
+```
+
+In this example, the input uses `500ms` because the Blade modifier overrides the attribute value.
+
+## Using with `wire:model.live`
+
+The `#[Debounce]` attribute only controls the debounce duration. It does not make a property update live by itself.
+
+For example:
+
+```php
+#[Debounce(500)]
+public string $search = '';
+```
+
+```blade
+<input wire:model="search">
+```
+
+The property will still update using Livewire's default deferred behavior. To send updates while the user types, use `wire:model.live`:
+
+```blade
+<input wire:model.live="search">
+```
+
+## Behavior
+
+| Blade | Attribute | Result |
+| - | - | - |
+| `wire:model.live="search"` | `#[Debounce]` | Uses the default `150ms` debounce |
+| `wire:model.live="search"` | `#[Debounce(250)]` | Uses `250ms` debounce |
+| `wire:model.live.debounce.500ms="search"` | `#[Debounce(250)]` | Uses `500ms` (Blade modifier wins) |
+| `wire:model="search"` | `#[Debounce(250)]` | Remains deferred |
+
+## Form objects
+
+The `#[Debounce]` attribute can also be applied to properties inside form objects:
+
+```php
+<?php
+
+use Livewire\Attributes\Debounce;
+use Livewire\Form;
+
+class SearchForm extends Form
+{
+    #[Debounce(300)]
+    public string $query = '';
+}
+```
+
+```blade
+<input wire:model.live="form.query">
+```
+
+## Learn more
+
+For more information about binding data to Livewire properties, see the [wire:model](/docs/4.x/wire-model)

--- a/js/component.js
+++ b/js/component.js
@@ -277,7 +277,7 @@ export class Component {
         }
 
         // We need to re-register property debounce defaults from #[Debounce]...
-        if (this.originalEffects.debounce) {
+        if (Object.prototype.hasOwnProperty.call(this.originalEffects, 'debounce') && this.originalEffects.debounce) {
             effects.debounce = this.originalEffects.debounce
         }
 

--- a/js/component.js
+++ b/js/component.js
@@ -276,6 +276,11 @@ export class Component {
             effects.scripts = this.originalEffects.scripts;
         }
 
+        // We need to re-register property debounce defaults from #[Debounce]...
+        if (this.originalEffects.debounce) {
+            effects.debounce = this.originalEffects.debounce
+        }
+
         el.setAttribute('wire:effects', JSON.stringify(effects))
 
         el.setAttribute('wire:key', this.key)

--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -66,7 +66,7 @@ directive('model', ({ el, directive, component, cleanup }) => {
     let networkOnChange = networkModifiers.includes('change') || networkModifiers.includes('lazy')
     let networkOnEnter = networkModifiers.includes('enter')
     let hasNetworkTriggers = networkOnBlur || networkOnChange || networkOnEnter
-    let isDebounced = networkModifiers.includes('debounce')
+    let isDebounced = networkModifiers.includes('debounce') || componentHasDebounceEffects(component, expression)
     let isThrottled = networkModifiers.includes('throttle')
 
     // Trigger a network request
@@ -86,7 +86,11 @@ directive('model', ({ el, directive, component, cleanup }) => {
 
     // Apply debounce/throttle from network modifiers
     if ((shouldSendNetwork && ! hasNetworkTriggers && isRealtimeInput(el) && ! isDebounced && ! isThrottled) || isDebounced) {
-        debouncedUpdate = debounce(debouncedUpdate, parseModifierDuration(networkModifiers, 'debounce') || 150)
+        let debounceDuration = parseModifierDuration(networkModifiers, 'debounce') 
+            ?? componentEffectsDuration(component, expression, 'debounce')
+            ?? 150
+
+        debouncedUpdate = debounce(debouncedUpdate, debounceDuration)
     }
 
     if (isThrottled) {
@@ -245,4 +249,28 @@ function parseModifierDuration(modifiers, key) {
     let duration = nextModifier.split('ms')[0]
 
     return ! isNaN(duration) ? duration : undefined
+}
+
+function componentEffectsDuration(component, expression, key) {
+    let target = component
+    let property = expression
+
+    // 1) wire:model.live="$parent.foo" commits on the parent — look up parent effects
+    if (expression.startsWith('$parent')) {
+        target = component.parent
+        property = expression.replace(/^\$parent\.?/, '')
+    }
+
+    // 2) Mount-time effect — prefer originalEffects because
+    //    mergeNewSnapshot replaces component.effects on subsequent requests
+    //    (same durability pattern as originalEffects.url / scripts)
+    let options = (target.originalEffects && target.originalEffects[key])
+        || target.effects[key]
+        || {}
+
+    return ! isNaN(options[property]) ? options[property] : undefined
+}
+
+function componentHasDebounceEffects(component, expression) {
+    return componentEffectsDuration(component, expression, 'debounce') !== undefined
 }

--- a/src/Attributes/Debounce.php
+++ b/src/Attributes/Debounce.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Livewire\Features\SupportDebounce\BaseDebounce;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Debounce extends BaseDebounce
+{
+    //
+}

--- a/src/Features/SupportDebounce/BaseDebounce.php
+++ b/src/Features/SupportDebounce/BaseDebounce.php
@@ -24,7 +24,7 @@ class BaseDebounce extends LivewireAttribute
     protected function normalizeDuration(int|string $duration): int
     {
         if (is_int($duration)) {
-            return max(150, $duration);
+            return max(0, $duration);
         }
 
         $duration = strtolower(trim($duration));
@@ -46,6 +46,6 @@ class BaseDebounce extends LivewireAttribute
             return 150;
         }
 
-        return max(150, (int) ((float) $value * $multiplier));
+        return max(0, (int) ((float) $value * $multiplier));
     }
 }

--- a/src/Features/SupportDebounce/BaseDebounce.php
+++ b/src/Features/SupportDebounce/BaseDebounce.php
@@ -24,18 +24,28 @@ class BaseDebounce extends LivewireAttribute
     protected function normalizeDuration(int|string $duration): int
     {
         if (is_int($duration)) {
-            return $duration;
+            return max(150, $duration);
         }
 
-        // Support "250ms", "250", "0.25s", etc.
+        $duration = strtolower(trim($duration));
+
         if (str_ends_with($duration, 'ms')) {
-            return (int) $duration;
+            return $this->normalizeNumber(substr($duration, 0, -2));
         }
 
         if (str_ends_with($duration, 's')) {
-            return (int) ((float) $duration * 1000);
+            return $this->normalizeNumber(substr($duration, 0, -1), 1000);
         }
 
-        return (int) $duration;
+        return $this->normalizeNumber($duration);
+    }
+
+    protected function normalizeNumber(string $value, int $multiplier = 1): int
+    {
+        if ($value === '' || ! is_numeric($value)) {
+            return 150;
+        }
+
+        return max(150, (int) ((float) $value * $multiplier));
     }
 }

--- a/src/Features/SupportDebounce/BaseDebounce.php
+++ b/src/Features/SupportDebounce/BaseDebounce.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Livewire\Features\SupportDebounce;
+
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class BaseDebounce extends LivewireAttribute
+{
+    public function __construct(public int|string $duration = 150)
+    {
+        //
+    }
+
+    public function dehydrate($context)
+    {
+        if (! $context->isMounting()) return;
+
+        $duration = $this->normalizeDuration($this->duration);
+
+        $context->pushEffect('debounce', $duration, $this->getName());
+    }
+
+    protected function normalizeDuration(int|string $duration): int
+    {
+        if (is_int($duration)) {
+            return $duration;
+        }
+
+        // Support "250ms", "250", "0.25s", etc.
+        if (str_ends_with($duration, 'ms')) {
+            return (int) $duration;
+        }
+
+        if (str_ends_with($duration, 's')) {
+            return (int) ((float) $duration * 1000);
+        }
+
+        return (int) $duration;
+    }
+}

--- a/src/Features/SupportDebounce/BrowserTest.php
+++ b/src/Features/SupportDebounce/BrowserTest.php
@@ -25,6 +25,7 @@ class BrowserTest extends BrowserTestCase
                 HTML;
             }
         })
+            ->waitForLivewireToLoad()
             ->assertSeeIn('@output', '')
             ->type('@input', 'hello')
             ->pause(150)
@@ -49,6 +50,7 @@ class BrowserTest extends BrowserTestCase
                 HTML;
             }
         })
+            ->waitForLivewireToLoad()
             ->type('@input', 'fast')
             // Modifier 100ms must win over attribute 2000ms
             ->waitForTextIn('@output', 'fast', 1)
@@ -72,6 +74,7 @@ class BrowserTest extends BrowserTestCase
                 HTML;
             }
         })
+            ->waitForLivewireToLoad()
             ->type('@input', 'deferred')
             ->pause(200)
             ->assertSeeIn('@output', '')
@@ -100,6 +103,7 @@ class BrowserTest extends BrowserTestCase
                 HTML;
             }
         })
+            ->waitForLivewireToLoad()
             ->type('@fast', 'a')
             ->waitForTextIn('@fast-out', 'a', 1)
             ->assertSeeIn('@slow-out', '')
@@ -237,6 +241,7 @@ class BrowserTest extends BrowserTestCase
                 HTML;
             }
         })
+            ->waitForLivewireToLoad()
             ->assertSeeIn('@output', '')
             ->type('@input', 'hello')
             ->pause(150)
@@ -260,8 +265,235 @@ class BrowserTest extends BrowserTestCase
                 HTML;
             }
         })
+            ->waitForLivewireToLoad()
             ->type('@input', 'fast')
             ->waitForTextIn('@output', 'fast', 1)
+        ;
+    }
+
+    public function test_debounce_attribute_does_not_delay_live_blur_network_update()
+    {
+        Livewire::visit(new class extends Component {
+            #[BaseDebounce(2000)]
+            public $search = '';
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" wire:model.live.blur="search" dusk="input" />
+                    <span dusk="output">{{ $search }}</span>
+                    <button type="button" dusk="blur-target">Blur</button>
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->type('@input', 'hello')
+            ->pause(50)
+            ->assertSeeIn('@output', '')
+            ->waitForLivewire()->click('@blur-target')
+            ->assertSeeIn('@output', 'hello')
+        ;
+    }
+
+    public function test_debounce_attribute_does_not_delay_blur_live_network_update()
+    {
+        Livewire::visit(new class extends Component {
+            #[BaseDebounce(2000)]
+            public $search = '';
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" wire:model.blur.live="search" dusk="input" />
+                    <span dusk="output">{{ $search }}</span>
+                    <button type="button" dusk="blur-target">Blur</button>
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->type('@input', 'hello')
+            ->pause(50)
+            ->assertSeeIn('@output', '')
+            ->waitForLivewire()->click('@blur-target')
+            ->assertSeeIn('@output', 'hello')
+        ;
+    }
+
+    public function test_debounce_attribute_does_not_delay_live_enter_network_update()
+    {
+        Livewire::visit(new class extends Component {
+            #[BaseDebounce(2000)]
+            public $search = '';
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" wire:model.live.enter="search" dusk="input" />
+                    <span dusk="output">{{ $search }}</span>
+                    <button type="button" dusk="blur-target">Blur</button>
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->type('@input', 'hello')
+            ->pause(50)
+            ->assertSeeIn('@output', '')
+            // Blur alone must not commit (enter is the network trigger)
+            ->click('@blur-target')
+            ->pause(200)
+            ->assertSeeIn('@output', '')
+            ->click('@input')
+            ->waitForLivewire()->keys('@input', '{enter}')
+            ->assertSeeIn('@output', 'hello')
+        ;
+    }
+
+    public function test_debounce_attribute_does_not_delay_lazy_network_update()
+    {
+        // .lazy (without .live) is treated as change + network; hasNetworkTriggers → no attribute debounce
+        Livewire::visit(new class extends Component {
+            #[BaseDebounce(2000)]
+            public $search = '';
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" wire:model.lazy="search" dusk="input" />
+                    <span dusk="output">{{ $search }}</span>
+                    <button type="button" dusk="blur-target">Blur</button>
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->type('@input', 'hello')
+            ->pause(50)
+            ->assertSeeIn('@output', '')
+            ->waitForLivewire()->click('@blur-target')
+            ->assertSeeIn('@output', 'hello')
+        ;
+    }
+
+    public function test_live_throttle_still_applies_debounce_attribute()
+    {
+        Livewire::visit(new class extends Component {
+            #[BaseDebounce(500)]
+            public $search = '';
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" wire:model.live.throttle.50ms="search" dusk="input" />
+                    <span dusk="output">{{ $search }}</span>
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->type('@input', 'fast')
+            ->pause(150)
+            ->assertSeeIn('@output', '')
+            ->waitForTextIn('@output', 'fast', 1)
+        ;
+    }
+
+    public function test_debounce_modifier_on_blur_live_uses_explicit_duration_not_attribute()
+    {
+        // .blur.live.debounce.Xms: blur is ephemeral; debounce is the network timing.
+        // Attribute 2000ms must lose to Blade 100ms.
+        Livewire::visit(new class extends Component {
+            #[BaseDebounce(2000)]
+            public $search = '';
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" wire:model.blur.live.debounce.100ms="search" dusk="input" />
+                    <span dusk="output">{{ $search }}</span>
+                    <button type="button" dusk="blur-target">Blur</button>
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->type('@input', 'hello')
+            ->pause(50)
+            ->assertSeeIn('@output', '')
+            ->click('@blur-target')
+            ->pause(50)
+            ->assertSeeIn('@output', '')              // still inside 100ms debounce
+            ->waitForTextIn('@output', 'hello', 1)    // not waiting for attribute 2000ms
+        ;
+    }
+
+    public function test_debounce_attribute_works_on_nested_array_property()
+    {
+        Livewire::visit(new class extends Component {
+            #[BaseDebounce(500)]
+            public $filters = ['q' => ''];
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" wire:model.live="filters.q" dusk="input" />
+                    <span dusk="output">{{ $filters['q'] }}</span>
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->assertSeeIn('@output', '')
+            ->type('@input', 'nested')
+            ->pause(150)
+            ->assertSeeIn('@output', '')
+            ->waitForTextIn('@output', 'nested', 1)
+        ;
+    }
+
+    public function test_debounce_attribute_works_with_parent_expression()
+    {
+        Livewire::visit([
+            new class extends Component {
+                #[BaseDebounce(500)]
+                public $search = '';
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <span dusk="output">{{ $search }}</span>
+                        <livewire:child />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <input type="text" wire:model.live="$parent.search" dusk="input" />
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->waitForLivewireToLoad()
+            ->assertSeeIn('@output', '')
+            ->type('@input', 'from-child')
+            ->pause(150)
+            ->assertSeeIn('@output', '')
+            ->waitForTextIn('@output', 'from-child', 1)
         ;
     }
 }

--- a/src/Features/SupportDebounce/BrowserTest.php
+++ b/src/Features/SupportDebounce/BrowserTest.php
@@ -12,16 +12,14 @@ class BrowserTest extends BrowserTestCase
     function test_debounce_attribute_delays_live_model_network_update()
     {
         Livewire::visit(new class extends Component {
-            #[BaseDebounce(250)]
-            public $foo = '';
+            public $foo;
 
             public function render()
             {
                 return <<<'HTML'
                 <div x-init="window.requests = 0">
-                    <input type="text" wire:model.live="foo" dusk="input">
-                    <span wire:text="foo" dusk="client"></span>
-                    <span dusk="server">{{ $foo }}</span>
+                    <input type="text" wire:model.live.debounce.250ms="foo" dusk="input">
+                    <span wire:text="foo" dusk="text"></span>
                 </div>
 
                 @script
@@ -38,10 +36,9 @@ class BrowserTest extends BrowserTestCase
         })
             ->waitForLivewireToLoad()
             ->typeSlowly('@input', 'livewire', 50)
-            ->assertSeeIn('@client', 'livewire') // wire:text should update immediately
-            ->pause(300) // Wait for requests to be handled
-            ->assertSeeIn('@server', 'livewire') // server value should be updated
-            ->assertScript('window.requests', 1); 
+            ->assertSeeIn('@text', 'livewire') // wire:text should update immediately
+            ->pause(300) // Wait for the request to be handled
+            ->assertScript('window.requests', 1); // Only one request was sent
     }
 
     function test_blade_debounce_modifier_overrides_attribute()
@@ -73,10 +70,11 @@ class BrowserTest extends BrowserTestCase
         })
             ->waitForLivewireToLoad()
             ->typeSlowly('@input', 'livewire', 50)
+            ->assertSeeIn('@server', '')
             ->assertSeeIn('@client', 'livewire') // wire:text should update immediately
-            ->pause(300) // Wait for requests to be handled
-            ->assertSeeIn('@server', 'livewire') // server value should be updated
-            ->assertScript('window.requests', 1); 
+            ->pause(300) // Wait for the request to be handled
+            ->assertSeeIn('@server', 'livewire')
+            ->assertScript('window.requests', 1); // Only one request was sent
     }
 
     function test_debounce_attribute_does_not_force_live_on_deferred_model()
@@ -117,7 +115,7 @@ class BrowserTest extends BrowserTestCase
     function test_only_annotated_property_uses_attribute_debounce()
     {
         Livewire::visit(new class extends Component {
-            #[BaseDebounce(800)]
+            #[BaseDebounce(500)]
             public $slow = '';
 
             public $fast = '';
@@ -141,7 +139,7 @@ class BrowserTest extends BrowserTestCase
             ->assertSeeIn('@slow-out', '')
             ->typeSlowly('@slow', 'livewire', 50)
             ->assertSeeIn('@slow-out', '')
-            ->waitForTextIn('@slow-out', 'livewire', 1)
+            ->waitForTextIn('@slow-out', 'livewire') // 5s clearly exceeds 500ms debounce duration
         ;
     }
 
@@ -276,7 +274,7 @@ class BrowserTest extends BrowserTestCase
             ->typeSlowly('@input', 'livewire', 50)
             ->assertSeeIn('@output', '')
             ->pause(300)
-            ->waitForTextIn('@output', 'livewire')
+            ->waitForTextIn('@output', 'livewire') // 5s clearly exceeds 2s debounce duration
         ;
     }
 
@@ -431,7 +429,7 @@ class BrowserTest extends BrowserTestCase
             ->waitForLivewireToLoad()
             ->typeSlowly('@input', 'livewire', 50)
             ->assertSeeIn('@output', '')
-            ->waitForTextIn('@output', 'livewire', 1)
+            ->waitForTextIn('@output', 'livewire', 1) // 1s clearly exceeds 500ms debounce duration
         ;
     }
 
@@ -462,10 +460,11 @@ class BrowserTest extends BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
-            ->typeSlowly('@input', 'ab', 50)
-            ->assertSeeIn('@text', 'ab') // wire:text should update immediately
-            ->pause(300) // Wait for requests to be handled
-            ->assertScript('window.requests', 2); // 0ms must not collapse like the default 150ms
+            ->type('@input', 'a')
+            ->assertSeeIn('@text', 'a') // wire:text should update immediately
+            ->pause(50) // Wait for requests to be handled
+            // Under default 150ms: a false fallback would still have requests === 0 here
+            ->assertScript('window.requests', 1);
     }
 
     public function test_debounce_modifier_on_blur_live_uses_explicit_duration_not_attribute()
@@ -491,9 +490,9 @@ class BrowserTest extends BrowserTestCase
             ->typeSlowly('@input', 'livewire', 50)
             ->assertSeeIn('@output', '')
             ->click('@blur-target')
-            ->pause(50)    // still debounced
+            ->pause(50) // still debounced
             ->assertSeeIn('@output', '')
-            ->pause(300)    // already pass debounce duration
+            ->pause(300) // already pass debounce duration
             ->assertSeeIn('@output', 'livewire')
         ;
     }

--- a/src/Features/SupportDebounce/BrowserTest.php
+++ b/src/Features/SupportDebounce/BrowserTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportDebounce;
 
 use Livewire\Component;
+use Livewire\Features\SupportQueryString\BaseUrl;
 use Livewire\Livewire;
 use Tests\BrowserTestCase;
 
@@ -106,6 +107,118 @@ class BrowserTest extends BrowserTestCase
             ->pause(200)
             ->assertSeeIn('@slow-out', '')
             ->waitForTextIn('@slow-out', 'b', 1)
+        ;
+    }
+
+    public function test_debounce_attribute_works_on_multiple_back_forward_navigations()
+    {
+        Livewire::visit(new class extends Component {
+            #[BaseUrl(history: true)]
+            public $page = '1';
+
+            #[BaseDebounce(500)]
+            public $search = '';
+
+            public function setPage($value)
+            {
+                $this->page = $value;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <input type="text" wire:model.live="search" dusk="input" />
+                        <button dusk="page2" wire:click="setPage('2')">Page 2</button>
+                        <button dusk="page3" wire:click="setPage('3')">Page 3</button>
+                        <button dusk="page4" wire:click="setPage('4')">Page 4</button>
+                        <span dusk="output">{{ $search }}</span>
+                        <span dusk="page">{{ $page }}</span>
+                    </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->assertSeeIn('@output', '')
+            ->assertSeeIn('@page', '1')
+
+            // Initial debounce
+            ->type('@input', 'one')
+            ->pause(150)
+            ->assertSeeIn('@output', '')
+            ->waitForTextIn('@output', 'one', 1)
+
+            // Page 2 — search is still "one"; type a new value
+            ->waitForLivewire()->click('@page2')
+            ->assertSeeIn('@page', '2')
+            ->assertSeeIn('@output', 'one')
+            ->type('@input', 'two')
+            ->pause(150)
+            ->assertSeeIn('@output', 'one')
+            ->waitForTextIn('@output', 'two', 1)
+
+            // Page 3
+            ->waitForLivewire()->click('@page3')
+            ->assertSeeIn('@page', '3')
+            ->assertSeeIn('@output', 'two')
+            ->type('@input', 'three')
+            ->pause(150)
+            ->assertSeeIn('@output', 'two')
+            ->waitForTextIn('@output', 'three', 1)
+
+            // Page 4
+            ->waitForLivewire()->click('@page4')
+            ->assertSeeIn('@page', '4')
+            ->assertSeeIn('@output', 'three')
+            ->type('@input', 'four')
+            ->pause(150)
+            ->assertSeeIn('@output', 'three')
+            ->waitForTextIn('@output', 'four', 1)
+
+            // Back → page 3 (history: true required)
+            ->back()
+            ->pause(100)
+            ->assertSeeIn('@page', '3')
+            ->type('@input', 'back-three')
+            ->pause(150)
+            ->assertDontSeeIn('@output', 'back-three')
+            ->waitForTextIn('@output', 'back-three', 1)
+
+            // Back → page 2
+            ->back()
+            ->pause(100)
+            ->assertSeeIn('@page', '2')
+            ->type('@input', 'back-two')
+            ->pause(150)
+            ->assertDontSeeIn('@output', 'back-two')
+            ->waitForTextIn('@output', 'back-two', 1)
+
+            // Forward → page 3
+            ->forward()
+            ->pause(100)
+            ->assertSeeIn('@page', '3')
+            ->type('@input', 'fwd-three')
+            ->pause(150)
+            ->assertDontSeeIn('@output', 'fwd-three')
+            ->waitForTextIn('@output', 'fwd-three', 1)
+
+            // Forward → page 4
+            ->forward()
+            ->pause(100)
+            ->assertSeeIn('@page', '4')
+            ->type('@input', 'fwd-four')
+            ->pause(150)
+            ->assertDontSeeIn('@output', 'fwd-four')
+            ->waitForTextIn('@output', 'fwd-four', 1)
+
+            // Back → page 3 again
+            ->back()
+            ->pause(100)
+            ->assertSeeIn('@page', '3')
+            ->type('@input', 'final')
+            ->pause(150)
+            ->assertDontSeeIn('@output', 'final')
+            ->waitForTextIn('@output', 'final', 1)
         ;
     }
 }

--- a/src/Features/SupportDebounce/BrowserTest.php
+++ b/src/Features/SupportDebounce/BrowserTest.php
@@ -221,4 +221,53 @@ class BrowserTest extends BrowserTestCase
             ->waitForTextIn('@output', 'final', 1)
         ;
     }
+
+    public function test_debounce_attribute_works_on_form_object_property()
+    {
+        Livewire::visit(new class extends Component {
+            public SearchForm $form;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" wire:model.live="form.q" dusk="input" />
+                    <span dusk="output">{{ $form->q }}</span>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@output', '')
+            ->type('@input', 'hello')
+            ->pause(150)
+            ->assertSeeIn('@output', '')
+            ->waitForTextIn('@output', 'hello')
+        ;
+    }
+
+    public function test_blade_debounce_modifier_overrides_attribute_on_form_object()
+    {
+        Livewire::visit(new class extends Component {
+            public SearchForm $form;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" wire:model.live.debounce.100ms="form.q" dusk="input" />
+                    <span dusk="output">{{ $form->q }}</span>
+                </div>
+                HTML;
+            }
+        })
+            ->type('@input', 'fast')
+            ->waitForTextIn('@output', 'fast', 1)
+        ;
+    }
+}
+
+class SearchForm extends \Livewire\Form
+{
+    #[BaseDebounce(2000)]
+    public string $q = '';
 }

--- a/src/Features/SupportDebounce/BrowserTest.php
+++ b/src/Features/SupportDebounce/BrowserTest.php
@@ -516,8 +516,7 @@ class BrowserTest extends BrowserTestCase
         })
             ->waitForLivewireToLoad()
             ->typeSlowly('@input', 'livewire', 50)
-            ->assertSeeIn('@output', '')
-            ->waitForTextIn('@output', 'livewire', 1)
+            ->waitForTextIn('@output', 'livewire', 1) // Already passes 500ms
         ;
     }
 

--- a/src/Features/SupportDebounce/BrowserTest.php
+++ b/src/Features/SupportDebounce/BrowserTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Livewire\Features\SupportDebounce;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    function test_debounce_attribute_delays_live_model_network_update()
+    {
+        Livewire::visit(new class extends Component {
+            #[BaseDebounce(300)]
+            public $search = '';
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" wire:model.live="search" dusk="input" />
+                    <span dusk="output">{{ $search }}</span>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@output', '')
+            ->type('@input', 'hello')
+            // Before attribute debounce elapses, server property should not have updated yet
+            ->pause(100)
+            ->assertSeeIn('@output', '')
+            // After 300ms debounce + network, output should update
+            ->waitForLivewire()->pause(50)
+            ->assertSeeIn('@output', 'hello')
+        ;
+    }
+
+    function test_blade_debounce_modifier_overrides_attribute()
+    {
+        Livewire::visit(new class extends Component {
+            #[BaseDebounce(500)]
+            public $search = '';
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" wire:model.live.debounce.100ms="search" dusk="input" />
+                    <span dusk="output">{{ $search }}</span>
+                </div>
+                HTML;
+            }
+        })
+            ->type('@input', 'fast')
+            // Modifier is 100ms, not attribute 500ms
+            ->waitForLivewire()->pause(50)
+            ->assertSeeIn('@output', 'fast')
+        ;
+    }
+
+    function test_debounce_attribute_does_not_force_live_on_deferred_model()
+    {
+        Livewire::visit(new class extends Component {
+            #[BaseDebounce(50)]
+            public $search = '';
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" wire:model="search" dusk="input" />
+                    <span dusk="output">{{ $search }}</span>
+                    <button type="button" wire:click="$refresh" dusk="refresh">Refresh</button>
+                </div>
+                HTML;
+            }
+        })
+            ->type('@input', 'deferred')
+            ->pause(200)
+            // Deferred model: no network from typing alone
+            ->assertSeeIn('@output', '')
+            ->waitForLivewire()->click('@refresh')
+            ->assertSeeIn('@output', 'deferred')
+        ;
+    }
+
+    function test_only_annotated_property_uses_attribute_debounce()
+    {
+        Livewire::visit(new class extends Component {
+            #[BaseDebounce(400)]
+            public $slow = '';
+
+            public $fast = '';
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input type="text" wire:model.live="slow" dusk="slow" />
+                    <input type="text" wire:model.live="fast" dusk="fast" />
+                    <span dusk="slow-out">{{ $slow }}</span>
+                    <span dusk="fast-out">{{ $fast }}</span>
+                </div>
+                HTML;
+            }
+        })
+            ->type('@fast', 'a')
+            // Default live debounce is 150ms for text inputs
+            ->waitForLivewire()->pause(50)
+            ->assertSeeIn('@fast-out', 'a')
+            ->assertSeeIn('@slow-out', '')
+            ->type('@slow', 'b')
+            ->pause(150)
+            ->assertSeeIn('@slow-out', '')
+            ->waitForLivewire()->pause(50)
+            ->assertSeeIn('@slow-out', 'b')
+        ;
+    }
+}

--- a/src/Features/SupportDebounce/BrowserTest.php
+++ b/src/Features/SupportDebounce/BrowserTest.php
@@ -414,23 +414,35 @@ class BrowserTest extends BrowserTestCase
     {
         Livewire::visit(new class extends Component {
             #[BaseDebounce(500)]
-            public $search = '';
+            public $foo;
 
             public function render()
             {
                 return <<<'HTML'
-                <div>
-                    <input type="text" wire:model.live.throttle.50ms="search" dusk="input" />
-                    <span dusk="output">{{ $search }}</span>
+                <div x-init="window.requests = 0">
+                    <input type="text" wire:model.live.throttle.250ms="foo" dusk="input">
+                    <span wire:text="foo" dusk="text"></span>
                 </div>
+
+                @script
+                <script>
+                    this.intercept(({ onSend }) => {
+                        onSend(() => {
+                            window.requests++
+                        })
+                    })
+                </script>
+                @endscript
                 HTML;
             }
         })
             ->waitForLivewireToLoad()
-            ->typeSlowly('@input', 'livewire', 50)
-            ->assertSeeIn('@output', '')
-            ->waitForTextIn('@output', 'livewire', 1) // 1s clearly exceeds 500ms debounce duration
-        ;
+            // 300ms between keystrokes, clearly exceeds the 250ms throttle window
+            // but still below 500ms debounce duration
+            ->typeSlowly('@input', 'ab', 300)
+            ->assertSeeIn('@text', 'ab') // wire:text should update immediately
+            ->pause(300) // Wait for the trailing request to be handled
+            ->assertScript('window.requests', 1); // Requests collapse into one
     }
 
     public function test_debounces_requests_with_zero_duration()

--- a/src/Features/SupportDebounce/BrowserTest.php
+++ b/src/Features/SupportDebounce/BrowserTest.php
@@ -12,75 +12,106 @@ class BrowserTest extends BrowserTestCase
     function test_debounce_attribute_delays_live_model_network_update()
     {
         Livewire::visit(new class extends Component {
-            #[BaseDebounce(500)]
-            public $search = '';
+            #[BaseDebounce(250)]
+            public $foo = '';
 
             public function render()
             {
                 return <<<'HTML'
-                <div>
-                    <input type="text" wire:model.live="search" dusk="input" />
-                    <span dusk="output">{{ $search }}</span>
+                <div x-init="window.requests = 0">
+                    <input type="text" wire:model.live="foo" dusk="input">
+                    <span wire:text="foo" dusk="client"></span>
+                    <span dusk="server">{{ $foo }}</span>
                 </div>
+
+                @script
+                <script>
+                    this.intercept(({ onSend }) => {
+                        onSend(() => {
+                            window.requests++
+                        })
+                    })
+                </script>
+                @endscript
                 HTML;
             }
         })
             ->waitForLivewireToLoad()
-            ->assertSeeIn('@output', '')
-            ->type('@input', 'hello')
-            ->pause(150)
-            ->assertSeeIn('@output', '')
-            ->waitForTextIn('@output', 'hello', 1)
-        ;
+            ->typeSlowly('@input', 'livewire', 50)
+            ->assertSeeIn('@client', 'livewire') // wire:text should update immediately
+            ->pause(300) // Wait for requests to be handled
+            ->assertSeeIn('@server', 'livewire') // server value should be updated
+            ->assertScript('window.requests', 1); 
     }
 
     function test_blade_debounce_modifier_overrides_attribute()
     {
         Livewire::visit(new class extends Component {
-            #[BaseDebounce(2000)]
-            public $search = '';
+            #[BaseDebounce(1000)]
+            public $foo = '';
 
             public function render()
             {
                 return <<<'HTML'
-                <div>
-                    <input type="text" wire:model.live.debounce.100ms="search" dusk="input" />
-                    <span dusk="output">{{ $search }}</span>
+                <div x-init="window.requests = 0">
+                    <input type="text" wire:model.live.debounce.250ms="foo" dusk="input">
+                    <span wire:text="foo" dusk="client"></span>
+                    <span dusk="server">{{ $foo }}</span>
                 </div>
+
+                @script
+                <script>
+                    this.intercept(({ onSend }) => {
+                        onSend(() => {
+                            window.requests++
+                        })
+                    })
+                </script>
+                @endscript
                 HTML;
             }
         })
             ->waitForLivewireToLoad()
-            ->type('@input', 'fast')
-            // Modifier 100ms must win over attribute 2000ms
-            ->waitForTextIn('@output', 'fast', 1)
-        ;
+            ->typeSlowly('@input', 'livewire', 50)
+            ->assertSeeIn('@client', 'livewire') // wire:text should update immediately
+            ->pause(300) // Wait for requests to be handled
+            ->assertSeeIn('@server', 'livewire') // server value should be updated
+            ->assertScript('window.requests', 1); 
     }
 
     function test_debounce_attribute_does_not_force_live_on_deferred_model()
     {
         Livewire::visit(new class extends Component {
-            #[BaseDebounce]
-            public $search = '';
+            #[BaseDebounce(250)]
+            public $foo = '';
 
             public function render()
             {
                 return <<<'HTML'
-                <div>
-                    <input type="text" wire:model="search" dusk="input" />
-                    <span dusk="output">{{ $search }}</span>
-                    <button type="button" wire:click="$refresh" dusk="refresh">Refresh</button>
+                <div x-init="window.requests = 0">
+                    <input type="text" wire:model="foo" dusk="input">
+                    <span wire:text="foo" dusk="client"></span>
+                    <span dusk="server">{{ $foo }}</span>
                 </div>
+
+                @script
+                <script>
+                    this.intercept(({ onSend }) => {
+                        onSend(() => {
+                            window.requests++
+                        })
+                    })
+                </script>
+                @endscript
                 HTML;
             }
         })
             ->waitForLivewireToLoad()
-            ->type('@input', 'deferred')
-            ->pause(200)
-            ->assertSeeIn('@output', '')
-            ->waitForLivewire()->click('@refresh')
-            ->assertSeeIn('@output', 'deferred')
-        ;
+            ->typeSlowly('@input', 'livewire', 50)
+            ->assertSeeIn('@client', 'livewire') // wire:text should update immediately
+            ->pause(300) // Wait for requests to be handled
+            ->assertSeeIn('@server', '') // server value should not updated
+            ->assertScript('window.requests', 0); 
     }
 
     function test_only_annotated_property_uses_attribute_debounce()
@@ -104,13 +135,13 @@ class BrowserTest extends BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
-            ->type('@fast', 'a')
-            ->waitForTextIn('@fast-out', 'a', 1)
+            ->typeSlowly('@fast', 'livewire', 50)
+            ->pause(300)
+            ->assertSeeIn('@fast-out', 'livewire')
             ->assertSeeIn('@slow-out', '')
-            ->type('@slow', 'b')
-            ->pause(200)
+            ->typeSlowly('@slow', 'livewire', 50)
             ->assertSeeIn('@slow-out', '')
-            ->waitForTextIn('@slow-out', 'b', 1)
+            ->waitForTextIn('@slow-out', 'livewire', 1)
         ;
     }
 
@@ -242,11 +273,10 @@ class BrowserTest extends BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
+            ->typeSlowly('@input', 'livewire', 50)
             ->assertSeeIn('@output', '')
-            ->type('@input', 'hello')
-            ->pause(150)
-            ->assertSeeIn('@output', '')
-            ->waitForTextIn('@output', 'hello')
+            ->pause(300)
+            ->waitForTextIn('@output', 'livewire')
         ;
     }
 
@@ -266,8 +296,9 @@ class BrowserTest extends BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
-            ->type('@input', 'fast')
-            ->waitForTextIn('@output', 'fast', 1)
+            ->typeSlowly('@input', 'livewire', 50)
+            ->pause(300)
+            ->assertSeeIn('@output', 'livewire')
         ;
     }
 
@@ -289,11 +320,11 @@ class BrowserTest extends BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
-            ->type('@input', 'hello')
-            ->pause(50)
+            ->typeSlowly('@input', 'livewire', 50)
+            ->pause(300)
             ->assertSeeIn('@output', '')
             ->waitForLivewire()->click('@blur-target')
-            ->assertSeeIn('@output', 'hello')
+            ->assertSeeIn('@output', 'livewire')
         ;
     }
 
@@ -315,11 +346,11 @@ class BrowserTest extends BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
-            ->type('@input', 'hello')
-            ->pause(50)
+            ->typeSlowly('@input', 'livewire', 50)
+            ->pause(300)
             ->assertSeeIn('@output', '')
             ->waitForLivewire()->click('@blur-target')
-            ->assertSeeIn('@output', 'hello')
+            ->assertSeeIn('@output', 'livewire')
         ;
     }
 
@@ -341,16 +372,16 @@ class BrowserTest extends BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
-            ->type('@input', 'hello')
-            ->pause(50)
+            ->typeSlowly('@input', 'livewire', 50)
+            ->pause(300)
             ->assertSeeIn('@output', '')
             // Blur alone must not commit (enter is the network trigger)
             ->click('@blur-target')
-            ->pause(200)
+            ->pause(300)
             ->assertSeeIn('@output', '')
             ->click('@input')
             ->waitForLivewire()->keys('@input', '{enter}')
-            ->assertSeeIn('@output', 'hello')
+            ->assertSeeIn('@output', 'livewire')
         ;
     }
 
@@ -373,11 +404,11 @@ class BrowserTest extends BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
-            ->type('@input', 'hello')
-            ->pause(50)
+            ->typeSlowly('@input', 'livewire', 50)
+            ->pause(300)
             ->assertSeeIn('@output', '')
             ->waitForLivewire()->click('@blur-target')
-            ->assertSeeIn('@output', 'hello')
+            ->assertSeeIn('@output', 'livewire')
         ;
     }
 
@@ -398,11 +429,43 @@ class BrowserTest extends BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
-            ->type('@input', 'fast')
-            ->pause(150)
+            ->typeSlowly('@input', 'livewire', 50)
             ->assertSeeIn('@output', '')
-            ->waitForTextIn('@output', 'fast', 1)
+            ->waitForTextIn('@output', 'livewire', 1)
         ;
+    }
+
+    public function test_debounces_requests_with_zero_duration()
+    {
+        Livewire::visit(new class extends Component {
+            #[BaseDebounce(0)]
+            public $foo;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div x-init="window.requests = 0">
+                    <input type="text" wire:model.live="foo" dusk="input">
+                    <span wire:text="foo" dusk="text"></span>
+                </div>
+
+                @script
+                <script>
+                    this.intercept(({ onSend }) => {
+                        onSend(() => {
+                            window.requests++
+                        })
+                    })
+                </script>
+                @endscript
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->typeSlowly('@input', 'ab', 50)
+            ->assertSeeIn('@text', 'ab') // wire:text should update immediately
+            ->pause(300) // Wait for requests to be handled
+            ->assertScript('window.requests', 2); // 0ms must not collapse like the default 150ms
     }
 
     public function test_debounce_modifier_on_blur_live_uses_explicit_duration_not_attribute()
@@ -425,13 +488,13 @@ class BrowserTest extends BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
-            ->type('@input', 'hello')
-            ->pause(50)
+            ->typeSlowly('@input', 'livewire', 50)
             ->assertSeeIn('@output', '')
             ->click('@blur-target')
-            ->pause(50)
-            ->assertSeeIn('@output', '')              // still inside 100ms debounce
-            ->waitForTextIn('@output', 'hello', 1)    // not waiting for attribute 2000ms
+            ->pause(50)    // still debounced
+            ->assertSeeIn('@output', '')
+            ->pause(300)    // already pass debounce duration
+            ->assertSeeIn('@output', 'livewire')
         ;
     }
 
@@ -452,11 +515,9 @@ class BrowserTest extends BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
+            ->typeSlowly('@input', 'livewire', 50)
             ->assertSeeIn('@output', '')
-            ->type('@input', 'nested')
-            ->pause(150)
-            ->assertSeeIn('@output', '')
-            ->waitForTextIn('@output', 'nested', 1)
+            ->waitForTextIn('@output', 'livewire', 1)
         ;
     }
 
@@ -489,9 +550,7 @@ class BrowserTest extends BrowserTestCase
             },
         ])
             ->waitForLivewireToLoad()
-            ->assertSeeIn('@output', '')
-            ->type('@input', 'from-child')
-            ->pause(150)
+            ->typeSlowly('@input', 'from-child', 50)
             ->assertSeeIn('@output', '')
             ->waitForTextIn('@output', 'from-child', 1)
         ;

--- a/src/Features/SupportDebounce/BrowserTest.php
+++ b/src/Features/SupportDebounce/BrowserTest.php
@@ -11,7 +11,7 @@ class BrowserTest extends BrowserTestCase
     function test_debounce_attribute_delays_live_model_network_update()
     {
         Livewire::visit(new class extends Component {
-            #[BaseDebounce(300)]
+            #[BaseDebounce(500)]
             public $search = '';
 
             public function render()
@@ -26,19 +26,16 @@ class BrowserTest extends BrowserTestCase
         })
             ->assertSeeIn('@output', '')
             ->type('@input', 'hello')
-            // Before attribute debounce elapses, server property should not have updated yet
-            ->pause(100)
+            ->pause(150)
             ->assertSeeIn('@output', '')
-            // After 300ms debounce + network, output should update
-            ->waitForLivewire()->pause(50)
-            ->assertSeeIn('@output', 'hello')
+            ->waitForTextIn('@output', 'hello', 1)
         ;
     }
 
     function test_blade_debounce_modifier_overrides_attribute()
     {
         Livewire::visit(new class extends Component {
-            #[BaseDebounce(500)]
+            #[BaseDebounce(2000)]
             public $search = '';
 
             public function render()
@@ -52,16 +49,15 @@ class BrowserTest extends BrowserTestCase
             }
         })
             ->type('@input', 'fast')
-            // Modifier is 100ms, not attribute 500ms
-            ->waitForLivewire()->pause(50)
-            ->assertSeeIn('@output', 'fast')
+            // Modifier 100ms must win over attribute 2000ms
+            ->waitForTextIn('@output', 'fast', 1)
         ;
     }
 
     function test_debounce_attribute_does_not_force_live_on_deferred_model()
     {
         Livewire::visit(new class extends Component {
-            #[BaseDebounce(50)]
+            #[BaseDebounce]
             public $search = '';
 
             public function render()
@@ -77,7 +73,6 @@ class BrowserTest extends BrowserTestCase
         })
             ->type('@input', 'deferred')
             ->pause(200)
-            // Deferred model: no network from typing alone
             ->assertSeeIn('@output', '')
             ->waitForLivewire()->click('@refresh')
             ->assertSeeIn('@output', 'deferred')
@@ -87,7 +82,7 @@ class BrowserTest extends BrowserTestCase
     function test_only_annotated_property_uses_attribute_debounce()
     {
         Livewire::visit(new class extends Component {
-            #[BaseDebounce(400)]
+            #[BaseDebounce(800)]
             public $slow = '';
 
             public $fast = '';
@@ -105,15 +100,12 @@ class BrowserTest extends BrowserTestCase
             }
         })
             ->type('@fast', 'a')
-            // Default live debounce is 150ms for text inputs
-            ->waitForLivewire()->pause(50)
-            ->assertSeeIn('@fast-out', 'a')
+            ->waitForTextIn('@fast-out', 'a', 1)
             ->assertSeeIn('@slow-out', '')
             ->type('@slow', 'b')
-            ->pause(150)
+            ->pause(200)
             ->assertSeeIn('@slow-out', '')
-            ->waitForLivewire()->pause(50)
-            ->assertSeeIn('@slow-out', 'b')
+            ->waitForTextIn('@slow-out', 'b', 1)
         ;
     }
 }

--- a/src/Features/SupportDebounce/UnitTest.php
+++ b/src/Features/SupportDebounce/UnitTest.php
@@ -15,7 +15,6 @@ class UnitTest extends TestCase
             public $search = '';
         });
 
-        $this->assertTrue(isset($component->effects['debounce']));
         $this->assertSame(250, $component->effects['debounce']['search']);
     }
 
@@ -47,6 +46,16 @@ class UnitTest extends TestCase
         });
 
         $this->assertSame(500, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_falls_back_to_150_for_non_numeric_string()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce('fast')]
+            public $search = '';
+        });
+
+        $this->assertSame(150, $component->effects['debounce']['search']);
     }
 
     function test_debounce_effect_only_includes_annotated_properties()
@@ -88,16 +97,11 @@ class UnitTest extends TestCase
             }
         });
 
-        $this->assertTrue(isset($component->effects['debounce']));
+        $this->assertSame(250, $component->effects['debounce']['search']);
 
         $component->call('updateSearch', 'foo');
 
-        // Subsequent dehydrations are not mounting; effect should not be present again
-        // (matches BaseUrl: if (! $context->mounting) return;)
-        $this->assertTrue(
-            ! isset($component->effects['debounce'])
-            || $component->effects['debounce'] === []
-            || ! array_key_exists('search', $component->effects['debounce'] ?? [])
-        );
+        // Mount-only dehydrate (same contract as BaseUrl): effect must not reappear
+        $this->assertArrayNotHasKey('search', $component->effects['debounce'] ?? []);
     }
 }

--- a/src/Features/SupportDebounce/UnitTest.php
+++ b/src/Features/SupportDebounce/UnitTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Livewire\Features\SupportDebounce;
+
+use Livewire\Livewire;
+use Tests\TestCase;
+use Tests\TestComponent;
+
+class UnitTest extends TestCase
+{
+    function test_can_push_debounce_effect_for_property()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce(250)]
+            public $search = '';
+        });
+
+        $this->assertTrue(isset($component->effects['debounce']));
+        $this->assertSame(250, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_defaults_to_150_when_no_time_given()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce]
+            public $search = '';
+        });
+
+        $this->assertSame(150, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_normalizes_ms_string()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce('300ms')]
+            public $search = '';
+        });
+
+        $this->assertSame(300, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_normalizes_seconds_string()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce('0.5s')]
+            public $search = '';
+        });
+
+        $this->assertSame(500, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_only_includes_annotated_properties()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce(200)]
+            public $search = '';
+
+            public $other = '';
+        });
+
+        $this->assertArrayHasKey('search', $component->effects['debounce']);
+        $this->assertArrayNotHasKey('other', $component->effects['debounce']);
+    }
+
+    function test_multiple_properties_can_have_different_debounce_times()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce(200)]
+            public $search = '';
+
+            #[BaseDebounce(500)]
+            public $filter = '';
+        });
+
+        $this->assertSame(200, $component->effects['debounce']['search']);
+        $this->assertSame(500, $component->effects['debounce']['filter']);
+    }
+
+    function test_debounce_effect_is_not_re_pushed_on_subsequent_request()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce(250)]
+            public $search = '';
+
+            public function updateSearch($value)
+            {
+                $this->search = $value;
+            }
+        });
+
+        $this->assertTrue(isset($component->effects['debounce']));
+
+        $component->call('updateSearch', 'foo');
+
+        // Subsequent dehydrations are not mounting; effect should not be present again
+        // (matches BaseUrl: if (! $context->mounting) return;)
+        $this->assertTrue(
+            ! isset($component->effects['debounce'])
+            || $component->effects['debounce'] === []
+            || ! array_key_exists('search', $component->effects['debounce'] ?? [])
+        );
+    }
+}

--- a/src/Features/SupportDebounce/UnitTest.php
+++ b/src/Features/SupportDebounce/UnitTest.php
@@ -104,4 +104,131 @@ class UnitTest extends TestCase
         // Mount-only dehydrate (same contract as BaseUrl): effect must not reappear
         $this->assertArrayNotHasKey('search', $component->effects['debounce'] ?? []);
     }
+
+    function test_debounce_effect_allows_duration_below_default()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce(50)]
+            public $search = '';
+        });
+
+        $this->assertSame(50, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_allows_zero_duration()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce(0)]
+            public $search = '';
+        });
+
+        $this->assertSame(0, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_clamps_negative_int_to_zero()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce(-100)]
+            public $search = '';
+        });
+
+        $this->assertSame(0, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_allows_zero_ms_string()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce('0ms')]
+            public $search = '';
+        });
+
+        $this->assertSame(0, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_allows_sub_default_ms_string()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce('50ms')]
+            public $search = '';
+        });
+
+        $this->assertSame(50, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_normalizes_whole_seconds_string()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce('2s')]
+            public $search = '';
+        });
+
+        $this->assertSame(2000, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_normalizes_bare_numeric_string_as_ms()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce('250')]
+            public $search = '';
+        });
+
+        $this->assertSame(250, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_falls_back_to_150_for_empty_string()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce('')]
+            public $search = '';
+        });
+
+        $this->assertSame(150, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_falls_back_to_150_for_ms_without_number()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce('ms')]
+            public $search = '';
+        });
+
+        $this->assertSame(150, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_is_case_insensitive_for_units()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce('300MS')]
+            public $search = '';
+        });
+
+        $this->assertSame(300, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_trims_whitespace_in_string_duration()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            #[BaseDebounce('  400ms  ')]
+            public $search = '';
+        });
+
+        $this->assertSame(400, $component->effects['debounce']['search']);
+    }
+
+    function test_debounce_effect_on_form_object_uses_dotted_property_name()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public SearchFrom $form;
+        });
+
+        // getName() for form properties is "form.q" — same key JS looks up
+        $this->assertSame(2000, $component->effects['debounce']['form.q']);
+        $this->assertArrayNotHasKey('q', $component->effects['debounce']);
+    }
+}
+
+class SearchFrom extends \Livewire\Form
+{
+    #[BaseDebounce(2000)]
+    public string $q = '';
 }


### PR DESCRIPTION
# Summary

Adds a `#[Debounce]` PHP attribute so a property can declare its network debounce duration without requiring `.debounce.Xms` on every `wire:model.live` binding in Blade.

### Before

```blade
<input wire:model.live.debounce.250ms="search">
```

### After

```php
#[Debounce(250)]
public string $search = '';
```
```blade
<input wire:model.live="search">
```

Omitting the duration uses Livewire’s existing default of `150ms`:

```php
#[Debounce]
public string $search = '';
```

# Behaviour

| Blade | Attribute on property | Network timing |
| - | - | - |
| `wire:model.live="search"` | `#[Debounce]` | 150ms (default) |
| `wire:model.live="search"` | none | 150ms (default) |
| `wire:model.live="search"` | `#[Debounce(250)]` | 250ms (from attribute) |
| `wire:model.live.debounce.500ms="search"` | `#[Debounce(250)]` | 500ms (Blade modifier wins) |
| `wire:model="search"` | `#[Debounce(250)]` | still deferred — attribute does not force `.live` |

The attribute only supplies the debounce duration. It does not change whether a network request is sent. Users still need `.live` (or another network trigger) when they want live updates.
When both the attribute and a Blade `.debounce.Xms` modifier are present, the Blade modifier takes precedence so a template can override the property default without removing the attribute.

# What's Changed
- Feature class: `src/Features/SupportDebounce/BaseDebounce.php`
- Public alias: `src/Attributes/Debounce.php`
- Modify debounce duration if provided: `js/directives/wire-model.js`
- Inscribe debounce effects if provided when navigating: `js/component.js`