### PR TITLE
Bump Alpine to 3.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,18 @@
             "name": "laravel-livewire",
             "license": "MIT",
             "dependencies": {
-                "@alpinejs/anchor": "^3.16.0",
-                "@alpinejs/collapse": "^3.16.0",
-                "@alpinejs/csp": "^3.16.0",
-                "@alpinejs/focus": "^3.16.0",
-                "@alpinejs/intersect": "^3.16.0",
-                "@alpinejs/mask": "^3.16.0",
-                "@alpinejs/morph": "^3.16.0",
-                "@alpinejs/persist": "^3.16.0",
-                "@alpinejs/resize": "^3.16.0",
-                "@alpinejs/sort": "^3.16.0",
+                "@alpinejs/anchor": "^3.16.1",
+                "@alpinejs/collapse": "^3.16.1",
+                "@alpinejs/csp": "^3.16.1",
+                "@alpinejs/focus": "^3.16.1",
+                "@alpinejs/intersect": "^3.16.1",
+                "@alpinejs/mask": "^3.16.1",
+                "@alpinejs/morph": "^3.16.1",
+                "@alpinejs/persist": "^3.16.1",
+                "@alpinejs/resize": "^3.16.1",
+                "@alpinejs/sort": "^3.16.1",
                 "@vue/reactivity": "^3.2.45",
-                "alpinejs": "^3.16.0",
+                "alpinejs": "^3.16.1",
                 "nprogress": "^0.2.0"
             },
             "devDependencies": {
@@ -29,24 +29,24 @@
             }
         },
         "node_modules/@alpinejs/anchor": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.16.0.tgz",
-            "integrity": "sha512-q4CcSaWCTzQRRyoXQgIEeR158Qqw1UgF8orxpw3oFcVLGgyEdUUGggFVZInKK5+0GHlbHswyV4baSl5kWMnoBA==",
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.16.1.tgz",
+            "integrity": "sha512-BtQpqFuVflPoux9hW72G51PmKyeg8vrFPWawbl86jPKK39oqQXMdxG7suYPcAEzHcqKx9X9bfC4Hrgn+IfIaaw==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.5.3"
             }
         },
         "node_modules/@alpinejs/collapse": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.16.0.tgz",
-            "integrity": "sha512-qXgeb99MhITdjd46SIDU0UuiArYGzpEyyr5t0XJlrqvBgURO/U16yxHN+x/L2AJnHGxfHfiBl4Fy77xPdJ08Ww==",
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.16.1.tgz",
+            "integrity": "sha512-02tk8uxvujlHAawm/0RIgmf0Myf08wMDSBRgmAGrvyuvhDgaZ8xArQFtFesINqp5DOblVUnMWiqe4kYN6/odhQ==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/csp": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.16.0.tgz",
-            "integrity": "sha512-Kd8TLkV1DnXJQFbUicKoalaYLlY6DmMdWjECRU4vEhbJyls4hQb5M4jKLL9p9hvdoHOuMn3su4IBDAXF2AavNg==",
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.16.1.tgz",
+            "integrity": "sha512-G5GZt26s2+TgQ8PetwTQ1S4YDHoKIFJ8THe3sOyMBYyHmMUb26TmC06xU+LzqLV4rxsLKFBsfNolveM9EnV6BA==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -68,9 +68,9 @@
             "license": "MIT"
         },
         "node_modules/@alpinejs/focus": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.16.0.tgz",
-            "integrity": "sha512-vzvavboGOgXt7pD4xzEZVc+mJevdOxGYGTbE9ymne1BONKoKo0QZGwFHz1Nc45q9igZ2LF1rabk8o62zERfQxg==",
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.16.1.tgz",
+            "integrity": "sha512-gB/VbkEyKzJcJ7axGxyPhEucPwawVNTbWU94blXRAsYnjsIYlRB2rpITZwZLXzY4ctYpQv2tupLklIEDMiMoyw==",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^8.0.0",
@@ -78,39 +78,39 @@
             }
         },
         "node_modules/@alpinejs/intersect": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.16.0.tgz",
-            "integrity": "sha512-DfXIJ9QBgHpjj8TAd2NGQRymU7fgn8ix0P5YZKF6INwuEHA1kQmrhbrDVp/OywJSWi2dUy91iWkl33nYROFkdw==",
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.16.1.tgz",
+            "integrity": "sha512-MN2UphEQ/C/iVJ/IrU/kHpoYbUNZhvhEXz+ZLF3sm2tkGNACUIWqeDVMSlJ2PSqnIiq7DE/tqUmgNIKJVOErvw==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/mask": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.16.0.tgz",
-            "integrity": "sha512-woyMnaNIWVNqSNZzISqKyePZJMitHjtal0z8OTWlrQTfHKi1MyaGGSjq4aHPj+uZtPZck5n3/8Y35UlOXW8Lbg==",
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.16.1.tgz",
+            "integrity": "sha512-pWVqQlgzaDh8L30fsPL05QpNmsSASByQ1mcZAwDsQsA7Drvh6ZyMW6eDmUwMQI8eZPgdpbClYyWF9feWHSIFJg==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/morph": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.16.0.tgz",
-            "integrity": "sha512-8SE450Ui6iS+/cdGGNoKpgAeQV0R+dXNkLugjmVYFKcTOW2RV+PdneruSbZfQ9A541ccPzn8PV93fH6T5FiqhQ==",
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.16.1.tgz",
+            "integrity": "sha512-HoTa8sqgNx6Ezmy8x0IwdF48Xmllttb7SHSmN0NhjGc6PNDqnrSShd3qyAcoxkqftliUf81qwEPwCRXodgWEWg==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/persist": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.16.0.tgz",
-            "integrity": "sha512-7zRK6/V1m+RQAdGB/JhJdirxcFHn5A74okPyjCxynJV4tU+fFqOMEuz4xHG6EI02sm3/zzi3Z30HTcbN97Bxfw==",
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.16.1.tgz",
+            "integrity": "sha512-h1Qv0s+O4XzBZDCl2Fu66PsYmCtI+e7BFcJcWq71MB8sQumVfy7ndXbZZYRkSCk71m2Q5xQOlAsU/Kx2SEeeww==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/resize": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.16.0.tgz",
-            "integrity": "sha512-EDrbtbcZ4eIJt11BLu3s3tKa6SdroDNAKW91rh5OczAH0168xH8To4dUMZ2xB24kjDBr7HyOEJdpsaVLaNNVhA==",
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.16.1.tgz",
+            "integrity": "sha512-bC15nTwIPhfF2VCOWYVmQpA8yhQ/BbJ9OAFq/z0CKjLVOGnm4HhqV9ZIKioVbSyu3oqUPJ/SScPzSyfSz2Lg6g==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/sort": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.16.0.tgz",
-            "integrity": "sha512-DSeqbyxL/vEqLQvN1BpAKfSUwdxPUGTCMBa04Z5J9ISKXAyBsC61kb7rXn1DxUuusgD/4er7hjynpZQZV7LQ6Q==",
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.16.1.tgz",
+            "integrity": "sha512-+UmVPX7zskSzj9gKjH9c7Sop5EcZb2RwJULjNYPiy/zuw8OgzGdMGE4z4CYUoNgcU0f/OhBUZeBdbtbU9fr8hg==",
             "license": "MIT",
             "dependencies": {
                 "sortablejs": "^1.15.2"
@@ -1281,9 +1281,9 @@
             }
         },
         "node_modules/alpinejs": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.16.0.tgz",
-            "integrity": "sha512-fRAp17Igmh2NHvgRGOY8n/x9o/g8rlseVn27awaq3wy7IsNYfu0lKnQGHn4WQx+NdjnpQFajhRiULah+R1Nsog==",
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.16.1.tgz",
+            "integrity": "sha512-QXcW8MK9JoG8GZ7vCt2cXJlcEPIA7Xk/7IQ1+L2iLp7sXcIxct0PrgidmHzK97gD9QlfUjHXPxujdZ1mC2PYVg==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"

--- a/package.json
+++ b/package.json
@@ -17,18 +17,18 @@
         "vitest": "^3.2.4"
     },
     "dependencies": {
-        "@alpinejs/anchor": "^3.16.0",
-        "@alpinejs/collapse": "^3.16.0",
-        "@alpinejs/csp": "^3.16.0",
-        "@alpinejs/focus": "^3.16.0",
-        "@alpinejs/intersect": "^3.16.0",
-        "@alpinejs/mask": "^3.16.0",
-        "@alpinejs/morph": "^3.16.0",
-        "@alpinejs/persist": "^3.16.0",
-        "@alpinejs/resize": "^3.16.0",
-        "@alpinejs/sort": "^3.16.0",
+        "@alpinejs/anchor": "^3.16.1",
+        "@alpinejs/collapse": "^3.16.1",
+        "@alpinejs/csp": "^3.16.1",
+        "@alpinejs/focus": "^3.16.1",
+        "@alpinejs/intersect": "^3.16.1",
+        "@alpinejs/mask": "^3.16.1",
+        "@alpinejs/morph": "^3.16.1",
+        "@alpinejs/persist": "^3.16.1",
+        "@alpinejs/resize": "^3.16.1",
+        "@alpinejs/sort": "^3.16.1",
         "@vue/reactivity": "^3.2.45",
-        "alpinejs": "^3.16.0",
+        "alpinejs": "^3.16.1",
         "nprogress": "^0.2.0"
     }
 }


### PR DESCRIPTION
Updates Alpine and all bundled plugins to 3.16.1, which restores Persist compatibility with older Alpine core versions.

Validation:
- `npm ci`
- `npm run test:run` — 109 passed, 1 skipped
- `npm run build`