### PR TITLE
Fix signed upload/preview URLs breaking when the proxy's forwarded origin isn't trusted

### DIFF
--- a/src/Facades/GenerateSignedUploadUrlFacade.php
+++ b/src/Facades/GenerateSignedUploadUrlFacade.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Facade;
  *
  * @method static string forLocal()
  * @method static string forS3($file, $visibility = 'private')
+ * @method static string signedRoute($name, $expiration, $parameters = [])
  *
  * @see \Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl
  */

--- a/src/Features/SupportFileUploads/BrowserTest.php
+++ b/src/Features/SupportFileUploads/BrowserTest.php
@@ -2,9 +2,12 @@
 
 namespace Livewire\Features\SupportFileUploads;
 
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
 use Livewire\WithFileUploads;
 use Livewire\Component;
+use Livewire\Facades\GenerateSignedUploadUrlFacade;
 use Livewire\Features\SupportValidation\BaseValidate;
 use Livewire\Livewire;
 
@@ -395,5 +398,57 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->pause(500)
         ->assertSeeIn('@result', 'rejected')
         ;
+    }
+
+    public function test_local_upload_succeeds_when_the_proxys_forwarded_https_origin_is_not_trusted()
+    {
+        // Signs under https, then swaps https:// for http:// on the URL —
+        // simulating a proxy Laravel doesn't trust to report its real origin.
+        $this->beforeServingApplication(function () {
+            Storage::persistentFake('tmp-for-tests');
+
+            GenerateSignedUploadUrlFacade::swap(new class extends GenerateSignedUploadUrl {
+                public function forLocal()
+                {
+                    URL::forceScheme('https');
+                    $url = parent::forLocal();
+                    URL::forceScheme(null);
+
+                    return preg_replace('#^https://#', 'http://', $url);
+                }
+            });
+
+            Livewire::component('https-signed-upload', HttpsSignedUploadComponent::class);
+
+            Route::get('/https-signed-upload', HttpsSignedUploadComponent::class)->middleware('web');
+        });
+
+        $this->browse(function ($browser) {
+            $browser->visit('/https-signed-upload')
+                ->assertMissing('@preview')
+                ->attach('@upload', __DIR__ . '/browser_test_image.png')
+                ->waitFor('@preview')
+                ->assertVisible('@preview')
+            ;
+        });
+    }
+}
+
+class HttpsSignedUploadComponent extends Component
+{
+    use WithFileUploads;
+
+    public $photo;
+
+    function render() {
+        return <<<'HTML'
+            <div>
+                <input type="file" wire:model="photo" dusk="upload">
+
+                @if ($photo)
+                    <img src="{{ $photo->temporaryUrl() }}" dusk="preview">
+                @endif
+            </div>
+        HTML;
     }
 }

--- a/src/Features/SupportFileUploads/FilePreviewController.php
+++ b/src/Features/SupportFileUploads/FilePreviewController.php
@@ -17,7 +17,7 @@ class FilePreviewController implements HasMiddleware
 
     public function handle($filename)
     {
-        abort_unless(request()->hasValidSignature(), 401);
+        abort_unless(request()->hasValidRelativeSignature(), 401);
 
         return Utils::pretendPreviewResponseIsPreviewFile($filename);
     }

--- a/src/Features/SupportFileUploads/FileUploadController.php
+++ b/src/Features/SupportFileUploads/FileUploadController.php
@@ -26,7 +26,7 @@ class FileUploadController implements HasMiddleware
 
     public function handle()
     {
-        abort_unless(request()->hasValidSignature(), 401);
+        abort_unless(request()->hasValidRelativeSignature(), 401);
 
         $disk = FileUploadConfiguration::disk();
 

--- a/src/Features/SupportFileUploads/GenerateSignedUploadUrl.php
+++ b/src/Features/SupportFileUploads/GenerateSignedUploadUrl.php
@@ -10,7 +10,7 @@ class GenerateSignedUploadUrl
 {
     public function forLocal()
     {
-        return URL::temporarySignedRoute(
+        return $this->signedRoute(
             'livewire.upload-file', now()->addMinutes(FileUploadConfiguration::maxUploadTime())
         );
     }
@@ -59,6 +59,15 @@ class GenerateSignedUploadUrl
             'url' => (string) $uri,
             'headers' => $this->headers($signedRequest, $fileType),
         ];
+    }
+
+    // Signs relative so the scheme can't mismatch behind a proxy; re-absolutized
+    // for a normal-looking URL. Validate with `hasValidRelativeSignature()`.
+    public function signedRoute($name, $expiration, $parameters = [])
+    {
+        $relative = URL::temporarySignedRoute($name, $expiration, $parameters, false);
+
+        return URL::to($relative);
     }
 
     protected function headers($signedRequest, $fileType)

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -4,9 +4,9 @@ namespace Livewire\Features\SupportFileUploads;
 
 use Illuminate\Support\Arr;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Storage;
 use League\MimeTypeDetection\FinfoMimeTypeDetector;
+use Livewire\Facades\GenerateSignedUploadUrlFacade;
 
 class TemporaryUploadedFile extends UploadedFile
 {
@@ -136,7 +136,7 @@ class TemporaryUploadedFile extends UploadedFile
             return $this->storage->temporaryUrl($this->path, now()->addDay());
         }
 
-        return URL::temporarySignedRoute(
+        return GenerateSignedUploadUrlFacade::signedRoute(
             'livewire.preview-file', now()->addMinutes(30)->endOfHour(), ['filename' => $this->getFilename()]
         );
     }

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -12,6 +12,7 @@ use Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButton
 use League\Flysystem\PathTraversalDetected;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Http\Testing\FileFactory;
 use Illuminate\Support\Arr;
@@ -1021,6 +1022,29 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertInstanceOf(TemporaryUploadedFile::class, $rows['one']['image']);
         $this->assertEquals(['image' => null, 'caption' => 'New row'], $rows['three']);
+    }
+
+    public function test_preview_succeeds_when_the_proxys_forwarded_https_origin_is_not_trusted()
+    {
+        // Signs under https, then swaps https:// for http:// on the URL,
+        // simulating a proxy Laravel doesn't trust to report its real origin.
+        Storage::fake('avatars');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', UploadedFile::fake()->image('avatar.jpg'))
+            ->viewData('photo');
+
+        \Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+
+        URL::forceScheme('https');
+        $url = $photo->temporaryUrl();
+        URL::forceScheme(null);
+
+        $this->assertStringStartsWith('https://', $url);
+
+        $url = preg_replace('#^https://#', 'http://', $url);
+
+        $this->get($url)->assertOk();
     }
 }
 


### PR DESCRIPTION
## Problem
`hasValidSignature()` rebuilds the signed URL from the raw request's scheme/host/port, the internal origin behind a proxy. But `URL::temporarySignedRoute()` signs using whatever origin the app declares public (e.g. via `forceScheme('https')` behind an SSL-terminating proxy). When those differ, every signed upload/preview request 401s, even though nothing is actually invalid. Relying on `TrustProxies` to reconcile them means trusting proxy IPs ahead of time, `*`, or `REMOTE_ADDR`, not something every deployment can or wants to do.

## Solution
- Adds `GenerateSignedUploadUrl::signedRoute()`: signs relatively (no scheme/host/port in the hash), then re-absolutizes via `URL::to()`, keeping the return format unchanged. (Extracted since the branch was originally built from `main`, where `forChunks()`/`forMultipart()` share it too; on `4.x` it's `forLocal()`'s only caller for now.)
- Switches `FileUploadController` and `FilePreviewController` to `hasValidRelativeSignature()`, Laravel's own method for exactly this case.
- `forS3()` is unaffected, AWS SigV4 signing doesn't go through Laravel's URL signer.

## Test plan
- `BrowserTest::test_local_upload_succeeds_when_the_proxys_forwarded_https_origin_is_not_trusted`: signs under https then serves the URL over http, verifies the upload still completes. Failing before the fix
- `UnitTest::test_preview_succeeds_when_the_proxys_forwarded_https_origin_is_not_trusted`: same scenario for the preview endpoint. Failing before the fix
- Existing unit + browser suites still green for upload and preview

>[!IMPORTANT]
>Couldn't reproduce a real proxy locally (no TLS in the test server), so the tests sign under https then swap to http before >use. Not exact, but same code path, should fix the issue.

Fixes #10573