### PR TITLE
[4.x] Discard stale responses when a newer request is in flight for model.live

### DIFF
--- a/js/request/index.js
+++ b/js/request/index.js
@@ -4,7 +4,7 @@ import { MessageRequest, PageRequest } from './request.js'
 import { InterceptorRegistry } from './interceptor.js'
 import { trigger, triggerAsync } from '@/hooks.js'
 import { showHtmlModal } from '@/utils/modal.js'
-import { MessageBus, scopeSymbolFromMessage } from './messageBus.js'
+import { getLiveVersionFor, incrementLiveVersionFor, MessageBus, scopeSymbolFromMessage } from './messageBus.js'
 import Message from './message.js'
 import Action from './action.js'
 
@@ -278,13 +278,13 @@ function sendMessages() {
                 updates: message.updates,
                 calls: message.calls,
             }
-        })
-    })
 
-    // Assign scope symbols to messages...
-    requests.forEach(request => {
-        request.messages.forEach(message => {
+            // Assign scope symbols & versions to messages...
             message.scope = scopeSymbolFromMessage(message)
+            let isModelLiveOnly = Array.from(message.actions).every(action => action.metadata.type === 'model.live')
+            if (isModelLiveOnly) {
+                message.liveVersion = incrementLiveVersionFor(message.component, message.scope)
+            }
         })
     })
 
@@ -438,6 +438,13 @@ function sendMessages() {
                         let snapshot = JSON.parse(snapshotEncoded)
 
                         if (snapshot.memo.id === message.component.id) {
+                            // Skip message if we have a newer version of the component already in-flight...
+                            if (message.liveVersion !== undefined && message.liveVersion < getLiveVersionFor(message.component, message.scope)) {
+                                message.resolveActionPromises([], [])
+                                message.invokeOnFinish()
+                                return
+                            }
+
                             message.responsePayload = { snapshot, effects }
 
                             message.invokeOnSuccess()

--- a/js/request/messageBus.js
+++ b/js/request/messageBus.js
@@ -1,6 +1,28 @@
 
 let componentSymbols = new WeakMap
 let componentIslandSymbols = new WeakMap
+let componentLiveVersions = new WeakMap
+
+export function incrementLiveVersionFor(component, scope) {
+    let scopes = componentLiveVersions.get(component)
+
+    if (! scopes) {
+        scopes = new Map
+        componentLiveVersions.set(component, scopes)
+    }
+
+    let version = (scopes.get(scope) || 0) + 1
+    scopes.set(scope, version)
+    return version
+}
+
+export function getLiveVersionFor(component, scope) {
+    let scopes = componentLiveVersions.get(component)
+
+    if (! scopes) return 0
+
+    return scopes.get(scope) || 0
+}
 
 export function scopeSymbolFromMessage(message) {
     let component = message.component


### PR DESCRIPTION
## Problem

When requests go out for a live component they can resolve out of order creating a pretty broken experience. The root cause being the older (late) response is parsed and displayed. This can be shown pretty simply with influenced delay on a DB query and the video below.

https://github.com/user-attachments/assets/099dbe32-e6ee-4cea-af8e-500ba5d9de3c

(I added some console logs to prove with simple incremental values that they can be parsed out of order)

This has been reported many times throughout the years: #8341, #2480 and #9030.

## Solution

You'd think a solution would be to cancel outbound requests when a newer one is made, but Livewire shares outbound calls with other components. You cannot safely abort requests due to this "batch" method. Instead, we decide to mark each message with a monotonic value that is incremented at payload build time assigned to each component (and scope) in a WeakMap.

When response comes back, any message who version is behind the component's current version is dropped. The promises are resolved as empty, but nothing is applied snapshot/effect wise.

https://github.com/user-attachments/assets/0b795557-1fe2-44ee-9635-9a2083d859d5

With more console logs. You can see the late response is ignored and thus the intended (current) version is the only one applied.

In testing I learned you can't apply this to every request, so we harden it down to only `model.live` types as those are exactly where the `.debounce` flaw occurs.

I did not understand why `requests.forEach` was done twice, the 2nd being to apply the `message.scope`, so I inlined that so I could apply my `.liveVersion` at same time.

## Testing
I cannot figure out a way to test this, because it seems the Dusk test server is a single process. So it doesn't matter the order of requests I send (even if I control the timing) because they run in order. So the entire parallel request aspect of the test I cannot test.