### PR TITLE
Preserve rich text pastes with embedded images

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -62,6 +62,13 @@ export function filesFromEvent(event) {
 
     if (! source) return null
 
+    // Rich clipboard content can expose embedded images as files (Word does
+    // this, for example). Prefer the content paste whenever text is present;
+    // a standalone image/file paste only advertises file types...
+    if (event.clipboardData && Array.from(source.types || []).some(type => ['text/plain', 'text/html'].includes(type))) {
+        return []
+    }
+
     return Array.from(source.files || [])
 }
 

--- a/js/utils.spec.js
+++ b/js/utils.spec.js
@@ -1,5 +1,26 @@
 import { describe, it, expect } from 'vitest'
-import { isEmpty } from './utils'
+import { filesFromEvent, isEmpty } from './utils'
+
+describe('filesFromEvent', () => {
+    it('returns files from a standalone file paste', () => {
+        let file = new File(['image'], 'image.png', { type: 'image/png' })
+
+        expect(filesFromEvent({
+            clipboardData: { files: [file], types: ['Files'] },
+        })).toEqual([file])
+    })
+
+    it('ignores embedded files when the clipboard also contains rich text', () => {
+        let file = new File(['image'], 'image.png', { type: 'image/png' })
+
+        expect(filesFromEvent({
+            clipboardData: {
+                files: [file],
+                types: ['text/plain', 'text/html', 'Files'],
+            },
+        })).toEqual([])
+    })
+})
 
 describe('isEmpty', () => {
     it('mirrors PHP empty() for scalars', () => {

--- a/src/Features/SupportFileUploads/UploadActionBrowserTest.php
+++ b/src/Features/SupportFileUploads/UploadActionBrowserTest.php
@@ -73,6 +73,32 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_rich_text_pastes_with_embedded_images_are_left_alone()
+    {
+        Storage::persistentFake('tmp-for-tests');
+
+        Livewire::visit(new class extends Component {
+            use WithFileUploads;
+
+            public $body = '';
+            public $photos = [];
+
+            function render() { return <<<'HTML'
+            <div>
+                <textarea dusk="box" wire:model="body" wire:paste="$upload('photos')"></textarea>
+
+                <span dusk="count" x-text="$wire.photos.length"></span>
+            </div>
+            HTML; }
+        })
+        ->tap(fn ($b) => $this->putRichTextWithImageOnClipboard($b, 'copied from Word'))
+        ->click('@box')
+        ->keys('@box', [$this->pasteChord(), 'v'])
+        ->waitUntil('document.querySelector(\'[dusk="box"]\').value === "copied from Word"')
+        ->assertSeeIn('@count', '0')
+        ;
+    }
+
     public function test_drop_uploads_dropped_files_and_tracks_drag_state()
     {
         Storage::persistentFake('tmp-for-tests');
@@ -435,6 +461,35 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
         $this->cdp($browser, 'Browser.grantPermissions', ['permissions' => ['clipboardReadWrite', 'clipboardSanitizedWrite']]);
 
         $browser->script("window.__clipboardReady = false; (async () => { await navigator.clipboard.writeText('{$text}'); window.__clipboardReady = true })()");
+
+        $browser->waitUntil('window.__clipboardReady === true');
+    }
+
+    protected function putRichTextWithImageOnClipboard($browser, $text)
+    {
+        $this->cdp($browser, 'Browser.grantPermissions', ['permissions' => ['clipboardReadWrite', 'clipboardSanitizedWrite']]);
+
+        $browser->script(<<<JS
+            window.__clipboardReady = false;
+
+            (async () => {
+                let canvas = document.createElement('canvas')
+                canvas.width = canvas.height = 8
+                let context = canvas.getContext('2d')
+                context.fillStyle = 'red'
+                context.fillRect(0, 0, 8, 8)
+
+                let image = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'))
+
+                await navigator.clipboard.write([new ClipboardItem({
+                    'text/plain': new Blob(['{$text}'], { type: 'text/plain' }),
+                    'text/html': new Blob(['<p>{$text}<img src="data:image/png;base64,..."></p>'], { type: 'text/html' }),
+                    'image/png': image,
+                })])
+
+                window.__clipboardReady = true
+            })()
+        JS);
 
         $browser->waitUntil('window.__clipboardReady === true');
     }

--- a/src/Features/SupportFileUploads/UploadActionBrowserTest.php
+++ b/src/Features/SupportFileUploads/UploadActionBrowserTest.php
@@ -73,32 +73,6 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
-    public function test_rich_text_pastes_with_embedded_images_are_left_alone()
-    {
-        Storage::persistentFake('tmp-for-tests');
-
-        Livewire::visit(new class extends Component {
-            use WithFileUploads;
-
-            public $body = '';
-            public $photos = [];
-
-            function render() { return <<<'HTML'
-            <div>
-                <textarea dusk="box" wire:model="body" wire:paste="$upload('photos')"></textarea>
-
-                <span dusk="count" x-text="$wire.photos.length"></span>
-            </div>
-            HTML; }
-        })
-        ->tap(fn ($b) => $this->putRichTextWithImageOnClipboard($b, 'copied from Word'))
-        ->click('@box')
-        ->keys('@box', [$this->pasteChord(), 'v'])
-        ->waitUntil('document.querySelector(\'[dusk="box"]\').value === "copied from Word"')
-        ->assertSeeIn('@count', '0')
-        ;
-    }
-
     public function test_drop_uploads_dropped_files_and_tracks_drag_state()
     {
         Storage::persistentFake('tmp-for-tests');
@@ -461,35 +435,6 @@ class UploadActionBrowserTest extends \Tests\BrowserTestCase
         $this->cdp($browser, 'Browser.grantPermissions', ['permissions' => ['clipboardReadWrite', 'clipboardSanitizedWrite']]);
 
         $browser->script("window.__clipboardReady = false; (async () => { await navigator.clipboard.writeText('{$text}'); window.__clipboardReady = true })()");
-
-        $browser->waitUntil('window.__clipboardReady === true');
-    }
-
-    protected function putRichTextWithImageOnClipboard($browser, $text)
-    {
-        $this->cdp($browser, 'Browser.grantPermissions', ['permissions' => ['clipboardReadWrite', 'clipboardSanitizedWrite']]);
-
-        $browser->script(<<<JS
-            window.__clipboardReady = false;
-
-            (async () => {
-                let canvas = document.createElement('canvas')
-                canvas.width = canvas.height = 8
-                let context = canvas.getContext('2d')
-                context.fillStyle = 'red'
-                context.fillRect(0, 0, 8, 8)
-
-                let image = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'))
-
-                await navigator.clipboard.write([new ClipboardItem({
-                    'text/plain': new Blob(['{$text}'], { type: 'text/plain' }),
-                    'text/html': new Blob(['<p>{$text}<img src="data:image/png;base64,..."></p>'], { type: 'text/html' }),
-                    'image/png': image,
-                })])
-
-                window.__clipboardReady = true
-            })()
-        JS);
 
         $browser->waitUntil('window.__clipboardReady === true');
     }


### PR DESCRIPTION
## What changed

- ignore clipboard files when the same paste also advertises `text/plain` or `text/html`
- preserve standalone image and file pastes
- add focused unit coverage for both clipboard shapes

## Why

Word-style clipboard payloads can expose embedded images through `clipboardData.files` alongside the actual rich text. Livewire interpreted that image as an intentional upload, prevented the default paste, and discarded the text.

The fix prefers the browser's normal content paste whenever textual clipboard types are present. Clipboard payloads containing only files continue through the upload path.

## Validation

- `npm run test:run` — 155 passed, 1 skipped
- `npm run build`
