### PR TITLE
[4.x] Move lazy-loading lifecycle flags into `InteractsWithLazyLoading` trait

### DIFF
--- a/src/ComponentHook.php
+++ b/src/ComponentHook.php
@@ -2,8 +2,12 @@
 
 namespace Livewire;
 
+use Livewire\Concerns\InteractsWithLazyLoading;
+
 abstract class ComponentHook
 {
+    use InteractsWithLazyLoading;
+
     protected $component;
 
     function setComponent($component)

--- a/src/Concerns/InteractsWithLazyLoading.php
+++ b/src/Concerns/InteractsWithLazyLoading.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Livewire\Concerns;
+
+trait InteractsWithLazyLoading
+{
+    protected function markLazyLoadMounting()
+    {
+        $this->storeSet('isLazyLoadMounting', true);
+    }
+
+    protected function markLazyLoadHydrating()
+    {
+        $this->storeSet('isLazyLoadHydrating', true);
+    }
+
+    protected function markLazyIsolated($isolate)
+    {
+        $this->storeSet('isLazyIsolated', $isolate);
+    }
+
+    protected function isLazyLoadMounting()
+    {
+        return $this->storeGet('isLazyLoadMounting', false);
+    }
+
+    protected function isLazyLoadHydrating()
+    {
+        return $this->storeGet('isLazyLoadHydrating', false);
+    }
+
+    protected function isLazyIsolated()
+    {
+        return $this->storeGet('isLazyIsolated');
+    }
+}

--- a/src/Features/SupportEvents/SupportEvents.php
+++ b/src/Features/SupportEvents/SupportEvents.php
@@ -55,9 +55,9 @@ class SupportEvents extends ComponentHook
     function dehydrate($context)
     {
         // Don't register listeners until a lazy component has fully mounted...
-        if ($this->storeGet('isLazyLoadMounting') === true) return;
+        if ($this->isLazyLoadMounting()) return;
 
-        if ($context->isMounting() || $this->storeGet('isLazyLoadHydrating') === true) {
+        if ($context->isMounting() || $this->isLazyLoadHydrating()) {
             $listeners = static::getListenerEventNames($this->component);
 
             $listeners && $context->addEffect('listeners', $listeners);

--- a/src/Features/SupportJsModules/SupportJsModules.php
+++ b/src/Features/SupportJsModules/SupportJsModules.php
@@ -45,13 +45,13 @@ class SupportJsModules extends ComponentHook
         // Don't add scriptModule effect during lazy-loading placeholder mount.
         // The component's view isn't rendered yet, so @assets won't have run.
         // The scriptModule will be added when __lazyLoad triggers the real mount.
-        if ($this->storeGet('isLazyLoadMounting') === true) return;
+        if ($this->isLazyLoadMounting()) return;
 
         // Add scriptModule effect during:
         // 1. Normal component mounting ($context->isMounting())
         // 2. Lazy-loaded component hydration (when __lazyLoad runs)
         $isNormalMount = $context->isMounting();
-        $isLazyLoadHydration = $this->storeGet('isLazyLoadHydrating') === true;
+        $isLazyLoadHydration = $this->isLazyLoadHydrating();
 
         if (! $isNormalMount && ! $isLazyLoadHydration) return;
 

--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -96,8 +96,8 @@ class SupportLazyLoading extends ComponentHook
 
         $this->component->skipMount();
 
-        $this->storeSet('isLazyLoadMounting', true);
-        $this->storeSet('isLazyIsolated', $isolate);
+        $this->markLazyLoadMounting();
+        $this->markLazyIsolated($isolate);
 
         $this->component->skipRender(
             $this->generatePlaceholderHtml($params, $isDeferred)
@@ -111,15 +111,15 @@ class SupportLazyLoading extends ComponentHook
 
         $this->component->skipHydrate();
 
-        $this->storeSet('isLazyLoadHydrating', true);
+        $this->markLazyLoadHydrating();
     }
 
     function dehydrate($context)
     {
-        if ($this->storeGet('isLazyLoadMounting') === true) {
+        if ($this->isLazyLoadMounting()) {
             $context->addMemo('lazyLoaded', false);
-            $context->addMemo('lazyIsolated', $this->storeGet('isLazyIsolated'));
-        } elseif ($this->storeGet('isLazyLoadHydrating') === true) {
+            $context->addMemo('lazyIsolated', $this->isLazyIsolated());
+        } elseif ($this->isLazyLoadHydrating()) {
             $context->addMemo('lazyLoaded', true);
         }
     }


### PR DESCRIPTION
This is an alternative for https://github.com/livewire/livewire/pull/10507

## Summary

Extract the transient lazy-loading flags (`isLazyLoadMounting`, `isLazyLoadHydrating`, and `isLazyIsolated`) from magic store keys into a dedicated `InteractsWithLazyLoading` trait that is mixed into the base `ComponentHook` class.

Other hooks that need to know about the lazy-loading lifecycle can now call typed, protected methods instead of reading magic strings from the store.

## Motivation

Several hooks must behave differently while a lazy component is still in its placeholder phase versus when it is actually mounting/hydrating:

- **SupportEvents** — must *not* register listeners during the placeholder mount; *must* register them when `__lazyLoad` triggers the real mount.
- **SupportJsModules** — must *not* emit the `scriptModule` effect during the placeholder mount (the view hasn’t run, so `@assets` hasn’t either); *must* emit it on the real mount/hydrate.

Previously those hooks reached into the component store with the same string keys that `SupportLazyLoading` wrote. That worked only because `ComponentHook::storeGet/Set` already target `store($this->component)`, but the coupling was implicit and fragile.

This change:

1. Makes the lifecycle state an explicit part of the **hook system** (not the public Component API).
2. Removes the need for other hooks to know the exact store key names.
3. Keeps storage location and runtime behavior identical.
4. Avoids adding any new methods to the base `Component` class (addresses the concern raised on the previous approach).

## Changes

**New file**

- `src/Concerns/InteractsWithLazyLoading.php`  
  Trait with protected helpers:
  - `markLazyLoadMounting()` / `markLazyLoadHydrating()` / `markLazyIsolated()`
  - `isLazyLoadMounting()` / `isLazyLoadHydrating()` / `isLazyIsolated()`

**Updated**

- `src/ComponentHook.php` — `use InteractsWithLazyLoading;`
- `src/Features/SupportLazyLoading/SupportLazyLoading.php`
- `src/Features/SupportEvents/SupportEvents.php`
- `src/Features/SupportJsModules/SupportJsModules.php`

**Intentionally unchanged**

- `src/Component.php` — no new public methods

## Pattern for future similar cases

When multiple component hooks need to share transient state that lives on the component store:

1. Create `src/Concerns/InteractsWith{Feature}.php`
2. Mix the trait into `ComponentHook`
3. Use protected `mark*` / `is*` methods inside the hooks
4. Never put these helpers on the public `Component` class unless they are intentionally part of the user-facing API

This keeps the Component surface area small while still giving us a single source of truth and typed access.