### PR TITLE
[4.x] Fix `#[Authorize]` attribute doesnt trigger component exception hook

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -20,14 +20,13 @@ use Livewire\Features\SupportRenderless\HandlesRenderless;
 use Livewire\Exceptions\PropertyNotFoundException;
 use Livewire\Concerns\InteractsWithProperties;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use BadMethodCallException;
+use Livewire\Features\SupportAuthorization\HandlesAuthorization;
 
 abstract class Component
 {
     use Macroable { __call as macroCall; }
 
-    use AuthorizesRequests;
     use InteractsWithProperties;
     use HandlesEvents;
     use HandlesIslands;
@@ -44,6 +43,7 @@ abstract class Component
     use HandlesSlots;
     use HandlesHtmlAttributeForwarding;
     use HandlesRenderless;
+    use HandlesAuthorization;
 
     protected $__id;
     protected $__name;

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -2,89 +2,25 @@
 
 namespace Livewire\Features\SupportAuthorization;
 
-use Attribute;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use Illuminate\Support\Arr;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
-use Livewire\ImplicitlyBoundMethod;
-use UnitEnum;
 
-use function Illuminate\Support\enum_value;
+use function Livewire\wrap;
 
-#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_METHOD)]
 class BaseAuthorize extends LivewireAttribute
 {
-    use AuthorizesRequests;
-
     public function __construct(
-        public UnitEnum|string $ability,
+        public \UnitEnum|string $ability,
         public array|string|null $argument = null,
     ) {}
 
     public function call(array $parameters) : void
     {
-        // Action that does not require a model or class...
-        if (is_null($this->argument)) {
-            $this->authorize($this->ability);
-
-            return;
-        }
-
-        $arguments = Arr::wrap($this->argument);
-
-        // Resolve method dependencies lazily, then reuse them for multi-argument authorization checks...
-        $methodDependencies = null;
-        $resolveMethodDependencies = function () use (&$methodDependencies, $parameters): array {
-            return $methodDependencies ??= ImplicitlyBoundMethod::resolveMethodDependencies(
-                app(),
-                [$this->component, $this->getName()],
-                $parameters,
-            );
-        };
-
-        // Resolve each argument (prioritize method parameters first, then component properties)
-        $resolved = [];
-        foreach ($arguments as $arg) {
-            $resolved[] = $this->resolveArgument($arg, $parameters, $resolveMethodDependencies);
-        }
-
-        $this->authorize($this->ability, $resolved);
-    }
-
-    /**
-     * Resolve a single argument.
-     */
-    protected function resolveArgument(string $arg, array $parameters, \Closure $resolveMethodDependencies): mixed
-    {
-        // Action that does not require a model, for example a 'create' action...
-        if (class_exists($arg)) {
-            return $arg;
-        }
-
-        // Try method parameter first (prioritized per rules)
-        $methodArgument = Arr::first(
-            (new \ReflectionObject($this->component))->getMethod($this->getName())->getParameters(),
-            fn (\ReflectionParameter $parameter) : bool => $parameter->getName() === $arg,
+        wrap($this->component)->authorizeFromAttribute(
+            $this->ability,
+            $this->argument,
+            $this->getName(),
+            $parameters
         );
-
-        if ($methodArgument instanceof \ReflectionParameter) {
-            $methodDependencies = $resolveMethodDependencies();
-
-            return $methodDependencies['named'][$arg];
-        }
-
-        // Fall back to component property
-        return data_get($this->component, $arg);
-    }
-
-    protected function parseAbilityAndArguments($ability, $arguments)
-    {
-        $ability = enum_value($ability);
-
-        if (is_string($ability) && ! str_contains($ability, '\\')) {
-            return [$ability, $arguments];
-        }
-
-        return [$this->normalizeGuessedAbilityName($this->getName()), $ability];
     }
 }

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Livewire\Features\SupportAuthorization;
+
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Arr;
+use Livewire\ImplicitlyBoundMethod;
+
+use function Illuminate\Support\enum_value;
+
+trait HandlesAuthorization
+{
+    use AuthorizesRequests;
+
+    public function authorizeFromAttribute($ability, $argument = null, $method = null, $parameters = [])
+    {
+        // Safety measure if this method get called directly inside component action
+        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
+
+        if (is_null($argument)) {
+            $ability = enum_value($ability);
+
+            if (is_string($ability) && ! str_contains($ability, '\\')) {
+                return $this->authorize($ability);
+            }
+
+            return $this->authorize($this->normalizeGuessedAbilityName($method), $ability);
+        }
+
+        // Resolve method dependencies lazily, then reuse them for multi-argument authorization checks...
+        $methodDependencies = null;
+        $resolveMethodDependencies = function () use ($method, &$methodDependencies, $parameters): array {
+            return $methodDependencies ??= ImplicitlyBoundMethod::resolveMethodDependencies(
+                app(),
+                [$this, $method],
+                $parameters,
+            );
+        };
+
+        // Resolve each argument (prioritize method parameters first, then component properties)
+        $resolved = [];
+        foreach (Arr::wrap($argument) as $arg) {
+            $resolved[] = $this->resolveArgument($arg, $method, $resolveMethodDependencies);
+        }
+
+        $this->authorize($ability, $resolved);
+    }
+
+    protected function resolveArgument(string|object $arg, string $method, \Closure $resolveMethodDependencies): mixed
+    {
+        // Action that does not require a model, for example a 'create' action...
+        if (is_object($arg) || (is_string($arg) && class_exists($arg))) {
+            return $arg;
+        }
+
+        // Try method parameter first (prioritized per rules)
+        $methodArgument = Arr::first(
+            (new \ReflectionObject($this))->getMethod($method)->getParameters(),
+            fn (\ReflectionParameter $parameter) : bool => $parameter->getName() === $arg,
+        );
+
+        if ($methodArgument instanceof \ReflectionParameter) {
+            $methodDependencies = $resolveMethodDependencies();
+
+            return $methodDependencies['named'][$arg];
+        }
+
+        // Fall back to component property
+        return data_get($this, $arg);
+    }
+}

--- a/src/Features/SupportAuthorization/HandlesAuthorization.php
+++ b/src/Features/SupportAuthorization/HandlesAuthorization.php
@@ -55,7 +55,7 @@ trait HandlesAuthorization
 
         // Try method parameter first (prioritized per rules)
         $methodArgument = Arr::first(
-            (new \ReflectionObject($this))->getMethod($method)->getParameters(),
+            (new \ReflectionMethod($this, $method))->getParameters(),
             fn (\ReflectionParameter $parameter) : bool => $parameter->getName() === $arg,
         );
 

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportAuthorization;
 
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User as AuthUser;
 use Illuminate\Routing\UrlGenerator;
@@ -893,6 +894,61 @@ class UnitTest extends TestCase
             })
             ->dispatch('some-event')
             ->assertForbidden();
+    }
+
+    public function test_authorize_attribute_trigger_component_exception_hook()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[BaseAuthorize(AuthorizationPost::class)]
+                public function store() : bool
+                {
+                    return true;
+                }
+
+                public function exception($e, $stopPropagation)
+                {
+                    if ($e instanceof AuthorizationException) {
+                        $stopPropagation();
+    
+                        Session::put('exception-hook-triggered', true);
+                    }
+                }
+            })
+            ->call('store')
+            ->assertOk();
+
+        $this->assertTrue(Session::has('exception-hook-triggered'));
+    }
+
+    public function test_can_authorize_using_attribute_and_trait_method_at_the_same_time()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[BaseAuthorize(AuthorizationPost::class)]
+                public function store(AuthorizationPost $post)
+                {
+                    $this->authorize(AuthorizationPost::class);
+                    $this->authorize('edit', $post);
+                }
+
+                public function exception($e, $stopPropagation)
+                {
+                    if ($e instanceof AuthorizationException) {
+                        $stopPropagation();
+    
+                        Session::put('exception-hook-triggered', true);
+                    }
+                }
+            })
+            ->call('store', post: 1)
+            ->assertOk();
+
+        $this->assertFalse(Session::has('exception-hook-triggered'));
     }
 }
 


### PR DESCRIPTION
# Scenario
When using `#[Authorize]` attribute to perform authorization as pre-method execution. It doesnt trigger the component `exception()` hook.
```php
class PostPolicy
{
    public function edit(User $user, Post $post)
    {
        return false;
    }
}
```

```php
<?php

use App\Models\Post;
use Livewire\Component;

new class extends Component
{
    #[Authorize('edit', 'post')]
    public function save(Post $post)
    {
        //
    }

    public function exception($e, $stopPropagation)
    {
        $stopPropagation();

        dd($e->getMessage()); // not triggered
    }
}
```

# Problem
Attribute `call()` handled by `SupportAttributes::call()` which is running before the actual method get called so any exception thrown will not get handled by component exception hook.


# Solution
Delegate authorization to `HandlesAuthorization` trait and inside `BaseAuthorize::call()`, wrap the component before performing the authorization from that trait. This way, any exception thrown can be catched from component `exception()` hook. All method parameters resolution handled just like before.

# Whats Changed
- New `HandlesAuthorization` trait
- Move `AuthorizesRequests` trait from `Component` to `HandlesAuthorization` trait
- Added regression tests to make sure both works as expected either using `#[Authorize]` attribute or `$this->authorize()`

Fix: https://github.com/livewire/livewire/issues/10410