### PR TITLE
[4.x] Fix component named Index resolving to an empty name

### DIFF
--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -332,15 +332,13 @@ class Finder
             $fullName = $fullName->substr(1);
         }
 
-        // If using an index component in a sub folder, remove the '.index' so the name is the subfolder name...
-        if ($fullName->endsWith('.index')) {
-            $fullName = $fullName->replaceLast('.index', '');
-        }
-
         $classNamespaces = collect($this->classNamespaces)
             ->map(fn ($classNamespace) => $classNamespace['classNamespace'])
             ->merge($this->classLocations)
             ->toArray();
+
+        $name = $fullName;
+        $prefix = '';
 
         foreach ($classNamespaces as $key => $classNamespace) {
             $namespace = str_replace(
@@ -354,18 +352,22 @@ class Finder
                 ->implode('.');
 
             if ($fullName->startsWith($namespace)) {
-                $name = (string) $fullName->substr(strlen($namespace) + 1);
+                $name = $fullName->substr(strlen($namespace) + 1);
 
-                // An index component at the namespace root collapses to an empty name, so restore 'index'...
-                if ($name === '') {
-                    $name = 'index';
-                }
+                $prefix = is_string($key) ? $key . '::' : '';
 
-                return is_string($key) ? $key . '::' . $name : $name;
+                break;
             }
         }
 
-        return (string) $fullName;
+        // If using an index component in a sub folder, remove the '.index' so the name is the subfolder name.
+        // This has to happen after the namespace is stripped, otherwise an 'Index' at the root of a namespace
+        // would collapse into the namespace itself and leave nothing behind to name the component with...
+        if ($name->endsWith('.index')) {
+            $name = $name->replaceLast('.index', '');
+        }
+
+        return $prefix . $name;
     }
 
     protected function normalizeClassName(string $className): string

--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -356,6 +356,11 @@ class Finder
             if ($fullName->startsWith($namespace)) {
                 $name = (string) $fullName->substr(strlen($namespace) + 1);
 
+                // An index component at the namespace root collapses to an empty name, so restore 'index'...
+                if ($name === '') {
+                    $name = 'index';
+                }
+
                 return is_string($key) ? $key . '::' . $name : $name;
             }
         }

--- a/src/Finder/UnitTest.php
+++ b/src/Finder/UnitTest.php
@@ -186,6 +186,21 @@ class UnitTest extends \Tests\TestCase
         $this->assertEquals('Livewire\Finder\Fixtures\IndexComponent\Index', $class);
     }
 
+    public function test_can_resolve_location_class_root_index_component()
+    {
+        $finder = new Finder();
+
+        $finder->addLocation(classNamespace: 'Livewire\Finder\Fixtures\IndexComponent');
+
+        $name = $finder->normalizeName(Index::class);
+
+        $this->assertEquals('index', $name);
+
+        $class = $finder->resolveClassComponentClassName($name);
+
+        $this->assertEquals('Livewire\Finder\Fixtures\IndexComponent\Index', $class);
+    }
+
     public function test_can_resolve_location_class_self_named_component()
     {
         $finder = new Finder();

--- a/src/Finder/UnitTest.php
+++ b/src/Finder/UnitTest.php
@@ -481,6 +481,21 @@ class UnitTest extends \Tests\TestCase
         $this->assertEquals('Livewire\Finder\Fixtures\IndexComponent\Index', $class);
     }
 
+    public function test_can_resolve_namespace_class_root_index_component()
+    {
+        $finder = new Finder();
+
+        $finder->addNamespace('admin', classNamespace: 'Livewire\Finder\Fixtures\IndexComponent');
+
+        $name = $finder->normalizeName(Index::class);
+
+        $this->assertEquals('admin::index', $name);
+
+        $class = $finder->resolveClassComponentClassName($name);
+
+        $this->assertEquals('Livewire\Finder\Fixtures\IndexComponent\Index', $class);
+    }
+
     public function test_can_resolve_namespace_class_self_named_component()
     {
         $finder = new Finder();

--- a/src/Tests/RootIndex/Index.php
+++ b/src/Tests/RootIndex/Index.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Livewire\Tests\RootIndex;
+
+use Livewire\Component;
+
+class Index extends Component
+{
+    public int $count = 1;
+
+    public function increment()
+    {
+        $this->count++;
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+            <div>
+                Count: {{ $count }}
+            </div>
+        HTML;
+    }
+}

--- a/src/Tests/RootIndexComponentUnitTest.php
+++ b/src/Tests/RootIndexComponentUnitTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Livewire\Tests;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Route;
+use Livewire\Livewire;
+use Livewire\Tests\RootIndex\Index;
+
+class RootIndexComponentUnitTest extends \Tests\TestCase
+{
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+
+        // Mirror an app that has `app/Livewire/Index.php` — an `Index` class sitting at the
+        // very root of the configured class namespace. This has to be set before the
+        // service provider boots, since that's where the location is registered...
+        $app['config']->set('livewire.class_namespace', 'Livewire\\Tests\\RootIndex');
+    }
+
+    public function test_root_index_class_gets_a_usable_name()
+    {
+        $this->assertEquals('index', Livewire::new(Index::class)->getName());
+    }
+
+    public function test_root_index_component_renders_as_a_page_component()
+    {
+        Route::get('/root-index-page', Index::class);
+
+        $this->get('/root-index-page')
+            ->assertOk()
+            ->assertSee('Count: 1');
+    }
+
+    public function test_root_index_component_renders_by_name()
+    {
+        Route::get('/root-index', fn () => Blade::render('<livewire:index />'));
+
+        $this->get('/root-index')
+            ->assertOk()
+            ->assertSee('Count: 1');
+    }
+
+    public function test_root_index_component_handles_a_subsequent_update_request()
+    {
+        Livewire::test(Index::class)
+            ->assertSee('Count: 1')
+            ->call('increment')
+            ->assertSee('Count: 2');
+    }
+}


### PR DESCRIPTION
A component class named `Index` at the root of the configured `class_namespace` (for example `App\Livewire\Index`) throws `ComponentNotFoundException` with an empty name ("Unable to find component: []").

`generateNameFromClass()` strips a trailing `.index` before it removes the namespace prefix, so `app.livewire.index` collapses to `app.livewire`. That makes the name equal to the namespace, so removing the prefix leaves an empty string. A root-level `Index` now falls back to `index`, the name it resolved to under v3.

Fixes #10473
