### PR TITLE
[4.x] Fix unhandled promise rejection on failed navigate request

### DIFF
--- a/js/plugins/navigate/fetch.js
+++ b/js/plugins/navigate/fetch.js
@@ -13,5 +13,8 @@ export function fetchHtml(destination, callback, errorCallback) {
 }
 
 export function performFetch(uri, callback, errorCallback) {
+    // `errorCallback` has already dealt with this failure by the time the promise
+    // rejects. Leaving it unobserved would surface it as an unhandled rejection,
+    // which every error-tracking SDK files as an application error...
     sendNavigateRequest(uri, callback, errorCallback).catch(() => {})
 }

--- a/js/plugins/navigate/fetch.js
+++ b/js/plugins/navigate/fetch.js
@@ -13,5 +13,6 @@ export function fetchHtml(destination, callback, errorCallback) {
 }
 
 export function performFetch(uri, callback, errorCallback) {
-    sendNavigateRequest(uri, callback, errorCallback)
+    // The failure is already handled by errorCallback, so swallow the rejection to avoid an unhandled promise rejection...
+    sendNavigateRequest(uri, callback, errorCallback).catch(() => {})
 }

--- a/js/plugins/navigate/fetch.js
+++ b/js/plugins/navigate/fetch.js
@@ -13,6 +13,5 @@ export function fetchHtml(destination, callback, errorCallback) {
 }
 
 export function performFetch(uri, callback, errorCallback) {
-    // The failure is already handled by errorCallback, so swallow the rejection to avoid an unhandled promise rejection...
     sendNavigateRequest(uri, callback, errorCallback).catch(() => {})
 }

--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -129,8 +129,22 @@ export default function (Alpine) {
                     })
                 })
             })
-        }, () => {
+        }, (error) => {
             showProgressBar && finishAndHideProgressBar()
+
+            // We cancelled this request ourselves, so the user is already on their
+            // way somewhere else. Sending them to a destination they abandoned
+            // would be worse than doing nothing...
+            if (requestWasCancelled(error)) return
+
+            // A rejected fetch doesn't always mean the network is gone — following a
+            // redirect to another origin fails the same way, and we deliberately stay
+            // put for those. Only when the browser tells us we're offline do we hand
+            // the navigation back, so the user gets the browser's own offline page
+            // instead of a click that silently did nothing...
+            if (navigator.onLine) return
+
+            window.location.href = destination.href
         })
     }
 
@@ -218,6 +232,10 @@ function fetchHtmlOrUsePrefetchedHtml(fromDestination, callback, errorCallback) 
     getPretchedHtmlOr(fromDestination, callback, () => {
         fetchHtml(fromDestination, callback, errorCallback)
     })
+}
+
+function requestWasCancelled(error) {
+    return error?.name === 'AbortError'
 }
 
 function preventAlpineFromPickingUpDomChanges(Alpine, callback) {

--- a/js/plugins/navigate/prefetch.js
+++ b/js/plugins/navigate/prefetch.js
@@ -13,17 +13,21 @@ export function prefetchHtml(destination, callback, errorCallback) {
 
     if (prefetches[uri]) return
 
-    prefetches[uri] = { finished: false, html: null, whenFinished: () => setTimeout(() => delete prefetches[uri], cacheDuration) }
+    prefetches[uri] = { finished: false, html: null, whenFinished: () => setTimeout(() => delete prefetches[uri], cacheDuration), whenFailed: () => {} }
 
     performFetch(uri, (html, routedUri, status) => {
         storeCurrentPageStatus(status)
 
         callback(html, routedUri)
     }, () => {
+        let whenFailed = prefetches[uri].whenFailed
+
         // If the fetch failed, remove the prefetch so it gets attempted again...
         delete prefetches[uri]
 
         errorCallback()
+
+        whenFailed()
     })
 }
 
@@ -56,6 +60,11 @@ export function getPretchedHtmlOr(destination, receive, ifNoPrefetchExists) {
 
             receive(html, finalDestination)
         }
+
+        // Someone is waiting on this in-flight prefetch. If it fails, they're
+        // left hanging with no navigation at all, so send them down the normal
+        // request path instead where a failure can be handled properly...
+        prefetches[uri].whenFailed = ifNoPrefetchExists
     }
 }
 

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -1291,7 +1291,6 @@ class BrowserTest extends \Tests\BrowserTestCase
             $browser
                 ->visit('/first')
                 ->assertSee('On first')
-                // Force the prefetch request to fail at the transport layer...
                 ->tap(fn ($b) => $b->script('window.fetch = () => Promise.reject(new TypeError("Failed to fetch"))'))
                 ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
                 ->pause(500)

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -1285,6 +1285,20 @@ class BrowserTest extends \Tests\BrowserTestCase
         });
     }
 
+    public function test_failed_navigate_prefetch_does_not_trigger_an_unhandled_promise_rejection()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first')
+                ->assertSee('On first')
+                // Force the prefetch request to fail at the transport layer...
+                ->tap(fn ($b) => $b->script('window.fetch = () => Promise.reject(new TypeError("Failed to fetch"))'))
+                ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+                ->pause(500)
+                ->assertConsoleLogHasNoErrors();
+        });
+    }
+
     public function test_navigate_hover_prefetches_and_caches_for_a_default_30_seconds()
     {
         $this->browse(function ($browser) {

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -1298,6 +1298,63 @@ class BrowserTest extends \Tests\BrowserTestCase
         });
     }
 
+    public function test_failed_navigate_prefetch_does_not_navigate_anywhere()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first')
+                ->assertSee('On first')
+                ->tap(fn ($b) => $b->script('window.fetch = () => Promise.reject(new TypeError("Failed to fetch"))'))
+                ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+                ->pause(500)
+                // A prefetch is speculative — the user never asked to go anywhere,
+                // so a failed one should do nothing at all...
+                ->assertSee('On first')
+                ->assertPathIs('/first');
+        });
+    }
+
+    public function test_failed_navigate_falls_back_to_a_hard_browser_navigation()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first')
+                ->tap(fn ($b) => $b->script('window._lw_dusk_test = true'))
+                ->assertScript('return window._lw_dusk_test')
+                ->assertSee('On first')
+                ->tap(fn ($b) => $b->script([
+                    'Object.defineProperty(navigator, "onLine", { get: () => false, configurable: true })',
+                    'window.fetch = () => Promise.reject(new TypeError("Failed to fetch"))',
+                ]))
+                ->click('@link.to.second')
+                ->waitForText('On second')
+                // The marker is gone, so the browser performed a full page load rather
+                // than swallowing the click and stranding the user on the first page...
+                ->assertScript('return window._lw_dusk_test', false);
+        });
+    }
+
+    public function test_navigate_falls_back_to_a_hard_browser_navigation_when_an_in_flight_prefetch_fails()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first')
+                ->tap(fn ($b) => $b->script('window._lw_dusk_test = true'))
+                ->assertScript('return window._lw_dusk_test')
+                ->assertSee('On first')
+                // Failing slowly means the prefetch kicked off by pressing the link is
+                // still in flight when the click is released, so the navigation ends up
+                // waiting on a request that is about to fail...
+                ->tap(fn ($b) => $b->script([
+                    'Object.defineProperty(navigator, "onLine", { get: () => false, configurable: true })',
+                    'window.fetch = () => new Promise((resolve, reject) => setTimeout(() => reject(new TypeError("Failed to fetch")), 500))',
+                ]))
+                ->click('@link.to.second')
+                ->waitForText('On second')
+                ->assertScript('return window._lw_dusk_test', false);
+        });
+    }
+
     public function test_navigate_hover_prefetches_and_caches_for_a_default_30_seconds()
     {
         $this->browse(function ($browser) {


### PR DESCRIPTION
`wire:navigate` prefetch and navigation call `sendNavigateRequest()` through `performFetch()` without awaiting or catching the returned promise. When the request fails at the transport layer (offline, an aborted prefetch, a proxy or ad-blocker blocking it), `sendNavigateRequest()` rethrows after `errorCallback` has already handled the failure, so the rejection escapes as an unhandled promise rejection.

Livewire itself recovers, but error-tracking SDKs that hook `unhandledrejection` (Sentry, Bugsnag, ...) log each one as `TypeError: Failed to fetch` with a stack that points only into the Livewire bundle. Prefetch fires on hover, so it happens often.

`performFetch()` now catches the rejection. `errorCallback` still deletes the prefetch cache entry and falls back to a hard navigation, so nothing else changes.

Fixes #10490