### PR TITLE
[4.x] Consolidate lazy loading setup to `HandlesLazyLoading` trait

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -22,6 +22,7 @@ use Livewire\Concerns\InteractsWithProperties;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use BadMethodCallException;
+use Livewire\Features\SupportLazyLoading\HandlesLazyLoading;
 
 abstract class Component
 {
@@ -44,6 +45,7 @@ abstract class Component
     use HandlesSlots;
     use HandlesHtmlAttributeForwarding;
     use HandlesRenderless;
+    use HandlesLazyLoading;
 
     protected $__id;
     protected $__name;

--- a/src/Features/SupportEvents/SupportEvents.php
+++ b/src/Features/SupportEvents/SupportEvents.php
@@ -55,9 +55,9 @@ class SupportEvents extends ComponentHook
     function dehydrate($context)
     {
         // Don't register listeners until a lazy component has fully mounted...
-        if ($this->storeGet('isLazyLoadMounting') === true) return;
+        if ($this->component->isLazyLoadMounting()) return;
 
-        if ($context->isMounting() || $this->storeGet('isLazyLoadHydrating') === true) {
+        if ($context->isMounting() || $this->component->isLazyLoadHydrating()) {
             $listeners = static::getListenerEventNames($this->component);
 
             $listeners && $context->addEffect('listeners', $listeners);

--- a/src/Features/SupportJsModules/SupportJsModules.php
+++ b/src/Features/SupportJsModules/SupportJsModules.php
@@ -45,13 +45,13 @@ class SupportJsModules extends ComponentHook
         // Don't add scriptModule effect during lazy-loading placeholder mount.
         // The component's view isn't rendered yet, so @assets won't have run.
         // The scriptModule will be added when __lazyLoad triggers the real mount.
-        if ($this->storeGet('isLazyLoadMounting') === true) return;
+        if ($this->component->isLazyLoadMounting()) return;
 
         // Add scriptModule effect during:
         // 1. Normal component mounting ($context->isMounting())
         // 2. Lazy-loaded component hydration (when __lazyLoad runs)
         $isNormalMount = $context->isMounting();
-        $isLazyLoadHydration = $this->storeGet('isLazyLoadHydrating') === true;
+        $isLazyLoadHydration = $this->component->isLazyLoadHydrating();
 
         if (! $isNormalMount && ! $isLazyLoadHydration) return;
 

--- a/src/Features/SupportLazyLoading/HandlesLazyLoading.php
+++ b/src/Features/SupportLazyLoading/HandlesLazyLoading.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Livewire\Features\SupportLazyLoading;
+
+use function Livewire\store;
+
+trait HandlesLazyLoading
+{
+    public function lazyLoadMounting()
+    {
+        store($this)->set('isLazyLoadMounting', true);
+    }
+
+    public function lazyLoadHydrating()
+    {
+        store($this)->set('isLazyLoadHydrating', true);
+    }
+
+    public function isLazyLoadMounting()
+    {
+        return store($this)->get('isLazyLoadMounting', false);
+    }
+
+    public function isLazyLoadHydrating()
+    {
+        return store($this)->get('isLazyLoadHydrating', false);
+    }
+}

--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -96,7 +96,7 @@ class SupportLazyLoading extends ComponentHook
 
         $this->component->skipMount();
 
-        $this->storeSet('isLazyLoadMounting', true);
+        $this->component->lazyLoadMounting();
         $this->storeSet('isLazyIsolated', $isolate);
 
         $this->component->skipRender(
@@ -111,15 +111,15 @@ class SupportLazyLoading extends ComponentHook
 
         $this->component->skipHydrate();
 
-        $this->storeSet('isLazyLoadHydrating', true);
+        $this->component->lazyLoadHydrating();
     }
 
     function dehydrate($context)
     {
-        if ($this->storeGet('isLazyLoadMounting') === true) {
+        if ($this->component->isLazyLoadMounting()) {
             $context->addMemo('lazyLoaded', false);
             $context->addMemo('lazyIsolated', $this->storeGet('isLazyIsolated'));
-        } elseif ($this->storeGet('isLazyLoadHydrating') === true) {
+        } elseif ($this->component->isLazyLoadHydrating()) {
             $context->addMemo('lazyLoaded', true);
         }
     }


### PR DESCRIPTION
## Summary

Move the transient `isLazyLoadMounting` / `isLazyLoadHydrating` flags from ad-hoc component-store keys (set/read via `ComponentHook::storeSet/Get`) into an explicit `HandlesLazyLoading` trait on the base `Component`. Other hooks that need to know about the lazy-loading lifecycle now call typed methods on the component instead of reading magic strings from the store.

## Motivation

Several hooks must behave differently while a lazy component is still in its placeholder phase versus when it is actually mounting/hydrating:

- **`SupportEvents`** — must *not* register listeners during the placeholder mount; *must* register them when `__lazyLoad` triggers the real mount.
- **`SupportJsModules`** — must *not* emit the `scriptModule` effect during the placeholder mount (the view hasn’t run, so `@assets` hasn’t either); *must* emit it on the real mount/hydrate.

Previously those hooks reached into the component store with the same string keys that `SupportLazyLoading` wrote. That worked only because `ComponentHook::storeGet/Set` already target `store($this->component)`, but the coupling was implicit and fragile.

This change:

1. Makes the lifecycle state part of the component’s public internal API (same pattern as `skipMount()`, `skipHydrate()`, `HandlesEvents`, `HandlesIslands`, …).
2. Removes the need for other hooks to know the exact store key names.
3. Keeps storage location and runtime behavior identical.

## Changes

**New file**

- `src/Features/SupportLazyLoading/HandlesLazyLoading.php`  
  Trait with:
  - `lazyLoadMounting()` / `lazyLoadHydrating()` — set the flags
  - `isLazyLoadMounting()` / `isLazyLoadHydrating()` — read the flags (default `false`)

**Updated**

- `src/Component.php` — `use HandlesLazyLoading;`
- `src/Features/SupportLazyLoading/SupportLazyLoading.php`
  - `mount()` → `$this->component->lazyLoadMounting()`
  - `hydrate()` → `$this->component->lazyLoadHydrating()`
  - `dehydrate()` → `$this->component->isLazyLoadMounting()` / `isLazyLoadHydrating()`
- `src/Features/SupportEvents/SupportEvents.php` — same boolean checks via the component
- `src/Features/SupportJsModules/SupportJsModules.php` — same boolean checks via the component

**Intentionally unchanged**

- `isLazyIsolated` stays on the hook store — it is only consumed inside `SupportLazyLoading` itself.