### PR TITLE
Backport proxy-safe upload URLs to 3.x

### DIFF
--- a/src/Features/SupportFileUploads/BrowserTest.php
+++ b/src/Features/SupportFileUploads/BrowserTest.php
@@ -2,9 +2,12 @@
 
 namespace Livewire\Features\SupportFileUploads;
 
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
 use Livewire\WithFileUploads;
 use Livewire\Component;
+use Facades\Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl as GenerateSignedUploadUrlFacade;
 use Livewire\Features\SupportValidation\BaseValidate;
 use Livewire\Livewire;
 
@@ -273,5 +276,57 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->waitUntil("document.querySelector('[dusk=\"upload\"]')?.value === ''")
         ->assertInputValue('@upload', null)
         ;
+    }
+
+    public function test_local_upload_succeeds_when_the_proxys_forwarded_https_origin_is_not_trusted()
+    {
+        // Signs under https, then swaps https:// for http:// on the URL —
+        // simulating a proxy Laravel doesn't trust to report its real origin.
+        $this->beforeServingApplication(function () {
+            Storage::persistentFake('tmp-for-tests');
+
+            GenerateSignedUploadUrlFacade::swap(new class extends GenerateSignedUploadUrl {
+                public function forLocal()
+                {
+                    URL::forceScheme('https');
+                    $url = parent::forLocal();
+                    URL::forceScheme(null);
+
+                    return preg_replace('#^https://#', 'http://', $url);
+                }
+            });
+
+            Livewire::component('https-signed-upload', HttpsSignedUploadComponent::class);
+
+            Route::get('/https-signed-upload', HttpsSignedUploadComponent::class)->middleware('web');
+        });
+
+        $this->browse(function ($browser) {
+            $browser->visit('/https-signed-upload')
+                ->assertMissing('@preview')
+                ->attach('@upload', __DIR__ . '/browser_test_image.png')
+                ->waitFor('@preview')
+                ->assertVisible('@preview')
+            ;
+        });
+    }
+}
+
+class HttpsSignedUploadComponent extends Component
+{
+    use WithFileUploads;
+
+    public $photo;
+
+    function render() {
+        return <<<'HTML'
+            <div>
+                <input type="file" wire:model="photo" dusk="upload">
+
+                @if ($photo)
+                    <img src="{{ $photo->temporaryUrl() }}" dusk="preview">
+                @endif
+            </div>
+        HTML;
     }
 }

--- a/src/Features/SupportFileUploads/FilePreviewController.php
+++ b/src/Features/SupportFileUploads/FilePreviewController.php
@@ -17,7 +17,7 @@ class FilePreviewController implements HasMiddleware
 
     public function handle($filename)
     {
-        abort_unless(request()->hasValidSignature(), 401);
+        abort_unless(request()->hasValidRelativeSignature(), 401);
 
         return Utils::pretendPreviewResponseIsPreviewFile($filename);
     }

--- a/src/Features/SupportFileUploads/FileUploadController.php
+++ b/src/Features/SupportFileUploads/FileUploadController.php
@@ -26,7 +26,7 @@ class FileUploadController implements HasMiddleware
 
     public function handle()
     {
-        abort_unless(request()->hasValidSignature(), 401);
+        abort_unless(request()->hasValidRelativeSignature(), 401);
 
         $disk = FileUploadConfiguration::disk();
 

--- a/src/Features/SupportFileUploads/GenerateSignedUploadUrl.php
+++ b/src/Features/SupportFileUploads/GenerateSignedUploadUrl.php
@@ -10,7 +10,7 @@ class GenerateSignedUploadUrl
 {
     public function forLocal()
     {
-        return URL::temporarySignedRoute(
+        return $this->signedRoute(
             'livewire.upload-file', now()->addMinutes(FileUploadConfiguration::maxUploadTime())
         );
     }
@@ -59,6 +59,15 @@ class GenerateSignedUploadUrl
             'url' => (string) $uri,
             'headers' => $this->headers($signedRequest, $fileType),
         ];
+    }
+
+    // Signs relative so the scheme can't mismatch behind a proxy; re-absolutized
+    // for a normal-looking URL. Validate with `hasValidRelativeSignature()`.
+    public function signedRoute($name, $expiration, $parameters = [])
+    {
+        $relative = URL::temporarySignedRoute($name, $expiration, $parameters, false);
+
+        return URL::to($relative);
     }
 
     protected function headers($signedRequest, $fileType)

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -4,9 +4,9 @@ namespace Livewire\Features\SupportFileUploads;
 
 use Illuminate\Support\Arr;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Storage;
 use League\MimeTypeDetection\FinfoMimeTypeDetector;
+use Facades\Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl as GenerateSignedUploadUrlFacade;
 
 class TemporaryUploadedFile extends UploadedFile
 {
@@ -135,7 +135,7 @@ class TemporaryUploadedFile extends UploadedFile
             return $this->storage->temporaryUrl($this->path, now()->addDay());
         }
 
-        return URL::temporarySignedRoute(
+        return GenerateSignedUploadUrlFacade::signedRoute(
             'livewire.preview-file', now()->addMinutes(30)->endOfHour(), ['filename' => $this->getFilename()]
         );
     }

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -11,6 +11,7 @@ use Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButton
 use League\Flysystem\PathTraversalDetected;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Http\UploadedFile;
 use Facades\Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl;
 use Illuminate\Http\Testing\FileFactory;
@@ -951,6 +952,29 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertInstanceOf(TemporaryUploadedFile::class, $rows['one']['image']);
         $this->assertEquals(['image' => null, 'caption' => 'New row'], $rows['three']);
+    }
+
+    public function test_preview_succeeds_when_the_proxys_forwarded_https_origin_is_not_trusted()
+    {
+        // Signs under https, then swaps https:// for http:// on the URL,
+        // simulating a proxy Laravel doesn't trust to report its real origin.
+        Storage::fake('avatars');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', UploadedFile::fake()->image('avatar.jpg'))
+            ->viewData('photo');
+
+        SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+
+        URL::forceScheme('https');
+        $url = $photo->temporaryUrl();
+        URL::forceScheme(null);
+
+        $this->assertStringStartsWith('https://', $url);
+
+        $url = preg_replace('#^https://#', 'http://', $url);
+
+        $this->get($url)->assertOk();
     }
 
     protected function useS3LikeTemporaryUploadDisk()


### PR DESCRIPTION
Backports the proxy-safe local upload and preview URL fix from 4.x #10574 to 3.x, adapted to the real-time facades used on this line.

The branch was rebased after repeated lazy-load handling landed independently in 3.x via #10586, so that duplicate change is no longer part of this PR.

Validation:
- 62 focused unit tests, 145 assertions, 1 skipped before the rebase
- proxy-origin unit and real-browser regressions passed again after the rebase
- production npm audit: zero vulnerabilities
- Composer audit: no advisories or abandoned packages
- full npm audit retains one pre-existing development-only esbuild advisory
- production build and diff checks passed
- both complete GitHub matrices are green