### PR TITLE
[4.x] Fix reactive Eloquent models throws `CannotMutateReactivePropException` when relations are lazy-loaded

### DIFF
--- a/src/Features/SupportReactiveProps/BaseReactive.php
+++ b/src/Features/SupportReactiveProps/BaseReactive.php
@@ -17,7 +17,7 @@ class BaseReactive extends LivewireAttribute
 
         $this->storePush('reactiveProps', $property);
 
-        $this->originalValueHash = crc32(json_encode($this->getValue()));
+        $this->originalValueHash = SupportReactiveProps::hashValue($this->getValue());
     }
 
     public function hydrate()
@@ -32,13 +32,10 @@ class BaseReactive extends LivewireAttribute
 
             // Only trigger lifecycle hooks if value actually changed
             // Use the same comparison method as dehydrate() for consistency (handles arrays/objects)
-            $currentHash = crc32(json_encode($currentValue));
-            $updatedHash = crc32(json_encode($updatedValue));
-
-            if ($currentHash !== $updatedHash) {
+            if (! SupportReactiveProps::hashesMatch($currentValue, $updatedValue)) {
                 // Set value immediately so lifecycle hooks (boot/hydrate/booted) see updated data
                 $this->setValue($updatedValue);
-                $this->originalValueHash = crc32(json_encode($updatedValue));
+                $this->originalValueHash = SupportReactiveProps::hashValue($updatedValue);
 
                 // Queue the update trigger for after hydrate so updating*/updated* hooks fire
                 // Pass both old and new values plus a setValue callback so that
@@ -55,12 +52,12 @@ class BaseReactive extends LivewireAttribute
             }
         }
 
-        $this->originalValueHash = crc32(json_encode($this->getValue()));
+        $this->originalValueHash = SupportReactiveProps::hashValue($this->getValue());
     }
 
     public function dehydrate($context)
     {
-        if ($this->originalValueHash !== crc32(json_encode($this->getValue()))) {
+        if ($this->originalValueHash !== SupportReactiveProps::hashValue($this->getValue())) {
             throw new CannotMutateReactivePropException($this->component->getName(), $this->getName());
         }
 

--- a/src/Features/SupportReactiveProps/SupportReactiveProps.php
+++ b/src/Features/SupportReactiveProps/SupportReactiveProps.php
@@ -6,6 +6,7 @@ use function Livewire\on;
 use function Livewire\after;
 use function Livewire\trigger;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Livewire\ComponentHook;
 
 class SupportReactiveProps extends ComponentHook
@@ -53,8 +54,16 @@ class SupportReactiveProps extends ComponentHook
     static function hashValue(mixed $value): ?string
     {
         if ($value instanceof Model) {
+            $class = $value::class;
+
+            $morphMap = Relation::morphMap();
+
+            $alias = in_array($class, $morphMap)
+                ? array_search($class, $morphMap, true)
+                : $class;
+
             $payload = json_encode([
-                'class' => $value::class,
+                'class' => $alias,
                 'key' => $value->getKey(),
                 'attributes' => $value->getAttributes(),
             ]);

--- a/src/Features/SupportReactiveProps/SupportReactiveProps.php
+++ b/src/Features/SupportReactiveProps/SupportReactiveProps.php
@@ -50,6 +50,35 @@ class SupportReactiveProps extends ComponentHook
         });
     }
 
+    static function hashValue(mixed $value): ?string
+    {
+        if ($value instanceof Model) {
+            $payload = json_encode([
+                'class' => $value::class,
+                'key' => $value->getKey(),
+                'attributes' => $value->getAttributes(),
+            ]);
+
+            return $payload === false ? null : (string) crc32($payload);
+        }
+
+        $json = json_encode($value);
+
+        return $json === false ? null : (string) crc32($json);
+    }
+
+    static function hashesMatch(mixed $left, mixed $right): bool
+    {
+        $leftHash = static::hashValue($left);
+        $rightHash = static::hashValue($right);
+
+        if ($leftHash === null || $rightHash === null) {
+            return false;
+        }
+
+        return $leftHash === $rightHash;
+    }
+
     static function shouldSkipUpdate($snapshot, $calls): bool
     {
         $id = $snapshot['memo']['id'] ?? null;

--- a/src/Features/SupportReactiveProps/UnitTest.php
+++ b/src/Features/SupportReactiveProps/UnitTest.php
@@ -102,22 +102,20 @@ class UnitTest extends \Tests\TestCase
             }
         }, ['article' => $article]);
 
-        $snapshot = $child->snapshot;
-
         SupportReactiveProps::$pendingChildParams[$child->id()] = ['article' => $article];
 
         $this->withHeaders(['X-Livewire' => 'true'])
             ->postJson(EndpointResolver::updatePath(), [
                 'components' => [
                     [
-                        'snapshot' => json_encode($snapshot),
+                        'snapshot' => json_encode($child->snapshot),
                         'updates' => [],
                         'calls' => [
                             ['method' => '$refresh', 'params' => [], 'metadata' => []],
                         ],
                     ],
                 ],
-            ]);
+            ])->assertOk();
 
         $child->assertSee('Ghabriel');
     }
@@ -140,20 +138,18 @@ class UnitTest extends \Tests\TestCase
 
         SupportReactiveProps::$pendingChildParams[$child->id()] = ['article' => $article];
 
-        $snapshot = $child->snapshot;
-
         $this->withHeaders(['X-Livewire' => 'true'])
             ->postJson(EndpointResolver::updatePath(), [
                 'components' => [
                     [
-                        'snapshot' => json_encode($snapshot),
+                        'snapshot' => json_encode($child->snapshot),
                         'updates' => [],
                         'calls' => [
                             ['method' => '$refresh', 'params' => [], 'metadata' => []],
                         ],
                     ],
                 ],
-            ]);
+            ])->assertOk();
 
         $child->assertSee('Ghabriel');
     }
@@ -181,21 +177,49 @@ class UnitTest extends \Tests\TestCase
 
         SupportReactiveProps::$pendingChildParams[$child->id()] = ['article' => $article];
 
+        $child->call('rename');
+    }
+
+    public function test_parent_passed_dirty_model_does_not_false_positive_when_child_does_nothing()
+    {
+        $article = Article::first();
+
+        $article->title = 'Dirty from parent';
+
+        $this->assertTrue($article->isDirty('title'));
+
+        $child = Livewire::test(new class extends Component {
+            #[BaseReactive]
+            public $article;
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>{{ $article->title }}</div>
+                HTML;
+            }
+        }, ['article' => $article]);
+
+        SupportReactiveProps::$pendingChildParams[$child->id()] = ['article' => $article];
+
         $snapshot = $child->snapshot;
 
-        $this->withoutExceptionHandling()
-            ->withHeaders(['X-Livewire' => 'true'])
+        // Simulate a subsequent request where the parent again passes the
+        // same (still dirty) model and the child only refreshes.
+        $this->withHeaders(['X-Livewire' => 'true'])
             ->postJson(EndpointResolver::updatePath(), [
                 'components' => [
                     [
                         'snapshot' => json_encode($snapshot),
                         'updates' => [],
                         'calls' => [
-                            ['method' => 'rename', 'params' => [], 'metadata' => []],
+                            ['method' => '$refresh', 'params' => [], 'metadata' => []],
                         ],
                     ],
                 ],
-            ]);
+            ])->assertOk();
+
+        $child->assertSee('Dirty from parent');
     }
 }
 

--- a/src/Features/SupportReactiveProps/UnitTest.php
+++ b/src/Features/SupportReactiveProps/UnitTest.php
@@ -4,6 +4,7 @@ namespace Livewire\Features\SupportReactiveProps;
 
 use Livewire\Component;
 use Livewire\Livewire;
+use Livewire\Mechanisms\HandleRequests\EndpointResolver;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -69,6 +70,133 @@ class UnitTest extends \Tests\TestCase
         $this->assertFalse(SupportReactiveProps::valuesMatch([1, 2, 3], [1, 2, 4]));
         $this->assertFalse(SupportReactiveProps::valuesMatch('5', 5));
     }
+
+    public function test_values_match_ignores_loaded_relations_on_pending_model()
+    {
+        $article = Article::query()->first();
+        $article->setRelation('author', Author::query()->first());
+
+        $snapshotValue = [null, [
+            'class' => Article::class,
+            'key' => $article->getKey(),
+            's' => 'mdl',
+        ]];
+
+        // Relations are not part of model identity on the wire (ModelSynth).
+        $this->assertTrue(SupportReactiveProps::valuesMatch($snapshotValue, $article));
+    }
+
+    public function test_accessing_lazy_loaded_relation_on_reactive_model_does_not_throw()
+    {
+        $article = Article::first();
+
+        $child = Livewire::test(new class extends Component {
+            #[BaseReactive]
+            public $article;
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>{{ $article->author->name }}</div>
+                HTML;
+            }
+        }, ['article' => $article]);
+
+        $snapshot = $child->snapshot;
+
+        SupportReactiveProps::$pendingChildParams[$child->id()] = ['article' => $article];
+
+        $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), [
+                'components' => [
+                    [
+                        'snapshot' => json_encode($snapshot),
+                        'updates' => [],
+                        'calls' => [
+                            ['method' => '$refresh', 'params' => [], 'metadata' => []],
+                        ],
+                    ],
+                ],
+            ]);
+
+        $child->assertSee('Ghabriel');
+    }
+
+    public function test_accessing_eager_load_relation_on_reactive_model_does_not_throw()
+    {
+        $article = Article::with('author')->first();
+
+        $child = Livewire::test(new class extends Component {
+            #[BaseReactive]
+            public $article;
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>{{ $article->author->name }}</div>
+                HTML;
+            }
+        }, ['article' => $article]);
+
+        SupportReactiveProps::$pendingChildParams[$child->id()] = ['article' => $article];
+
+        $snapshot = $child->snapshot;
+
+        $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), [
+                'components' => [
+                    [
+                        'snapshot' => json_encode($snapshot),
+                        'updates' => [],
+                        'calls' => [
+                            ['method' => '$refresh', 'params' => [], 'metadata' => []],
+                        ],
+                    ],
+                ],
+            ]);
+
+        $child->assertSee('Ghabriel');
+    }
+
+    public function test_mutating_reactive_model_attributes_still_throws()
+    {
+        $this->expectException(CannotMutateReactivePropException::class);
+
+        $article = Article::first();
+
+        $child = Livewire::test(new class extends Component {
+            #[BaseReactive]
+            public $article;
+
+            public function rename()
+            {
+                $this->article->title = 'Changed';
+            }
+
+            public function render()
+            {
+                return '<div></div>';
+            }
+        }, ['article' => $article]);
+
+        SupportReactiveProps::$pendingChildParams[$child->id()] = ['article' => $article];
+
+        $snapshot = $child->snapshot;
+
+        $this->withoutExceptionHandling()
+            ->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), [
+                'components' => [
+                    [
+                        'snapshot' => json_encode($snapshot),
+                        'updates' => [],
+                        'calls' => [
+                            ['method' => 'rename', 'params' => [], 'metadata' => []],
+                        ],
+                    ],
+                ],
+            ]);
+    }
 }
 
 class ChildWithLifecycleHooks extends Component
@@ -124,5 +252,29 @@ class ChildWithUpdateHooks extends Component
     public function render()
     {
         return '<div>{{ $count }}</div>';
+    }
+}
+
+class Author extends \Illuminate\Database\Eloquent\Model
+{
+    use \Sushi\Sushi;
+
+    protected $rows = [
+        ['id' => 1, 'name' => 'Ghabriel'],
+    ];
+}
+
+class Article extends \Illuminate\Database\Eloquent\Model
+{
+    use \Sushi\Sushi;
+
+    protected $rows = [
+        ['id' => 1, 'title' => 'First', 'author_id' => 1],
+        ['id' => 2, 'title' => 'Second', 'author_id' => 1],
+    ];
+
+    public function author()
+    {
+        return $this->belongsTo(Author::class);
     }
 }


### PR DESCRIPTION
## Problem

`BaseReactive` detected changes with:

```php
crc32(json_encode($this->getValue()))
```

For Eloquent models, `json_encode()` includes loaded relations. A normal app pattern:

```php
#[Reactive]
public Article $article;

public function render()
{
    return view('...', [
        'author' => $this->article->author->name, // lazy load
    ]);
}
```

Lazy load model mutates the in-memory parent model (relation loaded), changes the hash, and throws on dehydrate:
`Cannot mutate reactive prop [article] in component: [...]`

That conflicts with how Livewire treats models elsewhere:
- `ModelSynth` only dehydrates **class + key** (no attributes, no relations)
- `SupportReactiveProps::modelMatchesSnapshot()` compares identity + dirty/changed flags for skip, and also ignores relations

So mutation detection was stricter (and noisier) than the rest of the model pipeline.

`BaseReactive` also lacked the `json_encode === false` guard that `valuesMatch()` already has (NAN/INF/etc. can collide on `crc32(false)`).

## Solution
Add a shared hasher on `SupportReactiveProps` and use it from `BaseReactive` for mount / hydrate / dehydrate:
- **Models:** hash `class` + `key` + `getAttributes()` — not relations
  - Relation reads (`$this->article->author` — lazy load) → no throw
  - Attribute writes (`$this->article->title = 'New title'`) → still throw
  - Different model identity → still throw
- **Other values:** `crc32(json_encode($value))`, or `null` if encoding fails (same idea as `valuesMatch`)

```php
static function hashValue(mixed $value): ?string
{
    if ($value instanceof Model) {
        $class = $value::class;

        $morphMap = Relation::morphMap();

        $alias = in_array($class, $morphMap)
            ? array_search($class, $morphMap, true)
            : $class;

        $payload = json_encode([
            'class' => $alias,
            'key' => $value->getKey(),
            'attributes' => $value->getAttributes(),
        ]);

        return $payload === false ? null : (string) crc32($payload);
    }

    $json = json_encode($value);

    return $json === false ? null : (string) crc32($json);
}
```

`shouldSkipUpdate()` / `modelMatchesSnapshot()` are **unchanged**. Skip remains identity-based, consistent with `ModelSynth`.

> [!IMPORTANT]
> There are still some issues thats not fixed with this PR as I'm not sure if we should support these cases:
> 1. Reactive collections / arrays of models – still use full json_encode, so the original bug can still appear.
> 2. Custom objects that implement JsonSerializable and embed models

## Tests
Five tests:
- One regression test (accessing lazy load relation)
- Four complementary tests to make sure this PR doesnt break anything

### Why attributes are in the model hash
Hashing attributes preserves the existing reactive contract (“child must not mutate the prop”) while excluding relations so display-only lazy loads are safe.
`isDirty()` / `wasChanged()` alone are not used on dehydrate: the parent may pass an already-dirty model; those flags would false-positive after `setValue`. Comparing attribute snapshots from hydrate → dehydrate avoids that.

### Why cast `crc32` value to string
On `32-bit` builds the value from `crc32` can be negative because PHP integers are signed. On `64-bit` builds it is always non-negative. See [PHP Manual](https://www.php.net/manual/en/function.crc32.php)

Discussions: https://github.com/livewire/livewire/discussions/6090, https://github.com/livewire/livewire/discussions/6033