### PR TITLE
Add continuous visibility timing to wire:intersect

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -733,18 +733,25 @@ Run actions when elements enter or leave the viewport, similar to Alpine's [`x-i
 <div wire:intersect:leave="pauseVideo">...</div>
 <div wire:intersect.half="loadMore">...</div>
 <div wire:intersect.full="startAnimation">...</div>
+<div wire:intersect.half.dwell.500ms="trackImpression">...</div>
 
 <!-- With options -->
 <div wire:intersect.margin.200px="loadMore">...</div>
 <div wire:intersect.threshold.50="trackScroll">...</div>
+<div wire:intersect.parent="loadWithinScroller">...</div>
 ```
 
 Available modifiers:
 - `.once` - Fire only once
+- `.dwell.Xms` - Require continuous intersection for a duration (250ms by default)
 - `.half` - Wait until half is visible
 - `.full` - Wait until fully visible
 - `.threshold.X` - Custom visibility percentage (0-100)
 - `.margin.Xpx` or `.margin.X%` - Intersection margin
+- `.parent` - Observe relative to the element's parent
+- `.renderless` - Skip rendering after the action
+- `.async` - Run the action in parallel
+- `.preserve-scroll` - Preserve the page scroll position
 
 [Learn more about wire:intersect →](/docs/4.x/wire-intersect)
 

--- a/docs/wire-intersect.md
+++ b/docs/wire-intersect.md
@@ -72,6 +72,35 @@ Use the `.once` modifier to ensure the action only fires on the first intersecti
 
 This is particularly useful for analytics or tracking when you only want to record the first time a user sees something.
 
+## Require continuous visibility
+
+Use `.dwell` when an element must remain visible before the action runs. The default dwell time is 250 milliseconds:
+
+```blade
+<div wire:intersect.dwell="trackView">...</div>
+```
+
+Add a duration modifier to choose a different interval:
+
+```blade
+<!-- Run after 500 milliseconds of continuous visibility -->
+<div wire:intersect.dwell.500ms="trackView">...</div>
+```
+
+The dwell timer resets if the element stops meeting its visibility threshold or the page moves to the background. It starts again when the element becomes eligible in a visible page.
+
+For `wire:intersect:leave`, the dwell interval instead begins after visibility falls below the configured threshold:
+
+```blade
+<div wire:intersect:leave.half.dwell.500ms="pauseVideo">...</div>
+```
+
+Combine `.dwell` with a visibility threshold and `.once` to record a qualified impression:
+
+```blade
+<div wire:intersect.once.half.dwell.1000ms="trackImpression">...</div>
+```
+
 ## Combining modifiers
 
 You can combine multiple modifiers to create precise behaviors:
@@ -178,7 +207,12 @@ wire:intersect:leave="action"
 | Modifier | Description |
 |----------|-------------|
 | `.once` | Only fire the action on the first intersection |
+| `.dwell.[duration]` | Require continuous visibility before firing (defaults to `250ms`) |
 | `.half` | Trigger when half of the element is visible |
 | `.full` | Trigger when the entire element is visible |
 | `.threshold.[0-100]` | Trigger at a custom visibility threshold percentage |
 | `.margin.[value]` | Add margin around the viewport (e.g., `.margin.200px`, `.margin.10%`) |
+| `.parent` | Observe visibility within the element's parent instead of the browser viewport |
+| `.renderless` | Run the action without rendering the component |
+| `.async` | Run the action in a parallel request |
+| `.preserve-scroll` | Preserve the page's scroll position through the action |

--- a/src/Features/SupportWireIntersect/BrowserTest.php
+++ b/src/Features/SupportWireIntersect/BrowserTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Livewire\Features\SupportWireIntersect;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    public function test_dwell_modifier_is_forwarded_to_alpine()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            public function track()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <p dusk="count">Count: {{ $count }}</p>
+
+                    <div dusk="viewport" style="height: 200px; overflow-y: auto;">
+                        <div style="height: 200px;"></div>
+                        <div wire:intersect.once.parent.dwell.1000ms="track" style="height: 200px;">Target</div>
+                    </div>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@count', 'Count: 0')
+        ->tap(fn ($browser) => $browser->script("document.querySelector('[dusk=viewport]').scrollTop = 200"))
+        ->pause(200)
+        ->assertSeeIn('@count', 'Count: 0')
+        ->waitForText('Count: 1');
+    }
+
+    public function test_dwell_initializes_on_elements_added_during_a_morph()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            public $targetVisible = false;
+
+            public function revealTarget()
+            {
+                $this->targetVisible = true;
+            }
+
+            public function track()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="revealTarget" dusk="show">Show target</button>
+                    <p dusk="count">Count: {{ $count }}</p>
+
+                    @if ($targetVisible)
+                        <div dusk="viewport" style="height: 200px; overflow-y: auto;">
+                            <div style="height: 200px;"></div>
+                            <div wire:intersect.once.half.parent.dwell.300ms="track" style="height: 200px;">Target</div>
+                        </div>
+                    @endif
+                </div>
+                HTML;
+            }
+        })
+        ->assertNotPresent('@viewport')
+        ->waitForLivewire()->click('@show')
+        ->assertPresent('@viewport')
+        ->tap(fn ($browser) => $browser->script("document.querySelector('[dusk=viewport]').scrollTop = 110"))
+        ->waitForText('Count: 1');
+    }
+
+    public function test_dwell_supports_renderless_actions()
+    {
+        Livewire::visit(new class extends Component {
+            public $renders = 0;
+
+            public function track()
+            {
+                $this->js('window.livewireIntersectTracked = true');
+            }
+
+            public function render()
+            {
+                $this->renders++;
+
+                return <<<'HTML'
+                <div x-init="window.livewireIntersectTracked = false">
+                    <p dusk="renders">Renders: {{ $renders }}</p>
+
+                    <div dusk="viewport" style="height: 200px; overflow-y: auto;">
+                        <div style="height: 200px;"></div>
+                        <div wire:intersect.once.half.parent.dwell.300ms.renderless="track" style="height: 200px;">Target</div>
+                    </div>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@renders', 'Renders: 1')
+        ->tap(fn ($browser) => $browser->script("document.querySelector('[dusk=viewport]').scrollTop = 110"))
+        ->waitUntil('window.livewireIntersectTracked === true')
+        ->assertSeeIn('@renders', 'Renders: 1');
+    }
+}


### PR DESCRIPTION
## Why

`wire:intersect` can currently tell when an element crosses a visibility threshold, but not whether it remains there. A fast scroll, layout shift, or backgrounded tab can therefore trigger work that was intended only for genuinely viewed content.

This adds a continuous-visibility contract that reads naturally in Blade:

```blade
<div wire:intersect.once.half.dwell.500ms="trackImpression">
    ...
</div>
```

The action runs only after the element stays at least half visible for 500 milliseconds. Dropping below the threshold or moving the page to the background resets the dwell interval.

Leave actions use the same vocabulary:

```blade
<video wire:intersect:leave.half.dwell.750ms="pausePreview">...</video>
```

This makes qualified impressions, deferred media work, reading-progress signals, and similar visibility-sensitive actions declarative without application-owned observers and timers.

## What changed

- Documents `.dwell` with its 250 ms default, explicit durations, thresholds, leave behavior, page-visibility reset, and `.once` composition.
- Adds a narrow browser contract proving the complete modifier suffix reaches Alpine, plus Livewire-owned morph initialization and renderless action integration.
- Keeps the Livewire bridge itself unchanged: `wire:intersect` already forwards every modifier to Alpine `x-intersect`, so duplicating the dwell state machine in Livewire would create two implementations.

## Dependency

This draft depends on [alpinejs/alpine#4884](https://github.com/alpinejs/alpine/pull/4884), which implements the continuous dwell primitive in `@alpinejs/intersect`.

Livewire 4.x currently installs `@alpinejs/intersect` 3.16.3, which does not include `.dwell`. Livewire CI also links Alpine `main`, so this browser contract becomes available after the Alpine PR merges and the normal published Alpine dependency bump is applied. This PR should not merge before that sequence; it deliberately contains no fork reference, unpublished dependency, or duplicate JavaScript implementation.

## Validation

- Focused browser contract: 3 tests, 6 assertions (using the locally linked Alpine feature branch)
- JavaScript suite: 110 passed, 1 skipped
- PHP unit suite: 1,391 tests, 3,964 assertions, 13 skipped, 3 incomplete
- Production asset build passed
- Diff checks passed
