### PR TITLE
[4.x] Introduce `Effects` class and replace `Object.prototype.hasOwnProperty.call` checks

### DIFF
--- a/js/component.js
+++ b/js/component.js
@@ -29,8 +29,8 @@ export class Component {
 
         this.name = this.snapshot.memo.name
 
-        this.effects = new Effects(JSON.parse(el.getAttribute('wire:effects') ?? '{}'))
-        this.originalEffects = new Effects(deepClone(this.effects))
+        this.effects = Effects.from(JSON.parse(el.getAttribute('wire:effects') ?? '{}'))
+        this.originalEffects = Effects.from(deepClone(this.effects))
 
         // "canonical" data represents the last known server state.
         this.canonical = extractData(deepClone(this.snapshot.data))
@@ -83,7 +83,7 @@ export class Component {
 
         this.snapshot = snapshot
 
-        this.effects = effects instanceof Effects ? effects : new Effects(effects)
+        this.effects = Effects.from(effects)
 
         this.canonical = extractData(deepClone(snapshot.data))
 
@@ -151,7 +151,7 @@ export class Component {
      * users interact with, triggering reactive effects.
      */
     processEffects(effects, request) {
-        effects = effects instanceof Effects ? effects : new Effects(effects)
+        effects = Effects.from(effects)
 
         // This is for BC.
         trigger('effects', this, effects)

--- a/js/component.js
+++ b/js/component.js
@@ -29,7 +29,7 @@ export class Component {
 
         this.name = this.snapshot.memo.name
 
-        this.effects = new Effects(JSON.parse(el.getAttribute('wire:effects') || {}))
+        this.effects = new Effects(JSON.parse(el.getAttribute('wire:effects') ?? '{}'))
         this.originalEffects = new Effects(deepClone(this.effects))
 
         // "canonical" data represents the last known server state.

--- a/js/component.js
+++ b/js/component.js
@@ -3,6 +3,7 @@ import { generateWireObject } from '@/$wire'
 import { findComponentByEl, findComponent, hasComponent } from '@/store'
 import { trigger } from '@/hooks'
 import { setNextActionOrigin } from '@/request'
+import { Effects } from '@/effects'
 
 export class Component {
     constructor(el) {
@@ -28,8 +29,8 @@ export class Component {
 
         this.name = this.snapshot.memo.name
 
-        this.effects = JSON.parse(el.getAttribute('wire:effects'))
-        this.originalEffects = deepClone(this.effects)
+        this.effects = new Effects(JSON.parse(el.getAttribute('wire:effects') || {}))
+        this.originalEffects = new Effects(deepClone(this.effects))
 
         // "canonical" data represents the last known server state.
         this.canonical = extractData(deepClone(this.snapshot.data))
@@ -82,7 +83,7 @@ export class Component {
 
         this.snapshot = snapshot
 
-        this.effects = effects
+        this.effects = effects instanceof Effects ? effects : new Effects(effects)
 
         this.canonical = extractData(deepClone(snapshot.data))
 
@@ -137,11 +138,11 @@ export class Component {
     }
 
     replayUpdate(snapshot, html) {
-        let effects = { ...this.effects, html}
+        let effects = new Effects({ ...this.effects, html })
 
         this.mergeNewSnapshot(JSON.stringify(snapshot), effects)
 
-        this.processEffects({ html })
+        this.processEffects(new Effects({ html }))
     }
 
     /**
@@ -150,6 +151,8 @@ export class Component {
      * users interact with, triggering reactive effects.
      */
     processEffects(effects, request) {
+        effects = effects instanceof Effects ? effects : new Effects(effects)
+
         // This is for BC.
         trigger('effects', this, effects)
 
@@ -262,18 +265,18 @@ export class Component {
         let effects = {}
 
         // We need to re-register any event listeners that were originally registered...
-        if (Object.prototype.hasOwnProperty.call(this.originalEffects, 'listeners') && this.originalEffects.listeners) {
+        if (this.originalEffects.has('listeners')) {
             effects.listeners = this.originalEffects.listeners
         }
 
         // We need to re-register any url/query-string bindings...
-        if (Object.prototype.hasOwnProperty.call(this.originalEffects, 'url') && this.originalEffects.url) {
+        if (this.originalEffects.has('url')) {
             effects.url = this.originalEffects.url
         }
 
         // We need to re-register any scripts that were originally registered...
-        if (Object.prototype.hasOwnProperty.call(this.originalEffects, 'scripts') && this.originalEffects.scripts) {
-            effects.scripts = this.originalEffects.scripts;
+        if (this.originalEffects.has('scripts')) {
+            effects.scripts = this.originalEffects.scripts
         }
 
         el.setAttribute('wire:effects', JSON.stringify(effects))

--- a/js/component.js
+++ b/js/component.js
@@ -265,17 +265,17 @@ export class Component {
         let effects = {}
 
         // We need to re-register any event listeners that were originally registered...
-        if (this.originalEffects.has('listeners')) {
+        if (this.originalEffects.hasValue('listeners')) {
             effects.listeners = this.originalEffects.listeners
         }
 
         // We need to re-register any url/query-string bindings...
-        if (this.originalEffects.has('url')) {
+        if (this.originalEffects.hasValue('url')) {
             effects.url = this.originalEffects.url
         }
 
         // We need to re-register any scripts that were originally registered...
-        if (this.originalEffects.has('scripts')) {
+        if (this.originalEffects.hasValue('scripts')) {
             effects.scripts = this.originalEffects.scripts
         }
 

--- a/js/effects.js
+++ b/js/effects.js
@@ -1,0 +1,17 @@
+export class Effects {
+    constructor(data = {}) {
+        Object.assign(this, data && typeof data === 'object' ? data : {})
+    }
+
+    has(key) {
+        return Object.prototype.hasOwnProperty.call(this, key)
+    }
+
+    hasValue(key) {
+        return this.has(key) && !! this[key]
+    }
+
+    toJSON() {
+        return { ...this }
+    }
+}

--- a/js/effects.js
+++ b/js/effects.js
@@ -1,6 +1,14 @@
 export class Effects {
     constructor(data = {}) {
-        Object.assign(this, data && typeof data === 'object' ? data : {})
+        let source = isObject(data) ? data : {}
+
+        for (let key of Object.keys(source)) {
+            if (! isReservedKey(key)) this[key] = source[key]
+        }
+    }
+
+    static from(data) {
+        return data instanceof Effects ? data : new Effects(data)
     }
 
     has(key) {
@@ -14,4 +22,14 @@ export class Effects {
     toJSON() {
         return { ...this }
     }
+}
+
+function isObject(source)
+{
+    return source !== null && typeof source === 'object' && ! Array.isArray(source)
+}
+
+function isReservedKey(key)
+{
+    return key === 'has' || key === 'hasValue' || key === 'toJSON'
 }

--- a/js/effects.spec.js
+++ b/js/effects.spec.js
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest'
+import { Effects } from './effects'
+
+describe('Effects', () => {
+    describe('constructor', () => {
+        it('creates an empty effects instance by default', () => {
+            let effects = new Effects()
+
+            expect(effects).toBeInstanceOf(Effects)
+            expect(Object.keys(effects)).toEqual([])
+        })
+
+        it('assigns own properties from a plain object', () => {
+            let effects = new Effects({ html: '<div></div>', redirect: '/home' })
+
+            expect(effects.html).toBe('<div></div>')
+            expect(effects.redirect).toBe('/home')
+        })
+
+        it('ignores non-object data', () => {
+            expect(Object.keys(new Effects(null))).toEqual([])
+            expect(Object.keys(new Effects(undefined))).toEqual([])
+            expect(Object.keys(new Effects('string'))).toEqual([])
+            expect(Object.keys(new Effects(42))).toEqual([])
+            expect(Object.keys(new Effects(true))).toEqual([])
+        })
+
+        it('does not copy inherited properties', () => {
+            let proto = { inherited: true }
+            let data = Object.create(proto)
+            data.own = 'value'
+
+            let effects = new Effects(data)
+
+            expect(effects.own).toBe('value')
+            expect(effects.inherited).toBeUndefined()
+            expect(effects.has('inherited')).toBe(false)
+        })
+    })
+
+    describe('has', () => {
+        it('returns true for an own key that exists', () => {
+            let effects = new Effects({ redirect: '/home' })
+
+            expect(effects.has('redirect')).toBe(true)
+        })
+
+        it('returns false for a missing key', () => {
+            let effects = new Effects({ redirect: '/home' })
+
+            expect(effects.has('html')).toBe(false)
+        })
+
+        it('returns true for falsy own values', () => {
+            let effects = new Effects({
+                empty: '',
+                zero: 0,
+                no: false,
+                nothing: null,
+                missing: undefined,
+            })
+
+            expect(effects.has('empty')).toBe(true)
+            expect(effects.has('zero')).toBe(true)
+            expect(effects.has('no')).toBe(true)
+            expect(effects.has('nothing')).toBe(true)
+            expect(effects.has('missing')).toBe(true)
+        })
+
+        it('does not match prototype properties', () => {
+            let effects = new Effects({})
+
+            expect(effects.has('hasOwnProperty')).toBe(false)
+            expect(effects.has('toString')).toBe(false)
+            expect(effects.has('constructor')).toBe(false)
+        })
+    })
+
+    describe('hasValue', () => {
+        it('returns true for a truthy own value', () => {
+            let effects = new Effects({ html: '<div></div>', listeners: ['foo'] })
+
+            expect(effects.hasValue('html')).toBe(true)
+            expect(effects.hasValue('listeners')).toBe(true)
+        })
+
+        it('returns false for a missing key', () => {
+            let effects = new Effects({ html: '<div></div>' })
+
+            expect(effects.hasValue('redirect')).toBe(false)
+        })
+
+        it('returns false for falsy own values', () => {
+            let effects = new Effects({
+                empty: '',
+                zero: 0,
+                no: false,
+                nothing: null,
+                missing: undefined,
+            })
+
+            expect(effects.hasValue('empty')).toBe(false)
+            expect(effects.hasValue('zero')).toBe(false)
+            expect(effects.hasValue('no')).toBe(false)
+            expect(effects.hasValue('nothing')).toBe(false)
+            expect(effects.hasValue('missing')).toBe(false)
+        })
+
+        it('returns true for objects and arrays (including empty ones)', () => {
+            // !!{} and !![] are both true in JS, so hasValue treats them as present values
+            let effects = new Effects({
+                obj: {},
+                emptyItems: [],
+                items: ['a'],
+            })
+
+            expect(effects.hasValue('obj')).toBe(true)
+            expect(effects.hasValue('emptyItems')).toBe(true)
+            expect(effects.hasValue('items')).toBe(true)
+        })
+    })
+
+    describe('property access', () => {
+        it('allows direct property reads used throughout the codebase', () => {
+            let effects = new Effects({
+                redirect: '/dashboard',
+                html: '<span>hi</span>',
+                dispatches: [{ name: 'saved' }],
+            })
+
+            expect(effects.redirect).toBe('/dashboard')
+            expect(effects.html).toBe('<span>hi</span>')
+            expect(effects.dispatches).toEqual([{ name: 'saved' }])
+        })
+    })
+
+    describe('toJSON', () => {
+        it('returns a plain object of own data properties', () => {
+            let effects = new Effects({ html: '<div></div>', redirect: '/home' })
+
+            expect(effects.toJSON()).toEqual({
+                html: '<div></div>',
+                redirect: '/home',
+            })
+        })
+
+        it('does not include class methods', () => {
+            let effects = new Effects({ html: '<div></div>' })
+            let json = effects.toJSON()
+
+            expect(json.has).toBeUndefined()
+            expect(json.hasValue).toBeUndefined()
+            expect(json.toJSON).toBeUndefined()
+        })
+
+        it('works with JSON.stringify for wire:effects attributes', () => {
+            let effects = new Effects({
+                listeners: ['foo', 'bar'],
+                url: { search: true },
+            })
+
+            expect(JSON.stringify(effects)).toBe(JSON.stringify({
+                listeners: ['foo', 'bar'],
+                url: { search: true },
+            }))
+        })
+
+        it('round-trips through JSON for inscription', () => {
+            let original = new Effects({
+                listeners: ['saved'],
+                scripts: { 'app.js': true },
+            })
+
+            let restored = new Effects(JSON.parse(JSON.stringify(original)))
+
+            expect(restored.hasValue('listeners')).toBe(true)
+            expect(restored.listeners).toEqual(['saved'])
+            expect(restored.hasValue('scripts')).toBe(true)
+            expect(restored.scripts).toEqual({ 'app.js': true })
+            expect(restored.has('html')).toBe(false)
+        })
+    })
+
+    describe('spread compatibility', () => {
+        it('can be spread into a plain object without copying methods', () => {
+            let effects = new Effects({ html: '<div></div>', redirect: '/home' })
+            let plain = { ...effects }
+
+            expect(plain).toEqual({ html: '<div></div>', redirect: '/home' })
+            expect(plain.has).toBeUndefined()
+            expect(plain.hasValue).toBeUndefined()
+        })
+
+        it('supports constructing a new Effects from a spread', () => {
+            let effects = new Effects({ redirect: '/home' })
+            let merged = new Effects({ ...effects, html: '<div></div>' })
+
+            expect(merged.hasValue('redirect')).toBe(true)
+            expect(merged.hasValue('html')).toBe(true)
+            expect(merged.redirect).toBe('/home')
+            expect(merged.html).toBe('<div></div>')
+        })
+    })
+})

--- a/js/features/supportCssModules.js
+++ b/js/features/supportCssModules.js
@@ -5,7 +5,7 @@ let loadedStyles = new Set()
 
 on('effect', ({ component, effects }) => {
     // Handle scoped styles
-    if (Object.prototype.hasOwnProperty.call(effects, 'styleModule') && effects.styleModule) {
+    if (effects.hasValue('styleModule')) {
         let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
         let path = `${getModuleUrl()}/css/${encodedName}.css?v=${effects.styleModule}`
 
@@ -16,7 +16,7 @@ on('effect', ({ component, effects }) => {
     }
 
     // Handle global styles
-    if (Object.prototype.hasOwnProperty.call(effects, 'globalStyleModule') && effects.globalStyleModule) {
+    if (effects.hasValue('globalStyleModule')) {
         let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
         let path = `${getModuleUrl()}/css/${encodedName}.global.css?v=${effects.globalStyleModule}`
 

--- a/js/features/supportDispatches.js
+++ b/js/features/supportDispatches.js
@@ -12,7 +12,7 @@ on('effect', ({ component, effects }) => {
             queueMicrotask(() => {
                 let dispatches = []
 
-                if (Object.prototype.hasOwnProperty.call(effects, 'dispatches') && effects.dispatches) {
+                if (effects.hasValue('dispatches')) {
                     dispatches = effects.dispatches
                 }
 

--- a/js/features/supportFileDownloads.js
+++ b/js/features/supportFileDownloads.js
@@ -4,7 +4,7 @@ on('commit', ({ succeed }) => {
     succeed(({ effects }) => {
         let download
 
-        if (Object.prototype.hasOwnProperty.call(effects, 'download')) {
+        if (effects.has('download')) {
             download = effects.download
         }
 

--- a/js/features/supportIslands.js
+++ b/js/features/supportIslands.js
@@ -57,7 +57,7 @@ interceptMessage(({ message, onSuccess, onStream }) => {
         onMorph(async () => {
             let fragments = []
 
-            if (Object.prototype.hasOwnProperty.call(payload.effects, 'islandFragments') && payload.effects.islandFragments) {
+            if (payload.effects.hasValue('islandFragments')) {
                 fragments = payload.effects.islandFragments
             }
 

--- a/js/features/supportJsEvaluation.js
+++ b/js/features/supportJsEvaluation.js
@@ -14,11 +14,11 @@ on('effect', ({ component, effects }) => {
     let js
     let xjs
 
-    if (Object.prototype.hasOwnProperty.call(effects, 'js')) {
+    if (effects.has('js')) {
         js = effects.js
     }
 
-    if (Object.prototype.hasOwnProperty.call(effects, 'xjs')) {
+    if (effects.has('xjs')) {
         xjs = effects.xjs
     }
 

--- a/js/features/supportJsModules.js
+++ b/js/features/supportJsModules.js
@@ -6,7 +6,7 @@ let pendingComponentAssets = new WeakMap()
 on('effect', ({ component, effects }) => {
     let scriptModuleHash
 
-    if (Object.prototype.hasOwnProperty.call(effects, 'scriptModule')) {
+    if (effects.has('scriptModule')) {
         scriptModuleHash = effects.scriptModule
     }
 

--- a/js/features/supportLaravelEcho.js
+++ b/js/features/supportLaravelEcho.js
@@ -10,7 +10,7 @@ on('request', ({ options }) => {
 on('effect', ({ component, effects }) => {
     let listeners = []
 
-    if (Object.prototype.hasOwnProperty.call(effects, 'listeners') && effects.listeners) {
+    if (effects.hasValue('listeners')) {
         listeners = effects.listeners
     }
 

--- a/js/features/supportListeners.js
+++ b/js/features/supportListeners.js
@@ -3,7 +3,7 @@ import { on as hook } from '@/hooks'
 hook('effect', ({ component, effects }) => {
     let listeners = []
 
-    if (Object.prototype.hasOwnProperty.call(effects, 'listeners') && effects.listeners) {
+    if (effects.hasValue('listeners')) {
         listeners = effects.listeners
     }
 

--- a/js/features/supportMorphDom.js
+++ b/js/features/supportMorphDom.js
@@ -6,7 +6,7 @@ interceptMessage(({ message, onSuccess }) => {
         onMorph(async () => {
             let html
 
-            if (Object.prototype.hasOwnProperty.call(payload.effects, 'html')) {
+            if (payload.effects.has('html')) {
                 html = payload.effects.html
             }
 

--- a/js/features/supportNavigate.js
+++ b/js/features/supportNavigate.js
@@ -19,7 +19,7 @@ function forwardEvent(name, original) {
 export function shouldRedirectUsingNavigateOr(effects, url, or) {
     let forceNavigate
 
-    if (Object.prototype.hasOwnProperty.call(effects, 'redirectUsingNavigate')) {
+    if (effects.has('redirectUsingNavigate')) {
         forceNavigate = effects.redirectUsingNavigate
     }
 

--- a/js/features/supportQueryString.js
+++ b/js/features/supportQueryString.js
@@ -6,8 +6,8 @@ import { track } from '@/plugins/history'
 on('effect', ({ component, effects, cleanup }) => {
     let queryString
 
-    if (Object.prototype.hasOwnProperty.call(effects, 'url')) {
-        queryString = effects['url']
+    if (effects.has('url')) {
+        queryString = effects.url
     }
 
     if (! queryString) return

--- a/js/features/supportRedirects.js
+++ b/js/features/supportRedirects.js
@@ -2,15 +2,15 @@ import { on } from "@/hooks"
 import { shouldRedirectUsingNavigateOr } from "./supportNavigate"
 
 on('effect', ({ effects, request }) => {
-    if (! Object.prototype.hasOwnProperty.call(effects, 'redirect') || ! effects['redirect']) return
+    if (! effects.hasValue('redirect')) return
 
     let preventDefault = false
 
-    request.invokeOnRedirect({ url: effects['redirect'], preventDefault: () => preventDefault = true })
+    request.invokeOnRedirect({ url: effects.redirect, preventDefault: () => preventDefault = true })
 
     if (preventDefault) return
 
-    let url = effects['redirect']
+    let url = effects.redirect
 
     shouldRedirectUsingNavigateOr(effects, url, () => {
         window.location.href = url

--- a/js/features/supportScriptsAndAssets.js
+++ b/js/features/supportScriptsAndAssets.js
@@ -33,7 +33,7 @@ on('component.init', ({ component }) => {
 on('effect', ({ component, effects }) => {
     let scripts
 
-    if (Object.prototype.hasOwnProperty.call(effects, 'scripts')) {
+    if (effects.has('scripts')) {
         scripts = effects.scripts
     }
 

--- a/js/features/supportSlots.js
+++ b/js/features/supportSlots.js
@@ -8,7 +8,7 @@ interceptMessage(({ message, onSuccess, onStream }) => {
         onMorph(async () => {
             let fragments = []
 
-            if (Object.prototype.hasOwnProperty.call(payload.effects, 'slotFragments') && payload.effects.slotFragments) {
+            if (payload.effects.hasValue('slotFragments')) {
                 fragments = payload.effects.slotFragments
             }
 

--- a/js/morph.js
+++ b/js/morph.js
@@ -57,7 +57,7 @@ export async function morph(component, el, html) {
 
     let transitionOptions = {}
 
-    if (Object.prototype.hasOwnProperty.call(component.effects, 'transition') && component.effects.transition) {
+    if (component.effects.hasValue('transition')) {
         transitionOptions = component.effects.transition
     }
 
@@ -96,7 +96,7 @@ export async function morphFragment(component, startNode, endNode, toHTML) {
 
     let transitionOptions = {}
 
-    if (Object.prototype.hasOwnProperty.call(component.effects, 'transition') && component.effects.transition) {
+    if (component.effects.hasValue('transition')) {
         transitionOptions = component.effects.transition
     }
 

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -7,6 +7,7 @@ import { showHtmlModal } from '@/utils/modal.js'
 import { MessageBus, scopeSymbolFromMessage } from './messageBus.js'
 import Message from './message.js'
 import Action from './action.js'
+import { Effects } from '@/effects.js'
 
 let outstandingActionOrigin = null
 let outstandingActionMetadata = {}
@@ -444,6 +445,8 @@ function sendMessages() {
 
                         let { snapshot: snapshotEncoded, effects } = payload
                         let snapshot = JSON.parse(snapshotEncoded)
+
+                        effects = effects instanceof Effects ? effects : new Effects(effects)
 
                         if (snapshot.memo.id === message.component.id) {
                             message.responsePayload = { snapshot, effects }

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -446,7 +446,7 @@ function sendMessages() {
                         let { snapshot: snapshotEncoded, effects } = payload
                         let snapshot = JSON.parse(snapshotEncoded)
 
-                        effects = effects instanceof Effects ? effects : new Effects(effects)
+                        effects = Effects.from(effects)
 
                         if (snapshot.memo.id === message.component.id) {
                             message.responsePayload = { snapshot, effects }

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -7,7 +7,7 @@ import { showHtmlModal } from '@/utils/modal.js'
 import { MessageBus, scopeSymbolFromMessage } from './messageBus.js'
 import Message from './message.js'
 import Action from './action.js'
-import { Effects } from '@/effects.js'
+import { Effects } from '@/effects'
 
 let outstandingActionOrigin = null
 let outstandingActionMetadata = {}

--- a/js/request/message.js
+++ b/js/request/message.js
@@ -205,12 +205,12 @@ export default class Message {
         this.pendingReturns = []
         this.pendingReturnsMeta = {}
 
-        if (Object.prototype.hasOwnProperty.call(this.responsePayload.effects, 'returns') && this.responsePayload.effects['returns']) {
-            this.pendingReturns = this.responsePayload.effects['returns']
+        if (this.responsePayload.effects.hasValue('returns')) {
+            this.pendingReturns = this.responsePayload.effects.returns
         }
 
-        if (Object.prototype.hasOwnProperty.call(this.responsePayload.effects, 'returnsMeta') && this.responsePayload.effects['returnsMeta']) {
-            this.pendingReturnsMeta = this.responsePayload.effects['returnsMeta']
+        if (this.responsePayload.effects.hasValue('returnsMeta')) {
+            this.pendingReturnsMeta = this.responsePayload.effects.returnsMeta
         }
     }
 


### PR DESCRIPTION
## Summary
Introduce a small `Effects` class for Livewire’s server-driven side-effect payloads, and replace every `Object.prototype.hasOwnProperty.call(effects, …)` check with `effects.has()` / `effects.hasValue()`. Construction is centralized at the few places effects enter the system so the rest of the codebase can use a clear API without changing behavior.

## Why this is needed
Effects are a plain object parsed from `wire:effects` or from the JSON response (`redirect`, `html`, `listeners`, `scripts`, `download`, `dispatches`, `styleModule`, `globalStyleModule`, etc.). Feature code repeatedly asks **“does this payload include key X?”** in the most defensive way possible:

```js
Object.prototype.hasOwnProperty.call(effects, 'globalStyleModule') && effects.globalStyleModule
```

That pattern appears **20 times** across core and feature files. It is:
1. **Hard to read** — the intent is “does this effect exist?”, not “borrow `hasOwnProperty` from `Object.prototype`.”
2. **Easy to get wrong** — some sites check ownership only, others ownership and truthiness; the difference is easy to miss in review.
3. **Inconsistent** — mix of `effects.key`, `effects['key']`, and the long `hasOwnProperty` form for the same idea.
4. **Awkward to extend** — any new helper (safe get, “has non-empty value”, iteration helpers) would be duplicated or require another shared util with no clear owner.

Livewire already treats effects as a distinct concept (`constructor`, `mergeNewSnapshot`, `processEffects`, `inscribeSnapshotAndEffectsOnElement`, request success path). Giving that concept a type makes the boundary explicit and removes the need for the low-level ownership ceremony at every call site.

## What's Changed
1. **New `js/effects.js`**
    - Own keys stay on the instance so existing `effects.redirect`, `effects.html`, etc. keep working.
    - `has()` / `hasValue()` encode 2 patterns already used in the codebase (ownership vs ownership + truthy).
    - `toJSON` keeps `JSON.stringify` / `wire:effects` attributes as plain data.
2. **Construct `Effects` only at entry points**

| Files | Where |
| - | - |
| `js/component.js` | Constructor (`wire:effects`), `mergeNewSnapshot`, `replayUpdate`, `processEffects` |
| `js/request/index.js` | After unpacking `effects` from the component payload on success |

After these sites, `component.effects`, `component.originalEffects`, `message.responsePayload.effects`, and the `effects` argument to `on('effect', …)` are always `Effects` instances (or normalized inside `processEffects`).

3. **Replace every effects ownership check**

| File | Keys |
| - | - |
| `js/component.js` | `listeners`, `url`, `scripts` (on `originalEffects` when inscribing) |
| `js/request/message.js` | `returns`, `returnsMeta` |
| `js/features/supportCssModules.js` | `styleModule`, `globalStyleModule` |
| `js/features/supportListeners.js` | `listeners` |
| `js/features/supportScriptsAndAssets.js` | `scripts` |
| `js/features/supportRedirects.js` | `redirect` |
| `js/features/supportNavigate.js` | `redirectUsingNavigate` |
| `js/features/supportFileDownloads.js` | `download` |
| `js/features/supportDispatches.js` | `dispatches` |
| `js/features/supportQueryString.js` | `url` |
| `js/features/supportJsEvaluation.js` | `js`, `xjs` |
| `js/features/supportJsModules.js` | `scriptModule` |
| `js/features/supportMorphDom.js` | `html` |
| `js/features/supportIslands.js` | `islandFragments` |
| `js/features/supportLaravelEcho.js` | `listeners` |

Example:
```js
// before
if (Object.prototype.hasOwnProperty.call(effects, 'redirect')) { ... }

if (Object.prototype.hasOwnProperty.call(effects, 'globalStyleModule') && effects.globalStyleModule) { ... }

// after
if (effects.has('redirect')) { ... }

if (effects.hasValue('globalStyleModule')) { ... }
```
