### PR TITLE
Port content-based temporary upload MIME detection to 4.x

### DIFF
--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -14,6 +14,7 @@ class TemporaryUploadedFile extends UploadedFile
     protected $storage;
     protected $path;
     protected $metaFileData;
+    protected $detectedMimeType;
 
     public function __construct($path, $disk)
     {
@@ -77,17 +78,30 @@ class TemporaryUploadedFile extends UploadedFile
             }
         }
 
-        $mimeType = $this->storage->mimeType($this->path);
+        return $this->detectedMimeType ??= $this->detectMimeTypeFromContents();
+    }
 
-        // Flysystem V2.0+ removed guess mimeType from extension support, so it has been re-added back
-        // in here to ensure the correct mimeType is returned when using faked files in tests
-        if (in_array($mimeType, ['application/octet-stream', 'inode/x-empty', 'application/x-empty'])) {
-            $detector = new FinfoMimeTypeDetector();
+    protected function detectMimeTypeFromContents(): string
+    {
+        $stream = $this->storage->readStream($this->path);
 
-            $mimeType = $detector->detectMimeTypeFromPath($this->path) ?: 'text/plain';
+        if (! is_resource($stream)) {
+            return 'application/octet-stream';
         }
 
-        return $mimeType;
+        try {
+            // Avoid downloading the entire object when the temporary disk is remote...
+            $contents = stream_get_contents($stream, 64 * 1024);
+        } finally {
+            fclose($stream);
+        }
+
+        if ($contents === false || $contents === '') {
+            return 'application/octet-stream';
+        }
+
+        return (new FinfoMimeTypeDetector())->detectMimeTypeFromBuffer($contents)
+            ?: 'application/octet-stream';
     }
 
     public function getFilename(): string

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -901,6 +901,47 @@ class UnitTest extends \Tests\TestCase
             ]);
     }
 
+    public function test_temporary_upload_validation_uses_file_contents_instead_of_storage_metadata()
+    {
+        $disk = $this->useS3LikeTemporaryUploadDisk();
+
+        $disk->put('livewire-tmp/png-disguised-as.webp', file_get_contents(__DIR__.'/browser_test_image.png'));
+
+        $this->assertSame('image/webp', $disk->mimeType('livewire-tmp/png-disguised-as.webp'));
+
+        $file = TemporaryUploadedFile::createFromLivewire('png-disguised-as.webp');
+
+        $this->assertSame('image/png', $file->getMimeType());
+        $this->assertTrue(validator(['file' => $file], ['file' => 'mimes:png|mimetypes:image/png'])->passes());
+        $this->assertFalse(validator(['file' => $file], ['file' => 'mimes:webp|mimetypes:image/webp'])->passes());
+        $this->assertSame(1, $disk->readStreamCalls);
+    }
+
+    public function test_temporary_upload_mime_type_does_not_fall_back_to_storage_metadata_for_empty_files()
+    {
+        $disk = $this->useS3LikeTemporaryUploadDisk();
+
+        $disk->put('livewire-tmp/empty.webp', '');
+
+        $this->assertSame('image/webp', $disk->mimeType('livewire-tmp/empty.webp'));
+
+        $file = TemporaryUploadedFile::createFromLivewire('empty.webp');
+
+        $this->assertSame('application/octet-stream', $file->getMimeType());
+    }
+
+    public function test_temporary_upload_mime_type_is_unknown_when_the_file_cannot_be_read()
+    {
+        $disk = $this->useS3LikeTemporaryUploadDisk();
+
+        $disk->put('livewire-tmp/unreadable.webp', file_get_contents(__DIR__.'/browser_test_image.png'));
+        $disk->canRead = false;
+
+        $file = TemporaryUploadedFile::createFromLivewire('unreadable.webp');
+
+        $this->assertSame('application/octet-stream', $file->getMimeType());
+    }
+
     public function test_the_default_file_upload_controller_middleware_overwritten()
     {
         config()->set('livewire.temporary_file_upload.middleware', ['throttle:60,1']);
@@ -1045,6 +1086,36 @@ class UnitTest extends \Tests\TestCase
         $url = preg_replace('#^https://#', 'http://', $url);
 
         $this->get($url)->assertOk();
+    }
+
+    protected function useS3LikeTemporaryUploadDisk()
+    {
+        config()->set('livewire.temporary_file_upload.disk', 'tmp-for-tests');
+
+        // Simulate a remote disk returning stored upload metadata instead of inspecting the file...
+        $adapter = new \League\Flysystem\Local\LocalFilesystemAdapter(
+            $root = storage_path('framework/testing/disks/tmp-for-tests'),
+            null,
+            LOCK_EX,
+            \League\Flysystem\Local\LocalFilesystemAdapter::DISALLOW_LINKS,
+            new \League\MimeTypeDetection\ExtensionMimeTypeDetector(),
+        );
+
+        $disk = new class(new \League\Flysystem\Filesystem($adapter), $adapter, ['root' => $root]) extends FilesystemAdapter {
+            public $canRead = true;
+            public $readStreamCalls = 0;
+
+            public function readStream($path)
+            {
+                $this->readStreamCalls++;
+
+                return $this->canRead ? parent::readStream($path) : null;
+            }
+        };
+
+        Storage::set('tmp-for-tests', $disk);
+
+        return $disk;
     }
 }
 


### PR DESCRIPTION
Ports the 3.x temporary-upload MIME fix to 4.x while preserving 4.x test metadata handling. Remote files are sampled from their contents instead of trusting extension-derived storage metadata; unreadable and empty files remain application/octet-stream.

Validation:
- 62 SupportFileUploads unit tests, 152 assertions
- Composer audit: no advisories or abandoned packages
- PHP syntax and diff checks passed

Source commit: 11ee40d2 / PR #10440.