### PR TITLE
[4.x] Renderless batched render skipped

### DIFF
--- a/src/Features/SupportRenderless/BaseRenderless.php
+++ b/src/Features/SupportRenderless/BaseRenderless.php
@@ -11,6 +11,7 @@ class BaseRenderless extends LivewireAttribute
     {
         $this->storeSet('skipIslandsRender', true);
 
-        $this->component->skipRender();
+        // Record the opt-out; the render is only skipped once every action in the request has (see HandleComponents::callMethods).
+        $this->storeSet('renderlessCallCount', $this->storeGet('renderlessCallCount', 0) + 1);
     }
 }

--- a/src/Features/SupportRenderless/BrowserTest.php
+++ b/src/Features/SupportRenderless/BrowserTest.php
@@ -81,4 +81,31 @@ class BrowserTest extends BrowserTestCase
             ->waitForLivewire()->click('@button')
             ->assertSeeIn('@button', '1');
     }
+
+    public function test_render_is_not_skipped_when_a_renderless_action_is_batched_with_a_normal_action()
+    {
+        Livewire::visit(new class extends Component {
+            public $name = 'foo';
+
+            #[BaseRenderless]
+            function renderlessAction() { }
+
+            function updateName()
+            {
+                $this->name = 'bar';
+            }
+
+            function render()
+            {
+                return Blade::render(<<<'HTML'
+                <div>
+                    <button x-on:click="$wire.renderlessAction(); $wire.updateName()" dusk="button">{{ $name }}</button>
+                </div>
+                HTML, ['name' => $this->name]);
+            }
+        })
+            ->assertSeeIn('@button', 'foo')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@button', 'bar');
+    }
 }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -583,7 +583,7 @@ class HandleComponents extends Mechanism
 
                 // Support `.renderless` on magic actions like `wire:model.renderless.live`...
                 if ($metadata['renderless'] ?? false) {
-                    $root->skipRender();
+                    $this->markCallRenderless($root);
                 }
 
                 $returns[] = $return;
@@ -622,11 +622,24 @@ class HandleComponents extends Mechanism
 
             // Support `Wire:click.renderless`...
             if ($metadata['renderless'] ?? false) {
-                $root->skipRender();
+                $this->markCallRenderless($root);
             }
         }
 
+        // Only skip the render once EVERY action in the request has opted out of
+        // rendering. A renderless action batched alongside a non-renderless one
+        // (e.g. `$wire.renderlessAction(); $wire.normalAction()` collapsed into a
+        // single request) must not suppress the render the normal action needs.
+        if (count($calls) > 0 && store($root)->get('renderlessCallCount', 0) >= count($calls)) {
+            $root->skipRender();
+        }
+
         $componentContext->addEffect('returns', $returns);
+    }
+
+    protected function markCallRenderless($root)
+    {
+        store($root)->set('renderlessCallCount', store($root)->get('renderlessCallCount', 0) + 1);
     }
 
     protected function pushOntoComponentStack($component)

--- a/src/Mechanisms/Tests/ComponentSkipRenderUnitTest.php
+++ b/src/Mechanisms/Tests/ComponentSkipRenderUnitTest.php
@@ -47,6 +47,26 @@ class ComponentSkipRenderUnitTest extends \Tests\TestCase
         Route::get('/403', ComponentSkipRenderOnRedirectHelperInMountStub::class);
         $this->get('/403')->assertRedirect('/bar');
     }
+
+    public function test_render_is_not_skipped_when_a_renderless_call_is_batched_with_a_normal_call()
+    {
+        $component = Livewire::test(ComponentRenderlessBatchStub::class);
+
+        $component->assertSee('foo');
+
+        // Simulate the browser batching two $wire calls into a single request,
+        // e.g. `$wire.renderlessAction(); $wire.updateName()`.
+        $component->update(calls: [
+            ['method' => 'renderlessAction', 'params' => [], 'path' => ''],
+            ['method' => 'updateName', 'params' => [], 'path' => ''],
+        ]);
+
+        // The non-renderless updateName() mutated state the view depends on...
+        $component->assertSetStrict('name', 'bar');
+
+        // ...so the component should re-render, despite the batched renderless call.
+        $component->assertSee('bar');
+    }
 }
 
 class ComponentSkipRenderStub extends Component
@@ -87,6 +107,29 @@ class ComponentSkipRenderAttributeStub extends Component
         }
 
         return app('view')->make('null-view');
+    }
+}
+
+class ComponentRenderlessBatchStub extends Component
+{
+    public $name = 'foo';
+
+    #[\Livewire\Attributes\Renderless]
+    public function renderlessAction()
+    {
+        //
+    }
+
+    public function updateName()
+    {
+        $this->name = 'bar';
+    }
+
+    public function render()
+    {
+        return <<<'blade'
+            <div>{{ $name }}</div>
+blade;
     }
 }
 


### PR DESCRIPTION
Resolves issue #10495 

Includes unit and browser test.

**The change:** Instead of skipping immediately, each renderless action now just *records* that it opted out of rendering (a per-request count). After all the actions in the request have run, `callMethods` skips the render only when the count covers **every** action in the request. So a lone renderless action still skips (count == total), but a renderless action batched with a normal one now renders (count < total). Imperative `$this->skipRender()`, event listeners, islands, redirects, slots, and nesting are untouched.
