### PR TITLE
[4.x] Fix server-side JS evaluation on mount running before the component is registered

### DIFF
--- a/js/component.js
+++ b/js/component.js
@@ -49,9 +49,6 @@ export class Component {
         el.$wire = this.$wire
 
         this.cleanups = []
-
-        // Effects will be processed after every request, but we'll also handle them on initialization.
-        this.processEffects(this.effects)
     }
 
     addActionContext(context) {

--- a/js/store.js
+++ b/js/store.js
@@ -16,6 +16,9 @@ export function initComponent(el) {
 
     components[component.id] = component
 
+    // Process initial effects after registering so mount-time effects like `$this->js()` can resolve `$wire`...
+    component.processEffects(component.effects)
+
     return component
 }
 

--- a/src/Features/SupportJsEvaluation/BrowserTest.php
+++ b/src/Features/SupportJsEvaluation/BrowserTest.php
@@ -75,6 +75,33 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_can_evaluate_js_on_mount_that_calls_a_livewire_action()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $count = 0;
+
+                public function mount()
+                {
+                    $this->js('$wire.increment()');
+                }
+
+                public function increment()
+                {
+                    $this->count++;
+                }
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <span dusk="count">{{ $count }}</span>
+                </div>
+                HTML; }
+        })
+        ->waitForText('1')
+        ->assertSeeIn('@count', '1')
+        ;
+    }
+
     public function test_can_define_js_actions_though_dollar_wire_on_a_component()
     {
         Livewire::visit(


### PR DESCRIPTION
When a component calls `$this->js()` inside `mount()`, that JavaScript ships in the initial page payload as a mount-time effect. Livewire ran those effects from the `Component` constructor, before `initComponent` had registered the component in the JS store. So any `$wire` action in that JavaScript couldn't resolve its component, the `$wire` proxy caught the error and returned a silent no-op, and the action never fired.

Processing the initial effects after the component is registered lets those mount-time `$wire` calls resolve normally.

Fixes #10493