### PR TITLE
Backport eligible 4.x fixes to 3.x

### DIFF
--- a/docs/computed-properties.md
+++ b/docs/computed-properties.md
@@ -117,7 +117,7 @@ In the above component, the computed property is cached before a new post is cre
 
 Sometimes you would like to cache the value of a computed property for the lifespan of a Livewire component, rather than it being cleared after every request. In these cases, you can use [Laravel's caching utilities](https://laravel.com/docs/cache#retrieve-store).
 
-Below is an example of a computed property named `user()`, where instead of executing the Eloquent query directly, we wrap the query in `Cache::remember()` to ensure that any future requests retrieve it from Laravel's cache instead of re-executing the query:
+Below is an example of a computed property named `userName()`, where instead of executing the Eloquent query directly, we wrap the query in `Cache::remember()` to ensure that any future requests retrieve the name from Laravel's cache instead of re-executing the query:
 
 ```php
 <?php
@@ -132,13 +132,13 @@ class ShowUser extends Component
     public $userId;
 
     #[Computed]
-    public function user()
+    public function userName()
     {
-        $key = 'user'.$this->getId();
+        $key = 'user-name'.$this->getId();
         $seconds = 3600; // 1 hour...
 
         return Cache::remember($key, $seconds, function () {
-            return User::find($this->userId);
+            return User::find($this->userId)->name;
         });
     }
 
@@ -155,13 +155,13 @@ use Livewire\Attributes\Computed;
 use App\Models\User;
 
 #[Computed(persist: true)]
-public function user()
+public function userName()
 {
-    return User::find($this->userId);
+    return User::find($this->userId)->name;
 }
 ```
 
-In the example above, when `$this->user` is accessed from your component, it will continue to be cached for the duration of the Livewire component on the page. This means the actual Eloquent query will only be executed once.
+In the example above, when `$this->userName` is accessed from your component, it will continue to be cached for the duration of the Livewire component on the page. This means the actual Eloquent query will only be executed once.
 
 Livewire caches persisted values for 3600 seconds (one hour). You can override this default by passing an additional `seconds` parameter to the `#[Computed]` attribute:
 
@@ -169,8 +169,19 @@ Livewire caches persisted values for 3600 seconds (one hour). You can override t
 #[Computed(persist: true, seconds: 7200)]
 ```
 
-> [!tip] Calling `unset()` will bust this cache
-> As previously discussed, you can clear a computed property's cache using PHP's `unset()` method. This also applies to computed properties using the `persist: true` parameter. When calling `unset()` on a cached computed property, Livewire will clear not only the computed property cache, but also the underlying cached value in Laravel's cache.
+> [!warning] Caching objects on Laravel 13
+> New Laravel 13 applications only unserialize explicitly allowed PHP classes from cache. When Laravel cannot restore an object returned by a persisted or cached computed property, Livewire re-evaluates the property so the value remains correct. In debug mode, Livewire also writes a warning to the application log because the value was not served from cache.
+>
+> Prefer caching scalars or arrays. To intentionally cache an object, add every class in its object graph to `cache.serializable_classes` in `config/cache.php`:
+>
+> ```php
+> 'serializable_classes' => [
+>     App\Models\User::class,
+> ],
+> ```
+
+> [!tip] Calling `unset()` will clear both memo and cache
+> As previously discussed, you can clear a computed property's memo using PHP's `unset()` method. This also applies to computed properties using the `persist: true` parameter. When calling `unset()` on a persisted computed property, Livewire will clear not only the in-request memo, but also the underlying cached value in Laravel's cache.
 
 ## Caching across all components
 
@@ -181,13 +192,13 @@ use Livewire\Attributes\Computed;
 use App\Models\Post;
 
 #[Computed(cache: true)]
-public function posts()
+public function postTitles()
 {
-    return Post::all();
+    return Post::query()->pluck('title', 'id')->all();
 }
 ```
 
-In the above example, until the cache expires or is busted, every instance of this component in your application will share the same cached value for `$this->posts`.
+In the above example, until the cache expires or is busted, every instance of this component in your application will share the same cached value for `$this->postTitles`.
 
 If you need to manually clear the cache for a computed property, you may set a custom cache key using the `key` parameter:
 
@@ -196,9 +207,9 @@ use Livewire\Attributes\Computed;
 use App\Models\Post;
 
 #[Computed(cache: true, key: 'homepage-posts')]
-public function posts()
+public function postTitles()
 {
-    return Post::all();
+    return Post::query()->pluck('title', 'id')->all();
 }
 ```
 

--- a/js/features/supportScriptsAndAssets.js
+++ b/js/features/supportScriptsAndAssets.js
@@ -86,7 +86,12 @@ async function addAssetsToHeadTagOfPage(rawHtml) {
     let newDocument = (new DOMParser()).parseFromString(rawHtml, "text/html")
     let newHead = document.adoptNode(newDocument.head)
 
-    for (let child of newHead.children) {
+    // Take a static copy of the children. Appending a non-script asset moves it
+    // out of this document, and iterating the live collection while it shrinks
+    // would skip the asset right after it...
+    let children = [...newHead.children]
+
+    for (let child of children) {
         try {
             await runAssetSynchronously(child)
         } catch (error) {

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -70,10 +70,12 @@ class BaseComputed extends Attribute
 
         $closure = fn () => $this->evaluateComputed();
 
-        return match(Cache::supportsTags() && !empty($this->tags)) {
+        $value = match(Cache::supportsTags() && !empty($this->tags)) {
             true => Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
             default => Cache::remember($key, $this->seconds, $closure)
         };
+
+        return $this->resolveCachedValue($value, $closure);
     }
 
     protected function handleCachedGet()
@@ -82,10 +84,42 @@ class BaseComputed extends Attribute
 
         $closure = fn () => $this->evaluateComputed();
 
-        return match(Cache::supportsTags() && !empty($this->tags)) {
+        $value = match(Cache::supportsTags() && !empty($this->tags)) {
             true => Cache::tags($this->tags)->remember($key, $this->seconds, $closure),
             default => Cache::remember($key, $this->seconds, $closure)
         };
+
+        return $this->resolveCachedValue($value, $closure);
+    }
+
+    protected function resolveCachedValue($value, $closure)
+    {
+        $class = $this->findIncompleteClass($value);
+
+        if ($class === null) return $value;
+
+        if (config('app.debug')) {
+            logger()->warning(
+                "Livewire re-evaluated cached computed property [{$this->component->getName()}::{$this->getName()}] because Laravel could not unserialize [{$class}]. The value is correct, but it was not served from cache. Return a scalar or array, or add the class to [cache.serializable_classes]."
+            );
+        }
+
+        return $closure();
+    }
+
+    protected function findIncompleteClass($value)
+    {
+        if ($value instanceof \__PHP_Incomplete_Class) {
+            return ((array) $value)['__PHP_Incomplete_Class_Name'] ?? \__PHP_Incomplete_Class::class;
+        }
+
+        if (! is_array($value)) return null;
+
+        foreach ($value as $item) {
+            if ($class = $this->findIncompleteClass($item)) return $class;
+        }
+
+        return null;
     }
 
     protected function handlePersistedUnset()

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -13,6 +13,15 @@ use Livewire\Features\SupportEvents\BaseOn;
 
 class UnitTest extends TestCase
 {
+    protected function skipUnlessCacheSupportsSerializableClassRestrictions()
+    {
+        $constructor = new \ReflectionMethod(\Illuminate\Cache\ArrayStore::class, '__construct');
+
+        if ($constructor->getNumberOfParameters() < 2) {
+            $this->markTestSkipped('This Laravel version does not support cache serializable class restrictions.');
+        }
+    }
+
     function test_can_make_method_a_computed()
     {
         Livewire::test(new class extends TestComponent {
@@ -95,6 +104,144 @@ class UnitTest extends TestCase
             ->assertSetStrict('count', 2)
             ->call('$refresh')
             ->assertSetStrict('count', 4);
+    }
+
+    function test_cached_computed_property_is_recomputed_when_the_cached_value_cannot_be_unserialized()
+    {
+        $this->skipUnlessCacheSupportsSerializableClassRestrictions();
+
+        config()->set('app.debug', true);
+        config()->set('cache.serializable_classes', false);
+        config()->set('cache.stores.array.serialize', true);
+        Cache::purge('array');
+        Cache::setDefaultDriver('array');
+
+        $component = Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
+            #[Computed(cache: true)]
+            function foo() {
+                $this->count++;
+
+                return (object) ['bar' => 'baz'];
+            }
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $this->foo->bar }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobaz')
+            ->assertSetStrict('count', 1);
+
+        $logger = \Mockery::mock(\Psr\Log\LoggerInterface::class);
+        $logger->shouldReceive('warning')
+            ->once()
+            ->withArgs(fn ($message) => str_contains($message, '::foo]')
+                && str_contains($message, '[stdClass]')
+                && str_contains($message, 'was not served from cache'));
+        app()->instance('log', $logger);
+
+        $component->call('$refresh')
+            ->assertSee('foobaz')
+            ->assertSetStrict('count', 2);
+    }
+
+    function test_persisted_computed_property_is_recomputed_when_the_cached_value_cannot_be_unserialized()
+    {
+        $this->skipUnlessCacheSupportsSerializableClassRestrictions();
+
+        config()->set('cache.serializable_classes', false);
+        config()->set('cache.stores.array.serialize', true);
+        Cache::purge('array');
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
+            #[Computed(persist: true)]
+            function foo() {
+                $this->count++;
+
+                return (object) ['bar' => 'baz'];
+            }
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $this->foo->bar }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobaz')
+            ->assertSetStrict('count', 1)
+            ->call('$refresh')
+            ->assertSee('foobaz')
+            ->assertSetStrict('count', 2);
+    }
+
+    function test_persisted_computed_property_is_recomputed_when_an_array_it_returns_holds_a_value_that_cannot_be_unserialized()
+    {
+        $this->skipUnlessCacheSupportsSerializableClassRestrictions();
+
+        config()->set('cache.serializable_classes', false);
+        config()->set('cache.stores.array.serialize', true);
+        Cache::purge('array');
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
+            #[Computed(persist: true)]
+            function foo() {
+                $this->count++;
+
+                return ['bar' => (object) ['baz' => 'bob']];
+            }
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $this->foo['bar']->baz }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobob')
+            ->assertSetStrict('count', 1)
+            ->call('$refresh')
+            ->assertSee('foobob')
+            ->assertSetStrict('count', 2);
+    }
+
+    function test_cached_computed_property_is_not_recomputed_when_its_class_is_allowed_to_be_unserialized()
+    {
+        $this->skipUnlessCacheSupportsSerializableClassRestrictions();
+
+        config()->set('cache.serializable_classes', [\stdClass::class]);
+        config()->set('cache.stores.array.serialize', true);
+        Cache::purge('array');
+        Cache::setDefaultDriver('array');
+
+        Livewire::test(new class extends TestComponent {
+            public $count = 0;
+
+            #[Computed(cache: true)]
+            function foo() {
+                $this->count++;
+
+                return (object) ['bar' => 'baz'];
+            }
+
+            function render() {
+                return <<<'HTML'
+                    <div>foo{{ $this->foo->bar }}</div>
+                HTML;
+            }
+        })
+            ->assertSee('foobaz')
+            ->assertSetStrict('count', 1)
+            ->call('$refresh')
+            ->assertSee('foobaz')
+            ->assertSetStrict('count', 1);
     }
 
     function test_can_tag_cached_computed_property()

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -866,6 +866,67 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertEquals(['tenant', 'throttle:60,1'], $middleware);
     }
+
+    public function test_nested_uploads_survive_an_update_to_one_of_their_ancestor_paths()
+    {
+        $component = Livewire::test(NestedFileUploadComponent::class)
+            ->set('data.sections.first.rows.one.image', UploadedFile::fake()->image('one.jpg'))
+            ->set('data.sections.first.rows.two.image', UploadedFile::fake()->image('two.jpg'));
+
+        $one = $component->viewData('data')['sections']['first']['rows']['one']['image'];
+        $two = $component->viewData('data')['sections']['first']['rows']['two']['image'];
+
+        $component->set('data.sections.first', [
+            'rows' => [
+                'one' => ['image' => $one->serializeForLivewireResponse(), 'caption' => 'Updated'],
+                'two' => ['image' => $two->serializeForLivewireResponse(), 'caption' => ''],
+            ],
+        ]);
+
+        $rows = $component->viewData('data')['sections']['first']['rows'];
+
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $rows['one']['image']);
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $rows['two']['image']);
+        $this->assertEquals('one.jpg', $rows['one']['image']->getClientOriginalName());
+        $this->assertEquals('two.jpg', $rows['two']['image']->getClientOriginalName());
+        $this->assertEquals('Updated', $rows['one']['caption']);
+    }
+
+    public function test_a_row_added_alongside_a_nested_upload_doesnt_disturb_it()
+    {
+        $component = Livewire::test(NestedFileUploadComponent::class)
+            ->set('data.sections.first.rows.one.image', UploadedFile::fake()->image('one.jpg'));
+
+        $one = $component->viewData('data')['sections']['first']['rows']['one']['image'];
+
+        $component->set('data.sections.first', [
+            'rows' => [
+                'one' => ['image' => $one->serializeForLivewireResponse(), 'caption' => ''],
+                'three' => ['image' => null, 'caption' => 'New row'],
+            ],
+        ]);
+
+        $rows = $component->viewData('data')['sections']['first']['rows'];
+
+        $this->assertInstanceOf(TemporaryUploadedFile::class, $rows['one']['image']);
+        $this->assertEquals(['image' => null, 'caption' => 'New row'], $rows['three']);
+    }
+}
+
+class NestedFileUploadComponent extends TestComponent
+{
+    use WithFileUploads;
+
+    public $data = [
+        'sections' => [
+            'first' => [
+                'rows' => [
+                    'one' => ['image' => null, 'caption' => ''],
+                    'two' => ['image' => null, 'caption' => ''],
+                ],
+            ],
+        ],
+    ];
 }
 
 class DummyMiddleware

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -98,6 +98,30 @@ class UnitTest extends \Tests\TestCase
         $this->assertCount(1, $tmpFiles);
     }
 
+    public function test_can_remove_a_file_from_a_collection_of_files_property()
+    {
+        $file1 = UploadedFile::fake()->image('avatar1.jpg');
+        $file2 = UploadedFile::fake()->image('avatar2.jpg');
+
+        $component = Livewire::test(FileUploadComponent::class)
+            ->set('photos', [$file1, $file2]);
+
+        $tmpFiles = $component->viewData('photos');
+
+        // Convert the photos property into a Collection of TemporaryUploadedFile instances
+        $component->set('photos', collect($tmpFiles));
+
+        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $component->viewData('photos'));
+
+        $component->call('_removeUpload', 'photos', $tmpFiles[1]->getFilename())
+            ->assertDispatched('upload:removed', name: 'photos', tmpFilename: $tmpFiles[1]->getFilename());
+
+        $remainingFiles = $component->call('$refresh')->viewData('photos');
+
+        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $remainingFiles);
+        $this->assertCount(1, $remainingFiles);
+    }
+
     public function test_if_the_file_property_is_an_array_the_uploaded_file_will_append_to_the_array()
     {
         Storage::fake('avatars');

--- a/src/Features/SupportFileUploads/WithFileUploads.php
+++ b/src/Features/SupportFileUploads/WithFileUploads.php
@@ -88,17 +88,23 @@ trait WithFileUploads
     {
         $uploads = $this->getPropertyValue($name);
 
-        if (is_array($uploads) && isset($uploads[0]) && $uploads[0] instanceof TemporaryUploadedFile) {
+        $isCollection = $uploads instanceof \Illuminate\Support\Collection;
+
+        $items = $isCollection ? $uploads->all() : $uploads;
+
+        if (is_array($items) && isset($items[0]) && $items[0] instanceof TemporaryUploadedFile) {
             $this->dispatch('upload:removed', name: $name, tmpFilename: $tmpFilename)->self();
 
-            app('livewire')->updateProperty($this, $name, array_values(array_filter($uploads, function ($upload) use ($tmpFilename) {
+            $filtered = array_values(array_filter($items, function ($upload) use ($tmpFilename) {
                 if ($upload->getFilename() === $tmpFilename) {
                     $upload->delete();
                     return false;
                 }
 
                 return true;
-            })));
+            }));
+
+            app('livewire')->updateProperty($this, $name, $isCollection ? collect($filtered) : $filtered);
         } elseif ($uploads instanceof TemporaryUploadedFile && $uploads->getFilename() === $tmpFilename) {
             $uploads->delete();
 

--- a/src/Features/SupportReactiveProps/BaseReactive.php
+++ b/src/Features/SupportReactiveProps/BaseReactive.php
@@ -18,7 +18,7 @@ class BaseReactive extends LivewireAttribute
 
         store($this->component)->push('reactiveProps', $property);
 
-        $this->originalValueHash = crc32(json_encode($this->getValue()));
+        $this->originalValueHash = SupportReactiveProps::hashValue($this->getValue());
     }
 
     public function hydrate()
@@ -31,12 +31,12 @@ class BaseReactive extends LivewireAttribute
             $this->setValue($updatedValue);
         }
 
-        $this->originalValueHash = crc32(json_encode($this->getValue()));
+        $this->originalValueHash = SupportReactiveProps::hashValue($this->getValue());
     }
 
     public function dehydrate($context)
     {
-        if ($this->originalValueHash !== crc32(json_encode($this->getValue()))) {
+        if ($this->originalValueHash !== SupportReactiveProps::hashValue($this->getValue())) {
             throw new CannotMutateReactivePropException($this->component->getName(), $this->getName());
         }
 

--- a/src/Features/SupportReactiveProps/SupportReactiveProps.php
+++ b/src/Features/SupportReactiveProps/SupportReactiveProps.php
@@ -2,6 +2,8 @@
 
 namespace Livewire\Features\SupportReactiveProps;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use function Livewire\on;
 use Livewire\ComponentHook;
 
@@ -16,6 +18,29 @@ class SupportReactiveProps extends ComponentHook
         on('mount.stub', function ($tag, $id, $params, $parent, $key) {
             static::$pendingChildParams[$id] = $params;
         });
+    }
+
+    static function hashValue(mixed $value): ?string
+    {
+        if ($value instanceof Model) {
+            $class = $value::class;
+            $morphMap = Relation::morphMap();
+            $alias = in_array($class, $morphMap)
+                ? array_search($class, $morphMap, true)
+                : $class;
+
+            $payload = json_encode([
+                'class' => $alias,
+                'key' => $value->getKey(),
+                'attributes' => $value->getAttributes(),
+            ]);
+
+            return $payload === false ? null : (string) crc32($payload);
+        }
+
+        $json = json_encode($value);
+
+        return $json === false ? null : (string) crc32($json);
     }
 
     static function hasPassedInProps($id) {

--- a/src/Features/SupportReactiveProps/UnitTest.php
+++ b/src/Features/SupportReactiveProps/UnitTest.php
@@ -53,5 +53,66 @@ class UnitTest extends \Tests\TestCase
         $component->set('todos', ['todo 1', 'todo 2', 'todo 3']);
         $component->assertSee('Count: 3.');
     }
+
+    function test_accessing_lazy_loaded_relation_on_reactive_model_does_not_throw()
+    {
+        $article = ReactiveArticle::query()->first();
+
+        Livewire::test(new class extends Component {
+            #[BaseReactive]
+            public $article;
+
+            public function render()
+            {
+                return '<div>{{ $article->author->name }}</div>';
+            }
+        }, ['article' => $article])
+            ->assertSee('Ghabriel');
+    }
+
+    function test_mutating_reactive_model_attributes_still_throws()
+    {
+        $this->expectException(CannotMutateReactivePropException::class);
+
+        $article = ReactiveArticle::query()->first();
+
+        Livewire::test(new class extends Component {
+            #[BaseReactive]
+            public $article;
+
+            public function rename()
+            {
+                $this->article->title = 'Changed';
+            }
+
+            public function render()
+            {
+                return '<div></div>';
+            }
+        }, ['article' => $article])
+            ->call('rename');
+    }
 }
 
+class ReactiveAuthor extends \Illuminate\Database\Eloquent\Model
+{
+    use \Sushi\Sushi;
+
+    protected $rows = [
+        ['id' => 1, 'name' => 'Ghabriel'],
+    ];
+}
+
+class ReactiveArticle extends \Illuminate\Database\Eloquent\Model
+{
+    use \Sushi\Sushi;
+
+    protected $rows = [
+        ['id' => 1, 'title' => 'First', 'author_id' => 1],
+    ];
+
+    public function author()
+    {
+        return $this->belongsTo(ReactiveAuthor::class, 'author_id');
+    }
+}

--- a/src/Features/SupportScriptsAndAssets/BrowserTest.php
+++ b/src/Features/SupportScriptsAndAssets/BrowserTest.php
@@ -16,6 +16,14 @@ class BrowserTest extends \Tests\BrowserTestCase
                 return Utils::pretendResponseIsFile(__DIR__.'/non-livewire-asset.js');
             });
 
+            Route::get('/asset-stylesheet.css', function () {
+                return Utils::pretendResponseIsFile(__DIR__.'/asset-stylesheet.css', 'text/css');
+            });
+
+            Route::get('/asset-after-stylesheet.js', function () {
+                return Utils::pretendResponseIsFile(__DIR__.'/asset-after-stylesheet.js');
+            });
+
             Route::get('/non-livewire-assets', function () {
                 return Blade::render(<<< BLADE
                 <html>
@@ -222,6 +230,45 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->waitForTextIn('@output', 'foo')
         ->waitForLivewire()->click('@button')
         ->waitUntil('!! window.datePicker === true')
+        ;
+    }
+
+    public function test_assets_after_a_stylesheet_are_not_skipped()
+    {
+        // Assets are appended to the head one at a time. Non-script elements are
+        // moved out of the parsed document as they are appended, so iterating its
+        // live children collection skips whatever followed them, so the script
+        // after the stylesheet never ran.
+        Livewire::visit([new class extends \Livewire\Component {
+            public $load = false;
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button wire:click="$toggle('load')" dusk="button">Load assets</button>
+
+                <span dusk="output" x-text="'foo'"></span>
+
+                @if ($load)
+                    <livewire:child />
+                @endif
+            </div>
+            HTML; }
+        },
+        'child' => new class extends \Livewire\Component {
+            public function render() { return <<<'HTML'
+            <div>On child</div>
+
+            @assets
+                <link rel="stylesheet" type="text/css" href="/asset-stylesheet.css">
+                <script src="/asset-after-stylesheet.js"></script>
+            @endassets
+            HTML; }
+        },
+        ])
+        ->waitForTextIn('@output', 'foo')
+        ->waitForLivewire()->click('@button')
+        ->waitForText('On child')
+        ->waitUntil('!! window.assetAfterStylesheetLoaded === true')
         ;
     }
 

--- a/src/Features/SupportScriptsAndAssets/asset-after-stylesheet.js
+++ b/src/Features/SupportScriptsAndAssets/asset-after-stylesheet.js
@@ -1,0 +1,1 @@
+window.assetAfterStylesheetLoaded = true

--- a/src/Features/SupportScriptsAndAssets/asset-stylesheet.css
+++ b/src/Features/SupportScriptsAndAssets/asset-stylesheet.css
@@ -1,0 +1,1 @@
+/* Only here so that the asset before the script is a non-script element... */

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -239,7 +239,7 @@ class HandleComponents extends Mechanism
         });
     }
 
-    protected function hydratePropertyUpdate($valueOrTuple, $context, $path)
+    protected function hydratePropertyUpdate($valueOrTuple, $context, $path, $raw = null)
     {
         if (! Utils::isSyntheticTuple($value = $tuple = $valueOrTuple)) return $value;
 
@@ -252,8 +252,14 @@ class HandleComponents extends Mechanism
 
         $synth = $this->propertySynth($meta['s'], $context, $path);
 
-        return $synth->hydrate($value, $meta, function ($name, $child) {
-            return $child;
+        return $synth->hydrate($value, $meta, function ($name, $child) use ($context, $path, $raw) {
+            if ($raw === null || is_object($child)) return $child;
+
+            $childPath = "{$path}.{$name}";
+
+            if (! $childMeta = $this->getMetaForPath($raw, $childPath)) return $child;
+
+            return $this->hydratePropertyUpdate([$child, $childMeta], $context, $childPath, $raw);
         });
     }
 
@@ -380,7 +386,7 @@ class HandleComponents extends Mechanism
 
         // If we have meta data already for this property, let's use that to get a synth...
         if ($meta) {
-            return $this->hydratePropertyUpdate([$value, $meta], $context, $path);
+            return $this->hydratePropertyUpdate([$value, $meta], $context, $path, $raw);
         }
 
         // If we don't, let's check to see if it's a typed property and fetch the synth that way...

--- a/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
@@ -14,7 +14,7 @@ class EnumSynth extends Synth {
     }
 
     static function hydrateFromType($type, $value) {
-        if ($value === '') return null;
+        if ($value === null || $value === '') return null;
 
         return $type::from($value);
     }

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -30,6 +30,14 @@ class EnumUnitTest extends \Tests\TestCase
         $testable->updateProperty('status', 'Be excellent excellent to each other');
     }
 
+    public function test_nullable_public_property_can_be_updated_to_null_while_already_null()
+    {
+        Livewire::test(ComponentWithNullablePublicEnumCaster::class)
+            ->assertSetStrict('status', null)
+            ->updateProperty('status', null)
+            ->assertSetStrict('status', null);
+    }
+
     public function test_an_enum_can_be_validated()
     {
         Livewire::test(ComponentWithValidatedEnum::class)


### PR DESCRIPTION
## What changed

Backports fixes whose APIs and architecture exist on 3.x:

- assets following stylesheets are no longer skipped
- Collection upload removal
- recursive nested synthesizer hydration
- Laravel 13 computed-cache recovery
- nullable enum updates
- reactive Eloquent relation hashing

V4-only islands, SFC modules, route macros, and action-promise changes are intentionally excluded.

## Validation

- full 3.x unit suite: 927 tests / 2,974 assertions; 17 skipped, 3 incomplete
- focused asset browser regression passed
- production asset build passed