### PR TITLE
[4.x] Fix assets after a stylesheet never being loaded

### DIFF
--- a/js/features/supportScriptsAndAssets.js
+++ b/js/features/supportScriptsAndAssets.js
@@ -106,7 +106,12 @@ async function addAssetsToHeadTagOfPage(rawHtml) {
     let newDocument = (new DOMParser()).parseFromString(rawHtml, "text/html")
     let newHead = document.adoptNode(newDocument.head)
 
-    for (let child of newHead.children) {
+    // Take a static copy of the children. Appending a non-script asset moves it
+    // out of this document, and iterating the live collection while it shrinks
+    // would skip the asset right after it...
+    let children = [...newHead.children]
+
+    for (let child of children) {
         try {
             await runAssetSynchronously(child)
         } catch (error) {

--- a/src/Features/SupportScriptsAndAssets/BrowserTest.php
+++ b/src/Features/SupportScriptsAndAssets/BrowserTest.php
@@ -18,6 +18,14 @@ class BrowserTest extends \Tests\BrowserTestCase
                 return Utils::pretendResponseIsFile(__DIR__.'/non-livewire-asset.js');
             });
 
+            Route::get('/asset-stylesheet.css', function () {
+                return Utils::pretendResponseIsFile(__DIR__.'/asset-stylesheet.css', 'text/css');
+            });
+
+            Route::get('/asset-after-stylesheet.js', function () {
+                return Utils::pretendResponseIsFile(__DIR__.'/asset-after-stylesheet.js');
+            });
+
             Route::get('/non-livewire-assets', function () {
                 return Blade::render(<<< BLADE
                 <html>
@@ -224,6 +232,45 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->waitForTextIn('@output', 'foo')
         ->waitForLivewire()->click('@button')
         ->waitUntil('!! window.datePicker === true')
+        ;
+    }
+
+    public function test_assets_after_a_stylesheet_are_not_skipped()
+    {
+        // Assets are appended to the head one at a time. Non-script elements are
+        // moved out of the parsed document as they are appended, so iterating its
+        // live children collection skips whatever followed them, so the script
+        // after the stylesheet never ran.
+        Livewire::visit([new class extends \Livewire\Component {
+            public $load = false;
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button wire:click="$toggle('load')" dusk="button">Load assets</button>
+
+                <span dusk="output" x-text="'foo'"></span>
+
+                @if ($load)
+                    <livewire:child />
+                @endif
+            </div>
+            HTML; }
+        },
+        'child' => new class extends \Livewire\Component {
+            public function render() { return <<<'HTML'
+            <div>On child</div>
+
+            @assets
+                <link rel="stylesheet" type="text/css" href="/asset-stylesheet.css">
+                <script src="/asset-after-stylesheet.js"></script>
+            @endassets
+            HTML; }
+        },
+        ])
+        ->waitForTextIn('@output', 'foo')
+        ->waitForLivewire()->click('@button')
+        ->waitForText('On child')
+        ->waitUntil('!! window.assetAfterStylesheetLoaded === true')
         ;
     }
 

--- a/src/Features/SupportScriptsAndAssets/asset-after-stylesheet.js
+++ b/src/Features/SupportScriptsAndAssets/asset-after-stylesheet.js
@@ -1,0 +1,1 @@
+window.assetAfterStylesheetLoaded = true

--- a/src/Features/SupportScriptsAndAssets/asset-stylesheet.css
+++ b/src/Features/SupportScriptsAndAssets/asset-stylesheet.css
@@ -1,0 +1,1 @@
+/* Only here so that the asset before the script is a non-script element... */


### PR DESCRIPTION
Reopening #10458 against `4.x` as requested - same change, rebased onto `4.x` and re-verified there.

## Problem

When `@assets` are injected by an update request, every asset that directly follows a non-script asset is silently dropped. So this block loads the stylesheet but never runs the script:

```blade
@assets
    <link rel="stylesheet" href="/plugin.css">
    <script src="/plugin.js"></script>
@endassets
```

Swap the two lines and both load. Nothing throws - the component renders, and only whatever the script provided is missing (`window.Plugin is not defined`, an editor that never initialises, a picker that stays a plain input).

This bites hardest with bundler output, where a `@vite()` directive expands to preload links followed by the module script: the links load, the script that actually does the work is skipped. Assets injected into the initial page HTML are unaffected - only assets arriving with a Livewire update go through this path, which in practice means components rendered into a modal or behind a toggle.

## Cause

`addAssetsToHeadTagOfPage()` iterates `newHead.children`, which is a **live** `HTMLCollection`:

```javascript
for (let child of newHead.children) {
    await runAssetSynchronously(child)
}
```

`runAssetSynchronously()` clones script tags (the original stays put), but appends every other element directly - which *moves* it out of `newHead`. The collection shrinks under the iterator, every remaining element shifts down one index, and the loop's next index lands one element too far.

With `[link, script]` the link is moved, the script shifts to index 0, the loop asks for index 1 and finds nothing. The `try/catch` inside the loop is for asset load errors, so nothing surfaces.

## Fix

Iterate a static copy:

```javascript
// Take a static copy of the children. Appending a non-script asset moves it
// out of this document, and iterating the live collection while it shrinks
// would skip the asset right after it...
let children = [...newHead.children]

for (let child of children) {
```

## Test

`SupportScriptsAndAssets\BrowserTest::test_assets_after_a_stylesheet_are_not_skipped` - a deferred nested component whose `@assets` block is a stylesheet followed by a script, using the same shape as the existing deferred-asset tests in that file. The existing coverage happens to declare the script *before* the stylesheet, which is the order that works.

## Verification

Run against this branch's base (`4.x`, `e95c7735`), Chrome 150, PHP 8.5:

| | |
|---|---|
| the new test, with the fix removed | **fails** - times out waiting for the script to run |
| the new test, with the fix in place | **passes** |
| `--filter="SupportScriptsAndAssets"` | 15 tests pass |
| `--filter="SupportNavigate"` | 55 tests, 372 assertions pass |
| `--filter="SupportLazyLoading"` | 23 tests, 60 assertions pass |
| `--filter="SupportJsModules"` | 3 tests pass |
| `--filter="SupportAutoInjectedAssets"` | 1 test passes |
| `composer test:unit` | 1329 tests, 3789 assertions pass (13 skipped, 3 incomplete - same on the unmodified branch base) |
| `npm run test:run` | 101 tests pass |

Originally found on 4.3.3 in a production app, reproduced on current `4.x` by the test above.
