### PR TITLE
[4.x] Fix `parseModifierDuration` in `wire-model.js` returns string number insead integer

### DIFF
--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -263,8 +263,8 @@ function parseModifierDuration(modifiers, key) {
     let index = modifiers.indexOf(key)
     if (index === -1) return undefined
 
-    let nextModifier = modifiers[modifiers.indexOf(key)+1] || 'invalid-wait'
-    let duration = nextModifier.split('ms')[0]
+    let nextModifier = modifiers[index + 1] || 'invalid-wait'
+    let duration = parseInt(nextModifier.split('ms')[0], 10)
 
     return ! isNaN(duration) ? duration : undefined
 }

--- a/src/Tests/WireModelBrowserTest.php
+++ b/src/Tests/WireModelBrowserTest.php
@@ -148,6 +148,42 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             ->assertScript('window.requests', 1); // Only one request was sent
     }
 
+    public function test_debounce_attribute_zero_duration_is_ignored()
+    {
+        Livewire::visit(new class extends Component {
+            public $foo;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div x-init="window.requests = 0">
+                    <input type="text" wire:model.live.debounce.0ms="foo" dusk="input">
+                    <span wire:text="foo" dusk="text"></span>
+                </div>
+
+                @script
+                <script>
+                    this.intercept(({ onSend }) => {
+                        onSend(() => {
+                            window.requests++
+                        })
+                    })
+                </script>
+                @endscript
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->typeSlowly('@input', 'livewire', 30)
+            ->assertSeeIn('@text', 'livewire') // wire:text should update immediately
+            ->pause(300) // Wait for the request to be handled
+
+            // Originally, '0' will be used as debounce duration so this will fails
+            // When `parseModifierDuration()` returns integer 0, this will passes
+            // because its will fallback to 150ms debounce duration, not 0
+            ->assertScript('window.requests', 1);
+    }
+
     public function test_throttles_requests_with_custom_duration()
     {
         Livewire::visit(new class extends Component {

--- a/src/Tests/WireModelBrowserTest.php
+++ b/src/Tests/WireModelBrowserTest.php
@@ -148,7 +148,7 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             ->assertScript('window.requests', 1); // Only one request was sent
     }
 
-    public function test_debounce_attribute_zero_duration_is_ignored()
+    public function test_debounce_requests_with_zero_duration_modifier_is_ignored()
     {
         Livewire::visit(new class extends Component {
             public $foo;

--- a/src/Tests/WireModelBrowserTest.php
+++ b/src/Tests/WireModelBrowserTest.php
@@ -148,7 +148,7 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             ->assertScript('window.requests', 1); // Only one request was sent
     }
 
-    public function test_debounce_requests_with_zero_duration_modifier_is_ignored()
+    public function test_debounce_requests_with_zero_duration_modifier_is_honored()
     {
         Livewire::visit(new class extends Component {
             public $foo;
@@ -174,14 +174,10 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             }
         })
             ->waitForLivewireToLoad()
-            ->typeSlowly('@input', 'livewire', 30)
-            ->assertSeeIn('@text', 'livewire') // wire:text should update immediately
+            ->typeSlowly('@input', 'ab', 50)
+            ->assertSeeIn('@text', 'ab') // wire:text should update immediately
             ->pause(300) // Wait for the request to be handled
-
-            // Originally, '0' will be used as debounce duration so this will fails
-            // When `parseModifierDuration()` returns integer 0, this will passes
-            // because its will fallback to 150ms debounce duration, not 0
-            ->assertScript('window.requests', 1);
+            ->assertScript('window.requests', 2); // Should be two requests sent
     }
 
     public function test_throttles_requests_with_custom_duration()


### PR DESCRIPTION
## Summary
In `wire-model.js`, function `parseModifierDuration` returns string number or `undefined` eventhough `setTimeout` expect non-negative integer as delay.

From [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout)
> If the value isn't a number, implicit [type coercion](https://developer.mozilla.org/en-US/docs/Glossary/Type_coercion) is silently done on the value to convert it to a number. This can lead to unexpected and surprising results — see [Non-number delay values are silently coerced into numbers](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#non-number_delay_values_are_silently_coerced_into_numbers) for an example.

## Solution
Since `setTimeout` expect non-negative integer as argument, it would make more sense to provide an integer instead string number. In `parseModifierDuration`, parse the duration before checking

```js
function parseModifierDuration(modifiers, key) {
    let index = modifiers.indexOf(key)
    if (index === -1) return undefined

    let nextModifier = modifiers[index + 1] || 'invalid-wait'
    let duration = parseInt(nextModifier.split('ms')[0], 10)

    return ! isNaN(duration) ? duration : undefined
}
```

In addition use existing `index` instead repeating `modifiers.indexOf(key)`