### PR TITLE
[4.x] Support exception hook for computed properties

### DIFF
--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportComputed;
 
 use function Livewire\invade;
+use function Livewire\trigger;
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
@@ -158,7 +159,19 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
-        return invade($this->component)->{parent::getName()}();
+        try {
+            return invade($this->component)->{parent::getName()}();
+        } catch (\Throwable $e) {
+            $shouldPropagate = true;
+
+            $stopPropagation = function () use (&$shouldPropagate) {
+                $shouldPropagate = false;
+            };
+
+            trigger('exception', $this->component, $e, $stopPropagation);
+
+            $shouldPropagate && throw $e;
+        }
     }
 
     public function getName()
@@ -170,6 +183,4 @@ class BaseComputed extends Attribute
     {
         return str($value)->camel()->toString();
     }
-
-
 }

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -2,8 +2,7 @@
 
 namespace Livewire\Features\SupportComputed;
 
-use function Livewire\invade;
-use function Livewire\trigger;
+use function Livewire\{ invade, wrap };
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
@@ -159,19 +158,13 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
-        try {
-            return invade($this->component)->{parent::getName()}();
-        } catch (\Throwable $e) {
-            $shouldPropagate = true;
+        $value = null;
 
-            $stopPropagation = function () use (&$shouldPropagate) {
-                $shouldPropagate = false;
-            };
+        wrap($this->component)->tap(function ($component) use (&$value) {
+            $value = invade($component)->{parent::getName()}();
+        });
 
-            trigger('exception', $this->component, $e, $stopPropagation);
-
-            $shouldPropagate && throw $e;
-        }
+        return $value;
     }
 
     public function getName()

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -735,6 +735,36 @@ class UnitTest extends TestCase
             ->dispatch('bar', 'baz')
             ->assertSetStrict('foo', 'baz');
     }
+
+    public function test_computed_attribute_can_trigger_component_exception_hook()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Computed]
+            public function foo(): string
+            {
+                throw new ComputedPropertyException('Exception from computed property');
+            }
+
+            public function exception($e, $stopPropagation)
+            {
+                if ($e instanceof ComputedPropertyException) {
+                    $stopPropagation();
+
+                    session()->put('exception-hook-triggered', true);
+                }
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>{{ $this->foo }}</div>
+                HTML;
+            }
+        })
+            ->assertOk();
+
+        $this->assertTrue(session()->has('exception-hook-triggered'));
+    }
 }
 
 class ComputedPropertyStub extends Component
@@ -878,5 +908,16 @@ class NullIssetComputedPropertyStub extends Component{
             {{ var_dump(isset($this->foo)) }}
         </div>
         HTML;
+    }
+}
+
+class ComputedPropertyException extends \Exception
+{
+    public function __construct(
+        string $message = '',
+        int $code = 0,
+        \Throwable|null $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
     }
 }


### PR DESCRIPTION
## Summary
Allow exceptions thrown from `#[Computed]` attribute to trigger the component's `exception` hook.

## Problem
Exception thrown inside computed properties was ignored by component exception hook while there is non-zero chance it can throw exception such `ModelNotFoundException`. Inside `BaseComputed::evaluateComputed()`, the component wrapped with `invade()` not `wrap()` which is make sense since computed properties doesnt have any parameters to resolved.

## Solution
Using `wrap()` + `Component::tap()`  following how `BaseAuthorize::call()` forwards the exception to component exception hook.

> [!NOTE]
> Replacing `invade()` with `wrap()` will make it more simple **but** might cause breaking change because computed properties could be a protected method

```php
protected function evaluateComputed()
{
    $value = null;

    wrap($this->component)->tap(function ($component) use (&$value) {
        $value = invade($component)->{parent::getName()}();
    });

    return $value;
}
```

## Test
- Add unit test for the exception hook on computed properties

Related discussion: https://github.com/livewire/livewire/discussions/8373