### PR TITLE
fix route model binding issue that causes 404 on update route

### DIFF
--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -3,6 +3,7 @@
 namespace Livewire\Mechanisms\PersistentMiddleware;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Routing\Router;
 use Livewire\Mechanisms\Mechanism;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -118,7 +119,11 @@ class PersistentMiddleware extends Mechanism
         // Only send through pipeline if there are middleware found
         if (is_null($middleware) || $middleware === []) return;
 
-        Utils::applyMiddleware($request, $middleware);
+        try {
+            Utils::applyMiddleware($request, $middleware);
+        } catch (ModelNotFoundException $e) {
+            return;
+        }
 
         $this->middlewareAppliedFor[$routeKey] = true;
 

--- a/src/Mechanisms/PersistentMiddleware/UnitTest.php
+++ b/src/Mechanisms/PersistentMiddleware/UnitTest.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Livewire\Component as BaseComponent;
 use Livewire\Livewire;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
@@ -150,6 +151,39 @@ class UnitTest extends \LegacyTests\Unit\TestCase
         $response->assertJsonPath('components.0.snapshot', $snapshot);
     }
 
+    public function test_it_catches_model_not_found_from_persistent_middleware_pipeline()
+    {
+        $base = Livewire::getPersistentMiddleware();
+
+        try {
+            Livewire::addPersistentMiddleware(ThrowingMiddleware::class);
+
+            $component = Livewire::test(EmptyComponent::class);
+            $snapshot = json_encode($component->snapshot);
+
+            foreach (app('router')->getRoutes() as $route) {
+                if (str_contains($route->uri(), 'livewire-unit-test-endpoint')) {
+                    $route->middleware([ThrowingMiddleware::class]);
+                    break;
+                }
+            }
+
+            $response = $this->withHeaders(['X-Livewire' => 'true'])
+                ->postJson(EndpointResolver::updatePath(), [
+                    'components' => [[
+                        'calls'    => [],
+                        'updates'  => [],
+                        'snapshot' => $snapshot,
+                    ]],
+                ]);
+
+            $response->assertStatus(200);
+            $response->assertJsonPath('components.0.snapshot', $snapshot);
+        } finally {
+            Livewire::setPersistentMiddleware($base);
+        }
+    }
+
 }
 
 class EmptyComponent extends BaseComponent
@@ -161,5 +195,13 @@ class EmptyComponent extends BaseComponent
 
         </div>
         HTML;
+    }
+}
+
+class ThrowingMiddleware
+{
+    public function handle(Request $request, \Closure $next): \Symfony\Component\HttpFoundation\Response
+    {
+        throw (new ModelNotFoundException)->setModel('App\\MissingModel', ['not-exists']);
     }
 }


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

I encountered this issue during work where we saw this happen on our website, i did not create a discussion first. 

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

yes i did create a branch.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

It just this change, with test.

4️⃣ Does it include tests? (Required)

yes

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

What happened is that when having a livewire component on a 404 page and that component calling the livewire update route, we got another 404 page in a popup. After some digging we found that when livewire calls that route it also tries to build/fake the route that 404'd. This had been caught for routes that do not exist but not for routes that do exist but where the route model binding throws a 404.
This change fixes that by catching the `ModelNotFoundException` when trying to apply the middleware to the fake request in order to not recieve a 404 on the update route.

Thanks for contributing! 🙌
