### PR TITLE
[4.x] Add `#[Middleware]` attribute

### DIFF
--- a/src/Attributes/Middleware.php
+++ b/src/Attributes/Middleware.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Livewire\Attributes;
+
+use Livewire\Features\SupportActionMiddleware\BaseMiddleware;
+
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_METHOD)]
+class Middleware extends BaseMiddleware
+{
+    //
+}

--- a/src/Features/SupportActionMiddleware/BaseMiddleware.php
+++ b/src/Features/SupportActionMiddleware/BaseMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Livewire\Features\SupportActionMiddleware;
+
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_METHOD)]
+class BaseMiddleware extends LivewireAttribute
+{
+    public function __construct(public string $middleware)
+    {
+        //
+    }
+
+    function boot()
+    {
+        $middleware = $this->storeFind('middlewareAttributes', $this->getName(), []);
+
+        $middleware[] = $this->middleware;
+
+        $this->storePush('middlewareAttributes', $middleware, $this->getName());
+    }
+}

--- a/src/Features/SupportActionMiddleware/BrowserTest.php
+++ b/src/Features/SupportActionMiddleware/BrowserTest.php
@@ -1,0 +1,359 @@
+<?php
+
+namespace Livewire\Features\SupportActionMiddleware;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Route;
+use Livewire\Attributes\Middleware;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+use Tests\TestComponent;
+
+class BrowserTest extends BrowserTestCase
+{
+    public static function tweakApplicationHook()
+    {
+        return function () {
+            Route::livewire('/somewhere', new class extends TestComponent {})
+                ->middleware('web')
+                ->name('somewhere');
+
+            Route::livewire('/somewhere-else', new class extends TestComponent {})
+                ->middleware('web')
+                ->name('somewhere.else');
+        };
+    }
+
+    public function test_middleware_attribute_can_redirect_inside_middleware()
+    {
+        Livewire::visit(new class extends Component {
+            #[Middleware(RedirectMiddleware::class)]
+            public function redirectSomewhere()
+            {
+                $this->redirect('/somewhere');
+            }
+
+            public function render() 
+            {
+                return <<<'HTML'
+                <div>
+                    <button type="button" dusk="button" wire:click="redirectSomewhere">Protected Action</button>
+                </div>
+                HTML;
+            }
+        })
+        ->waitForText('Protected Action')
+        ->waitForLivewire()->click('@button')
+        ->assertRouteIs('somewhere.else');
+    }
+
+    public function test_middleware_attribute_from_child_can_redirect_inside_middleware()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public function render() 
+                {
+                    return <<<'HTML'
+                    <div>
+                        <div dusk="parent">Parent Component</div>
+                        <livewire:child />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                #[Middleware(RedirectMiddleware::class)]
+                public function redirectSomewhere()
+                {
+                    $this->redirect('/somewhere');
+                }
+
+                public function render() 
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button type="button" dusk="button" wire:click="redirectSomewhere">Protected Action</button>
+                    </div>
+                    HTML;
+                }
+            }])
+        ->waitForText('Protected Action')
+        ->waitForLivewire()->click('@button')
+        ->assertRouteIs('somewhere.else');
+    }
+
+    public function test_middleware_attribute_can_redirect_inside_middleware_using_event_listener()
+    {
+        Livewire::visit(new class extends Component {
+            #[Middleware(RedirectMiddleware::class)]
+            #[On('redirect-somewhere')]
+            public function redirectSomewhere()
+            {
+                $this->redirect('/somewhere');
+            }
+
+            public function render() 
+            {
+                return <<<'HTML'
+                <div>
+                    <button type="button" dusk="button" wire:click="$dispatch('redirect-somewhere')">Protected Action</button>
+                </div>
+                HTML;
+            }
+        })
+        ->waitForText('Protected Action')
+        ->waitForLivewire()->click('@button')
+        ->assertRouteIs('somewhere.else');
+    }
+
+    public function test_can_redirect_from_action_when_middleware_attribute_passed()
+    {
+        Livewire::visit(new class extends Component {
+            #[Middleware(AllowMiddleware::class)]
+            public function redirectSomewhere()
+            {
+                $this->redirect('/somewhere');
+            }
+
+            public function render() 
+            {
+                return <<<'HTML'
+                <div>
+                    <button type="button" dusk="button" wire:click="redirectSomewhere">Protected Action</button>
+                </div>
+                HTML;
+            }
+        })
+        ->waitForText('Protected Action')
+        ->waitForLivewire()->click('@button')
+        ->assertRouteIs('somewhere');
+    }
+
+    public function test_can_redirect_from_action_using_event_listener_when_middleware_attribute_passed()
+    {
+        Livewire::visit(new class extends Component {
+            #[Middleware(AllowMiddleware::class)]
+            #[On('redirect-somewhere')]
+            public function redirectSomewhere()
+            {
+                $this->redirect('/somewhere');
+            }
+
+            public function render() 
+            {
+                return <<<'HTML'
+                <div>
+                    <button type="button" dusk="button" wire:click="$dispatch('redirect-somewhere')">Protected Action</button>
+                </div>
+                HTML;
+            }
+        })
+        ->waitForText('Protected Action')
+        ->waitForLivewire()->click('@button')
+        ->assertRouteIs('somewhere');
+    }
+
+    public function test_can_update_property_when_middleware_attribute_passed()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            #[Middleware(AllowMiddleware::class)]
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render() 
+            {
+                return Blade::render(<<<'HTML'
+                <div>
+                    <button type="button" dusk="button" wire:click="increment">Protected Action</button>
+                    <div dusk="count">{{ $count }}</div>
+                </div>
+                HTML, ['count' => $this->count]);
+            }
+        })
+        ->waitForText('Protected Action')
+        ->waitForLivewire()->click('@button')
+        ->assertSeeIn('@count', '1');
+    }
+
+    public function test_cannot_update_property_when_middleware_attribute_not_passed()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            #[Middleware(DenyMiddleware::class)]
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render() 
+            {
+                return Blade::render(<<<'HTML'
+                <div>
+                    <button type="button" dusk="button" wire:click="increment">Protected Action</button>
+                    <div dusk="count">{{ $count }}</div>
+                </div>
+                HTML, ['count' => $this->count]);
+            }
+        })
+        ->waitForText('Protected Action')
+        ->waitForLivewire()->click('@button')
+        ->assertSeeIn('@count', '0');
+    }
+
+    public function test_can_update_property_using_event_listener_when_middleware_attribute_passed()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            #[Middleware(AllowMiddleware::class)]
+            #[On('increment-count')]
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render() 
+            {
+                return Blade::render(<<<'HTML'
+                <div>
+                    <button type="button" dusk="button" wire:click="$dispatch('increment-count')">Protected Action</button>
+                    <div dusk="count">{{ $count }}</div>
+                </div>
+                HTML, ['count' => $this->count]);
+            }
+        })
+        ->waitForText('Protected Action')
+        ->waitForLivewire()->click('@button')
+        ->assertSeeIn('@count', '1');
+    }
+
+    public function test_cannot_update_property_using_event_listener_when_middleware_attribute_not_passed()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            #[Middleware(DenyMiddleware::class)]
+            #[On('increment-count')]
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render() 
+            {
+                return Blade::render(<<<'HTML'
+                <div>
+                    <button type="button" dusk="button" wire:click="$dispatch('increment-count')">Protected Action</button>
+                    <div dusk="count">{{ $count }}</div>
+                </div>
+                HTML, ['count' => $this->count]);
+            }
+        })
+        ->waitForText('Protected Action')
+        ->waitForLivewire()->click('@button')
+        ->assertSeeIn('@count', '0');
+    }
+
+    public function test_middleware_attribute_can_be_triggered_from_child()
+    {
+        Livewire::visit([
+            new class extends Component {
+                #[Middleware(RedirectMiddleware::class)]
+                public function redirectSomewhere()
+                {
+                    $this->redirect('/somewhere');
+                }
+
+                public function render() 
+                {
+                    return <<<'HTML'
+                    <div>
+                        <div dusk="parent">Parent Component</div>
+                        <livewire:child />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public function render() 
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button type="button" dusk="button" wire:click="$parent.redirectSomewhere">Protected Action</button>
+                    </div>
+                    HTML;
+                }
+            }])
+        ->waitForText('Protected Action')
+        ->waitForLivewire()->click('@button')
+        ->assertRouteIs('somewhere.else');
+    }
+
+    public function test_middleware_attribute_can_be_triggered_from_child_using_event_listener()
+    {
+        Livewire::visit([
+            new class extends Component {
+                #[Middleware(RedirectMiddleware::class)]
+                #[On('redirect-somewhere')]
+                public function redirectSomewhere()
+                {
+                    $this->redirect('/somewhere');
+                }
+
+                public function render() 
+                {
+                    return <<<'HTML'
+                    <div>
+                        <div dusk="parent">Parent Component</div>
+                        <livewire:child />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public function render() 
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button type="button" dusk="button" wire:click="$dispatch('redirect-somewhere')">Protected Action</button>
+                    </div>
+                    HTML;
+                }
+            }])
+        ->waitForText('Protected Action')
+        ->waitForLivewire()->click('@button')
+        ->assertRouteIs('somewhere.else');
+    }
+}
+
+class RedirectMiddleware
+{
+    public function handle(Request $request, \Closure $next)
+    {
+        return redirect('/somewhere-else');
+    }
+}
+
+class AllowMiddleware
+{
+    public function handle(Request $request, \Closure $next)
+    {
+        return $next($request);
+    }
+}
+
+class DenyMiddleware
+{
+    public function handle(Request $request, \Closure $next)
+    {
+        return back();
+    }
+}

--- a/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
+++ b/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Livewire\Features\SupportActionMiddleware;
+
+use Illuminate\Auth\Middleware\Authorize as AuthorizeMiddleware;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Authorize;
+use Livewire\ComponentHook;
+use Livewire\Drawer\Utils;
+use Livewire\Exceptions\EventHandlerDoesNotExist;
+use Livewire\Features\SupportEvents\SupportEvents;
+use Livewire\Mechanisms\HandleRequests\HandleRequests;
+use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
+
+use function Livewire\{ on, store};
+
+class SupportActionMiddleware extends ComponentHook
+{
+    public static function provide()
+    {
+        on('call', function ($component, $method, $params, $context, $earlyReturn, $metadata) {
+            if (! app(HandleRequests::class)->isLivewireRoute()) return;
+
+            static::applyActionMiddleware($component, $method, $params);
+        });
+    }
+
+    // Following how SupportPagination and SupportQueryString set property attribute,
+    // any authorize middleware will be convert into `#[Authorize]` attribute for that method
+    // See: HandlesAttributes::setMethodAttribute()
+    function boot()
+    {
+        if (! app(HandleRequests::class)->isLivewireRoute()) return;
+
+        $middlewareAttributes = $this->storeGet('middlewareAttributes', []);
+
+        $filtered = [];
+        foreach ($middlewareAttributes as $method => $attributeArguments) {
+            $resolved = app('router')->resolveMiddleware($attributeArguments);
+
+            foreach ($resolved as $middleware) {
+                if (str_starts_with($middleware, AuthorizeMiddleware::class)) {
+                    [$ability, $arguments] = $this->parseMiddleware($middleware);
+
+                    $attribute = new Authorize($ability, $arguments);
+
+                    $this->component->setMethodAttribute($method, $attribute);
+
+                    continue;
+                }
+
+                $filtered[$method][] = $middleware;
+            }
+        }
+
+        $this->storeSet('middlewareAttributes', $filtered);
+    }
+
+    protected static function applyActionMiddleware($component, $method, $params)
+    {
+        $method = static::resolveMethodName($component, $method, $params);
+
+        // Return early if there is no middleware attribute on called method
+        if (! $actionMiddleware = store($component)->find('middlewareAttributes', $method)) return;
+
+        [$request, $middleware] = static::filterMiddleware($actionMiddleware);
+
+        if (empty($middleware)) return;
+
+        // Gather all action middleware from method and apply it all at once
+        Utils::applyMiddleware($request, $middleware);
+    }
+
+    protected static function resolveMethodName($component, $method, $params)
+    {
+        if ($method === '__dispatch') {
+            [$name, $params] = $params;
+
+            $names = SupportEvents::getListenerEventNames($component);
+
+            if (! in_array($name, $names)) {
+                throw new EventHandlerDoesNotExist($name);
+            }
+
+            return SupportEvents::getListenerMethodName($component, $name);
+        }
+
+        return $method;
+    }
+
+    protected static function filterMiddleware(array $middleware): array
+    {
+        $mechanism = app(PersistentMiddleware::class);
+
+        [$request, $excludedMiddleware] = (function () {
+            $request = $this->makeFakeRequest();
+
+            return [
+                $request,    
+                $this->getApplicablePersistentMiddleware($request)
+            ];
+        })->call($mechanism);
+
+        // Exclude any middleware that has been applied by PersistentMiddleware.
+        // If middleware not registered as persistent middleware and applied
+        // on both route level and attribute, it will runs twice as intended behavior
+        // because middleware attribute only applied on subsequent request that hit Livewire update endpoint.
+        $resolved = collect($middleware)
+            ->reject(function ($value, $key) use ($excludedMiddleware) {
+                return collect($excludedMiddleware)->contains(function ($iValue, $iKey) use ($value) {
+                    // Some middlewares can be closures.
+                    if (! is_string($value)) return true;
+
+                    // Ensure any middleware arguments aren't included in the comparison
+                    return Str::before($value, ':') == $iValue;
+                });
+            })
+            ->values()
+            ->all();
+
+        return [$request, $resolved];
+    }
+
+    protected function parseMiddleware($middleware)
+    {
+        [$name, $parameters] = array_pad(explode(':', $middleware, 2), 2, []);
+
+        if (is_string($parameters)) {
+            $parameters = explode(',', $parameters);
+        }
+
+        $ability = array_shift($parameters);
+
+        $arguments = empty($parameters) ? null : $parameters;
+
+        return [$ability, $arguments];
+    }
+}

--- a/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
+++ b/src/Features/SupportActionMiddleware/SupportActionMiddleware.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportActionMiddleware;
 
 use Illuminate\Auth\Middleware\Authorize as AuthorizeMiddleware;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Authorize;
 use Livewire\ComponentHook;
@@ -12,7 +13,7 @@ use Livewire\Features\SupportEvents\SupportEvents;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
 use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
 
-use function Livewire\{ on, store};
+use function Livewire\{on, store};
 
 class SupportActionMiddleware extends ComponentHook
 {
@@ -26,7 +27,7 @@ class SupportActionMiddleware extends ComponentHook
     }
 
     // Following how SupportPagination and SupportQueryString set property attribute,
-    // any authorize middleware will be convert into `#[Authorize]` attribute for that method
+    // any authorize middleware will be converted into `#[Authorize]` attribute for that method
     // See: HandlesAttributes::setMethodAttribute()
     function boot()
     {
@@ -105,9 +106,9 @@ class SupportActionMiddleware extends ComponentHook
         // If middleware not registered as persistent middleware and applied
         // on both route level and attribute, it will runs twice as intended behavior
         // because middleware attribute only applied on subsequent request that hit Livewire update endpoint.
-        $resolved = collect($middleware)
+        $resolved = (new Collection($middleware))
             ->reject(function ($value, $key) use ($excludedMiddleware) {
-                return collect($excludedMiddleware)->contains(function ($iValue, $iKey) use ($value) {
+                return (new Collection($excludedMiddleware))->contains(function ($iValue, $iKey) use ($value) {
                     // Some middlewares can be closures.
                     if (! is_string($value)) return true;
 

--- a/src/Features/SupportActionMiddleware/UnitTest.php
+++ b/src/Features/SupportActionMiddleware/UnitTest.php
@@ -1,0 +1,477 @@
+<?php
+
+namespace Livewire\Features\SupportActionMiddleware;
+
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User as AuthUser;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Session;
+use Livewire\Attributes\Authorize;
+use Livewire\Attributes\Middleware;
+use Livewire\Attributes\On;
+use Livewire\Livewire;
+use Sushi\Sushi;
+use Tests\TestCase;
+use Tests\TestComponent;
+
+class UnitTest extends TestCase
+{
+    public function test_can_apply_middleware_with_class_name()
+    {        
+        Livewire::actingAs(MiddlewareTestUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Middleware(Authenticate::class)]
+                public function protectedAction()
+                {
+                    Session::put('action-was-called', true);
+                }
+            })
+            ->call('protectedAction')
+            ->assertOk();
+
+        $this->assertTrue(Session::has('action-was-called'));
+    }
+
+    public function test_can_apply_middleware_with_class_name_for_unauthenticated_user()
+    {
+        $this->registerNamedRoute();
+
+        $this->expectException(AuthenticationException::class);
+
+        Livewire::test(new class extends TestComponent {
+                #[Middleware(Authenticate::class)]
+                public function protectedAction()
+                {
+                    Session::put('action-was-called', true);
+                }
+            })
+            ->call('protectedAction')
+            ->assertRedirectToRoute('login');
+
+        $this->assertFalse(Session::has('action-was-called'));
+    }
+
+    public function test_can_apply_middleware_with_alias()
+    {
+        Livewire::actingAs(MiddlewareTestUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Middleware('auth')]
+                public function protectedAction()
+                {
+                    Session::put('action-was-called', true);
+                }
+            })
+            ->call('protectedAction')
+            ->assertOk();
+
+        $this->assertTrue(Session::has('action-was-called'));
+    }
+
+    public function test_can_apply_middleware_with_alias_for_unauthenticated_user()
+    {
+        $this->registerNamedRoute();
+
+        $this->expectException(AuthenticationException::class);
+
+        Livewire::test(new class extends TestComponent {
+                #[Middleware('auth')]
+                public function protectedAction()
+                {
+                    Session::put('action-was-called', true);
+                }
+            })
+            ->call('protectedAction')
+            ->assertRedirectToRoute('login');
+
+        $this->assertFalse(Session::has('action-was-called'));
+    }
+
+    public function test_can_apply_multiple_middleware_to_action()
+    {
+        Livewire::actingAs(MiddlewareTestUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Middleware('auth')]
+                #[Middleware(MiddlewareForbiddenTest::class)]
+                public function protectedAction()
+                {
+                    Session::put('action-was-called', true);
+                }
+            })
+            ->call('protectedAction')
+            ->assertForbidden();
+
+        $this->assertFalse(Session::has('action-was-called'));
+    }
+
+    public function test_can_apply_multiple_middleware_to_action_for_unauthenticated_user()
+    {
+        $this->registerNamedRoute();
+
+        $this->expectException(AuthenticationException::class);
+
+        Livewire::test(new class extends TestComponent {
+            #[Middleware('auth')]
+            #[Middleware(MiddlewareForbiddenTest::class)]
+            public function protectedAction()
+            {
+                Session::put('action-was-called', true);
+            }
+        })
+        ->call('protectedAction')
+        ->assertRedirectToRoute('login');
+
+        $this->assertFalse(Session::has('action-was-called'));
+    }
+
+    public function test_middleware_works_with_event_listeners()
+    {
+        Livewire::actingAs(MiddlewareTestUser::find(1))
+            ->test(new class extends TestComponent {
+                #[On('some-event')]
+                #[Middleware('auth')]
+                public function handleEvent()
+                {
+                    Session::put('event-was-handled', true);
+                }
+            })
+            ->dispatch('some-event')
+            ->assertOk();
+
+        $this->assertTrue(Session::has('event-was-handled'));
+    }
+
+    public function test_middleware_on_event_listener_prevents_unauthorized_calls()
+    {
+        $this->registerNamedRoute();
+
+        $this->expectException(AuthenticationException::class);
+
+        Livewire::test(new class extends TestComponent {
+            #[On('protected-event')]
+            #[Middleware('auth')]
+            public function handleEvent()
+            {
+                Session::put('should-never-be-set', true);
+            }
+        })
+        ->dispatch('protected-event')
+        ->assertRedirectToRoute('login');
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
+    public function test_middleware_integrates_with_multiple_actions()
+    {
+        Livewire::actingAs(MiddlewareTestUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Middleware('auth')]
+                public function protectedAction()
+                {
+                    Session::put('protected-action-called', true);
+                }
+
+                public function publicAction()
+                {
+                    Session::put('public-action-called', true);
+                }
+            })
+            ->call('protectedAction')
+            ->assertOk()
+            ->call('publicAction')
+            ->assertOk();
+
+        $this->assertTrue(Session::has('protected-action-called'));
+        $this->assertTrue(Session::has('public-action-called'));
+    }
+
+    public function test_middleware_integrates_with_multiple_actions_for_unauthenticated_user()
+    {
+        $this->registerNamedRoute();
+
+        $this->expectException(AuthenticationException::class);
+
+        Livewire::test(new class extends TestComponent {
+                #[Middleware('auth')]
+                public function protectedAction()
+                {
+                    Session::put('protected-action-called', true);
+                }
+
+                public function publicAction()
+                {
+                    Session::put('public-action-called', true);
+                }
+            })
+            ->call('publicAction')
+            ->assertOk()
+            ->call('protectedAction')
+            ->assertRedirectToRoute('login');
+
+        $this->assertTrue(Session::has('public-action-called'));
+        $this->assertFalse(Session::has('protected-action-called'));
+    }
+
+    public function test_can_redirect_inside_action_when_middleware_passed()
+    {
+        Livewire::actingAs(MiddlewareTestUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Middleware('auth')]
+                public function goSomewhere()
+                {
+                    return redirect('/somewhere');
+                }
+            })
+            ->call('goSomewhere')
+            ->assertRedirect('/somewhere');
+
+        Livewire::actingAs(MiddlewareTestUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Middleware('auth')]
+                public function goSomewhereElse()
+                {
+                    return $this->redirect('/somewhere-else');
+                }
+            })
+            ->call('goSomewhereElse')
+            ->assertRedirect('/somewhere-else');
+    }
+
+    public function test_can_redirect_inside_action_when_middleware_passed_with_event()
+    {
+        Livewire::actingAs(MiddlewareTestUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Middleware('auth')]
+                #[On('go-somewhere')]
+                public function goSomewhere()
+                {
+                    return redirect('/somewhere');
+                }
+            })
+            ->dispatch('go-somewhere')
+            ->assertRedirect('/somewhere');
+
+        Livewire::actingAs(MiddlewareTestUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Middleware('auth')]
+                #[On('go-somewhere-else')]
+                public function goSomewhereElse()
+                {
+                    return $this->redirect('/somewhere-else');
+                }
+            })
+            ->dispatch('go-somewhere-else')
+            ->assertRedirect('/somewhere-else');
+    }
+    
+    public function test_can_abort_inside_middleware()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Middleware(MiddlewareAbortTest::class)]
+            public function goSomewhere()
+            {
+                Session::put('should-never-be-set', true);
+            }
+        })
+        ->call('goSomewhere')
+        ->assertNotFound();
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
+    public function test_can_redirect_inside_middleware()
+    {
+        $this->registerNamedRoute();
+
+        Livewire::test(new class extends TestComponent {
+            #[Middleware(MiddlewareRedirectTest::class)]
+            public function goSomewhere()
+            {
+                Session::put('should-never-be-set', true);
+            }
+        })
+        ->call('goSomewhere')
+        ->assertStatus(302);
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
+    public function test_can_throw_exception_inside_middleware()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Middleware throws an exception');
+
+        Livewire::test(new class extends TestComponent {
+            #[Middleware(MiddlewareExceptionTest::class)]
+            public function goSomewhere()
+            {
+                Session::put('should-never-be-set', true);
+            }
+        })
+        ->call('goSomewhere');
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
+    public function test_middleware_attribute_take_precedence_over_authorize()
+    {
+        $this->registerNamedRoute();
+
+        $this->expectException(AuthenticationException::class);
+
+        Gate::define('not-triggered', fn () => false);
+
+        Livewire::test(new class extends TestComponent {
+            #[Middleware('auth')]
+            #[Authorize('not-triggered')]
+            public function goSomewhere()
+            {
+                Session::put('should-never-be-set', true);
+            }
+        })
+        ->call('goSomewhere')
+        ->assertRedirectToRoute('login');
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
+    public function test_middleware_attribute_take_precedence_over_authorize_with_event_listener()
+    {
+        $this->registerNamedRoute();
+
+        $this->expectException(AuthenticationException::class);
+
+        Gate::define('not-triggered', fn () => false);
+
+        Livewire::test(new class extends TestComponent {
+            #[Middleware('auth')]
+            #[Authorize('not-triggered')]
+            #[On('go-somewhere')]
+            public function goSomewhere()
+            {
+                Session::put('should-never-be-set', true);
+            }
+        })
+        ->dispatch('go-somewhere')
+        ->assertRedirectToRoute('login');
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
+    public function test_authorize_middleware_transformed_to_authorize_attribute()
+    {
+        Gate::define('interact', fn () => false);
+
+        Livewire::actingAs(MiddlewareTestUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Middleware('auth')]
+                #[Middleware('can:interact')]
+                public function goSomewhere()
+                {
+                    Session::put('should-never-be-set', true);
+                }
+            })
+            ->call('goSomewhere')
+            ->assertForbidden();
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
+    public function test_authorize_middleware_transformed_to_authorize_attribute_with_event_listener()
+    {
+        Gate::define('interact', fn () => false);
+
+        Livewire::actingAs(MiddlewareTestUser::find(1))
+            ->test(new class extends TestComponent {
+                #[Middleware('auth')]
+                #[Middleware('can:interact')]
+                #[On('go-somewhere')]
+                public function goSomewhere()
+                {
+                    Session::put('should-never-be-set', true);
+                }
+            })
+            ->dispatch('go-somewhere')
+            ->assertForbidden();
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
+    public function test_unresolved_middleware_class_throws_exception()
+    {
+        $this->expectException(BindingResolutionException::class);
+        $this->expectExceptionMessage('Target class [ghabriel25] does not exist.');
+
+        Livewire::test(new class extends TestComponent {
+            #[Middleware('ghabriel25')]
+            public function goSomewhere()
+            {
+                Session::put('should-never-be-set', true);
+            }
+        })
+        ->call('goSomewhere')
+        ->assertStatus(500);
+
+        $this->assertFalse(Session::has('should-never-be-set'));
+    }
+
+    protected function registerNamedRoute()
+    {
+        Route::livewire('/login', new class extends TestComponent {})->name('login');
+    }
+}
+
+class MiddlewareTestUser extends AuthUser
+{
+    use Sushi;
+
+    protected $rows = [
+        ['id' => 1, 'name' => 'First User', 'email' => 'first@example.com', 'password' => ''],
+        ['id' => 2, 'name' => 'Second User', 'email' => 'second@example.com', 'password' => ''],
+    ];
+}
+
+class MiddlewareTestPost extends Model
+{
+    use Sushi;
+
+    protected $rows = [
+        ['id' => 1, 'title' => 'First', 'user_id' => 1],
+    ];
+}
+
+class MiddlewareForbiddenTest
+{
+    public function handle(Request $request, \Closure $next)
+    {
+        abort(403);
+    }
+}
+
+class MiddlewareAbortTest
+{
+    public function handle(Request $request, \Closure $next)
+    {
+        abort(404);
+    }
+}
+
+class MiddlewareRedirectTest
+{
+    public function handle(Request $request, \Closure $next)
+    {
+        return redirect('/login');
+    }
+}
+
+class MiddlewareExceptionTest
+{
+    public function handle(Request $request, \Closure $next)
+    {
+        throw new \Exception('Middleware throws an exception');
+    }
+}

--- a/src/Features/SupportAttributes/HandlesAttributes.php
+++ b/src/Features/SupportAttributes/HandlesAttributes.php
@@ -18,6 +18,13 @@ trait HandlesAttributes
         $this->mergeOutsideAttributes(new AttributeCollection([$attribute]));
     }
 
+    function setMethodAttribute($method, $attribute)
+    {
+        $attribute->__boot($this, AttributeLevel::METHOD, $method);
+
+        $this->mergeOutsideAttributes(new AttributeCollection([$attribute]));
+    }
+
     function mergeOutsideAttributes(AttributeCollection $attributes)
     {
         $this->attributes = $this->getAttributes()->concat($attributes);

--- a/src/Features/SupportRedirects/Redirector.php
+++ b/src/Features/SupportRedirects/Redirector.php
@@ -13,23 +13,12 @@ class Redirector extends BaseRedirector
     {
         $this->component->redirect($this->generator->to($path, [], $secure));
 
-        return $this;
+        return parent::to($path, $status, $headers, $secure);
     }
 
     public function away($path, $status = 302, $headers = [])
     {
         return $this->to($path, $status, $headers);
-    }
-
-    public function with($key, $value = null)
-    {
-        $key = is_array($key) ? $key : [$key => $value];
-
-        foreach ($key as $k => $v) {
-            $this->session->flash($k, $v);
-        }
-
-        return $this;
     }
 
     public function component(Component $component)

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -205,6 +205,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
             Features\SupportEvents\SupportEvents::class,
             Features\SupportSlots\SupportSlots::class,
             Features\SupportJson\SupportJson::class,
+            Features\SupportActionMiddleware\SupportActionMiddleware::class,
 
             // Some features we want to have priority over others...
             Features\SupportLifecycleHooks\SupportLifecycleHooks::class,


### PR DESCRIPTION
> [!NOTE]
> This PR includes the changes from PR https://github.com/livewire/livewire/pull/10398 so that tests pass locally.
> Once that PR is merged,  I will rebase/clean this PR and mark as ready

## Summary

This PR adds a new `#[Middleware]` attribute that allows developers to apply Laravel middleware (class names or aliases, with optional parameters) directly to individual Livewire component actions.

Livewire actions are public methods that can be invoked from the frontend via `wire:click`, forms, or events. While route-level middleware (via `PersistentMiddleware`) and `#[Authorize]` already exist, there has been no first-class, declarative way to protect a specific action with arbitrary middleware the same way Laravel controllers support middleware attributes.

This feature closes that gap by enabling early, method-level protection so that unauthorized or restricted calls never reach business logic.

This PR resolve the concern from this comment https://github.com/livewire/livewire/pull/10374#pullrequestreview-4629568219 and some regression test added to ensure that it works as expected. 

Need to mention that this attribute does not behave like `#[Authorize]` which can be called in collection loop inside `SupportEvents` or regular attribute call hook. The reason is this attribute should gather all middleware and apply it all at once (not one by one) just like `PersistentMiddleware` therefore it takes precedence over event and attribute `call()` hook.

## How it works

1. **Collection (boot time)**  
   The `#[Middleware]` attribute stores middleware definitions (class or alias) in the component’s internal store, keyed by method name.

2. **Authorization conversion (boot time)**  
   Any middleware that resolves to `Illuminate\Auth\Middleware\Authorize` (including the `can:` alias) is automatically converted into a real `#[Authorize]` attribute on the method. This keeps the two systems consistent and reuses the existing authorization infrastructure.

3. **Application (call time)**  
   On the `call` lifecycle event (only for requests hitting Livewire update endpoint):
   - The real method name is resolved (including event listeners via `__dispatch`).
   - Middleware already applied by `PersistentMiddleware` is filtered out to avoid unnecessary duplicates.
   - Remaining middleware is applied **all at once** through the existing `Utils::applyMiddleware()` pipeline using a fake request (the same technique used by `PersistentMiddleware`).

Because middleware is gathered and applied as a single batch on the `call` event, it runs **before** normal attribute `call()` hooks and event listeners. This gives middleware precedence over `#[Authorize]`.

## Usage examples

**Basic usage (class or alias)**

```php
#[Middleware('auth')]
#[Middleware(EnsureEmailIsVerified::class)]
public function showContent()
{
    //
}

#[Middleware('guest')]
public function bookmarkPost()
{
    //
}
```

**With parameters**

```php
#[Middleware('auth')]
#[Middleware('throttle:10')]
public function likePost(Post $post) { ... }

#[Middleware(CustomRoleMiddleware::class . ':admin')]
public function adminOnly() { ... }
```

**With events**

```php
#[On('mark-as-read')]
#[Middleware('auth')]
public function markAsRead()
{
    //
}
```

**Precedence over authorization**

```php
#[Middleware('auth')]
#[Authorize('update', 'post')] // only runs if auth middleware passes
public function save(Post $post) { ... }
```

**Automatic conversion of authorize middleware**

```php
#[Middleware('can:update,post')]
// is converted at boot time into:
// #[Authorize('update', 'post')]
```

## Important behavioral notes

- The attribute only runs on subsequent Livewire update requests (the same constraint as PersistentMiddleware). It does not run on the initial page load.
- Middleware already registered as persistent is automatically excluded to avoid double execution.
- Middleware that is not registered as persistent but is applied both at the route level and via the attribute will run twice. This is intentional.

## What's changed

- New feature: `SupportActionMiddleware`
- New attribute: `Livewire\Attributes\Middleware` (extends internal `BaseMiddleware`)
- Small extension to `HandlesAttributes` (`setMethodAttribute`) so authorize conversion can inject attributes cleanly
- `PersistentMiddleware` now exposes the list of middleware it actually applied so the new feature can filter against it without re-resolving
- Registered in the service provider alongside other features

The design deliberately reuses existing infrastructure (Utils::applyMiddleware, the fake-request pattern, the attribute store, and the event listener resolution logic) rather than introducing a parallel system.