### PR TITLE
Harden page layout text assertions

### DIFF
--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -21,7 +21,7 @@ class UnitTest extends \Tests\TestCase
             ->withoutExceptionHandling()
             ->get('/configurable-layout')
             ->assertSee('foo')
-            ->assertDontSee('baz');
+            ->assertDontSeeText('baz');
     }
 
     public function test_can_configure_a_default_layout()
@@ -47,7 +47,7 @@ class UnitTest extends \Tests\TestCase
             ->get('/configurable-layout')
             ->assertSee('foo')
             ->assertSee('bar')
-            ->assertDontSee('baz');
+            ->assertDontSeeText('baz');
     }
 
     public function test_can_show_params_with_a_configured_class_based_component_layout()
@@ -85,7 +85,7 @@ class UnitTest extends \Tests\TestCase
             ->get('/configurable-layout')
             ->assertSee('foo')
             ->assertSee('bar')
-            ->assertDontSee('baz');
+            ->assertDontSeeText('baz');
     }
 
     public function test_can_show_params_with_a_configured_anonymous_component_layout()


### PR DESCRIPTION
The 4.x unit matrix failed when a random Livewire snapshot ID happened to contain baz, causing a raw-response assertDontSee check to report a false positive even though the visible page text was correct.

This switches the three negative layout assertions in the same test group to assertDontSeeText, keeping the assertions focused on the rendered text they intend to verify.

Verification:
- vendor/bin/phpunit --configuration phpunit.xml.dist src/Features/SupportPageComponents/UnitTest.php (41 tests, 78 assertions; 1 skipped)
- git diff --check