### PR TITLE
[4.x] Use null coalescing instead logical `OR` in `wire-model.js` debounce and throttle duration

### DIFF
--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -242,7 +242,7 @@ function parseModifierDuration(modifiers, key) {
     if (index === -1) return undefined
 
     let nextModifier = modifiers[modifiers.indexOf(key)+1] || 'invalid-wait'
-    let duration = nextModifier.split('ms')[0]
+    let duration = parseInt(nextModifier.split('ms')[0], 10)
 
     return ! isNaN(duration) ? duration : undefined
 }

--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -90,7 +90,7 @@ directive('model', ({ el, directive, component, cleanup }) => {
     }
 
     if (isThrottled) {
-        debouncedUpdate = throttle(debouncedUpdate, parseModifierDuration(networkModifiers, 'throttle') || 150)
+        debouncedUpdate = throttle(debouncedUpdate, parseModifierDuration(networkModifiers, 'throttle') ?? 150)
     }
 
     // Build the bindings object
@@ -244,5 +244,5 @@ function parseModifierDuration(modifiers, key) {
     let nextModifier = modifiers[modifiers.indexOf(key)+1] || 'invalid-wait'
     let duration = nextModifier.split('ms')[0]
 
-    return ! isNaN(duration) ? duration : undefined
+    return ! isNaN(duration) ? parseInt(duration) : undefined
 }

--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -242,7 +242,7 @@ function parseModifierDuration(modifiers, key) {
     if (index === -1) return undefined
 
     let nextModifier = modifiers[modifiers.indexOf(key)+1] || 'invalid-wait'
-    let duration = parseInt(nextModifier.split('ms')[0], 10)
+    let duration = nextModifier.split('ms')[0]
 
-    return ! isNaN(duration) ? duration : undefined
+    return ! isNaN(duration) ? Number(duration) : undefined
 }

--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -242,7 +242,7 @@ function parseModifierDuration(modifiers, key) {
     if (index === -1) return undefined
 
     let nextModifier = modifiers[modifiers.indexOf(key)+1] || 'invalid-wait'
-    let duration = nextModifier.split('ms')[0]
+    let duration = parseInt(nextModifier.split('ms')[0], 10)
 
-    return ! isNaN(duration) ? parseInt(duration) : undefined
+    return ! isNaN(duration) ? duration : undefined
 }

--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -86,7 +86,7 @@ directive('model', ({ el, directive, component, cleanup }) => {
 
     // Apply debounce/throttle from network modifiers
     if ((shouldSendNetwork && ! hasNetworkTriggers && isRealtimeInput(el) && ! isDebounced && ! isThrottled) || isDebounced) {
-        debouncedUpdate = debounce(debouncedUpdate, parseModifierDuration(networkModifiers, 'debounce') || 150)
+        debouncedUpdate = debounce(debouncedUpdate, parseModifierDuration(networkModifiers, 'debounce') ?? 150)
     }
 
     if (isThrottled) {

--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -242,7 +242,7 @@ function parseModifierDuration(modifiers, key) {
     if (index === -1) return undefined
 
     let nextModifier = modifiers[modifiers.indexOf(key)+1] || 'invalid-wait'
-    let duration = parseInt(nextModifier.split('ms')[0], 10)
+    let duration = nextModifier.split('ms')[0]
 
     return ! isNaN(duration) ? duration : undefined
 }

--- a/src/Tests/WireModelBrowserTest.php
+++ b/src/Tests/WireModelBrowserTest.php
@@ -142,10 +142,11 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
-            ->typeSlowly('@input', 'ab') // Default 100ms between keystrokes, clearly exceeds the 0ms debounce duration
-            ->assertSeeIn('@text', 'ab') // wire:text should update immediately
-            ->pause(300) // Wait for the request to be handled
-            ->assertScript('window.requests', 2); // Should be eight requests sent (length of 'livewire')
+            ->type('@input', 'a')
+            ->assertSeeIn('@text', 'a') // wire:text should update immediately
+            ->pause(50) // Wait for request to be handled
+            // Under default 150ms: a false fallback would still have requests === 0 here
+            ->assertScript('window.requests', 1);
     }
 
     public function test_debounces_requests_with_custom_duration()

--- a/src/Tests/WireModelBrowserTest.php
+++ b/src/Tests/WireModelBrowserTest.php
@@ -116,6 +116,38 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             ->assertScript('window.requests', 1); // Only one request was sent
     }
 
+    public function test_debounces_requests_with_zero_duration()
+    {
+        Livewire::visit(new class extends Component {
+            public $foo;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div x-init="window.requests = 0">
+                    <input type="text" wire:model.live.debounce.0ms="foo" dusk="input">
+                    <span wire:text="foo" dusk="text"></span>
+                </div>
+
+                @script
+                <script>
+                    this.intercept(({ onSend }) => {
+                        onSend(() => {
+                            window.requests++
+                        })
+                    })
+                </script>
+                @endscript
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->typeSlowly('@input', 'livewire', 50)
+            ->assertSeeIn('@text', 'livewire') // wire:text should update immediately
+            ->pause(200) // Wait for requests to be handled
+            ->assertScript('window.requests > 1'); // 0ms must not collapse like the default 150ms
+    }
+
     public function test_debounces_requests_with_custom_duration()
     {
         Livewire::visit(new class extends Component {

--- a/src/Tests/WireModelBrowserTest.php
+++ b/src/Tests/WireModelBrowserTest.php
@@ -180,11 +180,7 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             ->assertScript('window.requests', 1); // Only one request was sent
     }
 
-<<<<<<< HEAD
     public function test_pure_throttles_requests_not_auto_debounced_from_live_modifier()
-=======
-    public function test_throttle_requests_with_zero_duration_modifier_is_honored()
->>>>>>> 604fe983 (Add debounce and throttle with zero duration browser tests)
     {
         Livewire::visit(new class extends Component {
             public $foo;
@@ -193,11 +189,7 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             {
                 return <<<'HTML'
                 <div x-init="window.requests = 0">
-<<<<<<< HEAD
                     <input type="text" wire:model.live.throttle.30ms="foo" dusk="input">
-=======
-                    <input type="text" wire:model.live.throttle.0ms="foo" dusk="input">
->>>>>>> 604fe983 (Add debounce and throttle with zero duration browser tests)
                     <span wire:text="foo" dusk="text"></span>
                 </div>
 
@@ -214,18 +206,11 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
-<<<<<<< HEAD
             ->typeSlowly('@input', 'ab', 50)
             ->assertSeeIn('@text', 'ab') // wire:text should update immediately
             ->pause(300) // Wait for the trailing request to be handled
             // The requests will collapse into one if `.live` auto debounced applied
             ->assertScript('window.requests', 2);
-=======
-            ->typeSlowly('@input', 'ab') // Default 100ms between keystrokes, clearly exceeds the 0ms throttle window
-            ->assertSeeIn('@text', 'ab') // wire:text should update immediately
-            ->pause(300) // Wait for the trailing request to be handled
-            ->assertScript('window.requests', 2); // Two requests: one per throttle window
->>>>>>> 604fe983 (Add debounce and throttle with zero duration browser tests)
     }
 
     public function test_throttles_requests_with_custom_duration()

--- a/src/Tests/WireModelBrowserTest.php
+++ b/src/Tests/WireModelBrowserTest.php
@@ -116,38 +116,6 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             ->assertScript('window.requests', 1); // Only one request was sent
     }
 
-    public function test_debounces_requests_with_zero_duration()
-    {
-        Livewire::visit(new class extends Component {
-            public $foo;
-
-            public function render()
-            {
-                return <<<'HTML'
-                <div x-init="window.requests = 0">
-                    <input type="text" wire:model.live.debounce.0ms="foo" dusk="input">
-                    <span wire:text="foo" dusk="text"></span>
-                </div>
-
-                @script
-                <script>
-                    this.intercept(({ onSend }) => {
-                        onSend(() => {
-                            window.requests++
-                        })
-                    })
-                </script>
-                @endscript
-                HTML;
-            }
-        })
-            ->waitForLivewireToLoad()
-            ->typeSlowly('@input', 'livewire', 50)
-            ->assertSeeIn('@text', 'livewire') // wire:text should update immediately
-            ->pause(200) // Wait for requests to be handled
-            ->assertScript('window.requests > 1'); // 0ms must not collapse like the default 150ms
-    }
-
     public function test_debounces_requests_with_custom_duration()
     {
         Livewire::visit(new class extends Component {

--- a/src/Tests/WireModelBrowserTest.php
+++ b/src/Tests/WireModelBrowserTest.php
@@ -116,6 +116,38 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             ->assertScript('window.requests', 1); // Only one request was sent
     }
 
+    public function test_debounce_requests_with_zero_duration_modifier_is_honored()
+    {
+        Livewire::visit(new class extends Component {
+            public $foo;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div x-init="window.requests = 0">
+                    <input type="text" wire:model.live.debounce.0ms="foo" dusk="input">
+                    <span wire:text="foo" dusk="text"></span>
+                </div>
+
+                @script
+                <script>
+                    this.intercept(({ onSend }) => {
+                        onSend(() => {
+                            window.requests++
+                        })
+                    })
+                </script>
+                @endscript
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->typeSlowly('@input', 'ab') // Default 100ms between keystrokes, clearly exceeds the 0ms debounce duration
+            ->assertSeeIn('@text', 'ab') // wire:text should update immediately
+            ->pause(300) // Wait for the request to be handled
+            ->assertScript('window.requests', 2); // Should be eight requests sent (length of 'livewire')
+    }
+
     public function test_debounces_requests_with_custom_duration()
     {
         Livewire::visit(new class extends Component {
@@ -148,7 +180,11 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             ->assertScript('window.requests', 1); // Only one request was sent
     }
 
+<<<<<<< HEAD
     public function test_pure_throttles_requests_not_auto_debounced_from_live_modifier()
+=======
+    public function test_throttle_requests_with_zero_duration_modifier_is_honored()
+>>>>>>> 604fe983 (Add debounce and throttle with zero duration browser tests)
     {
         Livewire::visit(new class extends Component {
             public $foo;
@@ -157,7 +193,11 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             {
                 return <<<'HTML'
                 <div x-init="window.requests = 0">
+<<<<<<< HEAD
                     <input type="text" wire:model.live.throttle.30ms="foo" dusk="input">
+=======
+                    <input type="text" wire:model.live.throttle.0ms="foo" dusk="input">
+>>>>>>> 604fe983 (Add debounce and throttle with zero duration browser tests)
                     <span wire:text="foo" dusk="text"></span>
                 </div>
 
@@ -174,11 +214,18 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
+<<<<<<< HEAD
             ->typeSlowly('@input', 'ab', 50)
             ->assertSeeIn('@text', 'ab') // wire:text should update immediately
             ->pause(300) // Wait for the trailing request to be handled
             // The requests will collapse into one if `.live` auto debounced applied
             ->assertScript('window.requests', 2);
+=======
+            ->typeSlowly('@input', 'ab') // Default 100ms between keystrokes, clearly exceeds the 0ms throttle window
+            ->assertSeeIn('@text', 'ab') // wire:text should update immediately
+            ->pause(300) // Wait for the trailing request to be handled
+            ->assertScript('window.requests', 2); // Two requests: one per throttle window
+>>>>>>> 604fe983 (Add debounce and throttle with zero duration browser tests)
     }
 
     public function test_throttles_requests_with_custom_duration()


### PR DESCRIPTION
## Summary
Improve correctness and precision of debounce/throttle duration parsing in `wire-model.js` align with how alpine parse the duration modifer

## Problem
`parseModifierDuration()` currently returns a string (e.g. `"150"`) or `undefined`.
That value is then used like this:

```js
debounce(..., parseModifierDuration(...) || 150)
throttle(..., parseModifierDuration(...) || 150)
```

Two issues arise:

1. **String** → **number** coercion – `setTimeout` receives a string and must coerce it. While browsers handle this, it is unnecessary and slightly imprecise.
2. **Zero is treated as falsy** – A legitimate duration that forces to integer `0` is currently ignored and falls back to the default `150`. Zero is a valid and useful value (“no artificial delay”).

## Solution
- Parse the duration to an integer with `Number(duration)` so the function returns a proper number (or `undefined`).
- Replace the logical OR (`||`) with nullish coalescing (`??`) so only `null`/`undefined` trigger the 150 ms default.
Integer `0` is now correctly honored.

```js
// before
parseModifierDuration(...) || 150

// after
parseModifierDuration(...) ?? 150
```