### PR TITLE
[4.x] Fix renderless calls incorrectly skipping render when batched with normal calls

### DIFF
--- a/src/Features/SupportEvents/SupportEvents.php
+++ b/src/Features/SupportEvents/SupportEvents.php
@@ -9,7 +9,6 @@ use Livewire\Features\SupportAttributes\AttributeLevel;
 use Livewire\ComponentHook;
 use Livewire\Exceptions\EventHandlerDoesNotExist;
 use Livewire\Features\SupportAuthorization\BaseAuthorize;
-use Livewire\Features\SupportRenderless\BaseRenderless;
 
 class SupportEvents extends ComponentHook
 {
@@ -38,17 +37,6 @@ class SupportEvents extends ComponentHook
             $returnEarly(
                 wrap($this->component)->$method(...$params)
             );
-
-            // Here we have to manually check to see if the event listener method
-            // is "renderless" as it's normal "call" hook doesn't get run when
-            // the method is called as an event listener...
-            $isRenderless = $this->component->getAttributes()
-                ->filter(fn ($i) => $i instanceof BaseRenderless)
-                ->filter(fn ($i) => $i->getName() === $method)
-                ->filter(fn ($i) => $i->getLevel() === AttributeLevel::METHOD)
-                ->count() > 0;
-
-            if ($isRenderless) $this->component->markAsRenderless();
         }
     }
 

--- a/src/Features/SupportEvents/SupportEvents.php
+++ b/src/Features/SupportEvents/SupportEvents.php
@@ -48,7 +48,7 @@ class SupportEvents extends ComponentHook
                 ->filter(fn ($i) => $i->getLevel() === AttributeLevel::METHOD)
                 ->count() > 0;
 
-            if ($isRenderless) $this->component->skipRender();
+            if ($isRenderless) $this->component->markAsRenderless();
         }
     }
 

--- a/src/Features/SupportRenderless/BaseRenderless.php
+++ b/src/Features/SupportRenderless/BaseRenderless.php
@@ -11,6 +11,6 @@ class BaseRenderless extends LivewireAttribute
     {
         $this->component->skipIslandsRender();
 
-        $this->component->skipRender();
+        $this->component->markAsRenderless();
     }
 }

--- a/src/Features/SupportRenderless/BaseRenderless.php
+++ b/src/Features/SupportRenderless/BaseRenderless.php
@@ -10,7 +10,5 @@ class BaseRenderless extends LivewireAttribute
     function call()
     {
         $this->component->skipIslandsRender();
-
-        $this->component->markAsRenderless();
     }
 }

--- a/src/Features/SupportRenderless/HandlesRenderless.php
+++ b/src/Features/SupportRenderless/HandlesRenderless.php
@@ -3,7 +3,6 @@
 namespace Livewire\Features\SupportRenderless;
 
 use Livewire\Features\SupportAttributes\AttributeLevel;
-use Livewire\Features\SupportEvents\SupportEvents;
 
 use function Livewire\store;
 
@@ -33,39 +32,16 @@ trait HandlesRenderless
         return store($this)->get('skipRender', false);
     }
 
-    public function shouldSkipRenderAfterCalls($calls)
+    public function isRenderlessMethod($method)
     {
-        if (count($calls) === 0) return false;
-
-        $renderlessMethods = $this->getAttributes()
+        return $this->getAttributes()
             ->whereInstanceOf(BaseRenderless::class)
             ->filter(fn ($attribute) => $attribute->getLevel() === AttributeLevel::METHOD)
-            ->map(fn ($attribute) => $attribute->getName());
-
-        return collect($calls)->every(
-            fn ($call) => ($call['metadata']['renderless'] ?? false)
-                || $renderlessMethods->contains($this->resolveCalledMethod($call))
-        );
+            ->contains(fn ($attribute) => $attribute->getName() === $method);
     }
 
     public function shouldSkipIslandsRender()
     {
         return store($this)->get('skipIslandsRender', false);
-    }
-
-    protected function resolveCalledMethod($call)
-    {
-        if ($call['method'] !== '__dispatch' || ! isset($call['params'][0])) {
-            return $call['method'];
-        }
-
-        $event = $call['params'][0];
-
-        // Event listeners travel as __dispatch calls, but their attributes belong to the listener method...
-        if (! in_array($event, SupportEvents::getListenerEventNames($this))) {
-            return $call['method'];
-        }
-
-        return SupportEvents::getListenerMethodName($this, $event);
     }
 }

--- a/src/Features/SupportRenderless/HandlesRenderless.php
+++ b/src/Features/SupportRenderless/HandlesRenderless.php
@@ -11,6 +11,11 @@ trait HandlesRenderless
         $this->skipRender();
     }
 
+    public function markAsRenderless($skip = true)
+    {
+        store($this)->set('markAsRenderless', $skip);
+    }
+
     public function skipRender($html = null)
     {
         if (store($this)->has('forceRender')) {
@@ -33,5 +38,10 @@ trait HandlesRenderless
     public function shouldSkipIslandsRender()
     {
         return store($this)->get('skipIslandsRender', false);
+    }
+
+    public function isRenderless()
+    {
+        return store($this)->get('markAsRenderless', false);
     }
 }

--- a/src/Features/SupportRenderless/HandlesRenderless.php
+++ b/src/Features/SupportRenderless/HandlesRenderless.php
@@ -2,6 +2,9 @@
 
 namespace Livewire\Features\SupportRenderless;
 
+use Livewire\Features\SupportAttributes\AttributeLevel;
+use Livewire\Features\SupportEvents\SupportEvents;
+
 use function Livewire\store;
 
 trait HandlesRenderless
@@ -9,11 +12,6 @@ trait HandlesRenderless
     public function renderless()
     {
         $this->skipRender();
-    }
-
-    public function markAsRenderless($skip = true)
-    {
-        store($this)->set('markAsRenderless', $skip);
     }
 
     public function skipRender($html = null)
@@ -35,13 +33,39 @@ trait HandlesRenderless
         return store($this)->get('skipRender', false);
     }
 
+    public function shouldSkipRenderAfterCalls($calls)
+    {
+        if (count($calls) === 0) return false;
+
+        $renderlessMethods = $this->getAttributes()
+            ->whereInstanceOf(BaseRenderless::class)
+            ->filter(fn ($attribute) => $attribute->getLevel() === AttributeLevel::METHOD)
+            ->map(fn ($attribute) => $attribute->getName());
+
+        return collect($calls)->every(
+            fn ($call) => ($call['metadata']['renderless'] ?? false)
+                || $renderlessMethods->contains($this->resolveCalledMethod($call))
+        );
+    }
+
     public function shouldSkipIslandsRender()
     {
         return store($this)->get('skipIslandsRender', false);
     }
 
-    public function isRenderless()
+    protected function resolveCalledMethod($call)
     {
-        return store($this)->get('markAsRenderless', false);
+        if ($call['method'] !== '__dispatch' || ! isset($call['params'][0])) {
+            return $call['method'];
+        }
+
+        $event = $call['params'][0];
+
+        // Event listeners travel as __dispatch calls, but their attributes belong to the listener method...
+        if (! in_array($event, SupportEvents::getListenerEventNames($this))) {
+            return $call['method'];
+        }
+
+        return SupportEvents::getListenerMethodName($this, $event);
     }
 }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -10,6 +10,7 @@ use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Exceptions\MaxNestingDepthExceededException;
 use Livewire\Exceptions\TooManyCallsException;
 use Livewire\Drawer\Utils;
+use Livewire\Features\SupportEvents\SupportEvents;
 use Livewire\Features\SupportFormObjects\Form;
 use Illuminate\Support\Facades\View;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -530,7 +531,7 @@ class HandleComponents extends Mechanism
         }
 
         $returns = [];
-        $shouldSkipRender = $root->shouldSkipRenderAfterCalls($calls);
+        $shouldSkipRender = $this->shouldSkipRenderAfterCalls($root, $calls);
 
         foreach ($calls as $idx => $call) {
             $method = $call['method'];
@@ -594,6 +595,37 @@ class HandleComponents extends Mechanism
         }
 
         $componentContext->addEffect('returns', $returns);
+    }
+
+    protected function shouldSkipRenderAfterCalls($root, $calls)
+    {
+        if (count($calls) === 0) return false;
+
+        return collect($calls)->every(
+            fn ($call) => $this->isCallRenderless($root, $call)
+        );
+    }
+
+    protected function isCallRenderless($root, $call)
+    {
+        return ($call['metadata']['renderless'] ?? false)
+            || $root->isRenderlessMethod($this->resolveCalledMethod($root, $call));
+    }
+
+    protected function resolveCalledMethod($root, $call)
+    {
+        if ($call['method'] !== '__dispatch' || ! isset($call['params'][0])) {
+            return $call['method'];
+        }
+
+        $event = $call['params'][0];
+
+        // Event listeners travel as __dispatch calls, but their attributes belong to the listener method...
+        if (! in_array($event, SupportEvents::getListenerEventNames($root))) {
+            return $call['method'];
+        }
+
+        return SupportEvents::getListenerMethodName($root, $event);
     }
 
     protected function pushOntoComponentStack($component)

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -537,14 +537,15 @@ class HandleComponents extends Mechanism
             $params = $call['params'];
             $metadata = $call['metadata'] ?? [];
 
-            $root->markAsRenderless(false);
-
             $earlyReturnCalled = false;
             $earlyReturn = null;
             $returnEarly = function ($return = null) use (&$earlyReturnCalled, &$earlyReturn) {
                 $earlyReturnCalled = true;
                 $earlyReturn = $return;
             };
+
+            // Reset the mark before each call so one renderless call cannot poison the next
+            $root->markAsRenderless(false);
 
             $finish = trigger('call', $root, $method, $params, $componentContext, $returnEarly, $metadata, $idx);
 
@@ -601,6 +602,7 @@ class HandleComponents extends Mechanism
             }
         }
 
+        // Only skip render if all calls are renderless
         if (count($calls) > 0 && $skipRender >= count($calls)) {
             $root->skipRender();
         }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -530,11 +530,14 @@ class HandleComponents extends Mechanism
         }
 
         $returns = [];
+        $skipRender = 0;
 
         foreach ($calls as $idx => $call) {
             $method = $call['method'];
             $params = $call['params'];
             $metadata = $call['metadata'] ?? [];
+
+            $root->markAsRenderless(false);
 
             $earlyReturnCalled = false;
             $earlyReturn = null;
@@ -555,9 +558,9 @@ class HandleComponents extends Mechanism
                     $return = null;
                 }
 
-                // Support `.renderless` on magic actions like `wire:model.renderless.live`...
-                if ($metadata['renderless'] ?? false) {
-                    $root->skipRender();
+                // Support `.renderless` on magic actions like `wire:model.renderless.live` and `#[Renderless]`...
+                if ($root->isRenderless() || ($metadata['renderless'] ?? false)) {
+                    $skipRender++;
                 }
 
                 $returns[] = $return;
@@ -592,10 +595,14 @@ class HandleComponents extends Mechanism
 
             $returns[] = $return;
 
-            // Support `Wire:click.renderless`...
-            if ($metadata['renderless'] ?? false) {
-                $root->skipRender();
+            // Support `wire:click.renderless` and `#[Renderless]`...
+            if ($root->isRenderless() || ($metadata['renderless'] ?? false)) {
+                $skipRender++;
             }
+        }
+
+        if (count($calls) > 0 && $skipRender >= count($calls)) {
+            $root->skipRender();
         }
 
         $componentContext->addEffect('returns', $returns);

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -530,7 +530,7 @@ class HandleComponents extends Mechanism
         }
 
         $returns = [];
-        $skipRender = 0;
+        $shouldSkipRender = $root->shouldSkipRenderAfterCalls($calls);
 
         foreach ($calls as $idx => $call) {
             $method = $call['method'];
@@ -544,9 +544,6 @@ class HandleComponents extends Mechanism
                 $earlyReturn = $return;
             };
 
-            // Reset the mark before each call so one renderless call cannot poison the next
-            $root->markAsRenderless(false);
-
             $finish = trigger('call', $root, $method, $params, $componentContext, $returnEarly, $metadata, $idx);
 
             if ($earlyReturnCalled) {
@@ -557,11 +554,6 @@ class HandleComponents extends Mechanism
                 // so we will just set it to `null` instead...
                 if ($return instanceof StreamedResponse || $return instanceof BinaryFileResponse) {
                     $return = null;
-                }
-
-                // Support `.renderless` on magic actions like `wire:model.renderless.live` and `#[Renderless]`...
-                if ($root->isRenderless() || ($metadata['renderless'] ?? false)) {
-                    $skipRender++;
                 }
 
                 $returns[] = $return;
@@ -595,15 +587,9 @@ class HandleComponents extends Mechanism
             }
 
             $returns[] = $return;
-
-            // Support `wire:click.renderless` and `#[Renderless]`...
-            if ($root->isRenderless() || ($metadata['renderless'] ?? false)) {
-                $skipRender++;
-            }
         }
 
-        // Only skip render if all calls are renderless
-        if (count($calls) > 0 && $skipRender >= count($calls)) {
+        if ($shouldSkipRender) {
             $root->skipRender();
         }
 

--- a/src/Mechanisms/Tests/ComponentSkipRenderUnitTest.php
+++ b/src/Mechanisms/Tests/ComponentSkipRenderUnitTest.php
@@ -47,6 +47,46 @@ class ComponentSkipRenderUnitTest extends \Tests\TestCase
         Route::get('/403', ComponentSkipRenderOnRedirectHelperInMountStub::class);
         $this->get('/403')->assertRedirect('/bar');
     }
+
+    public function test_render_not_skipped_when_a_renderless_action_attribute_is_batched_with_a_normal_call()
+    {
+        $component = Livewire::test(ComponentRenderlessBatchStub::class);
+
+        $component->assertSee('foo');
+
+        // Simulate the browser batching two $wire calls into a single request,
+        // e.g. `$wire.renderlessAction(); $wire.updateName()`.
+        $component->update(calls: [
+            ['method' => 'renderlessActionAttribute', 'params' => [], 'path' => ''],
+            ['method' => 'updateName', 'params' => [], 'path' => ''],
+        ]);
+
+        // The non-renderless updateName() mutated state the view depends on...
+        $component->assertSetStrict('name', 'bar');
+
+        // ...so the component should re-render, despite the batched renderless call.
+        $component->assertSee('bar');
+    }
+
+    public function test_render_not_skipped_when_a_renderless_action_call_is_batched_with_a_normal_call()
+    {
+        $component = Livewire::test(ComponentRenderlessBatchStub::class);
+
+        $component->assertSee('foo');
+
+        // Simulate the browser batching two $wire calls into a single request,
+        // e.g. `$wire.renderlessAction(); $wire.updateName()`.
+        $component->update(calls: [
+            ['method' => 'renderlessActionCall', 'params' => [], 'path' => '', 'metadata' => ['renderless' => true]],
+            ['method' => 'updateName', 'params' => [], 'path' => ''],
+        ]);
+
+        // The non-renderless updateName() mutated state the view depends on...
+        $component->assertSetStrict('name', 'bar');
+
+        // ...so the component should re-render, despite the batched renderless call.
+        $component->assertSee('bar');
+    }
 }
 
 class ComponentSkipRenderStub extends Component
@@ -87,6 +127,34 @@ class ComponentSkipRenderAttributeStub extends Component
         }
 
         return app('view')->make('null-view');
+    }
+}
+
+class ComponentRenderlessBatchStub extends Component
+{
+    public $name = 'foo';
+
+    #[\Livewire\Attributes\Renderless]
+    public function renderlessActionAttribute()
+    {
+        //
+    }
+
+    public function renderlessActionCall()
+    {
+        //
+    }
+
+    public function updateName()
+    {
+        $this->name = 'bar';
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+            <div>{{ $name }}</div>
+        HTML;
     }
 }
 

--- a/src/Mechanisms/Tests/ComponentSkipRenderUnitTest.php
+++ b/src/Mechanisms/Tests/ComponentSkipRenderUnitTest.php
@@ -87,6 +87,26 @@ class ComponentSkipRenderUnitTest extends \Tests\TestCase
         // ...so the component should re-render, despite the batched renderless call.
         $component->assertSee('bar');
     }
+
+    public function test_render_not_skipped_when_a_renderless_action_attribute_event_is_batched_with_a_normal_call()
+    {
+        $component = Livewire::test(ComponentRenderlessBatchStub::class);
+
+        $component->assertSee('foo');
+
+        // Simulate the browser batching two $wire calls into a single request,
+        // e.g. `$wire.renderlessAction(); $wire.updateName()`.
+        $component->update(calls: [
+            ['method' => '__dispatch', 'params' => ['some-event', []], 'path' => ''],
+            ['method' => 'updateName', 'params' => [], 'path' => ''],
+        ]);
+
+        // The non-renderless updateName() mutated state the view depends on...
+        $component->assertSetStrict('name', 'bar');
+
+        // ...so the component should re-render, despite the batched renderless call.
+        $component->assertSee('bar');
+    }
 }
 
 class ComponentSkipRenderStub extends Component
@@ -136,6 +156,13 @@ class ComponentRenderlessBatchStub extends Component
 
     #[\Livewire\Attributes\Renderless]
     public function renderlessActionAttribute()
+    {
+        //
+    }
+
+    #[\Livewire\Attributes\Renderless]
+    #[\Livewire\Attributes\On('some-event')]
+    public function renderlessActionEventAttribute()
     {
         //
     }

--- a/src/Mechanisms/Tests/ComponentSkipRenderUnitTest.php
+++ b/src/Mechanisms/Tests/ComponentSkipRenderUnitTest.php
@@ -54,17 +54,12 @@ class ComponentSkipRenderUnitTest extends \Tests\TestCase
 
         $component->assertSee('foo');
 
-        // Simulate the browser batching two $wire calls into a single request,
-        // e.g. `$wire.renderlessAction(); $wire.updateName()`.
         $component->update(calls: [
             ['method' => 'renderlessActionAttribute', 'params' => [], 'path' => ''],
             ['method' => 'updateName', 'params' => [], 'path' => ''],
         ]);
 
-        // The non-renderless updateName() mutated state the view depends on...
         $component->assertSetStrict('name', 'bar');
-
-        // ...so the component should re-render, despite the batched renderless call.
         $component->assertSee('bar');
     }
 
@@ -74,17 +69,12 @@ class ComponentSkipRenderUnitTest extends \Tests\TestCase
 
         $component->assertSee('foo');
 
-        // Simulate the browser batching two $wire calls into a single request,
-        // e.g. `$wire.renderlessAction(); $wire.updateName()`.
         $component->update(calls: [
             ['method' => 'renderlessActionCall', 'params' => [], 'path' => '', 'metadata' => ['renderless' => true]],
             ['method' => 'updateName', 'params' => [], 'path' => ''],
         ]);
 
-        // The non-renderless updateName() mutated state the view depends on...
         $component->assertSetStrict('name', 'bar');
-
-        // ...so the component should re-render, despite the batched renderless call.
         $component->assertSee('bar');
     }
 
@@ -94,18 +84,74 @@ class ComponentSkipRenderUnitTest extends \Tests\TestCase
 
         $component->assertSee('foo');
 
-        // Simulate the browser batching two $wire calls into a single request,
-        // e.g. `$wire.renderlessAction(); $wire.updateName()`.
         $component->update(calls: [
             ['method' => '__dispatch', 'params' => ['some-event', []], 'path' => ''],
             ['method' => 'updateName', 'params' => [], 'path' => ''],
         ]);
 
-        // The non-renderless updateName() mutated state the view depends on...
         $component->assertSetStrict('name', 'bar');
-
-        // ...so the component should re-render, despite the batched renderless call.
         $component->assertSee('bar');
+    }
+
+    public function test_renderless_batching_is_order_independent()
+    {
+        $component = Livewire::test(ComponentRenderlessBatchStub::class);
+
+        $component->update(calls: [
+            ['method' => 'updateName', 'params' => [], 'path' => ''],
+            ['method' => 'renderlessActionAttribute', 'params' => [], 'path' => ''],
+        ]);
+
+        $component->assertSee('bar');
+    }
+
+    public function test_render_is_skipped_when_all_batched_calls_are_renderless()
+    {
+        $component = Livewire::test(ComponentRenderlessBatchStub::class);
+
+        $component->update(calls: [
+            ['method' => 'preventRender', 'params' => [], 'path' => ''],
+            ['method' => 'renderlessActionCall', 'params' => [], 'path' => '', 'metadata' => ['renderless' => true]],
+        ]);
+
+        $component->assertSetStrict('renderShouldFail', true);
+    }
+
+    public function test_renderless_event_is_counted_as_a_renderless_call()
+    {
+        $component = Livewire::test(ComponentRenderlessBatchStub::class);
+
+        $component->update(calls: [
+            ['method' => '__dispatch', 'params' => ['some-event', []], 'path' => ''],
+            ['method' => 'preventRender', 'params' => [], 'path' => ''],
+        ]);
+
+        $component->assertSetStrict('renderShouldFail', true);
+    }
+
+    public function test_magic_action_makes_a_renderless_batch_render()
+    {
+        $component = Livewire::test(ComponentRenderlessBatchStub::class);
+
+        $component->update(calls: [
+            ['method' => 'renderlessUpdateName', 'params' => [], 'path' => ''],
+            ['method' => '$refresh', 'params' => [], 'path' => ''],
+        ]);
+
+        $component->assertSee('bar');
+    }
+
+    public function test_imperative_skip_render_still_skips_a_mixed_batch()
+    {
+        $component = Livewire::test(ComponentRenderlessBatchStub::class);
+
+        $component->update(calls: [
+            ['method' => 'updateName', 'params' => [], 'path' => ''],
+            ['method' => 'skipRenderImperatively', 'params' => [], 'path' => ''],
+        ]);
+
+        $component->assertSetStrict('name', 'bar');
+        $component->assertSetStrict('renderShouldFail', true);
     }
 }
 
@@ -153,6 +199,7 @@ class ComponentSkipRenderAttributeStub extends Component
 class ComponentRenderlessBatchStub extends Component
 {
     public $name = 'foo';
+    public $renderShouldFail = false;
 
     #[\Livewire\Attributes\Renderless]
     public function renderlessActionAttribute()
@@ -172,13 +219,36 @@ class ComponentRenderlessBatchStub extends Component
         //
     }
 
+    #[\Livewire\Attributes\Renderless]
+    public function renderlessUpdateName()
+    {
+        $this->name = 'bar';
+    }
+
+    #[\Livewire\Attributes\Renderless]
+    public function preventRender()
+    {
+        $this->renderShouldFail = true;
+    }
+
     public function updateName()
     {
         $this->name = 'bar';
     }
 
+    public function skipRenderImperatively()
+    {
+        $this->renderShouldFail = true;
+
+        $this->skipRender();
+    }
+
     public function render()
     {
+        if ($this->renderShouldFail) {
+            throw new \RuntimeException('Render should have been skipped');
+        }
+
         return <<<'HTML'
             <div>{{ $name }}</div>
         HTML;


### PR DESCRIPTION
Based on https://github.com/livewire/livewire/pull/10497 so the credit goes to the PR's owner @TWithers .

## Summary
When a renderless action (`#[Renderless]` or `renderless` metadata) is batched in the same request as a normal action, Livewire was calling `skipRender()` as soon as the renderless call ran. That flag is request-scoped, so the later normal call could mutate view state without a re-render, leaving the DOM stale.

## What's changed
- Introduce `markAsRenderless()` and `isRenderless()` on `HandlesRenderless` as a soft per-call flag (does not set `skipRender`).
- `BaseRenderless`and `SupportEvents` now marks the call as renderless instead of calling `skipRender()` immediately.
- In `HandleComponents::callMethods`, count renderless calls across the batch and call `skipRender()` only if every call in the batch is renderless.
- Reset the mark at the start of each call so one renderless call cannot poison the next.
- Add unit tests for mixed batches (attribute + metadata paths).

## Simulated batches
- `[#[Renderless] a, normal b]`
Soft count 1 of 2 → no end `skipRender()` → **renders**.
- `[normal b, #[Renderless] a]`
Reset soft flag each call; count 1 of 2 → **renders**. Order-independent for soft marks.
- `[#[Renderless] a]`
Count 1 of 1 → `skipRender()` → **no render**. Same as main.
- `[metadata renderless, metadata renderless]`
Count 2 of 2 → skip. Same as main’s “all `.renderless`”.
- `[#[Renderless] a, normal b]` **where** `b` **calls** `$this->skipRender()`
Hard flag set in `b` → **no render**, even though soft count is 1. Correct for imperative API.
- `[#[Renderless] a, normal b]` **where** `b` throws
Exception aborts; no successful render response. Soft end-of-loop skip never runs.
- `[__dispatch renderless listener, normal b]`
Events path marks soft; count 1 of 2 → **renders**. Covered by PR test.
- Empty `$calls`
`count($calls) > 0` guard → PR does not call `skipRender()` from the counter. Render still depends on other flags (redirect, island, etc.).
- `forceRender()` **then all-renderless batch**
End `skipRender()` no-ops because of `forceRender` → **renders**. Same guard as main.
- **Double-count risk (attribute + metadata on same call)**
Condition is `isRenderless() || metadata['renderless']` — one increment per call, not two. Safe.

Fix: https://github.com/livewire/livewire/issues/10495