### PR TITLE
[v3.x] fix: wire:dirty losing reactivity for targets listed after a dirty one

### DIFF
--- a/js/directives/wire-dirty.js
+++ b/js/directives/wire-dirty.js
@@ -34,12 +34,10 @@ directive('dirty', ({ el, directive, component }) => {
         if (targets.length === 0) {
             isDirty = JSON.stringify(component.canonical) !== JSON.stringify(component.reactive)
         } else {
-            for (let i = 0; i < targets.length; i++) {
-                if (isDirty) break;
-
-                let target = targets[i]
-
-                isDirty = JSON.stringify(dataGet(component.canonical, target)) !== JSON.stringify(dataGet(component.reactive, target))
+            for (let target of targets) {
+                if (JSON.stringify(dataGet(component.canonical, target)) !== JSON.stringify(dataGet(component.reactive, target))) {
+                    isDirty = true
+                }
             }
         }
 

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -14,25 +14,44 @@ class BrowserTest extends BrowserTestCase
         Livewire::visit(new class extends Component {
             public $prop = false;
 
+            public $other = '';
+
             public function render()
             {
                 return <<<'BLADE'
                     <div>
                         <input dusk="checkbox" type="checkbox" wire:model="prop" value="true"  />
+                        <input dusk="other" type="text" wire:model="other" />
+
+                        <button dusk="commit" type="button" wire:click="$commit">Commit</button>
 
                         <div wire:dirty>Unsaved changes...</div>
                         <div wire:dirty.remove>The data is in-sync...</div>
+
+                        <div wire:dirty.class="dirty" wire:target="prop, other" dusk="targeted">Targeted...</div>
                     </div>
                 BLADE;
             }
         })
             ->assertSee('The data is in-sync...')
             ->check('@checkbox')
+            ->pause(50)
             ->assertDontSee('The data is in-sync')
             ->assertSee('Unsaved changes...')
+            ->assertAttributeContains('@targeted', 'class', 'dirty')
             ->uncheck('@checkbox')
+            ->pause(50)
             ->assertSee('The data is in-sync...')
             ->assertDontSee('Unsaved changes...')
+            ->assertAttributeDoesntContain('@targeted', 'class', 'dirty')
+            ->check('@checkbox')
+            ->pause(50)
+            ->assertAttributeContains('@targeted', 'class', 'dirty')
+            ->waitForLivewire()->click('@commit')
+            ->waitUntil("!document.querySelector('[dusk=\"targeted\"]').classList.contains('dirty')")
+            ->type('@other', 'Hello')
+            ->pause(50)
+            ->assertAttributeContains('@targeted', 'class', 'dirty')
         ;
     }
 


### PR DESCRIPTION
Backport of https://github.com/livewire/livewire/pull/10603 to `3.x`.

## Issue

When `wire:dirty` watches multiple targets (e.g. `wire:dirty.class="unsaved" wire:target="a, b, c"`), the directive permanently stops reacting to any target listed *after* one that becomes dirty and is then committed. Issue reported on coollabsio/coolify#11265.

## Root cause

The dirty check loops over targets inside an `Alpine.effect` and `breaks` as soon as one target is dirty. Alpine's reactivity re-tracks effect dependencies on every run, only properties actually read during the latest run stay subscribed. Breaking early means later targets aren't read, so the effect drops its subscription to them.

The dirty state is then cleared out-of-band after a commit (the `on('commit')` hook calls `refreshDirtyState(false)` directly instead of re-running the effect), so the effect never performs a full read again.