### PR TITLE
[4.x] Recursively hydrate nested synthesizers during property updates

### DIFF
--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -941,6 +941,79 @@ class UnitTest extends \Tests\TestCase
         Storage::disk('default-disk')->assertExists('images/avatar.jpg');
         Storage::disk('tmp-for-tests')->assertMissing('images/avatar.jpg');
     }
+
+    public function test_nested_uploads_survive_an_update_to_one_of_their_ancestor_paths()
+    {
+        // Nested repeaters (a Filament repeater inside a repeater, for
+        // example) update an ancestor path rather than the file's own leaf
+        // path. The browser strips synthesizer meta out of update payloads,
+        // so already-uploaded files arrive as their raw serialized strings
+        // and have to be re-hydrated from the previous snapshot's meta...
+        $component = Livewire::test(NestedFileUploadComponent::class)
+            ->set('data.sections.first.rows.one.image', UploadedFile::fake()->image('one.jpg'))
+            ->set('data.sections.first.rows.two.image', UploadedFile::fake()->image('two.jpg'));
+
+        $one = $component->viewData('data')['sections']['first']['rows']['one']['image'];
+        $two = $component->viewData('data')['sections']['first']['rows']['two']['image'];
+
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $one);
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $two);
+
+        // Typing into a caption of one row sends the whole section back...
+        $component->set('data.sections.first', [
+            'rows' => [
+                'one' => ['image' => $one->serializeForLivewireResponse(), 'caption' => 'Updated'],
+                'two' => ['image' => $two->serializeForLivewireResponse(), 'caption' => ''],
+            ],
+        ]);
+
+        $rows = $component->viewData('data')['sections']['first']['rows'];
+
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $rows['one']['image']);
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $rows['two']['image']);
+        $this->assertEquals('one.jpg', $rows['one']['image']->getClientOriginalName());
+        $this->assertEquals('two.jpg', $rows['two']['image']->getClientOriginalName());
+        $this->assertEquals('Updated', $rows['one']['caption']);
+    }
+
+    public function test_a_row_added_alongside_a_nested_upload_doesnt_disturb_it()
+    {
+        $component = Livewire::test(NestedFileUploadComponent::class)
+            ->set('data.sections.first.rows.one.image', UploadedFile::fake()->image('one.jpg'));
+
+        $one = $component->viewData('data')['sections']['first']['rows']['one']['image'];
+
+        // A brand new row has no counterpart in the previous snapshot, so
+        // there's no meta to hydrate it with — it stays plain data while its
+        // existing sibling is still reconstructed...
+        $component->set('data.sections.first', [
+            'rows' => [
+                'one' => ['image' => $one->serializeForLivewireResponse(), 'caption' => ''],
+                'three' => ['image' => null, 'caption' => 'New row'],
+            ],
+        ]);
+
+        $rows = $component->viewData('data')['sections']['first']['rows'];
+
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $rows['one']['image']);
+        $this->assertEquals(['image' => null, 'caption' => 'New row'], $rows['three']);
+    }
+}
+
+class NestedFileUploadComponent extends TestComponent
+{
+    use WithFileUploads;
+
+    public $data = [
+        'sections' => [
+            'first' => [
+                'rows' => [
+                    'one' => ['image' => null, 'caption' => ''],
+                    'two' => ['image' => null, 'caption' => ''],
+                ],
+            ],
+        ],
+    ];
 }
 
 class FileUploadToDefaultDiskComponent extends TestComponent

--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -111,12 +111,18 @@ class HandleSynths extends Mechanism
             // for example — have no meta to reconstruct them from...
             if (! $childMeta = $this->getMetaForPath($raw, $childPath)) return $child;
 
+            // The child value is untrusted update data and may itself look like a
+            // synthetic tuple. Always pair it with the authenticated snapshot meta;
+            // never let an update choose its own synthesizer or class...
             return $this->hydratePropertyUpdate([$child, $childMeta], $context, $childPath, $raw);
         });
     }
 
     public function hydrateForUpdate($raw, $path, $value, $context)
     {
+        // This is a trust boundary: $value came from the update payload, while
+        // $raw came from the snapshot that Checksum::verify() authenticated. Synth
+        // identity and class must only ever be selected from the latter...
         $meta = $this->getMetaForPath($raw, $path);
 
         // If we have meta data already for this property, let's use that to get a synth...

--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -76,7 +76,7 @@ class HandleSynths extends Mechanism
         });
     }
 
-    public function hydratePropertyUpdate($valueOrTuple, $context, $path)
+    public function hydratePropertyUpdate($valueOrTuple, $context, $path, $raw = null)
     {
         if (! Utils::isSyntheticTuple($value = $tuple = $valueOrTuple)) return $value;
 
@@ -94,8 +94,24 @@ class HandleSynths extends Mechanism
 
         $synth = $this->resolve($meta['s'], $context, $path);
 
-        return $synth->hydrate($value, $meta, function ($name, $child) {
-            return $child;
+        return $synth->hydrate($value, $meta, function ($name, $child) use ($context, $path, $raw) {
+            // Updates carry values only — the browser strips synthesizer meta out
+            // of the payload — so nested values can only be reconstructed from the
+            // meta in the previous, checksum-verified snapshot...
+            if ($raw === null) return $child;
+
+            // Wire data is JSON: scalars, arrays, null. Anything already a PHP
+            // object was set server-side (the testing helpers do this) and is
+            // in its final form...
+            if (is_object($child)) return $child;
+
+            $childPath = "{$path}.{$name}";
+
+            // Children the snapshot has never seen — a freshly added repeater row,
+            // for example — have no meta to reconstruct them from...
+            if (! $childMeta = $this->getMetaForPath($raw, $childPath)) return $child;
+
+            return $this->hydratePropertyUpdate([$child, $childMeta], $context, $childPath, $raw);
         });
     }
 
@@ -105,7 +121,7 @@ class HandleSynths extends Mechanism
 
         // If we have meta data already for this property, let's use that to get a synth...
         if ($meta) {
-            return $this->hydratePropertyUpdate([$value, $meta], $context, $path);
+            return $this->hydratePropertyUpdate([$value, $meta], $context, $path, $raw);
         }
 
         // If we don't, let's check to see if it's a typed property and fetch the synth that way...

--- a/src/Mechanisms/HandleSynths/UnitTest.php
+++ b/src/Mechanisms/HandleSynths/UnitTest.php
@@ -4,7 +4,9 @@ namespace Livewire\Mechanisms\HandleSynths;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Livewire\Livewire;
 use Livewire\Mechanisms\HandleComponents\ComponentContext;
+use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\CollectionSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Tests\TestComponent;
@@ -233,6 +235,60 @@ class UnitTest extends \Tests\TestCase
         $this->expectExceptionMessage('is not allowed to be instantiated');
 
         $synths->hydrateForUpdate($raw, 'data.section', ['nested' => ['x' => 2]], $context);
+    }
+
+    public function test_hydrate_for_update_never_trusts_synthesizer_meta_from_the_update_payload()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => ['tags' => collect(['safe'])],
+        ], $context, 'data')];
+
+        // This value deliberately has the shape of a synthetic tuple and claims
+        // a denylisted class. It came from the update payload, so both the synth
+        // key and class must remain plain collection data. Only the previous,
+        // authenticated Collection meta is allowed to choose the hydrator...
+        $forgedTuple = [
+            ['attacker-controlled'],
+            ['s' => 'arr', 'class' => \Symfony\Component\Process\Process::class],
+        ];
+
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', [
+            'tags' => $forgedTuple,
+        ], $context);
+
+        $this->assertInstanceOf(Collection::class, $updated['tags']);
+        $this->assertSame($forgedTuple, $updated['tags']->all());
+    }
+
+    public function test_nested_synthesizer_meta_in_the_previous_snapshot_cannot_be_tampered_with()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public $data;
+
+            public function mount()
+            {
+                $this->data = ['section' => ['tags' => collect(['safe'])]];
+            }
+        });
+
+        $snapshot = $component->snapshot;
+
+        // Replace the nested Collection synth with attacker-selected metadata.
+        // The request must be rejected by checksum verification before recursive
+        // update hydration gets any opportunity to resolve it...
+        $snapshot['data']['data'][0]['section'][0]['tags'][1] = [
+            's' => 'arr',
+            'class' => \Symfony\Component\Process\Process::class,
+        ];
+
+        $component->snapshot = $snapshot;
+
+        $this->expectException(CorruptComponentPayloadException::class);
+
+        $component->set('data.section', ['tags' => ['attacker-controlled']]);
     }
 }
 

--- a/src/Mechanisms/HandleSynths/UnitTest.php
+++ b/src/Mechanisms/HandleSynths/UnitTest.php
@@ -131,6 +131,109 @@ class UnitTest extends \Tests\TestCase
 
         $synths->hydratePropertyUpdate($tuple, $context, 'evil');
     }
+
+    /*
+     * An update sends values without synthesizer meta — the browser strips
+     * it. When the updated path sits ABOVE a synthesized value (updating
+     * `data.section` when `data.section.row.tags` is a collection), the
+     * nested values can only be reconstructed from the meta in the previous,
+     * checksum-verified snapshot. See hydratePropertyUpdate().
+     */
+
+    public function test_hydrate_for_update_recursively_hydrates_nested_synthetic_values()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => [
+                'row' => ['tags' => collect(['a']), 'title' => 'Original'],
+            ],
+        ], $context, 'data')];
+
+        // The browser sends the whole section back with meta stripped...
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', [
+            'row' => ['tags' => ['a', 'b'], 'title' => 'Updated'],
+        ], $context);
+
+        $this->assertInstanceOf(Collection::class, $updated['row']['tags']);
+        $this->assertSame(['a', 'b'], $updated['row']['tags']->all());
+        $this->assertSame('Updated', $updated['row']['title']);
+    }
+
+    public function test_hydrate_for_update_leaves_children_the_snapshot_has_no_meta_for_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => ['tags' => collect(['a'])],
+        ], $context, 'data')];
+
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', [
+            'tags' => ['a'],
+            'brandNew' => ['some' => 'array'],
+        ], $context);
+
+        $this->assertInstanceOf(Collection::class, $updated['tags']);
+        $this->assertSame(['some' => 'array'], $updated['brandNew']);
+    }
+
+    public function test_hydrate_for_update_passes_nested_removals_through_untouched()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => ['tags' => collect(['a']), 'other' => collect(['b'])],
+        ], $context, 'data')];
+
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', [
+            'tags' => '__rm__',
+            'other' => ['b'],
+        ], $context);
+
+        $this->assertSame('__rm__', $updated['tags']);
+        $this->assertInstanceOf(Collection::class, $updated['other']);
+    }
+
+    public function test_hydrate_for_update_leaves_already_hydrated_children_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => ['tags' => collect(['a'])],
+        ], $context, 'data')];
+
+        // Updates coming off the wire are JSON, but Livewire's testing
+        // helpers set real PHP values. Those are already in their final
+        // form and mustn't be run back through a synthesizer...
+        $tags = collect(['a', 'b']);
+
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', ['tags' => $tags], $context);
+
+        $this->assertSame($tags, $updated['tags']);
+    }
+
+    public function test_hydrate_for_update_runs_the_security_policy_over_nested_meta()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        // Meta declaring a denylisted gadget class, nested a level below the
+        // updated path. Recursion must not skip the denylist check...
+        $raw = ['data' => [[
+            'section' => [[
+                'nested' => [['x' => 1], ['s' => 'arr', 'class' => \Symfony\Component\Process\Process::class]],
+            ], ['s' => 'arr']],
+        ], ['s' => 'arr']]];
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not allowed to be instantiated');
+
+        $synths->hydrateForUpdate($raw, 'data.section', ['nested' => ['x' => 2]], $context);
+    }
 }
 
 class CustomThing


### PR DESCRIPTION
Re-targeted from #10471 at @joshhanley's request — same change, branched off `4.x` instead of `main`.

Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

**1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?**

No discussion — this is a bug fix that comes with a failing test, so it seemed more useful to bring the reproduction. Happy to open one if you'd prefer to talk it through.

**2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)**

Yes — `fix-nested-synth-hydration-on-property-updates-4x`, targeting `4.x`.

**3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.**

No. One change in `HandleSynths`, plus tests.

**4️⃣ Does it include tests? (Required)**

Yes — 9 tests. Six reproduce the bug and fail on `4.x` without the change, one guards the already-hydrated testing path, and two lock down the snapshot/update trust boundary:

- `src/Mechanisms/HandleSynths/UnitTest.php` — the mechanism itself (recursion, missing meta, `__rm__`, already-hydrated values, security policy over nested meta, forged update tuples, and checksum-protected nested meta)
- `src/Features/SupportFileUploads/UnitTest.php` — the real-world symptom (nested uploads surviving an ancestor update)

**5️⃣ Please include a thorough description of the improvement and reasons why it's useful.**

### The bug

Non-primitive values ride the wire as a `[value, meta]` tuple, where the meta says which synthesizer rebuilds the PHP value. Full hydration walks that tree recursively:

```php
// HandleSynths::hydrate()
return $synth->hydrate($value, $meta, function ($name, $child) use ($context, $path) {
    return $this->hydrate($child, $context, "{$path}.{$name}");
});
```

Property updates did not:

```php
// HandleSynths::hydratePropertyUpdate()
return $synth->hydrate($value, $meta, function ($name, $child) {
    return $child;
});
```

So when an update targets a path *above* a synthesized value, the synth at the updated path is applied but everything nested under it comes back as raw wire data.

### How you hit it

Nested repeaters. With state shaped like `data.sections.{section}.rows.{row}.image`, editing any field in the section sends an update for the ancestor path (`data.sections.first`), not for the image leaf. The payload contains the already-uploaded file as its serialized string, and — because the browser strips meta out of update payloads — there is no meta on it. The property is then repopulated with:

```php
'image' => 'livewire-file:BToZJYNz....jpg'   // a string, not a TemporaryUploadedFile
```

The upload is still on disk, but nothing downstream recognises it any more, so the file "disappears" from the form. In Filament this shows up as a nested repeater losing images from rows the user never touched. Related report: https://github.com/livewire/livewire/discussions/6203

It isn't specific to file uploads — any nested synthesized value (collections, enums, Carbon instances, custom synths) is affected; uploads just make the loss visible.

### The fix

Hydrate nested children during an update too, using the meta from the **previous snapshot** rather than the update payload:

```php
$childPath = "{$path}.{$name}";

if (! $childMeta = $this->getMetaForPath($raw, $childPath)) return $child;

return $this->hydratePropertyUpdate([$child, $childMeta], $context, $childPath, $raw);
```

`$raw` is the snapshot data that `update()` already verified with `Checksum::verify()`, and it is the same source the top-level `hydratePropertyUpdate()` call already trusts for meta — the update payload never gets a say in which class is instantiated. Because the recursion goes back through `hydratePropertyUpdate()`, every nested tuple still passes `SecurityPolicy::validateClass()` and still honours the `__rm__` removal sentinel.

### Security contract

The update payload controls values, never type identity. Synthesizer keys, classes, and other hydration metadata are read only from the previous snapshot after `Checksum::verify()` authenticates it with the application key. A tuple-shaped update value is therefore ordinary input data; it cannot select a synthesizer or class.

The security tests exercise both sides of that boundary:

- An update value shaped exactly like a synth tuple and claiming a denylisted `Symfony\Component\Process\Process` class remains ordinary data inside the Collection selected by the authenticated snapshot meta.
- Replacing that nested Collection meta inside the previous snapshot is rejected with `CorruptComponentPayloadException` before update hydration runs.
- Authenticated nested classes still pass through `SecurityPolicy::validateClass()` and each synth's own class constraints during recursive hydration.

This grants no new write authority: a client that can submit a consolidated ancestor update could already submit the equivalent granular leaf update. The change makes both routes apply the same snapshot-derived hydration contract.

Two deliberate bail-outs:

- **No meta in the snapshot → the value is left alone.** New children (a repeater row added this request) are plain data, exactly as before.
- **A child that is already a PHP object is left alone.** Real update payloads are JSON, so an object can only have been set server-side — `Livewire::test()->set('list', [SomeEnum::TEST])`, for instance. Running those back through a synth would be wrong (and would break `EnumUnitTest::test_an_array_of_enums`).

`hydratePropertyUpdate()`'s new `$raw` argument is optional and defaults to `null` (old, non-recursive behaviour), so external callers of the method are unaffected.

### Relationship to #10431

#10431 ("Keep rich synth values out of consolidated diffs") attacks the same symptom from the client: it stops `diffAndConsolidate()` from replacing per-leaf diffs with a whole-parent update when the subtree holds rich synth values. That's a good mitigation, but it's on `main` only, and it's complementary rather than overlapping:

- It can only see values JS knows are rich — types registered via `Livewire.synth()`. Server-only synthesizers (`Collection`, `Carbon`, enums, `stdClass`, userland `Synth`/`Wireable`) have no JS counterpart, so they're still consolidated and still lose their type.
- On `4.x` uploads aren't a JS synth at all (that arrived with `js/features/supportFileUploads/synth.js` on `main`), so a backport of #10431 alone would not fix the upload case here.
- Ancestor updates also arrive by routes the differ doesn't control — `$wire.$set('data.sections', {...})`, a package writing parent state, or a hand-crafted request. The server should reconstruct correctly regardless of how the payload was produced.

### Notes

- `vendor/bin/phpunit --testsuite Unit` on this branch: 1344 tests, with exactly the same 5 pre-existing `FrontendAssets` failures that a clean `4.x` produces in my environment (Laravel 13-dev / PHP 8.5) — 1335 tests there, same 4 errors + 1 failure.
- The same bug exists on `3.x`, where these methods live in `HandleComponents` — happy to send that backport too if you want it.
