### PR TITLE
[4.x] Add `hasModifier()` helper to `Directive` and migrate existing usages

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -107,6 +107,10 @@ export class Directive {
         return methods[0].params
     }
 
+    hasModifier(key) {
+        return this.modifiers.includes(key)
+    }
+
     parseOutMethodsAndParams(rawMethod) {
         let methods = []
 

--- a/js/directives/shared.js
+++ b/js/directives/shared.js
@@ -1,8 +1,8 @@
 
 export function toggleBooleanStateDirective(el, directive, isTruthy, cachedDisplay = null) {
-    isTruthy = directive.modifiers.includes('remove') ? ! isTruthy : isTruthy
+    isTruthy = directive.hasModifier('remove') ? ! isTruthy : isTruthy
 
-    if (directive.modifiers.includes('class')) {
+    if (directive.hasModifier('class')) {
         let classes = directive.expression.split(' ').filter(String)
 
         if (isTruthy) {
@@ -10,7 +10,7 @@ export function toggleBooleanStateDirective(el, directive, isTruthy, cachedDispl
         } else {
             el.classList.remove(...classes)
         }
-    } else if (directive.modifiers.includes('attr')) {
+    } else if (directive.hasModifier('attr')) {
         if (isTruthy) {
             el.setAttribute(directive.expression, true)
         } else {
@@ -22,11 +22,11 @@ export function toggleBooleanStateDirective(el, directive, isTruthy, cachedDispl
             .getPropertyValue('display')
 
         let display = (['inline', 'list-item', 'block', 'table', 'flex', 'grid', 'inline-flex']
-            .filter(i => directive.modifiers.includes(i))[0] || 'inline-block')
+            .filter(i => directive.hasModifier(i))[0] || 'inline-block')
 
         // If element is to be removed, set display to its current value...
-        // display = (directive.modifiers.includes('remove') && ! isTruthy)
-        display = (directive.modifiers.includes('remove') && ! isTruthy)
+        // display = (directive.hasModifier('remove') && ! isTruthy)
+        display = (directive.hasModifier('remove') && ! isTruthy)
             ? cache : display
 
         el.style.display = isTruthy ? display : 'none'

--- a/js/directives/wire-confirm.js
+++ b/js/directives/wire-confirm.js
@@ -2,7 +2,7 @@ import { directive } from "@/directives"
 
 directive('confirm', ({ el, directive }) => {
     let message = directive.expression
-    let shouldPrompt = directive.modifiers.includes('prompt')
+    let shouldPrompt = directive.hasModifier('prompt')
 
     // Convert sanitized linebreaks ("\n") to real line breaks...
     message = message.replaceAll('\\n', '\n')

--- a/js/directives/wire-current.js
+++ b/js/directives/wire-current.js
@@ -13,9 +13,9 @@ globalDirective('current', ({ el, directive, cleanup }) => {
     let expression = directive.expression
 
     let options = {
-        exact: directive.modifiers.includes('exact'),
-        strict: directive.modifiers.includes('strict'),
-        ignore: directive.modifiers.includes('ignore'),
+        exact: directive.hasModifier('exact'),
+        strict: directive.hasModifier('strict'),
+        ignore: directive.hasModifier('ignore'),
     }
 
     if (options.ignore) return

--- a/js/directives/wire-ignore.js
+++ b/js/directives/wire-ignore.js
@@ -1,9 +1,9 @@
 import { directive } from "@/directives"
 
 directive('ignore', ({ el, directive }) => {
-    if (directive.modifiers.includes('self')) {
+    if (directive.hasModifier('self')) {
         el.__livewire_ignore_self = true
-    } else if (directive.modifiers.includes('children')) {
+    } else if (directive.hasModifier('children')) {
         el.__livewire_ignore_children = true
     } else {
         el.__livewire_ignore = true

--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -26,7 +26,7 @@ directive('loading', ({ el, directive, component, cleanup }) => {
 })
 
 function applyDelay(directive) {
-    if (! directive.modifiers.includes('delay') || directive.modifiers.includes('none')) return [i => i(), i => i()]
+    if (! directive.hasModifier('delay') || directive.hasModifier('none')) return [i => i(), i => i()]
 
     let duration = 200
 
@@ -41,7 +41,7 @@ function applyDelay(directive) {
     }
 
     Object.keys(delayModifiers).some(key => {
-        if (directive.modifiers.includes(key)) {
+        if (directive.hasModifier(key)) {
             duration = delayModifiers[key]
 
             return true
@@ -195,7 +195,7 @@ function getTargets(el) {
     if (directives.has('target')) {
         let directive = directives.get('target')
 
-        if (directive.modifiers.includes("except")) inverted = true
+        if (directive.hasModifier("except")) inverted = true
 
         directive.methods.forEach(({ method, params }) => {
             targets.push({

--- a/js/directives/wire-poll.js
+++ b/js/directives/wire-poll.js
@@ -102,11 +102,11 @@ function theDirectiveIsOffTheElement(el) {
 }
 
 function theDirectiveIsMissingKeepAlive(directive) {
-    return ! directive.modifiers.includes('keep-alive')
+    return ! directive.hasModifier('keep-alive')
 }
 
 function theDirectiveHasVisible(directive) {
-    return directive.modifiers.includes('visible')
+    return directive.hasModifier('visible')
 }
 
 function theElementIsNotInTheViewport(el) {

--- a/js/directives/wire-replace.js
+++ b/js/directives/wire-replace.js
@@ -1,7 +1,7 @@
 import { directive } from "@/directives"
 
 directive('replace', ({ el, directive }) => {
-    if (directive.modifiers.includes('self')) {
+    if (directive.hasModifier('self')) {
         el.__livewire_replace_self = true
     } else {
         el.__livewire_replace = true

--- a/js/directives/wire-wildcard.js
+++ b/js/directives/wire-wildcard.js
@@ -12,27 +12,27 @@ on('directive.init', ({ el, directive, cleanup, component }) => {
     let attribute = directive.rawName.replace('wire:', 'x-on:')
 
     // Automatically add .prevent to wire:submit, if they didn't add it themselves...
-    if (directive.value === 'submit' && ! directive.modifiers.includes('prevent')) {
+    if (directive.value === 'submit' && ! directive.hasModifier('prevent')) {
         attribute = attribute + '.prevent'
     }
 
     // Strip .async from Alpine expression because it only concerns Livewire and trips up Alpine...
-    if (directive.modifiers.includes('async')) {
+    if (directive.hasModifier('async')) {
         attribute = attribute.replace('.async', '')
     }
 
     // Strip .renderless from Alpine expression because it only concerns Livewire and trips up Alpine...
-    if (directive.modifiers.includes('renderless')) {
+    if (directive.hasModifier('renderless')) {
         attribute = attribute.replace('.renderless', '')
     }
 
     // Strip .prepend from Alpine expression because it only concerns Livewire and trips up Alpine...
-    if (directive.modifiers.includes('prepend')) {
+    if (directive.hasModifier('prepend')) {
         attribute = attribute.replace('.prepend', '')
     }
 
     // Strip .append from Alpine expression because it only concerns Livewire and trips up Alpine...
-    if (directive.modifiers.includes('append')) {
+    if (directive.hasModifier('append')) {
         attribute = attribute.replace('.append', '')
     }
 

--- a/js/features/supportPreserveScroll.js
+++ b/js/features/supportPreserveScroll.js
@@ -9,7 +9,7 @@ interceptMessage(({ message, onSuccess }) => {
 
             let directive = origin.directive
 
-            if (! directive.modifiers.includes('preserve-scroll')) return
+            if (! directive.hasModifier('preserve-scroll')) return
 
             let oldHeight
             let oldScroll

--- a/js/features/supportWireSort.js
+++ b/js/features/supportWireSort.js
@@ -29,22 +29,22 @@ Alpine.interceptInit(el => {
             let attribute = directive.rawName.replace('wire:', 'x-')
 
             // Strip .async from Alpine expression because it only concerns Livewire and trips up Alpine...
-            if (directive.modifiers.includes('async')) {
+            if (directive.hasModifier('async')) {
                 attribute = attribute.replace('.async', '')
             }
 
             // Strip .renderless from Alpine expression because it only concerns Livewire and trips up Alpine...
-            if (directive.modifiers.includes('renderless')) {
+            if (directive.hasModifier('renderless')) {
                 attribute = attribute.replace('.renderless', '')
             }
 
             // Strip .prepend from Alpine expression because it only concerns Livewire and trips up Alpine...
-            if (directive.modifiers.includes('prepend')) {
+            if (directive.hasModifier('prepend')) {
                 attribute = attribute.replace('.prepend', '')
             }
 
             // Strip .append from Alpine expression because it only concerns Livewire and trips up Alpine...
-            if (directive.modifiers.includes('append')) {
+            if (directive.hasModifier('append')) {
                 attribute = attribute.replace('.append', '')
             }
 


### PR DESCRIPTION
## Summary

Adds a `hasModifier(key)` helper to the JavaScript `Directive` class and migrates existing call sites from the low-level `directive.modifiers.includes(...)` pattern.

This is a pure internal refactor with no behavioural changes. It improves consistency and readability, and brings the JS side in line with the existing PHP `WireDirective::hasModifier()` method.

### Motivation

- Many directives repeatedly reach into the raw `modifiers` array.
- A small helper makes the intent clearer and gives us a single place to evolve modifier checking in the future (aliases, normalization, etc.).
- Creates nice symmetry with the PHP API.

### Changes

- Added `Directive#hasModifier(key)` in `js/directives.js`.
- Updated all (or the majority of) call sites in:
  - `shared.js`
  - `wire-confirm.js`
  - `wire-current.js`
  - `wire-ignore.js`
  - `wire-loading.js`
  - `wire-poll.js`
  - `wire-replace.js`
  - `wire-wildcard.js`
  - `supportPreserveScroll.js`
  - `supportWireSort.js`