### PR TITLE
[4.x] Fix recursive errors when calling livewire action from 404 error page

### DIFF
--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -3,6 +3,7 @@
 namespace Livewire\Mechanisms\PersistentMiddleware;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Routing\Router;
 use Livewire\Mechanisms\Mechanism;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -176,7 +177,16 @@ class PersistentMiddleware extends Mechanism
 
         if (! $route) return [];
 
-        $middleware = app('router')->gatherRouteMiddleware($route);
+        $router = app('router');
+
+        try {
+            $router->substituteBindings($route);
+            $router->substituteImplicitBindings($route);
+        } catch (ModelNotFoundException $e) {
+            return [];
+        }
+
+        $middleware = $router->gatherRouteMiddleware($route);
 
         return $this->filterMiddlewareByPersistentMiddleware($middleware);
     }

--- a/src/Mechanisms/PersistentMiddleware/UnitTest.php
+++ b/src/Mechanisms/PersistentMiddleware/UnitTest.php
@@ -2,13 +2,16 @@
 
 namespace Livewire\Mechanisms\PersistentMiddleware;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Route;
 use Livewire\Component as BaseComponent;
 use Livewire\Livewire;
+use Livewire\Mechanisms\HandleComponents\Checksum;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
+use Sushi\Sushi;
 
 class UnitTest extends \LegacyTests\Unit\TestCase
 {
@@ -150,6 +153,49 @@ class UnitTest extends \LegacyTests\Unit\TestCase
         $response->assertJsonPath('components.0.snapshot', $snapshot);
     }
 
+    public function test_it_does_not_fail_update_when_original_route_model_binding_is_missing()
+    {
+        // Route exists; model key does not → SubstituteBindings throws ModelNotFoundException
+        Route::get('/posts/{post}', function (BindingPost $post) {
+            return 'ok';
+        })->middleware('web');
+
+        $component = Livewire::test(EmptyComponent::class);
+        $snapshot = $component->snapshot;
+
+        // Point the memo at a non-existent model on a matching route
+        $snapshot['memo']['path'] = 'posts/999999';
+        $snapshot['memo']['method'] = 'GET';
+
+        // Mutating memo will trigger CorruptComponentPayloadException -> 419
+        // Unset original checksum and generate a new one
+        unset($snapshot['checksum']);
+        $snapshot['checksum'] = Checksum::generate($snapshot);
+
+        $snapshotJson = json_encode($snapshot);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), [
+                'components' => [[
+                    'calls'    => [],
+                    'updates'  => [],
+                    'snapshot' => $snapshotJson,
+                ]],
+            ]);
+
+        // Update endpoint must stay healthy; page-level 404 must not leak
+        $response->assertStatus(200);
+        $response->assertJsonPath('components.0.snapshot', $snapshotJson);
+    }
+}
+
+class BindingPost extends Model
+{
+    use Sushi;
+
+    protected $rows = [
+        ['id' => 1, 'title' => 'Exists'],
+    ];
 }
 
 class EmptyComponent extends BaseComponent


### PR DESCRIPTION
This is an alternative for https://github.com/livewire/livewire/pull/10572

## Summary

Calling a Livewire action from a page whose original route model binding no longer resolves (most commonly a 404 / model-not-found error page that still contains Livewire components) causes the update request itself to fail with a page-level 404. That failure can replace the page again and produce recursive errors.

## Scenario

1. Publish Laravel error pages
```bash
php artisan vendor:publish --tag=laravel-errors
```
2. Add Livewire component to `404.blade.php` page
3. Calling component action will trigger another 404 page but this time inside a modal

https://github.com/user-attachments/assets/4ff1f09a-6a2f-4d12-9d7b-10a7ea6f92c2

## Problem

`PersistentMiddleware` re-applies the original page route’s middleware on every Livewire update. To do that it:

1. Rebuilds a fake request from the path/method stored in the component snapshot memo
2. Matches the route
5. Runs `substituteBindings()` / `substituteImplicitBindings()`

When the route has an explicit or implicit model binding and the model key no longer exists (deleted model, typed a bad ID, custom error page for a missing record, etc.), step 3 throws `ModelNotFoundException`.

That exception is not handled inside `PersistentMiddleware`, so it bubbles up through the Livewire update endpoint and Laravel renders a normal 404 response instead of the expected Livewire JSON. If the 404 view also embeds Livewire components, interacting with them repeats the same failure.

## Solution

Because this is related to route level where route exists, has an implicit/explicit binding but model not found, catch `ModelNotFoundException` while resolving bindings and treat it the same as an unmatched route: return an empty middleware list and let the update proceed. The Livewire request stays healthy; only the (now invalid) route middleware is skipped.

```php
try {
    $router->substituteBindings($route);
    $router->substituteImplicitBindings($route);
} catch (ModelNotFoundException $e) {
    return [];
}