### PR TITLE
[4.x] Improve Eloquent models restoration on subsequent request

### DIFF
--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -77,21 +77,37 @@ class EloquentCollectionSynth extends Synth {
         }
 
         return $this->makeLazyProxy($class, $meta, function () use ($modelClass, $keys, $meta) {
-            // We are using Laravel's method here for restoring the collection, which ensures
-            // that all models in the collection are restored in one query, preventing n+1
-            // issues and also only restores models that exist.
-            $collection = (new $modelClass)->newQueryForRestoration($keys)->useWritePdo()->get();
+            $mechanism = app(PersistentMiddleware::class);
+
+            // Reuse models already loaded in this request (route binding or ModelSynth).
+            $missing = [];
+            foreach ($keys as $key) {
+                if (! $mechanism->getResolvedRouteModel($modelClass, $key)) {
+                    $missing[] = $key;
+                }
+            }
+
+            $collection = collect();
+
+            if (count($missing) > 0) {
+                // We are using Laravel's method here for restoring the collection, which ensures
+                // that all models in the collection are restored in one query, preventing n+1
+                // issues and also only restores models that exist.
+                $collection = (new $modelClass)->newQueryForRestoration($missing)->useWritePdo()->get();
+
+                // Cache every model so individual ModelSynth hydrates can reuse them.
+                foreach ($collection as $model) {
+                    $mechanism->rememberResolvedModel($model);
+                }
+            }
 
             $collection = $collection->keyBy->getKey();
 
-            // Cache every model so individual ModelSynth hydrates can reuse them.
-            foreach ($collection as $model) {
-                app(PersistentMiddleware::class)->rememberResolvedModel($model);
-            }
-
             return new $meta['class'](
-                collect($meta['keys'])->map(function ($id) use ($collection) {
-                    return $collection[$id] ?? null;
+                collect($keys)->map(function ($id) use ($mechanism, $modelClass, $collection) {
+                    return $mechanism->getResolvedRouteModel($modelClass, $id)
+                        ?? $collection[$id]
+                        ?? null;
                 })->filter()
             );
         });

--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -87,16 +87,18 @@ class EloquentCollectionSynth extends Synth {
                 }
             }
 
-            $missingKeys = count($missingKeys) > 0 ? $missingKeys : $keys;
+            $collection = collect();
 
-            // We are using Laravel's method here for restoring the collection, which ensures
-            // that all models in the collection are restored in one query, preventing n+1
-            // issues and also only restores models that exist.
-            $collection = (new $modelClass)->newQueryForRestoration($missingKeys)->useWritePdo()->get();
+            if (count($missingKeys) > 0) {
+                // We are using Laravel's method here for restoring the collection, which ensures
+                // that all models in the collection are restored in one query, preventing n+1
+                // issues and also only restores models that exist.
+                $collection = (new $modelClass)->newQueryForRestoration($missingKeys)->useWritePdo()->get();
 
-            // Cache every model so individual ModelSynth hydrates can reuse them.
-            foreach ($collection as $model) {
-                $mechanism->rememberResolvedModel($model);
+                // Cache every model so individual ModelSynth hydrates can reuse them.
+                foreach ($collection as $model) {
+                    $mechanism->rememberResolvedModel($model);
+                }
             }
 
             $collection = $collection->keyBy->getKey();

--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -97,7 +97,7 @@ class EloquentCollectionSynth extends Synth {
 
                 // Cache every model so individual ModelSynth hydrates can reuse them.
                 foreach ($collection as $model) {
-                    $mechanism->rememberResolvedModel($model->withoutRelations());
+                    $mechanism->rememberResolvedModel($model);
                 }
             }
 

--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -97,7 +97,7 @@ class EloquentCollectionSynth extends Synth {
 
                 // Cache every model so individual ModelSynth hydrates can reuse them.
                 foreach ($collection as $model) {
-                    $mechanism->rememberResolvedModel($model);
+                    $mechanism->rememberResolvedModel($model->withoutRelations());
                 }
             }
 

--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -7,6 +7,7 @@ use Livewire\Mechanisms\HandleComponents\ComponentContext;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
 
 class EloquentCollectionSynth extends Synth {
     use SerializesAndRestoresModelIdentifiers, IsLazy;
@@ -82,6 +83,11 @@ class EloquentCollectionSynth extends Synth {
             $collection = (new $modelClass)->newQueryForRestoration($keys)->useWritePdo()->get();
 
             $collection = $collection->keyBy->getKey();
+
+            // Cache every model so individual ModelSynth hydrates can reuse them.
+            foreach ($collection as $model) {
+                app(PersistentMiddleware::class)->rememberResolvedModel($model);
+            }
 
             return new $meta['class'](
                 collect($meta['keys'])->map(function ($id) use ($collection) {

--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -80,31 +80,29 @@ class EloquentCollectionSynth extends Synth {
             $mechanism = app(PersistentMiddleware::class);
 
             // Reuse models already loaded in this request (route binding or ModelSynth).
-            $missing = [];
+            $missingKeys = [];
             foreach ($keys as $key) {
                 if (! $mechanism->getResolvedRouteModel($modelClass, $key)) {
-                    $missing[] = $key;
+                    $missingKeys[] = $key;
                 }
             }
 
-            $collection = collect();
+            $missingKeys = count($missingKeys) > 0 ? $missingKeys : $keys;
 
-            if (count($missing) > 0) {
-                // We are using Laravel's method here for restoring the collection, which ensures
-                // that all models in the collection are restored in one query, preventing n+1
-                // issues and also only restores models that exist.
-                $collection = (new $modelClass)->newQueryForRestoration($missing)->useWritePdo()->get();
+            // We are using Laravel's method here for restoring the collection, which ensures
+            // that all models in the collection are restored in one query, preventing n+1
+            // issues and also only restores models that exist.
+            $collection = (new $modelClass)->newQueryForRestoration($missingKeys)->useWritePdo()->get();
 
-                // Cache every model so individual ModelSynth hydrates can reuse them.
-                foreach ($collection as $model) {
-                    $mechanism->rememberResolvedModel($model);
-                }
+            // Cache every model so individual ModelSynth hydrates can reuse them.
+            foreach ($collection as $model) {
+                $mechanism->rememberResolvedModel($model);
             }
 
             $collection = $collection->keyBy->getKey();
 
             return new $meta['class'](
-                collect($keys)->map(function ($id) use ($mechanism, $modelClass, $collection) {
+                collect($meta['keys'])->map(function ($id) use ($mechanism, $modelClass, $collection) {
                     return $mechanism->getResolvedRouteModel($modelClass, $id)
                         ?? $collection[$id]
                         ?? null;

--- a/src/Features/SupportModels/EloquentModelRestorationUnitTest.php
+++ b/src/Features/SupportModels/EloquentModelRestorationUnitTest.php
@@ -48,6 +48,48 @@ class EloquentModelRestorationUnitTest extends \Tests\TestCase
         $this->assertCount(count($queriesAfterCollection), $connection->getQueryLog());
     }
 
+    public function test_collection_reuses_already_materialized_single_model()
+    {
+        Post::first();
+        app('livewire')->flushState();
+
+        $connection = Post::resolveConnection();
+        $connection->enableQueryLog();
+        $connection->flushQueryLog();
+
+        $component = new class extends TestComponent {};
+        $context = new ComponentContext($component);
+
+        $modelSynth = new ModelSynth($context, 'first');
+        $collectionSynth = new EloquentCollectionSynth($context, 'posts');
+
+        // Materialize a single model first.
+        $model = $modelSynth->hydrate(null, ['class' => Post::class, 'key' => 1]);
+        $this->assertSame('First', $model->title);
+
+        $queriesAfterModel = $connection->getQueryLog();
+        $this->assertCount(1, $queriesAfterModel);
+
+        // Hydrate a collection that includes the already-cached key plus another.
+        $collection = $collectionSynth->hydrate(null, [
+            'keys' => [1, 2],
+            'class' => Collection::class,
+            'modelClass' => Post::class,
+        ], fn ($property, $value) => $value);
+
+        $this->assertCount(2, $collection);
+        $this->assertSame('First', $collection->firstWhere('id', 1)->title);
+        $this->assertSame('Second', $collection->firstWhere('id', 2)->title);
+
+        $postQueries = array_values(array_filter(
+            $connection->getQueryLog(),
+            fn ($q) => str_contains($q['query'], 'posts')
+        ));
+
+        // 1 query for the single model + 1 query for the remaining key only.
+        $this->assertCount(2, $postQueries);
+    }
+
     public function test_same_model_is_only_queried_once_when_hydrated_on_multiple_properties()
     {
         Post::first();
@@ -128,26 +170,63 @@ class EloquentModelRestorationUnitTest extends \Tests\TestCase
         $this->assertCount(2, $postQueries);
     }
 
-    public function test_cached_model_does_not_leak_relations()
+    public function test_cached_model_preserves_default_eager_loads_from_restoration()
+    {
+        // PostWithAuthor declares protected $with = ['author'].
+        // newQueryForRestoration applies that $with, so a correct cache entry
+        // must still have author loaded — withoutRelations() would break this.
+        PostWithAuthor::first();
+        Author::first();
+        app('livewire')->flushState();
+
+        $component = new class extends TestComponent {};
+        $context = new ComponentContext($component);
+
+        $collectionSynth = new EloquentCollectionSynth($context, 'posts');
+        $modelSynth = new ModelSynth($context, 'first');
+
+        $collection = $collectionSynth->hydrate(null, [
+            'keys' => [1],
+            'class' => Collection::class,
+            'modelClass' => PostWithAuthor::class,
+        ], fn ($property, $value) => $value);
+
+        $this->assertCount(1, $collection);
+        $this->assertTrue($collection->first()->relationLoaded('author'));
+
+        // Reuse via ModelSynth — must keep the same restoration shape ($with intact).
+        $model = $modelSynth->hydrate(null, [
+            'class' => PostWithAuthor::class,
+            'key' => 1,
+        ]);
+
+        $this->assertSame('First', $model->title);
+        $this->assertTrue($model->relationLoaded('author'));
+        $this->assertSame('Jane', $model->author->name);
+    }
+
+    public function test_first_materialization_wins_and_is_not_overwritten()
     {
         Post::first();
         app('livewire')->flushState();
 
         $mechanism = app(PersistentMiddleware::class);
 
-        $post = Post::first();
-        $post->setRelation('author', Author::first());
+        $first = Post::first();
+        $mechanism->rememberResolvedModel($first);
 
-        $this->assertTrue($post->relationLoaded('author'));
+        $second = Post::first();
+        $second->setRelation('author', Author::first());
+        $this->assertTrue($second->relationLoaded('author'));
 
-        $mechanism->rememberResolvedModel($post->withoutRelations());
+        // First write wins — a later remember must not replace the cached instance.
+        $mechanism->rememberResolvedModel($second);
 
-        $resolved = $mechanism->getResolvedRouteModel(Post::class, $post->getKey());
+        $resolved = $mechanism->getResolvedRouteModel(Post::class, $first->getKey());
 
         $this->assertNotNull($resolved);
         $this->assertFalse($resolved->relationLoaded('author'));
-        $this->assertSame($post->getKey(), $resolved->getKey());
-        $this->assertSame('First', $resolved->title);
+        $this->assertSame($first->getKey(), $resolved->getKey());
     }
 }
 
@@ -156,9 +235,28 @@ class Post extends \Illuminate\Database\Eloquent\Model
     use \Sushi\Sushi;
 
     protected $rows = [
-        ['title' => 'First'],
-        ['title' => 'Second'],
+        ['title' => 'First', 'author_id' => 1],
+        ['title' => 'Second', 'author_id' => 2],
     ];
+
+    public function author()
+    {
+        return $this->belongsTo(Author::class);
+    }
+}
+
+class PostWithAuthor extends \Illuminate\Database\Eloquent\Model
+{
+    use \Sushi\Sushi;
+
+    protected $table = 'posts';
+
+    protected $rows = [
+        ['title' => 'First', 'author_id' => 1],
+        ['title' => 'Second', 'author_id' => 2],
+    ];
+
+    protected $with = ['author'];
 
     public function author()
     {
@@ -172,5 +270,6 @@ class Author extends \Illuminate\Database\Eloquent\Model
 
     protected $rows = [
         ['id' => 1, 'name' => 'Jane'],
+        ['id' => 2, 'name' => 'Brian'],
     ];
 }

--- a/src/Features/SupportModels/EloquentModelRestorationUnitTest.php
+++ b/src/Features/SupportModels/EloquentModelRestorationUnitTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Livewire\Features\SupportModels;
+
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Livewire;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
+use Tests\TestComponent;
+
+class EloquentModelRestorationUnitTest extends \Tests\TestCase
+{
+    public function test_model_synth_reuses_models_remembered_by_collection_synth()
+    {
+        // Boot Sushi so resolveConnection() is real.
+        Post::first();
+        app('livewire')->flushState();
+
+        $connection = Post::resolveConnection();
+        $connection->enableQueryLog();
+        $connection->flushQueryLog();
+
+        $component = new class extends TestComponent {};
+        $context = new ComponentContext($component);
+
+        $collectionSynth = new EloquentCollectionSynth($context, 'posts');
+        $modelSynth = new ModelSynth($context, 'first');
+
+        // Hydrate a collection of both posts (may be a lazy proxy on PHP 8.4+).
+        $collection = $collectionSynth->hydrate(null, [
+            'keys' => [1, 2],
+            'class' => Collection::class,
+            'modelClass' => Post::class,
+        ], fn ($property, $value) => $value);
+
+        // Materialize the collection — one bulk SELECT; models are remembered.
+        $this->assertCount(2, $collection);
+
+        $queriesAfterCollection = $connection->getQueryLog();
+        $this->assertCount(1, $queriesAfterCollection);
+
+        // Hydrate a single model that was part of that collection.
+        $model = $modelSynth->hydrate(null, ['class' => Post::class, 'key' => 1]);
+
+        // Materialize the model — must not issue another SELECT.
+        $this->assertSame('First', $model->title);
+
+        $this->assertCount(count($queriesAfterCollection), $connection->getQueryLog());
+    }
+
+    public function test_same_model_is_only_queried_once_when_hydrated_on_multiple_properties()
+    {
+        Post::first();
+        app('livewire')->flushState();
+
+        $connection = Post::resolveConnection();
+        $connection->enableQueryLog();
+        $connection->flushQueryLog();
+
+        $component = new class extends TestComponent {};
+        $context = new ComponentContext($component);
+        $synth = new ModelSynth($context, 'post');
+
+        $a = $synth->hydrate(null, ['class' => Post::class, 'key' => 1]);
+        $b = $synth->hydrate(null, ['class' => Post::class, 'key' => 1]);
+
+        // Force materialization (no-ops on PHP < 8.4 where hydrate already queried).
+        $this->assertSame('First', $a->title);
+        $this->assertSame('First', $b->title);
+        $this->assertSame($a->getKey(), $b->getKey());
+
+        $postQueries = array_values(array_filter(
+            $connection->getQueryLog(),
+            fn ($q) => str_contains($q['query'], 'posts')
+        ));
+
+        // One restoration for the same class:key, not two.
+        $this->assertCount(1, $postQueries);
+    }
+
+    public function test_collection_and_single_model_of_same_class_share_one_query_on_refresh()
+    {
+        Post::first();
+        app('livewire')->flushState();
+
+        $connection = Post::resolveConnection();
+        $connection->enableQueryLog();
+        $connection->flushQueryLog();
+
+        Livewire::test(new class extends TestComponent {
+            public Collection $posts;
+            public Post $selected;
+
+            public function mount()
+            {
+                $this->posts = Post::all();
+                $this->selected = $this->posts->first();
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        @foreach ($posts as $article)
+                            {{ $article->title }}
+                        @endforeach
+                        selected: {{ $selected->title }}
+                    </div>
+                HTML;
+            }
+        })
+            ->assertSee('First')
+            ->assertSee('Second')
+            ->assertSee('selected: First')
+            ->call('$refresh')
+            ->assertSee('First')
+            ->assertSee('Second')
+            ->assertSee('selected: First');
+
+        $postQueries = array_values(array_filter(
+            $connection->getQueryLog(),
+            fn ($q) => str_contains($q['query'], 'posts')
+        ));
+
+        // Mount: 1× SELECT for the collection (selected is the same instance, no extra query).
+        // Refresh: 1× bulk restore for the collection; selected reuses the cached model.
+        // Total: 2 queries, not 3 (or more).
+        $this->assertCount(2, $postQueries);
+    }
+
+    public function test_cached_model_does_not_leak_relations()
+    {
+        Post::first();
+        app('livewire')->flushState();
+
+        $mechanism = app(PersistentMiddleware::class);
+
+        $post = Post::first();
+        $post->setRelation('author', Author::first());
+
+        $this->assertTrue($post->relationLoaded('author'));
+
+        $mechanism->rememberResolvedModel($post);
+
+        $resolved = $mechanism->getResolvedRouteModel(Post::class, $post->getKey());
+
+        $this->assertNotNull($resolved);
+        $this->assertFalse($resolved->relationLoaded('author'));
+        $this->assertSame($post->getKey(), $resolved->getKey());
+        $this->assertSame('First', $resolved->title);
+    }
+}
+
+class Post extends \Illuminate\Database\Eloquent\Model
+{
+    use \Sushi\Sushi;
+
+    protected $rows = [
+        ['title' => 'First'],
+        ['title' => 'Second'],
+    ];
+
+    public function author()
+    {
+        return $this->belongsTo(Author::class);
+    }
+}
+
+class Author extends \Illuminate\Database\Eloquent\Model
+{
+    use \Sushi\Sushi;
+
+    protected $rows = [
+        ['id' => 1, 'name' => 'Jane'],
+    ];
+}

--- a/src/Features/SupportModels/EloquentModelRestorationUnitTest.php
+++ b/src/Features/SupportModels/EloquentModelRestorationUnitTest.php
@@ -35,20 +35,22 @@ class EloquentModelRestorationUnitTest extends \Tests\TestCase
 
         // Materialize the collection — one bulk SELECT; models are remembered.
         $this->assertCount(2, $collection);
+        $this->assertCount(1, $connection->getQueryLog());
 
-        $queriesAfterCollection = $connection->getQueryLog();
-        $this->assertCount(1, $queriesAfterCollection);
+        // Hydrate two models that was part of that collection.
+        $a = $modelSynth->hydrate(null, ['class' => Post::class, 'key' => 1]);
+        $b = $modelSynth->hydrate(null, ['class' => Post::class, 'key' => 2]);
+        $this->assertSame('First', $a->title);
+        $this->assertSame('Second', $b->title);
 
-        // Hydrate a single model that was part of that collection.
-        $model = $modelSynth->hydrate(null, ['class' => Post::class, 'key' => 1]);
+        // Same instances that were remembered — not newly queried models.
+        $this->assertTrue($a->is($collection->firstWhere('id', 1)));
+        $this->assertTrue($b->is($collection->firstWhere('id', 2)));
 
-        // Materialize the model — must not issue another SELECT.
-        $this->assertSame('First', $model->title);
-
-        $this->assertCount(count($queriesAfterCollection), $connection->getQueryLog());
+        $this->assertCount(1, $connection->getQueryLog());
     }
 
-    public function test_collection_reuses_already_materialized_single_model()
+    public function test_collection_reuses_already_materialized_single_models()
     {
         Post::first();
         app('livewire')->flushState();
@@ -63,14 +65,13 @@ class EloquentModelRestorationUnitTest extends \Tests\TestCase
         $modelSynth = new ModelSynth($context, 'first');
         $collectionSynth = new EloquentCollectionSynth($context, 'posts');
 
-        // Materialize a single model first.
-        $model = $modelSynth->hydrate(null, ['class' => Post::class, 'key' => 1]);
-        $this->assertSame('First', $model->title);
+        $a = $modelSynth->hydrate(null, ['class' => Post::class, 'key' => 1]);
+        $b = $modelSynth->hydrate(null, ['class' => Post::class, 'key' => 2]);
+        $this->assertSame('First', $a->title);
+        $this->assertSame('Second', $b->title);
 
-        $queriesAfterModel = $connection->getQueryLog();
-        $this->assertCount(1, $queriesAfterModel);
+        $this->assertCount(2, $connection->getQueryLog());
 
-        // Hydrate a collection that includes the already-cached key plus another.
         $collection = $collectionSynth->hydrate(null, [
             'keys' => [1, 2],
             'class' => Collection::class,
@@ -78,16 +79,13 @@ class EloquentModelRestorationUnitTest extends \Tests\TestCase
         ], fn ($property, $value) => $value);
 
         $this->assertCount(2, $collection);
-        $this->assertSame('First', $collection->firstWhere('id', 1)->title);
-        $this->assertSame('Second', $collection->firstWhere('id', 2)->title);
 
-        $postQueries = array_values(array_filter(
-            $connection->getQueryLog(),
-            fn ($q) => str_contains($q['query'], 'posts')
-        ));
+        // Same instances that were remembered — not newly queried models.
+        $this->assertTrue($a->is($collection->firstWhere('id', 1)));
+        $this->assertTrue($b->is($collection->firstWhere('id', 2)));
 
-        // 1 query for the single model + 1 query for the remaining key only.
-        $this->assertCount(2, $postQueries);
+        // Still 2 — collection did not query again.
+        $this->assertCount(2, $connection->getQueryLog());
     }
 
     public function test_same_model_is_only_queried_once_when_hydrated_on_multiple_properties()
@@ -105,19 +103,12 @@ class EloquentModelRestorationUnitTest extends \Tests\TestCase
 
         $a = $synth->hydrate(null, ['class' => Post::class, 'key' => 1]);
         $b = $synth->hydrate(null, ['class' => Post::class, 'key' => 1]);
-
-        // Force materialization (no-ops on PHP < 8.4 where hydrate already queried).
         $this->assertSame('First', $a->title);
         $this->assertSame('First', $b->title);
-        $this->assertSame($a->getKey(), $b->getKey());
-
-        $postQueries = array_values(array_filter(
-            $connection->getQueryLog(),
-            fn ($q) => str_contains($q['query'], 'posts')
-        ));
+        $this->assertTrue($a->is($b));
 
         // One restoration for the same class:key, not two.
-        $this->assertCount(1, $postQueries);
+        $this->assertCount(1, $connection->getQueryLog());
     }
 
     public function test_collection_and_single_model_of_same_class_share_one_query_on_refresh()
@@ -159,15 +150,10 @@ class EloquentModelRestorationUnitTest extends \Tests\TestCase
             ->assertSee('Second')
             ->assertSee('selected: First');
 
-        $postQueries = array_values(array_filter(
-            $connection->getQueryLog(),
-            fn ($q) => str_contains($q['query'], 'posts')
-        ));
-
         // Mount: 1× SELECT for the collection (selected is the same instance, no extra query).
         // Refresh: 1× bulk restore for the collection; selected reuses the cached model.
         // Total: 2 queries, not 3 (or more).
-        $this->assertCount(2, $postQueries);
+        $this->assertCount(2, $connection->getQueryLog());
     }
 
     public function test_cached_model_preserves_default_eager_loads_from_restoration()
@@ -212,8 +198,8 @@ class EloquentModelRestorationUnitTest extends \Tests\TestCase
 
         $mechanism = app(PersistentMiddleware::class);
 
-        $first = Post::first();
-        $mechanism->rememberResolvedModel($first);
+        $model = Post::first();
+        $mechanism->rememberResolvedModel($model);
 
         $second = Post::first();
         $second->setRelation('author', Author::first());
@@ -222,11 +208,11 @@ class EloquentModelRestorationUnitTest extends \Tests\TestCase
         // First write wins — a later remember must not replace the cached instance.
         $mechanism->rememberResolvedModel($second);
 
-        $resolved = $mechanism->getResolvedRouteModel(Post::class, $first->getKey());
+        $resolvedModel = $mechanism->getResolvedRouteModel(Post::class, $model->getKey());
 
-        $this->assertNotNull($resolved);
-        $this->assertFalse($resolved->relationLoaded('author'));
-        $this->assertSame($first->getKey(), $resolved->getKey());
+        $this->assertNotNull($resolvedModel);
+        $this->assertFalse($resolvedModel->relationLoaded('author'));
+        $this->assertTrue($resolvedModel->is($model));
     }
 }
 

--- a/src/Features/SupportModels/EloquentModelRestorationUnitTest.php
+++ b/src/Features/SupportModels/EloquentModelRestorationUnitTest.php
@@ -140,7 +140,7 @@ class EloquentModelRestorationUnitTest extends \Tests\TestCase
 
         $this->assertTrue($post->relationLoaded('author'));
 
-        $mechanism->rememberResolvedModel($post);
+        $mechanism->rememberResolvedModel($post->withoutRelations());
 
         $resolved = $mechanism->getResolvedRouteModel(Post::class, $post->getKey());
 

--- a/src/Features/SupportModels/ModelSynth.php
+++ b/src/Features/SupportModels/ModelSynth.php
@@ -94,7 +94,7 @@ class ModelSynth extends Synth {
             $model = (new $class)->newQueryForRestoration($key)->useWritePdo()->firstOrFail();
 
             // Remember it so later hydrates of the same class:key are free.
-            $mechanism->rememberResolvedModel($model->withoutRelations());
+            $mechanism->rememberResolvedModel($model);
 
             return $model;
         });

--- a/src/Features/SupportModels/ModelSynth.php
+++ b/src/Features/SupportModels/ModelSynth.php
@@ -74,16 +74,29 @@ class ModelSynth extends Synth {
 
         $key = $meta['key'];
 
+        $mechanism = app(PersistentMiddleware::class);
+
         // If this model was already resolved by route binding (via
         // SubstituteBindings middleware), reuse it to avoid a duplicate query.
-        $resolvedModel = app(PersistentMiddleware::class)->getResolvedRouteModel($class, $key);
+        $resolvedModel = $mechanism->getResolvedRouteModel($class, $key);
 
         if ($resolvedModel) {
             return $resolvedModel;
         }
 
-        return $this->makeLazyProxy($class, $meta, function () use ($class, $key) {
-            return (new $class)->newQueryForRestoration($key)->useWritePdo()->firstOrFail();
+        return $this->makeLazyProxy($class, $meta, function () use ($mechanism, $class, $key) {
+            // Check again at materialization time — a sibling collection may have
+            // loaded and remembered this model since hydrate() ran.
+            if ($resolved = $mechanism->getResolvedRouteModel($class, $key)) {
+                return $resolved;
+            }
+
+            $model = (new $class)->newQueryForRestoration($key)->useWritePdo()->firstOrFail();
+
+            // Remember it so later hydrates of the same class:key are free.
+            $mechanism->rememberResolvedModel($model);
+
+            return $model;
         });
     }
 

--- a/src/Features/SupportModels/ModelSynth.php
+++ b/src/Features/SupportModels/ModelSynth.php
@@ -94,7 +94,7 @@ class ModelSynth extends Synth {
             $model = (new $class)->newQueryForRestoration($key)->useWritePdo()->firstOrFail();
 
             // Remember it so later hydrates of the same class:key are free.
-            $mechanism->rememberResolvedModel($model);
+            $mechanism->rememberResolvedModel($model->withoutRelations());
 
             return $model;
         });

--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Route;
 use Livewire\Drawer\Utils;
 use Livewire\Livewire;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
 use Sushi\Sushi;
 use Tests\TestComponent;
 
@@ -351,6 +352,74 @@ class UnitTest extends \Tests\TestCase
         } finally {
             restore_error_handler();
         }
+    }
+
+    public function test_model_synth_reuses_models_remembered_by_collection_synth()
+    {
+        // Boot Sushi so resolveConnection() is real.
+        Article::first();
+        app('livewire')->flushState();
+
+        $connection = Article::resolveConnection();
+        $connection->enableQueryLog();
+        $connection->flushQueryLog();
+
+        $component = new class extends TestComponent {};
+        $context = new ComponentContext($component);
+
+        $collectionSynth = new EloquentCollectionSynth($context, 'articles');
+        $modelSynth = new ModelSynth($context, 'first');
+
+        // Hydrate a collection of both articles (may be a lazy proxy on PHP 8.4+).
+        $collection = $collectionSynth->hydrate(null, [
+            'keys' => [1, 2],
+            'class' => Collection::class,
+            'modelClass' => Article::class,
+        ], fn ($property, $value) => $value);
+
+        // Materialize the collection — one bulk SELECT; models are remembered.
+        $this->assertCount(2, $collection);
+
+        $queriesAfterCollection = $connection->getQueryLog();
+        $this->assertCount(1, $queriesAfterCollection);
+
+        // Hydrate a single model that was part of that collection.
+        $model = $modelSynth->hydrate(null, ['class' => Article::class, 'key' => 1]);
+
+        // Materialize the model — must not issue another SELECT.
+        $this->assertSame('First', $model->title);
+
+        $this->assertCount(count($queriesAfterCollection), $connection->getQueryLog());
+    }
+
+    public function test_same_model_is_only_queried_once_when_hydrated_on_multiple_properties()
+    {
+        Article::first();
+        app('livewire')->flushState();
+
+        $connection = Article::resolveConnection();
+        $connection->enableQueryLog();
+        $connection->flushQueryLog();
+
+        $component = new class extends TestComponent {};
+        $context = new ComponentContext($component);
+        $synth = new ModelSynth($context, 'article');
+
+        $a = $synth->hydrate(null, ['class' => Article::class, 'key' => 1]);
+        $b = $synth->hydrate(null, ['class' => Article::class, 'key' => 1]);
+
+        // Force materialization (no-ops on PHP < 8.4 where hydrate already queried).
+        $this->assertSame('First', $a->title);
+        $this->assertSame('First', $b->title);
+        $this->assertSame($a->getKey(), $b->getKey());
+
+        $articleQueries = array_values(array_filter(
+            $connection->getQueryLog(),
+            fn ($q) => str_contains($q['query'], 'articles')
+        ));
+
+        // One restoration for the same class:key, not two.
+        $this->assertCount(1, $articleQueries);
     }
 }
 

--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -421,6 +421,56 @@ class UnitTest extends \Tests\TestCase
         // One restoration for the same class:key, not two.
         $this->assertCount(1, $articleQueries);
     }
+
+    public function test_collection_and_single_model_of_same_class_share_one_query_on_refresh()
+    {
+        Article::first();
+        app('livewire')->flushState();
+
+        $connection = Article::resolveConnection();
+        $connection->enableQueryLog();
+        $connection->flushQueryLog();
+
+        Livewire::test(new class extends TestComponent {
+            public Collection $articles;
+            public Article $selected;
+
+            public function mount()
+            {
+                $this->articles = Article::all();
+                $this->selected = $this->articles->first();
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        @foreach ($articles as $article)
+                            {{ $article->title }}
+                        @endforeach
+                        selected: {{ $selected->title }}
+                    </div>
+                HTML;
+            }
+        })
+            ->assertSee('First')
+            ->assertSee('Second')
+            ->assertSee('selected: First')
+            ->call('$refresh')
+            ->assertSee('First')
+            ->assertSee('Second')
+            ->assertSee('selected: First');
+
+        $articleQueries = array_values(array_filter(
+            $connection->getQueryLog(),
+            fn ($q) => str_contains($q['query'], 'articles')
+        ));
+
+        // Mount: 1× SELECT for the collection (selected is the same instance, no extra query).
+        // Refresh: 1× bulk restore for the collection; selected reuses the cached model.
+        // Total: 2 queries, not 3 (or more).
+        $this->assertCount(2, $articleQueries);
+    }
 }
 
 #[\Attribute]

--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Route;
 use Livewire\Drawer\Utils;
 use Livewire\Livewire;
-use Livewire\Mechanisms\HandleComponents\ComponentContext;
 use Sushi\Sushi;
 use Tests\TestComponent;
 
@@ -352,124 +351,6 @@ class UnitTest extends \Tests\TestCase
         } finally {
             restore_error_handler();
         }
-    }
-
-    public function test_model_synth_reuses_models_remembered_by_collection_synth()
-    {
-        // Boot Sushi so resolveConnection() is real.
-        Article::first();
-        app('livewire')->flushState();
-
-        $connection = Article::resolveConnection();
-        $connection->enableQueryLog();
-        $connection->flushQueryLog();
-
-        $component = new class extends TestComponent {};
-        $context = new ComponentContext($component);
-
-        $collectionSynth = new EloquentCollectionSynth($context, 'articles');
-        $modelSynth = new ModelSynth($context, 'first');
-
-        // Hydrate a collection of both articles (may be a lazy proxy on PHP 8.4+).
-        $collection = $collectionSynth->hydrate(null, [
-            'keys' => [1, 2],
-            'class' => Collection::class,
-            'modelClass' => Article::class,
-        ], fn ($property, $value) => $value);
-
-        // Materialize the collection — one bulk SELECT; models are remembered.
-        $this->assertCount(2, $collection);
-
-        $queriesAfterCollection = $connection->getQueryLog();
-        $this->assertCount(1, $queriesAfterCollection);
-
-        // Hydrate a single model that was part of that collection.
-        $model = $modelSynth->hydrate(null, ['class' => Article::class, 'key' => 1]);
-
-        // Materialize the model — must not issue another SELECT.
-        $this->assertSame('First', $model->title);
-
-        $this->assertCount(count($queriesAfterCollection), $connection->getQueryLog());
-    }
-
-    public function test_same_model_is_only_queried_once_when_hydrated_on_multiple_properties()
-    {
-        Article::first();
-        app('livewire')->flushState();
-
-        $connection = Article::resolveConnection();
-        $connection->enableQueryLog();
-        $connection->flushQueryLog();
-
-        $component = new class extends TestComponent {};
-        $context = new ComponentContext($component);
-        $synth = new ModelSynth($context, 'article');
-
-        $a = $synth->hydrate(null, ['class' => Article::class, 'key' => 1]);
-        $b = $synth->hydrate(null, ['class' => Article::class, 'key' => 1]);
-
-        // Force materialization (no-ops on PHP < 8.4 where hydrate already queried).
-        $this->assertSame('First', $a->title);
-        $this->assertSame('First', $b->title);
-        $this->assertSame($a->getKey(), $b->getKey());
-
-        $articleQueries = array_values(array_filter(
-            $connection->getQueryLog(),
-            fn ($q) => str_contains($q['query'], 'articles')
-        ));
-
-        // One restoration for the same class:key, not two.
-        $this->assertCount(1, $articleQueries);
-    }
-
-    public function test_collection_and_single_model_of_same_class_share_one_query_on_refresh()
-    {
-        Article::first();
-        app('livewire')->flushState();
-
-        $connection = Article::resolveConnection();
-        $connection->enableQueryLog();
-        $connection->flushQueryLog();
-
-        Livewire::test(new class extends TestComponent {
-            public Collection $articles;
-            public Article $selected;
-
-            public function mount()
-            {
-                $this->articles = Article::all();
-                $this->selected = $this->articles->first();
-            }
-
-            public function render()
-            {
-                return <<<'HTML'
-                    <div>
-                        @foreach ($articles as $article)
-                            {{ $article->title }}
-                        @endforeach
-                        selected: {{ $selected->title }}
-                    </div>
-                HTML;
-            }
-        })
-            ->assertSee('First')
-            ->assertSee('Second')
-            ->assertSee('selected: First')
-            ->call('$refresh')
-            ->assertSee('First')
-            ->assertSee('Second')
-            ->assertSee('selected: First');
-
-        $articleQueries = array_values(array_filter(
-            $connection->getQueryLog(),
-            fn ($q) => str_contains($q['query'], 'articles')
-        ));
-
-        // Mount: 1× SELECT for the collection (selected is the same instance, no extra query).
-        // Refresh: 1× bulk restore for the collection; selected reuses the cached model.
-        // Total: 2 queries, not 3 (or more).
-        $this->assertCount(2, $articleQueries);
     }
 }
 

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -82,10 +82,12 @@ class PersistentMiddleware extends Mechanism
 
         $key = get_class($model).':'.$model->getKey();
 
-        // Keep the first clean instance for this identity.
-        if (isset($this->resolvedRouteModels[$key])) return;
+        $resolvedModel = $this->resolvedRouteModels[$key] ?? null;
 
-        // withoutRelations() returns a clone with no loaded relations.
+        // Check if model already stored and its the same model
+        if (! is_null($resolvedModel) && $model->is($resolvedModel)) return;
+
+        // Store the model so it can be reused later
         $this->resolvedRouteModels[$key] = $model;
     }
 

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -80,7 +80,13 @@ class PersistentMiddleware extends Mechanism
     {
         if (! $model->exists) return;
 
-        $this->resolvedRouteModels[get_class($model).':'.$model->getKey()] = $model;
+        $key = get_class($model).':'.$model->getKey();
+
+        // Keep the first clean instance for this identity.
+        if (isset($this->resolvedRouteModels[$key])) return;
+
+        // withoutRelations() returns a clone with no loaded relations.
+        $this->resolvedRouteModels[$key] = $model->withoutRelations();
     }
 
     protected function extractPathAndMethodFromRequest()

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -76,6 +76,13 @@ class PersistentMiddleware extends Mechanism
         return $this->resolvedRouteModels[$class.':'.$key] ?? null;
     }
 
+    function rememberResolvedModel(Model $model)
+    {
+        if (! $model->exists) return;
+
+        $this->resolvedRouteModels[get_class($model).':'.$model->getKey()] = $model;
+    }
+
     protected function extractPathAndMethodFromRequest()
     {
         if (app(HandleRequests::class)->isLivewireRoute()) {
@@ -128,8 +135,7 @@ class PersistentMiddleware extends Mechanism
         if ($route = $request->route()) {
             foreach ($route->parameters() as $parameter) {
                 if ($parameter instanceof Model) {
-                    $key = get_class($parameter).':'.$parameter->getKey();
-                    $this->resolvedRouteModels[$key] = $parameter;
+                    $this->rememberResolvedModel($parameter);
                 }
             }
         }

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -86,7 +86,7 @@ class PersistentMiddleware extends Mechanism
         if (isset($this->resolvedRouteModels[$key])) return;
 
         // withoutRelations() returns a clone with no loaded relations.
-        $this->resolvedRouteModels[$key] = $model->withoutRelations();
+        $this->resolvedRouteModels[$key] = $model;
     }
 
     protected function extractPathAndMethodFromRequest()


### PR DESCRIPTION
> [!NOTE]
> I notice this behavior when creating comment feature for my app where it has load comment button to refresh the component which lead to duplicate queries

```
// $post->comments
User A comment
  - User B comment
  - User A comment
  - User B comment
  - User A comment
```

This will create duplicate queries for the same user model even with eager loading enabled. Because each model hydration will create another query. 

Imagine how many queries it will created for **Like a comment** feature where it only has a list of user who likes the comment and each of that user appear on the same page of comment section page

## The Scenario

Livewire restores Eloquent models from snapshot metadata (`class` + `key`) on every request via `ModelSynth` and `EloquentCollectionSynth`. Each property is hydrated on its own. The only reuse today is for models already resolved by route binding (`PersistentMiddleware::$resolvedRouteModels`). https://github.com/livewire/livewire/pull/9935

Minimal snippet to reproduce the issue
```php
<?php

namespace App\Livewire;

use App\Models\User;
use Livewire\Attributes\Computed;
use Livewire\Component;

class UserManager extends Component
{
    public User $selected;
    
    #[Computed]
    public function users()
    {
        return User::query()->limit(3)->get();
    }

    public function mount()
    {
        $this->selected = $this->users->first();
    }

    public function select(int $id)
    {
        $this->selected = $this->users->firstWhere('id', $id)
            ?? User::findOrFail($id);
    }

    public function render()
    {
        return view('livewire.user-manager');
    }
}
```

```blade
<div>
    <flux:main>
        <flux:heading size="xl">Users</flux:heading>

        <ul class="space-y-6">
            @foreach ($this->users as $user)
                <li class="space-x-4" wire:key="{{ $user->id }}">
                    <span>{{ $user->name }}</span>
                    <flux:button wire:click="select({{ $user->id }})">
                        Select
                    </flux:button>
                </li>
            @endforeach
        </ul>

        <hr class="my-4">

        <div class="space-y-4">
            <p>Selected: {{ $selected->name }} (ID: {{ $selected->id }})</p>
            <flux:button wire:click="$refresh">Refresh</flux:button>
        </div>
    </flux:main>
</div>
```
> [!NOTE]
> The output below still same regardless using `#[Computed]` attribute or using `Collection` as property
> Tested with php version 8.3, 8.4, and 8.5

1. Click `Refresh`, notice duplicate queries
    - `select * from "users" where "users"."id" = 1 limit 1`
    - `select * from "users" where "users"."id" in (1, 2, 3)`
2. Select a user
    - `select * from "users" where "users"."id" in (1, 2, 3)`
3. Click `Refresh` again, same result with (1)

## The Problem

The same database row is often represented more than once in a single request graph, for example:

* A parent holds `Collection $posts` and a child (or the parent itself) also holds `Post $selected` that is one of those posts
* Nested / reactive children each receive the same `User`, `Order`, or `Team` the parent already loaded
* Several components on one page hydrate the same model after a shared action or island update
* A full-page component uses a route-bound model while child components also declare that model as a public property

Each of those paths can call `newQueryForRestoration()` again for an id that was already loaded earlier in the same request. Under PHP 8.4+ the query is deferred until the proxy is touched, but it still runs once per property, not once per unique `class:key`.

## The Solution

> [!IMPORTANT]
> There are two different cases here:
> **Selected rendered first → collection second:**
> 1. Selected materializes
>     - cache miss
>     - `select * from "users" where "users"."id" = 1 limit 1`
>     - remembers the model
> 2. Collection materializes
>     - cache hit only for rendered selected
>     - `select * from "users" where "users"."id" in (2, 3)` (selected model **excluded**)
>     - remembers remaining models
>
>  **Collection rendered first → selected second**
> 1. Collection materializes
>     - cache miss
>     - `select * from "users" where "users"."id" in (1, 2, 3)`
>     - remembers all models
> 2. Selected materializes
>     - hit cache
>     - no additional query (selected model already **included** in collection query)

Extend the existing request-scoped map on `PersistentMiddleware` so **any** materialized model can be reused for the rest of the request—not only route bindings:

1. **`rememberResolvedModel(Model $model)`** — store original model under `class:key` when a model is loaded. The first materialization of a given identity wins for the rest of the request.
5. **`ModelSynth`** — consult the cache before querying, and again inside the lazy-proxy callback (so a collection that materializes later can still satisfy a sibling model property).
6. **`EloquentCollectionSynth`** — after a bulk restore, remember each model so later `ModelSynth` hydrates can skip their own `SELECT`.

No change to snapshot shape or checksum behaviour. The map is still cleared on `flush-state`.

## Tests

To be honest, the tests was written by AI as I'm not sure how to test this. I only test this on fresh Laravel + Livewire apps.

* Two hydrates of the same `class:key` issue one query
* Models remembered from an `EloquentCollectionSynth` bulk load are reused by a following `ModelSynth` hydrate with no extra query
* `Collection` + selected model of the same class share one query on `$refresh` (end-to-end)