### PR TITLE
[3.x] Ignore a repeat `__lazyLoad` call instead of throwing

### DIFF
--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -76,7 +76,12 @@ class SupportLazyLoading extends ComponentHook
     public function hydrate($memo)
     {
         if (! isset($memo['lazyLoaded'])) return;
-        if ($memo['lazyLoaded'] === true) return;
+
+        if ($memo['lazyLoaded'] === true) {
+            $this->storeSet('hasAlreadyLazyLoaded', true);
+
+            return;
+        }
 
         $this->component->skipHydrate();
 
@@ -99,7 +104,16 @@ class SupportLazyLoading extends ComponentHook
         if ($method !== '__lazyLoad') return;
 
         // Only applies while a lazy load is being resumed.
-        if ($this->storeGet('isLazyLoadHydrating') !== true) return;
+        if ($this->storeGet('isLazyLoadHydrating') !== true) {
+            // The placeholder's `x-intersect` has no `.once` modifier, so it can fire again
+            // while the first resume is still in flight. That duplicate is queued client-side
+            // and sent afterwards carrying the post-load snapshot, so it lands here on an
+            // already-resumed component. Swallow it rather than letting it fall through to
+            // method resolution, which would throw MethodNotFoundException.
+            if ($this->storeGet('hasAlreadyLazyLoaded') === true) $returnEarly();
+
+            return;
+        }
 
         [ $encoded ] = $params;
 

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -61,6 +61,26 @@ class UnitTest extends \Tests\TestCase
             ->assertSee('level:5');
     }
 
+    public function test_a_repeat_lazy_load_call_is_ignored_rather_than_throwing()
+    {
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        Livewire::component('lazy-alpha', LazyAlpha::class);
+
+        $html = html_entity_decode(Livewire::mount('lazy-alpha', ['level' => 5]));
+        preg_match("/__lazyLoad\('([^']+)'\)/", $html, $matches);
+
+        $this->assertNotEmpty($matches[1] ?? null);
+
+        // The placeholder's `x-intersect` has no `.once` modifier, so the browser can queue a
+        // second `__lazyLoad` behind the first and send it with the post-load snapshot.
+        Livewire::test('lazy-alpha')
+            ->call('__lazyLoad', $matches[1])
+            ->call('__lazyLoad', $matches[1])
+            ->assertOk()
+            ->assertSee('level:5');
+    }
+
     public function test_a_mount_params_container_is_scoped_to_its_own_component()
     {
         SupportLazyLoading::$disableWhileTesting = false;


### PR DESCRIPTION
Fixes #10570.

## The problem

Since v3.8.5, a repeat `__lazyLoad` call throws `MethodNotFoundException` — a 500 from `/livewire/update`, leaving the lazy component stuck on its placeholder. No application code is needed to trigger it: the duplicate is produced by Livewire's own placeholder and commit queue when a user scrolls a lazy component in and out of view.

1. `generatePlaceholderHtml()` stamps `x-intersect="$wire.__lazyLoad('<encoded>')"` on the placeholder root, with no `.once` modifier, so it re-fires on every re-entry into the viewport.
2. Fire it while the first resume is in flight and `CommitBus.corraleCommitsIntoPools()` skips the second commit (`findPoolWithComponent()` hits), leaving it queued for `sendAnyQueuedCommits()`.
3. `Commit.toRequestPayload()` reads `snapshotEncoded` at send time, so the queued duplicate goes out carrying the post-load snapshot (`memo.lazyLoaded: true`).
4. `hydrate()` returns early on that memo, so `isLazyLoadHydrating` is never set, so the guard added in 19a4a028 makes `call()` decline to intercept — and `__lazyLoad` reaches `HandleComponents::callMethods()`, which throws.

Before 19a4a028 the same duplicate was absorbed: `call()` intercepted unconditionally, re-ran `resurrectMountParams()` (the `forComponent` check passes, it is the same component) and `callMountLifecycleMethod()`, then returned early. I checked each v3 tag — the guard is absent in v3.0.0 through v3.8.4 and present from v3.8.5.

## The fix

Record that a component arrived already-resumed, and swallow the repeat call instead of letting it reach method resolution. A genuine first-time resume is unaffected, and since only method dispatch is skipped the component still re-renders, so the duplicate request just re-morphs the already-correct output.

I kept it to the narrow case rather than making `call()` swallow every `__lazyLoad` it does not handle, so a `__lazyLoad` on a component that was never lazy still surfaces as an error.

## Tests

`test_a_repeat_lazy_load_call_is_ignored_rather_than_throwing` in the existing `SupportLazyLoading\UnitTest`, following the `Livewire::mount()` + `preg_match` pattern the neighbouring mount-params tests already use. It reproduces the production error without the fix and passes with it.

`--testsuite Unit --filter SupportLazyLoading` is green (5 tests, 12 assertions).

## Note on `.once`

Adding `.once` to the placeholder's `x-intersect` would stop the duplicate request being sent at all, but it would also remove the retry when a lazy load genuinely fails on a flaky connection — so it looked like the wrong trade to make on its own. Happy to add it as well if you would rather have both.