### PR TITLE
[4.x] Fix browser events dispatched by an update firing before the morph inserts their target

### DIFF
--- a/js/features/supportDispatches.js
+++ b/js/features/supportDispatches.js
@@ -1,26 +1,57 @@
 import { dispatch, dispatchEl, dispatchRef, dispatchSelf, dispatchTo } from '@/events'
 import { on } from '@/hooks'
+import { interceptMessage } from '@/request'
 
-on('effect', ({ component, effects }) => {
-    // Wrapping this in a triple queueMicrotask...
-    // The first one puts it after all other "effect" hooks...
-    // The second one puts it after all reactive Alpine effects
-    // (that are processed via flushJobs in scheduler)...
-    // The third one puts it after morph changes have been applied...
+// Dispatches coming back from a server round-trip are anchored to the message's own
+// post-morph hook instead of a detached queueMicrotask chain. `Message.invokeOnMorph()`
+// awaits each interceptor's `onMorph()` serially, in registration order, and this file
+// is imported AFTER `supportIslands` and `supportMorphDom` in `features/index.js`, so by
+// the time this callback runs the new HTML has already been morphed into the DOM —
+// post-morph, but still pre-paint.
+//
+// The ordering is load-bearing for two reasons: element-targeted dispatches (`->el()` /
+// `->ref()`) resolve their target by querying the component's element at dispatch time,
+// and even a bubbling `dispatch()` only reaches listeners that are already bound — both
+// fail silently for an element this same update rendered if the event fires before the
+// morph.
+//
+// Note the converse: `supportSlots` is imported later still, so its slot-fragment morphs
+// have not yet run when this fires — events targeting elements inside a freshly rendered
+// slot are still subject to the original race.
+interceptMessage(({ message, onSuccess }) => {
+    onSuccess(({ payload, onMorph }) => {
+        onMorph(() => {
+            dispatchEvents(message.component, getDispatches(payload.effects))
+        })
+    })
+})
+
+// Effects that don't originate from a message never reach the interceptor above — the
+// only such case is the initial page load, where `store.js` calls `processEffects()`
+// without a request. Those mount-time dispatches still go out from here.
+//
+// Wrapping this in a triple queueMicrotask...
+// The first one puts it after all other "effect" hooks...
+// The second one puts it after all reactive Alpine effects
+// (that are processed via flushJobs in scheduler)...
+// The third one puts it after morph changes have been applied...
+on('effect', ({ component, effects, request }) => {
+    if (request) return
+
     queueMicrotask(() => {
         queueMicrotask(() => {
             queueMicrotask(() => {
-                let dispatches = []
-
-                if (Object.prototype.hasOwnProperty.call(effects, 'dispatches') && effects.dispatches) {
-                    dispatches = effects.dispatches
-                }
-
-                dispatchEvents(component, dispatches)
+                dispatchEvents(component, getDispatches(effects))
             })
         })
     })
 })
+
+function getDispatches(effects) {
+    if (! Object.prototype.hasOwnProperty.call(effects, 'dispatches')) return []
+
+    return effects.dispatches || []
+}
 
 function dispatchEvents(component, dispatches) {
     dispatches.forEach(({ name, params = {}, self = false, component: componentName, ref, el }) => {

--- a/src/Features/SupportEvents/BrowserTest.php
+++ b/src/Features/SupportEvents/BrowserTest.php
@@ -559,4 +559,103 @@ class BrowserTest extends BrowserTestCase
             ->click('@button')
             ->waitForTextIn('@output', 'baz');
     }
+
+    public function test_events_dispatched_alongside_newly_rendered_elements_are_received()
+    {
+        // Regression: livewire/livewire#10560 — when a single update both
+        // renders a brand-new element AND dispatches a browser event in the
+        // same round-trip, the event must not be fired before the morph has
+        // inserted that new element into the DOM (e.g. a Flux modal that is
+        // shown and opened in one click).
+        Livewire::visit(new class extends Component {
+            public $show = false;
+
+            function openPanel()
+            {
+                $this->show = true;
+
+                $this->dispatch('panel-opened');
+            }
+
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="openPanel" dusk="button">Open</button>
+
+                    @if ($show)
+                        <div x-data="{ message: 'closed' }" x-on:panel-opened.window="message = 'opened'">
+                            <span x-text="message" dusk="output"></span>
+                        </div>
+                    @endif
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewire()->click('@button')
+            ->waitForTextIn('@output', 'opened');
+    }
+
+    public function test_events_dispatched_to_a_newly_rendered_element_are_received()
+    {
+        // Regression: livewire/livewire#10560 — element-targeted dispatch
+        // (the exact mechanism Flux uses to show + open a modal in one
+        // round-trip) resolves its target via querySelectorAll at dispatch
+        // time, so it must also wait until after the morph has inserted the
+        // new element.
+        Livewire::visit(new class extends Component {
+            public $show = false;
+
+            function openPanel()
+            {
+                $this->show = true;
+
+                $this->dispatch('panel-opened')->el('#target');
+            }
+
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="openPanel" dusk="button">Open</button>
+
+                    @if ($show)
+                        <div id="target" x-data="{ message: 'closed' }" x-on:panel-opened="message = 'opened'">
+                            <span x-text="message" dusk="output"></span>
+                        </div>
+                    @endif
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewire()->click('@button')
+            ->waitForTextIn('@output', 'opened');
+    }
+
+    public function test_events_dispatched_during_mount_are_received_on_initial_page_load()
+    {
+        // Regression: livewire/livewire#10560 — dispatches that happen during
+        // mount() go out on initial page load, not through a message
+        // round-trip, so they never reach the interceptor in
+        // supportDispatches.js and instead take the `on('effect', ...)`
+        // fallback path guarded by `if (request) return`.
+        Livewire::visit(new class extends Component {
+            function mount()
+            {
+                $this->dispatch('mounted');
+            }
+
+            function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <div x-data="{ message: 'waiting' }" x-on:mounted.window="message = 'received'">
+                        <span x-text="message" dusk="output"></span>
+                    </div>
+                </div>
+                HTML;
+            }
+        })
+            ->waitForTextIn('@output', 'received');
+    }
 }


### PR DESCRIPTION
Fixes #10560

## Root cause

#10529 (commit `785465b7`, shipped in v4.4.1) changed `Message.invokeOnMorph()` to a serial `for … await interceptor.onMorph()` loop. Every `interceptMessage()` registration contributes a default no-op `async () => {}` `onMorph`, and each serial await burns a microtask generation — so `supportDispatches`' triple-`queueMicrotask` deferral now flushes before `supportMorphDom`'s interceptor morphs the DOM. Events targeting elements rendered by the same update are silently lost: `->el()`/`->ref()` dispatches resolve their target via `querySelectorAll` at dispatch time, and even bubbling dispatches only reach listeners already bound. Under 4.4.0's `Promise.all`, the morph mutated the DOM synchronously before any microtask flushed.

Concrete symptom: a Flux modal rendered and shown in one round-trip never opens.

## The fix

In `js/features/supportDispatches.js` only — message-driven effects now dispatch from the message's own `onMorph` hook (post-morph, pre-paint; `supportDispatches` is imported after `supportIslands` and `supportMorphDom`, and `invokeOnMorph()` awaits in registration order, so it runs after the DOM changes apply). The triple-queueMicrotask path is kept for request-less effects (initial page load via `store.js`), guarded by `if (request) return`. This restores the 4.4.0 contract — existing tests from #9933 already depend on post-morph dispatch.

## Tests

Three browser tests in `src/Features/SupportEvents/BrowserTest.php`:

1. Window listener on an element rendered by the same update that dispatches.
2. `->el('#target')` targeting an element rendered by the same update (the exact Flux mechanism — non-bubbling).
3. Mount-time dispatch on initial page load (covers the request-less fallback path).

Tests 1–2 fail on current `4.x` HEAD via wait timeout, pass with the fix. Full `SupportEvents` and `SupportIslands` browser suites and the vitest suite pass (`SupportIslands` protects #10529's island behavior). Also verified end-to-end against the repro app from #10560 (passes patched, fails on v4.4.1).

## Behavior notes

Deliberate edge-behavior changes, worth reviewer eyes:

- A message cancelled between effect-processing and the morph no longer fires its dispatches.
- If an earlier interceptor's `onMorph` throws, dispatches are dropped along with the rest of the morph pipeline — and conversely a throw during dispatch now propagates out of `invokeOnMorph()` (skipping `invokeOnRender`), though DOM listener exceptions don't propagate out of `dispatchEvent()` so userland handlers can't trigger that.
- Global `interceptMessage` `onMorph` callbacks registered by userland now run after dispatches — component-scoped interceptors (`$wire.$intercept`) still run before, since the registry orders component-scoped interceptors first.

## Separate pre-existing observation (not addressed here)

`supportSlots.js` uses a fire-and-forget `fragments.forEach(async …)` in its `onMorph`, so it resolves before its slot morphs complete; additionally `supportSlots` is imported after `supportDispatches`, so events targeting elements inside a freshly rendered slot fragment remain subject to the pre-existing race. Happy to file a separate issue.

## Note

`dist/` intentionally not included, per contributor convention.
