### PR TITLE
[4.x] Fix SFC detection for PHP attributes with array arguments

### DIFF
--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -394,8 +394,10 @@ class Finder
 
         // Light touch check: Look for the pattern that indicates an SFC
         // Pattern: <?php followed by 'new class' (with potential attributes/newlines between)
-        // This distinguishes SFCs from regular Blade views
-        return preg_match('/\<\?php.*\bnew\s+(?:#\[[^\]]*\]\s*)*class\b/s', $contents) === 1;
+        // The attribute portion matches balanced brackets so that attributes taking
+        // array arguments, such as #[Layout('layouts.app', ['title' => 'Dashboard'])],
+        // are still recognised. This distinguishes SFCs from regular Blade views
+        return preg_match('/\<\?php.*\bnew\s+(?:#(\[(?:[^\[\]]++|(?1))*\])\s*)*class\b/s', $contents) === 1;
     }
 
     protected function hasValidMultiFileComponentSource(string $dir, string $fileBaseName): bool

--- a/src/Finder/Fixtures/single-file-component-with-php-attribute-array-argument.blade.php
+++ b/src/Finder/Fixtures/single-file-component-with-php-attribute-array-argument.blade.php
@@ -1,0 +1,16 @@
+<?php
+
+use Livewire\Attributes\Layout;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+new
+#[Layout('layouts.app', ['title' => 'Dashboard'])]
+#[Title('Dashboard')]
+class extends Component
+{
+    //
+};
+?>
+
+<div>Finder Test Single File Component With Attribute Array Argument</div>

--- a/src/Finder/Fixtures/single-file-component-with-php-attribute-nested-array-argument.blade.php
+++ b/src/Finder/Fixtures/single-file-component-with-php-attribute-nested-array-argument.blade.php
@@ -1,0 +1,14 @@
+<?php
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+new
+#[Layout('layouts.app', ['meta' => ['og' => ['title' => 'Dashboard']], 'title' => 'Dashboard'])]
+class extends Component
+{
+    //
+};
+?>
+
+<div>Finder Test Single File Component With Attribute Nested Array Argument</div>

--- a/src/Finder/UnitTest.php
+++ b/src/Finder/UnitTest.php
@@ -239,6 +239,28 @@ class UnitTest extends \Tests\TestCase
         $this->assertEquals(__DIR__ . '/Fixtures/single-file-component-with-multiline-php-attribute.blade.php', $path);
     }
 
+    public function test_can_resolve_single_file_component_with_php_attribute_array_argument()
+    {
+        $finder = new Finder();
+
+        $finder->addLocation(viewPath: __DIR__ . '/Fixtures');
+
+        $path = $finder->resolveSingleFileComponentPath('single-file-component-with-php-attribute-array-argument');
+
+        $this->assertEquals(__DIR__ . '/Fixtures/single-file-component-with-php-attribute-array-argument.blade.php', $path);
+    }
+
+    public function test_can_resolve_single_file_component_with_php_attribute_nested_array_argument()
+    {
+        $finder = new Finder();
+
+        $finder->addLocation(viewPath: __DIR__ . '/Fixtures');
+
+        $path = $finder->resolveSingleFileComponentPath('single-file-component-with-php-attribute-nested-array-argument');
+
+        $this->assertEquals(__DIR__ . '/Fixtures/single-file-component-with-php-attribute-nested-array-argument.blade.php', $path);
+    }
+
     public function test_can_resolve_location_single_file_component_with_zap()
     {
         $finder = new Finder();


### PR DESCRIPTION
# The Scenario

A single-file component whose PHP attribute takes an array argument — for example a layout that receives data:

```blade
<?php

use Livewire\Attributes\Layout;
use Livewire\Component;

new
#[Layout("layouts.app", ["title" => "Dashboard"])]
class extends Component {
    public string $message = "Hello";
};

?>

<div>{{ $message }}</div>
```

On v4.3.3 this renders. On v4.3.4 resolving it throws:

```
Livewire\Exceptions\ComponentNotFoundException: Unable to find component: [pages::dashboard]
```

# The Problem

The narrowed SFC detection regex from #10367 matches attributes between `new` and `class` with `#\[[^\]]*\]`:

```php
preg_match("/\<\?php.*\bnew\s+(?:#\[[^\]]*\]\s*)*class\b/s", $contents)
```

`[^\]]*` stops at the **first** `]`. An attribute carrying an array argument contains a `]` of its own, so the attribute branch consumes only part of the attribute, `class` is no longer what follows, and the match fails. The file stops being treated as an SFC.

Layout data as a second argument is part of the attribute's public API — `BaseLayout::__construct(public $name, public $params = [])` — and #10367 intended to keep "valid SFC forms working, including inline and multiline attributes". The two fixtures it added only use attributes without array arguments, so this form was not covered by a test.

Reported in #10472. In the application where I hit this, it silently broke 247 of 251 page components.

# The Solution

Match balanced brackets with a recursive subpattern instead of "everything up to the first `]`":

```diff
-return preg_match("/\<\?php.*\bnew\s+(?:#\[[^\]]*\]\s*)*class\b/s", $contents) === 1;
+return preg_match("/\<\?php.*\bnew\s+(?:#(\[(?:[^\[\]]++|(?1))*\])\s*)*class\b/s", $contents) === 1;
```

This restores attributes with array arguments, nested to any depth, while still rejecting the Volt functional components #10367 was fixing — the attribute branch still only accepts genuine `#[...]` attributes between `new` and `class`, so `new \SplFileInfo(...)` followed by an HTML `class="..."` does not match.

| case | expected | v4.3.3 | v4.3.4 | this PR |
| --- | --- | --- | --- | --- |
| inline attribute fixture (#10367) | SFC | SFC | SFC | SFC |
| multiline attribute fixture (#10367) | SFC | SFC | SFC | SFC |
| Volt functional component (#10351) | not SFC | **SFC** | not SFC | not SFC |
| attribute with array argument (#10472) | SFC | SFC | **not SFC** | SFC |
| attribute with nested array argument | SFC | SFC | **not SFC** | SFC |

# Tests

Two fixtures and two tests are added alongside the existing attribute fixtures, covering a flat array argument and a nested one, so the form cannot regress again:

- `single-file-component-with-php-attribute-array-argument.blade.php`
- `single-file-component-with-php-attribute-nested-array-argument.blade.php`

`Livewire\Finder\UnitTest` passes in full (55 tests, 88 assertions), including the existing `test_volt_functional_component_is_not_resolved_as_single_file_component`.

Fixes #10472