### PR TITLE
Fix resetting uninitialized form properties

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -349,6 +349,16 @@ $this->reset('title');
 $this->reset(['title', 'content']);
 ```
 
+`reset()` restores each property to the state declared on the form class. If a typed property has no default value, it will be uninitialized after it is reset. Give fields a default value when they need to be read or rendered immediately after resetting:
+
+```php
+public string $title = '';
+
+public ?string $subtitle = null;
+```
+
+Alternatively, assign the property after calling `reset()` before reading it.
+
 ### Pulling form fields
 
 Alternatively, you can use the `pull()` method to both retrieve a form's properties and reset them in one operation.

--- a/src/Features/SupportFormObjects/BrowserTest.php
+++ b/src/Features/SupportFormObjects/BrowserTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Livewire\Features\SupportFormObjects;
+
+use Livewire\Component;
+use Livewire\Form;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    public function test_resetting_required_typed_form_properties_completes_the_next_render()
+    {
+        Livewire::visit(new class extends Component {
+            public BrowserRequiredPostForm $form;
+
+            public string $state = 'initialized';
+
+            public function mount()
+            {
+                $this->form->title = 'Some Title';
+            }
+
+            public function resetForm()
+            {
+                $this->form->reset();
+
+                $property = new \ReflectionProperty($this->form, 'title');
+
+                $this->state = $property->isInitialized($this->form)
+                    ? 'initialized'
+                    : 'uninitialized';
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <button dusk="reset" wire:click="resetForm">Reset</button>
+
+                        <span dusk="state">{{ $state }}</span>
+                    </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@state', 'initialized')
+            ->click('@reset')
+            ->waitForTextIn('@state', 'uninitialized');
+    }
+}
+
+class BrowserRequiredPostForm extends Form
+{
+    public string $title;
+}

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -108,6 +108,17 @@ class Form implements Arrayable
         $freshInstance = new static($this->getComponent(), $this->getPropertyName());
 
         foreach ($properties as $property) {
+            $property = str($property);
+
+            if (! $property->contains('.') && property_exists($freshInstance, (string) $property)) {
+                $isInitialized = (new \ReflectionProperty($freshInstance, (string) $property))->isInitialized($freshInstance);
+
+                if (! $isInitialized) {
+                    data_forget($this, (string) $property);
+                    continue;
+                }
+            }
+
             data_set($this, $property, data_get($freshInstance, $property));
         }
     }

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -1148,6 +1148,72 @@ class UnitTest extends \Tests\TestCase
             ->assertSetStrict('form', fn ($form) => $form instanceof PostFormStubWithDefaults)
         ;
     }
+
+    public function test_reset_restores_required_typed_properties_to_their_uninitialized_state()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public PostFormStubWithRequiredTypedProperties $form;
+
+            public function mount()
+            {
+                $this->form->title = 'Some Title';
+                $this->form->content = 'Some content...';
+            }
+
+            public function resetForm()
+            {
+                $this->form->reset();
+            }
+        })
+            ->call('resetForm')
+            ->assertOk();
+
+        $form = $component->instance()->form;
+
+        $this->assertFalse((new \ReflectionProperty($form, 'title'))->isInitialized($form));
+        $this->assertFalse((new \ReflectionProperty($form, 'content'))->isInitialized($form));
+    }
+
+    public function test_resetting_one_required_typed_property_preserves_sibling_values()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public PostFormStubWithRequiredTypedProperties $form;
+
+            public function mount()
+            {
+                $this->form->title = 'Some Title';
+                $this->form->content = 'Some content...';
+            }
+
+            public function resetTitle()
+            {
+                $this->form->reset('title');
+            }
+        })
+            ->call('resetTitle')
+            ->assertSetStrict('form.content', 'Some content...')
+            ->assertOk();
+
+        $form = $component->instance()->form;
+
+        $this->assertFalse((new \ReflectionProperty($form, 'title'))->isInitialized($form));
+    }
+
+    public function test_resetting_a_nested_path_continues_to_use_its_declared_default()
+    {
+        Livewire::test(new class extends TestComponent {
+            public PostFormStubWithNestedDefaults $form;
+
+            public function resetName()
+            {
+                $this->form->reset('profile.name');
+            }
+        })
+            ->set('form.profile.name', 'Taylor')
+            ->call('resetName')
+            ->assertSetStrict('form.profile.name', '')
+            ->assertOk();
+    }
 }
 
 class PostFormStub extends Form
@@ -1172,6 +1238,20 @@ class PostFormStubWithArrayDefaults extends Form
         1 => true,
         2 => false,
         'foo' => ['bar' => 'baz'],
+    ];
+}
+
+class PostFormStubWithRequiredTypedProperties extends Form
+{
+    public string $title;
+
+    public string $content;
+}
+
+class PostFormStubWithNestedDefaults extends Form
+{
+    public array $profile = [
+        'name' => '',
     ];
 }
 


### PR DESCRIPTION
## What changed

- Restore direct form properties to their declared uninitialized state instead of assigning `null`
- Keep dotted reset paths on the existing `data_get` / `data_set` path
- Cover full resets, single-property resets, nested paths, and the next browser render
- Document the need for an explicit default when a property is read immediately after reset

## Why

A fresh form instance leaves required typed properties such as `public string $title;` uninitialized. `Form::reset()` currently reads that missing value as `null` and then attempts to assign it back to the non-nullable property, which throws a `TypeError`.

Resetting should restore the state declared by the form class. For a required typed property without a default, that state is uninitialized.

Reflection is limited to direct properties so calls such as `reset('profile.name')` retain their existing nested-path behavior.

## Tests

- [x] Full unit suite: 1,394 tests, 3,972 assertions
- [x] Form object suite: 53 tests, 296 assertions
- [x] Browser regression: reset action completes and the following render observes the property as uninitialized
- [x] Livewire JavaScript bundle builds successfully
