### PR TITLE
Backport navigate rejection fix to 4.x

### DIFF
--- a/js/plugins/navigate/fetch.js
+++ b/js/plugins/navigate/fetch.js
@@ -13,5 +13,8 @@ export function fetchHtml(destination, callback, errorCallback) {
 }
 
 export function performFetch(uri, callback, errorCallback) {
-    sendNavigateRequest(uri, callback, errorCallback)
+    // `errorCallback` has already dealt with this failure by the time the promise
+    // rejects. Leaving it unobserved would surface it as an unhandled rejection,
+    // which every error-tracking SDK files as an application error...
+    sendNavigateRequest(uri, callback, errorCallback).catch(() => {})
 }

--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -129,8 +129,22 @@ export default function (Alpine) {
                     })
                 })
             })
-        }, () => {
+        }, (error) => {
             showProgressBar && finishAndHideProgressBar()
+
+            // We cancelled this request ourselves, so the user is already on their
+            // way somewhere else. Sending them to a destination they abandoned
+            // would be worse than doing nothing...
+            if (requestWasCancelled(error)) return
+
+            // A rejected fetch doesn't always mean the network is gone — following a
+            // redirect to another origin fails the same way, and we deliberately stay
+            // put for those. Only when the browser tells us we're offline do we hand
+            // the navigation back, so the user gets the browser's own offline page
+            // instead of a click that silently did nothing...
+            if (navigator.onLine) return
+
+            window.location.href = destination.href
         })
     }
 
@@ -218,6 +232,10 @@ function fetchHtmlOrUsePrefetchedHtml(fromDestination, callback, errorCallback) 
     getPretchedHtmlOr(fromDestination, callback, () => {
         fetchHtml(fromDestination, callback, errorCallback)
     })
+}
+
+function requestWasCancelled(error) {
+    return error?.name === 'AbortError'
 }
 
 function preventAlpineFromPickingUpDomChanges(Alpine, callback) {

--- a/js/plugins/navigate/prefetch.js
+++ b/js/plugins/navigate/prefetch.js
@@ -13,17 +13,21 @@ export function prefetchHtml(destination, callback, errorCallback) {
 
     if (prefetches[uri]) return
 
-    prefetches[uri] = { finished: false, html: null, whenFinished: () => setTimeout(() => delete prefetches[uri], cacheDuration) }
+    prefetches[uri] = { finished: false, html: null, whenFinished: () => setTimeout(() => delete prefetches[uri], cacheDuration), whenFailed: () => {} }
 
     performFetch(uri, (html, routedUri, status) => {
         storeCurrentPageStatus(status)
 
         callback(html, routedUri)
     }, () => {
+        let whenFailed = prefetches[uri].whenFailed
+
         // If the fetch failed, remove the prefetch so it gets attempted again...
         delete prefetches[uri]
 
         errorCallback()
+
+        whenFailed()
     })
 }
 
@@ -56,6 +60,11 @@ export function getPretchedHtmlOr(destination, receive, ifNoPrefetchExists) {
 
             receive(html, finalDestination)
         }
+
+        // Someone is waiting on this in-flight prefetch. If it fails, they're
+        // left hanging with no navigation at all, so send them down the normal
+        // request path instead where a failure can be handled properly...
+        prefetches[uri].whenFailed = ifNoPrefetchExists
     }
 }
 

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -1285,6 +1285,76 @@ class BrowserTest extends \Tests\BrowserTestCase
         });
     }
 
+    public function test_failed_navigate_prefetch_does_not_trigger_an_unhandled_promise_rejection()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first')
+                ->assertSee('On first')
+                ->tap(fn ($b) => $b->script('window.fetch = () => Promise.reject(new TypeError("Failed to fetch"))'))
+                ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+                ->pause(500)
+                ->assertConsoleLogHasNoErrors();
+        });
+    }
+
+    public function test_failed_navigate_prefetch_does_not_navigate_anywhere()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first')
+                ->assertSee('On first')
+                ->tap(fn ($b) => $b->script('window.fetch = () => Promise.reject(new TypeError("Failed to fetch"))'))
+                ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+                ->pause(500)
+                // A prefetch is speculative — the user never asked to go anywhere,
+                // so a failed one should do nothing at all...
+                ->assertSee('On first')
+                ->assertPathIs('/first');
+        });
+    }
+
+    public function test_failed_navigate_falls_back_to_a_hard_browser_navigation()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first')
+                ->tap(fn ($b) => $b->script('window._lw_dusk_test = true'))
+                ->assertScript('return window._lw_dusk_test')
+                ->assertSee('On first')
+                ->tap(fn ($b) => $b->script([
+                    'Object.defineProperty(navigator, "onLine", { get: () => false, configurable: true })',
+                    'window.fetch = () => Promise.reject(new TypeError("Failed to fetch"))',
+                ]))
+                ->click('@link.to.second')
+                ->waitForText('On second')
+                // The marker is gone, so the browser performed a full page load rather
+                // than swallowing the click and stranding the user on the first page...
+                ->assertScript('return window._lw_dusk_test', false);
+        });
+    }
+
+    public function test_navigate_falls_back_to_a_hard_browser_navigation_when_an_in_flight_prefetch_fails()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first')
+                ->tap(fn ($b) => $b->script('window._lw_dusk_test = true'))
+                ->assertScript('return window._lw_dusk_test')
+                ->assertSee('On first')
+                // Failing slowly means the prefetch kicked off by pressing the link is
+                // still in flight when the click is released, so the navigation ends up
+                // waiting on a request that is about to fail...
+                ->tap(fn ($b) => $b->script([
+                    'Object.defineProperty(navigator, "onLine", { get: () => false, configurable: true })',
+                    'window.fetch = () => new Promise((resolve, reject) => setTimeout(() => reject(new TypeError("Failed to fetch")), 500))',
+                ]))
+                ->click('@link.to.second')
+                ->waitForText('On second')
+                ->assertScript('return window._lw_dusk_test', false);
+        });
+    }
+
     public function test_navigate_hover_prefetches_and_caches_for_a_default_30_seconds()
     {
         $this->browse(function ($browser) {


### PR DESCRIPTION
Backports #10491 from `main` to `4.x`.

This prevents failed `wire:navigate` requests and prefetches from escaping as unhandled promise rejections, while preserving the existing hard-navigation fallback when offline.

Validation on the combined release-prep state:
- 39 focused PHP tests, 71 assertions
- 145 JS tests passing, 1 skipped
- `npm run build`