### PR TITLE
[4.x] Add `wire:dirty.persist` for dirty state that survives round-trips

### DIFF
--- a/docs/wire-dirty.md
+++ b/docs/wire-dirty.md
@@ -39,55 +39,6 @@ By adding the `.remove` modifier to `wire:dirty`, you can instead show an elemen
 <div wire:dirty.remove>The data is in-sync...</div>
 ```
 
-## Persisting dirty state across requests
-
-By default, "dirty" means "the client has changes the server hasn't seen yet". Any request resets it — including requests that save nothing, like `wire:poll`, a lazy load, or an unrelated action elsewhere in the component.
-
-That is the wrong measure for an "unsaved changes" warning, where you want to know whether anything has changed since the last *save*. The `.persist` modifier measures against the last saved state instead, and only an explicit rebaseline clears it:
-
-```blade
-<form wire:submit="save">
-    <input type="text" wire:model="title">
-
-    <button type="submit">Save</button>
-
-    <div wire:dirty.persist>Unsaved changes...</div> <!-- [tl! highlight] -->
-</form>
-```
-
-Tell Livewire when the state was saved by calling `rebaseline()` from the action that saved it:
-
-```php
-public function save()
-{
-    Post::create($this->only('title'));
-
-    $this->rebaseline(); // [tl! highlight]
-}
-```
-
-Until `save()` runs, the indicator stays visible — a poll ticking in the background no longer makes the form look saved.
-
-`.persist` composes with the other modifiers and with `wire:target`:
-
-```blade
-<div wire:dirty.persist wire:target="title">Unsaved title...</div>
-
-<div wire:dirty.persist.remove>All changes saved</div>
-
-<input wire:model="title" wire:dirty.persist.class="border-yellow-500">
-```
-
-### From Alpine
-
-`$dirty` takes the same option, and `$rebaseline()` clears it from the client:
-
-```blade
-<div x-show="$wire.$dirty('title', { persist: true })">Unsaved title...</div>
-
-<button x-on:click="$wire.$rebaseline()">Mark as saved</button>
-```
-
 ## Targeting property updates
 
 Imagine you are using `wire:model.live.blur` to update a property on the server immediately after a user leaves an input field. In this scenario, you can provide a "dirty" indication for only that property by adding `wire:target` to the element that contains the `wire:dirty` directive.
@@ -159,6 +110,59 @@ Or apply conditional classes with Alpine:
 >
 ```
 
+## Persisting dirty state across requests
+
+By default, "dirty" means "the client has changes the server hasn't seen yet". Any request resets it — including requests that save nothing, like `wire:poll`, a lazy load, or an unrelated action elsewhere in the component.
+
+An "unsaved changes" warning needs the other measure: whether anything has changed since the last *save*. The `.persist` modifier compares against the last saved state, and the action that saved it declares so with `rebaseline()`:
+
+```php
+<?php // resources/views/components/post/⚡create.blade.php
+
+use Livewire\Component;
+use App\Models\Post;
+
+new class extends Component {
+    public $title = '';
+
+    public function save()
+    {
+        Post::create($this->only(['title']));
+
+        $this->rebaseline(); // [tl! highlight]
+    }
+};
+?>
+
+<form wire:submit="save">
+    <input type="text" wire:model="title">
+
+    <button type="submit">Save</button>
+
+    <div wire:dirty.persist>Unsaved changes...</div> <!-- [tl! highlight] -->
+</form>
+```
+
+Until `save()` runs, the indicator stays visible — a poll ticking in the background no longer makes the form look saved.
+
+`.persist` composes with `wire:target` and the other modifiers:
+
+```blade
+<div wire:dirty.persist wire:target="title">Unsaved title...</div>
+
+<div wire:dirty.persist.remove>All changes saved</div>
+
+<input wire:model="title" wire:dirty.persist.class="border-yellow-500">
+```
+
+The `$dirty` expression takes the same option, and `$rebaseline()` clears it from the client:
+
+```blade
+<div x-show="$wire.$dirty('title', { persist: true })">Unsaved title...</div>
+
+<button x-on:click="$wire.$rebaseline()">Mark as saved</button>
+```
+
 ## Reference
 
 ```blade
@@ -182,6 +186,14 @@ wire:target="property"
 | `$dirty('property')` | Returns `true` if the specified property has unsaved changes |
 | `$dirty(['title', 'description'])` | Returns `true` if any of the specified properties have unsaved changes |
 | `$dirty('title', { persist: true })` | As above, but measured against the last saved state |
-| `$rebaseline()` | Treats the current server state as saved, clearing `.persist` dirty state |
 
 Can be used in Livewire directives like `wire:show="$dirty"` or in Alpine as `$wire.$dirty()`.
+
+### Rebaselining
+
+| Call | Description |
+|------|-------------|
+| `$this->rebaseline()` | Treats the state being returned by this request as saved |
+| `$wire.$rebaseline()` | The client-side equivalent, available in Alpine |
+
+Clears the dirty state reported by `.persist` and by `$dirty(..., { persist: true })`.

--- a/docs/wire-dirty.md
+++ b/docs/wire-dirty.md
@@ -39,6 +39,55 @@ By adding the `.remove` modifier to `wire:dirty`, you can instead show an elemen
 <div wire:dirty.remove>The data is in-sync...</div>
 ```
 
+## Persisting dirty state across requests
+
+By default, "dirty" means "the client has changes the server hasn't seen yet". Any request resets it — including requests that save nothing, like `wire:poll`, a lazy load, or an unrelated action elsewhere in the component.
+
+That is the wrong measure for an "unsaved changes" warning, where you want to know whether anything has changed since the last *save*. The `.persist` modifier measures against the last saved state instead, and only an explicit rebaseline clears it:
+
+```blade
+<form wire:submit="save">
+    <input type="text" wire:model="title">
+
+    <button type="submit">Save</button>
+
+    <div wire:dirty.persist>Unsaved changes...</div> <!-- [tl! highlight] -->
+</form>
+```
+
+Tell Livewire when the state was saved by calling `rebaseline()` from the action that saved it:
+
+```php
+public function save()
+{
+    Post::create($this->only('title'));
+
+    $this->rebaseline(); // [tl! highlight]
+}
+```
+
+Until `save()` runs, the indicator stays visible — a poll ticking in the background no longer makes the form look saved.
+
+`.persist` composes with the other modifiers and with `wire:target`:
+
+```blade
+<div wire:dirty.persist wire:target="title">Unsaved title...</div>
+
+<div wire:dirty.persist.remove>All changes saved</div>
+
+<input wire:model="title" wire:dirty.persist.class="border-yellow-500">
+```
+
+### From Alpine
+
+`$dirty` takes the same option, and `$rebaseline()` clears it from the client:
+
+```blade
+<div x-show="$wire.$dirty('title', { persist: true })">Unsaved title...</div>
+
+<button x-on:click="$wire.$rebaseline()">Mark as saved</button>
+```
+
 ## Targeting property updates
 
 Imagine you are using `wire:model.live.blur` to update a property on the server immediately after a user leaves an input field. In this scenario, you can provide a "dirty" indication for only that property by adding `wire:target` to the element that contains the `wire:dirty` directive.
@@ -123,6 +172,7 @@ wire:target="property"
 |----------|-------------|
 | `.remove` | Show element by default, hide when dirty |
 | `.class="class-name"` | Add a CSS class when dirty |
+| `.persist` | Measure against the last saved state instead of the last server response |
 
 ### `$dirty` expression
 
@@ -131,5 +181,7 @@ wire:target="property"
 | `$dirty` | Returns `true` if any property has unsaved changes |
 | `$dirty('property')` | Returns `true` if the specified property has unsaved changes |
 | `$dirty(['title', 'description'])` | Returns `true` if any of the specified properties have unsaved changes |
+| `$dirty('title', { persist: true })` | As above, but measured against the last saved state |
+| `$rebaseline()` | Treats the current server state as saved, clearing `.persist` dirty state |
 
 Can be used in Livewire directives like `wire:show="$dirty"` or in Alpine as `$wire.$dirty()`.

--- a/js/$wire.js
+++ b/js/$wire.js
@@ -36,6 +36,7 @@ let aliases = {
     'hook': '$hook',
     'watch': '$watch',
     'dirty': '$dirty',
+    'rebaseline': '$rebaseline',
     'effect': '$effect',
     'commit': '$commit',
     'errors': '$errors',
@@ -221,22 +222,28 @@ wireProperty('$refs', (component) => {
     })
 })
 
-wireProperty('$dirty', (component) => (property) => {
+wireProperty('$dirty', (component) => (property, options = {}) => {
+    let persist = options.persist ?? false
+
     let reactive = Alpine.reactive({ dirty: false })
+
+    let refresh = () => {
+        reactive.dirty = checkDirty(component, property, persist)
+    }
 
     interceptComponentMessage(component, ({ onFinish }) => {
         onFinish(() => {
-            queueMicrotask(() => {
-                reactive.dirty = checkDirty(component, property)
-            })
+            queueMicrotask(refresh)
         })
     })
 
-    Alpine.effect(() => {
-        reactive.dirty = checkDirty(component, property)
-    })
+    Alpine.effect(refresh)
 
     return reactive.dirty
+})
+
+wireProperty('$rebaseline', (component) => () => {
+    component.rebaseline()
 })
 
 wireProperty('$intercept', (component) => (actionNameOrCallback, maybeCallback) => {

--- a/js/component.js
+++ b/js/component.js
@@ -33,6 +33,13 @@ export class Component {
 
         // "canonical" data represents the last known server state.
         this.canonical = extractData(deepClone(this.snapshot.data))
+        // "baseline" represents the last state the component considers "saved". Unlike
+        // "canonical", it survives round-trips: it is only replaced by an explicit
+        // rebaseline. This is what `wire:dirty.persist` compares against.
+        this.baseline = extractData(deepClone(this.snapshot.data))
+        // The baseline itself is a plain object, so anything deriving from it tracks this
+        // counter to stay reactive across a rebaseline...
+        this.baselineVersion = Alpine.reactive({ value: 0 })
         // "ephemeral" represents the most current state. (This can be freely manipulated by end users)
         this.ephemeral = extractData(deepClone(this.snapshot.data))
         // "reactive" is just ephemeral, except when you mutate it, front-ends like Vue react.
@@ -97,6 +104,17 @@ export class Component {
         diffAndPatchRecursive(updatedOldCanonical, newData, this.reactive)
 
         return dirty
+    }
+
+    /**
+     * Treat the last known server state as the new "saved" state, so that
+     * `wire:dirty.persist` reports clean again. Called by the `rebaseline`
+     * effect and by `$wire.$rebaseline()`.
+     */
+    rebaseline() {
+        this.baseline = deepClone(this.canonical)
+
+        this.baselineVersion.value++
     }
 
     queueUpdate(propertyName, value) {

--- a/js/directives/wire-dirty.js
+++ b/js/directives/wire-dirty.js
@@ -8,13 +8,18 @@ let refreshDirtyStatesByComponent = new WeakBag
 on('commit', ({ component, succeed }) => {
     succeed(() => {
         setTimeout(() => { // Doing a "setTimeout" to let morphdom do its thing first...
-            refreshDirtyStatesByComponent.each(component, i => i(false))
+            refreshDirtyStatesByComponent.each(component, recompute => recompute(true))
         })
     })
 })
 
 directive('dirty', ({ el, directive, component }) => {
     let targets = dirtyTargets(el)
+
+    // `wire:dirty.persist` measures against the last *saved* state rather than the last
+    // server response, so a round-trip that doesn't save (a poll, a lazy load, a live
+    // model update, any unrelated action) no longer reports the component as clean...
+    let persist = directive.modifiers.includes('persist')
 
     let oldIsDirty = false
 
@@ -26,36 +31,49 @@ directive('dirty', ({ el, directive, component }) => {
         oldIsDirty = isDirty
     }
 
-    refreshDirtyStatesByComponent.add(component, refreshDirtyState)
+    // Re-derive the state rather than assuming "clean" after a round-trip. For a plain
+    // `wire:dirty` this is the same answer the old hard-coded `false` gave (canonical and
+    // reactive match once the snapshot is merged), but a `.persist` directive measures
+    // against the baseline and must stay dirty until it is explicitly rebaselined.
+    // `force` re-applies even when the value is unchanged, because the morph has just
+    // replaced the element's inline style with the server's markup...
+    let recompute = (force = false) => {
+        let isDirty = checkDirty(component, targets.length === 0 ? undefined : targets, persist)
 
-    Alpine.effect(() => {
-        let isDirty = false
-
-        isDirty = checkDirty(component, targets.length === 0 ? undefined : targets)
-
-        if (oldIsDirty !== isDirty) {
+        if (force || oldIsDirty !== isDirty) {
             refreshDirtyState(isDirty)
         }
 
         oldIsDirty = isDirty
-    })
+    }
+
+    refreshDirtyStatesByComponent.add(component, recompute)
+
+    Alpine.effect(() => recompute())
 })
 
-export function checkDirty(component, targets) {
+export function checkDirty(component, targets, persist = false) {
     let isDirty = false
 
+    // "canonical" is the last server response and is replaced on every round-trip.
+    // "baseline" is the last state the component considers saved. Touching the version
+    // keeps the surrounding Alpine effect subscribed to rebaselines...
+    if (persist) component.baselineVersion.value
+
+    let reference = persist ? component.baseline : component.canonical
+
     if (targets === undefined) {
-        isDirty = JSON.stringify(component.canonical) !== JSON.stringify(component.reactive)
+        isDirty = JSON.stringify(reference) !== JSON.stringify(component.reactive)
     } else if (Array.isArray(targets)) {
         for (let i = 0; i < targets.length; i++) {
             if (isDirty) break;
 
             let target = targets[i]
 
-            isDirty = JSON.stringify(dataGet(component.canonical, target)) !== JSON.stringify(dataGet(component.reactive, target))
+            isDirty = JSON.stringify(dataGet(reference, target)) !== JSON.stringify(dataGet(component.reactive, target))
         }
     } else {
-        isDirty = JSON.stringify(dataGet(component.canonical, targets)) !== JSON.stringify(dataGet(component.reactive, targets))
+        isDirty = JSON.stringify(dataGet(reference, targets)) !== JSON.stringify(dataGet(component.reactive, targets))
     }
 
     return isDirty

--- a/js/features/index.js
+++ b/js/features/index.js
@@ -24,6 +24,7 @@ import './supportSlots';
 import './supportDataLoading';
 import './supportDataCurrent';
 import './supportPreserveScroll';
+import './supportDirty';
 import './supportWireIntersect';
 import './supportWireSort';
 import './supportJsModules'

--- a/js/features/supportDirty.js
+++ b/js/features/supportDirty.js
@@ -1,0 +1,10 @@
+import { on } from '@/hooks'
+
+// The server can declare (via `$this->rebaseline()`) that the state it just returned
+// is the component's new "saved" state. Snapshots are merged before effects are
+// processed, so `component.canonical` already holds that state here...
+on('effect', ({ component, effects }) => {
+    if (! effects['rebaseline']) return
+
+    component.rebaseline()
+})

--- a/src/Component.php
+++ b/src/Component.php
@@ -13,6 +13,7 @@ use Livewire\Features\SupportJsEvaluation\HandlesJsEvaluation;
 use Livewire\Features\SupportIslands\HandlesIslands;
 use Livewire\Features\SupportFormObjects\HandlesFormObjects;
 use Livewire\Features\SupportEvents\HandlesEvents;
+use Livewire\Features\SupportDirty\HandlesDirty;
 use Livewire\Features\SupportHtmlAttributeForwarding\HandlesHtmlAttributeForwarding;
 use Livewire\Features\SupportDisablingBackButtonCache\HandlesDisablingBackButtonCache;
 use Livewire\Features\SupportAttributes\HandlesAttributes;
@@ -30,6 +31,7 @@ abstract class Component
     use AuthorizesRequests;
     use InteractsWithProperties;
     use HandlesEvents;
+    use HandlesDirty;
     use HandlesIslands;
     use HandlesRedirects;
     use HandlesTransitions;

--- a/src/Features/SupportDirty/BrowserTest.php
+++ b/src/Features/SupportDirty/BrowserTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Livewire\Features\SupportDirty;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    function test_wire_dirty_is_reset_by_an_unrelated_roundtrip()
+    {
+        Livewire::visit(new class extends Component {
+            public $title = '';
+            public $count = 0;
+
+            public function increment() { $this->count++; }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <input dusk="input" type="text" wire:model="title" />
+                        <button type="button" dusk="unrelated" wire:click="increment">{{ $count }}</button>
+
+                        <div dusk="dirty" wire:dirty wire:target="title">Unsaved changes</div>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertNotVisible('@dirty')
+            ->type('@input', 'Hello')
+            ->pause(50)
+            ->assertVisible('@dirty')
+            // An action that saves nothing still makes the component look clean...
+            ->waitForLivewire()->click('@unrelated')
+            ->pause(50)
+            ->assertNotVisible('@dirty')
+        ;
+    }
+
+    function test_wire_dirty_persist_survives_an_unrelated_roundtrip()
+    {
+        Livewire::visit(new class extends Component {
+            public $title = '';
+            public $count = 0;
+
+            public function increment() { $this->count++; }
+
+            public function save() { $this->rebaseline(); }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <input dusk="input" type="text" wire:model="title" />
+                        <button type="button" dusk="unrelated" wire:click="increment">{{ $count }}</button>
+                        <button type="button" dusk="save" wire:click="save">Save</button>
+
+                        <div dusk="dirty" wire:dirty.persist wire:target="title">Unsaved changes</div>
+                        <div dusk="clean" wire:dirty.persist.remove wire:target="title">All saved</div>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertNotVisible('@dirty')
+            ->assertVisible('@clean')
+            ->type('@input', 'Hello')
+            ->pause(50)
+            ->assertVisible('@dirty')
+            // Unlike plain wire:dirty, an unrelated round-trip leaves it dirty...
+            ->waitForLivewire()->click('@unrelated')
+            ->pause(50)
+            ->assertVisible('@dirty')
+            ->assertNotVisible('@clean')
+            // ...only an explicit rebaseline clears it...
+            ->waitForLivewire()->click('@save')
+            ->pause(50)
+            ->assertNotVisible('@dirty')
+            ->assertVisible('@clean')
+        ;
+    }
+
+    function test_dollar_dirty_accepts_a_persist_option_and_dollar_rebaseline_clears_it()
+    {
+        Livewire::visit(new class extends Component {
+            public $title = '';
+            public $count = 0;
+
+            public function increment() { $this->count++; }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <input dusk="input" type="text" wire:model="title" />
+                        <button type="button" dusk="unrelated" wire:click="increment">{{ $count }}</button>
+                        <button type="button" dusk="rebaseline" x-on:click="$wire.$rebaseline()">Rebaseline</button>
+
+                        <div dusk="dirty" x-show="$wire.$dirty('title', { persist: true })">Unsaved changes</div>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertNotVisible('@dirty')
+            ->type('@input', 'Hello')
+            ->pause(50)
+            ->assertVisible('@dirty')
+            ->waitForLivewire()->click('@unrelated')
+            ->pause(50)
+            ->assertVisible('@dirty')
+            ->click('@rebaseline')
+            ->pause(50)
+            ->assertNotVisible('@dirty')
+        ;
+    }
+
+    function test_persist_composes_with_the_class_modifier()
+    {
+        Livewire::visit(new class extends Component {
+            public $title = '';
+            public $count = 0;
+
+            public function increment() { $this->count++; }
+
+            public function save() { $this->rebaseline(); }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <input dusk="input" type="text" wire:model="title" wire:dirty.persist.class="unsaved" />
+                        <button type="button" dusk="unrelated" wire:click="increment">{{ $count }}</button>
+                        <button type="button" dusk="save" wire:click="save">Save</button>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertClassMissing('@input', 'unsaved')
+            ->type('@input', 'Hello')
+            ->pause(50)
+            ->assertHasClass('@input', 'unsaved')
+            ->waitForLivewire()->click('@unrelated')
+            ->pause(50)
+            ->assertHasClass('@input', 'unsaved')
+            ->waitForLivewire()->click('@save')
+            ->pause(50)
+            ->assertClassMissing('@input', 'unsaved')
+        ;
+    }
+}

--- a/src/Features/SupportDirty/BrowserTest.php
+++ b/src/Features/SupportDirty/BrowserTest.php
@@ -2,9 +2,9 @@
 
 namespace Livewire\Features\SupportDirty;
 
-use Livewire\Component;
-use Livewire\Livewire;
 use Tests\BrowserTestCase;
+use Livewire\Livewire;
+use Livewire\Component;
 
 class BrowserTest extends BrowserTestCase
 {

--- a/src/Features/SupportDirty/HandlesDirty.php
+++ b/src/Features/SupportDirty/HandlesDirty.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Livewire\Features\SupportDirty;
+
+use function Livewire\store;
+
+trait HandlesDirty
+{
+    /**
+     * Treat the state at the end of this request as the component's new "saved"
+     * state, so that `wire:dirty.persist` reports clean again. Typically called
+     * at the end of a save action.
+     */
+    public function rebaseline()
+    {
+        store($this)->set('rebaseline', true);
+    }
+}

--- a/src/Features/SupportDirty/SupportDirty.php
+++ b/src/Features/SupportDirty/SupportDirty.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Livewire\Features\SupportDirty;
+
+use Livewire\ComponentHook;
+
+class SupportDirty extends ComponentHook
+{
+    public function dehydrate($context)
+    {
+        if (! $this->storeGet('rebaseline')) {
+            return;
+        }
+
+        $context->addEffect('rebaseline', true);
+    }
+}

--- a/src/Features/SupportDirty/UnitTest.php
+++ b/src/Features/SupportDirty/UnitTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Livewire\Features\SupportDirty;
+
+use Tests\TestComponent;
+use Livewire\Livewire;
+
+class UnitTest extends \Tests\TestCase
+{
+    function test_rebaseline_adds_an_effect_for_the_request_that_called_it()
+    {
+        $component = Livewire::test(new class extends TestComponent
+        {
+            public $title = '';
+
+            public function save()
+            {
+                $this->rebaseline();
+            }
+
+            public function touch() {}
+        });
+
+        $this->assertArrayNotHasKey('rebaseline', $component->effects);
+
+        $component->call('save');
+
+        $this->assertTrue($component->effects['rebaseline']);
+
+        $component->call('touch');
+
+        $this->assertArrayNotHasKey('rebaseline', $component->effects);
+    }
+}

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -181,6 +181,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
             Features\SupportJsEvaluation\SupportJsEvaluation::class,
             Features\SupportMagicActions\SupportMagicActions::class,
             Features\SupportQueryString\SupportQueryString::class,
+            Features\SupportDirty\SupportDirty::class,
             Features\SupportFileUploads\SupportFileUploads::class,
             Features\SupportTeleporting\SupportTeleporting::class,
             Features\SupportLazyLoading\SupportLazyLoading::class,

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -136,7 +136,7 @@ class FrontendAssets extends Mechanism
                 display: none;
             }
 
-            [wire\:dirty]:not(textarea):not(input):not(select) {
+            [wire\:dirty]:not(textarea):not(input):not(select), [wire\:dirty\.persist]:not(textarea):not(input):not(select) {
                 display: none;
             }
 


### PR DESCRIPTION
## The problem

`$dirty` compares the reactive state against `component.canonical`, and `canonical` is replaced on every snapshot merge (`js/component.js`, `mergeNewSnapshot()`).

So `wire:dirty` answers *"are there changes the server hasn't seen yet"*, not *"are there unsaved changes"*. Any request resets it — a `wire:poll`, a lazy load, a `wire:model.live` update, an unrelated action elsewhere in the component. For the most common thing people reach for it for, an "unsaved changes" indicator or navigation guard, it reports clean while the form is still unsaved.

## The change

Components keep a second reference point next to `canonical`:

```js
// "baseline" represents the last state the component considers "saved". Unlike
// "canonical", it survives round-trips: it is only replaced by an explicit rebaseline.
this.baseline = extractData(deepClone(this.snapshot.data))
```

| API | |
|---|---|
| `wire:dirty.persist` | measures against the last **saved** state instead of the last server response |
| `$wire.$dirty('title', { persist: true })` | the same from Alpine |
| `$this->rebaseline()` | server-side: declares the state it is returning as saved |
| `$wire.$rebaseline()` | client-side equivalent |

```blade
<form wire:submit="save">
    <input type="text" wire:model="title">

    <div wire:dirty.persist>Unsaved changes...</div>
</form>
```

```php
public function save()
{
    Post::create($this->only('title'));

    $this->rebaseline();
}
```

`.persist` composes with `wire:target`, `.remove` and `.class`.

Existing behaviour is untouched — `persist` is opt-in and the default path still compares against `canonical`.

## Two supporting changes

**The post-commit refresh now re-derives the state** instead of hard-coding `false`:

```diff
-refreshDirtyStatesByComponent.each(component, i => i(false))
+refreshDirtyStatesByComponent.each(component, recompute => recompute(true))
```

For a plain `wire:dirty` this is the same answer the hard-coded `false` gave — once the snapshot is merged, `canonical` and `reactive` match — but a `.persist` directive has to be asked rather than assumed. The `force` flag preserves the existing "re-apply after the morph" behaviour.

**The injected stylesheet hides `[wire:dirty.persist]`** the way it already hides `[wire:dirty]`. The selector matches the exact attribute name, so a modifier variant would otherwise flash visible on first paint.

## Tests

Four browser tests in `src/Features/SupportDirty/BrowserTest.php`. The first one pins the *current* behaviour (an unrelated round-trip clears `wire:dirty`) so the difference is visible in the suite:

- `wire:dirty` is reset by an unrelated roundtrip
- `wire:dirty.persist` survives an unrelated roundtrip
- `$dirty` accepts a persist option and `$rebaseline` clears it
- persist composes with the class modifier

Docs updated in `docs/wire-dirty.md`.
