### PR TITLE
[4.x] Fix form reset throws `TypeError` on non-nullable properties without defaults

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -350,36 +350,57 @@ $this->reset(['title', 'content']);
 ```
 
 > [!important]
-> Form properties declared as non-nullable typed properties without defaults (e.g. `public string $title`) are left uninitialized after `reset()` (and when Livewire clears them via the form synthesizer). Accessing them in a view before assignment will throw. Use a default (`= ''`), a nullable type (`?string $title = null`), or null-safe access in the view.
+> Form properties declared as non-nullable typed properties without defaults (e.g. `public string $title`) are left uninitialized after `reset()` (and when Livewire clears them via the form synthesizer). Accessing them in a view before assignment will throw. Assign after reset, use a default value (`= ''`), a nullable type (`?string $title = null`), or null-safe access in the view (`$form?->title`).
 
 ```php
 <?php
 
 namespace App\Livewire\Forms;
 
-use Livewire\Attributes\Validate;
 use App\Models\Post;
 use Livewire\Form;
 
 class PostForm extends Form
 {
+    public ?Post $post;
+
     public string $title;
+
     public string $content;
 
-    public function mount()
+    public function setPost(Post $post)
     {
-        $this->title = 'A Title';
-        $this->content = 'Some content...';
+        $this->post = $post
+
+        $this->title = $post->title;
+
+        $this->content = $post->content;
+    }
+}
+```
+```php
+<?php
+
+use App\Livewire\Forms\PostForm;
+use Livewire\Component;
+use App\Models\Post;
+
+new class extends Component {
+    public Post $post;
+    public PostForm $form;
+
+    public function mount(Post $post)
+    {
+        $this->form->setPost($post);
     }
 
     public function resetForm()
     {
-        $this->reset();
+        $this->form->reset();
 
-        $this->title = 'A Title';  // [tl! highlight]
-        $this->content = 'Some content...';  // [tl! highlight]
+        $this->form->setPost($this->post); // [tl! highlight]
     }
-}
+};
 ```
 
 ### Pulling form fields

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -349,6 +349,39 @@ $this->reset('title');
 $this->reset(['title', 'content']);
 ```
 
+> [!important]
+> Form properties declared as non-nullable typed properties without defaults (e.g. `public string $title`) are left uninitialized after `reset()` (and when Livewire clears them via the form synthesizer). Accessing them in a view before assignment will throw. Use a default (`= ''`), a nullable type (`?string $title = null`), or null-safe access in the view.
+
+```php
+<?php
+
+namespace App\Livewire\Forms;
+
+use Livewire\Attributes\Validate;
+use App\Models\Post;
+use Livewire\Form;
+
+class PostForm extends Form
+{
+    public string $title;
+    public string $content;
+
+    public function mount()
+    {
+        $this->title = 'A Title';
+        $this->content = 'Some content...';
+    }
+
+    public function resetForm()
+    {
+        $this->reset();
+
+        $this->title = 'A Title';  // [tl! highlight]
+        $this->content = 'Some content...';  // [tl! highlight]
+    }
+}
+```
+
 ### Pulling form fields
 
 Alternatively, you can use the `pull()` method to both retrieve a form's properties and reset them in one operation.

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -108,14 +108,10 @@ class Form implements Arrayable
         $freshInstance = new static($this->getComponent(), $this->getPropertyName());
 
         foreach ($properties as $property) {
-            // Component reset may pass wildcards / nested segments (e.g. '*', 'foo')
-            // that are not real form properties. Keep data_get/data_set for those.
-            if (property_exists($freshInstance, $property)) {
-                // Handle resetting properties that are not initialized by default.
-                if (! (new \ReflectionProperty($freshInstance, $property))->isInitialized($freshInstance)) {
-                    data_forget($this, $property);
-                    continue;
-                }
+            // Handle resetting properties that are not initialized by default.
+            if (Utils::hasProperty($freshInstance, $property) && Utils::propertyIsTypedAndUninitialized($freshInstance, $property)) {
+                data_forget($this, $property);
+                continue;
             }
 
             data_set($this, $property, data_get($freshInstance, $property));

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -108,6 +108,32 @@ class Form implements Arrayable
         $freshInstance = new static($this->getComponent(), $this->getPropertyName());
 
         foreach ($properties as $property) {
+            $property = str($property);
+
+            // Check if the property contains a dot which means it is actually on a nested object
+            if (str($property)->contains('.')) {
+                $propertyName = $property->afterLast('.');
+                $objectName = $property->before('.');
+
+                $object = data_get($freshInstance, $objectName, null);
+
+                if (is_object($object)) {
+                    $isInitialized = (new \ReflectionProperty($object, (string) $propertyName))->isInitialized($object);
+                } elseif (is_array($object)) {
+                    $isInitialized = Arr::has($freshInstance->{$objectName}, Utils::afterFirstDot((string) $property));
+                } else {
+                    $isInitialized = false;
+                }
+            } else {
+                $isInitialized = (new \ReflectionProperty($freshInstance, (string) $property))->isInitialized($freshInstance);
+            }
+
+            // Handle resetting properties that are not initialized by default.
+            if (! $isInitialized) {
+                data_forget($this, (string) $property);
+                continue;
+            }
+
             data_set($this, $property, data_get($freshInstance, $property));
         }
     }

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -108,30 +108,14 @@ class Form implements Arrayable
         $freshInstance = new static($this->getComponent(), $this->getPropertyName());
 
         foreach ($properties as $property) {
-            $property = str($property);
-
-            // Check if the property contains a dot which means it is actually on a nested object
-            if (str($property)->contains('.')) {
-                $propertyName = $property->afterLast('.');
-                $objectName = $property->before('.');
-
-                $object = data_get($freshInstance, $objectName, null);
-
-                if (is_object($object)) {
-                    $isInitialized = (new \ReflectionProperty($object, (string) $propertyName))->isInitialized($object);
-                } elseif (is_array($object)) {
-                    $isInitialized = Arr::has($freshInstance->{$objectName}, Utils::afterFirstDot((string) $property));
-                } else {
-                    $isInitialized = false;
+            // Component reset may pass wildcards / nested segments (e.g. '*', 'foo')
+            // that are not real form properties. Keep data_get/data_set for those.
+            if (property_exists($freshInstance, $property)) {
+                // Handle resetting properties that are not initialized by default.
+                if (! (new \ReflectionProperty($freshInstance, $property))->isInitialized($freshInstance)) {
+                    data_forget($this, $property);
+                    continue;
                 }
-            } else {
-                $isInitialized = (new \ReflectionProperty($freshInstance, (string) $property))->isInitialized($freshInstance);
-            }
-
-            // Handle resetting properties that are not initialized by default.
-            if (! $isInitialized) {
-                data_forget($this, (string) $property);
-                continue;
             }
 
             data_set($this, $property, data_get($freshInstance, $property));

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -1148,6 +1148,69 @@ class UnitTest extends \Tests\TestCase
             ->assertSetStrict('form', fn ($form) => $form instanceof PostFormStubWithDefaults)
         ;
     }
+
+    public function test_form_reset_handles_non_nullable_typed_properties_without_defaults()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public TypedRequiredForm $form;
+
+            public function mount()
+            {
+                $this->form->title = 'A Title';
+                $this->form->content = 'Some content...';
+            }
+
+            public function resetForm()
+            {
+                $this->form->reset();
+            }
+        })
+            ->call('resetForm')
+            ->assertOk();
+
+        $form = $component->instance()->form;
+
+        $this->assertFalse(
+            (new \ReflectionProperty($form, 'title'))->isInitialized($form)
+        );
+
+        $this->assertFalse(
+            (new \ReflectionProperty($form, 'content'))->isInitialized($form)
+        );
+    }
+
+    public function test_form_reset_single_non_nullable_typed_property_without_default()
+    {
+        $component = Livewire::test(new class extends \Tests\TestComponent {
+            public TypedRequiredForm $form;
+
+            public function mount()
+            {
+                $this->form->title = 'A Title';
+                $this->form->content = 'Some content...';
+            }
+
+            public function resetTitle()
+            {
+                $this->form->reset('title');
+            }
+        })
+            ->call('resetTitle')
+            ->assertOk()
+            ->assertSetStrict('form.content', 'Some content...');
+
+        $form = $component->instance()->form;
+
+        $this->assertFalse(
+            (new \ReflectionProperty($form, 'title'))->isInitialized($form)
+        );
+    }
+}
+
+class TypedRequiredForm extends Form
+{
+    public string $title;
+    public string $content;
 }
 
 class PostFormStub extends Form

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Stringable;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
+use Livewire\Drawer\Utils;
 use Livewire\Form;
 use Livewire\Livewire;
 use PHPUnit\Framework\Assert;
@@ -1170,12 +1171,12 @@ class UnitTest extends \Tests\TestCase
 
         $form = $component->instance()->form;
 
-        $this->assertFalse(
-            (new \ReflectionProperty($form, 'title'))->isInitialized($form)
+        $this->assertTrue(
+            Utils::propertyIsTypedAndUninitialized($form, 'title')
         );
 
-        $this->assertFalse(
-            (new \ReflectionProperty($form, 'content'))->isInitialized($form)
+        $this->assertTrue(
+            Utils::propertyIsTypedAndUninitialized($form, 'content')
         );
     }
 
@@ -1201,8 +1202,8 @@ class UnitTest extends \Tests\TestCase
 
         $form = $component->instance()->form;
 
-        $this->assertFalse(
-            (new \ReflectionProperty($form, 'title'))->isInitialized($form)
+        $this->assertTrue(
+            Utils::propertyIsTypedAndUninitialized($form, 'title')
         );
     }
 }


### PR DESCRIPTION
## Summary
`Form::reset()` does not handle non-nullable typed properties that have no default. A fresh form instance leaves those properties uninitialized, `data_get()` returns `null`, and `data_set()` throws a `TypeError`.

`FormObjectSynth::set()` and `InteractsWithProperties::reset()` already handle this case by unsetting the property. `Form::reset()` did not.

## Scenario

```php
class PostForm extends Form
{
    public ?Post $post;

    public string $title;

    public int $views_count;

    public function setPost(Post $post)
    {
        $this->post = $post;

        $this->title = $post->title;

        $this->views_count = $post->views_count;
    }
}
```
```php
new class extends Component
{
    public PostForm $form;

    public function mount(Post $post)
    {
        $this->form->setPost($post);
    }

    public function resetForm()
    {
        $this->form->reset(); // TypeError: Cannot assign null to property ...::$title of type string
    }
}
```

## Problem

`Form::reset()` always did:
```php
data_set($this, $property, data_get($freshInstance, $property));
```

On a fresh instance, uninitialized typed properties yield `null` from `data_get()`, which cannot be assigned to `string` / `int`.

## Solution

- Check if property exists on Form object
- Reflect whether the property is initialized on the fresh instance
- If not, `data_forget()` instead of assigning `null`
- Otherwise, `data_set()` from the fresh instance as before

However, this still will throws exception if non-nullable typed properties accessed before assigning its value
```
Error: Typed property ...::$title must not be accessed before initialization
```

There is no way to mitigate this error so I add additional information to [Resetting form fields](https://livewire.laravel.com/docs/4.x/forms#resetting-form-fields)

```php
new class extends Component
{
    public Post $post;

    public PostForm $form;

    public function mount(Post $post)
    {
        $this->post = $post;

        $this->form->setPost($post);
    }

    public function resetForm()
    {
        $this->form->reset();

        $this->form->setPost($this->post);  // Assign after reset to prevent exception
    }
}
```