### PR TITLE
[4.x] Fix `#[Authorize]` attribute skip component exception hook

### DIFF
--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -10,6 +10,7 @@ use Livewire\ImplicitlyBoundMethod;
 use UnitEnum;
 
 use function Illuminate\Support\enum_value;
+use function Livewire\wrap;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
 class BaseAuthorize extends LivewireAttribute
@@ -23,32 +24,34 @@ class BaseAuthorize extends LivewireAttribute
 
     public function call(array $parameters) : void
     {
-        // Action that does not require a model or class...
-        if (is_null($this->argument)) {
-            $this->authorize($this->ability);
-
-            return;
-        }
-
-        $arguments = Arr::wrap($this->argument);
-
-        // Resolve method dependencies lazily, then reuse them for multi-argument authorization checks...
-        $methodDependencies = null;
-        $resolveMethodDependencies = function () use (&$methodDependencies, $parameters): array {
-            return $methodDependencies ??= ImplicitlyBoundMethod::resolveMethodDependencies(
-                app(),
-                [$this->component, $this->getName()],
-                $parameters,
-            );
-        };
-
-        // Resolve each argument (prioritize method parameters first, then component properties)
-        $resolved = [];
-        foreach ($arguments as $arg) {
-            $resolved[] = $this->resolveArgument($arg, $parameters, $resolveMethodDependencies);
-        }
-
-        $this->authorize($this->ability, $resolved);
+        wrap($this->component)->tap(function () use ($parameters) {
+            // Action that does not require a model or class...
+            if (is_null($this->argument)) {
+                $this->authorize($this->ability);
+    
+                return;
+            }
+    
+            $arguments = Arr::wrap($this->argument);
+    
+            // Resolve method dependencies lazily, then reuse them for multi-argument authorization checks...
+            $methodDependencies = null;
+            $resolveMethodDependencies = function () use (&$methodDependencies, $parameters): array {
+                return $methodDependencies ??= ImplicitlyBoundMethod::resolveMethodDependencies(
+                    app(),
+                    [$this->component, $this->getName()],
+                    $parameters,
+                );
+            };
+    
+            // Resolve each argument (prioritize method parameters first, then component properties)
+            $resolved = [];
+            foreach ($arguments as $arg) {
+                $resolved[] = $this->resolveArgument($arg, $parameters, $resolveMethodDependencies);
+            }
+    
+            $this->authorize($this->ability, $resolved);
+        });
     }
 
     /**
@@ -63,7 +66,7 @@ class BaseAuthorize extends LivewireAttribute
 
         // Try method parameter first (prioritized per rules)
         $methodArgument = Arr::first(
-            (new \ReflectionObject($this->component))->getMethod($this->getName())->getParameters(),
+            (new \ReflectionMethod($this->component, $this->getName()))->getParameters(),
             fn (\ReflectionParameter $parameter) : bool => $parameter->getName() === $arg,
         );
 

--- a/src/Features/SupportAuthorization/BaseAuthorize.php
+++ b/src/Features/SupportAuthorization/BaseAuthorize.php
@@ -2,37 +2,33 @@
 
 namespace Livewire\Features\SupportAuthorization;
 
-use Attribute;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Arr;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\ImplicitlyBoundMethod;
-use UnitEnum;
 
 use function Illuminate\Support\enum_value;
 use function Livewire\wrap;
 
-#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_METHOD)]
 class BaseAuthorize extends LivewireAttribute
 {
     use AuthorizesRequests;
 
     public function __construct(
-        public UnitEnum|string $ability,
+        public \UnitEnum|string $ability,
         public array|string|null $argument = null,
     ) {}
 
     public function call(array $parameters) : void
     {
         wrap($this->component)->tap(function () use ($parameters) {
-            // Action that does not require a model or class...
+            // Authorize defined gate or class name
             if (is_null($this->argument)) {
                 $this->authorize($this->ability);
     
                 return;
             }
-    
-            $arguments = Arr::wrap($this->argument);
     
             // Resolve method dependencies lazily, then reuse them for multi-argument authorization checks...
             $methodDependencies = null;
@@ -46,18 +42,15 @@ class BaseAuthorize extends LivewireAttribute
     
             // Resolve each argument (prioritize method parameters first, then component properties)
             $resolved = [];
-            foreach ($arguments as $arg) {
-                $resolved[] = $this->resolveArgument($arg, $parameters, $resolveMethodDependencies);
+            foreach (Arr::wrap($this->argument) as $arg) {
+                $resolved[] = $this->resolveArgument($arg, $resolveMethodDependencies);
             }
     
             $this->authorize($this->ability, $resolved);
         });
     }
 
-    /**
-     * Resolve a single argument.
-     */
-    protected function resolveArgument(string $arg, array $parameters, \Closure $resolveMethodDependencies): mixed
+    protected function resolveArgument(string $arg, \Closure $resolveMethodDependencies): mixed
     {
         // Action that does not require a model, for example a 'create' action...
         if (class_exists($arg)) {

--- a/src/Features/SupportAuthorization/UnitTest.php
+++ b/src/Features/SupportAuthorization/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportAuthorization;
 
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User as AuthUser;
 use Illuminate\Routing\UrlGenerator;
@@ -893,6 +894,61 @@ class UnitTest extends TestCase
             })
             ->dispatch('some-event')
             ->assertForbidden();
+    }
+
+    public function test_authorize_attribute_trigger_component_exception_hook()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(2))
+            ->test(new class extends TestComponent {
+                #[BaseAuthorize(AuthorizationPost::class)]
+                public function store() : bool
+                {
+                    return true;
+                }
+
+                public function exception($e, $stopPropagation)
+                {
+                    if ($e instanceof AuthorizationException) {
+                        $stopPropagation();
+    
+                        Session::put('exception-hook-triggered', true);
+                    }
+                }
+            })
+            ->call('store')
+            ->assertOk();
+
+        $this->assertTrue(Session::has('exception-hook-triggered'));
+    }
+
+    public function test_can_authorize_using_attribute_and_trait_method_at_the_same_time()
+    {
+        Gate::policy(AuthorizationPost::class, AuthorizationPostPolicy::class);
+
+        Livewire::actingAs(AuthorizationUser::find(1))
+            ->test(new class extends TestComponent {
+                #[BaseAuthorize(AuthorizationPost::class)]
+                public function store(AuthorizationPost $post)
+                {
+                    $this->authorize(AuthorizationPost::class);
+                    $this->authorize('edit', $post);
+                }
+
+                public function exception($e, $stopPropagation)
+                {
+                    if ($e instanceof AuthorizationException) {
+                        $stopPropagation();
+    
+                        Session::put('exception-hook-triggered', true);
+                    }
+                }
+            })
+            ->call('store', post: 1)
+            ->assertOk();
+
+        $this->assertFalse(Session::has('exception-hook-triggered'));
     }
 }
 


### PR DESCRIPTION
A very simple fix instead https://github.com/livewire/livewire/pull/10483

## Scenario
When using `#[Authorize]` attribute to perform authorization as pre-method execution. It doesnt trigger the component `exception()` hook.
```php
class PostPolicy
{
    public function edit(User $user, Post $post)
    {
        return false;
    }
}
```

```php
<?php

use App\Models\Post;
use Livewire\Component;

new class extends Component
{
    #[Authorize('edit', 'post')]
    public function save(Post $post)
    {
        //
    }

    public function exception($e, $stopPropagation)
    {
        $stopPropagation();

        dd($e->getMessage()); // not triggered
    }
}
```

## Problem
Attribute `call()` handled by `SupportAttributes::call()` which is running before the actual method get called so any exception thrown will not get handled by component exception hook.

## Solution
Wrap the component and perform authorization inside `tap()` callback. This way, all exception will go through the `Wrapper` class. This is simply following how `BaseValidate::update()` did the trick.
```php
use function Livewire\wrap;

public function call(array $parameters)
{
    wrap($this->component)->tap(function () use ($parameters) {
        // original code
    });
}
```

## What's Changed
- Regression tests added
- Change `ReflectionObject` to `ReflectionMethod`, reflection object has too many layers than direct reflection method


Fix: https://github.com/livewire/livewire/issues/10410