### PR TITLE
[4.x] Handle exceptions at the outermost wrapped call

### DIFF
--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -765,6 +765,40 @@ class UnitTest extends TestCase
 
         $this->assertTrue(session()->has('exception-hook-triggered'));
     }
+
+    public function test_handled_computed_exception_stops_action_execution()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $handled = false;
+
+            public $continued = false;
+
+            #[Computed]
+            public function foo(): string
+            {
+                throw new ComputedPropertyException('Exception from computed property');
+            }
+
+            public function save()
+            {
+                $this->foo;
+
+                $this->continued = true;
+            }
+
+            public function exception($e, $stopPropagation)
+            {
+                if ($e instanceof ComputedPropertyException) {
+                    $this->handled = true;
+
+                    $stopPropagation();
+                }
+            }
+        })
+            ->call('save')
+            ->assertSetStrict('handled', true)
+            ->assertSetStrict('continued', false);
+    }
 }
 
 class ComputedPropertyStub extends Component

--- a/src/Wrapped.php
+++ b/src/Wrapped.php
@@ -6,6 +6,8 @@ class Wrapped
 {
     protected $fallback;
 
+    protected static $activeCalls;
+
     function __construct(public $target) {}
 
     function withFallback($fallback)
@@ -19,9 +21,19 @@ class Wrapped
     {
         if (! method_exists($this->target, $method)) return value($this->fallback);
 
+        static::$activeCalls ??= new \WeakMap;
+
+        $isNested = isset(static::$activeCalls[$this->target]);
+
+        if (! $isNested) static::$activeCalls[$this->target] = true;
+
         try {
             return ImplicitlyBoundMethod::call(app(), [$this->target, $method], $params);
         } catch (\Throwable $e) {
+            // Let the outer wrapper handle exceptions from nested calls so that
+            // stopping propagation also stops the outer method's execution.
+            if ($isNested) throw $e;
+
             $shouldPropagate = true;
 
             $stopPropagation = function () use (&$shouldPropagate) {
@@ -31,10 +43,11 @@ class Wrapped
             trigger('exception', $this->target, $e, $stopPropagation);
 
             $shouldPropagate && throw $e;
+        } finally {
+            if (! $isNested) unset(static::$activeCalls[$this->target]);
         }
     }
 }
-
 
 
 


### PR DESCRIPTION
## Problem

#10543 added a `Wrapped` exception boundary around computed property evaluation so exceptions raised while rendering can reach the component's `exception()` hook.

When a computed property is accessed from an action or lifecycle hook, however, the component method is already executing inside `Wrapped`. If the computed property's inner wrapper catches an exception and the hook calls `$stopPropagation()`, that inner wrapper swallows the exception and returns `null`. The outer action then continues as though the computed property completed successfully.

## Fix

Treat nested wrapped calls for the same target as one exception boundary:

- the outermost `Wrapped` call owns exception handling
- nested calls rethrow to that outer boundary
- handled exceptions therefore unwind the complete action or lifecycle method
- standalone computed evaluation during view rendering retains its existing exception boundary

A `WeakMap` tracks active targets and is cleaned in `finally`, avoiding retained component references or leaked state in long-running workers.

This fixes the boundary behavior directly rather than coupling computed properties to render-stack internals or special-casing each invocation context.

## Test

Added a regression test proving that a handled computed-property exception triggers the component hook and prevents the remainder of the action from executing.

Relevant focused suite:

```
OK, but some tests were skipped!
Tests: 171, Assertions: 543, Skipped: 1.
```

Fixes #10588.