### PR TITLE
Fix ValueError when a nullable enum property is updated to null

### DIFF
--- a/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
@@ -14,7 +14,7 @@ class EnumSynth extends Synth {
     }
 
     static function hydrateFromType($type, $value) {
-        if ($value === '') return null;
+        if ($value === null || $value === '') return null;
 
         return $type::from($value);
     }

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -30,6 +30,14 @@ class EnumUnitTest extends \Tests\TestCase
         $testable->updateProperty('status', 'Be excellent excellent to each other');
     }
 
+    public function test_nullable_public_property_can_be_updated_to_null_while_already_null()
+    {
+        Livewire::test(ComponentWithNullablePublicEnumCaster::class)
+            ->assertSetStrict('status', null)
+            ->updateProperty('status', null)
+            ->assertSetStrict('status', null);
+    }
+
     public function test_an_enum_can_be_validated()
     {
         Livewire::test(ComponentWithValidatedEnum::class)


### PR DESCRIPTION
Fixes #10526 

`EnumSynth::hydrateFromType()` misses the same check that the sibling method `hydrate` already has:
```php
    // in hydrateFromType
    if ($value === '') return null;
    
    // in hydrate
    if ($value === null || $value === '') return null;
```

 the most minimal version to reproduce the bug that shows that the null check is missing is:
```php
<?php

use Livewire\Attributes\Layout;
use Livewire\Component;

enum Status: string
{
    case Released = 'released';
}

new #[Layout('layouts::auth')] class extends Component
{
    public ?Status $status = null;
}; ?>

<button type="button" x-on:click="$wire.$set('status', null)">Reset</button>
```

Updating a nullable backed-enum property to `null` throws `ValueError: "0" is not a valid backing value for enum Status`. The `"0"` is misleading — the client never sent it; it comes from PHP coercing `null` to `int 0` to `string "0"` at the `from()` call.