### PR TITLE
Bump Alpine to 3.16.0 on main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,18 @@
             "name": "laravel-livewire",
             "license": "MIT",
             "dependencies": {
-                "@alpinejs/anchor": "^3.15.12",
-                "@alpinejs/collapse": "^3.15.12",
-                "@alpinejs/csp": "^3.15.12",
-                "@alpinejs/focus": "^3.15.12",
-                "@alpinejs/intersect": "^3.15.12",
-                "@alpinejs/mask": "^3.15.12",
-                "@alpinejs/morph": "^3.15.12",
-                "@alpinejs/persist": "^3.15.12",
-                "@alpinejs/resize": "^3.15.12",
-                "@alpinejs/sort": "^3.15.12",
+                "@alpinejs/anchor": "^3.16.0",
+                "@alpinejs/collapse": "^3.16.0",
+                "@alpinejs/csp": "^3.16.0",
+                "@alpinejs/focus": "^3.16.0",
+                "@alpinejs/intersect": "^3.16.0",
+                "@alpinejs/mask": "^3.16.0",
+                "@alpinejs/morph": "^3.16.0",
+                "@alpinejs/persist": "^3.16.0",
+                "@alpinejs/resize": "^3.16.0",
+                "@alpinejs/sort": "^3.16.0",
                 "@vue/reactivity": "^3.2.45",
-                "alpinejs": "^3.15.12",
+                "alpinejs": "^3.16.0",
                 "nprogress": "^0.2.0"
             },
             "devDependencies": {
@@ -29,24 +29,24 @@
             }
         },
         "node_modules/@alpinejs/anchor": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.15.12.tgz",
-            "integrity": "sha512-8G9QGvWo9N+J16dEgbaXYIlxe8lWo25uNHhoAONZSDj1av+1VfIgU9FB4q+h6me0D/+7NqY+dw9OlIAAHQv4wg==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.16.0.tgz",
+            "integrity": "sha512-q4CcSaWCTzQRRyoXQgIEeR158Qqw1UgF8orxpw3oFcVLGgyEdUUGggFVZInKK5+0GHlbHswyV4baSl5kWMnoBA==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.5.3"
             }
         },
         "node_modules/@alpinejs/collapse": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.15.12.tgz",
-            "integrity": "sha512-BKNANLtNXuWYOSAnajSKLPjTsmHRNrv0ALFTbpmqt2/klHFooPhctSwkhFVPQb7rZ8BjEKHmNaBwnSbgtpk6xg==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.16.0.tgz",
+            "integrity": "sha512-qXgeb99MhITdjd46SIDU0UuiArYGzpEyyr5t0XJlrqvBgURO/U16yxHN+x/L2AJnHGxfHfiBl4Fy77xPdJ08Ww==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/csp": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.15.12.tgz",
-            "integrity": "sha512-9jielHzVPqMlO9zQ6K1WtdhSHVX5OZfq5ZDUSVZfY10VnXRoRBx8nOadWjsG1xev/kz4EPaNN9eDFWtZSvJHxA==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.16.0.tgz",
+            "integrity": "sha512-Kd8TLkV1DnXJQFbUicKoalaYLlY6DmMdWjECRU4vEhbJyls4hQb5M4jKLL9p9hvdoHOuMn3su4IBDAXF2AavNg==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -68,9 +68,9 @@
             "license": "MIT"
         },
         "node_modules/@alpinejs/focus": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.15.12.tgz",
-            "integrity": "sha512-lmqbFTlbQGywDgsW4dY0pv18CKhuHJrq8mffU1OO14J34uUk+lCQElmSgJdRGHYv9qBezE6zdvmhN6n2tg0A1A==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.16.0.tgz",
+            "integrity": "sha512-vzvavboGOgXt7pD4xzEZVc+mJevdOxGYGTbE9ymne1BONKoKo0QZGwFHz1Nc45q9igZ2LF1rabk8o62zERfQxg==",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^8.0.0",
@@ -78,39 +78,39 @@
             }
         },
         "node_modules/@alpinejs/intersect": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.15.12.tgz",
-            "integrity": "sha512-B2AlMDgx4xlRQjpDHO9SZrYur5cZkPZK0K6uY4Se+MmdePhIQ8m36gHGe0UKIYkFQkBGhVhPICGVoMYpSSYMWg==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.16.0.tgz",
+            "integrity": "sha512-DfXIJ9QBgHpjj8TAd2NGQRymU7fgn8ix0P5YZKF6INwuEHA1kQmrhbrDVp/OywJSWi2dUy91iWkl33nYROFkdw==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/mask": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.15.12.tgz",
-            "integrity": "sha512-FcOVQp+tsIiBeNwWsH1BjAhJa+R/b6Tv6sPfSMRZlp1e/4w4H44Kagd9Aq86xpFgeI5dibJil2TG0+3LqB4JoA==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.16.0.tgz",
+            "integrity": "sha512-woyMnaNIWVNqSNZzISqKyePZJMitHjtal0z8OTWlrQTfHKi1MyaGGSjq4aHPj+uZtPZck5n3/8Y35UlOXW8Lbg==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/morph": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.15.12.tgz",
-            "integrity": "sha512-x/QZUsbE3uMAVVzsEjSZf2xbjgzIqUZ+HW9GUtePheyIrOgHlqZETXBq1DpXg6H8kA0099SyAI9YWnKFDS31cg==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.16.0.tgz",
+            "integrity": "sha512-8SE450Ui6iS+/cdGGNoKpgAeQV0R+dXNkLugjmVYFKcTOW2RV+PdneruSbZfQ9A541ccPzn8PV93fH6T5FiqhQ==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/persist": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.15.12.tgz",
-            "integrity": "sha512-vzDRf/3r8B5ihHvLYUkkg+XbJz4nNst+5jR5BM4Uff3BhdRenJlXKFnd3kYbM2Z/KCU65zg5neqOVhbNpytZ9A==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.16.0.tgz",
+            "integrity": "sha512-7zRK6/V1m+RQAdGB/JhJdirxcFHn5A74okPyjCxynJV4tU+fFqOMEuz4xHG6EI02sm3/zzi3Z30HTcbN97Bxfw==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/resize": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.15.12.tgz",
-            "integrity": "sha512-NsPIlwRHsl3cZYXPPGAfJnTzubRz8jwAaZ/VFq2L8kmmR+hNGXaA+d7a4Eavav/hapuWIFlI9owDkRgb2jSDfw==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.16.0.tgz",
+            "integrity": "sha512-EDrbtbcZ4eIJt11BLu3s3tKa6SdroDNAKW91rh5OczAH0168xH8To4dUMZ2xB24kjDBr7HyOEJdpsaVLaNNVhA==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/sort": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.15.12.tgz",
-            "integrity": "sha512-DNIS7SQFg4H4o5faluRgqYEPi1Q7Hf+HMDgoCcIHXbXWH0g66WPEzz9OMk1zsUYib0KxMms4xXOqk+xh2tHZzg==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.16.0.tgz",
+            "integrity": "sha512-DSeqbyxL/vEqLQvN1BpAKfSUwdxPUGTCMBa04Z5J9ISKXAyBsC61kb7rXn1DxUuusgD/4er7hjynpZQZV7LQ6Q==",
             "license": "MIT",
             "dependencies": {
                 "sortablejs": "^1.15.2"
@@ -1281,9 +1281,9 @@
             }
         },
         "node_modules/alpinejs": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.12.tgz",
-            "integrity": "sha512-nJvPAQVNPdZZ0NrExJ/kzQco3ijR8LwvCOadQecllESiqT4NyZ/57sN9V2XyvhlBGAbmlKYgeWZvYdKq99ij/Q==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.16.0.tgz",
+            "integrity": "sha512-fRAp17Igmh2NHvgRGOY8n/x9o/g8rlseVn27awaq3wy7IsNYfu0lKnQGHn4WQx+NdjnpQFajhRiULah+R1Nsog==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"

--- a/package.json
+++ b/package.json
@@ -17,18 +17,18 @@
         "vitest": "^3.2.4"
     },
     "dependencies": {
-        "@alpinejs/anchor": "^3.15.12",
-        "@alpinejs/collapse": "^3.15.12",
-        "@alpinejs/csp": "^3.15.12",
-        "@alpinejs/focus": "^3.15.12",
-        "@alpinejs/intersect": "^3.15.12",
-        "@alpinejs/mask": "^3.15.12",
-        "@alpinejs/morph": "^3.15.12",
-        "@alpinejs/persist": "^3.15.12",
-        "@alpinejs/resize": "^3.15.12",
-        "@alpinejs/sort": "^3.15.12",
+        "@alpinejs/anchor": "^3.16.0",
+        "@alpinejs/collapse": "^3.16.0",
+        "@alpinejs/csp": "^3.16.0",
+        "@alpinejs/focus": "^3.16.0",
+        "@alpinejs/intersect": "^3.16.0",
+        "@alpinejs/mask": "^3.16.0",
+        "@alpinejs/morph": "^3.16.0",
+        "@alpinejs/persist": "^3.16.0",
+        "@alpinejs/resize": "^3.16.0",
+        "@alpinejs/sort": "^3.16.0",
         "@vue/reactivity": "^3.2.45",
-        "alpinejs": "^3.15.12",
+        "alpinejs": "^3.16.0",
         "nprogress": "^0.2.0"
     }
 }


### PR DESCRIPTION
Carries the Alpine 3.16.0 dependency bump onto `main` after the completed 4.x → main release-prep sync.

Merge #10522 into `4.x` before this PR.

Validation:
- `npm ci`
- `npm run test:run` (145 passing, 1 skipped)
- `npm run build`