### PR TITLE
[4.x] Only unwrap validated property, object, `Arrayable`, and Wireable siblings in `validateOnly`

### DIFF
--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -514,7 +514,7 @@ trait HandlesValidation
         return collect($data)->map(function ($value, $key) use ($property) {
             // Performance: skip siblings, Laravel can already traverse via Arr::get
             // (scalars + ArrayAccess like Collection / Model). Still unwrap Wireables
-            // and other non-Arrayables so nested dependent rules work
+            // and other non-ArrayAccess Arrayables so nested dependent rules work
             // (e.g. required_if:settings.mode,strict).
             if (
                 ! is_null($property)

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -381,7 +381,7 @@ trait HandlesValidation
 
         $ruleKeysToShorten = $this->getModelAttributeRuleKeysToShorten($data, $rules);
 
-        $data = $this->unwrapDataForValidation($data);
+        $data = $this->unwrapDataForValidation($data, $property);
 
         // If a matching rule is found, then filter collections down to keys specified in the field,
         // while leaving all other data intact. If a key isn't specified and instead there is a
@@ -509,9 +509,10 @@ trait HandlesValidation
         return Utils::getPublicPropertiesDefinedOnSubclass($this);
     }
 
-    protected function unwrapDataForValidation($data)
+    protected function unwrapDataForValidation($data, $property = null)
     {
-        return collect($data)->map(function ($value) {
+        return collect($data)->map(function ($value, $key) use ($property) {
+            if (! is_null($property) && $key !== $property) return $value;
 
             $synth = app('livewire')->findSynth($value, $this);
 

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -512,7 +512,17 @@ trait HandlesValidation
     protected function unwrapDataForValidation($data, $property = null)
     {
         return collect($data)->map(function ($value, $key) use ($property) {
-            if (! is_null($property) && $key !== $property) return $value;
+            // Performance: skip siblings, Laravel can already traverse via Arr::get
+            // (scalars + ArrayAccess like Collection / Model). Still unwrap Wireables
+            // and other non-Arrayables so nested dependent rules work
+            // (e.g. required_if:settings.mode,strict).
+            if (
+                ! is_null($property)
+                && $key !== $property
+                && (! is_object($value) || $value instanceof \ArrayAccess)
+            ) {
+                return $value;
+            }
 
             $synth = app('livewire')->findSynth($value, $this);
 

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -1036,6 +1036,51 @@ class UnitTest extends \Tests\TestCase
 
         $component->assertOnlyHasErrors(['foo' => 'min', 'bar' => 'min']);
     }
+
+    public function test_validate_only_skips_unwrapping_arrayable_siblings()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $title = 'ab';
+            public $sibling;
+
+            public function mount()
+            {
+                $this->sibling = collect([['id' => 1]]);
+            }
+
+            public function runValidateOnly()
+            {
+                $this->withValidator(function ($validator) {
+                    return $validator->getData()['sibling'] instanceof Collection;
+                })->validateOnly('title', [
+                    'title' => 'required|min:3',
+                ]);
+            }
+        })->call('runValidateOnly')->assertOnlyHasErrors(['title']);
+    }
+
+    public function test_validate_still_unwraps_arrayable_siblings()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $title = 'ok';
+            public $sibling;
+
+            public function mount()
+            {
+                $this->sibling = collect([['id' => 1]]);
+            }
+
+            public function runValidate()
+            {
+                $this->withValidator(function ($validator) {
+                    return is_array($validator->getData()['sibling']);
+                })->validate([
+                    'title' => 'required',
+                    'sibling' => 'required',
+                ]);
+            }
+        })->call('runValidate')->assertHasNoErrors(['title', 'sibling']);
+    }
 }
 
 class ComponentWithRulesProperty extends TestComponent


### PR DESCRIPTION
## Summary

`validateOnly()` currently runs `unwrapDataForValidation()` over **every** public property on the component or form object, even when only one field is being validated.

Unwrapping is only required for the property under validation (models / `Arrayable` / synth `unwrapForValidation`). Sibling scalars needed by rules like `same`, `confirmed`, or `required_if` are already plain values and do not need unwrapping.

This change passes the field’s root property into `unwrapDataForValidation()` from `validateOnly()` so unrelated properties are left alone. Full `validate()` behaviour is unchanged.

## Changes

- `unwrapDataForValidation($data, $property = null)` — when `$property` is set, only that key is unwrapped
- `validateOnly()` passes `(string) str($field)->before('.')` defined as `$property`
- `validate()` still calls `unwrapDataForValidation($data)` with no second argument

Related discussion: https://github.com/livewire/livewire/discussions/9416

## Benchmark test (not included in this PR)

```php
public function test_benchmark_validate_only_with_heavy_property()
{
    $component = Livewire::test(HeavyValidateOnlyComponent::class);

    $iterations = 2000;

    $start = hrtime(true);

    for ($i = 0; $i < $iterations; $i++) {
        try {
            $component->instance()->validateOnly('title');
        } catch (\Illuminate\Validation\ValidationException $e) {
            // ignore — we only care about unwrap cost
        }
    }

    $ms = (hrtime(true) - $start) / 1e6;

    dump(sprintf(
        'validateOnly x%d: %.2f ms (%.3f ms/call)',
        $iterations,
        $ms,
        $ms / $iterations
    ));

    $this->assertTrue(true);
}

class HeavyValidateOnlyComponent extends \Livewire\Component
{
    public $title = 'ab'; // fails min:3 so validation actually runs

    public $heavy;

    protected $rules = [
        'title' => 'required|min:3',
    ];

    public function mount()
    {
        // Arrayable path in unwrapDataForValidation
        $this->heavy = collect(range(1, 10_000))->map(fn ($i) => [
            'id' => $i,
            'name' => 'row-'.$i,
        ]);
    }

    public function render()
    {
        return '<div></div>';
    }
}
```

## Benchmark result

Component with a large unrelated `Collection` and `validateOnly('title')`, 2000 iterations, 5 runs :

| Run | Before | After |
|-----|--------|-------|
| 1 | 43124.92 ms (21.562 ms/call) | 1145.18 ms (0.573 ms/call) |
| 2 | 38404.66 ms (19.202 ms/call) | 1159.87 ms (0.580 ms/call) |
| 3 | 38168.06 ms (19.084 ms/call) | 1111.19 ms (0.556 ms/call) |
| 4 | 43080.27 ms (21.540 ms/call) | 1048.08 ms (0.524 ms/call) |
| 5 | 39143.12 ms (19.572 ms/call) | 1115.41 ms (0.558 ms/call) |
| **avg** | **40384.21 ms (20.192 ms/call)** | **1115.95 ms (0.558 ms/call)** |

About **36× faster** per `validateOnly` call on this workload (~97% less time). Full `validate()` is unchanged.