### PR TITLE
[3.x] Fix diff() emitting invalid root property paths

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -133,6 +133,21 @@ export function diff(left, right, diffs = {}, path = '') {
 
     // Did the key order change?
     if (isObject(left) && leftKeys.length === rightKeys.length && leftKeys.some((key, i) => key !== rightKeys[i])) {
+        // At the root there is no path to consolidate under — `diffs[''] = right`
+        // would send the entire component state keyed by an empty string, which
+        // the server resolves to an empty property name. Diff the root
+        // properties individually instead. Key order alone carries no meaning
+        // for the server, so an order-only change sends nothing...
+        if (path === '') {
+            Object.keys(right).forEach(key => {
+                if (JSON.stringify(left[key]) !== JSON.stringify(right[key])) {
+                    diffs[key] = right[key]
+                }
+            })
+
+            return diffs
+        }
+
         diffs[path] = right
         return diffs
     }
@@ -145,7 +160,7 @@ export function diff(left, right, diffs = {}, path = '') {
 
     // Mark any items for removal...
     leftKeys.forEach(key => {
-        diffs[`${path}.${key}`] = '__rm__'
+        diffs[path === '' ? key : `${path}.${key}`] = '__rm__'
     })
 
     return diffs

--- a/js/utils.js
+++ b/js/utils.js
@@ -133,23 +133,10 @@ export function diff(left, right, diffs = {}, path = '') {
 
     // Did the key order change?
     if (isObject(left) && leftKeys.length === rightKeys.length && leftKeys.some((key, i) => key !== rightKeys[i])) {
-        // At the root there is no path to consolidate under — `diffs[''] = right`
-        // would send the entire component state keyed by an empty string, which
-        // the server resolves to an empty property name. Diff the root
-        // properties individually instead. Key order alone carries no meaning
-        // for the server, so an order-only change sends nothing...
-        if (path === '') {
-            Object.keys(right).forEach(key => {
-                if (JSON.stringify(left[key]) !== JSON.stringify(right[key])) {
-                    diffs[key] = right[key]
-                }
-            })
-
+        if (path !== '') {
+            diffs[path] = right
             return diffs
         }
-
-        diffs[path] = right
-        return diffs
     }
 
     // Recursively diff the object's properties...

--- a/src/Mechanisms/HandleComponents/BrowserTest.php
+++ b/src/Mechanisms/HandleComponents/BrowserTest.php
@@ -143,6 +143,70 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertSeeIn('@selected', 'D')
         ;
     }
+
+    public function test_it_does_not_send_an_invalid_root_property_path_when_the_key_order_drifts()
+    {
+        // A deploy can add a public property to a component that a user already
+        // has open. The server snapshot then lists the properties in a different
+        // ORDER than the browser's ephemeral object, which appends unknown keys
+        // at the end. Previously diff() consolidated that at the root, sending
+        // the entire state keyed by an empty string, which the server resolved
+        // to an empty property name and rejected with a
+        // PublicPropertyNotFoundException — wedging the component until reload.
+        Livewire::visit(new class extends \Livewire\Component {
+            public $first = 'foo';
+
+            public $second = 'bar';
+
+            public $third = 'baz';
+
+            public $count = 0;
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <span dusk="count">{{ $count }}</span>
+
+                    <button type="button" wire:click="increment" dusk="increment">Increment</button>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@count', '0')
+
+        /**
+         * Move the first root key to the end of the ephemeral object, so its key
+         * order no longer matches the canonical (server) snapshot.
+         */
+        ->tap(function ($b) {
+            $b->script(<<<'JS'
+            let component = window.Livewire.all()[0]
+            let key = Object.keys(component.ephemeral)[0]
+            let value = component.ephemeral[key]
+
+            delete component.ephemeral[key]
+
+            component.ephemeral[key] = value
+            JS);
+        })
+
+        ->waitForLivewire()->click('@increment')
+        ->assertSeeIn('@count', '1')
+
+        /**
+         * The component keeps working on subsequent requests too — the bug
+         * wedged every following commit, not just the first.
+         */
+        ->waitForLivewire()->click('@increment')
+        ->assertSeeIn('@count', '2')
+        ;
+    }
 }
 
 enum Suit: string

--- a/src/Mechanisms/HandleComponents/BrowserTest.php
+++ b/src/Mechanisms/HandleComponents/BrowserTest.php
@@ -207,6 +207,46 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->assertSeeIn('@count', '2')
         ;
     }
+
+    public function test_it_tracks_root_removals_when_the_key_order_changes()
+    {
+        Livewire::visit(new class extends \Livewire\Component {
+            public $first = 'foo';
+
+            public $second = 'bar';
+
+            public $third = 'baz';
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button type="button" wire:click="$refresh" dusk="refresh">Refresh</button>
+                </div>
+                HTML;
+            }
+        })
+        ->tap(function ($b) {
+            $b->script(<<<'JS'
+            let component = window.Livewire.all()[0]
+
+            window.updates = null
+
+            window.Livewire.hook('commit', ({ component: committing, commit }) => {
+                if (committing === component) window.updates = commit.updates
+            })
+
+            component.canonical = { first: 'foo', second: 'bar' }
+            component.ephemeral = { first: 'foo', third: 'baz' }
+            JS);
+        })
+        ->waitForLivewire()->click('@refresh')
+        ->assertScript('return window.updates', [
+            'third' => 'baz',
+            'second' => '__rm__',
+        ])
+        ;
+    }
 }
 
 enum Suit: string
@@ -219,4 +259,3 @@ enum Suit: string
 
     case Spades = 'S';
 }
-


### PR DESCRIPTION
At the root of `diff()`, `path` is an empty string. Two branches could therefore emit update paths the server cannot resolve:

- key-order consolidation produced `{ "": <entire state> }`
- root removals produced leading-dot paths such as `{ ".foo": "__rm__" }`

The server resolves both to an empty property name and throws `Public property [$] not found`. Because the malformed diff is recomputed on every commit, an already-open component can remain wedged until the page is reloaded.

This can happen after a deploy changes the public properties in a component: the new server snapshot replaces `canonical`, while new root keys are appended to the existing `ephemeral` object, causing their key orders to drift.

## Findings

Nested key-order changes should still consolidate to their parent path, preserving the behavior added in #10001. Root-level changes cannot be consolidated because there is no valid parent path.

The 4.x recursive diff already handles this distinction by only consolidating when `path !== ''`.

## Proposed solution

- only consolidate key-order changes when `path !== ''`
- at the root, fall through to the existing recursive diff so real additions, changes, and removals are preserved
- build removal paths without a leading dot when `path === ''`

This keeps normal and nested diff behavior unchanged while preventing invalid root paths.

## Tests

Added browser coverage that:

- reorders root keys and verifies multiple subsequent commits still succeed
- replaces one root key with another and verifies the real commit payload contains both the addition and the `__rm__` removal marker

Local validation:

- `npm run build`
- `vendor/bin/phpunit src/Mechanisms/HandleComponents/BrowserTest.php` — 6 tests, 12 assertions
- `vendor/bin/phpunit --testsuite Unit` — 917 tests, 2,942 assertions

Fixes #10535.
