### PR TITLE
Fix Livewire updates from route binding error pages

### DIFF
--- a/src/Mechanisms/PersistentMiddleware/BrowserTest.php
+++ b/src/Mechanisms/PersistentMiddleware/BrowserTest.php
@@ -35,6 +35,11 @@ class BrowserTest extends BrowserTestCase
 
     public static function tweakApplicationHook() {
         return function() {
+            config()->set('view.paths', [
+                __DIR__.'/fixtures/views',
+                ...config('view.paths'),
+            ]);
+
             Livewire::addPersistentMiddleware([AllowListedMiddleware::class, IsBanned::class]);
 
             // Overwrite the default route for these tests, so the middleware is included
@@ -85,6 +90,7 @@ class BrowserTest extends BrowserTestCase
             Livewire::component('child-with-modelable', ChildComponentWithModelable::class);
             Livewire::component('page-with-explicit-binding', PageComponentWithExplicitBinding::class);
             Livewire::component('child-for-explicit-binding', ChildForExplicitBinding::class);
+            Livewire::component('error-page-counter', ErrorPageCounter::class);
 
             Route::get('/page-with-reactive-child/{post}', PageComponentWithReactiveChild::class)
                 ->middleware('web');
@@ -96,8 +102,22 @@ class BrowserTest extends BrowserTestCase
 
             Route::get('/explicit-binding/{bound_model}', PageComponentWithExplicitBinding::class)
                 ->middleware('web');
+
+            Route::get('/model-binding-error/{post}', fn (Post $post) => 'Found')
+                ->middleware('web');
         };
     }
+
+    public function test_component_on_route_model_binding_404_can_make_livewire_requests()
+    {
+        Livewire::visit(Component::class)
+            ->visit('/model-binding-error/40472')
+            ->assertSee('Count: 0')
+            ->waitForLivewire()->click('@error-page-increment')
+            ->assertSee('Count: 1')
+        ;
+    }
+
     public function test_that_persistent_middleware_is_applied_to_subsequent_livewire_requests()
     {
         // @todo: Copy implementation from V2 for persistent middleware and ensure localisation and subdirectory hosting are supported. https://github.com/livewire/livewire/pull/5490
@@ -724,6 +744,23 @@ class ChildForExplicitBinding extends BaseComponent
         <div>
             <span dusk="child-output">child loaded</span>
         </div>
+        HTML;
+    }
+}
+
+class ErrorPageCounter extends BaseComponent
+{
+    public $count = 0;
+
+    public function increment()
+    {
+        $this->count++;
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <button wire:click="increment" dusk="error-page-increment">Count: {{ $count }}</button>
         HTML;
     }
 }

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -3,6 +3,7 @@
 namespace Livewire\Mechanisms\PersistentMiddleware;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Routing\Router;
 use Livewire\Mechanisms\Mechanism;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -13,6 +14,8 @@ use Livewire\Mechanisms\HandleRequests\HandleRequests;
 
 class PersistentMiddleware extends Mechanism
 {
+    protected const ROUTE_BINDING_ERROR_PAGE_ATTRIBUTE = 'livewire_route_binding_error_page';
+
     protected static $persistentMiddleware = [
         \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
         \Laravel\Jetstream\Http\Middleware\AuthenticateSession::class,
@@ -31,7 +34,27 @@ class PersistentMiddleware extends Mechanism
 
     function boot()
     {
+        app('view')->composer('errors::*', function ($view) {
+            $exception = $view->getData()['exception'] ?? null;
+
+            if (
+                $exception instanceof NotFoundHttpException
+                && $exception->getPrevious() instanceof ModelNotFoundException
+            ) {
+                request()->attributes->set(static::ROUTE_BINDING_ERROR_PAGE_ATTRIBUTE, true);
+            }
+        });
+
         on('dehydrate', function ($component, $context) {
+            // Components rendered by a route model binding 404 never made it
+            // through the original route's middleware, so there is no
+            // successful middleware context to replay on their updates.
+            if (request()->attributes->get(static::ROUTE_BINDING_ERROR_PAGE_ATTRIBUTE)) {
+                $context->addMemo('routeBindingErrorPage', true);
+
+                return;
+            }
+
             [$path, $method] = $this->extractPathAndMethodFromRequest();
 
             $context->addMemo('path', $path);
@@ -41,6 +64,10 @@ class PersistentMiddleware extends Mechanism
         on('snapshot-verified', function ($snapshot) {
             // Only apply middleware to requests hitting the Livewire update endpoint, and not any fake requests such as a test.
             if (! app(HandleRequests::class)->isLivewireRoute()) return;
+
+            // This flag was added to the checksummed snapshot while Laravel
+            // rendered a route model binding 404 response.
+            if ($snapshot['memo']['routeBindingErrorPage'] ?? false) return;
 
             $this->extractPathAndMethodFromSnapshot($snapshot);
 

--- a/src/Mechanisms/PersistentMiddleware/fixtures/views/errors/404.blade.php
+++ b/src/Mechanisms/PersistentMiddleware/fixtures/views/errors/404.blade.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        @livewireStyles
+    </head>
+    <body>
+        <livewire:error-page-counter />
+
+        @livewireScripts
+    </body>
+</html>


### PR DESCRIPTION
## What changed

When Laravel renders an `errors::*` view because route model binding failed, mark Livewire components rendered on that error page in their checksummed snapshot. Subsequent updates for those components skip persistent middleware replay because the original route middleware pipeline never completed.

This is an alternative to #10572. Catching `ModelNotFoundException` around the full persistent middleware pipeline can convert a partial pipeline into a successful update and skip middleware that follows `SubstituteBindings`, including authorization. This approach limits the exception to snapshots the server can prove came from Laravel's route-model-binding error response.

A once-valid route whose model disappears later does not receive the marker, so persistent middleware continues to fail closed.

## Test

- Added a browser regression that renders a Livewire counter inside Laravel's model-binding 404 view and verifies it can update from 0 to 1.
- Ran `./vendor/bin/phpunit --configuration phpunit.xml.dist src/Mechanisms/PersistentMiddleware/UnitTest.php src/Mechanisms/PersistentMiddleware/BrowserTest.php`
- Result: 13 tests, 38 assertions.