### PR TITLE
[4.x] Fix exception thrown from computed properties does not stop propagating when called from lifecycle hooks

### DIFF
--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Features\SupportComputed;
 
-use function Livewire\{ invade, trigger };
+use function Livewire\{ invade, trigger, wrap};
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
@@ -158,19 +158,17 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
-        try {
+        if ($this->storeGet('exceptionHandlingDepth', 0) > 0) {
             return invade($this->component)->{parent::getName()}();
-        } catch (\Throwable $e) {
-            $shouldPropagate = true;
-
-            $stopPropagation = function () use (&$shouldPropagate) {
-                $shouldPropagate = false;
-            };
-
-            trigger('exception', $this->component, $e, $stopPropagation);
-
-            $shouldPropagate && throw $e;
         }
+
+        $value = null;
+
+        wrap($this->component)->tap(function ($component) use (&$value) {
+            $value = invade($component)->{parent::getName()}();
+        });
+
+        return $value;
     }
 
     public function getName()

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -161,7 +161,7 @@ class BaseComputed extends Attribute
     {
         $evaluated = fn () => invade($this->component)->{parent::getName()}();
 
-        if (empty(HandleComponents::$renderStack)) {
+        if (! in_array($this->component, HandleComponents::$renderStack, true)) {
             return $evaluated();
         }
 

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Features\SupportComputed;
 
-use function Livewire\{ invade, wrap};
+use function Livewire\{ invade, wrap };
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
@@ -158,10 +158,14 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
+        // If computed properties called from wrapped caller (e.g. lifecycle hooks)
+        // let it handles the exception
         if ($this->storeGet('exceptionHandlingDepth', 0) > 0) {
             return invade($this->component)->{parent::getName()}();
         }
 
+        // otherwise, if computed properties accessed directly from view (e.g. $this->foo)
+        // we need to wrap it so any exception thrown can be catch from exception() hook
         $value = null;
 
         wrap($this->component)->tap(function ($component) use (&$value) {

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -158,14 +158,6 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
-        // If computed properties called from wrapped caller (e.g. lifecycle hooks)
-        // let it handles the exception
-        if ($this->storeGet('exceptionHandlingDepth', 0) > 0) {
-            return invade($this->component)->{parent::getName()}();
-        }
-
-        // otherwise, if computed properties accessed directly from view (e.g. $this->foo)
-        // we need to wrap it so any exception thrown can be catch from exception() hook
         $value = null;
 
         wrap($this->component)->tap(function ($component) use (&$value) {

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Features\SupportComputed;
 
-use function Livewire\{ invade, wrap };
+use function Livewire\{ invade, trigger };
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
@@ -158,15 +158,19 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
-        $value = 'noneset';
+        try {
+            return invade($this->component)->{parent::getName()}();
+        } catch (\Throwable $e) {
+            $shouldPropagate = true;
 
-        wrap($this->component)->tap(function ($component) use (&$value) {
-            $value = invade($component)->{parent::getName()}();
-        });
+            $stopPropagation = function () use (&$shouldPropagate) {
+                $shouldPropagate = false;
+            };
 
-        if ($value === 'noneset') return;
+            trigger('exception', $this->component, $e, $stopPropagation);
 
-        return $value;
+            $shouldPropagate && throw $e;
+        }
     }
 
     public function getName()

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -6,6 +6,7 @@ use function Livewire\{ invade, wrap };
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
+use Livewire\Mechanisms\HandleComponents\HandleComponents;
 
 #[\Attribute]
 class BaseComputed extends Attribute
@@ -158,18 +159,16 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
-        // Check if computed properties accessed from lifecycle hooks that already has exception handler
-        // Return original value without wrapper
-        if ($this->storeGet('exceptionHandled')) {
-            return invade($this->component)->{parent::getName()}();
+        $evaluated = fn () => invade($this->component)->{parent::getName()}();
+
+        if (empty(HandleComponents::$renderStack)) {
+            return $evaluated();
         }
 
-        // Otherwise, if computed properties accessed from view that doesnt have exception handler,
-        // wrap it so any exception thrown from computed properties forwarded to component exception hook
         $value = null;
 
-        wrap($this->component)->tap(function ($component) use (&$value) {
-            $value = invade($component)->{parent::getName()}();
+        wrap($this->component)->tap(function () use (&$value, $evaluated) {
+            $value = $evaluated();
         });
 
         return $value;

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -158,11 +158,13 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
-        $value = null;
+        $value = 'noneset';
 
         wrap($this->component)->tap(function ($component) use (&$value) {
             $value = invade($component)->{parent::getName()}();
         });
+
+        if ($value === 'noneset') return;
 
         return $value;
     }

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Features\SupportComputed;
 
-use function Livewire\{ invade, trigger, wrap};
+use function Livewire\{ invade, wrap};
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -158,6 +158,14 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
+        // Check if computed properties accessed from lifecycle hooks that already has exception handler
+        // Return original value without wrapper
+        if ($this->storeGet('exceptionHandled')) {
+            return invade($this->component)->{parent::getName()}();
+        }
+
+        // Otherwise, if computed properties accessed from view that doesnt have exception handler,
+        // wrap it so any exception thrown from computed properties forwarded to component exception hook
         $value = null;
 
         wrap($this->component)->tap(function ($component) use (&$value) {

--- a/src/Features/SupportComputed/BrowserTest.php
+++ b/src/Features/SupportComputed/BrowserTest.php
@@ -124,4 +124,91 @@ class BrowserTest extends BrowserTestCase
         ->assertSeeIn('@foo', 'bar')
         ;
     }
+
+    public function test_exception_from_computed_properties_during_action_stops_further_execution()
+    {
+        Livewire::visit(new class extends Component {
+            public bool $handled = false;
+            public string $label = 'initial';
+
+            #[Computed]
+            public function failingValue(): string
+            {
+                throw new \RuntimeException('computed failed in action');
+            }
+
+            public function save()
+            {
+                $value = $this->failingValue;
+
+                // Must not run when stopPropagation() is called.
+                $this->label = $value;
+            }
+
+            public function exception($e, $stopPropagation): void
+            {
+                if ($e instanceof \RuntimeException) {
+                    $this->handled = true;
+                    $stopPropagation();
+                }
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="save" dusk="save">Save</button>
+                    <div dusk="label">{{ $label }}</div>
+                    <div dusk="handled">{{ $handled ? 'yes' : 'no' }}</div>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@label', 'initial')
+            ->assertSeeIn('@handled', 'no')
+            ->waitForLivewire()->click('@save')
+            ->assertSeeIn('@label', 'initial')
+            ->assertSeeIn('@handled', 'yes');
+    }
+
+    public function test_exception_from_computed_properties_during_mount_still_renders_after_stop()
+    {
+        Livewire::visit(new class extends Component {
+            public bool $handled = false;
+            public string $label = 'initial';
+
+            public function mount()
+            {
+                $value = $this->failingValue;
+
+                $this->label = is_string($value) ? $value : 'unchanged';
+            }
+
+            #[Computed]
+            public function failingValue(): string
+            {
+                throw new \RuntimeException('computed failed in mount');
+            }
+
+            public function exception($e, $stopPropagation): void
+            {
+                if ($e instanceof \RuntimeException) {
+                    $this->handled = true;
+                    $stopPropagation();
+                }
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <div dusk="label">{{ $label }}</div>
+                    <div dusk="handled">{{ $handled ? 'yes' : 'no' }}</div>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@label', 'initial')
+            ->assertSeeIn('@handled', 'yes');
+    }
 }

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportComputed;
 
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Cache;
 use Tests\TestComponent;
 use Tests\TestCase;
@@ -758,6 +759,27 @@ class UnitTest extends TestCase
         })
             ->call('save')
             ->assertOk()
+            ->assertSetStrict('otherValue', 'other')
+            ->assertSetStrict('handled', true);
+    }
+
+    public function test_stops_execution_after_computed_exception_is_handled_from_render()
+    {
+        Livewire::test(new class extends ComputedLifecycleExceptionStub {
+            public function mount() {}
+            public function render()
+            {
+                $value = $this->failingValue;
+
+                return Blade::render(<<<'HTML'
+                    <div>{{ $value }}</div>
+                    <div>{{ $otherValue }}</div>
+                HTML, ['value' => $value, 'otherValue' => $this->otherValue]);
+            }
+        })
+            ->call('save')
+            ->assertOk()
+            ->assertSee('other')
             ->assertSetStrict('otherValue', 'other')
             ->assertSetStrict('handled', true);
     }

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -761,6 +761,15 @@ class UnitTest extends TestCase
             ->assertSetStrict('otherValue', 'other')
             ->assertSetStrict('handled', true);
     }
+
+    public function test_nested_computed_exception_from_lifecycle_is_handled_once()
+    {
+        Livewire::test(ComputedNestedExceptionStub::class)
+            ->assertOk()
+            ->assertSetStrict('otherValue', 'other')
+            ->assertSetStrict('handled', true)
+            ->assertSetStrict('exceptionCalls', 1);
+    }
 }
 
 class ComputedPropertyStub extends Component
@@ -928,7 +937,7 @@ class ComputedViewExceptionStub extends TestComponent
         throw new ComputedPropertyException('Exception from computed property');
     }
 
-    public function exception($e, $stopPropagation): void
+    public function exception($e, $stopPropagation)
     {
         if ($e instanceof ComputedPropertyException) {
             $this->handled = true;
@@ -982,4 +991,39 @@ class ComputedLifecycleExceptionStub extends TestComponent
     }
 
     public function acceptsString(string $value) {}
+}
+
+class ComputedNestedExceptionStub extends TestComponent
+{
+    public bool $handled = false;
+    public $otherValue = 'other';
+    public int $exceptionCalls = 0;
+
+    public function mount()
+    {
+        $value = $this->outer;
+
+        $this->otherValue = $value;
+    }
+
+    #[Computed]
+    public function outer(): string
+    {
+        return $this->inner;
+    }
+
+    #[Computed]
+    public function inner(): string
+    {
+        throw new \RuntimeException('The computed value could not be loaded.');
+    }
+
+    public function exception($e, $stopPropagation): void
+    {
+        if ($e instanceof \RuntimeException) {
+            $this->exceptionCalls++;
+            $this->handled = true;
+            $stopPropagation();
+        }
+    }
 }

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -736,72 +736,27 @@ class UnitTest extends TestCase
             ->assertSetStrict('foo', 'baz');
     }
 
-    public function test_computed_attribute_can_trigger_component_exception_hook()
+    public function test_computed_properties_can_trigger_component_exception_hook()
     {
-        Livewire::test(new class extends TestComponent {
-            #[Computed]
-            public function foo(): string
-            {
-                throw new ComputedPropertyException('Exception from computed property');
-            }
-
-            public function exception($e, $stopPropagation)
-            {
-                if ($e instanceof ComputedPropertyException) {
-                    $stopPropagation();
-
-                    session()->put('exception-hook-triggered', true);
-                }
-            }
-
-            public function render()
-            {
-                return <<<'HTML'
-                    <div>{{ $this->foo }}</div>
-                HTML;
-            }
-        })
-            ->assertOk();
-
-        $this->assertTrue(session()->has('exception-hook-triggered'));
+        Livewire::test(ComputedViewExceptionStub::class)
+            ->assertOk()
+            ->assertSetStrict('handled', true);
     }
 
     public function test_stops_execution_after_an_exception_from_a_computed_property_is_handled()
     {
-        Livewire::test(new class extends TestComponent {
-            public bool $handled = false;
-            public $otherValue = 'other';
+        Livewire::test(ComputedLifecycleExceptionStub::class)
+            ->assertOk()
+            ->assertSetStrict('otherValue', 'other')
+            ->assertSetStrict('handled', true);
+    }
 
-            public function mount()
-            {
-                $value = $this->failingValue;
-
-                $this->otherValue = $value;
-
-                $this->acceptsString($value);
-            }
-
-            #[Computed]
-            public function failingValue(): string
-            {
-                throw new \RuntimeException('The computed value could not be loaded.');
-            }
-
-            public function exception($e, $stopPropagation): void
-            {
-                if (! $e instanceof \RuntimeException) {
-                    return;
-                }
-
-                $this->handled = true;
-                $stopPropagation();
-            }
-
-            public function acceptsString(string $value): void
-            {
-                //
-            }
+    public function test_stops_execution_after_computed_exception_is_handled_from_an_action()
+    {
+        Livewire::test(new class extends ComputedLifecycleExceptionStub {
+            public function mount() {}
         })
+            ->call('save')
             ->assertOk()
             ->assertSetStrict('otherValue', 'other')
             ->assertSetStrict('handled', true);
@@ -961,4 +916,70 @@ class ComputedPropertyException extends \Exception
     ) {
         parent::__construct($message, $code, $previous);
     }
+}
+
+class ComputedViewExceptionStub extends TestComponent
+{
+    public bool $handled = false;
+
+    #[Computed]
+    public function foo(): string
+    {
+        throw new ComputedPropertyException('Exception from computed property');
+    }
+
+    public function exception($e, $stopPropagation): void
+    {
+        if ($e instanceof ComputedPropertyException) {
+            $this->handled = true;
+            $stopPropagation();
+        }
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+            <div>{{ $this->foo }}</div>
+        HTML;
+    }
+}
+
+class ComputedLifecycleExceptionStub extends TestComponent
+{
+    public bool $handled = false;
+    public $otherValue = 'other';
+
+    public function mount()
+    {
+        $value = $this->failingValue;
+
+        $this->otherValue = $value;
+
+        $this->acceptsString($value);
+    }
+
+    public function save()
+    {
+        $value = $this->failingValue;
+
+        $this->otherValue = $value;
+
+        $this->acceptsString($value);
+    }
+
+    #[Computed]
+    public function failingValue(): string
+    {
+        throw new \RuntimeException('The computed value could not be loaded.');
+    }
+
+    public function exception($e, $stopPropagation): void
+    {
+        if ($e instanceof \RuntimeException) {
+            $this->handled = true;
+            $stopPropagation();
+        }
+    }
+
+    public function acceptsString(string $value) {}
 }

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -765,6 +765,38 @@ class UnitTest extends TestCase
 
         $this->assertTrue(session()->has('exception-hook-triggered'));
     }
+
+    public function test_computed_properties_does_not_return_anything_when_exception_thrown()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Computed]
+            public function foo()
+            {
+                $value = '1234';
+
+                throw_if($value === '1234', new ComputedPropertyException('Exception from computed property'));
+
+                return $value;
+            }
+
+            public function exception($e, $stopPropagation)
+            {
+                if ($e instanceof ComputedPropertyException) {
+                    $stopPropagation();
+                }
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>foo{{ $this->foo }}</div>
+                HTML;
+            }
+        })
+            ->assertOk()
+            ->assertDontSee('foo1234')
+            ->assertSetStrict('foo', null);
+    }
 }
 
 class ComputedPropertyStub extends Component

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -766,36 +766,41 @@ class UnitTest extends TestCase
         $this->assertTrue(session()->has('exception-hook-triggered'));
     }
 
-    public function test_computed_properties_does_not_return_anything_when_exception_thrown()
+    public function test_stops_execution_after_an_exception_from_a_computed_property_is_handled()
     {
         Livewire::test(new class extends TestComponent {
+            public bool $handled = false;
+
+            public function mount()
+            {
+                $value = $this->failingValue;
+
+                $this->acceptsString($value);
+            }
+
             #[Computed]
-            public function foo()
+            public function failingValue(): string
             {
-                $value = '1234';
-
-                throw_if($value === '1234', new ComputedPropertyException('Exception from computed property'));
-
-                return $value;
+                throw new \RuntimeException('The computed value could not be loaded.');
             }
 
-            public function exception($e, $stopPropagation)
+            public function exception($e, $stopPropagation): void
             {
-                if ($e instanceof ComputedPropertyException) {
-                    $stopPropagation();
+                if (! $e instanceof \RuntimeException) {
+                    return;
                 }
+
+                $this->handled = true;
+                $stopPropagation();
             }
 
-            public function render()
+            public function acceptsString(string $value): void
             {
-                return <<<'HTML'
-                    <div>foo{{ $this->foo }}</div>
-                HTML;
+                //
             }
         })
             ->assertOk()
-            ->assertDontSee('foo1234')
-            ->assertSetStrict('foo', null);
+            ->assertSetStrict('handled', true);
     }
 }
 

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -770,10 +770,13 @@ class UnitTest extends TestCase
     {
         Livewire::test(new class extends TestComponent {
             public bool $handled = false;
+            public $otherValue = 'other';
 
             public function mount()
             {
                 $value = $this->failingValue;
+
+                $this->otherValue = $value;
 
                 $this->acceptsString($value);
             }
@@ -800,6 +803,7 @@ class UnitTest extends TestCase
             }
         })
             ->assertOk()
+            ->assertSetStrict('otherValue', 'other')
             ->assertSetStrict('handled', true);
     }
 }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -319,9 +319,9 @@ class HandleComponents extends Mechanism
             ]);
         }
 
-        [ $view, $properties ] = $this->getView($component);
+        return $this->trackInRenderStack($component, function () use ($component) {
+            [ $view, $properties ] = $this->getView($component);
 
-        return $this->trackInRenderStack($component, function () use ($component, $view, $properties) {
             $finish = trigger('render', $component, $view, $properties);
 
             $revertA = Utils::shareWithViews('__livewire', $component);

--- a/src/Wrapped.php
+++ b/src/Wrapped.php
@@ -34,3 +34,7 @@ class Wrapped
         }
     }
 }
+
+
+
+

--- a/src/Wrapped.php
+++ b/src/Wrapped.php
@@ -5,7 +5,6 @@ namespace Livewire;
 class Wrapped
 {
     protected $fallback;
-    protected static $wrapping = [];
 
     function __construct(public $target) {}
 
@@ -20,13 +19,16 @@ class Wrapped
     {
         if (! method_exists($this->target, $method)) return value($this->fallback);
 
-        // Already inside a boundary for this component — run transparently
-        // so the outer wrap() remains the single exception handler.
-        if (in_array($this->target, static::$wrapping, true)) {
+        $store = store($this->target);
+
+        // Already inside an outer exception boundary — call through without
+        // creating a nested one so $stopPropagation() on the outer handler
+        // correctly halts further execution (e.g. computed props in lifecycle hooks).
+        if ($store->get('exceptionHandled')) {
             return ImplicitlyBoundMethod::call(app(), [$this->target, $method], $params);
         }
 
-        static::$wrapping[] = $this->target;
+        $store->set('exceptionHandled', true);
 
         try {
             return ImplicitlyBoundMethod::call(app(), [$this->target, $method], $params);
@@ -41,7 +43,7 @@ class Wrapped
 
             $shouldPropagate && throw $e;
         } finally {
-            array_pop(static::$wrapping);
+            $store->set('exceptionHandled', false);
         }
     }
 }

--- a/src/Wrapped.php
+++ b/src/Wrapped.php
@@ -5,6 +5,7 @@ namespace Livewire;
 class Wrapped
 {
     protected $fallback;
+    protected static $wrapping = [];
 
     function __construct(public $target) {}
 
@@ -19,16 +20,13 @@ class Wrapped
     {
         if (! method_exists($this->target, $method)) return value($this->fallback);
 
-        $store = store($this->target);
-
-        // Already inside an outer exception boundary — call through without
-        // creating a nested one so $stopPropagation() on the outer handler
-        // correctly halts further execution (e.g. computed props in lifecycle hooks).
-        if ($store->get('exceptionHandlingDepth') === true) {
+        // Already inside a boundary for this component — run transparently
+        // so the outer wrap() remains the single exception handler.
+        if (in_array($this->target, static::$wrapping, true)) {
             return ImplicitlyBoundMethod::call(app(), [$this->target, $method], $params);
         }
 
-        $store->set('exceptionHandlingDepth', true);
+        static::$wrapping[] = $this->target;
 
         try {
             return ImplicitlyBoundMethod::call(app(), [$this->target, $method], $params);
@@ -43,7 +41,7 @@ class Wrapped
 
             $shouldPropagate && throw $e;
         } finally {
-            $store->set('exceptionHandlingDepth', false);
+            array_pop(static::$wrapping);
         }
     }
 }

--- a/src/Wrapped.php
+++ b/src/Wrapped.php
@@ -19,16 +19,7 @@ class Wrapped
     {
         if (! method_exists($this->target, $method)) return value($this->fallback);
 
-        $store = store($this->target);
-
-        // Already inside an outer exception boundary — call through without
-        // creating a nested one so $stopPropagation() on the outer handler
-        // correctly halts further execution (e.g. computed props in lifecycle hooks).
-        if ($store->get('exceptionHandled')) {
-            return ImplicitlyBoundMethod::call(app(), [$this->target, $method], $params);
-        }
-
-        $store->set('exceptionHandled', true);
+        store($this->target)->set('exceptionHandled', true);
 
         try {
             return ImplicitlyBoundMethod::call(app(), [$this->target, $method], $params);
@@ -43,7 +34,7 @@ class Wrapped
 
             $shouldPropagate && throw $e;
         } finally {
-            $store->set('exceptionHandled', false);
+            store($this->target)->unset('exceptionHandled');
         }
     }
 }

--- a/src/Wrapped.php
+++ b/src/Wrapped.php
@@ -19,6 +19,12 @@ class Wrapped
     {
         if (! method_exists($this->target, $method)) return value($this->fallback);
 
+        $store = store($this->target);
+
+        $depth = $store->get('exceptionHandlingDepth', 0);
+
+        $store->set('exceptionHandlingDepth', $depth + 1);
+
         try {
             return ImplicitlyBoundMethod::call(app(), [$this->target, $method], $params);
         } catch (\Throwable $e) {
@@ -31,6 +37,11 @@ class Wrapped
             trigger('exception', $this->target, $e, $stopPropagation);
 
             $shouldPropagate && throw $e;
+        } finally {
+            $store->set(
+                'exceptionHandlingDepth',
+                max(0, $store->get('exceptionHandlingDepth', 0) - 1)
+            );
         }
     }
 }

--- a/src/Wrapped.php
+++ b/src/Wrapped.php
@@ -21,9 +21,14 @@ class Wrapped
 
         $store = store($this->target);
 
-        $depth = $store->get('exceptionHandlingDepth', 0);
+        // Already inside an outer exception boundary — call through without
+        // creating a nested one so $stopPropagation() on the outer handler
+        // correctly halts further execution (e.g. computed props in lifecycle hooks).
+        if ($store->get('exceptionHandlingDepth', 0) > 0) {
+            return ImplicitlyBoundMethod::call(app(), [$this->target, $method], $params);
+        }
 
-        $store->set('exceptionHandlingDepth', $depth + 1);
+        $store->set('exceptionHandlingDepth', 1);
 
         try {
             return ImplicitlyBoundMethod::call(app(), [$this->target, $method], $params);
@@ -38,14 +43,7 @@ class Wrapped
 
             $shouldPropagate && throw $e;
         } finally {
-            $store->set(
-                'exceptionHandlingDepth',
-                max(0, $store->get('exceptionHandlingDepth', 0) - 1)
-            );
+            $store->set('exceptionHandlingDepth', 0);
         }
     }
 }
-
-
-
-

--- a/src/Wrapped.php
+++ b/src/Wrapped.php
@@ -19,8 +19,6 @@ class Wrapped
     {
         if (! method_exists($this->target, $method)) return value($this->fallback);
 
-        store($this->target)->set('exceptionHandled', true);
-
         try {
             return ImplicitlyBoundMethod::call(app(), [$this->target, $method], $params);
         } catch (\Throwable $e) {
@@ -33,8 +31,6 @@ class Wrapped
             trigger('exception', $this->target, $e, $stopPropagation);
 
             $shouldPropagate && throw $e;
-        } finally {
-            store($this->target)->unset('exceptionHandled');
         }
     }
 }

--- a/src/Wrapped.php
+++ b/src/Wrapped.php
@@ -24,11 +24,11 @@ class Wrapped
         // Already inside an outer exception boundary — call through without
         // creating a nested one so $stopPropagation() on the outer handler
         // correctly halts further execution (e.g. computed props in lifecycle hooks).
-        if ($store->get('exceptionHandlingDepth', 0) > 0) {
+        if ($store->get('exceptionHandlingDepth') === true) {
             return ImplicitlyBoundMethod::call(app(), [$this->target, $method], $params);
         }
 
-        $store->set('exceptionHandlingDepth', 1);
+        $store->set('exceptionHandlingDepth', true);
 
         try {
             return ImplicitlyBoundMethod::call(app(), [$this->target, $method], $params);
@@ -43,7 +43,7 @@ class Wrapped
 
             $shouldPropagate && throw $e;
         } finally {
-            $store->set('exceptionHandlingDepth', 0);
+            $store->set('exceptionHandlingDepth', false);
         }
     }
 }


### PR DESCRIPTION
## Scenario

Accessing computed properties from view which throws an exception now handled by this PR https://github.com/livewire/livewire/pull/10543. However this introduce new regression where computed properties accessed inside component method (action / lifecycle hooks) which create nested exception handler.

## Problem

Component action / lifecycle hooks already use `Wrapped::__call`, so the regression create nested exception handler. If inner handler catch the exception and stop propagating, outer handler will treat it as no exception thrown therefore it will continue the exceution eventhough it shouldnt.

## Solution

Before returning the value from `evaluateComputed()`, we need to determine whether the computed property is being accessed from a component method or while rendering the view.

`HandleComponents::$renderStack` provides the necessary context: when the computed property is accessed while rendering the view, the stack is populated, so the computed method needs to be wrapped to ensure exceptions are handled by Livewire's `exception()` hook. When it is accessed from a component method that is already wrapped by Livewire, the stack is empty, so the computed method can be invoked directly and let the existing outer exception handler handle the exception.

However, an additional case occurs when a computed property is accessed from the component's `render()` method itself.

Currently, `HandleComponents::render()` resolves the view and properties before entering `trackInRenderStack()`:
```php
[ $view, $properties ] = $this->getView($component);

return $this->trackInRenderStack(...);
```
`getView()` invokes the component's `render()` method through `wrap()`:
```php
if (method_exists($component, 'render')) {
    $viewOrString = wrap($component)->render();
}
```
Therefore, when `render()` accesses a computed property, `$renderStack` is still empty. The computed property would be evaluated directly, causing its exception to propagate to the outer `wrap($component)->render()` handler. If the exception is handled with `$stopPropagation()`, that wrapper returns null, which subsequently causes an unrelated `ViewException` when `getView()` attempts to process the render result.

To avoid this, `getView()` needs to execute inside `trackInRenderStack()`:
```php
return $this->trackInRenderStack($component, function () use ($component) {
    [ $view, $properties ] = $this->getView($component);

    // ...
});
```
This ensures `$renderStack` is populated for the entire render lifecycle, including the component's `render()` method and the Blade view.

As a result:

- Component action/method → computed property → **no additional wrapper**
- Component `render()` → computed property → **computed is wrapped**
- Blade view → computed property → **computed is wrapped**

This prevents nested exception handlers for component actions while ensuring exceptions from computed properties accessed during rendering are correctly handled by Livewire's `exception()` hook.

## Fix
This PR only fix regression behavior that surface through this issue https://github.com/livewire/livewire/issues/10588 but does not solve the author's issue