### PR TITLE
[4.x] Fix `Route::lazy()` and `Route::defer()` macros not available for package service providers

### DIFF
--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -25,8 +25,6 @@ class SupportLazyLoading extends ComponentHook
 
     static function provide()
     {
-        static::registerRouteMacro();
-
         on('flush-state', function () {
             static::$disableWhileTesting = false;
         });

--- a/src/Mechanisms/HandleRouting/HandleRouting.php
+++ b/src/Mechanisms/HandleRouting/HandleRouting.php
@@ -4,6 +4,7 @@ namespace Livewire\Mechanisms\HandleRouting;
 
 use Illuminate\Routing\Route as IlluminateRoute;
 use Illuminate\Support\Facades\Route;
+use Livewire\Features\SupportLazyLoading\SupportLazyLoading;
 use Livewire\Mechanisms\Mechanism;
 
 class HandleRouting extends Mechanism
@@ -21,5 +22,7 @@ class HandleRouting extends Mechanism
                 $route->action['livewire_component'] = $component;
             });
         });
+
+        SupportLazyLoading::registerRouteMacro();
     }
 }

--- a/src/Mechanisms/HandleRouting/ProviderOrderUnitTest.php
+++ b/src/Mechanisms/HandleRouting/ProviderOrderUnitTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleRouting;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+use Livewire\LivewireServiceProvider;
+use Tests\TestCase;
+
+class ProviderOrderUnitTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            RoutesBeforeLivewireServiceProvider::class,
+            LivewireServiceProvider::class,
+        ];
+    }
+
+    public function test_lazy_route_macros_are_available_to_packages_that_boot_before_livewire()
+    {
+        $this->assertTrue(Route::getRoutes()->getByName('package.lazy')->defaults['lazy']);
+        $this->assertTrue(Route::getRoutes()->getByName('package.defer')->defaults['defer']);
+    }
+}
+
+class RoutesBeforeLivewireServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        Route::livewire('/package-lazy', 'package-lazy')->lazy()->name('package.lazy');
+        Route::livewire('/package-defer', 'package-defer')->defer()->name('package.defer');
+    }
+}


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?
This fixes the same class of bug as #9903, just for the `lazy()`/`defer()` route macros instead of `Route::livewire()`.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)
Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, single focused change.

4️⃣ Does it include tests? (Required)
Not yet, that's why this is a draft. I'd appreciate some help on how to best write a test for this, if one is needed.

5️⃣ Please include a thorough description...

# The Scenario

When a third-party package uses `Route::lazy()` or `Route::defer()` in its service provider to register a lazy-loaded Livewire route, the application throws a `BadMethodCallException` because the macros aren't registered yet at the time the package's routes are loaded.

# The Problem

The `lazy()` and `defer()` macros were registered in `SupportLazyLoading::provide()`, which runs during `LivewireServiceProvider::boot()`. Laravel's package discovery loads and boots service providers in an unpredictable order. If a third-party package's service provider boots *before* Livewire's service provider, the `lazy()`/`defer()` macros don't exist yet.

This is the same underlying issue that was fixed for `Route::livewire()` in #9903.

# The Solution

Register the `lazy()`/`defer()` macros inside `HandleRouting::register()` (a mechanism). Mechanisms run their `register()` phase before any service provider's `boot()` phase runs, so this guarantees the macros are available before any package's `boot()` method runs, regardless of provider boot order.