### PR TITLE
[4.x] Fix `wire:loading` finish before navigating

### DIFF
--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -114,6 +114,17 @@ function whenTargetsArePartOfRequest(component, el, targets, inverted, [ startLo
                 if (isRedirectUsingNavigate) {
                     waitForNavigate = true
 
+                    let onError = () => {
+                        if (cleared) return
+
+                        endLoading()
+                        cleared = true
+
+                        document.removeEventListener('livewire:navigate-error', onError)
+                    }
+
+                    document.addEventListener('livewire:navigate-error', onError)
+
                     return
                 }
 

--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -93,6 +93,7 @@ function whenTargetsArePartOfRequest(component, el, targets, inverted, [ startLo
 
         let matches = true
         let cleared = false
+        let waitForNavigate = false
 
         onSend(({ payload }) => {
             if (targets.length > 0 && containsTargets(payload, targets) === inverted) {
@@ -103,21 +104,30 @@ function whenTargetsArePartOfRequest(component, el, targets, inverted, [ startLo
         })
 
         // Clear loading before morph on success
-        onSuccess(({ onEffect }) => {
+        onSuccess(({ payload, onEffect }) => {
             onEffect(() => {
-                if (matches && ! cleared) {
-                    endLoading()
-                    cleared = true
+                if (! matches || cleared) return
+
+                let effects = payload?.effects || {}
+                let isRedirectUsingNavigate = effects.redirect && effects.redirectUsingNavigate
+
+                if (isRedirectUsingNavigate) {
+                    waitForNavigate = true
+
+                    return
                 }
+
+                endLoading()
+                cleared = true
             })
         })
 
         // Clear loading on cancel/error/failure (onFinish fires immediately on these paths)
         onFinish(() => {
-            if (matches && ! cleared) {
-                endLoading()
-                cleared = true
-            }
+            if (! matches || cleared || waitForNavigate) return
+
+            endLoading()
+            cleared = true
         })
     })
 }

--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -141,6 +141,8 @@ export default function (Alpine) {
         }, (error) => {
             showProgressBar && finishAndHideProgressBar()
 
+            document.dispatchEvent(new CustomEvent('livewire:navigate-error', { bubbles: true }))
+
             // We cancelled this request ourselves, so the user is already on their
             // way somewhere else. Sending them to a destination they abandoned
             // would be worse than doing nothing...

--- a/src/Features/SupportRedirects/BrowserTest.php
+++ b/src/Features/SupportRedirects/BrowserTest.php
@@ -54,6 +54,39 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_wire_loading_remains_active_while_a_navigate_redirect_is_in_progress()
+    {
+        Route::get('/slow-redirect-destination', function () {
+            sleep(1);
+
+            return response(<<<'HTML'
+                <!DOCTYPE html>
+                <html>
+                    <body>
+                        <h1 dusk="destination">Slow redirect destination</h1>
+                    </body>
+                </html>
+                HTML);
+        })->middleware('web');
+
+        Livewire::visit([new class extends Component {
+            public function save()
+            {
+                $this->redirect('/slow-redirect-destination', navigate: true);
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button type="button" dusk="save" wire:click="save" wire:loading.attr="disabled">Save</button>
+            </div>
+            HTML; }
+        }])
+            ->waitForLivewire()->click('@save')
+            ->assertAttribute('@save', 'disabled', 'true')
+            ->waitFor('@destination', 6)
+        ;
+    }
+
     public function test_session_flash_persists_when_redirecting_from_request_with_multiple_components_in_the_same_request()
     {
         config()->set('session.driver', 'file');

--- a/src/Features/SupportRedirects/BrowserTest.php
+++ b/src/Features/SupportRedirects/BrowserTest.php
@@ -87,6 +87,110 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_wire_loading_is_cleared_when_a_navigate_redirect_fetch_fails_while_online()
+    {
+        Route::get('/navigate-redirect-destination', function () {
+            return response(<<<'HTML'
+                <!DOCTYPE html>
+                <html>
+                    <body>
+                        <h1 dusk="destination">Navigate redirect destination</h1>
+                    </body>
+                </html>
+                HTML);
+        })->middleware('web');
+
+        Livewire::visit([new class extends Component {
+            public function save()
+            {
+                $this->redirect('/navigate-redirect-destination', navigate: true);
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button type="button" dusk="save" wire:click="save" wire:loading.attr="disabled">Save</button>
+                    <span dusk="status">Ready</span>
+                </div>
+                HTML;
+            }
+        }])
+            ->tap(fn ($b) => $b->script(<<<'JS'
+                window._lw_dusk_navigate_fetch_failed = false;
+
+                const originalFetch = window.fetch.bind(window);
+
+                window.fetch = function (input, init = {}) {
+                    const headers = new Headers(init.headers || {});
+
+                    if (headers.has('X-Livewire-Navigate')) {
+                        // Delay so the Livewire request can finish while loading is still held,
+                        // then fail the navigate fetch (same path as #9380 cleanup).
+                        return new Promise((_, reject) => {
+                            setTimeout(() => {
+                                window._lw_dusk_navigate_fetch_failed = true;
+                                reject(new TypeError('Failed to fetch'));
+                            }, 400);
+                        });
+                    }
+
+                    return originalFetch(input, init);
+                };
+
+                Object.defineProperty(navigator, 'onLine', {
+                    get: () => true,
+                    configurable: true,
+                });
+            JS))
+            ->waitForLivewire()->click('@save')
+            ->assertAttribute('@save', 'disabled', 'true')
+            ->pause(600) // 400ms reject + cleanup
+            ->assertScript('window._lw_dusk_navigate_fetch_failed === true', true)
+            ->assertAttributeMissing('@save', 'disabled')
+            ->assertSee('Ready')
+            ->assertMissing('@destination')
+            ;
+    }
+
+    public function test_wire_loading_is_cleared_when_navigate_redirect_targets_a_cross_origin_redirect_response()
+    {
+        Route::get('/redirects-off-origin', function () {
+            return redirect('https://www.google.com');
+        })->middleware('web');
+
+        Livewire::visit([new class extends Component {
+            public function save()
+            {
+                $this->redirect('/redirects-off-origin', navigate: true);
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button type="button" dusk="save" wire:click="save" wire:loading.attr="disabled">Save</button>
+                </div>
+                HTML;
+            }
+        }])
+            ->tap(fn ($b) => $b->script(<<<'JS'
+                Object.defineProperty(navigator, 'onLine', {
+                    get: () => true,
+                    configurable: true,
+                });
+            JS))
+            ->waitForLivewire()->click('@save')
+            ->assertAttribute('@save', 'disabled', 'true')
+            // Fetch fails / cannot be swapped in; progress bar path settles; loading must clear.
+            ->pause(500)
+            ->waitUntilMissing('#nprogress')
+            ->assertAttributeMissing('@save', 'disabled')
+            // Origin page still usable.
+            ->waitForLivewire()->click('@save')
+        ;
+    }
+
     public function test_session_flash_persists_when_redirecting_from_request_with_multiple_components_in_the_same_request()
     {
         config()->set('session.driver', 'file');


### PR DESCRIPTION
## Problem

When an action redirects with `navigate: true`, `wire:loading` (e.g. `wire:loading.attr="disabled"`) is cleared as soon as the Livewire request finishes.

Navigate redirects are handled asynchronously via `Alpine.navigate()`, so the UI can leave the loading state while the destination page is still loading. Users can double-submit / re-click during that window.

## Root cause

In `js/directives/wire-loading.js`, loading is ended on `onEffect` / `onFinish` after a successful message.

In `js/request/index.js`, success order is:

1. `processEffects()` → starts `Alpine.navigate(url)` for navigate redirects
2. `invokeOnEffect()` → ends loading
3. morph / finish

`Alpine.navigate()` does not wait for the new page, so loading ends too early.

## Solution

If the message payload effects include both `redirect` and `redirectUsingNavigate`, defer ending. Otherwise keep existing behavior (end on effect/finish).

## Browser test
Browser test comes from https://github.com/livewire/livewire/pull/10454

Related discussions: https://github.com/livewire/livewire/pull/8165, https://github.com/livewire/livewire/discussions/7578