### PR TITLE
Fix Laravel 10 enum cast test

### DIFF
--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -1319,12 +1319,9 @@ class PostForFormObjectTesting extends Model
         ],
     ];
 
-    protected function casts(): array
-    {
-        return [
-            'status' => FormEnumStub::class,
-        ];
-    }
+    protected $casts = [
+        'status' => FormEnumStub::class,
+    ];
 }
 
 class FormWithLiveValidation extends Form


### PR DESCRIPTION
## What changed

Use the Eloquent `$casts` property in the form-object test fixture instead of the `casts()` method.

## Why

Laravel 10 does not support model casts declared through `casts()`, so the newly added enum-cast test fails across the Laravel 10 CI matrix even though the production behavior is correct. The `$casts` property works across all supported Laravel versions.

## Validation

- Targeted form-object tests pass under Laravel 10 / PHP 8.4: 2 tests, 8 assertions.
- Full Laravel 10 unit suite reaches the relevant test successfully; unrelated asset tests require the workflow-built `dist` artifacts that are absent from the fresh clone.