### PR TITLE
Add static return type to page component view macros

### DIFF
--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -21,7 +21,7 @@ class SupportPageComponents extends ComponentHook
 
     static function registerLayoutViewMacros()
     {
-        View::macro('layoutData', function ($data = []) {
+        View::macro('layoutData', function ($data = []): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->mergeParams($data);
@@ -29,7 +29,7 @@ class SupportPageComponents extends ComponentHook
             return $this;
         });
 
-        View::macro('section', function ($section) {
+        View::macro('section', function ($section): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->slotOrSection = $section;
@@ -37,7 +37,7 @@ class SupportPageComponents extends ComponentHook
             return $this;
         });
 
-        View::macro('title', function ($title) {
+        View::macro('title', function ($title): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->mergeParams(['title' => $title]);
@@ -45,7 +45,7 @@ class SupportPageComponents extends ComponentHook
             return $this;
         });
 
-        View::macro('slot', function ($slot) {
+        View::macro('slot', function ($slot): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->slotOrSection = $slot;
@@ -53,7 +53,7 @@ class SupportPageComponents extends ComponentHook
             return $this;
         });
 
-        View::macro('extends', function ($view, $params = []) {
+        View::macro('extends', function ($view, $params = []): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->type = 'extends';
@@ -64,7 +64,7 @@ class SupportPageComponents extends ComponentHook
             return $this;
         });
 
-        View::macro('layout', function ($view, $params = []) {
+        View::macro('layout', function ($view, $params = []): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->type = 'component';
@@ -75,7 +75,7 @@ class SupportPageComponents extends ComponentHook
             return $this;
         });
 
-        View::macro('response', function (callable $callback) {
+        View::macro('response', function (callable $callback): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->response = $callback;


### PR DESCRIPTION
## Summary

`SupportPageComponents::registerLayoutViewMacros()` registers `title`,
`layout`, `extends`, `section`, `slot`, `layoutData`, and `response` as
macros on `Illuminate\View\View` to support the fluent
`$this->view()->title(...)->layout(...)` syntax used by
[page components](https://livewire.laravel.com/docs/4.x/pages). Every
closure already returns `$this` unconditionally, but none declare a
return type.

Because of that, static analysis tooling that resolves `Macroable`
macros by reflecting on the registered closure (e.g. Larastan's
`MacroMethodsClassReflectionExtension`) can find the method fine, but
resolves its return type as `mixed` instead of `View`/`static`, which
breaks type inference on the whole fluent chain.

## Fix

Add `: static` to each of the seven macro closures — matches what they
already return, no behavior change.

## Testing

- `php -l` on the changed file.
- Traced call sites in `interceptTheRenderOfTheComponentAndRetreiveTheLayoutConfiguration()`
  (`$view->layout(...)`, `$view->title(...)`) — unaffected, still just
  calls through `$this`.

## Context

Raised by [@calebdw](https://github.com/calebdw) here:
https://github.com/calebdw/larastan-livewire/pull/26#issuecomment-5331455444
— a downstream PHPStan extension package worked around the `mixed`
return type with a hand-maintained `MethodsClassReflectionExtension`
duplicating these seven signatures; fixing the return type here removes
the need for that duplication entirely, since Larastan already resolves
`View::macro()` calls during app bootstrap.