### PR TITLE
Harden timing-sensitive browser tests

### DIFF
--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -547,7 +547,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
         ])
-            ->assertQueryStringHas('foo', '')
+            ->waitForQueryString('foo', '')
             ->assertSee('foo', null)
             ->waitForLivewire()->click('@button')
             ->assertQueryStringHas('foo', 'second')
@@ -590,7 +590,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
         ])
-            ->assertQueryStringHas('foo', '')
+            ->waitForQueryString('foo', '')
             ->assertSee('foo', null)
             ->waitForLivewire()->click('@button')
             ->assertQueryStringHas('foo', '2')

--- a/src/Features/SupportRequestInteractions/BrowserTest.php
+++ b/src/Features/SupportRequestInteractions/BrowserTest.php
@@ -1019,7 +1019,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             ])
 
             ->waitUntil('window.intercepts.length >= 6')
-            ->assertScript('window.intercepts', [
+            ->assertScript('window.intercepts.slice(0, 6)', [
                 'userRequest-bar started',
                 'userRequest-bar sent',
                 'pollRequest-foo started',

--- a/src/Mechanisms/PersistentMiddleware/BrowserTest.php
+++ b/src/Mechanisms/PersistentMiddleware/BrowserTest.php
@@ -263,7 +263,7 @@ JS;
             ->assertDontSee('Protected Content')
             ->visit('/force-login/1')
             ->visit('/with-authorization/1/inline-auth')
-            ->assertSee('Protected Content')
+            ->waitForText('Protected Content')
             ->waitForLivewireToLoad()
             ->tap(function ($b) {
                 $script = <<<'JS'


### PR DESCRIPTION
## Summary

- wait for page authorization content before continuing
- wait for asynchronous query-string normalization in nullable enum tests
- assert the completed first poll lifecycle without rejecting a legitimate second poll

## Why

The failed jobs in 4.x run 32379807814 changed failure shape on retry. These assertions were observing asynchronous browser state too early or requiring the lifecycle log to stop at an exact length after the intended behavior had already completed.

This keeps the behavior coverage intact and uses observable state rather than arbitrary sleeps.

## Verification

- npm run build
- focused page-component authorization browser test
- both focused nullable-enum query-string browser tests
- focused overlapping island polling browser test
- five consecutive pre-rebase stress passes covering the same four tests
- git diff --check