### PR TITLE
[4.x] Fix single-file component detection when a PHP attribute has an array argument

### DIFF
--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -395,7 +395,7 @@ class Finder
         // Light touch check: Look for the pattern that indicates an SFC
         // Pattern: <?php followed by 'new class' (with potential attributes/newlines between)
         // This distinguishes SFCs from regular Blade views
-        return preg_match('/\<\?php.*\bnew\s+(?:#\[[^\]]*\]\s*)*class\b/s', $contents) === 1;
+        return preg_match('/\<\?php.*\bnew\s+(?:#\[(?:[^\[\]]|\[[^\[\]]*\])*\]\s*)*class\b/s', $contents) === 1;
     }
 
     protected function hasValidMultiFileComponentSource(string $dir, string $fileBaseName): bool

--- a/src/Finder/Fixtures/single-file-component-with-array-argument-php-attribute.blade.php
+++ b/src/Finder/Fixtures/single-file-component-with-array-argument-php-attribute.blade.php
@@ -1,0 +1,14 @@
+<?php
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+new
+#[Layout('layouts.app', ['title' => 'Dashboard'])]
+class extends Component
+{
+    //
+};
+?>
+
+<div>Finder Test Single File Component With Array Argument Attribute</div>

--- a/src/Finder/UnitTest.php
+++ b/src/Finder/UnitTest.php
@@ -239,6 +239,17 @@ class UnitTest extends \Tests\TestCase
         $this->assertEquals(__DIR__ . '/Fixtures/single-file-component-with-multiline-php-attribute.blade.php', $path);
     }
 
+    public function test_can_resolve_single_file_component_with_array_argument_php_attribute()
+    {
+        $finder = new Finder();
+
+        $finder->addLocation(viewPath: __DIR__ . '/Fixtures');
+
+        $path = $finder->resolveSingleFileComponentPath('single-file-component-with-array-argument-php-attribute');
+
+        $this->assertEquals(__DIR__ . '/Fixtures/single-file-component-with-array-argument-php-attribute.blade.php', $path);
+    }
+
     public function test_can_resolve_location_single_file_component_with_zap()
     {
         $finder = new Finder();


### PR DESCRIPTION
`#10367` narrowed single-file component detection to `new` followed by optional `#[...]` attributes and then `class`. The attribute part, `#\[[^\]]*\]`, stops at the first `]`, so an attribute whose argument contains an array closes early. The file is no longer seen as an SFC, and resolving it throws `ComponentNotFoundException`.

This stopped resolving after 4.3.4:

```blade
new
#[Layout('layouts.app', ['title' => 'Dashboard'])]
class extends Component { /* ... */ };
```

Allowing one level of bracket nesting in the attribute keeps array arguments working, and Volt functional components are still skipped as `#10367` intended.

Fixes #10472
