### PR TITLE
[3.x] Don't register listeners until a lazy component has fully mounted

### DIFF
--- a/src/Features/SupportEvents/SupportEvents.php
+++ b/src/Features/SupportEvents/SupportEvents.php
@@ -52,7 +52,10 @@ class SupportEvents extends ComponentHook
 
     function dehydrate($context)
     {
-        if ($context->mounting) {
+        // Don't register listeners until a lazy component has fully mounted...
+        if ($this->storeGet('isLazyLoadMounting') === true) return;
+
+        if ($context->isMounting() || $this->storeGet('isLazyLoadHydrating') === true) {
             $listeners = static::getListenerEventNames($this->component);
 
             $listeners && $context->addEffect('listeners', $listeners);

--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Route;
 use Tests\BrowserTestCase;
 use Livewire\Livewire;
 use Livewire\Component;
+use Livewire\Attributes\On;
 use Livewire\Attributes\Reactive;
 
 class BrowserTest extends BrowserTestCase
@@ -317,6 +318,91 @@ class BrowserTest extends BrowserTestCase
         ->assertDontSee('Child!')
         ->waitFor('#child')
         ->assertSee('Child!')
+        ;
+    }
+
+    public function test_lazy_component_receives_events_after_being_loaded()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public function render() {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="$dispatch('refresh-child')" dusk="button">Refresh</button>
+                        <livewire:child lazy />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public $count = 0;
+
+                #[On('refresh-child')]
+                public function refresh()
+                {
+                    $this->count++;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div id="child">
+                        <span dusk="count">{{ $count }}</span>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+        ->waitFor('#child')
+        ->assertSeeIn('@count', '0')
+        ->waitForLivewire()->click('@button')
+        ->assertSeeIn('@count', '1')
+        ;
+    }
+
+    public function test_lazy_component_can_use_dynamic_event_listeners_with_placeholders_set_in_mount()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public function render() {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="$dispatch('refresh-child:abc123')" dusk="button">Refresh</button>
+                        <livewire:child lazy />
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public string $parentId = '';
+                public int $count = 0;
+
+                public function mount(): void
+                {
+                    $this->parentId = 'abc123';
+                }
+
+                #[On('refresh-child:{parentId}')]
+                public function refresh(): void
+                {
+                    $this->count++;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div id="child">
+                        <span dusk="count">{{ $count }}</span>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+        ->waitFor('#child')
+        ->assertSeeIn('@count', '0')
+        ->waitForLivewire()->click('@button')
+        ->assertSeeIn('@count', '1')
+        ->assertConsoleLogHasNoErrors()
         ;
     }
 

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportLazyLoading;
 use Illuminate\Support\Facades\Route;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Lazy;
+use Livewire\Attributes\On;
 use Livewire\Component;
 use Livewire\Livewire;
 use Livewire\Exceptions\MethodNotFoundException;
@@ -60,6 +61,25 @@ class UnitTest extends \Tests\TestCase
         Livewire::test('lazy-alpha')
             ->call('__lazyLoad', $matches[1])
             ->assertSee('level:5');
+    }
+
+    public function test_a_lazy_component_registers_its_listeners_only_once_it_has_loaded()
+    {
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        Livewire::component('lazy-with-listener', LazyWithListener::class);
+
+        $component = Livewire::test('lazy-with-listener');
+
+        // The placeholder is dormant, so the browser has nothing to dispatch to yet...
+        $this->assertArrayNotHasKey('listeners', $component->effects);
+
+        preg_match("/__lazyLoad\('([^']+)'\)/", html_entity_decode($component->html()), $matches);
+
+        $component->call('__lazyLoad', $matches[1]);
+
+        // ...and the resume response is what registers them...
+        $this->assertEquals(['refresh-child'], $component->effects['listeners']);
     }
 
     public function test_a_repeat_lazy_load_call_is_ignored_after_the_component_has_loaded()
@@ -128,6 +148,24 @@ class LazyAlpha extends Component {
 
     public function render() {
         return '<div>level:'.$this->level.' mounts:'.$this->mounts.'</div>';
+    }
+}
+
+#[Lazy]
+class LazyWithListener extends Component {
+    public $count = 0;
+
+    #[On('refresh-child')]
+    public function refresh() {
+        $this->count++;
+    }
+
+    public function placeholder() {
+        return '<div>Loading...</div>';
+    }
+
+    public function render() {
+        return '<div>count:'.$this->count.'</div>';
     }
 }
 


### PR DESCRIPTION
Backports the 4.x fix ([#10221](https://github.com/livewire/livewire/pull/10221)) so both branches match.

## The problem

A lazy component registers its event listeners while it is still a placeholder. `SupportEvents::dehydrate()` on 3.x emits the `listeners` effect whenever `$context->mounting` is true, and the placeholder mount is a mount like any other. Client-side those listeners are bound at component init and never cleaned up until the component is destroyed, so the placeholder is live from the moment it renders.

That means an event dispatched before the component resumes is delivered to a component that never mounted. `SupportLazyLoading::hydrate()` calls `skipHydrate()` for a placeholder snapshot, and `mount()` only runs on the `__lazyLoad` call, so the listener method executes against declared defaults — uninitialized typed properties, empty collections, missing mount params. Worse, that request's `dehydrate()` stamps `lazyLoaded: true`, so the component is marked resumed without ever having mounted and stays wrong until a page reload.

It also breaks dynamic listener placeholders: `#[On('refresh-child:{parentId}')]` is serialized during the placeholder mount, before `mount()` has assigned `$parentId`, so the browser binds `refresh-child:` and the real event never matches.

This was reported for 3.x in [#8430](https://github.com/livewire/livewire/discussions/8430) and [#8978](https://github.com/livewire/livewire/pull/8978), where the expected behavior was settled:

> ahh intersting - i think if the component hasn't been initialized (because it's off the page for some reason) it shouldn't be responding to any events at all. think about like a lazy component inside a modal - it should just be lying dormant until it enters the viewport and is fully loaded. — @calebporzio

#10221 implemented exactly that on 4.x. 3.x never got it.

## The fix

Skip the `listeners` effect while the lazy placeholder is mounting, and emit it on the resume request instead:

```php
// Don't register listeners until a lazy component has fully mounted...
if ($this->storeGet('isLazyLoadMounting') === true) return;

if ($context->isMounting() || $this->storeGet('isLazyLoadHydrating') === true) {
```

Same code as 4.x, using the `ComponentHook` store helpers that already exist on this branch. No new public API — the `#[Lazy(listening:)]` opt-in floated in #8978 is deliberately left out, per @joshhanley's "hold off on the control for now and see how this goes first".

Both halves matter. Suppressing alone would leave a resumed component permanently deaf, since the resume response is the only other chance to emit the effect.

## Tests

Ports the two browser tests from #10221:

- `test_lazy_component_receives_events_after_being_loaded` — a guard that a resumed lazy component still handles events
- `test_lazy_component_can_use_dynamic_event_listeners_with_placeholders_set_in_mount` — the `{parentId}` case; errors without the fix

Adds one deterministic unit test so the behavior is covered without Dusk:

- `test_a_lazy_component_registers_its_listeners_only_once_it_has_loaded` — asserts no `listeners` effect on the placeholder response and `['refresh-child']` on the `__lazyLoad` response. Fails without the fix with *"Failed asserting that an array does not have the key 'listeners'"*.

`--testsuite Unit` is 934 tests green apart from the 5 pre-existing `FrontendAssets` failures from an unbuilt `dist/` (identical on a clean checkout). The two browser tests pass against a locally built `dist/`.
