### PR TITLE
[3.x] Ignore repeated lazy-load calls

### DIFF
--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -76,7 +76,12 @@ class SupportLazyLoading extends ComponentHook
     public function hydrate($memo)
     {
         if (! isset($memo['lazyLoaded'])) return;
-        if ($memo['lazyLoaded'] === true) return;
+
+        if ($memo['lazyLoaded'] === true) {
+            $this->storeSet('isLazyLoadAlreadyLoaded', true);
+
+            return;
+        }
 
         $this->component->skipHydrate();
 
@@ -88,7 +93,10 @@ class SupportLazyLoading extends ComponentHook
         if ($this->storeGet('isLazyLoadMounting') === true) {
             $context->addMemo('lazyLoaded', false);
             $context->addMemo('lazyIsolated', $this->storeGet('isLazyIsolated'));
-        } elseif ($this->storeGet('isLazyLoadHydrating') === true) {
+        } elseif (
+            $this->storeGet('isLazyLoadHydrating') === true
+            || $this->storeGet('isLazyLoadAlreadyLoaded') === true
+        ) {
             $context->addMemo('lazyLoaded', true);
         }
     }
@@ -97,6 +105,13 @@ class SupportLazyLoading extends ComponentHook
     function call($method, $params, $returnEarly)
     {
         if ($method !== '__lazyLoad') return;
+
+        // Ignore repeat calls after the component has already been loaded.
+        if ($this->storeGet('isLazyLoadAlreadyLoaded') === true) {
+            $returnEarly();
+
+            return;
+        }
 
         // Only applies while a lazy load is being resumed.
         if ($this->storeGet('isLazyLoadHydrating') !== true) return;

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -7,6 +7,7 @@ use Livewire\Attributes\Layout;
 use Livewire\Attributes\Lazy;
 use Livewire\Component;
 use Livewire\Livewire;
+use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
 
 class UnitTest extends \Tests\TestCase
@@ -61,6 +62,38 @@ class UnitTest extends \Tests\TestCase
             ->assertSee('level:5');
     }
 
+    public function test_a_repeat_lazy_load_call_is_ignored_after_the_component_has_loaded()
+    {
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        Livewire::component('lazy-alpha', LazyAlpha::class);
+
+        $component = Livewire::test('lazy-alpha', ['level' => 5]);
+
+        preg_match("/__lazyLoad\('([^']+)'\)/", html_entity_decode($component->html()), $matches);
+
+        $component
+            ->call('__lazyLoad', $matches[1])
+            ->assertSee('level:5')
+            ->call('__lazyLoad', $matches[1])
+            ->assertSee('level:5')
+            ->assertSee('mounts:1')
+            ->call('__lazyLoad', $matches[1])
+            ->assertSee('level:5')
+            ->assertSee('mounts:1');
+    }
+
+    public function test_a_lazy_load_call_on_a_non_lazy_component_is_not_claimed()
+    {
+        $this->expectException(MethodNotFoundException::class);
+
+        Livewire::test(new class extends Component {
+            public function render() {
+                return '<div></div>';
+            }
+        })->call('__lazyLoad', 'invalid');
+    }
+
     public function test_a_mount_params_container_is_scoped_to_its_own_component()
     {
         SupportLazyLoading::$disableWhileTesting = false;
@@ -82,9 +115,11 @@ class UnitTest extends \Tests\TestCase
 #[Lazy]
 class LazyAlpha extends Component {
     public $level = 0;
+    public $mounts = 0;
 
     public function mount($level = 0) {
         $this->level = $level;
+        $this->mounts++;
     }
 
     public function placeholder() {
@@ -92,7 +127,7 @@ class LazyAlpha extends Component {
     }
 
     public function render() {
-        return '<div>level:'.$this->level.'</div>';
+        return '<div>level:'.$this->level.' mounts:'.$this->mounts.'</div>';
     }
 }
 


### PR DESCRIPTION
Fixes #10570. Backports the 4.x fix (#10562) so both branches match.

## The problem

Since v3.8.5, a repeat `__lazyLoad` call throws `MethodNotFoundException` — a 500 from `/livewire/update` that leaves the lazy component stuck on its placeholder. No application code is needed to trigger it; scrolling a lazy component in and out of view is enough.

Credit to @robert-stanciu for the diagnosis in #10570, which traces it precisely:

1. `generatePlaceholderHtml()` stamps `x-intersect="$wire.__lazyLoad('<encoded>')"` with no `.once` modifier, so the observer re-fires on every re-entry into the viewport.
2. Fire it while the first resume is in flight and `CommitBus.corraleCommitsIntoPools()` queues the duplicate rather than sending it.
3. `Commit.toRequestPayload()` reads `snapshotEncoded` at send time, so the queued duplicate goes out carrying the post-load snapshot (`memo.lazyLoaded: true`).
4. `hydrate()` returned early on that memo, so `isLazyLoadHydrating` was never set, so the guard added in 19a4a028 made `call()` decline to intercept — and `__lazyLoad` reached `HandleComponents::callMethods()`, which throws.

## The fix

Record that the component arrived already-loaded, swallow repeat calls before method resolution, and carry `lazyLoaded: true` forward in the memo.

That last part matters. Swallowing the call alone is not enough: without the `dehydrate()` change the response drops `lazyLoaded` from the memo, so a *third* `__lazyLoad` hydrates with no memo key, the flag is never set, and it throws again. Momentum scrolling can queue more than one duplicate behind the first, so this is reachable. The added test asserts three consecutive replays.

Only method dispatch is skipped, so the component still re-renders and the duplicate request simply re-morphs the already-correct output.

## Tests

Ports the two tests from #10562:

- `test_a_repeat_lazy_load_call_is_ignored_after_the_component_has_loaded` — three consecutive replays, asserting `mounts:1` so mount runs exactly once
- `test_a_lazy_load_call_on_a_non_lazy_component_is_not_claimed` — `__lazyLoad` on a component that was never lazy still surfaces as an error

`--testsuite Unit --filter SupportLazyLoading` is green (6 tests, 15 assertions). Full Unit suite green apart from pre-existing `FrontendAssets` failures from unbuilt `dist/`.