### PR TITLE
Fix wire action collisions with Alpine scope variables

### DIFF
--- a/js/evaluator.js
+++ b/js/evaluator.js
@@ -65,7 +65,7 @@ export function evaluateReactiveExpression(el, expression, options = {}) {
 export function evaluateActionExpression(el, expression, options = {}) {
     if (! expression || expression.trim() === '') return
 
-    let contextualExpression = contextualizeExpression(expression, el)
+    let contextualExpression = contextualizeExpression(expression, el, ! isEvaluatingReactiveExpression())
 
     try {
         let result = Alpine.evaluateRaw(el, contextualExpression, options)
@@ -88,31 +88,53 @@ function reportExpressionError(error, expression, el) {
     console.error(error)
 }
 
-export function contextualizeExpression(expression, el) {
+export function contextualizeExpression(expression, el, preferWireAction = false) {
     let SKIP = ['JSON', 'true', 'false', 'null', 'undefined', 'this', '$wire', '$event']
+    let alpineScopeKeys = []
 
     // If an element is provided, collect Alpine scope keys between
     // this element and the Livewire component root so they don't
     // get incorrectly prefixed with $wire.
     if (el) {
-        SKIP.push(...getAlpineScopeKeys(el))
+        alpineScopeKeys = getAlpineScopeKeys(el)
+        SKIP.push(...alpineScopeKeys)
     }
-    let strings = []
+    let protectedExpressions = []
 
-    // 1. Yank out string literals so we don't touch them
-    let result = expression.replace(/(["'`])(?:(?!\1)[^\\]|\\.)*\1/g, (m) => {
-        strings.push(m)
-        return `___${strings.length - 1}___`
+    let actionTargetOffset = preferWireAction
+        ? getActionTargetOffset(expression)
+        : null
+
+    // 1. Yank out string literals and comments so we don't touch them
+    let result = expression.replace(/(["'`])(?:(?!\1)[^\\]|\\.)*\1|\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, (m) => {
+        protectedExpressions.push(m)
+        return `___${protectedExpressions.length - 1}___`
     })
 
     // 2. Prefix identifiers not after a dot (skip placeholders from step 1)
     //    Also skip object keys (identifiers immediately followed by colon)
     result = result.replace(/(^|[^.\w$])(\$?[a-zA-Z_]\w*)/g, (m, pre, ident, offset) => {
-        if (SKIP.includes(ident) || /^___\d+___$/.test(ident)) return pre + ident
+        let isWireActionTarget = alpineScopeKeys.includes(ident)
+            && offset + pre.length === actionTargetOffset
+
+        if ((SKIP.includes(ident) && ! isWireActionTarget) || /^___\d+___$/.test(ident)) return pre + ident
         if (result[offset + m.length] === ':') return pre + ident
         return pre + '$wire.' + ident
     })
 
-    // 3. Restore strings
-    return result.replace(/___(\d+)___/g, (m, i) => strings[i])
+    // 3. Restore strings and comments
+    return result.replace(/___(\d+)___/g, (m, i) => protectedExpressions[i])
+}
+
+function getActionTargetOffset(expression) {
+    let actionTarget = expression.match(/^(\s*)([a-zA-Z_]\w*)/)
+
+    if (! actionTarget) return null
+
+    let remainder = expression.slice(actionTarget[0].length)
+    let significantRemainder = remainder.replace(/^(?:(?:\s+)|(?:\/\*[\s\S]*?\*\/)|(?:\/\/[^\n]*(?:\n|$)))*/, '')
+
+    if (significantRemainder !== '' && ! significantRemainder.startsWith('(') && ! significantRemainder.startsWith(';')) return null
+
+    return actionTarget[1].length
 }

--- a/js/evaluator.spec.js
+++ b/js/evaluator.spec.js
@@ -52,6 +52,20 @@ describe('Contextualize expressions', () => {
         expect(contextualizeExpression('index', mockEl)).toBe('index')
     })
 
+    it('wire action targets take precedence over alpine scope variables', () => {
+        let mockEl = {
+            _x_dataStack: [{ open: false, save: false, user: {} }],
+            hasAttribute: () => false,
+            parentElement: null,
+        }
+
+        expect(contextualizeExpression('open(user)', mockEl, true)).toBe('$wire.open(user)')
+        expect(contextualizeExpression('save', mockEl, true)).toBe('$wire.save')
+        expect(contextualizeExpression('save;', mockEl, true)).toBe('$wire.save;')
+        expect(contextualizeExpression('open /* comment */ (user)', mockEl, true)).toBe('$wire.open /* comment */ (user)')
+        expect(contextualizeExpression('open = !open', mockEl, true)).toBe('open = !open')
+    })
+
     it('nested alpine scopes', () => {
         let parentEl = {
             _x_dataStack: [{ user: {} }],

--- a/src/Features/SupportJsEvaluation/BrowserTest.php
+++ b/src/Features/SupportJsEvaluation/BrowserTest.php
@@ -509,6 +509,50 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_wire_actions_take_precedence_over_nested_alpine_scope_variables()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $result = 'initial';
+
+                public function open($id) {
+                    $this->result = 'opened '.$id;
+                }
+
+                public function save() {
+                    $this->result = 'saved';
+                }
+
+                public function render() {
+                    return <<<'HTML'
+                        <div>
+                            <div x-data="{ open: false }">
+                                <button wire:click="open(1)" dusk="open">Open</button>
+                            </div>
+
+                            <form wire:submit="save;" x-data="{ save: false }">
+                                <button type="submit" dusk="save">Save</button>
+                            </form>
+
+                            <div x-data="{ open: 'alpine' }">
+                                <span wire:text="open" dusk="reactive"></span>
+                            </div>
+
+                            <span dusk="output">{{ $result }}</span>
+                        </div>
+                    HTML;
+                }
+            }
+        )
+        ->assertSeeIn('@output', 'initial')
+        ->assertSeeIn('@reactive', 'alpine')
+        ->waitForLivewire()->click('@open')
+        ->assertSeeIn('@output', 'opened 1')
+        ->waitForLivewire()->click('@save')
+        ->assertSeeIn('@output', 'saved')
+        ;
+    }
+
     public function test_parent_alpine_scope_does_not_leak_into_child_wire_click()
     {
         Livewire::visit([


### PR DESCRIPTION
Fixes #10558.

## Problem

When a `wire:*` action name collided with a nested Alpine scope variable, the contextual evaluator left the action Alpine-scoped. For example, `wire:click="open(1)"` inside `x-data="{ open: false }"` attempted to call the boolean instead of the Livewire component method.

## Fix

Prefer the leading target of non-reactive `wire:*` action expressions over colliding Alpine scope keys, while preserving Alpine scope resolution for action parameters and reactive directives such as `wire:text` and `wire:show`. The target detection also handles bare statements, semicolons, and comments.

## Verification

- `npm run test:run` (110 passed, 1 skipped)
- `vendor/bin/phpunit --configuration phpunit.xml.dist src/Features/SupportJsEvaluation/BrowserTest.php` (20 passed, 29 assertions)