### PR TITLE
[4.x] Don't send a duplicate request when a lazy placeholder re-enters the viewport

### DIFF
--- a/js/features/index.js
+++ b/js/features/index.js
@@ -21,6 +21,7 @@ import './supportRedirects';
 import './supportNavigate';
 import './supportEntangle';
 import './supportSlots';
+import './supportLazyLoading';
 import './supportDataLoading';
 import './supportDataCurrent';
 import './supportPreserveScroll';

--- a/js/features/supportLazyLoading.js
+++ b/js/features/supportLazyLoading.js
@@ -1,0 +1,25 @@
+import { overrideMethod } from '@/$wire'
+import { fireAction } from '@/request'
+import { on } from '@/hooks'
+
+on('component.init', ({ component }) => {
+    if (! component.isLazy || component.hasBeenLazyLoaded) return
+
+    let pending
+
+    // The placeholder's `x-intersect` has no `.once` modifier, so it fires again every time
+    // the element re-enters the viewport. Reuse the in-flight load rather than sending a
+    // duplicate request, but forget it afterwards so a load that failed on a flaky
+    // connection is still retried the next time the placeholder scrolls back in...
+    overrideMethod(component, '__lazyLoad', (params) => {
+        if (component.hasBeenLazyLoaded) return Promise.resolve()
+
+        if (pending) return pending
+
+        pending = fireAction(component, '__lazyLoad', params)
+
+        pending.catch(() => {}).finally(() => pending = null)
+
+        return pending
+    })
+})

--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -70,6 +70,51 @@ class BrowserTest extends BrowserTestCase
             ->assertSee('Child!');
     }
 
+    public function test_a_placeholder_scrolling_back_into_view_does_not_send_a_second_request()
+    {
+        Livewire::visit([new class extends Component {
+            public function mount() {
+                cache()->forever('lazy-render-count', 0);
+            }
+
+            public function render() { return <<<HTML
+            <div>
+                <div style="height: 200vh"></div>
+                <livewire:child lazy />
+            </div>
+            HTML; }
+        }, 'child' => new class extends Component {
+            public function mount() {
+                sleep(3);
+            }
+
+            public function render() {
+                $count = cache()->increment('lazy-render-count');
+
+                return <<<HTML
+                <div id="child">
+                    Child! renders:{$count}
+                </div>
+                HTML;
+            }
+        }])
+        ->assertDontSee('Child!')
+        // Scroll the placeholder in, back out, then in again while the load is still
+        // in flight. Without deduping, the second intersect sends its own request...
+        ->runScript('window.scrollTo(0, document.body.scrollHeight)')
+        ->pause(400)
+        ->runScript('window.scrollTo(0, 0)')
+        ->pause(400)
+        ->runScript('window.scrollTo(0, document.body.scrollHeight)')
+        ->pause(400)
+        ->runScript('window.scrollTo(0, 0)')
+        ->pause(400)
+        ->runScript('window.scrollTo(0, document.body.scrollHeight)')
+        ->waitFor('#child', 15)
+        ->pause(1500)
+        ->assertSeeIn('#child', 'renders:1');
+    }
+
     public function test_cant_lazy_load_a_component_on_intersect_outside_viewport()
     {
         Livewire::visit([new class extends Component {


### PR DESCRIPTION
Follow-up to #10570 / #10586. Those fix the *exception*; this removes the duplicate request that caused it.

## The problem

`generatePlaceholderHtml()` stamps `x-intersect="$wire.__lazyLoad('<encoded>')"` on the placeholder root with no `.once` modifier, so the observer fires again every time the element re-enters the viewport.

A call made while the first load is still in flight doesn't get dropped — `interceptAction` in `js/request/interactions.js` defers it and fires it once the in-flight message finishes:

```js
action.defer()

message.addInterceptor(({ onFinish }) => {
    onFinish(() => action.fire())
})
```

So it goes out as a second `/livewire/update` round-trip carrying the post-load snapshot, and the server renders the component a second time. That's the expensive part — a component is lazy precisely because rendering it is costly, and this pays for it twice on a single scroll wobble.

## The fix

Dedupe on the client: reuse the in-flight load, and no-op entirely once the component has loaded.

The pending promise is cleared when it settles, so a load that failed on a flaky connection is still retried the next time the placeholder scrolls back in. That's the reason not to just add `.once` to the `x-intersect` — same conclusion @robert-stanciu reached in #10570.

The post-load `hasBeenLazyLoaded` guard is reliable because #10562 made `dehydrate()` carry `lazyLoaded: true` forward in the memo; before that the flag was dropped after the resume request.

Registering on `component.init` is safe ordering-wise: `Alpine.interceptInit` runs `initComponent(el)` before Alpine initializes that element's own directives, so the override is in place before `x-intersect` can fire.

## Verification

`test_a_placeholder_scrolling_back_into_view_does_not_send_a_second_request` scrolls the placeholder in and out three times during a 3s load and asserts the component rendered once.

Instrumented while developing it, counting `performance.getEntriesByType('resource')` entries and IntersectionObserver fires:

| | intersect fires | `/livewire/update` requests | test |
|---|---|---|---|
| before | 3 | **2** | fails (`renders:2`) |
| after | 3 | **1** | passes |

- `SupportLazyLoading` browser suite: 24 tests, 62 assertions, green
- `SupportLazyLoading` unit suite: 10 tests, 23 assertions, green
- JS suite: 110 passed

Note this is a pure optimization — #10586 and #10562 already make the duplicate harmless. Happy to hold it until after today's release.