### PR TITLE
[4.x] Fix `SupportPageComponents` render listener cleanup on skip-render or exceptions

### DIFF
--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Features\SupportPageComponents;
 
-use function Livewire\{on, off, once};
+use function Livewire\{on, once};
 use Livewire\Drawer\ImplicitRouteBinding;
 use Livewire\ComponentHook;
 use Livewire\Mechanisms\HandleRouting\LivewirePageController;
@@ -112,13 +112,15 @@ class SupportPageComponents extends ComponentHook
             };
         });
 
-        on('render', $handler);
-        on('render.placeholder', $handler);
+        $render = on('render', $handler);
+        $renderPlaceholder = on('render.placeholder', $handler);
 
-        $callback();
-
-        off('render', $handler);
-        off('render.placeholder', $handler);
+        try {
+            $callback();
+        } finally {
+            $render();
+            $renderPlaceholder();
+        }
 
         return $layoutConfig;
     }

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -9,7 +9,10 @@ use Illuminate\Http\Response;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Blade;
 use Livewire\Component;
+use Livewire\EventBus;
 use Livewire\Livewire;
+
+use function Livewire\invade;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -477,6 +480,32 @@ class UnitTest extends \Tests\TestCase
             ->get('/teams/99/projects/42')
             ->assertSee('project:42')
             ->assertSee('team:none');
+    }
+
+    public function test_render_interceptor_removes_listeners_when_callback_throws()
+    {
+        $eventBus = invade(app(EventBus::class));
+
+        $renderListenersBefore = $eventBus->listeners['render'] ?? [];
+        $placeholderListenersBefore = $eventBus->listeners['render.placeholder'] ?? [];
+
+        try {
+            SupportPageComponents::interceptTheRenderOfTheComponentAndRetreiveTheLayoutConfiguration(function () {
+                throw new \RuntimeException;
+            });
+        } catch (\RuntimeException) {
+            //
+        }
+
+        $this->assertSame(
+            $renderListenersBefore,
+            $eventBus->listeners['render'] ?? [],
+        );
+
+        $this->assertSame(
+            $placeholderListenersBefore,
+            $eventBus->listeners['render.placeholder'] ?? [],
+        );
     }
 }
 

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -507,6 +507,22 @@ class UnitTest extends \Tests\TestCase
             $eventBus->listeners['render.placeholder'] ?? [],
         );
     }
+
+    public function test_page_component_falls_back_to_default_layout_when_no_layout_is_captured()
+    {
+        config()->set('livewire.component_layout', 'layouts::panel');
+
+        $layoutConfig = SupportPageComponents::interceptTheRenderOfTheComponentAndRetreiveTheLayoutConfiguration(function () {
+            // Intentionally do nothing – no render / render.placeholder is fired
+        });
+
+        $this->assertNull($layoutConfig);
+
+        // Exact fallback used by HandlesPageComponents::__invoke
+        $fallback = $layoutConfig ?: new PageComponentConfig;
+
+        $this->assertSame('layouts::panel', $fallback->view);
+    }
 }
 
 class ComponentForRouteWithoutMountParametersTest extends Component


### PR DESCRIPTION
> [!NOTE]
> I discovered this while reading Livewire codebase but I think this is somehow related with this issue  https://github.com/livewire/livewire/issues/10597

## Problem

When `SupportPageComponents::interceptTheRenderOfTheComponentAndRetreiveTheLayoutConfiguration()` registers its temporary `render` listeners, they are only removed after the callback completes successfully.

```php
on('render', $handler);
on('render.placeholder', $handler);

$callback();

off('render', $handler);
off('render.placeholder', $handler);
```

If the `$callback()` throws an exception (or the render path is skipped entirely via `shouldSkipRender` / short-circuit mount), the cleanup code is skipped and the listeners remain registered on the event bus. On a later request that **does** reach the page-component path, the already-spent `once()` handler is a no-op → `$layoutConfig` stays `null` then it will fallback to Livewire default layout.

```php
$layoutConfig = intercept(...) ?: new PageComponentConfig;
```

`PageComponentConfig` defaults to `config('livewire.component_layout') = 'layouts::app'`.

## Solution

This change wraps the callback in a try/finally block so the temporary listeners are always removed, while keeping the existing render interception flow unchanged.

A regression test is added to verify that both `render` and `render.placeholder` listeners are cleaned up when the callback throws an exception.