### PR TITLE
[4.x] Fix withoutScopedBindings() being ignored on full-page components

### DIFF
--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -154,7 +154,7 @@ class ImplicitRouteBinding
 
         $parent = $route->parentOfParameter($parameterName);
 
-        if ($parent instanceof UrlRoutable && ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
+        if ($parent instanceof UrlRoutable && ! $route->preventsScopedBindings() && ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
             $model = $parent->resolveChildRouteBinding($parameterName, $parameterValue, $route->bindingFieldFor($parameterName));
         } else {
             if ($route->allowsTrashedBindings()) {

--- a/src/Drawer/Tests/ImplicitRouteBindingUnitTest.php
+++ b/src/Drawer/Tests/ImplicitRouteBindingUnitTest.php
@@ -144,6 +144,24 @@ class ImplicitRouteBindingUnitTest extends \Tests\TestCase
             ->assertSeeText('Store ID: 2')
             ->assertSeeText('Book ID: 2');
     }
+
+    public function test_props_are_not_scoped_when_route_prevents_scoped_bindings()
+    {
+        Route::get('/unscoped-props/{store:name}/{book:name}', ComponentWithScopeBindings::class)->withoutScopedBindings();
+
+        $this->get('/unscoped-props/Second/Foo')
+            ->assertSeeText('Store ID: 2')
+            ->assertSeeText('Book ID: 1');
+    }
+
+    public function test_mount_params_are_not_scoped_when_route_prevents_scoped_bindings()
+    {
+        Route::get('/unscoped-mount/{store:name}/{book:name}', ComponentWithParentAndChildMountBindings::class)->withoutScopedBindings();
+
+        $this->get('/unscoped-mount/Second/Foo')
+            ->assertSeeText('Store ID: 2')
+            ->assertSeeText('Book ID: 1');
+    }
 }
 
 class PropBoundModel extends Model


### PR DESCRIPTION
A route that opts out of scoping with `withoutScopedBindings()` still resolved its later parameters through the parent model. `ImplicitRouteBinding::resolveParameter()` never checked `$route->preventsScopedBindings()`, so a parameter with an explicit binding field still went through the scoped `resolveChildRouteBinding()` path even when the route had opted out. This became visible for `mount()` parameters too after #10341, since every bindable parameter now goes through `resolveParameter()`.

Fixes #10503
