### PR TITLE
 [4.x] Fix JSON array strings being decoded as arrays

### DIFF
--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -61,13 +61,21 @@ class BaseUrl extends LivewireAttribute
 
         if ($initialValue === $nonExistentValue) return;
 
+        $original = $this->getValue();
+
         $decoded = is_array($initialValue)
             ? json_decode(json_encode($initialValue, flags: JSON_BIGINT_AS_STRING), true, flags: JSON_BIGINT_AS_STRING)
             : json_decode($initialValue ?? '', true, flags: JSON_BIGINT_AS_STRING);
 
+        // Query string arrays use bracket notation. If a scalar value decodes
+        // into structured JSON, preserve it when the property is a string...
+        if (is_string($initialValue) && is_array($decoded) && is_string($original)) {
+            $decoded = null;
+        }
+
         // If only part of an array is present in the query string,
         // we want to merge instead of override the value...
-        if (is_array($decoded) && is_array($original = $this->getValue())) {
+        if (is_array($decoded) && is_array($original)) {
             $decoded = $this->recursivelyMergeArraysWithoutAppendingDuplicateValues($original, $decoded);
         }
 

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\Features\SupportFormObjects\Form;
 use ReflectionClass;
+use ReflectionNamedType;
 
 #[\Attribute]
 class BaseUrl extends LivewireAttribute
@@ -49,6 +50,19 @@ class BaseUrl extends LivewireAttribute
         return false;
     }
 
+    protected function propertyIsTypedAsString()
+    {
+        $reflectionClass = new ReflectionClass($this->getSubTarget() ?? $this->getComponent());
+
+        if ($this->getSubName() && $reflectionClass->hasProperty($this->getSubName())) {
+            $type = $reflectionClass->getProperty($this->getSubName())->getType();
+
+            return $type instanceof ReflectionNamedType && $type->getName() === 'string';
+        }
+
+        return false;
+    }
+
     public function setPropertyFromQueryString()
     {
         if ($this->as === null && $this->isOnFormObjectProperty()) {
@@ -69,7 +83,7 @@ class BaseUrl extends LivewireAttribute
 
         // Query string arrays use bracket notation. If a scalar value decodes
         // into structured JSON, preserve it when the property is a string...
-        if (is_string($initialValue) && is_array($decoded) && is_string($original)) {
+        if (is_string($initialValue) && is_array($decoded) && (is_string($original) || $this->propertyIsTypedAsString())) {
             $decoded = null;
         }
 

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -109,6 +109,18 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame($largeNumber, $component->instance()->tableSearch);
     }
 
+    function test_json_array_strings_are_preserved_from_query_string()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => '[123]',
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public $search = '';
+        });
+
+        $this->assertSame('[123]', $component->instance()->search);
+    }
+
     function test_large_numbers_in_arrays_are_preserved_from_query_string()
     {
         $largeNumber = '74350194073086909398128';

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -121,6 +121,18 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame('[123]', $component->instance()->search);
     }
 
+    function test_json_array_strings_are_preserved_for_uninitialized_nullable_string_properties()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => '[123]',
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public ?string $search;
+        });
+
+        $this->assertSame('[123]', $component->instance()->search);
+    }
+
     function test_large_numbers_in_arrays_are_preserved_from_query_string()
     {
         $largeNumber = '74350194073086909398128';


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

Yes. This fixes filamentphp/filament#20372.

I did not open a separate discussion because the issue includes a reproduction.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

4️⃣ Does it include tests? (Required)

Yes.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

A scalar query string value like `[123]` is currently decoded into a PHP array by `json_decode()`, unexpectedly changing the value's type when the target `#[Url]` property is a string.

This cannot be reliably handled downstream because, after decoding, a scalar value like `?search=[123]` is indistinguishable from an actual query string array such as `?search[0]=123`.

This preserves the original scalar value while Livewire still knows how it was represented in the query string. Actual arrays using bracket notation continue to be handled as arrays.

Tests cover initialized strings and uninitialized nullable string properties.