### PR TITLE
[4.x] Prefer `new Collection()` over `collect()` helper

### DIFF
--- a/src/Drawer/BaseUtils.php
+++ b/src/Drawer/BaseUtils.php
@@ -2,6 +2,8 @@
 
 namespace Livewire\Drawer;
 
+use Illuminate\Support\Collection;
+
 class BaseUtils
 {
     protected static $reflectionCache = [];
@@ -40,7 +42,7 @@ class BaseUtils
 
     protected static function reflectAndCachePropertyMetadata($target, $filter = null)
     {
-        return collect((new \ReflectionObject($target))->getProperties())
+        return (new Collection((new \ReflectionObject($target))->getProperties()))
             ->filter(function ($property) {
                 return $property->isPublic() && ! $property->isStatic() && $property->isDefault();
             })
@@ -83,7 +85,7 @@ class BaseUtils
 
     static function getPublicProperties($target, $filter = null)
     {
-        return collect((new \ReflectionObject($target))->getProperties())
+        return (new Collection((new \ReflectionObject($target))->getProperties()))
             ->filter(function ($property) {
                 return $property->isPublic() && ! $property->isStatic() && $property->isDefault();
             })

--- a/src/Drawer/ImplicitRouteBinding.php
+++ b/src/Drawer/ImplicitRouteBinding.php
@@ -60,7 +60,7 @@ class ImplicitRouteBinding
             return new Collection();
         }
 
-        return collect((new ReflectionMethod($component, 'mount'))->getParameters())
+        return (new Collection((new ReflectionMethod($component, 'mount'))->getParameters()))
             ->mapWithKeys(function ($parameter) {
                 return [$parameter->getName() => Reflector::getParameterClassName($parameter)];
             });
@@ -132,7 +132,7 @@ class ImplicitRouteBinding
 
     public function getPublicPropertyTypes($component)
     {
-        return collect(Utils::getPublicPropertiesDefinedOnSubclass($component))
+        return (new Collection(Utils::getPublicPropertiesDefinedOnSubclass($component)))
             ->map(function ($value, $name) use ($component) {
                 return Reflector::getParameterClassName(new \ReflectionProperty($component, $name));
             });

--- a/src/Drawer/Utils.php
+++ b/src/Drawer/Utils.php
@@ -3,6 +3,7 @@
 namespace Livewire\Drawer;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Livewire\Exceptions\RootTagMissingFromViewException;
 
 use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
@@ -34,7 +35,7 @@ class Utils extends BaseUtils
 
     static function stringifyHtmlAttributes($attributes)
     {
-        return collect($attributes)
+        return (new Collection($attributes))
             ->mapWithKeys(function ($value, $key) {
                 return [$key => static::escapeStringForHtml($value)];
             })->map(function ($value, $key) {

--- a/src/Features/SupportCompiledWireKeys/SupportCompiledWireKeys.php
+++ b/src/Features/SupportCompiledWireKeys/SupportCompiledWireKeys.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportCompiledWireKeys;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Blade;
 use Livewire\ComponentHook;
 
@@ -122,7 +123,7 @@ class SupportCompiledWireKeys extends ComponentHook
         $value = Blade::compileEchos($keyString);
 
         // Escape single quotes only outside of PHP blocks...
-        $value = collect(token_get_all('<'.'?php ?'.'>'.$value))
+        $value = (new Collection(token_get_all('<'.'?php ?'.'>'.$value)))
             ->slice(2)
             ->map(function ($token) {
                 if (! is_array($token)) {

--- a/src/Features/SupportComputed/SupportLegacyComputedPropertySyntax.php
+++ b/src/Features/SupportComputed/SupportLegacyComputedPropertySyntax.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportComputed;
 
+use Illuminate\Support\Collection;
 use Livewire\ComponentHook;
 use Livewire\Drawer\Utils as SyntheticUtils;
 
@@ -63,7 +64,7 @@ class SupportLegacyComputedPropertySyntax extends ComponentHook
 
     public static function getComputedProperties($target)
     {
-        return collect(static::getComputedPropertyNames($target))
+        return (new Collection(static::getComputedPropertyNames($target)))
             ->mapWithKeys(function ($property) use ($target) {
                 return [$property => static::getComputedProperty($target, $property)];
             })
@@ -102,7 +103,7 @@ class SupportLegacyComputedPropertySyntax extends ComponentHook
 
         $methodNames = SyntheticUtils::getPublicMethodsDefinedBySubClass($target);
 
-        $computedPropertyNames = collect($methodNames)
+        $computedPropertyNames = (new Collection($methodNames))
             ->filter(function ($method) {
                 return str($method)->startsWith('get')
                     && str($method)->endsWith('Property');

--- a/src/Features/SupportConsoleCommands/Commands/ConvertCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/ConvertCommand.php
@@ -12,6 +12,7 @@ use Livewire\Compiler\Parser\MultiFileParser;
 use Illuminate\Support\Str;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 
 #[AsCommand(name: 'livewire:convert')]
 class ConvertCommand extends Command
@@ -219,7 +220,7 @@ class ConvertCommand extends Command
     {
         $stub = $this->files->get($this->getStubPath('livewire-mfc-test.stub'));
 
-        $componentName = collect(explode('.', $name))
+        $componentName = (new Collection(explode('.', $name)))
             ->map(fn ($segment) => Str::kebab($segment))
             ->implode('.');
 

--- a/src/Features/SupportConsoleCommands/Commands/LayoutCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/LayoutCommand.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportConsoleCommands\Commands;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -86,7 +87,7 @@ class LayoutCommand extends FileManipulationCommand
 
         $name = Str::kebab($directories->pop());
 
-        return $baseViewPath . DIRECTORY_SEPARATOR . collect()
+        return $baseViewPath . DIRECTORY_SEPARATOR . (new Collection())
             ->concat($directories)
             ->map([Str::class, 'kebab'])
             ->push("{$name}.blade.php")

--- a/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/MakeCommand.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Str;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 
 #[AsCommand(name: 'make:livewire')]
 class MakeCommand extends Command
@@ -321,7 +322,7 @@ class MakeCommand extends Command
         }
 
         if (! empty($namespaceSegments)) {
-            $namespace .= '\\' . collect($namespaceSegments)
+            $namespace .= '\\' . (new Collection($namespaceSegments))
                 ->map(fn($segment) => Str::studly($segment))
                 ->implode('\\');
         }
@@ -329,7 +330,7 @@ class MakeCommand extends Command
         // Get the configured view path and extract the view namespace from it
         $viewNamespace = $this->extractViewNamespace($viewPath);
 
-        $viewName = collect($segments)
+        $viewName = (new Collection($segments))
             ->map(fn($segment) => Str::kebab($segment))
             ->prepend($viewNamespace)
             ->filter()
@@ -378,7 +379,7 @@ class MakeCommand extends Command
     {
         $stub = $this->files->get($this->getStubPath('livewire-mfc-test.stub'));
 
-        $componentName = collect(explode('.', $name))
+        $componentName = (new Collection(explode('.', $name)))
             ->map(fn($segment) => Str::kebab($segment))
             ->implode('.');
 
@@ -408,7 +409,7 @@ class MakeCommand extends Command
         // Use same stub as MFC, same format
         $stub = $this->files->get($this->getStubPath('livewire-mfc-test.stub'));
 
-        $componentName = collect(explode('.', $name))
+        $componentName = (new Collection(explode('.', $name)))
             ->map(fn($segment) => Str::kebab($segment))
             ->implode('.');
 
@@ -428,7 +429,7 @@ class MakeCommand extends Command
         $path = base_path('tests/Feature/Livewire');
 
         if (! empty($namespaceSegments)) {
-            $path .= '/' . collect($namespaceSegments)
+            $path .= '/' . (new Collection($namespaceSegments))
                 ->map(fn($segment) => Str::studly($segment))
                 ->implode('/');
         }
@@ -441,7 +442,7 @@ class MakeCommand extends Command
         // Use same Pest-style stub as MFC/SFC for consistency
         $stub = $this->files->get($this->getStubPath('livewire-mfc-test.stub'));
 
-        $componentName = collect(explode('.', $name))
+        $componentName = (new Collection(explode('.', $name)))
             ->map(fn($segment) => Str::kebab($segment))
             ->implode('.');
 

--- a/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
+++ b/src/Features/SupportConsoleCommands/Commands/S3CleanupCommand.php
@@ -7,6 +7,7 @@ use function array_merge;
 use function Livewire\invade;
 use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'livewire:configure-s3-upload-cleanup')]
@@ -67,7 +68,7 @@ class S3CleanupCommand extends Command
     }
 
     private function checkIfLivewireConfigurationIsAlreadySet(array $existingConfigurationRules, string $bucket, S3Client $client, string $prefix) {
-        $existingConfigurationHasLivewire = collect($existingConfigurationRules)->contains('Filter.Prefix', $prefix);
+        $existingConfigurationHasLivewire = (new Collection($existingConfigurationRules))->contains('Filter.Prefix', $prefix);
 
         if($existingConfigurationHasLivewire) {
             $this->info('Livewire temporary S3 upload directory ['.$prefix.'] already set to automatically cleanup files older than 24hrs!');

--- a/src/Features/SupportEvents/SupportEvents.php
+++ b/src/Features/SupportEvents/SupportEvents.php
@@ -5,6 +5,8 @@ namespace Livewire\Features\SupportEvents;
 use function Livewire\wrap;
 use function Livewire\store;
 use function Livewire\invade;
+
+use Illuminate\Support\Collection;
 use Livewire\Features\SupportAttributes\AttributeLevel;
 use Livewire\ComponentHook;
 use Livewire\Exceptions\EventHandlerDoesNotExist;
@@ -72,7 +74,7 @@ class SupportEvents extends ComponentHook
     {
         $listeners = static::getComponentListeners($component);
 
-        return collect($listeners)
+        return (new Collection($listeners))
             ->map(fn ($value, $key) => is_numeric($key) ? $value : $key)
             ->values()
             ->toArray();
@@ -104,7 +106,7 @@ class SupportEvents extends ComponentHook
 
     function getServerDispatchedEvents($component)
     {
-        return collect(store($component)->get('dispatched', []))
+        return (new Collection(store($component)->get('dispatched', [])))
             ->map(fn ($event) => $event->serialize())
             ->toArray();
     }

--- a/src/Features/SupportFileUploads/FileUploadController.php
+++ b/src/Features/SupportFileUploads/FileUploadController.php
@@ -4,6 +4,7 @@ namespace Livewire\Features\SupportFileUploads;
 
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Controllers\Middleware;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Validator;
 
 class FileUploadController implements HasMiddleware
@@ -41,7 +42,7 @@ class FileUploadController implements HasMiddleware
             'files.*' => FileUploadConfiguration::rules()
         ])->validate();
 
-        $fileHashPaths = collect($files)->map(function ($file) use ($disk) {
+        $fileHashPaths = (new Collection($files))->map(function ($file) use ($disk) {
             return FileUploadConfiguration::storeTemporaryFile($file, $disk);
         });
 

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -4,6 +4,7 @@ namespace Livewire\Features\SupportFileUploads;
 
 use Illuminate\Support\Arr;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Storage;
 use League\MimeTypeDetection\FinfoMimeTypeDetector;
@@ -290,7 +291,7 @@ class TemporaryUploadedFile extends UploadedFile
         }
 
         if (is_array($subject)) {
-            return collect($subject)->contains(function ($value) {
+            return (new Collection($subject))->contains(function ($value) {
                 return static::canUnserialize($value);
             });
         }
@@ -308,7 +309,7 @@ class TemporaryUploadedFile extends UploadedFile
             if (str($subject)->startsWith('livewire-files:')) {
                 $paths = json_decode(str($subject)->after('livewire-files:'), true);
 
-                return collect($paths)->map(function ($path) { return static::createFromLivewire($path); })->toArray();
+                return (new Collection($paths))->map(function ($path) { return static::createFromLivewire($path); })->toArray();
             }
         }
 
@@ -328,6 +329,6 @@ class TemporaryUploadedFile extends UploadedFile
 
     public static function serializeMultipleForLivewireResponse($files)
     {
-        return 'livewire-files:'.json_encode(collect($files)->map->getFilename());
+        return 'livewire-files:'.json_encode((new Collection($files))->map->getFilename());
     }
 }

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -4,6 +4,7 @@ namespace Livewire\Features\SupportFileUploads;
 
 use Illuminate\Validation\ValidationException;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
 use Livewire\Attributes\Renderless;
 use Livewire\Facades\GenerateSignedUploadUrlFacade;
 
@@ -32,7 +33,7 @@ trait WithFileUploads
         }
 
         // Verify and extract paths from signed references.
-        $tmpPath = collect($tmpPath)->map(function ($signedPath) {
+        $tmpPath = (new Collection($tmpPath))->map(function ($signedPath) {
             $path = TemporaryUploadedFile::extractPathFromSignedPath($signedPath);
 
             if ($path === false) {
@@ -43,10 +44,10 @@ trait WithFileUploads
         })->toArray();
 
         if ($isMultiple) {
-            $file = collect($tmpPath)->map(function ($i) {
+            $file = (new Collection($tmpPath))->map(function ($i) {
                 return TemporaryUploadedFile::createFromLivewire($i);
             })->toArray();
-            $this->dispatch('upload:finished', name: $name, tmpFilenames: collect($file)->map->getFilename()->toArray())->self();
+            $this->dispatch('upload:finished', name: $name, tmpFilenames: (new Collection($file))->map->getFilename()->toArray())->self();
 
             if ($append) {
                 $existing = $this->getPropertyValue($name);

--- a/src/Features/SupportLegacyModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentCollectionSynth.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportLegacyModels;
 
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use LogicException;
 
@@ -165,7 +166,7 @@ class EloquentCollectionSynth extends Synth
             $collection = $collection->keyBy->getKey();
 
             return new $meta['class'](
-                collect($meta['keys'])->map(function ($id) use ($collection) {
+                (new Collection($meta['keys']))->map(function ($id) use ($collection) {
                     return $collection[$id] ?? null;
                 })->filter()
             );

--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -7,6 +7,7 @@ use Livewire\Mechanisms\HandleComponents\ComponentContext;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
 
 class EloquentCollectionSynth extends Synth {
     use SerializesAndRestoresModelIdentifiers, IsLazy;
@@ -84,7 +85,7 @@ class EloquentCollectionSynth extends Synth {
             $collection = $collection->keyBy->getKey();
 
             return new $meta['class'](
-                collect($meta['keys'])->map(function ($id) use ($collection) {
+                (new Collection($meta['keys']))->map(function ($id) use ($collection) {
                     return $collection[$id] ?? null;
                 })->filter()
             );

--- a/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
+++ b/src/Features/SupportMorphAwareBladeCompilation/SupportMorphAwareBladeCompilation.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportMorphAwareBladeCompilation;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Livewire\ComponentHook;
 use Livewire\Livewire;
 
@@ -380,7 +381,7 @@ class SupportMorphAwareBladeCompilation extends ComponentHook
     protected static function directivesPattern($directives)
     {
         $directivesPattern = '('
-            .collect($directives)
+            .(new Collection($directives))
                 // Ensure longer directives are in the pattern before shorter ones...
                 ->sortBy(fn ($directive) => strlen($directive), descending: true)
                 // Only match directives that are an exact match and not ones that

--- a/src/Features/SupportNestingComponents/SupportNestingComponents.php
+++ b/src/Features/SupportNestingComponents/SupportNestingComponents.php
@@ -5,6 +5,8 @@ namespace Livewire\Features\SupportNestingComponents;
 use function Livewire\trigger;
 use function Livewire\store;
 use function Livewire\on;
+
+use Illuminate\Support\Collection;
 use Livewire\ComponentHook;
 use Livewire\Drawer\Utils;
 
@@ -118,7 +120,7 @@ class SupportNestingComponents extends ComponentHook
     static function setParametersToMatchingProperties($component, $params)
     {
         // Assign all public component properties that have matching parameters.
-        collect(array_intersect_key($params, Utils::getPublicPropertiesDefinedOnSubclass($component)))
+        (new Collection(array_intersect_key($params, Utils::getPublicPropertiesDefinedOnSubclass($component))))
             ->each(function ($value, $property) use ($component) {
                 $component->{$property} = $value;
             });

--- a/src/Features/SupportPagination/HandlesPagination.php
+++ b/src/Features/SupportPagination/HandlesPagination.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportPagination;
 
 use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 trait HandlesPagination
@@ -11,7 +12,7 @@ trait HandlesPagination
 
     public function queryStringHandlesPagination()
     {
-        return collect($this->paginators)->mapWithKeys(function ($page, $pageName) {
+        return (new Collection($this->paginators))->mapWithKeys(function ($page, $pageName) {
             return ['paginators.'.$pageName => ['history' => true, 'as' => $pageName, 'keep' => false]];
         })->toArray();
     }

--- a/src/Features/SupportQueryString/SupportQueryString.php
+++ b/src/Features/SupportQueryString/SupportQueryString.php
@@ -3,6 +3,8 @@
 namespace Livewire\Features\SupportQueryString;
 
 use function Livewire\invade;
+
+use Illuminate\Support\Collection;
 use Livewire\ComponentHook;
 
 class SupportQueryString extends ComponentHook
@@ -38,7 +40,7 @@ class SupportQueryString extends ComponentHook
         if (method_exists($component, 'queryString')) $componentQueryString = invade($component)->queryString();
         elseif (property_exists($component, 'queryString')) $componentQueryString = invade($component)->queryString;
 
-        return $this->queryString = collect(class_uses_recursive($class = $component::class))
+        return $this->queryString = (new Collection(class_uses_recursive($class = $component::class)))
             ->map(function ($trait) use ($class, $component) {
                 $member = 'queryString' . class_basename($trait);
 

--- a/src/Features/SupportSlots/SupportSlots.php
+++ b/src/Features/SupportSlots/SupportSlots.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportSlots;
 
+use Illuminate\Support\Collection;
 use Livewire\ComponentHook;
 
 use function Livewire\on;
@@ -48,7 +49,7 @@ class SupportSlots extends ComponentHook
         // that they can be rendered and morph'd correctly. Full Slots are restored when
         // content was persisted from a skipped render (e.g. lazy components); otherwise
         // placeholders are used...
-        [$hydrated, $placeholders] = collect($memo['slots'] ?? [])
+        [$hydrated, $placeholders] = (new Collection($memo['slots'] ?? []))
             ->partition(fn ($s) => isset($s['content']));
 
         if ($hydrated->isNotEmpty()) $this->component->withHydratedSlots($hydrated->all());

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -13,6 +13,7 @@ use Illuminate\Support\MessageBag;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\ViewErrorBag;
 use Livewire\Form;
 
@@ -94,9 +95,9 @@ trait HandlesValidation
         $fields = (array) $field;
 
         return new MessageBag(
-            collect($this->getErrorBag())
+            (new Collection($this->getErrorBag()))
                 ->reject(function ($messages, $messageKey) use ($fields) {
-                    return collect($fields)->some(function ($field) use ($messageKey) {
+                    return (new Collection($fields))->some(function ($field) use ($messageKey) {
                         return str($messageKey)->is($field);
                     });
                 })
@@ -171,9 +172,9 @@ trait HandlesValidation
 
     public function rulesForModel($name)
     {
-        if (empty($this->getRules())) return collect();
+        if (empty($this->getRules())) return (new Collection());
 
-        return collect($this->getRules())
+        return (new Collection($this->getRules()))
             ->filter(function ($value, $key) use ($name) {
                 return Utils::beforeFirstDot($key) === $name;
             });
@@ -185,10 +186,10 @@ trait HandlesValidation
 
         // If property has numeric indexes in it,
         if ($dotNotatedProperty !== $propertyWithStarsInsteadOfNumbers) {
-            return collect($this->getRules())->keys()->contains($propertyWithStarsInsteadOfNumbers);
+            return (new Collection($this->getRules()))->keys()->contains($propertyWithStarsInsteadOfNumbers);
         }
 
-        return collect($this->getRules())
+        return (new Collection($this->getRules()))
             ->keys()
             ->map(function ($key) {
                 return (string) str($key)->before('.*');
@@ -224,7 +225,7 @@ trait HandlesValidation
 
     protected function checkRuleMatchesProperty($rules, $data)
     {
-        collect($rules)
+        (new Collection($rules))
             ->keys()
             ->each(function($ruleKey) use ($data) {
                 throw_unless(
@@ -347,7 +348,7 @@ trait HandlesValidation
         // Loop through rules and swap any wildcard '*' with keys from field, then filter down to only
         // rules that match the field, but return the rules without wildcard characters replaced,
         // so that custom attributes and messages still work as they need wildcards to work.
-        $rulesForField = collect($rules)
+        $rulesForField = (new Collection($rules))
             ->filter(function($value, $rule) use ($field) {
                 if(! str($field)->is($rule)) {
                     return false;
@@ -511,7 +512,7 @@ trait HandlesValidation
 
     protected function unwrapDataForValidation($data)
     {
-        return collect($data)->map(function ($value) {
+        return (new Collection($data))->map(function ($value) {
 
             $synth = app('livewire')->findSynth($value, $this);
 

--- a/src/Features/SupportValidation/SupportValidation.php
+++ b/src/Features/SupportValidation/SupportValidation.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportValidation;
 
+use Illuminate\Support\Collection;
 use Livewire\Drawer\Utils;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Support\ViewErrorBag;
@@ -58,7 +59,7 @@ class SupportValidation extends ComponentHook
 
         // Only persist errors that were born from properties on the component
         // and not from custom validators (Validator::make) that were run.
-        $context->addMemo('errors', collect($errors)
+        $context->addMemo('errors', (new Collection($errors))
             ->filter(function ($value, $key) {
                 return Utils::hasProperty($this->component, $key);
             })

--- a/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
+++ b/src/Features/SupportWireModelingNestedComponents/SupportWireModelingNestedComponents.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportWireModelingNestedComponents;
 
+use Illuminate\Support\Collection;
 use Livewire\ComponentHook;
 use Livewire\Drawer\Utils;
 use Livewire\Exceptions\ModelableRootHasWireModelException;
@@ -20,7 +21,7 @@ class SupportWireModelingNestedComponents extends ComponentHook
         // in a previous request, capture the value being passed in so we
         // can later set the child's property if it exists in this request.
         on('mount.stub', function ($tag, $id, $params, $parent, $key, $slots, $attributes) {
-            $outer = collect($attributes)->first(function ($value, $key) {
+            $outer = (new Collection($attributes))->first(function ($value, $key) {
                 return str($key)->startsWith('wire:model');
             });
 

--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Finder;
 
+use Illuminate\Support\Collection;
 use Livewire\Component;
 
 class Finder
@@ -298,7 +299,7 @@ class Finder
 
     protected function generateClassFromName($name, $classNamespaces = []): string
     {
-        $baseClass = collect(str($name)->explode('.'))
+        $baseClass = (new Collection(str($name)->explode('.')))
             ->map(fn ($segment) => (string) str($segment)->studly())
             ->join('\\');
 
@@ -324,7 +325,7 @@ class Finder
             $this->normalizePath($class)
         );
 
-        $fullName = str(collect(explode('.', $class))
+        $fullName = str((new Collection(explode('.', $class)))
             ->map(fn ($i) => \Illuminate\Support\Str::kebab($i))
             ->implode('.'));
 
@@ -332,7 +333,7 @@ class Finder
             $fullName = $fullName->substr(1);
         }
 
-        $classNamespaces = collect($this->classNamespaces)
+        $classNamespaces = (new Collection($this->classNamespaces))
             ->map(fn ($classNamespace) => $classNamespace['classNamespace'])
             ->merge($this->classLocations)
             ->toArray();
@@ -347,7 +348,7 @@ class Finder
                 $this->normalizePath($classNamespace)
             );
 
-            $namespace = collect(explode('.', $namespace))
+            $namespace = (new Collection(explode('.', $namespace)))
                 ->map(fn ($i) => \Illuminate\Support\Str::kebab($i))
                 ->implode('.');
 

--- a/src/Mechanisms/CompileLivewireTags/LivewireTagPrecompiler.php
+++ b/src/Mechanisms/CompileLivewireTags/LivewireTagPrecompiler.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Mechanisms\CompileLivewireTags;
 
+use Illuminate\Support\Collection;
 use Illuminate\View\Compilers\ComponentTagCompiler;
 use Livewire\Drawer\Regexes;
 use Livewire\Exceptions\ComponentAttributeMissingOnDynamicComponentException;
@@ -189,7 +190,7 @@ class LivewireTagPrecompiler extends ComponentTagCompiler
 
     protected function attributesToString(array $attributes, $escapeBound = true)
     {
-        return collect($attributes)
+        return (new Collection($attributes))
                 ->map(function (string $value, string $attribute) use ($escapeBound) {
                     return $escapeBound && isset($this->boundAttributes[$attribute]) && $value !== 'true' && ! is_numeric($value)
                                 ? "'{$attribute}' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute({$value})"

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -3,6 +3,8 @@
 namespace Livewire\Mechanisms\HandleComponents;
 
 use function Livewire\{on, trigger, wrap };
+
+use Illuminate\Support\Collection;
 use Livewire\Mechanisms\Mechanism;
 use Livewire\Mechanisms\HandleSynths\HandleSynths;
 use Livewire\Exceptions\PublicPropertyNotFoundException;
@@ -490,8 +492,8 @@ class HandleComponents extends Mechanism
 
         $method = ($synths->isRemoval($leafValue) && $isLastSegment) ? 'unset' : 'set';
 
-        $pathThusFar = collect([$baseProperty, ...$segments])->slice(0, $index + 1)->join('.');
-        $fullPath = collect([$baseProperty, ...$segments])->join('.');
+        $pathThusFar = (new Collection([$baseProperty, ...$segments]))->slice(0, $index + 1)->join('.');
+        $fullPath = (new Collection([$baseProperty, ...$segments]))->join('.');
 
         $synth->$method($target, $property, $toSet, $pathThusFar, $fullPath);
 

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -4,6 +4,7 @@ namespace Livewire\Mechanisms\PersistentMiddleware;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Collection;
 use Livewire\Mechanisms\Mechanism;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use function Livewire\on;
@@ -196,9 +197,9 @@ class PersistentMiddleware extends Mechanism
 
     protected function filterMiddlewareByPersistentMiddleware($middleware)
     {
-        $middleware = collect($middleware);
+        $middleware = new Collection($middleware);
 
-        $persistentMiddleware = collect(app(PersistentMiddleware::class)->getPersistentMiddleware());
+        $persistentMiddleware = new Collection(app(PersistentMiddleware::class)->getPersistentMiddleware());
 
         return $middleware
             ->filter(function ($value, $key) use ($persistentMiddleware) {


### PR DESCRIPTION
## Summary

This PR is a pure refactor that replaces calls to Laravel’s global `collect()` helper with direct instantiation of `new Collection(...)` throughout the Livewire 4.x codebase.

It aligns Livewire with a convention adopted in the Laravel framework itself, which prefers `new Collection()` for:

- Slightly better performance (one fewer function call)
- A shorter call stack
- Makes DX slightly better when navigating the framework
- Consistency across the framework internals

The change has no intended behavioral impact. All existing Collection method chaining, filtering, mapping, etc. continue to work exactly as before.

## Motivation
The `collect()` helper is a thin convenience wrapper without any logic in it. Calling the helper adds an unnecessary extra stack frame and a global function lookup.

Laravel core has begun preferring the explicit constructor in its own source for the reasons listed above. This PR brings Livewire in line with that style.