### PR TITLE
[3.x] Fix x-mask resurrecting cleared model values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@alpinejs/collapse": "^3.15.12",
                 "@alpinejs/focus": "^3.15.12",
                 "@alpinejs/intersect": "^3.15.12",
-                "@alpinejs/mask": "^3.15.12",
+                "@alpinejs/mask": "^3.16.2",
                 "@alpinejs/morph": "^3.15.12",
                 "@alpinejs/persist": "^3.15.12",
                 "@alpinejs/resize": "^3.15.12",
@@ -56,9 +56,9 @@
             "license": "MIT"
         },
         "node_modules/@alpinejs/mask": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.15.12.tgz",
-            "integrity": "sha512-FcOVQp+tsIiBeNwWsH1BjAhJa+R/b6Tv6sPfSMRZlp1e/4w4H44Kagd9Aq86xpFgeI5dibJil2TG0+3LqB4JoA==",
+            "version": "3.16.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.16.2.tgz",
+            "integrity": "sha512-UZbEEtC6DRGgpd9atqlKr5din2grjZP2Aie2iLepXTyUUIJJAbxT/bVIelPzqwhjGtNxmAYxokeGF4cjEvBAMg==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/morph": {
@@ -562,9 +562,9 @@
             "integrity": "sha512-B2AlMDgx4xlRQjpDHO9SZrYur5cZkPZK0K6uY4Se+MmdePhIQ8m36gHGe0UKIYkFQkBGhVhPICGVoMYpSSYMWg=="
         },
         "@alpinejs/mask": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.15.12.tgz",
-            "integrity": "sha512-FcOVQp+tsIiBeNwWsH1BjAhJa+R/b6Tv6sPfSMRZlp1e/4w4H44Kagd9Aq86xpFgeI5dibJil2TG0+3LqB4JoA=="
+            "version": "3.16.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.16.2.tgz",
+            "integrity": "sha512-UZbEEtC6DRGgpd9atqlKr5din2grjZP2Aie2iLepXTyUUIJJAbxT/bVIelPzqwhjGtNxmAYxokeGF4cjEvBAMg=="
         },
         "@alpinejs/morph": {
             "version": "3.15.12",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "@alpinejs/collapse": "^3.15.12",
         "@alpinejs/focus": "^3.15.12",
         "@alpinejs/intersect": "^3.15.12",
-        "@alpinejs/mask": "^3.15.12",
+        "@alpinejs/mask": "^3.16.2",
         "@alpinejs/morph": "^3.15.12",
         "@alpinejs/persist": "^3.15.12",
         "@alpinejs/resize": "^3.15.12",

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -277,6 +277,29 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_x_mask_does_not_recreate_a_cleared_alpine_model()
+    {
+        Livewire::visit(new class extends Component {
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div x-data="{ form: { amount: '5000' } }">
+                        <input x-model="form.amount" x-mask:dynamic="$money($input)" dusk="amount" />
+
+                        <span dusk="model-state" x-text="'amount' in form ? 'EXISTS' : 'GONE'"></span>
+
+                        <button x-on:click="form = {}" dusk="clear">Clear</button>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertInputValue('@amount', '5,000')
+            ->assertSeeIn('@model-state', 'EXISTS')
+            ->click('@clear')
+            ->assertSeeIn('@model-state', 'GONE')
+        ;
+    }
+
     public function test_blur_modifier_does_not_recreate_deleted_array_entries_when_submitting_with_enter()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
## Summary

- bump only `@alpinejs/mask` from `3.15.12` to `3.16.2`
- keep Alpine core and the other bundled plugins on `3.15.12`
- add browser coverage proving a cleared masked Alpine model is not recreated

Fixes #10551.

Alpine mask 3.15.x formats an `undefined` model value and writes it back through `x-model`, resurrecting a nested path after a repeater removes it. Alpine fixed that lifecycle in 3.16.0; the targeted plugin bump brings the released correction into Livewire 3 without pulling the rest of Alpine 3.16 into the bundle.

## Verification

- new regression fails with mask `3.15.12`: model remains `EXISTS` after clearing
- SupportDataBinding browser tests: 8 passed, 24 assertions
- unit suite: 930 passed, 2982 assertions (17 skipped, 3 incomplete)
- reporter reproduction: masked repeater remains `1 → 2 → 1 → 2`; one Livewire request per action; no browser errors
- `npm run build`