### PR TITLE
Synchronize eligible 4.x fixes into main

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -201,13 +201,14 @@ $wire.interceptMessage(({ message, cancel, onSend, onCancel, onSuccess, onSkippe
 
     onCancel(() => {})
 
-    onSuccess(({ payload, onSync, onEffect, onMorph, onRender }) => {
+    onSuccess(({ payload, onSync, onEffect, onMorph, onMorphed, onRender }) => {
         // payload: { snapshot, effects }
 
-        onSync(() => {})    // After state synced
-        onEffect(() => {})  // After effects processed
-        onMorph(async () => {})   // After DOM morphed (must be async)
-        onRender(() => {})  // After render complete
+        onSync(() => {})          // After state synced
+        onEffect(() => {})        // After effects processed
+        onMorph(async () => {})   // Advanced: add awaited DOM morph work
+        onMorphed(() => {})       // After all DOM morph work completes
+        onRender(() => {})        // In the next animation frame
     })
 
     onSkipped(() => {
@@ -222,8 +223,9 @@ $wire.interceptMessage(({ message, cancel, onSend, onCancel, onSuccess, onSkippe
 
     onFailure(({ error }) => {})
 
-    onStream(({ json }) => {
+    onStream(async ({ json }) => {
         // json: Parsed stream chunk
+        // Async work is awaited before the next chunk is processed
     })
 
     onFinish(() => {
@@ -232,6 +234,8 @@ $wire.interceptMessage(({ message, cancel, onSend, onCancel, onSuccess, onSkippe
 })
 ```
 
+`onMorph` is an advanced hook for contributing asynchronous DOM work that Livewire must wait for. Most code that needs to access the updated DOM should use `onMorphed`, which runs after the response's component, island, and slot morphs have all completed, but before action promises resolve and `onFinish` runs.
+
 #### Timing
 
 Hook execution order for successful requests:
@@ -239,9 +243,10 @@ Hook execution order for successful requests:
 1. `onSuccess` - Immediately after server response
 2. `onSync` - After state merged
 3. `onEffect` - After effects processed
-4. `onMorph` - After DOM morphed
-5. `onFinish` - After morph completes
-6. `onRender` - In `requestAnimationFrame` (post-paint)
+4. `onMorph` - During the awaited DOM morph phase
+5. `onMorphed` - After all DOM morph work completes
+6. `onFinish` - After `onMorphed`
+7. `onRender` - In the next `requestAnimationFrame`
 
 For skipped messages (e.g. an unchanged reactive child) `onSkipped` fires instead of `onSuccess`, then `onFinish`. None of the morph/render hooks fire since there's nothing to apply.
 
@@ -498,6 +503,14 @@ Livewire.hook('component.init', ({ component, cleanup }) => {
 })
 ```
 
+For advanced integrations that depend on Livewire's initial effects—such as event listeners, scripts, or server-dispatched JavaScript—use `component.initialized`. It runs after those effects have been processed, but before Livewire continues initializing the component's descendant elements:
+
+```js
+Livewire.hook('component.initialized', ({ component }) => {
+    //
+})
+```
+
 For more information, please consult the [documentation on the component object](#the-component-object).
 
 ### DOM element initialization
@@ -579,7 +592,7 @@ new class extends Component {
 };
 ```
 
-The JavaScript expression `alert('Post saved!')` will be executed on the client after the post has been saved to the database on the server.
+The JavaScript expression `alert('Post saved!')` will be executed on the client after the post has been saved to the database on the server and the response's DOM morph has completed.
 
 You can access the current component's `$wire` object inside the expression:
 

--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -1,6 +1,7 @@
 import { toggleBooleanStateDirective } from './shared'
 import { directive, getDirectives } from "@/directives"
 import { closestIsland } from '@/features/supportIslands'
+import { onNavigationStart } from '@/plugins/navigate/navigation'
 import { interceptMessage } from '@/request'
 import { listen } from '@/utils'
 
@@ -93,31 +94,53 @@ function whenTargetsArePartOfRequest(component, el, targets, inverted, [ startLo
 
         let matches = true
         let cleared = false
+        let navigationWasStarted = false
+        let stopWaitingForNavigation = () => {}
+
+        let finishLoading = () => {
+            if (! matches || cleared) return
+
+            stopWaitingForNavigation()
+
+            endLoading()
+            cleared = true
+        }
 
         onSend(({ payload }) => {
             if (targets.length > 0 && containsTargets(payload, targets) === inverted) {
                 matches = false
             }
 
-            matches && startLoading()
+            if (! matches) return
+
+            startLoading()
         })
 
         // Clear loading before morph on success
         onSuccess(({ onEffect }) => {
+            // Effects are processed before onEffect runs, so watch this window for a navigation...
+            stopWaitingForNavigation = onNavigationStart(navigation => {
+                navigationWasStarted = true
+
+                navigation.onDestinationSettled(finishLoading)
+            })
+
             onEffect(() => {
-                if (matches && ! cleared) {
-                    endLoading()
-                    cleared = true
-                }
+                stopWaitingForNavigation()
+
+                if (navigationWasStarted) return
+
+                finishLoading()
             })
         })
 
         // Clear loading on cancel/error/failure (onFinish fires immediately on these paths)
         onFinish(() => {
-            if (matches && ! cleared) {
-                endLoading()
-                cleared = true
-            }
+            stopWaitingForNavigation()
+
+            if (navigationWasStarted) return
+
+            finishLoading()
         })
     })
 }

--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -41,10 +41,10 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
         return callback()
     }
 
-    // Skip entirely if a modal dialog is already open (transitions behind
-    // a dialog are invisible to the user and the ::view-transition pseudo-
-    // elements would paint above the dialog during animation)...
-    if (document.querySelector('dialog:modal')) return callback()
+    // Skip entirely if a top-layer element is already open (transitions behind
+    // it are invisible to the user and the ::view-transition pseudo-elements
+    // would paint above it during animation)...
+    if (document.querySelector('dialog:modal, :popover-open')) return callback()
 
     // Set transition names right before the transition starts (not permanently)...
     setTransitionNames(fromEl, options)
@@ -95,12 +95,24 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
         clearTransitionNames(fromEl)
     }
 
-    // Watch for modal dialogs opening during the transition (e.g., via Alpine x-effect).
-    // ::view-transition pseudo-elements paint above the top layer, so elements with
-    // wire:transition would visually appear above dialog modals during animation.
-    // This observer catches showModal() the instant it sets the `open` attribute
-    // and skips the transition before the browser paints a frame...
-    let skipOnDialog = (transition) => {
+    // Watch for dialogs or popovers opening during the transition (e.g., via Alpine
+    // x-effect or a toast). ::view-transition pseudo-elements paint above the top
+    // layer, so the transition must be skipped before the browser paints a frame...
+    let skipOnTopLayer = (transition) => {
+        // Chromium rejects `ready` when skipTransition() is called. Consume that
+        // expected rejection so a deliberate policy skip is not reported as an error...
+        transition.ready.catch(() => {})
+
+        let onBeforeToggle = (event) => {
+            if (event.newState === 'open' && event.target.matches?.('dialog, [popover]')) {
+                transition.skipTransition()
+            }
+        }
+
+        document.addEventListener('beforetoggle', onBeforeToggle, true)
+
+        // Keep the attribute observer as a fallback for browsers that do not emit
+        // beforetoggle when a modal dialog is opened...
         let observer = new MutationObserver(() => {
             if (document.querySelector('dialog:modal')) {
                 transition.skipTransition()
@@ -114,24 +126,27 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
             subtree: true,
         })
 
-        transition.finished.finally(() => observer.disconnect())
+        transition.finished.finally(() => {
+            observer.disconnect()
+            document.removeEventListener('beforetoggle', onBeforeToggle, true)
+        }).catch(() => {})
     }
 
     try {
         let transition = document.startViewTransition(transitionConfig)
 
-        skipOnDialog(transition)
+        skipOnTopLayer(transition)
 
-        transition.finished.finally(cleanup)
+        transition.finished.finally(cleanup).catch(() => {})
 
         await transition.updateCallbackDone
     } catch (e) {
         // Firefox 144+ supports View Transitions but only with a callback, not a config object (no transition types support)
         let transition = document.startViewTransition(update)
 
-        skipOnDialog(transition)
+        skipOnTopLayer(transition)
 
-        transition.finished.finally(cleanup)
+        transition.finished.finally(cleanup).catch(() => {})
 
         await transition.updateCallbackDone
     }

--- a/js/evaluator.js
+++ b/js/evaluator.js
@@ -65,7 +65,7 @@ export function evaluateReactiveExpression(el, expression, options = {}) {
 export function evaluateActionExpression(el, expression, options = {}) {
     if (! expression || expression.trim() === '') return
 
-    let contextualExpression = contextualizeExpression(expression, el)
+    let contextualExpression = contextualizeExpression(expression, el, ! isEvaluatingReactiveExpression())
 
     try {
         let result = Alpine.evaluateRaw(el, contextualExpression, options)
@@ -88,21 +88,27 @@ function reportExpressionError(error, expression, el) {
     console.error(error)
 }
 
-export function contextualizeExpression(expression, el, extraSkip = []) {
+export function contextualizeExpression(expression, el, preferWireAction = false, extraSkip = []) {
     let SKIP = ['JSON', 'true', 'false', 'null', 'undefined', 'this', '$wire', '$event', ...extraSkip]
+    let alpineScopeKeys = []
 
     // If an element is provided, collect Alpine scope keys between
     // this element and the Livewire component root so they don't
     // get incorrectly prefixed with $wire.
     if (el) {
-        SKIP.push(...getAlpineScopeKeys(el))
+        alpineScopeKeys = getAlpineScopeKeys(el)
+        SKIP.push(...alpineScopeKeys)
     }
-    let strings = []
+    let protectedExpressions = []
 
-    // 1. Yank out string literals so we don't touch them
-    let result = expression.replace(/(["'`])(?:(?!\1)[^\\]|\\.)*\1/g, (m) => {
-        strings.push(m)
-        return `___${strings.length - 1}___`
+    let actionTargetOffset = preferWireAction
+        ? getActionTargetOffset(expression)
+        : null
+
+    // 1. Yank out string literals and comments so we don't touch them
+    let result = expression.replace(/(["'`])(?:(?!\1)[^\\]|\\.)*\1|\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, (m) => {
+        protectedExpressions.push(m)
+        return `___${protectedExpressions.length - 1}___`
     })
 
     // 1.5. Skip arrow-function parameters ('file' in 'files.some(file => ...)')
@@ -117,20 +123,36 @@ export function contextualizeExpression(expression, el, extraSkip = []) {
 
     // 1.75. Contextualize interpolations inside template literals so
     //       `${count} selected` becomes `${$wire.count} selected`...
-    strings = strings.map(string => {
+    protectedExpressions = protectedExpressions.map(string => {
         return string.startsWith('`') ? contextualizeTemplateLiteral(string, el, SKIP) : string
     })
 
     // 2. Prefix identifiers not after a dot (skip placeholders from step 1)
     //    Also skip object keys (identifiers immediately followed by colon)
     result = result.replace(/(^|[^.\w$])(\$?[a-zA-Z_]\w*)/g, (m, pre, ident, offset) => {
-        if (SKIP.includes(ident) || /^___\d+___$/.test(ident)) return pre + ident
+        let isWireActionTarget = alpineScopeKeys.includes(ident)
+            && offset + pre.length === actionTargetOffset
+
+        if ((SKIP.includes(ident) && ! isWireActionTarget) || /^___\d+___$/.test(ident)) return pre + ident
         if (result[offset + m.length] === ':') return pre + ident
         return pre + '$wire.' + ident
     })
 
-    // 3. Restore strings
-    return result.replace(/___(\d+)___/g, (m, i) => strings[i])
+    // 3. Restore strings and comments
+    return result.replace(/___(\d+)___/g, (m, i) => protectedExpressions[i])
+}
+
+function getActionTargetOffset(expression) {
+    let actionTarget = expression.match(/^(\s*)([a-zA-Z_]\w*)/)
+
+    if (! actionTarget) return null
+
+    let remainder = expression.slice(actionTarget[0].length)
+    let significantRemainder = remainder.replace(/^(?:(?:\s+)|(?:\/\*[\s\S]*?\*\/)|(?:\/\/[^\n]*(?:\n|$)))*/, '')
+
+    if (significantRemainder !== '' && ! significantRemainder.startsWith('(') && ! significantRemainder.startsWith(';')) return null
+
+    return actionTarget[1].length
 }
 
 function contextualizeTemplateLiteral(literal, el, skip) {
@@ -169,7 +191,7 @@ function contextualizeTemplateLiteral(literal, el, skip) {
                 j++
             }
 
-            result += '${' + contextualizeExpression(literal.slice(start, j), el, skip) + '}'
+            result += '${' + contextualizeExpression(literal.slice(start, j), el, false, skip) + '}'
             i = j + 1
         } else {
             result += literal[i]

--- a/js/evaluator.spec.js
+++ b/js/evaluator.spec.js
@@ -86,6 +86,20 @@ describe('Contextualize expressions', () => {
         expect(contextualizeExpression('index', mockEl)).toBe('index')
     })
 
+    it('wire action targets take precedence over alpine scope variables', () => {
+        let mockEl = {
+            _x_dataStack: [{ open: false, save: false, user: {} }],
+            hasAttribute: () => false,
+            parentElement: null,
+        }
+
+        expect(contextualizeExpression('open(user)', mockEl, true)).toBe('$wire.open(user)')
+        expect(contextualizeExpression('save', mockEl, true)).toBe('$wire.save')
+        expect(contextualizeExpression('save;', mockEl, true)).toBe('$wire.save;')
+        expect(contextualizeExpression('open /* comment */ (user)', mockEl, true)).toBe('$wire.open /* comment */ (user)')
+        expect(contextualizeExpression('open = !open', mockEl, true)).toBe('open = !open')
+    })
+
     it('nested alpine scopes', () => {
         let parentEl = {
             _x_dataStack: [{ user: {} }],

--- a/js/features/supportDataLoading.js
+++ b/js/features/supportDataLoading.js
@@ -1,6 +1,7 @@
 import { interceptMessage } from '@/request'
+import { releaseAfterNavigation } from '@/plugins/navigate/navigation'
 
-interceptMessage(({ message, onSend, onFinish }) => {
+interceptMessage(({ message, onSend, onSuccess, onFinish }) => {
     let undos = []
 
     onSend(() => {
@@ -23,5 +24,5 @@ interceptMessage(({ message, onSend, onFinish }) => {
         })
     })
 
-    onFinish(() => undos.forEach(undo => undo()))
+    releaseAfterNavigation({ onSuccess, onFinish }, () => undos.forEach(undo => undo()))
 })

--- a/js/features/supportDisablingFormsDuringRequest.js
+++ b/js/features/supportDisablingFormsDuringRequest.js
@@ -1,5 +1,7 @@
 import { getDirectives } from '@/directives'
 import { on } from '@/hooks'
+import { releaseAfterNavigation } from '@/plugins/navigate/navigation'
+import { interceptMessage } from '@/request'
 import { Bag } from '@/utils'
 import Alpine from 'alpinejs'
 
@@ -27,11 +29,13 @@ on('directive.init', ({ el, directive, cleanup, component }) => setTimeout(() =>
     })
 }))
 
-on('commit', ({ component, respond }) => {
-    respond(() => {
-        cleanups.each(component.id, i => i())
-        cleanups.remove(component.id)
-    })
+interceptMessage(({ message, onSuccess, onFinish }) => {
+    let enableForm = () => {
+        cleanups.each(message.component.id, cleanup => cleanup())
+        cleanups.remove(message.component.id)
+    }
+
+    releaseAfterNavigation({ onSuccess, onFinish }, enableForm)
 })
 
 function disableForm(formEl) {

--- a/js/features/supportDispatches.js
+++ b/js/features/supportDispatches.js
@@ -1,26 +1,37 @@
 import { dispatch, dispatchEl, dispatchRef, dispatchSelf, dispatchTo } from '@/events'
 import { on } from '@/hooks'
+import { interceptMessage } from '@/request'
 
-on('effect', ({ component, effects }) => {
-    // Wrapping this in a triple queueMicrotask...
-    // The first one puts it after all other "effect" hooks...
-    // The second one puts it after all reactive Alpine effects
+interceptMessage(({ message, onSuccess }) => {
+    onSuccess(({ payload, onMorphed }) => {
+        onMorphed(() => {
+            dispatchEvents(message.component, getDispatches(payload.effects))
+        })
+    })
+})
+
+on('component.initialized', ({ component }) => {
+    let dispatches = getDispatches(component.effects)
+
+    if (dispatches.length === 0) return
+
+    // Wrapping initial dispatches in a triple queueMicrotask...
+    // The first one puts them after all initialization and "effect" hooks...
+    // The second one puts them after all reactive Alpine effects
     // (that are processed via flushJobs in scheduler)...
-    // The third one puts it after morph changes have been applied...
+    // The third one puts them after DOM initialization changes have been applied...
     queueMicrotask(() => {
         queueMicrotask(() => {
             queueMicrotask(() => {
-                let dispatches = []
-
-                if (Object.prototype.hasOwnProperty.call(effects, 'dispatches') && effects.dispatches) {
-                    dispatches = effects.dispatches
-                }
-
                 dispatchEvents(component, dispatches)
             })
         })
     })
 })
+
+function getDispatches(effects) {
+    return effects.dispatches || []
+}
 
 function dispatchEvents(component, dispatches) {
     dispatches.forEach(({ name, params = {}, self = false, component: componentName, ref, el }) => {

--- a/js/features/supportFileUploads/synth.js
+++ b/js/features/supportFileUploads/synth.js
@@ -56,7 +56,14 @@ export class TemporaryUpload {
     get name() { return this.file?.name ?? this.meta.name ?? this.filename }
 
     // The hashed temporary filename on the server (used by $wire.removeUpload())...
-    get filename() { return this.serialized === null ? null : this.serialized.replace('livewire-file:', '') }
+    get filename() {
+        if (this.serialized === null) return null
+
+        let signedFilename = this.serialized.replace('livewire-file:', '')
+        let tokenSeparator = signedFilename.indexOf(':')
+
+        return tokenSeparator === -1 ? signedFilename : signedFilename.slice(tokenSeparator + 1)
+    }
 
     get extension() { return this.name?.split('.').pop() }
 

--- a/js/features/supportFileUploads/synth.spec.js
+++ b/js/features/supportFileUploads/synth.spec.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { TemporaryUpload } from './synth'
+
+describe('TemporaryUpload filename', () => {
+    it('extracts the server filename from a signed wire value', () => {
+        let upload = new TemporaryUpload('livewire-file:deadbeef:abc123-photo.png')
+
+        expect(upload.filename).toBe('abc123-photo.png')
+    })
+
+    it('continues to read legacy unsigned wire values', () => {
+        let upload = new TemporaryUpload('livewire-file:abc123-photo.png')
+
+        expect(upload.filename).toBe('abc123-photo.png')
+    })
+})

--- a/js/features/supportIslands.js
+++ b/js/features/supportIslands.js
@@ -45,12 +45,12 @@ interceptAction(({ action }) => {
 })
 
 interceptMessage(({ message, onSuccess, onStream }) => {
-    onStream(({ json }) => {
+    onStream(async ({ json }) => {
         let { type, islandFragment } = json
 
         if (type !== 'island') return
 
-        renderIsland(message.component, islandFragment)
+        await renderIsland(message.component, islandFragment)
     })
 
     onSuccess(({ payload, onMorph }) => {

--- a/js/features/supportJsEvaluation.js
+++ b/js/features/supportJsEvaluation.js
@@ -1,6 +1,7 @@
 import { evaluateExpression } from '../evaluator'
 import { findComponentByEl } from '@/store'
 import { overrideMethod } from '@/$wire'
+import { interceptMessage } from '@/request'
 import { on } from '@/hooks'
 import Alpine from 'alpinejs'
 
@@ -10,17 +11,19 @@ Alpine.magic('js', el => {
     return component.$wire.js
 })
 
-on('effect', ({ component, effects }) => {
-    let js
-    let xjs
+on('component.initialized', ({ component }) => {
+    evaluateJsEffects(component, component.effects)
+})
 
-    if (Object.prototype.hasOwnProperty.call(effects, 'js')) {
-        js = effects.js
-    }
+interceptMessage(({ message, onSuccess }) => {
+    onSuccess(({ payload, onMorphed }) => {
+        onMorphed(() => evaluateJsEffects(message.component, payload.effects))
+    })
+})
 
-    if (Object.prototype.hasOwnProperty.call(effects, 'xjs')) {
-        xjs = effects.xjs
-    }
+function evaluateJsEffects(component, effects) {
+    let js = effects.js
+    let xjs = effects.xjs
 
     if (js) {
         Object.entries(js).forEach(([method, body]) => {
@@ -37,4 +40,4 @@ on('effect', ({ component, effects }) => {
             evaluateExpression(component.el, expression, { scope: component.getJsActions(), params })
         })
     }
-})
+}

--- a/js/features/supportScriptsAndAssets.js
+++ b/js/features/supportScriptsAndAssets.js
@@ -31,11 +31,11 @@ on('component.init', ({ component }) => {
 })
 
 on('effect', ({ component, effects }) => {
-    let scripts
+    evaluateScripts(component, effects)
+})
 
-    if (Object.prototype.hasOwnProperty.call(effects, 'scripts')) {
-        scripts = effects.scripts
-    }
+function evaluateScripts(component, effects) {
+    let scripts = effects.scripts
 
     if (scripts) {
         Object.entries(scripts).forEach(([key, content]) => {
@@ -61,7 +61,7 @@ on('effect', ({ component, effects }) => {
             })
         })
     }
-})
+}
 
 function onlyIfScriptHasntBeenRunAlreadyForThisComponent(component, key, callback) {
     if (executedScripts.has(component)) {
@@ -149,4 +149,3 @@ async function runAssetSynchronously(child) {
 function isScript(el)   {
     return el.tagName.toLowerCase() === 'script'
 }
-

--- a/js/features/supportSlots.js
+++ b/js/features/supportSlots.js
@@ -12,9 +12,9 @@ interceptMessage(({ message, onSuccess, onStream }) => {
                 fragments = payload.effects.slotFragments
             }
 
-            fragments.forEach(async fragmentHtml => {
+            for (let fragmentHtml of fragments) {
                 await renderSlot(message.component, fragmentHtml)
-            })
+            }
         })
     })
 })

--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -8,6 +8,7 @@ import { finishAndHideProgressBar, removeAnyLeftOverStaleProgressBars, showAndSt
 import { packUpPersistedPopovers, unPackPersistedPopovers } from "./popover"
 import { swapCurrentPageWithNewHtml } from "./page"
 import { fetchHtml } from "./fetch"
+import { startNavigation } from "./navigation"
 
 let enablePersist = true
 let showProgressBar = true
@@ -79,12 +80,21 @@ export default function (Alpine) {
     })
 
     function navigateTo(destination, { preserveScroll = false, shouldPushToHistoryState = true }) {
+        let navigation = startNavigation()
+
         showProgressBar && showAndStartProgressBar()
 
         fetchHtmlOrUsePrefetchedHtml(destination, (html, finalDestination) => {
             // The request may have been redirected off to another origin. We can't
             // swap that page into this document, so let the browser visit it...
-            if (! isSameOrigin(finalDestination)) return visitNatively(finalDestination)
+            if (! isSameOrigin(finalDestination)) {
+                navigation.ready()
+                navigation.finish()
+
+                return visitNatively(finalDestination)
+            }
+
+            navigation.ready()
 
             // Fire the navigating event, allowing listeners to register onSwap callbacks
             let swapCallbacks = []
@@ -133,12 +143,15 @@ export default function (Alpine) {
                             autofocusElementsWithTheAutofocusAttribute()
 
                             fireEventForOtherLibrariesToHookInto('alpine:navigated')
+                            navigation.finish()
                             showProgressBar && finishAndHideProgressBar()
                         })
                     })
                 })
             })
         }, (error) => {
+            navigation.cancel()
+
             showProgressBar && finishAndHideProgressBar()
 
             // We cancelled this request ourselves, so the user is already on their
@@ -180,12 +193,16 @@ export default function (Alpine) {
 
             if (prevented) return
 
+            let navigation = startNavigation()
+
             // @todo: see if there's a way to update the current HTML BEFORE
             // the back button is hit, and not AFTER:
             storeScrollInformationInHtmlBeforeNavigatingAway()
 
             // Fire the navigating event, allowing listeners to register onSwap callbacks
             let swapCallbacks = []
+
+            navigation.ready()
 
             fireEventForOtherLibrariesToHookInto('alpine:navigating', {
                 onSwap: (callback) => swapCallbacks.push(callback)
@@ -224,6 +241,7 @@ export default function (Alpine) {
                         autofocusElementsWithTheAutofocusAttribute()
 
                         fireEventForOtherLibrariesToHookInto('alpine:navigated')
+                        navigation.finish()
                     })
                 })
             })

--- a/js/plugins/navigate/navigation.js
+++ b/js/plugins/navigate/navigation.js
@@ -1,0 +1,169 @@
+let activeNavigation
+let navigationStartListeners = new Set
+
+export function startNavigation() {
+    activeNavigation?.cancel()
+
+    let navigation = new Navigation(() => {
+        if (activeNavigation === navigation) activeNavigation = undefined
+    })
+
+    activeNavigation = navigation
+
+    navigationStartListeners.forEach(callback => callback(navigation))
+
+    return navigation
+}
+
+export function onNavigationStart(callback) {
+    navigationStartListeners.add(callback)
+
+    return () => navigationStartListeners.delete(callback)
+}
+
+export function releaseAfterNavigation({ onSuccess, onFinish }, release) {
+    let navigationWasStarted = false
+    let stopWaitingForNavigation = () => {}
+
+    onSuccess(({ onEffect }) => {
+        stopWaitingForNavigation = onNavigationStart(navigation => {
+            navigationWasStarted = true
+
+            navigation.onDestinationSettled(release)
+        })
+
+        onEffect(stopWaitingForNavigation)
+    })
+
+    onFinish(() => {
+        stopWaitingForNavigation()
+
+        if (navigationWasStarted) return
+
+        release()
+    })
+}
+
+export function getActiveNavigation() {
+    return activeNavigation
+}
+
+export function isNavigating() {
+    return activeNavigation !== undefined
+}
+
+class Navigation {
+    constructor(onComplete) {
+        this.state = 'fetching'
+        this.onComplete = onComplete
+        this.listeners = {
+            ready: new Set,
+            cancelled: new Set,
+            finished: new Set,
+        }
+    }
+
+    onReady(callback) {
+        if (this.state === 'ready' || this.state === 'finished') {
+            callback()
+
+            return () => {}
+        }
+
+        return this.listen('ready', callback)
+    }
+
+    onCancelled(callback) {
+        if (this.state === 'cancelled') {
+            callback()
+
+            return () => {}
+        }
+
+        return this.listen('cancelled', callback)
+    }
+
+    onFinished(callback) {
+        if (this.state === 'finished') {
+            callback()
+
+            return () => {}
+        }
+
+        return this.listen('finished', callback)
+    }
+
+    onDestinationSettled(callback) {
+        if (this.state === 'ready' || this.state === 'finished') {
+            callback()
+
+            return () => {}
+        }
+
+        if (this.state === 'cancelled') {
+            callback()
+
+            return () => {}
+        }
+
+        let removeReadyListener = this.listen('ready', () => {
+            removeCancelledListener()
+
+            callback()
+        })
+
+        let removeCancelledListener = this.listen('cancelled', () => {
+            removeReadyListener()
+
+            callback()
+        })
+
+        return () => {
+            removeReadyListener()
+            removeCancelledListener()
+        }
+    }
+
+    ready() {
+        if (this.state !== 'fetching') return
+
+        this.state = 'ready'
+
+        this.emit('ready')
+    }
+
+    cancel() {
+        if (this.state === 'cancelled' || this.state === 'finished') return
+
+        this.state = 'cancelled'
+
+        this.emit('cancelled')
+        this.complete()
+    }
+
+    finish() {
+        if (this.state === 'cancelled' || this.state === 'finished') return
+
+        this.state = 'finished'
+
+        this.emit('finished')
+        this.complete()
+    }
+
+    listen(event, callback) {
+        this.listeners[event].add(callback)
+
+        return () => this.listeners[event].delete(callback)
+    }
+
+    emit(event) {
+        this.listeners[event].forEach(callback => callback())
+        this.listeners[event].clear()
+    }
+
+    complete() {
+        Object.values(this.listeners).forEach(listeners => listeners.clear())
+
+        this.onComplete()
+    }
+}

--- a/js/request/index.js
+++ b/js/request/index.js
@@ -347,14 +347,14 @@ function sendMessages() {
                 let finalResponse = ''
 
                 try {
-                    finalResponse = await interceptStreamAndReturnFinalResponse(response, json => {
+                    finalResponse = await interceptStreamAndReturnFinalResponse(response, async json => {
                         let componentId = json.id
 
-                        request.messages.forEach(message => {
+                        for (let message of request.messages) {
                             if (message.component.id === componentId) {
-                                message.invokeOnStream({ json })
+                                await message.invokeOnStream({ json })
                             }
-                        })
+                        }
 
                         trigger('stream', json)
                     })
@@ -480,6 +480,8 @@ function sendMessages() {
                                 await message.invokeOnMorph()
 
                                 morphed = true
+
+                                message.invokeOnMorphed()
                             }).finally(() => {
                                 // Using `finally` so a broken effect or morph can't strand the
                                 // component with a stuck loading state and an action promise
@@ -634,9 +636,9 @@ async function interceptStreamAndReturnFinalResponse(response, callback) {
 
         let [ streams, remaining ] = extractStreamObjects(remainingResponse + output)
 
-        streams.forEach(stream => {
-            callback(stream)
-        })
+        for (let stream of streams) {
+            await callback(stream)
+        }
 
         remainingResponse = remaining
 

--- a/js/request/interceptor.js
+++ b/js/request/interceptor.js
@@ -5,13 +5,14 @@ export class MessageInterceptor {
     onCancel = () => {}
     onFailure = () => {}
     onError = () => {}
-    onStream = () => {}
+    onStream = null
     onSuccess = () => {}
     onSkipped = () => {}
     onFinish = () => {}
     onSync = () => {}
     onEffect = () => {}
     onMorph = async () => {}
+    onMorphed = () => {}
     onRender = () => {}
 
     constructor(message, callback) {

--- a/js/request/message.js
+++ b/js/request/message.js
@@ -187,8 +187,10 @@ export default class Message {
         this.invokeOnFinish()
     }
 
-    invokeOnStream({ json }) {
-        this.interceptors.forEach(interceptor => interceptor.onStream({ json }))
+    async invokeOnStream({ json }) {
+        for (let interceptor of this.interceptors) {
+            if (interceptor.onStream) await interceptor.onStream({ json })
+        }
     }
 
     invokeOnSuccess() {
@@ -198,6 +200,7 @@ export default class Message {
                 onSync: callback => interceptor.onSync = callback,
                 onEffect: callback => interceptor.onEffect = callback,
                 onMorph: callback => interceptor.onMorph = callback,
+                onMorphed: callback => interceptor.onMorphed = callback,
                 onRender: callback => interceptor.onRender = callback
             })
         })
@@ -227,6 +230,10 @@ export default class Message {
         for (let interceptor of this.interceptors) {
             await interceptor.onMorph()
         }
+    }
+
+    invokeOnMorphed() {
+        this.interceptors.forEach(interceptor => interceptor.onMorphed())
     }
 
     invokeOnRender() {

--- a/js/store.js
+++ b/js/store.js
@@ -19,6 +19,8 @@ export function initComponent(el) {
     // Process initial effects after registering so mount-time effects like `$this->js()` can resolve `$wire`...
     component.processEffects(component.effects)
 
+    trigger('component.initialized', { component })
+
     return component
 }
 

--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -100,6 +100,14 @@ trait InteractsWithProperties
                     $isInitialized = false;
                 }
             } else {
+                // Form objects are typed and have no default, so they appear
+                // uninitialized on a fresh instance. Reset their internal state
+                // instead of unsetting the property.
+                if (isset($this->{$property}) && is_subclass_of($this->{$property}, Form::class)) {
+                    $this->{$property}->reset();
+                    continue;
+                }
+
                 $isInitialized = (new \ReflectionProperty($freshInstance, (string) $property))->isInitialized($freshInstance);
             }
 

--- a/src/Concerns/InteractsWithProperties.php
+++ b/src/Concerns/InteractsWithProperties.php
@@ -30,13 +30,24 @@ trait InteractsWithProperties
     public function fill($values)
     {
         $publicProperties = array_keys($this->all());
+        $model = $values instanceof Model ? $values : null;
 
-        if ($values instanceof Model) {
-            $values = $values->toArray();
-        }
+        if ($model) $values = $model->toArray();
 
         foreach ($values as $key => $value) {
-            if (in_array(Utils::beforeFirstDot($key), $publicProperties)) {
+            if (! in_array(Utils::beforeFirstDot($key), $publicProperties)) continue;
+
+            try {
+                if (! str_contains($key, '.') && $this->hasVirtualProperty($key)) {
+                    $this->setVirtualProperty($key, $value);
+                } else {
+                    data_set($this, $key, $value);
+                }
+            } catch (\TypeError $exception) {
+                if (! $model) throw $exception;
+
+                $value = $model->getAttribute($key);
+
                 if (! str_contains($key, '.') && $this->hasVirtualProperty($key)) {
                     $this->setVirtualProperty($key, $value);
                 } else {

--- a/src/Facades/GenerateSignedUploadUrlFacade.php
+++ b/src/Facades/GenerateSignedUploadUrlFacade.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Facade;
  *
  * @method static string forLocal()
  * @method static string forS3($file, $visibility = 'private')
+ * @method static string signedRoute($name, $expiration, $parameters = [])
  *
  * @see \Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl
  */

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Features\SupportComputed;
 
-use function Livewire\invade;
+use function Livewire\{ invade, wrap };
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
@@ -158,7 +158,13 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
-        return invade($this->component)->{parent::getName()}();
+        $value = null;
+
+        wrap($this->component)->tap(function ($component) use (&$value) {
+            $value = invade($component)->{parent::getName()}();
+        });
+
+        return $value;
     }
 
     public function getName()
@@ -170,6 +176,4 @@ class BaseComputed extends Attribute
     {
         return str($value)->camel()->toString();
     }
-
-
 }

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -735,6 +735,36 @@ class UnitTest extends TestCase
             ->dispatch('bar', 'baz')
             ->assertSetStrict('foo', 'baz');
     }
+
+    public function test_computed_attribute_can_trigger_component_exception_hook()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Computed]
+            public function foo(): string
+            {
+                throw new ComputedPropertyException('Exception from computed property');
+            }
+
+            public function exception($e, $stopPropagation)
+            {
+                if ($e instanceof ComputedPropertyException) {
+                    $stopPropagation();
+
+                    session()->put('exception-hook-triggered', true);
+                }
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>{{ $this->foo }}</div>
+                HTML;
+            }
+        })
+            ->assertOk();
+
+        $this->assertTrue(session()->has('exception-hook-triggered'));
+    }
 }
 
 class ComputedPropertyStub extends Component
@@ -878,5 +908,16 @@ class NullIssetComputedPropertyStub extends Component{
             {{ var_dump(isset($this->foo)) }}
         </div>
         HTML;
+    }
+}
+
+class ComputedPropertyException extends \Exception
+{
+    public function __construct(
+        string $message = '',
+        int $code = 0,
+        \Throwable|null $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Features/SupportEvents/BrowserTest.php
+++ b/src/Features/SupportEvents/BrowserTest.php
@@ -497,6 +497,58 @@ class BrowserTest extends BrowserTestCase
             ->waitForTextIn('@output', 'bar');
     }
 
+    public function test_can_dispatch_to_an_element_rendered_by_the_same_update()
+    {
+        Livewire::visit(new class extends Component {
+            public $show = false;
+
+            public function revealTarget()
+            {
+                $this->show = true;
+
+                $this->dispatch('opened')->el('#target');
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="revealTarget" dusk="button">Show target</button>
+
+                    @if ($show)
+                        <div id="target" x-data="{ received: false }" x-on:opened="received = true">
+                            <span dusk="output" x-text="received ? 'received' : 'waiting'"></span>
+                        </div>
+                    @endif
+                </div>
+                HTML;
+            }
+        })
+            ->assertMissing('@output')
+            ->waitForLivewire()->click('@button')
+            ->waitForTextIn('@output', 'received');
+    }
+
+    public function test_can_dispatch_during_mount()
+    {
+        Livewire::visit(new class extends Component {
+            public function mount()
+            {
+                $this->dispatch('mounted');
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div x-data="{ received: false }" x-on:mounted.window="received = true">
+                    <span dusk="output" x-text="received ? 'received' : 'waiting'"></span>
+                </div>
+                HTML;
+            }
+        })
+            ->waitForTextIn('@output', 'received');
+    }
+
     public function test_can_dispatch_to_element_using_wire_dispatch_ref()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportFileUploads/BrowserTest.php
+++ b/src/Features/SupportFileUploads/BrowserTest.php
@@ -2,9 +2,12 @@
 
 namespace Livewire\Features\SupportFileUploads;
 
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
 use Livewire\WithFileUploads;
 use Livewire\Component;
+use Livewire\Facades\GenerateSignedUploadUrlFacade;
 use Livewire\Features\SupportValidation\BaseValidate;
 use Livewire\Livewire;
 
@@ -738,5 +741,57 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->pause(500)
         ->assertSeeIn('@result', 'rejected')
         ;
+    }
+
+    public function test_local_upload_succeeds_when_the_proxys_forwarded_https_origin_is_not_trusted()
+    {
+        // Signs under https, then swaps https:// for http:// on the URL —
+        // simulating a proxy Laravel doesn't trust to report its real origin.
+        $this->beforeServingApplication(function () {
+            Storage::persistentFake('tmp-for-tests');
+
+            GenerateSignedUploadUrlFacade::swap(new class extends GenerateSignedUploadUrl {
+                public function forLocal()
+                {
+                    URL::forceScheme('https');
+                    $url = parent::forLocal();
+                    URL::forceScheme(null);
+
+                    return preg_replace('#^https://#', 'http://', $url);
+                }
+            });
+
+            Livewire::component('https-signed-upload', HttpsSignedUploadComponent::class);
+
+            Route::get('/https-signed-upload', HttpsSignedUploadComponent::class)->middleware('web');
+        });
+
+        $this->browse(function ($browser) {
+            $browser->visit('/https-signed-upload')
+                ->assertMissing('@preview')
+                ->attach('@upload', __DIR__ . '/browser_test_image.png')
+                ->waitFor('@preview')
+                ->assertVisible('@preview')
+            ;
+        });
+    }
+}
+
+class HttpsSignedUploadComponent extends Component
+{
+    use WithFileUploads;
+
+    public $photo;
+
+    function render() {
+        return <<<'HTML'
+            <div>
+                <input type="file" wire:model="photo" dusk="upload">
+
+                @if ($photo)
+                    <img src="{{ $photo->temporaryUrl() }}" dusk="preview">
+                @endif
+            </div>
+        HTML;
     }
 }

--- a/src/Features/SupportFileUploads/FilePreviewController.php
+++ b/src/Features/SupportFileUploads/FilePreviewController.php
@@ -17,7 +17,7 @@ class FilePreviewController implements HasMiddleware
 
     public function handle($filename)
     {
-        abort_unless(request()->hasValidSignature(), 401);
+        abort_unless(request()->hasValidRelativeSignature(), 401);
 
         return Utils::pretendPreviewResponseIsPreviewFile($filename);
     }

--- a/src/Features/SupportFileUploads/FileUploadController.php
+++ b/src/Features/SupportFileUploads/FileUploadController.php
@@ -26,7 +26,7 @@ class FileUploadController implements HasMiddleware
 
     public function handle()
     {
-        abort_unless(request()->hasValidSignature(), 401);
+        abort_unless(request()->hasValidRelativeSignature(), 401);
 
         $disk = FileUploadConfiguration::disk();
 

--- a/src/Features/SupportFileUploads/GenerateSignedUploadUrl.php
+++ b/src/Features/SupportFileUploads/GenerateSignedUploadUrl.php
@@ -10,7 +10,7 @@ class GenerateSignedUploadUrl
 
     public function forLocal()
     {
-        return URL::temporarySignedRoute(
+        return $this->signedRoute(
             'livewire.upload-file', now()->addMinutes(FileUploadConfiguration::maxUploadTime())
         );
     }
@@ -56,6 +56,15 @@ class GenerateSignedUploadUrl
             'url' => $this->finalizeSignedUri($signedRequest->getUri()),
             'headers' => $this->headers($signedRequest, $fileType),
         ];
+    }
+
+    // Signs relative so the scheme can't mismatch behind a proxy; re-absolutized
+    // for a normal-looking URL. Validate with `hasValidRelativeSignature()`.
+    public function signedRoute($name, $expiration, $parameters = [])
+    {
+        $relative = URL::temporarySignedRoute($name, $expiration, $parameters, false);
+
+        return URL::to($relative);
     }
 
     protected function headers($signedRequest, $fileType)

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -5,9 +5,9 @@ namespace Livewire\Features\SupportFileUploads;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Number;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Storage;
 use League\MimeTypeDetection\FinfoMimeTypeDetector;
+use Livewire\Facades\GenerateSignedUploadUrlFacade;
 
 class TemporaryUploadedFile extends UploadedFile
 {
@@ -158,7 +158,7 @@ class TemporaryUploadedFile extends UploadedFile
             return $this->storage->temporaryUrl($this->path, now()->addDay());
         }
 
-        return URL::temporarySignedRoute(
+        return GenerateSignedUploadUrlFacade::signedRoute(
             'livewire.preview-file', now()->addMinutes(30)->endOfHour(), ['filename' => $this->getFilename()]
         );
     }

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -355,13 +355,20 @@ class TemporaryUploadedFile extends UploadedFile
     {
         if (is_string($subject)) {
             if (str($subject)->startsWith('livewire-file:')) {
-                return static::createFromLivewire(str($subject)->after('livewire-file:'));
+                $path = static::extractPathFromSignedPath(str($subject)->after('livewire-file:'));
+
+                return $path === false ? null : static::createFromLivewire($path);
             }
 
             if (str($subject)->startsWith('livewire-files:')) {
-                $paths = json_decode(str($subject)->after('livewire-files:'), true);
+                $signedPaths = json_decode(str($subject)->after('livewire-files:'), true) ?: [];
 
-                return collect($paths)->map(function ($path) { return static::createFromLivewire($path); })->toArray();
+                return collect($signedPaths)
+                    ->map(function ($signedPath) { return static::extractPathFromSignedPath($signedPath); })
+                    ->filter(function ($path) { return $path !== false; })
+                    ->map(function ($path) { return static::createFromLivewire($path); })
+                    ->values()
+                    ->all();
             }
         }
 
@@ -376,11 +383,13 @@ class TemporaryUploadedFile extends UploadedFile
 
     public function serializeForLivewireResponse()
     {
-        return 'livewire-file:'.$this->getFilename();
+        return 'livewire-file:'.static::signPath($this->getFilename());
     }
 
     public static function serializeMultipleForLivewireResponse($files)
     {
-        return 'livewire-files:'.json_encode(collect($files)->map->getFilename());
+        return 'livewire-files:'.json_encode(collect($files)->map(function ($file) {
+            return static::signPath($file->getFilename());
+        }));
     }
 }

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -16,6 +16,7 @@ class TemporaryUploadedFile extends UploadedFile
     protected $path;
     protected $metaFileData;
     protected $cachedTemporaryUrl;
+    protected $detectedMimeType;
 
     public function __construct($path, $disk)
     {
@@ -84,17 +85,30 @@ class TemporaryUploadedFile extends UploadedFile
             }
         }
 
-        $mimeType = $this->storage->mimeType($this->path);
+        return $this->detectedMimeType ??= $this->detectMimeTypeFromContents();
+    }
 
-        // Flysystem V2.0+ removed guess mimeType from extension support, so it has been re-added back
-        // in here to ensure the correct mimeType is returned when using faked files in tests
-        if (in_array($mimeType, ['application/octet-stream', 'inode/x-empty', 'application/x-empty'])) {
-            $detector = new FinfoMimeTypeDetector();
+    protected function detectMimeTypeFromContents(): string
+    {
+        $stream = $this->storage->readStream($this->path);
 
-            $mimeType = $detector->detectMimeTypeFromPath($this->path) ?: 'text/plain';
+        if (! is_resource($stream)) {
+            return 'application/octet-stream';
         }
 
-        return $mimeType;
+        try {
+            // Avoid downloading the entire object when the temporary disk is remote...
+            $contents = stream_get_contents($stream, 64 * 1024);
+        } finally {
+            fclose($stream);
+        }
+
+        if ($contents === false || $contents === '') {
+            return 'application/octet-stream';
+        }
+
+        return (new FinfoMimeTypeDetector())->detectMimeTypeFromBuffer($contents)
+            ?: 'application/octet-stream';
     }
 
     public function getFilename(): string

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -12,6 +12,7 @@ use Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButton
 use League\Flysystem\PathTraversalDetected;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Http\Testing\FileFactory;
 use Illuminate\Support\Arr;
@@ -1250,6 +1251,29 @@ class UnitTest extends \Tests\TestCase
         $rows = $component->viewData('data')['sections']['first']['rows'];
         $this->assertInstanceOf(TemporaryUploadedFile::class, $rows['one']['image']);
         $this->assertEquals(['image' => null, 'caption' => 'New row'], $rows['three']);
+    }
+
+    public function test_preview_succeeds_when_the_proxys_forwarded_https_origin_is_not_trusted()
+    {
+        // Signs under https, then swaps https:// for http:// on the URL,
+        // simulating a proxy Laravel doesn't trust to report its real origin.
+        Storage::fake('avatars');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', UploadedFile::fake()->image('avatar.jpg'))
+            ->viewData('photo');
+
+        \Livewire\Features\SupportDisablingBackButtonCache\SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+
+        URL::forceScheme('https');
+        $url = $photo->temporaryUrl();
+        URL::forceScheme(null);
+
+        $this->assertStringStartsWith('https://', $url);
+
+        $url = preg_replace('#^https://#', 'http://', $url);
+
+        $this->get($url)->assertOk();
     }
 }
 

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -711,7 +711,7 @@ class UnitTest extends \Tests\TestCase
             ->set('photo', $file);
 
         // Try to hijack the photo property to a path outside the temporary livewire directory root.
-        $component->set('photo', 'livewire-file:../dangerous.png')
+        $component->set('photo', 'livewire-file:'.TemporaryUploadedFile::signPath('../dangerous.png'))
             ->call('$refresh');
     }
 

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -946,6 +946,47 @@ class UnitTest extends \Tests\TestCase
             ]);
     }
 
+    public function test_temporary_upload_validation_uses_file_contents_instead_of_storage_metadata()
+    {
+        $disk = $this->useS3LikeTemporaryUploadDisk();
+
+        $disk->put('livewire-tmp/png-disguised-as.webp', file_get_contents(__DIR__.'/browser_test_image.png'));
+
+        $this->assertSame('image/webp', $disk->mimeType('livewire-tmp/png-disguised-as.webp'));
+
+        $file = TemporaryUploadedFile::createFromLivewire('png-disguised-as.webp');
+
+        $this->assertSame('image/png', $file->getMimeType());
+        $this->assertTrue(validator(['file' => $file], ['file' => 'mimes:png|mimetypes:image/png'])->passes());
+        $this->assertFalse(validator(['file' => $file], ['file' => 'mimes:webp|mimetypes:image/webp'])->passes());
+        $this->assertSame(1, $disk->readStreamCalls);
+    }
+
+    public function test_temporary_upload_mime_type_does_not_fall_back_to_storage_metadata_for_empty_files()
+    {
+        $disk = $this->useS3LikeTemporaryUploadDisk();
+
+        $disk->put('livewire-tmp/empty.webp', '');
+
+        $this->assertSame('image/webp', $disk->mimeType('livewire-tmp/empty.webp'));
+
+        $file = TemporaryUploadedFile::createFromLivewire('empty.webp');
+
+        $this->assertSame('application/octet-stream', $file->getMimeType());
+    }
+
+    public function test_temporary_upload_mime_type_is_unknown_when_the_file_cannot_be_read()
+    {
+        $disk = $this->useS3LikeTemporaryUploadDisk();
+
+        $disk->put('livewire-tmp/unreadable.webp', file_get_contents(__DIR__.'/browser_test_image.png'));
+        $disk->canRead = false;
+
+        $file = TemporaryUploadedFile::createFromLivewire('unreadable.webp');
+
+        $this->assertSame('application/octet-stream', $file->getMimeType());
+    }
+
     public function test_the_default_file_upload_controller_middleware_overwritten()
     {
         config()->set('livewire.temporary_file_upload.middleware', ['throttle:60,1']);
@@ -1274,6 +1315,36 @@ class UnitTest extends \Tests\TestCase
         $url = preg_replace('#^https://#', 'http://', $url);
 
         $this->get($url)->assertOk();
+    }
+
+    protected function useS3LikeTemporaryUploadDisk()
+    {
+        config()->set('livewire.temporary_file_upload.disk', 'tmp-for-tests');
+
+        // Simulate a remote disk returning stored upload metadata instead of inspecting the file...
+        $adapter = new \League\Flysystem\Local\LocalFilesystemAdapter(
+            $root = storage_path('framework/testing/disks/tmp-for-tests'),
+            null,
+            LOCK_EX,
+            \League\Flysystem\Local\LocalFilesystemAdapter::DISALLOW_LINKS,
+            new \League\MimeTypeDetection\ExtensionMimeTypeDetector(),
+        );
+
+        $disk = new class(new \League\Flysystem\Filesystem($adapter), $adapter, ['root' => $root]) extends FilesystemAdapter {
+            public $canRead = true;
+            public $readStreamCalls = 0;
+
+            public function readStream($path)
+            {
+                $this->readStreamCalls++;
+
+                return $this->canRead ? parent::readStream($path) : null;
+            }
+        };
+
+        Storage::set('tmp-for-tests', $disk);
+
+        return $disk;
     }
 }
 

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -1069,6 +1069,42 @@ class UnitTest extends \Tests\TestCase
         // This should throw because stdClass doesn't extend Form
         $synth->hydrate(['title' => 'test'], ['class' => \stdClass::class], fn($k, $v) => $v);
     }
+
+    public function test_can_fill_a_form_object_from_eloquent_model_with_enum_cast()
+    {
+        Livewire::test(new class extends TestComponent {
+            public FormWithEnumPropertyStub $form;
+
+            public function fillForm($values)
+            {
+                $this->form->fill($values);
+            }
+        })
+            ->assertSetStrict('form.title', '')
+            ->assertSetStrict('form.status', FormEnumStub::Draft)
+            ->call('fillForm', PostForFormObjectTesting::first())
+            ->assertSetStrict('form.title', 'A Title')
+            ->assertSetStrict('form.status', FormEnumStub::Active)
+        ;
+    }
+
+    public function test_fill_preserves_serialized_model_values_for_untyped_properties()
+    {
+        Livewire::test(new class extends TestComponent {
+            public FormWithUntypedEnumPropertyStub $form;
+
+            public function fillForm($values)
+            {
+                $this->form->fill($values);
+            }
+        })
+            ->assertSetStrict('form.title', '')
+            ->assertSetStrict('form.status', null)
+            ->call('fillForm', PostForFormObjectTesting::first())
+            ->assertSetStrict('form.title', 'A Title')
+            ->assertSetStrict('form.status', 'active')
+        ;
+    }
 }
 
 class PostFormStub extends Form
@@ -1279,8 +1315,16 @@ class PostForFormObjectTesting extends Model
         [
             'title' => 'A Title',
             'content' => 'Some content',
+            'status' => 'active',
         ],
     ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => FormEnumStub::class,
+        ];
+    }
 }
 
 class FormWithLiveValidation extends Form
@@ -1431,6 +1475,12 @@ class FormWithEnumPropertyStub extends Form
 {
     public string $title = '';
     public FormEnumStub $status = FormEnumStub::Draft;
+}
+
+class FormWithUntypedEnumPropertyStub extends Form
+{
+    public string $title = '';
+    public $status;
 }
 
 class FormWithUpdatedHookStub extends Form

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -1319,12 +1319,9 @@ class PostForFormObjectTesting extends Model
         ],
     ];
 
-    protected function casts(): array
-    {
-        return [
-            'status' => FormEnumStub::class,
-        ];
-    }
+    protected $casts = [
+        'status' => FormEnumStub::class,
+    ];
 }
 
 class FormWithLiveValidation extends Form

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -1105,6 +1105,49 @@ class UnitTest extends \Tests\TestCase
             ->assertSetStrict('form.status', 'active')
         ;
     }
+
+    public function test_resetting_component_does_not_unset_form_object()
+    {
+        Livewire::test(new class extends TestComponent {
+            public PostFormStubWithDefaults $form;
+
+            public $other = 'keep';
+
+            public function resetAll()
+            {
+                $this->reset();
+            }
+
+            public function resetFormProperty()
+            {
+                $this->reset('form');
+            }
+        })
+            ->assertSetStrict('form.title', 'foo')
+            ->assertSetStrict('form.content', 'bar')
+            ->set('form.title', 'Some Title')
+            ->set('form.content', 'Some content...')
+            ->set('other', 'changed')
+            ->assertSetStrict('form.title', 'Some Title')
+            ->assertSetStrict('form.content', 'Some content...')
+            ->assertSetStrict('other', 'changed')
+            // $this->reset() must reset form fields to their defaults, not unset the form
+            ->call('resetAll')
+            ->assertSetStrict('form.title', 'foo')
+            ->assertSetStrict('form.content', 'bar')
+            ->assertSetStrict('other', 'keep')
+            ->assertSetStrict('form', fn ($form) => $form instanceof PostFormStubWithDefaults)
+            ->set('form.title', 'Another Title')
+            ->set('form.content', 'More content...')
+            ->assertSetStrict('form.title', 'Another Title')
+            ->assertSetStrict('form.content', 'More content...')
+            // $this->reset('form') must do the same
+            ->call('resetFormProperty')
+            ->assertSetStrict('form.title', 'foo')
+            ->assertSetStrict('form.content', 'bar')
+            ->assertSetStrict('form', fn ($form) => $form instanceof PostFormStubWithDefaults)
+        ;
+    }
 }
 
 class PostFormStub extends Form

--- a/src/Features/SupportIslands/BrowserTest.php
+++ b/src/Features/SupportIslands/BrowserTest.php
@@ -507,6 +507,44 @@ class BrowserTest extends BrowserTestCase
             ;
     }
 
+    public function test_action_promises_wait_for_streamed_island_morphs()
+    {
+        Livewire::visit([new class extends \Livewire\Component {
+            public $count = 0;
+
+            public function increment()
+            {
+                $this->count++;
+
+                $this->streamIsland('counter');
+                $this->skipRender();
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div x-data="{ result: '' }">
+                    <button
+                        type="button"
+                        dusk="increment"
+                        x-on:click="await $wire.increment(); result = document.querySelector('[dusk=island-count]').textContent.trim()"
+                    >Increment</button>
+
+                    <span dusk="result" x-text="result"></span>
+
+                    @island(name: 'counter')
+                        <div wire:transition dusk="island-count">Count: {{ $count }}</div>
+                    @endisland
+                </div>
+                HTML;
+            }
+        }])
+            ->assertSeeIn('@island-count', 'Count: 0')
+            ->click('@increment')
+            ->waitForTextIn('@result', 'Count: 1')
+            ->assertSeeIn('@island-count', 'Count: 1')
+            ;
+    }
+
     public function test_append_and_prepend_islands()
     {
         Livewire::visit([new class extends \Livewire\Component {

--- a/src/Features/SupportJsEvaluation/BrowserTest.php
+++ b/src/Features/SupportJsEvaluation/BrowserTest.php
@@ -509,6 +509,50 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_wire_actions_take_precedence_over_nested_alpine_scope_variables()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $result = 'initial';
+
+                public function open($id) {
+                    $this->result = 'opened '.$id;
+                }
+
+                public function save() {
+                    $this->result = 'saved';
+                }
+
+                public function render() {
+                    return <<<'HTML'
+                        <div>
+                            <div x-data="{ open: false }">
+                                <button wire:click="open(1)" dusk="open">Open</button>
+                            </div>
+
+                            <form wire:submit="save;" x-data="{ save: false }">
+                                <button type="submit" dusk="save">Save</button>
+                            </form>
+
+                            <div x-data="{ open: 'alpine' }">
+                                <span wire:text="open" dusk="reactive"></span>
+                            </div>
+
+                            <span dusk="output">{{ $result }}</span>
+                        </div>
+                    HTML;
+                }
+            }
+        )
+        ->assertSeeIn('@output', 'initial')
+        ->assertSeeIn('@reactive', 'alpine')
+        ->waitForLivewire()->click('@open')
+        ->assertSeeIn('@output', 'opened 1')
+        ->waitForLivewire()->click('@save')
+        ->assertSeeIn('@output', 'saved')
+        ;
+    }
+
     public function test_parent_alpine_scope_does_not_leak_into_child_wire_click()
     {
         Livewire::visit([

--- a/src/Features/SupportJsEvaluation/BrowserTest.php
+++ b/src/Features/SupportJsEvaluation/BrowserTest.php
@@ -75,6 +75,36 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_js_runs_after_new_dom_is_morphed()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $show = false;
+
+                public function reveal()
+                {
+                    $this->show = true;
+
+                    $this->js("document.querySelector('[dusk=target]').textContent = 'evaluated'");
+                }
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <button wire:click="reveal" dusk="reveal">Reveal</button>
+
+                    @if ($show)
+                        <div dusk="target">waiting</div>
+                    @endif
+                </div>
+                HTML; }
+            }
+        )
+        ->assertMissing('@target')
+        ->waitForLivewire()->click('@reveal')
+        ->waitForTextIn('@target', 'evaluated')
+        ;
+    }
+
     public function test_can_evaluate_js_on_mount_that_calls_a_livewire_action()
     {
         Livewire::visit(

--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -108,7 +108,12 @@ class SupportLazyLoading extends ComponentHook
     public function hydrate($memo)
     {
         if (! isset($memo['lazyLoaded'])) return;
-        if ($memo['lazyLoaded'] === true) return;
+
+        if ($memo['lazyLoaded'] === true) {
+            $this->storeSet('isLazyLoadAlreadyLoaded', true);
+
+            return;
+        }
 
         $this->component->skipHydrate();
 
@@ -120,7 +125,10 @@ class SupportLazyLoading extends ComponentHook
         if ($this->storeGet('isLazyLoadMounting') === true) {
             $context->addMemo('lazyLoaded', false);
             $context->addMemo('lazyIsolated', $this->storeGet('isLazyIsolated'));
-        } elseif ($this->storeGet('isLazyLoadHydrating') === true) {
+        } elseif (
+            $this->storeGet('isLazyLoadHydrating') === true
+            || $this->storeGet('isLazyLoadAlreadyLoaded') === true
+        ) {
             $context->addMemo('lazyLoaded', true);
         }
     }
@@ -129,6 +137,13 @@ class SupportLazyLoading extends ComponentHook
     function call($method, $params, $returnEarly)
     {
         if ($method !== '__lazyLoad') return;
+
+        // Ignore repeat calls after the component has already been loaded.
+        if ($this->storeGet('isLazyLoadAlreadyLoaded') === true) {
+            $returnEarly();
+
+            return;
+        }
 
         // Only applies while a lazy load is being resumed.
         if ($this->storeGet('isLazyLoadHydrating') !== true) return;

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -7,6 +7,7 @@ use Livewire\Attributes\Defer;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Lazy;
 use Livewire\Component;
+use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Livewire;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
 
@@ -90,6 +91,38 @@ class UnitTest extends \Tests\TestCase
             ->assertSee('level:5');
     }
 
+    public function test_a_repeat_lazy_load_call_is_ignored_after_the_component_has_loaded()
+    {
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        Livewire::component('lazy-alpha', LazyAlpha::class);
+
+        $component = Livewire::test('lazy-alpha', ['level' => 5]);
+
+        preg_match("/__lazyLoad\('([^']+)'\)/", html_entity_decode($component->html()), $matches);
+
+        $component
+            ->call('__lazyLoad', $matches[1])
+            ->assertSee('level:5')
+            ->call('__lazyLoad', $matches[1])
+            ->assertSee('level:5')
+            ->assertSee('mounts:1')
+            ->call('__lazyLoad', $matches[1])
+            ->assertSee('level:5')
+            ->assertSee('mounts:1');
+    }
+
+    public function test_a_lazy_load_call_on_a_non_lazy_component_is_not_claimed()
+    {
+        $this->expectException(MethodNotFoundException::class);
+
+        Livewire::test(new class extends Component {
+            public function render() {
+                return '<div></div>';
+            }
+        })->call('__lazyLoad', 'invalid');
+    }
+
     public function test_a_mount_params_container_is_scoped_to_its_own_component()
     {
         SupportLazyLoading::$disableWhileTesting = false;
@@ -111,9 +144,11 @@ class UnitTest extends \Tests\TestCase
 #[Lazy]
 class LazyAlpha extends Component {
     public $level = 0;
+    public $mounts = 0;
 
     public function mount($level = 0) {
         $this->level = $level;
+        $this->mounts++;
     }
 
     public function placeholder() {
@@ -121,7 +156,7 @@ class LazyAlpha extends Component {
     }
 
     public function render() {
-        return '<div>level:'.$this->level.'</div>';
+        return '<div>level:'.$this->level.' mounts:'.$this->mounts.'</div>';
     }
 }
 
@@ -181,4 +216,3 @@ class PageWithCustomLayoutOnView extends Component {
         return view('show-name', ['name' => 'foo'])->layout('components.layouts.custom');
     }
 }
-

--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -93,6 +93,28 @@ class EloquentModelSynth extends Synth
         return $model;
     }
 
+    public function unwrapForValidation($model)
+    {
+        $values = $model->toArray();
+        $attributes = $model->getAttributes();
+
+        foreach ($attributes as $key => $attribute) {
+            if (! array_key_exists($key, $values)) continue;
+
+            $casted = $values[$key];
+
+            if (
+                is_scalar($attribute)
+                && is_scalar($casted)
+                && $attribute != $casted
+            ) {
+                $values[$key] = $attribute;
+            }
+        }
+
+        return $values;
+    }
+
     public function get(&$target, $key)
     {
         return $target->$key;

--- a/src/Features/SupportLegacyModels/Tests/ModelValidationBrowserTest.php
+++ b/src/Features/SupportLegacyModels/Tests/ModelValidationBrowserTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Livewire\Features\SupportLegacyModels\Tests;
+
+use Illuminate\Validation\ValidationException;
+use Laravel\Dusk\Browser;
+use LegacyTests\Browser\TestCase;
+
+class ModelValidationBrowserTest extends TestCase
+{
+    use Concerns\EnableLegacyModels;
+
+    public function test_validating_casted_model_attribute_throws_validation_exception_on_wrong_value_type()
+    {
+        $this->browse(function (Browser $browser) {
+            $this->visitLivewireComponent($browser, ModelValidationComponent::class)
+                ->assertValue('@age', '40')
+                ->type('@age', '32.5')
+                ->assertValue('@age', '32.5')
+                ->waitForLivewire()->click('@save')
+                ->assertSeeIn('@message', 'The age field must be an integer.');
+        });
+    }
+}
+
+class ModelValidationUser extends \Illuminate\Database\Eloquent\Model
+{
+    use \Sushi\Sushi;
+
+    protected $guarded = [];
+
+    protected $rows = [
+        ['id' => 1, 'name' => 'Bob', 'age' => 40],
+    ];
+
+    protected $casts = ['age' => 'integer'];
+}
+
+class ModelValidationComponent extends \Livewire\Component
+{
+    public ?ModelValidationUser $foo;
+
+    protected $rules = [
+        'foo.age' => 'required|integer'
+    ];
+
+    public function mount()
+    {
+        $this->foo = ModelValidationUser::first();
+    }
+
+    public function save()
+    {
+        $this->validate();
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+            <div>
+                <input dusk="age" wire:model="foo.age" />
+                <button dusk="save" wire:click="save">Save</button>
+                @error('foo.age')
+                    <div dusk="message">{{ $message }}</div>
+                @enderror
+            </div>
+        HTML;
+    }
+}

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -21,7 +21,7 @@ class SupportPageComponents extends ComponentHook
 
     static function registerLayoutViewMacros()
     {
-        View::macro('layoutData', function ($data = []) {
+        View::macro('layoutData', function ($data = []): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->mergeParams($data);
@@ -29,7 +29,7 @@ class SupportPageComponents extends ComponentHook
             return $this;
         });
 
-        View::macro('section', function ($section) {
+        View::macro('section', function ($section): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->slotOrSection = $section;
@@ -37,7 +37,7 @@ class SupportPageComponents extends ComponentHook
             return $this;
         });
 
-        View::macro('title', function ($title) {
+        View::macro('title', function ($title): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->mergeParams(['title' => $title]);
@@ -45,7 +45,7 @@ class SupportPageComponents extends ComponentHook
             return $this;
         });
 
-        View::macro('slot', function ($slot) {
+        View::macro('slot', function ($slot): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->slotOrSection = $slot;
@@ -53,7 +53,7 @@ class SupportPageComponents extends ComponentHook
             return $this;
         });
 
-        View::macro('extends', function ($view, $params = []) {
+        View::macro('extends', function ($view, $params = []): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->type = 'extends';
@@ -64,7 +64,7 @@ class SupportPageComponents extends ComponentHook
             return $this;
         });
 
-        View::macro('layout', function ($view, $params = []) {
+        View::macro('layout', function ($view, $params = []): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->type = 'component';
@@ -75,7 +75,7 @@ class SupportPageComponents extends ComponentHook
             return $this;
         });
 
-        View::macro('response', function (callable $callback) {
+        View::macro('response', function (callable $callback): static {
             if (! isset($this->layoutConfig)) $this->layoutConfig = new PageComponentConfig;
 
             $this->layoutConfig->response = $callback;

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -21,7 +21,7 @@ class UnitTest extends \Tests\TestCase
             ->withoutExceptionHandling()
             ->get('/configurable-layout')
             ->assertSee('foo')
-            ->assertDontSee('baz');
+            ->assertDontSeeText('baz');
     }
 
     public function test_can_configure_a_default_layout()
@@ -47,7 +47,7 @@ class UnitTest extends \Tests\TestCase
             ->get('/configurable-layout')
             ->assertSee('foo')
             ->assertSee('bar')
-            ->assertDontSee('baz');
+            ->assertDontSeeText('baz');
     }
 
     public function test_can_show_params_with_a_configured_class_based_component_layout()
@@ -85,7 +85,7 @@ class UnitTest extends \Tests\TestCase
             ->get('/configurable-layout')
             ->assertSee('foo')
             ->assertSee('bar')
-            ->assertDontSee('baz');
+            ->assertDontSeeText('baz');
     }
 
     public function test_can_show_params_with_a_configured_anonymous_component_layout()

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -547,7 +547,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
         ])
-            ->assertQueryStringHas('foo', '')
+            ->waitForQueryString('foo', '')
             ->assertSee('foo', null)
             ->waitForLivewire()->click('@button')
             ->assertQueryStringHas('foo', 'second')
@@ -590,7 +590,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                 }
             },
         ])
-            ->assertQueryStringHas('foo', '')
+            ->waitForQueryString('foo', '')
             ->assertSee('foo', null)
             ->waitForLivewire()->click('@button')
             ->assertQueryStringHas('foo', '2')

--- a/src/Features/SupportRedirects/BrowserTest.php
+++ b/src/Features/SupportRedirects/BrowserTest.php
@@ -54,6 +54,173 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_loading_state_remains_active_during_navigation_but_is_not_stored_in_history()
+    {
+        Route::get('/slow-navigate-destination', function () {
+            sleep(1);
+
+            return response(<<<'HTML'
+                <!DOCTYPE html>
+                <html>
+                    <body>
+                        <h1 dusk="navigate-destination">Destination</h1>
+                    </body>
+                </html>
+                HTML);
+        })->middleware('web');
+
+        Livewire::visit([new class extends Component {
+            public function save()
+            {
+                $this->redirect('/slow-navigate-destination', navigate: true);
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button type="button" dusk="save" wire:click="save" wire:loading.attr="disabled">Save</button>
+            </div>
+            HTML; }
+        }])
+            ->waitForLivewire()->click('@save')
+            ->assertAttribute('@save', 'disabled', 'true')
+            ->assertAttribute('@save', 'data-loading', 'true')
+            ->waitFor('@navigate-destination', 5)
+            ->waitForNavigate()->back()
+            ->assertAttributeMissing('@save', 'disabled')
+            ->assertAttributeMissing('@save', 'data-loading')
+            ->waitForNavigate()->forward()
+            ->waitFor('@navigate-destination', 5)
+            ->waitForNavigate()->back()
+            ->assertAttributeMissing('@save', 'disabled')
+            ->assertAttributeMissing('@save', 'data-loading')
+            ->waitForLivewire()->click('@save')
+            ->assertAttribute('@save', 'disabled', 'true')
+            ->assertAttribute('@save', 'data-loading', 'true')
+            ->waitFor('@navigate-destination', 5)
+            ->assertConsoleLogHasNoErrors()
+        ;
+    }
+
+    public function test_form_protection_remains_active_while_a_navigate_redirect_fetches_its_destination()
+    {
+        Route::get('/slow-form-navigate-destination', function () {
+            sleep(1);
+
+            return response(<<<'HTML'
+                <!DOCTYPE html>
+                <html>
+                    <body>
+                        <h1 dusk="navigate-destination">Destination</h1>
+                    </body>
+                </html>
+                HTML);
+        })->middleware('web');
+
+        Livewire::visit([new class extends Component {
+            public function save()
+            {
+                $this->redirect('/slow-form-navigate-destination', navigate: true);
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <form wire:submit="save">
+                    <input type="text" dusk="name">
+                    <button type="submit" dusk="save">Save</button>
+                </form>
+            </div>
+            HTML; }
+        }])
+            ->waitForLivewire()->click('@save')
+            ->assertAttribute('@name', 'readonly', 'true')
+            ->assertAttribute('@save', 'disabled', 'true')
+            ->assertAttribute('@save', 'data-loading', 'true')
+            ->waitFor('@navigate-destination', 5)
+            ->waitForNavigate()->back()
+            ->assertAttributeMissing('@name', 'readonly')
+            ->assertAttributeMissing('@save', 'disabled')
+            ->assertAttributeMissing('@save', 'data-loading')
+        ;
+    }
+
+    public function test_loading_state_clears_when_a_navigate_redirect_is_prevented()
+    {
+        Livewire::visit([new class extends Component {
+            public function save()
+            {
+                $this->redirect('/prevented-navigate-destination', navigate: true);
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button type="button" dusk="save" wire:click="save" wire:loading.attr="disabled">Save</button>
+
+                @script
+                <script>
+                    document.addEventListener('livewire:navigate', event => event.preventDefault(), { once: true })
+                </script>
+                @endscript
+            </div>
+            HTML; }
+        }])
+            ->waitForLivewire()->click('@save')
+            ->assertAttributeMissing('@save', 'disabled')
+            ->assertAttributeMissing('@save', 'data-loading')
+        ;
+    }
+
+    public function test_loading_state_clears_when_a_navigate_redirect_is_cancelled()
+    {
+        Route::get('/cancelled-navigate-destination', function () {
+            sleep(1);
+
+            return response(<<<'HTML'
+                <!DOCTYPE html>
+                <html>
+                    <body>
+                        <h1 dusk="navigate-destination">Destination</h1>
+                    </body>
+                </html>
+                HTML);
+        })->middleware('web');
+
+        Livewire::visit([new class extends Component {
+            public function save()
+            {
+                $this->redirect('/cancelled-navigate-destination', navigate: true);
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button type="button" dusk="save" wire:click="save" wire:loading.attr="disabled">Save</button>
+
+                @script
+                <script>
+                    let removeHook = Livewire.hook('navigate.request', ({ options }) => {
+                        let controller = new AbortController()
+
+                        controller.abort()
+                        options.signal = controller.signal
+
+                        removeHook()
+                    })
+                </script>
+                @endscript
+            </div>
+            HTML; }
+        }])
+            ->waitForLivewire()->click('@save')
+            ->waitUntil("! document.querySelector('[dusk=\"save\"]').hasAttribute('disabled')")
+            ->assertAttributeMissing('@save', 'disabled')
+            ->assertAttributeMissing('@save', 'data-loading')
+            ->waitForLivewire()->click('@save')
+            ->assertAttribute('@save', 'disabled', 'true')
+            ->assertAttribute('@save', 'data-loading', 'true')
+            ->waitFor('@navigate-destination', 5)
+            ->assertConsoleLogHasNoErrors()
+        ;
+    }
+
     public function test_session_flash_persists_when_redirecting_from_request_with_multiple_components_in_the_same_request()
     {
         config()->set('session.driver', 'file');

--- a/src/Features/SupportRedirects/BrowserTest.php
+++ b/src/Features/SupportRedirects/BrowserTest.php
@@ -335,6 +335,60 @@ class BrowserTest extends BrowserTestCase
             ;
         });
     }
+
+    public function test_redirect_helper_with_flash_persists_on_destination_page()
+    {
+        config()->set('session.driver', 'file');
+
+        Route::get('/redirect', RedirectComponent::class)->middleware('web');
+
+        Livewire::visit([
+            new class extends Component {
+                public function doRedirect()
+                {
+                    return redirect('/redirect')->with('alert', 'Session flash data');
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="doRedirect" dusk="button">Do redirect</button>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->waitForLivewire()->click('@button')
+            ->waitForTextIn('@session-message', 'Session flash data');
+    }
+
+    public function test_redirect_to_with_flash_persists_on_destination_page()
+    {
+        config()->set('session.driver', 'file');
+
+        Route::get('/redirect', RedirectComponent::class)->middleware('web');
+
+        Livewire::visit([
+            new class extends Component {
+                public function doRedirect()
+                {
+                    return redirect()->to('/redirect')->with('alert', 'Session flash data');
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="doRedirect" dusk="button">Do redirect</button>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->waitForLivewire()->click('@button')
+            ->waitForTextIn('@session-message', 'Session flash data');
+    }
 }
 
 class RedirectComponent extends Component {

--- a/src/Features/SupportRedirects/Redirector.php
+++ b/src/Features/SupportRedirects/Redirector.php
@@ -13,23 +13,12 @@ class Redirector extends BaseRedirector
     {
         $this->component->redirect($this->generator->to($path, [], $secure));
 
-        return $this;
+        return parent::to($path, $status, $headers, $secure);
     }
 
     public function away($path, $status = 302, $headers = [])
     {
         return $this->to($path, $status, $headers);
-    }
-
-    public function with($key, $value = null)
-    {
-        $key = is_array($key) ? $key : [$key => $value];
-
-        foreach ($key as $k => $v) {
-            $this->session->flash($k, $v);
-        }
-
-        return $this;
     }
 
     public function component(Component $component)

--- a/src/Features/SupportRedirects/UnitTest.php
+++ b/src/Features/SupportRedirects/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportRedirects;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
@@ -226,6 +227,67 @@ class UnitTest extends \Tests\TestCase
         $this->assertNull(session()->get('foo'));
     }
 
+    public function test_redirect_helper_preserves_redirect_effects()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectHelper');
+
+        $component->assertRedirect('/foo');
+    }
+
+    public function test_redirect_helper_returns_redirect_response_instance()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $return = $component->instance()->triggerRedirectHelper();
+
+        $this->assertInstanceOf(RedirectResponse::class, $return);
+        $this->assertEquals(url('foo'), $return->getTargetUrl());
+    }
+
+    public function test_redirect_helper_to_method_returns_redirect_response_instance()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $return = $component->instance()->triggerRedirectHelperUsingTo();
+
+        $this->assertInstanceOf(RedirectResponse::class, $return);
+        $this->assertEquals(url('foo'), $return->getTargetUrl());
+    }
+
+    public function test_redirect_helper_route_method_returns_redirect_response_instance()
+    {
+        $this->registerNamedRoute();
+
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $return = $component->instance()->triggerRedirectHelperUsingRoute();
+
+        $this->assertInstanceOf(RedirectResponse::class, $return);
+        $this->assertEquals(route('foo'), $return->getTargetUrl());
+    }
+
+    public function test_typed_redirect_response_return_does_not_throw()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerTypedRedirectResponse');
+
+        $component->assertRedirect('/foo');
+    }
+
+    public function test_redirect_helper_to_then_with_flashes_session()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectHelperUsingToThenWith');
+
+        $component->assertRedirect('/foo');
+
+        $this->assertEquals('livewire-is-awesome', Session::get('success'));
+    }
+
     protected function registerNamedRoute()
     {
         Route::get('foo', function () {
@@ -276,6 +338,21 @@ class TriggersRedirectStub extends TestComponent
         return redirect('foo')->with([
             'success' => 'livewire-is-awesome'
         ]);
+    }
+
+    public function triggerRedirectHelperUsingTo()
+    {
+        return redirect()->to('foo');
+    }
+
+    public function triggerTypedRedirectResponse(): RedirectResponse
+    {
+        return redirect('foo');
+    }
+
+    public function triggerRedirectHelperUsingToThenWith()
+    {
+        return redirect()->to('foo')->with('success', 'livewire-is-awesome');
     }
 
     public function triggerRedirectFacadeUsingTo()

--- a/src/Features/SupportRequestInteractions/BrowserTest.php
+++ b/src/Features/SupportRequestInteractions/BrowserTest.php
@@ -1019,7 +1019,7 @@ class BrowserTest extends \Tests\BrowserTestCase
             ])
 
             ->waitUntil('window.intercepts.length >= 6')
-            ->assertScript('window.intercepts', [
+            ->assertScript('window.intercepts.slice(0, 6)', [
                 'userRequest-bar started',
                 'userRequest-bar sent',
                 'pollRequest-foo started',

--- a/src/Features/SupportScriptsAndAssets/BrowserTest.php
+++ b/src/Features/SupportScriptsAndAssets/BrowserTest.php
@@ -153,6 +153,45 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_conditionally_added_scripts_register_alpine_data_before_new_dom_is_initialized()
+    {
+        Livewire::visit(new class extends \Livewire\Component {
+            public $show = false;
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button dusk="button" wire:click="$set('show', true)">Show</button>
+
+                @if ($show)
+                    <button
+                        wire:transition
+                        dusk="target"
+                        x-data="timingTest"
+                        x-init="$el.textContent = 'ready'"
+                        x-on:click="initialize"
+                    >waiting</button>
+
+                    @script
+                    <script>
+                        Alpine.data('timingTest', () => ({
+                            initialize() {
+                                this.$el.textContent = 'initialized'
+                            },
+                        }))
+                    </script>
+                    @endscript
+                @endif
+            </div>
+            HTML; }
+        })
+        ->assertMissing('@target')
+        ->waitForLivewire()->click('@button')
+        ->waitForTextIn('@target', 'ready')
+        ->click('@target')
+        ->waitForTextIn('@target', 'initialized')
+        ;
+    }
+
     public function test_assets_can_be_loaded()
     {
         Route::get('/test.js', function () {

--- a/src/Features/SupportSlots/BrowserTest.php
+++ b/src/Features/SupportSlots/BrowserTest.php
@@ -8,6 +8,51 @@ use Livewire\Component;
 
 class BrowserTest extends BrowserTestCase
 {
+    public function test_action_promises_resolve_after_transitioned_slots_finish_morphing()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public $count = 0;
+
+                public function increment()
+                {
+                    $this->count++;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div x-data="{ result: '' }">
+                        <button
+                            dusk="increment"
+                            x-on:click="await $wire.increment(); result = document.querySelector('[dusk=slot-count]').textContent.trim()"
+                        >Increment</button>
+
+                        <span dusk="result" x-text="result"></span>
+
+                        <livewire:modal>
+                            <div dusk="slot-count" wire:transition>Count: {{ $count }}</div>
+                        </livewire:modal>
+                    </div>
+                    HTML;
+                }
+            },
+            'modal' => new class extends Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>{{ $slot }}</div>
+                    HTML;
+                }
+            },
+        ])
+            ->assertSeeIn('@slot-count', 'Count: 0')
+            ->click('@increment')
+            ->waitForTextIn('@result', 'Count: 1')
+            ->assertSeeIn('@slot-count', 'Count: 1')
+            ;
+    }
+
     public function test_default_slots()
     {
         Livewire::visit([

--- a/src/Features/SupportTransitions/BrowserTest.php
+++ b/src/Features/SupportTransitions/BrowserTest.php
@@ -210,6 +210,71 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_transition_is_skipped_when_popover_opens_during_morph()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $items = ['Item A', 'Item B'];
+                public $showPopover = false;
+
+                public function openPopover()
+                {
+                    $this->showPopover = true;
+                }
+
+                public function render() { return <<<'HTML'
+                <div>
+                    <style>
+                        ::view-transition-old(*) { animation: 2s ease-out fade-out; }
+                        ::view-transition-new(*) { animation: 2s ease-in fade-in; }
+                        @keyframes fade-out { to { opacity: 0; } }
+                        @keyframes fade-in { from { opacity: 0; } }
+                    </style>
+
+                    @foreach ($items as $index => $item)
+                        <div
+                            wire:transition="card-{{ $index }}"
+                            wire:key="item-{{ $index }}"
+                            dusk="card-{{ $index }}"
+                        >
+                            {{ $item }}
+                        </div>
+                    @endforeach
+
+                    <button wire:click="openPopover" dusk="open">Open</button>
+
+                    <div
+                        popover="manual"
+                        x-ref="popover"
+                        x-effect="
+                            if ($wire.showPopover) { if (!$refs.popover.matches(':popover-open')) $refs.popover.showPopover() }
+                        "
+                    >
+                        Popover Content
+                    </div>
+                </div>
+                HTML; }
+            }
+        )
+        ->tap(fn ($browser) => $browser->script(<<<'JS'
+            window.__transitionUnhandledRejection = null
+
+            window.addEventListener('unhandledrejection', event => {
+                window.__transitionUnhandledRejection = event.reason?.name
+            })
+        JS))
+        ->waitForLivewire()->click('@open')
+        ->waitUntil("document.querySelector('[popover]').matches(':popover-open')")
+
+        // Without the fix, the 2s view transition animations would still be playing
+        // and the transitioning elements would appear above the popover.
+        // With the fix, the transition is skipped the instant the popover opens...
+        ->assertScript('document.getAnimations().some(a => a.playState === "running")', false)
+        ->pause(50)
+        ->assertScript('window.__transitionUnhandledRejection', null)
+        ;
+    }
+
     public function test_can_transition_dynamic_component_swap()
     {
         $animationsRunning = 'document.getAnimations().some(a => a.playState === "running")';

--- a/src/Mechanisms/PersistentMiddleware/BrowserTest.php
+++ b/src/Mechanisms/PersistentMiddleware/BrowserTest.php
@@ -263,7 +263,7 @@ JS;
             ->assertDontSee('Protected Content')
             ->visit('/force-login/1')
             ->visit('/with-authorization/1/inline-auth')
-            ->assertSee('Protected Content')
+            ->waitForText('Protected Content')
             ->waitForLivewireToLoad()
             ->tap(function ($b) {
                 $script = <<<'JS'


### PR DESCRIPTION
Ports the eligible 4.x release range into main while preserving main-only virtual properties and expression contextualization.

Included: computed exception hooks, model and form casting fixes, top-layer transitions, navigate loading state, signed upload references, redirect typing, form resets, page-view typing, legacy-model validation, Alpine-scope action precedence, repeated lazy-load handling, browser-test hardening, asynchronous morph ordering, proxy-safe upload URLs, and content-based upload MIME detection.

Intentionally omitted: the failed-response recovery commit and its immediate revert, which are a net-zero pair. Main-only rich-upload size APIs remain intact.

Conflict and adaptation decisions:
- retained main virtual-property filling while adding Eloquent cast fallback
- combined main arrow and template expression contextualization with 4.x wire-action precedence
- retained main cached temporary URLs alongside content MIME detection
- taught main rich upload objects to extract their raw filename from signed temporary-file references, preserving local previews and removal

Validation:
- 165 JavaScript tests passed, 1 skipped
- production asset build passed
- 233 focused PHP tests passed, 696 assertions, 1 skipped
- seven representative browser regressions passed, including signed rich-upload previews and removal, upload actions, navigate loading, wire and Alpine action collision, streamed-island morph ordering, and proxy-safe uploads
- Composer and production npm audits report zero advisories or vulnerabilities
- diff checks passed
- both complete GitHub matrices are green