### PR TITLE
[4.x] Fix casted Eloquent attributes bypassing validation under legacy model binding

### DIFF
--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -7,6 +7,7 @@ use Illuminate\Database\ClassMorphViolationException;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Livewire\Drawer\Utils;
 
 class EloquentModelSynth extends Synth
 {
@@ -91,6 +92,31 @@ class EloquentModelSynth extends Synth
         $this->setDataOnModel($model, $data);
 
         return $model;
+    }
+
+    public function unwrapForValidation($model)
+    {
+        $values = $model->toArray();
+        $attributes = $model->getAttributes();
+
+        foreach ($model->getCasts() as $key => $cast) {
+            if (! is_string($cast) || ! array_key_exists($key, $attributes)) continue;
+
+            $cast = strtolower($cast);
+
+            $isScalar = in_array($cast, [
+                'int', 'integer',
+                'real', 'float', 'double',
+                'bool', 'boolean',
+                'timestamp',
+            ], true) || str_starts_with($cast, 'decimal:');
+
+            if ($isScalar) {
+                $values[$key] = $attributes[$key];
+            }
+        }
+
+        return $values;
     }
 
     public function get(&$target, $key)

--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -104,8 +104,8 @@ class EloquentModelSynth extends Synth
             $casted = $values[$key];
 
             if (
-                is_numeric($attribute)
-                && is_numeric($casted)
+                is_scalar($attribute)
+                && is_scalar($casted)
                 && $attribute != $casted
             ) {
                 $values[$key] = $attribute;

--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -99,20 +99,17 @@ class EloquentModelSynth extends Synth
         $values = $model->toArray();
         $attributes = $model->getAttributes();
 
-        foreach ($model->getCasts() as $key => $cast) {
-            if (! is_string($cast) || ! array_key_exists($key, $attributes)) continue;
+        foreach ($attributes as $key => $attribute) {
+            if (! array_key_exists($key, $values)) continue;
 
-            $cast = strtolower($cast);
+            $casted = $values[$key];
 
-            $isScalar = in_array($cast, [
-                'int', 'integer',
-                'real', 'float', 'double',
-                'bool', 'boolean',
-                'timestamp',
-            ], true) || str_starts_with($cast, 'decimal:');
-
-            if ($isScalar) {
-                $values[$key] = $attributes[$key];
+            if (
+                is_numeric($attribute)
+                && is_numeric($casted)
+                && $attribute != $casted
+            ) {
+                $values[$key] = $attribute;
             }
         }
 

--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -7,7 +7,6 @@ use Illuminate\Database\ClassMorphViolationException;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Livewire\Drawer\Utils;
 
 class EloquentModelSynth extends Synth
 {

--- a/src/Features/SupportLegacyModels/Tests/ModelValidationBrowserTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelValidationBrowserTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Livewire\Features\SupportLegacyModels\Tests;
+
+use Illuminate\Validation\ValidationException;
+use Laravel\Dusk\Browser;
+use LegacyTests\Browser\TestCase;
+
+class ModelValidationBrowserTest extends TestCase
+{
+    use Concerns\EnableLegacyModels;
+
+    public function test_validating_casted_model_attribute_throws_validation_exception_on_wrong_value_type()
+    {
+        $this->browse(function (Browser $browser) {
+            $this->visitLivewireComponent($browser, ModelValidationComponent::class)
+                ->assertValue('@age', '40')
+                ->type('@age', '32.5')
+                ->assertValue('@age', '32.5')
+                ->waitForLivewire()->click('@save')
+                ->assertSeeIn('@message', 'The age field must be an integer.');
+        });
+    }
+}
+
+class ModelValidationUser extends \Illuminate\Database\Eloquent\Model
+{
+    use \Sushi\Sushi;
+
+    protected $guarded = [];
+
+    protected $rows = [
+        ['id' => 1, 'name' => 'Bob', 'age' => 40],
+    ];
+
+    protected $casts = ['age' => 'integer'];
+}
+
+class ModelValidationComponent extends \Livewire\Component
+{
+    public ?ModelValidationUser $foo;
+
+    protected $rules = [
+        'foo.age' => 'required|integer'
+    ];
+
+    public function mount()
+    {
+        $this->foo = ModelValidationUser::first();
+    }
+
+    public function save()
+    {
+        $this->validate();
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+            <div>
+                <input dusk="age" wire:model="foo.age" />
+                <button dusk="save" wire:click="save">Save</button>
+                @error('foo.age')
+                    <div dusk="message">{{ $message }}</div>
+                @enderror
+            </div>
+        HTML;
+    }
+}

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -515,8 +515,17 @@ trait HandlesValidation
 
             $synth = app('livewire')->findSynth($value, $this);
 
-            if ($synth && method_exists($synth, 'unwrapForValidation')) return $synth->unwrapForValidation($value);
-            else if ($value instanceof Arrayable) return $value->toArray();
+            if ($synth && method_exists($synth, 'unwrapForValidation')) {
+                return $synth->unwrapForValidation($value);
+            }
+
+            if ($value instanceof Model) {
+                return $value->getAttributes();
+            }
+
+            if ($value instanceof Arrayable) {
+                return $value->toArray();
+            }
 
             return $value;
         })->all();

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -515,17 +515,8 @@ trait HandlesValidation
 
             $synth = app('livewire')->findSynth($value, $this);
 
-            if ($synth && method_exists($synth, 'unwrapForValidation')) {
-                return $synth->unwrapForValidation($value);
-            }
-
-            if ($value instanceof Model) {
-                return $value->getAttributes();
-            }
-
-            if ($value instanceof Arrayable) {
-                return $value->toArray();
-            }
+            if ($synth && method_exists($synth, 'unwrapForValidation')) return $synth->unwrapForValidation($value);
+            else if ($value instanceof Arrayable) return $value->toArray();
 
             return $value;
         })->all();


### PR DESCRIPTION
## Affected version
- 3.x (Backport)
- 4.x (Current PR)

## Summary

When validating nested Eloquent model properties (especially with **legacy model binding**), Livewire prepared validation data via `Model::toArray()`, which applies attribute **casts**. That meant user input could be mutated before the validator ran—for example `32.5` on an `integer`-cast field became `32`, so `integer` rules passed incorrectly.

This delegate unwraps models to `EloquentModelSynth` (legacy models) instead of `toArray()` (casted values), so validation sees the values the user actually submitted.

## The problem

Minimal snippet to reprocude the issue
```blade
<div>
    <input wire:model="user.age" />
    <button wire:click="save">Save</button>
</div>
```

```php
'legacy_model_binding' => true,
```

```php
<?php

use App\Models\User;
use Livewire\Component;

new class extends Component
{
    public User $user;

    protected function rules(): array
    {
        return [
            'user.age' => 'required|integer'
        ];
    }

    public function save()
    {
        $this->validate(); // this is actually passed the validation

        $this->user->save();
    }
};
```
1. User enters `32.5` into `wire:model="user.age"`.
2. On `$this->validate()`, data was unwrapped with `$model->toArray()`.
3. Cast turned `32.5` → `32` **before** the validator ran.
4. The `integer` rule passed even though the input was not an integer.

## Solution

In `HandlesValidation::unwrapDataForValidation()`:
- Prefer **validate before cast**
- Prefer synthesizer `unwrapForValidation()` when available.
- For `Model` instances, delegate to `EloquentModelSynth` legacy models instead of falling through to `Arrayable::toArray()`
- Keep existing `Arrayable` behavior for other values.

## What is not fully covered
1. **Boolean soft values** — `'yes'`, `'true'`, `''` often won’t restore because of PHP’s loose `!=` with `true/false`.
2. **Float type-only changes** — `'3.14'` vs `3.14` not restored (`!=` is false).
3. **Dates** — only if raw string ≠ serialized casted string.
4. **Custom `CastsAttributes`** — if casted form is an object, `is_scalar(casted)` is false → keep casted (same idea as the synth’s dehydrate path for class casts).
5. **Any rule that expects the post-cast representation** (e.g. already-rounded decimal) — may now see pre-cast input instead.

Fixes: https://github.com/livewire/livewire/discussions/3400