### PR TITLE
[4.x] Provide data store helper

### DIFF
--- a/src/ComponentHook.php
+++ b/src/ComponentHook.php
@@ -108,6 +108,11 @@ abstract class ComponentHook
         return store($this->component)->get($key, $default);
     }
 
+    function storeFind($key, $iKey = null, $default = null)
+    {
+        return store($this->component)->find($key, $iKey, $default);
+    }
+
     function storeHas($key)
     {
         return store($this->component)->has($key);

--- a/src/Features/SupportAttributes/Attribute.php
+++ b/src/Features/SupportAttributes/Attribute.php
@@ -4,6 +4,8 @@ namespace Livewire\Features\SupportAttributes;
 
 use Livewire\Component;
 
+use function Livewire\store;
+
 abstract class Attribute
 {
     protected Component $component;
@@ -103,5 +105,30 @@ abstract class Attribute
         }
 
         return false;
+    }
+
+    function storeSet($key, $value)
+    {
+        store($this->component)->set($key, $value);
+    }
+
+    function storePush($key, $value, $iKey = null)
+    {
+        store($this->component)->push($key, $value, $iKey);
+    }
+
+    function storeGet($key, $default = null)
+    {
+        return store($this->component)->get($key, $default);
+    }
+
+    function storeFind($key, $iKey = null, $default = null)
+    {
+        return store($this->component)->find($key, $iKey, $default);
+    }
+
+    function storeHas($key)
+    {
+        return store($this->component)->has($key);
     }
 }


### PR DESCRIPTION
This was originally merged into `main` branch (https://github.com/livewire/livewire/pull/10444/changes/e7d08de5f5c3b98383b71769cfcea032fb0a9e73, https://github.com/livewire/livewire/pull/10442/changes/f4c83fc9bea70677a1664565514ba235ff22a3f7) but not included in new `4.x`.

## What's changed
- Provide data store helper in base Livewire `Attribute`
- In addition, complement for missing `$this->storeFind()` helper in `ComponentHook`