### PR TITLE
[4.x] Don't reuse snapshot synthesizer meta when an updated value changes type

### DIFF
--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -116,7 +116,7 @@ class HandleSynths extends Mechanism
             // The update can also swap a child between an array and a scalar —
             // a Wireable replaced by an integer, say — and the previous meta no
             // longer describes a value of that shape...
-            if (is_array($child) !== is_array($childData) || is_null($child) !== is_null($childData)) return $child;
+            if (! $this->metaStillApplies($child, $childData)) return $child;
 
             // The child value is untrusted update data and may itself look like a
             // synthetic tuple. Always pair it with the authenticated snapshot meta;
@@ -130,10 +130,10 @@ class HandleSynths extends Mechanism
         // This is a trust boundary: $value came from the update payload, while
         // $raw came from the snapshot that Checksum::verify() authenticated. Synth
         // identity and class must only ever be selected from the latter...
-        $meta = $this->getMetaForPath($raw, $path);
+        [$data, $meta] = $this->getTupleForPath($raw, $path);
 
         // If we have meta data already for this property, let's use that to get a synth...
-        if ($meta) {
+        if ($meta && $this->metaStillApplies($value, $data)) {
             return $this->hydratePropertyUpdate([$value, $meta], $context, $path, $raw);
         }
 
@@ -221,6 +221,15 @@ class HandleSynths extends Mechanism
         }
 
         return null;
+    }
+
+    protected function metaStillApplies($value, $data)
+    {
+        // Wire data is JSON: scalars, arrays, null. Anything already a PHP object
+        // was set server-side and is in its final form...
+        if (is_object($value)) return true;
+
+        return is_array($value) === is_array($data) && is_null($value) === is_null($data);
     }
 
     protected function getMetaForPath($raw, $path)

--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -113,10 +113,10 @@ class HandleSynths extends Mechanism
             // for example — have no meta to reconstruct them from...
             if (! $childMeta) return $child;
 
-            // The update can also replace a child with a value of an entirely
-            // different type, in which case the previous meta no longer
-            // describes it and hydrating with it would fail...
-            if (get_debug_type($child) !== get_debug_type($childData)) return $child;
+            // The update can also swap a child between an array and a scalar —
+            // a Wireable replaced by an integer, say — and the previous meta no
+            // longer describes a value of that shape...
+            if (is_array($child) !== is_array($childData) || is_null($child) !== is_null($childData)) return $child;
 
             // The child value is untrusted update data and may itself look like a
             // synthetic tuple. Always pair it with the authenticated snapshot meta;

--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -107,9 +107,16 @@ class HandleSynths extends Mechanism
 
             $childPath = "{$path}.{$name}";
 
+            [$childData, $childMeta] = $this->getTupleForPath($raw, $childPath);
+
             // Children the snapshot has never seen — a freshly added repeater row,
             // for example — have no meta to reconstruct them from...
-            if (! $childMeta = $this->getMetaForPath($raw, $childPath)) return $child;
+            if (! $childMeta) return $child;
+
+            // The update can also replace a child with a value of an entirely
+            // different type, in which case the previous meta no longer
+            // describes it and hydrating with it would fail...
+            if (get_debug_type($child) !== get_debug_type($childData)) return $child;
 
             // The child value is untrusted update data and may itself look like a
             // synthetic tuple. Always pair it with the authenticated snapshot meta;
@@ -218,6 +225,11 @@ class HandleSynths extends Mechanism
 
     protected function getMetaForPath($raw, $path)
     {
+        return $this->getTupleForPath($raw, $path)[1];
+    }
+
+    protected function getTupleForPath($raw, $path)
+    {
         $segments = explode('.', $path);
 
         $first = array_shift($segments);
@@ -227,9 +239,9 @@ class HandleSynths extends Mechanism
         if ($path !== '') {
             $value = $data[$first] ?? null;
 
-            return $this->getMetaForPath($value, implode('.', $segments));
+            return $this->getTupleForPath($value, implode('.', $segments));
         }
 
-        return $meta;
+        return [$data, $meta];
     }
 }

--- a/src/Mechanisms/HandleSynths/UnitTest.php
+++ b/src/Mechanisms/HandleSynths/UnitTest.php
@@ -181,20 +181,40 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame(['some' => 'array'], $updated['brandNew']);
     }
 
-    public function test_hydrate_for_update_leaves_children_whose_type_changed_alone()
+    public function test_hydrate_for_update_leaves_children_whose_shape_changed_alone()
     {
         $synths = app(HandleSynths::class);
         $context = new ComponentContext(new TestComponent);
 
         $raw = ['data' => $synths->dehydrate([
-            'section' => ['tags' => collect(['a'])],
+            'section' => ['tags' => collect(['a']), 'other' => collect(['b'])],
         ], $context, 'data')];
 
         // The Collection has been replaced with a scalar, so the meta describing
         // it no longer applies to the incoming value...
-        $updated = $synths->hydrateForUpdate($raw, 'data.section', ['tags' => 1], $context);
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', [
+            'tags' => 1,
+            'other' => ['b'],
+        ], $context);
 
         $this->assertSame(1, $updated['tags']);
+        $this->assertInstanceOf(Collection::class, $updated['other']);
+    }
+
+    public function test_hydrate_for_update_still_hydrates_children_sent_as_a_different_scalar_type()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => ['status' => IntBackedEnum::Active],
+        ], $context, 'data')];
+
+        // The browser sends numbers back as strings, so an int-backed enum
+        // arrives as a string and still has to hydrate...
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', ['status' => '2'], $context);
+
+        $this->assertSame(IntBackedEnum::Active, $updated['status']);
     }
 
     public function test_hydrate_for_update_passes_nested_removals_through_untouched()
@@ -306,6 +326,11 @@ class UnitTest extends \Tests\TestCase
 
         $component->set('data.section', ['tags' => ['attacker-controlled']]);
     }
+}
+
+enum IntBackedEnum: int
+{
+    case Active = 2;
 }
 
 class CustomThing

--- a/src/Mechanisms/HandleSynths/UnitTest.php
+++ b/src/Mechanisms/HandleSynths/UnitTest.php
@@ -181,6 +181,22 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame(['some' => 'array'], $updated['brandNew']);
     }
 
+    public function test_hydrate_for_update_leaves_children_whose_type_changed_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => ['tags' => collect(['a'])],
+        ], $context, 'data')];
+
+        // The Collection has been replaced with a scalar, so the meta describing
+        // it no longer applies to the incoming value...
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', ['tags' => 1], $context);
+
+        $this->assertSame(1, $updated['tags']);
+    }
+
     public function test_hydrate_for_update_passes_nested_removals_through_untouched()
     {
         $synths = app(HandleSynths::class);

--- a/src/Mechanisms/HandleSynths/UnitTest.php
+++ b/src/Mechanisms/HandleSynths/UnitTest.php
@@ -9,6 +9,7 @@ use Livewire\Mechanisms\HandleComponents\ComponentContext;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\CollectionSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+use Livewire\Wireable;
 use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
@@ -201,6 +202,20 @@ class UnitTest extends \Tests\TestCase
         $this->assertInstanceOf(Collection::class, $updated['other']);
     }
 
+    public function test_hydrate_for_update_leaves_the_updated_path_itself_alone_when_its_shape_changed()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate(['thing' => new SomeWireable('a')], $context, 'data')];
+
+        // The updated path is the synthesized value here, not one of its
+        // children, and its meta is just as stale...
+        $updated = $synths->hydrateForUpdate($raw, 'data.thing', 1, $context);
+
+        $this->assertSame(1, $updated);
+    }
+
     public function test_hydrate_for_update_still_hydrates_children_sent_as_a_different_scalar_type()
     {
         $synths = app(HandleSynths::class);
@@ -331,6 +346,15 @@ class UnitTest extends \Tests\TestCase
 enum IntBackedEnum: int
 {
     case Active = 2;
+}
+
+class SomeWireable implements Wireable
+{
+    public function __construct(public string $value) {}
+
+    public function toLivewire() { return ['value' => $this->value]; }
+
+    public static function fromLivewire($value) { return new static($value['value']); }
 }
 
 class CustomThing


### PR DESCRIPTION
## The problem

Since 4.4.1, updating a property to a value of a different shape than the one in the previous snapshot throws. Setting an array item to a `Wireable` object and then to an integer gives `foreach() argument must be of type array|object, int given` from `WireableSynth::hydrate()`.

Recursive update hydration reconstructs nested values from the meta in the previous snapshot, since the browser strips meta out of update payloads. It was applying that meta to whatever came back for the path, even when the new value can't be what the meta describes, so a synthesizer expecting an array got handed a scalar.

## The fix

Reuse the previous meta only when the incoming value still has the same wire shape as the value it was recorded for, comparing array against scalar against null rather than the exact PHP type. Anything else passes through as-is, which is what happened before 4.4.1.

Comparing the exact type would have been too strict: the browser sends numbers back as strings, so an int-backed enum arrives as `"2"` where the snapshot holds `2`, and that has to keep hydrating.

## Verification

- `phpunit --testsuite=Unit src/Mechanisms/HandleSynths/UnitTest.php` — 20 passed. Both new tests fail on 4.x without the change.
- Full unit suite: 1393 tests, no new failures.
- The nested denylist and forged-meta tests from #10489 still reach the security path rather than returning early at the new check.

Fixes #10606
