### PR TITLE
[4.x] Fix SFC detection for PHP attribute array arguments

### DIFF
--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -392,10 +392,14 @@ class Finder
             return false;
         }
 
+        // Ignore quoted strings and non-bracket content while balancing attribute brackets.
+        // This ignores the bracket in 'Dashboard ] overview' while matching nested arrays like ['meta' => ['title' => 'Dashboard']].
+        $contentIgnoredWhileMatchingBracketsPattern = '(?:(?>[^\[\]\'\"]+)|\'(?:\\\\.|[^\'\\\\])*\'|"(?:\\\\.|[^"\\\\])*")';
+
         // Light touch check: Look for the pattern that indicates an SFC
         // Pattern: <?php followed by 'new class' (with potential attributes/newlines between)
         // This distinguishes SFCs from regular Blade views
-        return preg_match('/\<\?php.*\bnew\s+(?:#\[[^\]]*\]\s*)*class\b/s', $contents) === 1;
+        return preg_match('/\<\?php.*\bnew\s+(?:#(\[(?:' . $contentIgnoredWhileMatchingBracketsPattern . '|(?1))*\])\s*)*class\b/s', $contents) === 1;
     }
 
     protected function hasValidMultiFileComponentSource(string $dir, string $fileBaseName): bool

--- a/src/Finder/Fixtures/non-single-file-component-with-closing-brackets-and-class-text.blade.php
+++ b/src/Finder/Fixtures/non-single-file-component-with-closing-brackets-and-class-text.blade.php
@@ -1,0 +1,14 @@
+<?php
+
+$download = function () {
+    $file = new \SplFileInfo('#[value] class');
+    $options = ['] class'];
+
+    return response()->download($file->getPathname(), options: $options);
+};
+
+?>
+
+<div class="download">
+    <button wire:click="download">Download</button>
+</div>

--- a/src/Finder/Fixtures/non-single-file-component-with-separated-closing-bracket-and-class-text.blade.php
+++ b/src/Finder/Fixtures/non-single-file-component-with-separated-closing-bracket-and-class-text.blade.php
@@ -1,0 +1,7 @@
+<?php
+
+$message = 'new #[first] unrelated ] class';
+
+?>
+
+<div>{{ $message }}</div>

--- a/src/Finder/Fixtures/single-file-component-with-array-argument-php-attribute.blade.php
+++ b/src/Finder/Fixtures/single-file-component-with-array-argument-php-attribute.blade.php
@@ -1,0 +1,14 @@
+<?php
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+new
+#[Layout('layouts.app', ['title' => 'Dashboard'])]
+class extends Component
+{
+    //
+};
+?>
+
+<div>Finder Test Single File Component With Array Argument Attribute</div>

--- a/src/Finder/Fixtures/single-file-component-with-closing-bracket-in-attribute-string.blade.php
+++ b/src/Finder/Fixtures/single-file-component-with-closing-bracket-in-attribute-string.blade.php
@@ -1,0 +1,14 @@
+<?php
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+new
+#[Layout('layouts.app', ['title' => 'Dashboard ] overview'])]
+class extends Component
+{
+    //
+};
+?>
+
+<div>Finder Test Single File Component With Closing Bracket In Attribute String</div>

--- a/src/Finder/Fixtures/single-file-component-with-closing-bracket-in-class.blade.php
+++ b/src/Finder/Fixtures/single-file-component-with-closing-bracket-in-class.blade.php
@@ -1,0 +1,14 @@
+<?php
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+new
+#[Layout('layouts.app')]
+class extends Component
+{
+    public array $items = ['first', 'second'];
+};
+?>
+
+<div>Finder Test Single File Component With Closing Bracket In Class</div>

--- a/src/Finder/Fixtures/single-file-component-with-nested-array-argument-php-attribute.blade.php
+++ b/src/Finder/Fixtures/single-file-component-with-nested-array-argument-php-attribute.blade.php
@@ -1,0 +1,14 @@
+<?php
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+new
+#[Layout('layouts.app', ['meta' => ['title' => 'Dashboard']])]
+class extends Component
+{
+    //
+};
+?>
+
+<div>Finder Test Single File Component With Nested Array Argument Attribute</div>

--- a/src/Finder/UnitTest.php
+++ b/src/Finder/UnitTest.php
@@ -239,6 +239,50 @@ class UnitTest extends \Tests\TestCase
         $this->assertEquals(__DIR__ . '/Fixtures/single-file-component-with-multiline-php-attribute.blade.php', $path);
     }
 
+    public function test_can_resolve_single_file_component_with_array_argument_php_attribute()
+    {
+        $finder = new Finder();
+
+        $finder->addLocation(viewPath: __DIR__ . '/Fixtures');
+
+        $path = $finder->resolveSingleFileComponentPath('single-file-component-with-array-argument-php-attribute');
+
+        $this->assertEquals(__DIR__ . '/Fixtures/single-file-component-with-array-argument-php-attribute.blade.php', $path);
+    }
+
+    public function test_can_resolve_single_file_component_with_nested_array_argument_php_attribute()
+    {
+        $finder = new Finder();
+
+        $finder->addLocation(viewPath: __DIR__ . '/Fixtures');
+
+        $path = $finder->resolveSingleFileComponentPath('single-file-component-with-nested-array-argument-php-attribute');
+
+        $this->assertEquals(__DIR__ . '/Fixtures/single-file-component-with-nested-array-argument-php-attribute.blade.php', $path);
+    }
+
+    public function test_can_resolve_single_file_component_with_closing_bracket_in_php_attribute_string()
+    {
+        $finder = new Finder();
+
+        $finder->addLocation(viewPath: __DIR__ . '/Fixtures');
+
+        $path = $finder->resolveSingleFileComponentPath('single-file-component-with-closing-bracket-in-attribute-string');
+
+        $this->assertEquals(__DIR__ . '/Fixtures/single-file-component-with-closing-bracket-in-attribute-string.blade.php', $path);
+    }
+
+    public function test_can_resolve_single_file_component_with_closing_bracket_in_class()
+    {
+        $finder = new Finder();
+
+        $finder->addLocation(viewPath: __DIR__ . '/Fixtures');
+
+        $path = $finder->resolveSingleFileComponentPath('single-file-component-with-closing-bracket-in-class');
+
+        $this->assertEquals(__DIR__ . '/Fixtures/single-file-component-with-closing-bracket-in-class.blade.php', $path);
+    }
+
     public function test_can_resolve_location_single_file_component_with_zap()
     {
         $finder = new Finder();
@@ -709,6 +753,22 @@ class UnitTest extends \Tests\TestCase
         $finder->addLocation(viewPath: __DIR__ . '/Fixtures');
 
         $this->assertNull($finder->resolveSingleFileComponentPath('volt-functional-component'));
+    }
+
+    public function test_non_single_file_component_with_closing_brackets_and_class_text_is_not_resolved_as_single_file_component()
+    {
+        $finder = new Finder();
+        $finder->addLocation(viewPath: __DIR__ . '/Fixtures');
+
+        $this->assertNull($finder->resolveSingleFileComponentPath('non-single-file-component-with-closing-brackets-and-class-text'));
+    }
+
+    public function test_non_single_file_component_with_separated_closing_bracket_and_class_text_is_not_resolved_as_single_file_component()
+    {
+        $finder = new Finder();
+        $finder->addLocation(viewPath: __DIR__ . '/Fixtures');
+
+        $this->assertNull($finder->resolveSingleFileComponentPath('non-single-file-component-with-separated-closing-bracket-and-class-text'));
     }
 }
 


### PR DESCRIPTION
# The Scenario

After upgrading from Livewire v4.3.3 to v4.3.4, a single-file component is no longer resolved when an attribute receives an array argument due to the changes in PR #10367. Attempting to mount the component throws `ComponentNotFoundException`.

```blade
<?php

use Livewire\Attributes\Layout;
use Livewire\Component;

new
#[Layout('layouts.app', ['title' => 'Dashboard'])]
class extends Component {
    public string $message = 'Hello';
};

?>

<div>
    {{ $message }}
</div>
```

# The Problem

SFC detection matches attributes between `new` and `class` using `#\[[^\]]*\]`.

This assumes the first `]` closes the attribute. When an attribute contains an array argument, the array's closing bracket is encountered first. The remaining attribute content prevents the pattern from reaching `class`, so Finder rejects the file as an SFC.

# The Solution

The solution is to replace the first-closing-bracket match with a recursive pattern that recognises balanced square brackets.

The attribute's outer brackets become the first capture group. When another `[` is encountered inside the attribute, `(?1)` recursively applies that same capture group. This allows arrays to be nested to any depth before the attribute's closing bracket is matched.

Quoted PHP strings are matched and ignored while balancing brackets. This means brackets inside values such as `'Dashboard ] overview'` are consumed as string content rather than treated as structural brackets. Escaped characters inside single- and double-quoted strings are handled by the same pattern.

Content that does not affect bracket balancing is extracted into `$contentIgnoredWhileMatchingBracketsPattern`. This keeps the recursive part focused on structural brackets and makes the intent of the complete expression clearer.

The surrounding `new`, optional attributes, then `class` structure remains unchanged, preserving the Volt detection fix from PR #10367.

Fixes #10472
