### PR TITLE
[4.x] Fix throttle requests get debounced by `.live` modifier

### DIFF
--- a/js/directives/wire-model.js
+++ b/js/directives/wire-model.js
@@ -85,7 +85,7 @@ directive('model', ({ el, directive, component, cleanup }) => {
     let debouncedUpdate = update
 
     // Apply debounce/throttle from network modifiers
-    if ((shouldSendNetwork && ! hasNetworkTriggers && isRealtimeInput(el)) || isDebounced) {
+    if ((shouldSendNetwork && ! hasNetworkTriggers && isRealtimeInput(el) && ! isDebounced && ! isThrottled) || isDebounced) {
         debouncedUpdate = debounce(debouncedUpdate, parseModifierDuration(networkModifiers, 'debounce') || 150)
     }
 

--- a/src/Tests/WireModelBrowserTest.php
+++ b/src/Tests/WireModelBrowserTest.php
@@ -148,6 +148,39 @@ class WireModelBrowserTest extends \Tests\BrowserTestCase
             ->assertScript('window.requests', 1); // Only one request was sent
     }
 
+    public function test_pure_throttles_requests_not_auto_debounced_from_live_modifier()
+    {
+        Livewire::visit(new class extends Component {
+            public $foo;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div x-init="window.requests = 0">
+                    <input type="text" wire:model.live.throttle.30ms="foo" dusk="input">
+                    <span wire:text="foo" dusk="text"></span>
+                </div>
+
+                @script
+                <script>
+                    this.intercept(({ onSend }) => {
+                        onSend(() => {
+                            window.requests++
+                        })
+                    })
+                </script>
+                @endscript
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->typeSlowly('@input', 'ab', 50)
+            ->assertSeeIn('@text', 'ab') // wire:text should update immediately
+            ->pause(300) // Wait for the trailing request to be handled
+            // The requests will collapse into one if `.live` auto debounced applied
+            ->assertScript('window.requests', 2);
+    }
+
     public function test_throttles_requests_with_custom_duration()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
## Problem
When using pure `.throttle` modifier on input element
```blade
<input wire:model.live.throttle.30ms="search" />
```
It will get auto debounced by `150ms` from `.live` modifier eventhough it doesnt include `.debounce` modifier. This is hardly get noticed without browser test.

Looking back at the commits history, this was introduced in https://github.com/livewire/livewire/pull/9597 and follow up by https://github.com/livewire/livewire/pull/9832 but never get fixed. The main problem was logical `||` from this

```js
if ((shouldSendNetwork && ! hasNetworkTriggers && isRealtimeInput(el)) || isDebounced) {
    debouncedUpdate = debounce(debouncedUpdate, parseModifierDuration(networkModifiers, 'debounce') || 150)
}

if (isThrottled) {
    debouncedUpdate = throttle(debouncedUpdate, parseModifierDuration(networkModifiers, 'throttle') || 150)
}
```
From example above, this will produce
```js
debouncedUpdate = throttle(debounce(update, 150), 30)
```

Why? because even if it doesnt have `.debounce` modifier, it still have `.live` modifier which will apply default `150ms` debounce duration.

## Solution
Add guard for `.live` that it's not throttled / debounced
```js
if ((shouldSendNetwork && ! hasNetworkTriggers && isRealtimeInput(el) && ! isDebounced && ! isThrottled) || isDebounced) {
    debouncedUpdate = debounce(debouncedUpdate, parseModifierDuration(networkModifiers, 'debounce') || 150)
}

if (isThrottled) {
    debouncedUpdate = throttle(debouncedUpdate, parseModifierDuration(networkModifiers, 'throttle') || 150)
}
```
This way, throttle requests will only get debounced if there is `.debounce` modifier
