### PR TITLE
Ignore repeated lazy-load calls

### DIFF
--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -108,7 +108,12 @@ class SupportLazyLoading extends ComponentHook
     public function hydrate($memo)
     {
         if (! isset($memo['lazyLoaded'])) return;
-        if ($memo['lazyLoaded'] === true) return;
+
+        if ($memo['lazyLoaded'] === true) {
+            $this->storeSet('isLazyLoadAlreadyLoaded', true);
+
+            return;
+        }
 
         $this->component->skipHydrate();
 
@@ -120,7 +125,10 @@ class SupportLazyLoading extends ComponentHook
         if ($this->storeGet('isLazyLoadMounting') === true) {
             $context->addMemo('lazyLoaded', false);
             $context->addMemo('lazyIsolated', $this->storeGet('isLazyIsolated'));
-        } elseif ($this->storeGet('isLazyLoadHydrating') === true) {
+        } elseif (
+            $this->storeGet('isLazyLoadHydrating') === true
+            || $this->storeGet('isLazyLoadAlreadyLoaded') === true
+        ) {
             $context->addMemo('lazyLoaded', true);
         }
     }
@@ -129,6 +137,13 @@ class SupportLazyLoading extends ComponentHook
     function call($method, $params, $returnEarly)
     {
         if ($method !== '__lazyLoad') return;
+
+        // Ignore repeat calls after the component has already been loaded.
+        if ($this->storeGet('isLazyLoadAlreadyLoaded') === true) {
+            $returnEarly();
+
+            return;
+        }
 
         // Only applies while a lazy load is being resumed.
         if ($this->storeGet('isLazyLoadHydrating') !== true) return;

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -7,6 +7,7 @@ use Livewire\Attributes\Defer;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Lazy;
 use Livewire\Component;
+use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Livewire;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
 
@@ -90,6 +91,38 @@ class UnitTest extends \Tests\TestCase
             ->assertSee('level:5');
     }
 
+    public function test_a_repeat_lazy_load_call_is_ignored_after_the_component_has_loaded()
+    {
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        Livewire::component('lazy-alpha', LazyAlpha::class);
+
+        $component = Livewire::test('lazy-alpha', ['level' => 5]);
+
+        preg_match("/__lazyLoad\('([^']+)'\)/", html_entity_decode($component->html()), $matches);
+
+        $component
+            ->call('__lazyLoad', $matches[1])
+            ->assertSee('level:5')
+            ->call('__lazyLoad', $matches[1])
+            ->assertSee('level:5')
+            ->assertSee('mounts:1')
+            ->call('__lazyLoad', $matches[1])
+            ->assertSee('level:5')
+            ->assertSee('mounts:1');
+    }
+
+    public function test_a_lazy_load_call_on_a_non_lazy_component_is_not_claimed()
+    {
+        $this->expectException(MethodNotFoundException::class);
+
+        Livewire::test(new class extends Component {
+            public function render() {
+                return '<div></div>';
+            }
+        })->call('__lazyLoad', 'invalid');
+    }
+
     public function test_a_mount_params_container_is_scoped_to_its_own_component()
     {
         SupportLazyLoading::$disableWhileTesting = false;
@@ -111,9 +144,11 @@ class UnitTest extends \Tests\TestCase
 #[Lazy]
 class LazyAlpha extends Component {
     public $level = 0;
+    public $mounts = 0;
 
     public function mount($level = 0) {
         $this->level = $level;
+        $this->mounts++;
     }
 
     public function placeholder() {
@@ -121,7 +156,7 @@ class LazyAlpha extends Component {
     }
 
     public function render() {
-        return '<div>level:'.$this->level.'</div>';
+        return '<div>level:'.$this->level.' mounts:'.$this->mounts.'</div>';
     }
 }
 
@@ -181,4 +216,3 @@ class PageWithCustomLayoutOnView extends Component {
         return view('show-name', ['name' => 'foo'])->layout('components.layouts.custom');
     }
 }
-


### PR DESCRIPTION
## What changed

- Ignore repeated `__lazyLoad` calls after a lazy component has already loaded
- Preserve the `lazyLoaded: true` state across subsequent snapshots
- Keep ordinary non-lazy `__lazyLoad` calls unclaimed
- Verify mount runs only once across consecutive replays

## Why

A late or repeated internal lazy-load call currently falls through to normal method dispatch after the component has loaded, causing a `MethodNotFoundException` and a full-screen error dialog.

Discussion: https://github.com/livewire/livewire/discussions/10557

## Verification

- Lazy-loading and component-security unit suites: 31 tests, 44 assertions
- Existing focused lazy-loading browser test: 1 test, 2 assertions
- Real Laravel reproduction: three consecutive replays ignored, mount count remains one, no exception dialog
- `git diff --check`