### PR TITLE
[4.x] Don't include redirect responses in the returns effect

### DIFF
--- a/src/Features/SupportRedirects/UnitTest.php
+++ b/src/Features/SupportRedirects/UnitTest.php
@@ -288,6 +288,15 @@ class UnitTest extends \Tests\TestCase
         $this->assertEquals('livewire-is-awesome', Session::get('success'));
     }
 
+    public function test_redirect_response_is_not_included_in_returns()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectHelper');
+
+        $this->assertNull($component->effects['returns'][0]);
+    }
+
     protected function registerNamedRoute()
     {
         Route::get('foo', function () {

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -14,6 +14,7 @@ use Livewire\Features\SupportEvents\SupportEvents;
 use Livewire\Features\SupportFormObjects\Form;
 use Illuminate\Support\Facades\View;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class HandleComponents extends Mechanism
@@ -550,10 +551,10 @@ class HandleComponents extends Mechanism
             if ($earlyReturnCalled) {
                 $return = $finish($earlyReturn);
 
-                // File downloads are sent to the browser through the download effect, so we shouldn't add
-                // the response object as a return here. But we need to keep it's position in `returns`
-                // so we will just set it to `null` instead...
-                if ($return instanceof StreamedResponse || $return instanceof BinaryFileResponse) {
+                // File downloads and redirects are sent to the browser through their own effects, so we
+                // shouldn't add the response object as a return here. But we need to keep it's position
+                // in `returns` so we will just set it to `null` instead...
+                if ($return instanceof StreamedResponse || $return instanceof BinaryFileResponse || $return instanceof RedirectResponse) {
                     $return = null;
                 }
 
@@ -580,10 +581,10 @@ class HandleComponents extends Mechanism
 
             $return = $finish($return);
 
-            // File downloads are sent to the browser through the download effect, so we shouldn't add
-            // the response object as a return here. But we need to keep it's position in `returns`
-            // so we will just set it to `null` instead...
-            if ($return instanceof StreamedResponse || $return instanceof BinaryFileResponse) {
+            // File downloads and redirects are sent to the browser through their own effects, so we
+            // shouldn't add the response object as a return here. But we need to keep it's position
+            // in `returns` so we will just set it to `null` instead...
+            if ($return instanceof StreamedResponse || $return instanceof BinaryFileResponse || $return instanceof RedirectResponse) {
                 $return = null;
             }
 


### PR DESCRIPTION
Since #10555, `Redirector::to()` returns a real `RedirectResponse` instead of `$this`. An action that returns `redirect()->route(...)` now drops that response object into `effects.returns`, where it gets JSON encoded along with the rest of the payload. Depending on what the response is carrying, encoding can fail with `InvalidArgumentException: Type is not supported`, and the update request 500s even though the action itself ran fine.

The redirect already reaches the browser through the `redirect` effect, so the response object has no reason to sit in `returns`. It's now nulled out there, the same way `StreamedResponse` and `BinaryFileResponse` already are.

Fixes #10595