### PR TITLE
Skip transitions for top-layer UI

### DIFF
--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -41,10 +41,10 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
         return callback()
     }
 
-    // Skip entirely if a modal dialog is already open (transitions behind
-    // a dialog are invisible to the user and the ::view-transition pseudo-
-    // elements would paint above the dialog during animation)...
-    if (document.querySelector('dialog:modal')) return callback()
+    // Skip entirely if a top-layer element is already open (transitions behind
+    // it are invisible to the user and the ::view-transition pseudo-elements
+    // would paint above it during animation)...
+    if (document.querySelector('dialog:modal, :popover-open')) return callback()
 
     // Set transition names right before the transition starts (not permanently)...
     setTransitionNames(fromEl, options)
@@ -95,12 +95,24 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
         clearTransitionNames(fromEl)
     }
 
-    // Watch for modal dialogs opening during the transition (e.g., via Alpine x-effect).
-    // ::view-transition pseudo-elements paint above the top layer, so elements with
-    // wire:transition would visually appear above dialog modals during animation.
-    // This observer catches showModal() the instant it sets the `open` attribute
-    // and skips the transition before the browser paints a frame...
-    let skipOnDialog = (transition) => {
+    // Watch for dialogs or popovers opening during the transition (e.g., via Alpine
+    // x-effect or a toast). ::view-transition pseudo-elements paint above the top
+    // layer, so the transition must be skipped before the browser paints a frame...
+    let skipOnTopLayer = (transition) => {
+        // Chromium rejects `ready` when skipTransition() is called. Consume that
+        // expected rejection so a deliberate policy skip is not reported as an error...
+        transition.ready.catch(() => {})
+
+        let onBeforeToggle = (event) => {
+            if (event.newState === 'open' && event.target.matches?.('dialog, [popover]')) {
+                transition.skipTransition()
+            }
+        }
+
+        document.addEventListener('beforetoggle', onBeforeToggle, true)
+
+        // Keep the attribute observer as a fallback for browsers that do not emit
+        // beforetoggle when a modal dialog is opened...
         let observer = new MutationObserver(() => {
             if (document.querySelector('dialog:modal')) {
                 transition.skipTransition()
@@ -114,24 +126,27 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
             subtree: true,
         })
 
-        transition.finished.finally(() => observer.disconnect())
+        transition.finished.finally(() => {
+            observer.disconnect()
+            document.removeEventListener('beforetoggle', onBeforeToggle, true)
+        }).catch(() => {})
     }
 
     try {
         let transition = document.startViewTransition(transitionConfig)
 
-        skipOnDialog(transition)
+        skipOnTopLayer(transition)
 
-        transition.finished.finally(cleanup)
+        transition.finished.finally(cleanup).catch(() => {})
 
         await transition.updateCallbackDone
     } catch (e) {
         // Firefox 144+ supports View Transitions but only with a callback, not a config object (no transition types support)
         let transition = document.startViewTransition(update)
 
-        skipOnDialog(transition)
+        skipOnTopLayer(transition)
 
-        transition.finished.finally(cleanup)
+        transition.finished.finally(cleanup).catch(() => {})
 
         await transition.updateCallbackDone
     }

--- a/src/Features/SupportTransitions/BrowserTest.php
+++ b/src/Features/SupportTransitions/BrowserTest.php
@@ -210,6 +210,71 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_transition_is_skipped_when_popover_opens_during_morph()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $items = ['Item A', 'Item B'];
+                public $showPopover = false;
+
+                public function openPopover()
+                {
+                    $this->showPopover = true;
+                }
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <style>
+                        ::view-transition-old(*) { animation: 2s ease-out fade-out; }
+                        ::view-transition-new(*) { animation: 2s ease-in fade-in; }
+                        @keyframes fade-out { to { opacity: 0; } }
+                        @keyframes fade-in { from { opacity: 0; } }
+                    </style>
+
+                    @foreach ($items as $index => $item)
+                        <div
+                            wire:transition="card-{{ $index }}"
+                            wire:key="item-{{ $index }}"
+                            dusk="card-{{ $index }}"
+                        >
+                            {{ $item }}
+                        </div>
+                    @endforeach
+
+                    <button wire:click="openPopover" dusk="open">Open</button>
+
+                    <div
+                        popover="manual"
+                        x-ref="popover"
+                        x-effect="
+                            if ($wire.showPopover) { if (!$refs.popover.matches(':popover-open')) $refs.popover.showPopover() }
+                        "
+                    >
+                        Popover Content
+                    </div>
+                </div>
+                HTML; }
+            }
+        )
+        ->tap(fn ($browser) => $browser->script(<<<'JS'
+            window.__transitionUnhandledRejection = null
+
+            window.addEventListener('unhandledrejection', event => {
+                window.__transitionUnhandledRejection = event.reason?.name
+            })
+        JS))
+        ->waitForLivewire()->click('@open')
+        ->waitUntil("document.querySelector('[popover]').matches(':popover-open')")
+
+        // Without the fix, the 2s view transition animations would still be playing
+        // and the transitioning elements would appear above the popover.
+        // With the fix, the transition is skipped the instant the popover opens...
+        ->assertScript('document.getAnimations().some(a => a.playState === "running")', false)
+        ->pause(50)
+        ->assertScript('window.__transitionUnhandledRejection', null)
+        ;
+    }
+
     public function test_can_transition_dynamic_component_swap()
     {
         $animationsRunning = 'document.getAnimations().some(a => a.playState === "running")';


### PR DESCRIPTION
Fixes livewire/flux#2740.

## What changed

- Skip a View Transition when a modal dialog or popover is already open.
- Listen for captured `beforetoggle` events and skip an active transition when a dialog or popover opens.
- Keep the existing dialog `open` attribute observer as a browser fallback.
- Consume the expected rejected View Transition promises after an intentional skip.
- Add a browser regression test using a native manual popover.

## Why

The browser's `::view-transition` pseudo-element overlay paints above the top layer. This means a Flux toast can be open as a popover but remain visually covered by a transitioning element until the animation finishes. CSS and z-index cannot change that ordering.

Livewire already skips transitions when modal dialogs open. This generalizes the same policy to popovers, so top-layer UI appears immediately while transitions without top-layer UI continue normally.

## Validation

- `npm run build`
- `composer test:browser -- --filter="SupportTransitions"` — 8 tests, 25 assertions
- Verified the original Flux toast scenario and a transition-only control in the local before/after playground
