### PR TITLE
[4.x] Fix typed-return conflict in Livewire redirector

### DIFF
--- a/src/Features/SupportRedirects/BrowserTest.php
+++ b/src/Features/SupportRedirects/BrowserTest.php
@@ -168,6 +168,60 @@ class BrowserTest extends BrowserTestCase
             ;
         });
     }
+
+    public function test_redirect_helper_with_flash_persists_on_destination_page()
+    {
+        config()->set('session.driver', 'file');
+
+        Route::get('/redirect', RedirectComponent::class)->middleware('web');
+
+        Livewire::visit([
+            new class extends Component {
+                public function doRedirect()
+                {
+                    return redirect('/redirect')->with('alert', 'Session flash data');
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="doRedirect" dusk="button">Do redirect</button>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->waitForLivewire()->click('@button')
+            ->waitForTextIn('@session-message', 'Session flash data');
+    }
+
+    public function test_redirect_to_with_flash_persists_on_destination_page()
+    {
+        config()->set('session.driver', 'file');
+
+        Route::get('/redirect', RedirectComponent::class)->middleware('web');
+
+        Livewire::visit([
+            new class extends Component {
+                public function doRedirect()
+                {
+                    return redirect()->to('/redirect')->with('alert', 'Session flash data');
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="doRedirect" dusk="button">Do redirect</button>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->waitForLivewire()->click('@button')
+            ->waitForTextIn('@session-message', 'Session flash data');
+    }
 }
 
 class RedirectComponent extends Component {

--- a/src/Features/SupportRedirects/Redirector.php
+++ b/src/Features/SupportRedirects/Redirector.php
@@ -13,23 +13,12 @@ class Redirector extends BaseRedirector
     {
         $this->component->redirect($this->generator->to($path, [], $secure));
 
-        return $this;
+        return parent::to($path, $status, $headers, $secure);
     }
 
     public function away($path, $status = 302, $headers = [])
     {
         return $this->to($path, $status, $headers);
-    }
-
-    public function with($key, $value = null)
-    {
-        $key = is_array($key) ? $key : [$key => $value];
-
-        foreach ($key as $k => $v) {
-            $this->session->flash($k, $v);
-        }
-
-        return $this;
     }
 
     public function component(Component $component)

--- a/src/Features/SupportRedirects/UnitTest.php
+++ b/src/Features/SupportRedirects/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportRedirects;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
@@ -226,6 +227,55 @@ class UnitTest extends \Tests\TestCase
         $this->assertNull(session()->get('foo'));
     }
 
+    public function test_redirect_helper_returns_redirect_response_instance()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $return = $component->instance()->triggerRedirectHelper();
+
+        $this->assertInstanceOf(RedirectResponse::class, $return);
+        $this->assertEquals(url('foo'), $component->effects['redirect'] ?? $return->getTargetUrl());
+    }
+
+    public function test_redirect_helper_to_method_returns_redirect_response_instance()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $return = $component->instance()->triggerRedirectHelperUsingTo();
+
+        $this->assertInstanceOf(RedirectResponse::class, $return);
+    }
+
+    public function test_redirect_helper_route_method_returns_redirect_response_instance()
+    {
+        $this->registerNamedRoute();
+
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $return = $component->instance()->triggerRedirectHelperUsingRoute();
+
+        $this->assertInstanceOf(RedirectResponse::class, $return);
+    }
+
+    public function test_typed_redirect_response_return_does_not_throw()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerTypedRedirectResponse');
+
+        $this->assertEquals(url('foo'), $component->effects['redirect']);
+    }
+
+    public function test_redirect_helper_to_then_with_flashes_session()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectHelperUsingToThenWith');
+
+        $this->assertEquals(url('foo'), $component->effects['redirect']);
+        $this->assertEquals('livewire-is-awesome', Session::get('success'));
+    }
+
     protected function registerNamedRoute()
     {
         Route::get('foo', function () {
@@ -276,6 +326,21 @@ class TriggersRedirectStub extends TestComponent
         return redirect('foo')->with([
             'success' => 'livewire-is-awesome'
         ]);
+    }
+
+    public function triggerRedirectHelperUsingTo()
+    {
+        return redirect()->to('foo');
+    }
+
+    public function triggerTypedRedirectResponse(): RedirectResponse
+    {
+        return redirect('foo');
+    }
+
+    public function triggerRedirectHelperUsingToThenWith()
+    {
+        return redirect()->to('foo')->with('success', 'livewire-is-awesome');
     }
 
     public function triggerRedirectFacadeUsingTo()

--- a/src/Features/SupportRedirects/UnitTest.php
+++ b/src/Features/SupportRedirects/UnitTest.php
@@ -233,7 +233,7 @@ class UnitTest extends \Tests\TestCase
 
         $component->runAction('triggerRedirectHelper');
 
-        $this->assertEquals(url('foo'), $component->effects['redirect']);
+        $component->assertRedirect('/foo');
     }
 
     public function test_redirect_helper_returns_redirect_response_instance()
@@ -253,6 +253,7 @@ class UnitTest extends \Tests\TestCase
         $return = $component->instance()->triggerRedirectHelperUsingTo();
 
         $this->assertInstanceOf(RedirectResponse::class, $return);
+        $this->assertEquals(url('foo'), $return->getTargetUrl());
     }
 
     public function test_redirect_helper_route_method_returns_redirect_response_instance()
@@ -264,6 +265,7 @@ class UnitTest extends \Tests\TestCase
         $return = $component->instance()->triggerRedirectHelperUsingRoute();
 
         $this->assertInstanceOf(RedirectResponse::class, $return);
+        $this->assertEquals(route('foo'), $return->getTargetUrl());
     }
 
     public function test_typed_redirect_response_return_does_not_throw()
@@ -272,7 +274,7 @@ class UnitTest extends \Tests\TestCase
 
         $component->runAction('triggerTypedRedirectResponse');
 
-        $this->assertEquals(url('foo'), $component->effects['redirect']);
+        $component->assertRedirect('/foo');
     }
 
     public function test_redirect_helper_to_then_with_flashes_session()
@@ -281,7 +283,8 @@ class UnitTest extends \Tests\TestCase
 
         $component->runAction('triggerRedirectHelperUsingToThenWith');
 
-        $this->assertEquals(url('foo'), $component->effects['redirect']);
+        $component->assertRedirect('/foo');
+
         $this->assertEquals('livewire-is-awesome', Session::get('success'));
     }
 

--- a/src/Features/SupportRedirects/UnitTest.php
+++ b/src/Features/SupportRedirects/UnitTest.php
@@ -227,6 +227,15 @@ class UnitTest extends \Tests\TestCase
         $this->assertNull(session()->get('foo'));
     }
 
+    public function test_redirect_helper_preserves_redirect_effects()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectHelper');
+
+        $this->assertEquals(url('foo'), $component->effects['redirect']);
+    }
+
     public function test_redirect_helper_returns_redirect_response_instance()
     {
         $component = Livewire::test(TriggersRedirectStub::class);
@@ -234,7 +243,7 @@ class UnitTest extends \Tests\TestCase
         $return = $component->instance()->triggerRedirectHelper();
 
         $this->assertInstanceOf(RedirectResponse::class, $return);
-        $this->assertEquals(url('foo'), $component->effects['redirect'] ?? $return->getTargetUrl());
+        $this->assertEquals(url('foo'), $return->getTargetUrl());
     }
 
     public function test_redirect_helper_to_method_returns_redirect_response_instance()


### PR DESCRIPTION
## Affected version
- 3.x (Backport)
- 4.x (Current PR)

## Problem
`Livewire\Features\SupportRedirects\Redirector` overrides `to()` (and related methods) to return `$this` instead of an `Illuminate\Http\RedirectResponse`. This violates the return type of the parent `Illuminate\Routing\Redirector` and causes:

- Custom exception handler that convert the exception into redirect will throw `ErrorException: Undefined property \Livewire\Features\SupportRedirects\Redirector::$headers`
- TypeErrors when a method is typed as `RedirectResponse`
- Static-analysis / IDE / Larastan complaints when typed as `Livewire\Redirector`
- Friction for shared code, middleware, exception handlers, and action classes that expect a real response

## Solution
After recording the Livewire redirect effect, still return a real `RedirectResponse` created via the parent’s `to()`. Behaviour for Livewire components is unchanged; the declared contract is restored.

## Tests
- Browser tests for flash session persisted on redirect
- Unit tests to assert return type is `RedirectResponse` and redirect effects preserved
  - intentionally use `assertRedirect()` instead `$this->assertEquals()` because `assertRedirect($url)` already assert redirect effects

Related discussions: https://github.com/livewire/livewire/issues/1658, https://github.com/livewire/livewire/discussions/9245