### PR TITLE
[4.x] Add type validation to CarbonSynth and EnumSynth

### DIFF
--- a/src/Mechanisms/HandleComponents/Synthesizers/CarbonSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CarbonSynth.php
@@ -47,6 +47,10 @@ class CarbonSynth extends Synth {
     function hydrate($value, $meta) {
         if ($value === '' || $value === null) return null;
 
+        if (! isset($meta['type']) || ! isset(static::$types[$meta['type']])) {
+            throw new \Exception("Livewire: Type [{$meta['type']}] is not a valid DateTime type.");
+        }
+
         return new static::$types[$meta['type']]($value);
     }
 }

--- a/src/Mechanisms/HandleComponents/Synthesizers/CarbonSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CarbonSynth.php
@@ -47,10 +47,12 @@ class CarbonSynth extends Synth {
     function hydrate($value, $meta) {
         if ($value === '' || $value === null) return null;
 
-        if (! isset($meta['type']) || ! isset(static::$types[$meta['type']])) {
-            throw new \Exception("Livewire: Type [{$meta['type']}] is not a valid DateTime type.");
+        $type = $meta['type'] ?? null;
+
+        if (! $type || ! isset(static::$types[$type])) {
+            throw new \Exception("Livewire: Type [{$type}] is not a valid DateTime type.");
         }
 
-        return new static::$types[$meta['type']]($value);
+        return new static::$types[$type]($value);
     }
 }

--- a/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
@@ -29,6 +29,10 @@ class EnumSynth extends Synth {
     function hydrate($value, $meta) {
         if ($value === null || $value === '') return null;
 
+        if (! isset($meta['class']) || ! is_a($meta['class'], \BackedEnum::class, true)) {
+            throw new \Exception("Livewire: Class [{$meta['class']}] is not a valid Enum type.");
+        }
+
         $class = $meta['class'];
 
         return $class::from($value);

--- a/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
@@ -29,11 +29,11 @@ class EnumSynth extends Synth {
     function hydrate($value, $meta) {
         if ($value === null || $value === '') return null;
 
-        if (! isset($meta['class']) || ! is_a($meta['class'], \BackedEnum::class, true)) {
-            throw new \Exception("Livewire: Class [{$meta['class']}] is not a valid Enum type.");
-        }
+        $class = $meta['class'] ?? null;
 
-        $class = $meta['class'];
+        if (! $class || ! is_a($class, \BackedEnum::class, true)) {
+            throw new \Exception("Livewire: Class [{$class}] is not a valid Enum type.");
+        }
 
         return $class::from($value);
     }


### PR DESCRIPTION
Add type validation in:

- **EnumSynth** — `$meta['class']` must be a `BackedEnum`
- **CarbonSynth** — `$meta['type']` must be a known key in `$types`

Matches the existing pattern in `CollectionSynth`, `FormObjectSynth`, and `WireableSynth`.

Follow-up to the note in #9969.