### PR TITLE
Recover only the model update that caused a failed request

### DIFF
--- a/js/component.js
+++ b/js/component.js
@@ -1,4 +1,4 @@
-import { dataSet, deepClone, diff, diffAndConsolidate, diffAndPatchRecursive, extractData} from '@/utils'
+import { dataDelete, dataGet, dataSet, deepClone, deeplyEqual, diff, diffAndConsolidate, diffAndPatchRecursive, extractData} from '@/utils'
 import { generateWireObject } from '@/$wire'
 import { findComponentByEl, findComponent, hasComponent } from '@/store'
 import { trigger } from '@/hooks'
@@ -126,6 +126,26 @@ export class Component {
         let propertiesDiff = diffAndConsolidate(this.canonical, this.ephemeral)
 
         return this.mergeQueuedUpdates(propertiesDiff)
+    }
+
+    revertUpdates(updates) {
+        Object.entries(updates).forEach(([path, { exists, value }]) => {
+            let currentValue = dataGet(this.ephemeral, path)
+            let stillMatchesSentValue = exists
+                ? deeplyEqual(currentValue, value)
+                : currentValue === undefined
+
+            // Preserve a newer edit made while the failed request was in flight...
+            if (! stillMatchesSentValue) return
+
+            let canonicalValue = dataGet(this.canonical, path)
+
+            if (canonicalValue === undefined) {
+                dataDelete(this.reactive, path)
+            } else {
+                dataSet(this.reactive, path, deepClone(canonicalValue))
+            }
+        })
     }
 
     applyUpdates(object, updates) {

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -267,6 +267,7 @@ function sendMessages() {
         request.messages.forEach(message => {
             message.snapshot = message.component.getEncodedSnapshotWithLatestChildrenMergedIn()
             message.updates = message.component.getUpdates()
+            message.captureModelUpdates()
             message.calls = Array.from(message.actions).map(i => ({
                 method: i.name,
                 params: i.params,

--- a/js/request/message.js
+++ b/js/request/message.js
@@ -1,9 +1,11 @@
 import { MessageInterceptor } from "./interceptor"
+import { dataGet, deepClone } from "@/utils"
 
 export default class Message {
     actions = new Set()
     snapshot = null
     updates = null
+    modelUpdates = {}
     calls = null
     payload = null
     responsePayload = null
@@ -31,6 +33,35 @@ export default class Message {
 
     constructor(component) {
         this.component = component
+    }
+
+    captureModelUpdates() {
+        let capture = action => {
+            let directive = action.origin?.directive
+
+            if (directive?.value !== 'model' || ! directive.expression) return
+
+            let path = directive.expression.replace(/^\$parent\./, '')
+            let wasSent = Object.keys(this.updates).some(updatePath => {
+                return updatePath === path
+                    || updatePath.startsWith(`${path}.`)
+                    || path.startsWith(`${updatePath}.`)
+            })
+
+            if (! wasSent) return
+
+            let value = dataGet(this.component.ephemeral, path)
+
+            this.modelUpdates[path] = {
+                exists: value !== undefined,
+                value: value === undefined ? null : deepClone(value),
+            }
+        }
+
+        this.actions.forEach(action => {
+            capture(action)
+            action.squashedActions.forEach(capture)
+        })
     }
 
     addAction(action) {
@@ -174,6 +205,11 @@ export default class Message {
 
         // Invoke action-level onError callbacks
         Array.from(this.actions).forEach(action => action.invokeOnError({ response, body, preventDefault }))
+
+        // Only revert the model values that directly initiated this request.
+        // Other dirty state may have been bundled into the same message and
+        // must remain untouched when an action or render fails...
+        if (! this.isCancelled()) this.component.revertUpdates(this.modelUpdates)
 
         // Try to parse body as JSON for the rejection payload
         let json = null

--- a/src/Features/SupportErrorResponses/BrowserTest.php
+++ b/src/Features/SupportErrorResponses/BrowserTest.php
@@ -49,6 +49,110 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_only_the_model_that_started_a_failed_request_is_reverted()
+    {
+        Livewire::visit(new class extends BaseComponent {
+            public $count = 0;
+            public $form = [
+                'name' => '',
+                'notes' => '',
+            ];
+
+            public function updatedForm($value, $key)
+            {
+                if ($key === 'name' || ($key === null && $value['name'] !== '')) {
+                    abort(500);
+                }
+            }
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input dusk="name" wire:model.live="form.name" />
+                    <input dusk="notes" wire:model="form.notes" />
+
+                    <button dusk="increment" wire:click="increment">Increment</button>
+
+                    <span dusk="count">{{ $count }}</span>
+                </div>
+                HTML;
+            }
+        })
+            // This deferred draft will be bundled into the failed model request...
+            ->type('@notes', 'Keep this draft')
+            ->type('@name', 'x')
+            ->waitFor('#livewire-error')
+            ->keys('#livewire-error', '{escape}')
+            ->waitUntilMissing('#livewire-error')
+            // Revert only the model that initiated the request...
+            ->assertValue('@name', '')
+            ->assertValue('@notes', 'Keep this draft')
+            // The rejected model is no longer replayed and unrelated state can sync...
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '1')
+            ->assertValue('@notes', 'Keep this draft')
+            ->pause(100)
+            ->assertMissing('#livewire-error')
+        ;
+    }
+
+    public function test_deferred_form_values_survive_a_failed_action()
+    {
+        Livewire::visit(new class extends BaseComponent {
+            public $count = 0;
+            public $first = '';
+            public $last = '';
+
+            public function save()
+            {
+                abort(500);
+            }
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input dusk="first" wire:model="first" />
+                    <input dusk="last" wire:model="last" />
+
+                    <button dusk="save" wire:click="save">Save</button>
+                    <button dusk="increment" wire:click="increment">Increment</button>
+
+                    <span dusk="count">{{ $count }}</span>
+                </div>
+                HTML;
+            }
+        })
+            ->type('@first', 'Ada')
+            ->type('@last', 'Lovelace')
+            ->click('@save')
+            ->waitFor('#livewire-error')
+            ->keys('#livewire-error', '{escape}')
+            ->waitUntilMissing('#livewire-error')
+            // An action error says nothing about whether these updates were accepted...
+            ->assertValue('@first', 'Ada')
+            ->assertValue('@last', 'Lovelace')
+            // A different action can accept the drafts and continue normally...
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '1')
+            ->assertValue('@first', 'Ada')
+            ->assertValue('@last', 'Lovelace')
+            ->pause(100)
+            ->assertMissing('#livewire-error')
+        ;
+    }
+
     public function test_it_does_not_show_html_modal_after_session_expired_dialog()
     {
         if (app()->version() >= '13') {


### PR DESCRIPTION
## What changed

When a `wire:model.live` update receives an HTTP error, the rejected value remains dirty and is resent with later requests. That can leave an otherwise healthy component unable to make progress.

This captures only the model values whose directives directly initiated the failed message. If one of those values has not changed again while the request was in flight, it is restored to the last server-confirmed value.

## Deliberate boundary

A Livewire message may bundle unrelated deferred input with the action that triggered the request. An error response does not prove all of that input was rejected, so this PR does not roll back the entire update payload.

- Deferred values bundled into a failed model request remain in the UI.
- A custom action or render failure does not discard bundled form input.
- Validation responses are successful Livewire responses and remain unaffected.
- Network failures keep local changes available for retry.
- A newer edit made while a request is in flight is preserved.
- Promise rejection behavior is unchanged.

This is intentionally narrower than #10438, which was reverted in 9a5fee98a0a3f22aaede8f3a8d9a1fde9ea3e51e.

## Verification

- `npm run build`
- `npm run test:run` — 110 passed, 1 skipped
- `composer test:browser -- src/Features/SupportErrorResponses/BrowserTest.php` — 7 passed/skipped as expected, 22 assertions
- Real Laravel playground: rejected live model recovers; a later action succeeds; all 13 deferred form fields survive an action-level 500; newer in-flight edits survive
