### PR TITLE
[3.x] Backport synth type validation

### DIFF
--- a/src/Mechanisms/HandleComponents/Synthesizers/CarbonSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CarbonSynth.php
@@ -47,6 +47,12 @@ class CarbonSynth extends Synth {
     function hydrate($value, $meta) {
         if ($value === '' || $value === null) return null;
 
-        return new static::$types[$meta['type']]($value);
+        $type = $meta['type'] ?? null;
+
+        if (! $type || ! isset(static::$types[$type])) {
+            throw new \Exception("Livewire: Type [{$type}] is not a valid DateTime type.");
+        }
+
+        return new static::$types[$type]($value);
     }
 }

--- a/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
@@ -29,7 +29,11 @@ class EnumSynth extends Synth {
     function hydrate($value, $meta) {
         if ($value === null || $value === '') return null;
 
-        $class = $meta['class'];
+        $class = $meta['class'] ?? null;
+
+        if (! $class || ! is_a($class, \BackedEnum::class, true)) {
+            throw new \Exception("Livewire: Class [{$class}] is not a valid Enum type.");
+        }
 
         return $class::from($value);
     }


### PR DESCRIPTION
Backports the Carbon and backed-enum metadata validation from 4.x so malformed synthesizer metadata fails with a controlled Livewire exception instead of an undefined-index or invalid-class error.

Source: #10541

Validation: 10 focused tests, 38 assertions.