### PR TITLE
[4.x] Fix resetting component properties unsets form object

### DIFF
--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -82,6 +82,14 @@ trait InteractsWithProperties
                     $isInitialized = false;
                 }
             } else {
+                // Form objects are typed and have no default, so they appear
+                // uninitialized on a fresh instance. Reset their internal state
+                // instead of unsetting the property.
+                if (isset($this->{$property}) && is_subclass_of($this->{$property}, Form::class)) {
+                    $this->{$property}->reset();
+                    continue;
+                }
+
                 $isInitialized = (new \ReflectionProperty($freshInstance, (string) $property))->isInitialized($freshInstance);
             }
 

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -1105,6 +1105,49 @@ class UnitTest extends \Tests\TestCase
             ->assertSetStrict('form.status', 'active')
         ;
     }
+
+    public function test_resetting_component_does_not_unset_form_object()
+    {
+        Livewire::test(new class extends TestComponent {
+            public PostFormStubWithDefaults $form;
+
+            public $other = 'keep';
+
+            public function resetAll()
+            {
+                $this->reset();
+            }
+
+            public function resetFormProperty()
+            {
+                $this->reset('form');
+            }
+        })
+            ->assertSetStrict('form.title', 'foo')
+            ->assertSetStrict('form.content', 'bar')
+            ->set('form.title', 'Some Title')
+            ->set('form.content', 'Some content...')
+            ->set('other', 'changed')
+            ->assertSetStrict('form.title', 'Some Title')
+            ->assertSetStrict('form.content', 'Some content...')
+            ->assertSetStrict('other', 'changed')
+            // $this->reset() must reset form fields to their defaults, not unset the form
+            ->call('resetAll')
+            ->assertSetStrict('form.title', 'foo')
+            ->assertSetStrict('form.content', 'bar')
+            ->assertSetStrict('other', 'keep')
+            ->assertSetStrict('form', fn ($form) => $form instanceof PostFormStubWithDefaults)
+            // $this->reset('form') must do the same
+            ->set('form.title', 'Another Title')
+            ->set('form.content', 'More content...')
+            ->assertSetStrict('form.title', 'Another Title')
+            ->assertSetStrict('form.content', 'More content...')
+            ->call('resetFormProperty')
+            ->assertSetStrict('form.title', 'foo')
+            ->assertSetStrict('form.content', 'bar')
+            ->assertSetStrict('form', fn ($form) => $form instanceof PostFormStubWithDefaults)
+        ;
+    }
 }
 
 class PostFormStub extends Form

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -1137,11 +1137,11 @@ class UnitTest extends \Tests\TestCase
             ->assertSetStrict('form.content', 'bar')
             ->assertSetStrict('other', 'keep')
             ->assertSetStrict('form', fn ($form) => $form instanceof PostFormStubWithDefaults)
-            // $this->reset('form') must do the same
             ->set('form.title', 'Another Title')
             ->set('form.content', 'More content...')
             ->assertSetStrict('form.title', 'Another Title')
             ->assertSetStrict('form.content', 'More content...')
+            // $this->reset('form') must do the same
             ->call('resetFormProperty')
             ->assertSetStrict('form.title', 'foo')
             ->assertSetStrict('form.content', 'bar')


### PR DESCRIPTION
## Affected version
- 3.x (Backport)
- 4.x (Current PR)

## Problem

Calling `$this->reset()` (or `$this->reset('form')`) on a component that has a form object property unsets the form instead of resetting its fields. Form objects are declared as typed properties with no default:

```php
public MyForm $form;
```

`reset()` builds a fresh component instance and checks whether each property is initialized. Because the form property is uninitialized on that fresh instance, it hits:

```php
if (! $isInitialized) {
    data_forget($this, (string) $property);
    continue;
}
```
and the form object is removed. Accessing `$this->form` afterwards throws `Livewire\Exceptions\PropertyNotFoundException`.

Minimal snippet to reproduce the issue

**Form**
```php
<?php

namespace App\Livewire\Forms;

use Livewire\Form;

class MyForm extends Form
{
    public $title = 'My Title';
}
```

**Component**
```php
<?php

use App\Livewire\Forms\MyForm;
use Livewire\Component;

new class extends Component
{
    public MyForm $form;

    public function save()
    {
        $this->reset();
    }
};
```

```blade
<div>
    <div>{{ $form->title }}</div>
    <button wire:click="save">Save</button>
</div>
```

## Solution

When resetting a top-level property that is a form object, call its `reset()` method instead of unsetting it:

```php
if (isset($this->{$property}) && is_subclass_of($this->{$property}, Form::class)) {
    $this->{$property}->reset();
    continue;
}
```
This matches the existing dotted-path behaviour and leaves other uninitialized properties unchanged.

## Test

Added a regression test covering both `$this->reset()` and `$this->reset('form')`, asserting the form object remains intact and its fields are restored to defaults.

Fixes: https://github.com/livewire/livewire/discussions/9449