### PR TITLE
Prepare Alpine 3.16.3 on main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,18 @@
             "name": "laravel-livewire",
             "license": "MIT",
             "dependencies": {
-                "@alpinejs/anchor": "^3.16.2",
-                "@alpinejs/collapse": "^3.16.2",
-                "@alpinejs/csp": "^3.16.2",
-                "@alpinejs/focus": "^3.16.2",
-                "@alpinejs/intersect": "^3.16.2",
-                "@alpinejs/mask": "^3.16.2",
-                "@alpinejs/morph": "^3.16.2",
-                "@alpinejs/persist": "^3.16.2",
-                "@alpinejs/resize": "^3.16.2",
-                "@alpinejs/sort": "^3.16.2",
+                "@alpinejs/anchor": "^3.16.3",
+                "@alpinejs/collapse": "^3.16.3",
+                "@alpinejs/csp": "^3.16.3",
+                "@alpinejs/focus": "^3.16.3",
+                "@alpinejs/intersect": "^3.16.3",
+                "@alpinejs/mask": "^3.16.3",
+                "@alpinejs/morph": "^3.16.3",
+                "@alpinejs/persist": "^3.16.3",
+                "@alpinejs/resize": "^3.16.3",
+                "@alpinejs/sort": "^3.16.3",
                 "@vue/reactivity": "^3.2.45",
-                "alpinejs": "^3.16.2",
+                "alpinejs": "^3.16.3",
                 "nprogress": "^0.2.0"
             },
             "devDependencies": {
@@ -29,33 +29,33 @@
             }
         },
         "node_modules/@alpinejs/anchor": {
-            "version": "3.16.2",
-            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.16.2.tgz",
-            "integrity": "sha512-LvYAC/GKAsTX/DQEZObt/WiZgpm/rDVe92d683aBfwCiUxgtg91a0ZJhJO3DM+TpLgvtD+wtYsGEILGv9MmL9A==",
+            "version": "3.16.3",
+            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.16.3.tgz",
+            "integrity": "sha512-l53MqW/ZNzR+0jmQ6WhRWEb0K3ZxXhWxgjnLTA+GDX99wCO47lYaD8SIPjxXRARfcrRKPzrpj1llKa0pfwg1kw==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.5.3"
             }
         },
         "node_modules/@alpinejs/collapse": {
-            "version": "3.16.2",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.16.2.tgz",
-            "integrity": "sha512-3WDwJ6RMEYlfilk1pCm0LMZvCrBU7JgTWqTuz0MdcZ3Jpg4hxeV+cGyuYOeRB5/3+YaDsoO5lUlor0VYE2EHYA==",
+            "version": "3.16.3",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.16.3.tgz",
+            "integrity": "sha512-ekH5VBTpMBNnffAfvL+3mqFLIWNW4bUmCExEl+1WdGPewtVYBI2kMWNd2lVOsrvsDRSij7VGmAG0AK5s8WD03g==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/csp": {
-            "version": "3.16.2",
-            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.16.2.tgz",
-            "integrity": "sha512-GLyXO4adqFJhdXg+OZH0nAJVDVUwJRQ6cphJs4jsZmNP7q9PlbeIdIJIdtXgD1of97n8b0NMe8ADZj0tT2SxdQ==",
+            "version": "3.16.3",
+            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.16.3.tgz",
+            "integrity": "sha512-eqz6rpWDXuJOGp3YvsXQqZljjBz7ZWAkEmJUt3zTJyK9SEjUcInfOx7sRLzEUlrU+o9r2UhxCVhFBc5eJAUMdA==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.5.40"
             }
         },
         "node_modules/@alpinejs/focus": {
-            "version": "3.16.2",
-            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.16.2.tgz",
-            "integrity": "sha512-B0if1ez97E2iuQ7W6VVFydrZq5K58TMfWHr3zW99Bwpz3YVX1rD3PRO6M9/CATvKMtNXjnO66MBAzatde44PTQ==",
+            "version": "3.16.3",
+            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.16.3.tgz",
+            "integrity": "sha512-MwEeux0W+/DP4B3FyNHPs+kzqMmgfWRf25WsJLBH1kahBqiVHNLewSJotbO+9345A8WsHz3yx8XkaeNnepDv3Q==",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^8.0.0",
@@ -63,39 +63,39 @@
             }
         },
         "node_modules/@alpinejs/intersect": {
-            "version": "3.16.2",
-            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.16.2.tgz",
-            "integrity": "sha512-qRguIfwsvMrQwl5vgHm0wDKgexa9kjaInge8+3zJLhluSlwXf+ksg1ZdPINvFOFnrtD2WOABBqyDhCBZ815TOQ==",
+            "version": "3.16.3",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.16.3.tgz",
+            "integrity": "sha512-hGiwxwfuRjiYpxnuZOD5ymQAPhyxspVfhwuSEg/TdJhfqmfacJd4Z42LIKIdXoDE8JaexXvrUeg5MBxzLVgMmQ==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/mask": {
-            "version": "3.16.2",
-            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.16.2.tgz",
-            "integrity": "sha512-UZbEEtC6DRGgpd9atqlKr5din2grjZP2Aie2iLepXTyUUIJJAbxT/bVIelPzqwhjGtNxmAYxokeGF4cjEvBAMg==",
+            "version": "3.16.3",
+            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.16.3.tgz",
+            "integrity": "sha512-BKu3IT4kk1GqgH8Lsn8ekV6nrbbMJgjOuI6zC+rJ+m/iPxBstH80ELauD23a7OiJAVQZjdS+lmYFfCVAbk3Rqg==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/morph": {
-            "version": "3.16.2",
-            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.16.2.tgz",
-            "integrity": "sha512-PQEuQg19QSauhj2t2XCZnFUh8YGNGH2CXwukp8eufKBp4X9CNUKqK2OxDOxonWXj9xfbBQqHZGWRVqrRnrg9ig==",
+            "version": "3.16.3",
+            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.16.3.tgz",
+            "integrity": "sha512-JUrZ9tCXTgdQRoHAIdCDzdrkyEC8ffXwFlynEQ7it0jFy2UW4X0jpcRRBUhvyD94OiMpN6bd82eWhd+3PaqP+g==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/persist": {
-            "version": "3.16.2",
-            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.16.2.tgz",
-            "integrity": "sha512-KOqh+3Dkn/jPWoXpwnouT2n8iPCXxm0F9BWcOw+pd3PdJJQEYzV6RlBOGa85+A7HSLPyIi11AVxlxH+EPyjg1g==",
+            "version": "3.16.3",
+            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.16.3.tgz",
+            "integrity": "sha512-VyhG3C1CKTvGwHQICw1GLfqIuUt++q54oSRGstX+Y30yjj+JK6HrWj50yzAS+C2K8SXnR99ipY6SQevLaHAgog==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/resize": {
-            "version": "3.16.2",
-            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.16.2.tgz",
-            "integrity": "sha512-XzYzKmV/6weRar4T2Vvg3u4mBHr7wQ1qrAvlK04ifAIzPehFL5vqM7cKaRyjnIzEyzPQFHYYIcyeZBSqxDMaqQ==",
+            "version": "3.16.3",
+            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.16.3.tgz",
+            "integrity": "sha512-3GG13wnOqdYduvT1DPpdJolY254cT8eHw32bx3Ibay2v9HnPzRTDZ9BiZe4iI+1rEcH4E6IKsM7RsEjAaSO0Og==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/sort": {
-            "version": "3.16.2",
-            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.16.2.tgz",
-            "integrity": "sha512-82zdilMSFHkkMU5qDnBXKwOYXnofkq9BtMSupTN7lAguQG66UCrxC5/9T3DDzJfWX8G4KCE4zHdkowQtsFnekg==",
+            "version": "3.16.3",
+            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.16.3.tgz",
+            "integrity": "sha512-LEmI3oE+oIrWmAWoA4PhkA0/kvbrlAr5hBrAvreWU63U4oleTDpgp0LS0qzxBMLOzoEJKwupWuq9l2j6fz2erg==",
             "license": "MIT",
             "dependencies": {
                 "sortablejs": "^1.15.2"
@@ -1266,9 +1266,9 @@
             }
         },
         "node_modules/alpinejs": {
-            "version": "3.16.2",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.16.2.tgz",
-            "integrity": "sha512-6kbqqrRK7iGPYx5upTfqc8Tcl1xhpcurLCxTdn4/ym2Kb68+cYj+2I5Zji53vUIPf7zj3C1DoIvrDkgrNDCXdA==",
+            "version": "3.16.3",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.16.3.tgz",
+            "integrity": "sha512-kLIO2JOPs5ZY3mHPH+CHHPzp89Y6Gb2luLRy+RDIb1oG9y6N5Vfc75kkEoaSOPhJqvakuPiAsnd9paNPNSZyVg==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.5.40"

--- a/package.json
+++ b/package.json
@@ -17,18 +17,18 @@
         "vitest": "^3.2.4"
     },
     "dependencies": {
-        "@alpinejs/anchor": "^3.16.2",
-        "@alpinejs/collapse": "^3.16.2",
-        "@alpinejs/csp": "^3.16.2",
-        "@alpinejs/focus": "^3.16.2",
-        "@alpinejs/intersect": "^3.16.2",
-        "@alpinejs/mask": "^3.16.2",
-        "@alpinejs/morph": "^3.16.2",
-        "@alpinejs/persist": "^3.16.2",
-        "@alpinejs/resize": "^3.16.2",
-        "@alpinejs/sort": "^3.16.2",
+        "@alpinejs/anchor": "^3.16.3",
+        "@alpinejs/collapse": "^3.16.3",
+        "@alpinejs/csp": "^3.16.3",
+        "@alpinejs/focus": "^3.16.3",
+        "@alpinejs/intersect": "^3.16.3",
+        "@alpinejs/mask": "^3.16.3",
+        "@alpinejs/morph": "^3.16.3",
+        "@alpinejs/persist": "^3.16.3",
+        "@alpinejs/resize": "^3.16.3",
+        "@alpinejs/sort": "^3.16.3",
         "@vue/reactivity": "^3.2.45",
-        "alpinejs": "^3.16.2",
+        "alpinejs": "^3.16.3",
         "nprogress": "^0.2.0"
     }
 }


### PR DESCRIPTION
Updates Livewire main constraints for Alpine and all ten bundled Alpine plugins from 3.16.2 to 3.16.3.

Alpine 3.16.3 is published. The lockfile was regenerated from the real npm registry and pins every Alpine package to 3.16.3.

Validation:
- npm clean install passed from the regenerated lockfile
- 162 JavaScript tests passed, 1 skipped
- production asset build passed
- production npm audit reports zero vulnerabilities
- both complete GitHub matrices are green