### PR TITLE
Prevent infinite request loops when referencing component methods in reactive directives

### DIFF
--- a/js/directives/wire-bind.js
+++ b/js/directives/wire-bind.js
@@ -1,5 +1,5 @@
 import Alpine from 'alpinejs'
-import { evaluateActionExpression } from '../evaluator'
+import { evaluateReactiveExpression } from '../evaluator'
 
 Alpine.interceptInit(el => {
     for (let i = 0; i < el.attributes.length; i++) {
@@ -12,7 +12,7 @@ Alpine.interceptInit(el => {
 
             Alpine.bind(el, {
                 ['x-bind' + remainder]() {
-                    return evaluateActionExpression(el, expression)
+                    return evaluateReactiveExpression(el, expression)
                 }
             })
         }

--- a/js/directives/wire-if.js
+++ b/js/directives/wire-if.js
@@ -1,4 +1,4 @@
-import { evaluateActionExpression } from '../evaluator'
+import { evaluateReactiveExpression } from '../evaluator'
 import Alpine from 'alpinejs'
 
 // Skipped during clone-mode init (morphing seeds incoming trees that way) —
@@ -17,7 +17,7 @@ Alpine.interceptInit(
 
         Alpine.bind(el, {
             ['x-if']() {
-                return evaluateActionExpression(el, expression)
+                return evaluateReactiveExpression(el, expression)
             }
         })
     })

--- a/js/directives/wire-show.js
+++ b/js/directives/wire-show.js
@@ -1,4 +1,4 @@
-import { evaluateActionExpression } from '../evaluator'
+import { evaluateReactiveExpression } from '../evaluator'
 import Alpine from 'alpinejs'
 
 Alpine.interceptInit(el => {
@@ -12,7 +12,7 @@ Alpine.interceptInit(el => {
 
             Alpine.bind(el, {
                 ['x-show' + modifierString]() {
-                    return evaluateActionExpression(el, expression)
+                    return evaluateReactiveExpression(el, expression)
                 }
             })
         }

--- a/js/directives/wire-text.js
+++ b/js/directives/wire-text.js
@@ -1,5 +1,5 @@
 import Alpine from 'alpinejs'
-import { evaluateActionExpression } from '../evaluator'
+import { evaluateReactiveExpression } from '../evaluator'
 
 Alpine.interceptInit(el => {
     for (let i = 0; i < el.attributes.length; i++) {
@@ -12,7 +12,7 @@ Alpine.interceptInit(el => {
 
             Alpine.bind(el, {
                 ['x-text' + modifierString]() {
-                    return evaluateActionExpression(el, expression)
+                    return evaluateReactiveExpression(el, expression)
                 }
             })
         }

--- a/js/evaluator.js
+++ b/js/evaluator.js
@@ -39,6 +39,25 @@ export function evaluateExpression(el, expression, options = {}) {
     return result
 }
 
+import { getCurrentWatcher } from '@vue/reactivity'
+
+let isEvaluatingReactiveExpression = false
+
+export function isEvaluatingReactive() {
+    return isEvaluatingReactiveExpression || getCurrentWatcher() !== undefined
+}
+
+export function evaluateReactiveExpression(el, expression, options = {}) {
+    let prev = isEvaluatingReactiveExpression
+    isEvaluatingReactiveExpression = true
+
+    try {
+        return evaluateActionExpression(el, expression, options)
+    } finally {
+        isEvaluatingReactiveExpression = prev
+    }
+}
+
 export function evaluateActionExpression(el, expression, options = {}) {
     if (! expression || expression.trim() === '') return
 

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -7,6 +7,7 @@ import { showHtmlModal } from '@/utils/modal.js'
 import { MessageBus, scopeSymbolFromMessage } from './messageBus.js'
 import Message from './message.js'
 import Action from './action.js'
+import { isEvaluatingReactive } from '@/evaluator'
 
 let outstandingActionOrigin = null
 let outstandingActionMetadata = {}
@@ -119,6 +120,11 @@ queueMicrotask(() => {
 })
 
 export function fireAction(component, method, params = [], metadata = {}) {
+    if (isEvaluatingReactive()) {
+        console.warn(`Livewire: Cannot call server method "${method}" inside reactive bindings (e.g. wire:text, wire:show, wire:bind, wire:if).`, component?.el)
+        return Promise.resolve()
+    }
+
     if (component.__isWireProxy) component = component.__instance
 
     let action = constructAction(component, method, params, metadata)

--- a/src/Features/SupportWireText/BrowserTest.php
+++ b/src/Features/SupportWireText/BrowserTest.php
@@ -69,4 +69,30 @@ class BrowserTest extends BrowserTestCase
         ->waitForLivewire()->click('@change')
         ->assertSeeIn('@label', 'bar');
     }
+
+    public function test_wire_text_does_not_call_component_method_repeatedly()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            public function foo()
+            {
+                $this->count++;
+                return 'foo-result';
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <div wire:text="foo" dusk="label"></div>
+                    <div dusk="count">{{ $count }}</div>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@count', '0')
+        ->pause(1000)
+        ->assertSeeIn('@count', '0');
+    }
 }


### PR DESCRIPTION
Fixes #10477

### Problem
When client-side reactive binding directives (`wire:text`, `wire:show`, `wire:bind`, `wire:if`) evaluate an expression that points to a PHP component method instead of a public property (e.g., `<span wire:text="foo"></span>`), accessing `$wire.foo` returns a fallback action wrapper function.

Because Alpine's expression evaluator automatically executes functions returned inside reactive getters (`x-text`, `x-show`, etc.), Alpine invokes the action function on every render cycle. This fires `fireAction()`, sending a network request to the server. When the server response updates component state, Alpine's reactive effect re-evaluates the directive, triggering another request in an infinite HTTP request loop.

### Solution
1. Added `evaluateReactiveExpression` to mark execution context while evaluating reactive DOM binding directives.
2. Combined `@vue/reactivity` active watcher detection (`getCurrentWatcher()`) to catch both `wire:*` directives and direct Alpine `x-text="$wire.foo()"` usage.
3. Added a guard in `fireAction()` that prevents firing server network requests during reactive evaluations, logging a clear console warning instead (`Livewire: Cannot call server method "foo" inside reactive bindings...`).
4. Added Dusk browser tests in `SupportWireText/BrowserTest.php` to prevent regressions.