### PR TITLE
Add return types on public FrontendAssets methods

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -63,26 +63,17 @@ class FrontendAssets extends Mechanism
         $this->javaScriptRoute = $route;
     }
 
-    /**
-     * @return string
-     */
-    public static function livewireScripts($expression)
+    public static function livewireScripts($expression): string
     {
         return '{!! \Livewire\Mechanisms\FrontendAssets\FrontendAssets::scripts('.$expression.') !!}';
     }
 
-    /**
-     * @return string
-     */
-    public static function livewireScriptConfig($expression)
+    public static function livewireScriptConfig($expression): string
     {
         return '{!! \Livewire\Mechanisms\FrontendAssets\FrontendAssets::scriptConfig('.$expression.') !!}';
     }
 
-    /**
-     * @return string
-     */
-    public static function livewireStyles($expression)
+    public static function livewireStyles($expression): string
     {
         return '{!! \Livewire\Mechanisms\FrontendAssets\FrontendAssets::styles('.$expression.') !!}';
     }
@@ -114,10 +105,7 @@ class FrontendAssets extends Mechanism
         return Utils::pretendResponseIsFile(__DIR__.'/../../../dist/livewire.csp.min.js.map');
     }
 
-    /**
-     * @return string
-     */
-    public static function styles($options = [])
+    public static function styles($options = []): string
     {
         if (app(static::class)->hasRenderedStyles) return '';
 
@@ -170,10 +158,7 @@ class FrontendAssets extends Mechanism
         return static::minify($html);
     }
 
-    /**
-     * @return string
-     */
-    public static function scripts($options = [])
+    public static function scripts($options = []): string
     {
         if (app(static::class)->hasRenderedScripts) return '';
 
@@ -191,10 +176,7 @@ class FrontendAssets extends Mechanism
         return implode("\n", $html);
     }
 
-    /**
-     * @return string
-     */
-    public static function js($options)
+    public static function js($options): string
     {
         // Use the default endpoint...
         $url = url(app(static::class)->javaScriptRoute->uri);
@@ -245,10 +227,7 @@ class FrontendAssets extends Mechanism
         HTML;
     }
 
-    /**
-     * @return string
-     */
-    public static function scriptConfig($options = [])
+    public static function scriptConfig($options = []): string
     {
         app(static::class)->hasRenderedScripts = true;
 

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -63,16 +63,25 @@ class FrontendAssets extends Mechanism
         $this->javaScriptRoute = $route;
     }
 
+    /**
+     * @return string
+     */
     public static function livewireScripts($expression)
     {
         return '{!! \Livewire\Mechanisms\FrontendAssets\FrontendAssets::scripts('.$expression.') !!}';
     }
 
+    /**
+     * @return string
+     */
     public static function livewireScriptConfig($expression)
     {
         return '{!! \Livewire\Mechanisms\FrontendAssets\FrontendAssets::scriptConfig('.$expression.') !!}';
     }
 
+    /**
+     * @return string
+     */
     public static function livewireStyles($expression)
     {
         return '{!! \Livewire\Mechanisms\FrontendAssets\FrontendAssets::styles('.$expression.') !!}';
@@ -182,6 +191,9 @@ class FrontendAssets extends Mechanism
         return implode("\n", $html);
     }
 
+    /**
+     * @return string
+     */
     public static function js($options)
     {
         // Use the default endpoint...
@@ -233,6 +245,9 @@ class FrontendAssets extends Mechanism
         HTML;
     }
 
+    /**
+     * @return string
+     */
     public static function scriptConfig($options = [])
     {
         app(static::class)->hasRenderedScripts = true;


### PR DESCRIPTION
This allows `@livewireScriptConfig` and a few other things to pass type checking in applications that have that enabled.