### PR TITLE
[4.x] Fix cached computed properties returning broken objects on Laravel 13

### DIFF
--- a/docs/computed-properties.md
+++ b/docs/computed-properties.md
@@ -113,7 +113,7 @@ In the above component, the computed property is memoized before a new post is c
 
 Sometimes you would like to cache the value of a computed property for the lifespan of a Livewire component, rather than it being cleared after every request. In these cases, you can use [Laravel's caching utilities](https://laravel.com/docs/cache#retrieve-store).
 
-Below is an example of a computed property named `user()`, where instead of executing the Eloquent query directly, we wrap the query in `Cache::remember()` to ensure that any future requests retrieve it from Laravel's cache instead of re-executing the query:
+Below is an example of a computed property named `userName()`, where instead of executing the Eloquent query directly, we wrap the query in `Cache::remember()` to ensure that any future requests retrieve the name from Laravel's cache instead of re-executing the query:
 
 ```php
 <?php // resources/views/components/⚡show-user.blade.php
@@ -127,13 +127,13 @@ new class extends Component {
     public $userId;
 
     #[Computed]
-    public function user()
+    public function userName()
     {
-        $key = 'user'.$this->getId();
+        $key = 'user-name'.$this->getId();
         $seconds = 3600; // 1 hour...
 
         return Cache::remember($key, $seconds, function () {
-            return User::find($this->userId);
+            return User::find($this->userId)->name;
         });
     }
 
@@ -150,13 +150,13 @@ use Livewire\Attributes\Computed;
 use App\Models\User;
 
 #[Computed(persist: true)]
-public function user()
+public function userName()
 {
-    return User::find($this->userId);
+    return User::find($this->userId)->name;
 }
 ```
 
-In the example above, when `$this->user` is accessed from your component, it will continue to be cached for the duration of the Livewire component on the page. This means the actual Eloquent query will only be executed once.
+In the example above, when `$this->userName` is accessed from your component, it will continue to be cached for the duration of the Livewire component on the page. This means the actual Eloquent query will only be executed once.
 
 Livewire caches persisted values for 3600 seconds (one hour). You can override this default by passing an additional `seconds` parameter to the `#[Computed]` attribute:
 
@@ -165,7 +165,15 @@ Livewire caches persisted values for 3600 seconds (one hour). You can override t
 ```
 
 > [!warning] Caching objects on Laravel 13
-> New Laravel 13 applications ship with `cache.serializable_classes` set to `false` in the `config/cache.php` file, meaning objects pulled back out of the cache are no longer restored to their original class. Livewire detects this and re-evaluates the method instead of handing your component a broken object, so the value stays correct but is never actually served from the cache. To get the caching back, add the classes you're caching to `cache.serializable_classes`.
+> New Laravel 13 applications only unserialize explicitly allowed PHP classes from cache. When Laravel cannot restore an object returned by a persisted or cached computed property, Livewire re-evaluates the property so the value remains correct. In debug mode, Livewire also writes a warning to the application log because the value was not served from cache.
+>
+> Prefer caching scalars or arrays. To intentionally cache an object, add every class in its object graph to `cache.serializable_classes` in `config/cache.php`:
+>
+> ```php
+> 'serializable_classes' => [
+>     App\Models\User::class,
+> ],
+> ```
 
 > [!tip] Calling `unset()` will clear both memo and cache
 > As previously discussed, you can clear a computed property's memo using PHP's `unset()` method. This also applies to computed properties using the `persist: true` parameter. When calling `unset()` on a persisted computed property, Livewire will clear not only the in-request memo, but also the underlying cached value in Laravel's cache.
@@ -179,13 +187,13 @@ use Livewire\Attributes\Computed;
 use App\Models\Post;
 
 #[Computed(cache: true)]
-public function posts()
+public function postTitles()
 {
-    return Post::all();
+    return Post::query()->pluck('title', 'id')->all();
 }
 ```
 
-In the above example, until the cache expires or is busted, every instance of this component in your application will share the same cached value for `$this->posts`.
+In the above example, until the cache expires or is busted, every instance of this component in your application will share the same cached value for `$this->postTitles`.
 
 If you need to manually clear the cache for a computed property, you may set a custom cache key using the `key` parameter:
 
@@ -194,9 +202,9 @@ use Livewire\Attributes\Computed;
 use App\Models\Post;
 
 #[Computed(cache: true, key: 'homepage-posts')]
-public function posts()
+public function postTitles()
 {
-    return Post::all();
+    return Post::query()->pluck('title', 'id')->all();
 }
 ```
 

--- a/docs/computed-properties.md
+++ b/docs/computed-properties.md
@@ -164,6 +164,9 @@ Livewire caches persisted values for 3600 seconds (one hour). You can override t
 #[Computed(persist: true, seconds: 7200)]
 ```
 
+> [!warning] Caching objects on Laravel 13
+> New Laravel 13 applications ship with `cache.serializable_classes` set to `false` in the `config/cache.php` file, meaning objects pulled back out of the cache are no longer restored to their original class. Livewire detects this and re-evaluates the method instead of handing your component a broken object, so the value stays correct but is never actually served from the cache. To get the caching back, add the classes you're caching to `cache.serializable_classes`.
+
 > [!tip] Calling `unset()` will clear both memo and cache
 > As previously discussed, you can clear a computed property's memo using PHP's `unset()` method. This also applies to computed properties using the `persist: true` parameter. When calling `unset()` on a persisted computed property, Livewire will clear not only the in-request memo, but also the underlying cached value in Laravel's cache.
 

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -76,10 +76,12 @@ class BaseComputed extends Attribute
 
         $closure = fn () => $this->evaluateComputed();
 
-        return match(Cache::supportsTags() && !empty($this->tags)) {
+        $value = match(Cache::supportsTags() && !empty($this->tags)) {
             true => Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
             default => Cache::remember($key, $this->seconds, $closure)
         };
+
+        return $this->wasNotFullyUnserialized($value) ? $closure() : $value;
     }
 
     protected function handleCachedGet()
@@ -88,10 +90,25 @@ class BaseComputed extends Attribute
 
         $closure = fn () => $this->evaluateComputed();
 
-        return match(Cache::supportsTags() && !empty($this->tags)) {
+        $value = match(Cache::supportsTags() && !empty($this->tags)) {
             true => Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
             default => Cache::remember($key, $this->seconds, $closure)
         };
+
+        return $this->wasNotFullyUnserialized($value) ? $closure() : $value;
+    }
+
+    protected function wasNotFullyUnserialized($value)
+    {
+        if ($value instanceof \__PHP_Incomplete_Class) return true;
+
+        if (! is_array($value)) return false;
+
+        foreach ($value as $item) {
+            if ($this->wasNotFullyUnserialized($item)) return true;
+        }
+
+        return false;
     }
 
     protected function handlePersistedUnset()

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -81,7 +81,7 @@ class BaseComputed extends Attribute
             default => Cache::remember($key, $this->seconds, $closure)
         };
 
-        return $this->wasNotFullyUnserialized($value) ? $closure() : $value;
+        return $this->resolveCachedValue($value, $closure);
     }
 
     protected function handleCachedGet()
@@ -95,20 +95,37 @@ class BaseComputed extends Attribute
             default => Cache::remember($key, $this->seconds, $closure)
         };
 
-        return $this->wasNotFullyUnserialized($value) ? $closure() : $value;
+        return $this->resolveCachedValue($value, $closure);
     }
 
-    protected function wasNotFullyUnserialized($value)
+    protected function resolveCachedValue($value, $closure)
     {
-        if ($value instanceof \__PHP_Incomplete_Class) return true;
+        $class = $this->findIncompleteClass($value);
 
-        if (! is_array($value)) return false;
+        if ($class === null) return $value;
 
-        foreach ($value as $item) {
-            if ($this->wasNotFullyUnserialized($item)) return true;
+        if (config('app.debug')) {
+            logger()->warning(
+                "Livewire re-evaluated cached computed property [{$this->component->getName()}::{$this->getName()}] because Laravel could not unserialize [{$class}]. The value is correct, but it was not served from cache. Return a scalar or array, or add the class to [cache.serializable_classes]."
+            );
         }
 
-        return false;
+        return $closure();
+    }
+
+    protected function findIncompleteClass($value)
+    {
+        if ($value instanceof \__PHP_Incomplete_Class) {
+            return ((array) $value)['__PHP_Incomplete_Class_Name'] ?? \__PHP_Incomplete_Class::class;
+        }
+
+        if (! is_array($value)) return null;
+
+        foreach ($value as $item) {
+            if ($class = $this->findIncompleteClass($item)) return $class;
+        }
+
+        return null;
     }
 
     protected function handlePersistedUnset()

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -211,14 +211,19 @@ class UnitTest extends TestCase
 
     function test_cached_computed_property_is_recomputed_when_the_cached_value_cannot_be_unserialized()
     {
+        config()->set('app.debug', true);
         config()->set('cache.serializable_classes', false);
         config()->set('cache.stores.array.serialize', true);
         Cache::purge('array');
         Cache::setDefaultDriver('array');
 
-        Livewire::test(new class extends TestComponent {
+        $component = Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
             #[Computed(cache: true)]
             function foo() {
+                $this->count++;
+
                 return (object) ['bar' => 'baz'];
             }
 
@@ -229,8 +234,19 @@ class UnitTest extends TestCase
             }
         })
             ->assertSee('foobaz')
-            ->call('$refresh')
-            ->assertSee('foobaz');
+            ->assertSetStrict('count', 1);
+
+        $logger = \Mockery::mock(\Psr\Log\LoggerInterface::class);
+        $logger->shouldReceive('warning')
+            ->once()
+            ->withArgs(fn ($message) => str_contains($message, '::foo]')
+                && str_contains($message, '[stdClass]')
+                && str_contains($message, 'was not served from cache'));
+        app()->instance('log', $logger);
+
+        $component->call('$refresh')
+            ->assertSee('foobaz')
+            ->assertSetStrict('count', 2);
     }
 
     function test_persisted_computed_property_is_recomputed_when_the_cached_value_cannot_be_unserialized()
@@ -241,8 +257,12 @@ class UnitTest extends TestCase
         Cache::setDefaultDriver('array');
 
         Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
             #[Computed(persist: true)]
             function foo() {
+                $this->count++;
+
                 return (object) ['bar' => 'baz'];
             }
 
@@ -253,8 +273,10 @@ class UnitTest extends TestCase
             }
         })
             ->assertSee('foobaz')
+            ->assertSetStrict('count', 1)
             ->call('$refresh')
-            ->assertSee('foobaz');
+            ->assertSee('foobaz')
+            ->assertSetStrict('count', 2);
     }
 
     function test_persisted_computed_property_is_recomputed_when_an_array_it_returns_holds_a_value_that_cannot_be_unserialized()
@@ -265,8 +287,12 @@ class UnitTest extends TestCase
         Cache::setDefaultDriver('array');
 
         Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
             #[Computed(persist: true)]
             function foo() {
+                $this->count++;
+
                 return ['bar' => (object) ['baz' => 'bob']];
             }
 
@@ -277,8 +303,40 @@ class UnitTest extends TestCase
             }
         })
             ->assertSee('foobob')
+            ->assertSetStrict('count', 1)
             ->call('$refresh')
-            ->assertSee('foobob');
+            ->assertSee('foobob')
+            ->assertSetStrict('count', 2);
+    }
+
+    function test_cached_computed_property_is_not_recomputed_when_its_class_is_allowed_to_be_unserialized()
+    {
+        config()->set('cache.serializable_classes', [\stdClass::class]);
+        config()->set('cache.stores.array.serialize', true);
+        Cache::purge('array');
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
+            #[Computed(cache: true)]
+            function foo() {
+                $this->count++;
+
+                return (object) ['bar' => 'baz'];
+            }
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $this->foo->bar }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobaz')
+            ->assertSetStrict('count', 1)
+            ->call('$refresh')
+            ->assertSee('foobaz')
+            ->assertSetStrict('count', 1);
     }
 
     function test_can_tag_cached_computed_property()

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -13,6 +13,15 @@ use Livewire\Features\SupportEvents\BaseOn;
 
 class UnitTest extends TestCase
 {
+    protected function skipUnlessCacheSupportsSerializableClassRestrictions()
+    {
+        $constructor = new \ReflectionMethod(\Illuminate\Cache\ArrayStore::class, '__construct');
+
+        if ($constructor->getNumberOfParameters() < 2) {
+            $this->markTestSkipped('This Laravel version does not support cache serializable class restrictions.');
+        }
+    }
+
     function test_can_make_method_a_computed()
     {
         Livewire::test(new class extends TestComponent {
@@ -211,6 +220,8 @@ class UnitTest extends TestCase
 
     function test_cached_computed_property_is_recomputed_when_the_cached_value_cannot_be_unserialized()
     {
+        $this->skipUnlessCacheSupportsSerializableClassRestrictions();
+
         config()->set('app.debug', true);
         config()->set('cache.serializable_classes', false);
         config()->set('cache.stores.array.serialize', true);
@@ -251,6 +262,8 @@ class UnitTest extends TestCase
 
     function test_persisted_computed_property_is_recomputed_when_the_cached_value_cannot_be_unserialized()
     {
+        $this->skipUnlessCacheSupportsSerializableClassRestrictions();
+
         config()->set('cache.serializable_classes', false);
         config()->set('cache.stores.array.serialize', true);
         Cache::purge('array');
@@ -281,6 +294,8 @@ class UnitTest extends TestCase
 
     function test_persisted_computed_property_is_recomputed_when_an_array_it_returns_holds_a_value_that_cannot_be_unserialized()
     {
+        $this->skipUnlessCacheSupportsSerializableClassRestrictions();
+
         config()->set('cache.serializable_classes', false);
         config()->set('cache.stores.array.serialize', true);
         Cache::purge('array');
@@ -311,6 +326,8 @@ class UnitTest extends TestCase
 
     function test_cached_computed_property_is_not_recomputed_when_its_class_is_allowed_to_be_unserialized()
     {
+        $this->skipUnlessCacheSupportsSerializableClassRestrictions();
+
         config()->set('cache.serializable_classes', [\stdClass::class]);
         config()->set('cache.stores.array.serialize', true);
         Cache::purge('array');

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -209,6 +209,78 @@ class UnitTest extends TestCase
             ->assertSetStrict('count', 2);
     }
 
+    function test_cached_computed_property_is_recomputed_when_the_cached_value_cannot_be_unserialized()
+    {
+        config()->set('cache.serializable_classes', false);
+        config()->set('cache.stores.array.serialize', true);
+        Cache::purge('array');
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            #[Computed(cache: true)]
+            function foo() {
+                return (object) ['bar' => 'baz'];
+            }
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $this->foo->bar }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobaz')
+            ->call('$refresh')
+            ->assertSee('foobaz');
+    }
+
+    function test_persisted_computed_property_is_recomputed_when_the_cached_value_cannot_be_unserialized()
+    {
+        config()->set('cache.serializable_classes', false);
+        config()->set('cache.stores.array.serialize', true);
+        Cache::purge('array');
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            #[Computed(persist: true)]
+            function foo() {
+                return (object) ['bar' => 'baz'];
+            }
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $this->foo->bar }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobaz')
+            ->call('$refresh')
+            ->assertSee('foobaz');
+    }
+
+    function test_persisted_computed_property_is_recomputed_when_an_array_it_returns_holds_a_value_that_cannot_be_unserialized()
+    {
+        config()->set('cache.serializable_classes', false);
+        config()->set('cache.stores.array.serialize', true);
+        Cache::purge('array');
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            #[Computed(persist: true)]
+            function foo() {
+                return ['bar' => (object) ['baz' => 'bob']];
+            }
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $this->foo['bar']->baz }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobob')
+            ->call('$refresh')
+            ->assertSee('foobob');
+    }
+
     function test_can_tag_cached_computed_property()
     {
         // need to set a cache driver, which can handle tags


### PR DESCRIPTION
## What changed

Laravel 13 defaults `cache.serializable_classes` to `false`. On serialized cache stores, an object returned by a `persist: true` or `cache: true` computed property works during the request that fills the cache, but a later request receives `__PHP_Incomplete_Class` instead of the original model, collection, or object.

Livewire now treats incomplete top-level values and incomplete values nested in arrays as unusable cache hits. It re-evaluates the computed property so the component remains correct instead of handing the view a broken object.

When `app.debug` is enabled, Livewire also writes an actionable warning containing the component, computed property, and rejected class. The warning explains that the value was re-evaluated rather than served from cache and points to the two supported remedies: cache a scalar or array, or explicitly allowlist the cached classes in Laravel.

The computed-property documentation now:

- uses cache-safe strings and arrays for the default cross-request examples;
- explains Laravel 13's object-unserialization policy;
- shows how to intentionally allowlist an object class.

No Livewire option bypasses Laravel's cache security policy. Once the application allowlists the required classes, the reconstructed object is served from cache normally.

Fixes #10524.

## Validation

- Computed-property suite: 31 tests, 64 assertions.
- Full unit suite: 1,353 tests, 3,863 assertions; 13 skipped and 3 existing incomplete tests.
- Added coverage proving restricted objects are re-evaluated, arrays containing restricted objects are handled, a debug warning is emitted, and explicitly allowlisted objects remain cached.
