### PR TITLE
[4.x] Restore existing attributes and classes after wire:loading

### DIFF
--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -124,6 +124,7 @@ function whenTargetsArePartOfRequest(component, el, targets, inverted, [ startLo
         let cleared = false
         let navigationWasStarted = false
         let stopWaitingForNavigation = () => {}
+
         let finishLoading = () => {
             if (! matches || cleared) return
 

--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -15,7 +15,14 @@ directive('loading', ({ el, directive, component, cleanup }) => {
 
     let startLoading = () => {
         if (activeLoadingCount === 0) {
-            if (directive.modifiers.includes('attr')) {
+            if (directive.modifiers.includes('class')) {
+                let classes = directive.expression.split(' ').filter(String)
+                let classStates = classes.map(className => [className, el.classList.contains(className)])
+
+                restoreLoadingState = () => classStates.forEach(([className, wasPresent]) => {
+                    el.classList.toggle(className, wasPresent)
+                })
+            } else if (directive.modifiers.includes('attr')) {
                 let attribute = directive.expression
                 let value = el.getAttribute(attribute)
 

--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -10,14 +10,29 @@ directive('loading', ({ el, directive, component, cleanup }) => {
 
     let [delay, abortDelay] = applyDelay(directive)
 
+    let restoreLoadingState = () => toggleBooleanStateDirective(el, directive, false)
+
+    let startLoading = () => {
+        if (directive.modifiers.includes('attr')) {
+            let attribute = directive.expression
+            let value = el.getAttribute(attribute)
+
+            restoreLoadingState = value === null
+                ? () => el.removeAttribute(attribute)
+                : () => el.setAttribute(attribute, value)
+        }
+
+        toggleBooleanStateDirective(el, directive, true)
+    }
+
     let cleanupA = whenTargetsArePartOfRequest(component, el, targets, inverted, [
-        () => delay(() => toggleBooleanStateDirective(el, directive, true)),
-        () => abortDelay(() => toggleBooleanStateDirective(el, directive, false)),
+        () => delay(startLoading),
+        () => abortDelay(restoreLoadingState),
     ])
 
     let cleanupB = whenTargetsArePartOfFileUpload(component, targets, [
-        () => delay(() => toggleBooleanStateDirective(el, directive, true)),
-        () => abortDelay(() => toggleBooleanStateDirective(el, directive, false)),
+        () => delay(startLoading),
+        () => abortDelay(restoreLoadingState),
     ])
 
     cleanup(() => {

--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -8,8 +8,6 @@ import { listen } from '@/utils'
 directive('loading', ({ el, directive, component, cleanup }) => {
     let { targets, inverted } = getTargets(el)
 
-    let [delay, abortDelay] = applyDelay(directive)
-
     let restoreLoadingState = () => toggleBooleanStateDirective(el, directive, false)
     let activeLoadingCount = 0
 
@@ -38,15 +36,11 @@ directive('loading', ({ el, directive, component, cleanup }) => {
         if (activeLoadingCount === 0) restoreLoadingState()
     }
 
-    let cleanupA = whenTargetsArePartOfRequest(component, el, targets, inverted, [
-        () => delay(startLoading),
-        () => abortDelay(endLoading),
-    ])
+    let startLoadingWithDelay = applyDelay(directive, startLoading, endLoading)
 
-    let cleanupB = whenTargetsArePartOfFileUpload(component, targets, [
-        () => delay(startLoading),
-        () => abortDelay(endLoading),
-    ])
+    let cleanupA = whenTargetsArePartOfRequest(component, el, targets, inverted, startLoadingWithDelay)
+
+    let cleanupB = whenTargetsArePartOfFileUpload(component, targets, startLoadingWithDelay)
 
     cleanup(() => {
         cleanupA()
@@ -54,8 +48,14 @@ directive('loading', ({ el, directive, component, cleanup }) => {
     })
 })
 
-function applyDelay(directive) {
-    if (! directive.modifiers.includes('delay') || directive.modifiers.includes('none')) return [i => i(), i => i()]
+function applyDelay(directive, startLoading, endLoading) {
+    if (! directive.modifiers.includes('delay') || directive.modifiers.includes('none')) {
+        return () => {
+            startLoading()
+
+            return endLoading
+        }
+    }
 
     let duration = 200
 
@@ -77,29 +77,26 @@ function applyDelay(directive) {
         }
     })
 
-    let timeout
-    let started = false
+    return () => {
+        let started = false
 
-    return [
-        (callback) => { // Initiate delay...
-            timeout = setTimeout(() => {
-                callback()
+        let timeout = setTimeout(() => {
+            startLoading()
 
-                started = true
-            }, duration)
-        },
-        async (callback) => { // Execute or abort...
+            started = true
+        }, duration)
+
+        return () => {
             if (started) {
-                await callback()
-                started = false
+                endLoading()
             } else {
                 clearTimeout(timeout)
             }
-        },
-    ]
+        }
+    }
 }
 
-function whenTargetsArePartOfRequest(component, el, targets, inverted, [ startLoading, endLoading ]) {
+function whenTargetsArePartOfRequest(component, el, targets, inverted, startLoading) {
     return interceptMessage(({ message, onSend, onSuccess, onFinish }) => {
         if (component !== message.component) return
 
@@ -124,6 +121,7 @@ function whenTargetsArePartOfRequest(component, el, targets, inverted, [ startLo
         let cleared = false
         let navigationWasStarted = false
         let stopWaitingForNavigation = () => {}
+        let endLoading = () => {}
 
         let finishLoading = () => {
             if (! matches || cleared) return
@@ -141,7 +139,7 @@ function whenTargetsArePartOfRequest(component, el, targets, inverted, [ startLo
 
             if (! matches) return
 
-            startLoading()
+            endLoading = startLoading()
         })
 
         // Clear loading before morph on success
@@ -173,7 +171,9 @@ function whenTargetsArePartOfRequest(component, el, targets, inverted, [ startLo
     })
 }
 
-function whenTargetsArePartOfFileUpload(component, targets, [ startLoading, endLoading ]) {
+function whenTargetsArePartOfFileUpload(component, targets, startLoading) {
+    let endLoadingByProperty = new Map
+
     let eventMismatch = e => {
         let { id, property } = e.detail
 
@@ -183,23 +183,31 @@ function whenTargetsArePartOfFileUpload(component, targets, [ startLoading, endL
         return false
     }
 
+    let finishLoading = e => {
+        if (eventMismatch(e)) return
+
+        let { property } = e.detail
+        let pending = endLoadingByProperty.get(property)
+        let endLoading = pending?.shift()
+
+        endLoading?.()
+
+        if (pending?.length === 0) endLoadingByProperty.delete(property)
+    }
+
     let cleanupA = listen(window, 'livewire-upload-start', e => {
         if (eventMismatch(e)) return
 
-        startLoading()
+        let { property } = e.detail
+        let pending = endLoadingByProperty.get(property) ?? []
+
+        pending.push(startLoading())
+        endLoadingByProperty.set(property, pending)
     })
 
-    let cleanupB = listen(window, 'livewire-upload-finish', e => {
-        if (eventMismatch(e)) return
+    let cleanupB = listen(window, 'livewire-upload-finish', finishLoading)
 
-        endLoading()
-    })
-
-    let cleanupC = listen(window, 'livewire-upload-error', e => {
-        if (eventMismatch(e)) return
-
-        endLoading()
-    })
+    let cleanupC = listen(window, 'livewire-upload-error', finishLoading)
 
     return () => {
         cleanupA()

--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -11,28 +11,41 @@ directive('loading', ({ el, directive, component, cleanup }) => {
     let [delay, abortDelay] = applyDelay(directive)
 
     let restoreLoadingState = () => toggleBooleanStateDirective(el, directive, false)
+    let activeLoadingCount = 0
 
     let startLoading = () => {
-        if (directive.modifiers.includes('attr')) {
-            let attribute = directive.expression
-            let value = el.getAttribute(attribute)
+        if (activeLoadingCount === 0) {
+            if (directive.modifiers.includes('attr')) {
+                let attribute = directive.expression
+                let value = el.getAttribute(attribute)
 
-            restoreLoadingState = value === null
-                ? () => el.removeAttribute(attribute)
-                : () => el.setAttribute(attribute, value)
+                restoreLoadingState = value === null
+                    ? () => el.removeAttribute(attribute)
+                    : () => el.setAttribute(attribute, value)
+            }
+
+            toggleBooleanStateDirective(el, directive, true)
         }
 
-        toggleBooleanStateDirective(el, directive, true)
+        activeLoadingCount++
+    }
+
+    let endLoading = () => {
+        if (activeLoadingCount === 0) return
+
+        activeLoadingCount--
+
+        if (activeLoadingCount === 0) restoreLoadingState()
     }
 
     let cleanupA = whenTargetsArePartOfRequest(component, el, targets, inverted, [
         () => delay(startLoading),
-        () => abortDelay(restoreLoadingState),
+        () => abortDelay(endLoading),
     ])
 
     let cleanupB = whenTargetsArePartOfFileUpload(component, targets, [
         () => delay(startLoading),
-        () => abortDelay(restoreLoadingState),
+        () => abortDelay(endLoading),
     ])
 
     cleanup(() => {

--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -8,6 +8,8 @@ import { listen } from '@/utils'
 directive('loading', ({ el, directive, component, cleanup }) => {
     let { targets, inverted } = getTargets(el)
 
+    let [delay, abortDelay] = applyDelay(directive)
+
     let restoreLoadingState = () => toggleBooleanStateDirective(el, directive, false)
     let activeLoadingCount = 0
 
@@ -22,7 +24,7 @@ directive('loading', ({ el, directive, component, cleanup }) => {
                     : () => el.setAttribute(attribute, value)
             }
 
-            toggleBooleanStateDirective(el, directive, true)
+            delay(() => toggleBooleanStateDirective(el, directive, true))
         }
 
         activeLoadingCount++
@@ -33,14 +35,18 @@ directive('loading', ({ el, directive, component, cleanup }) => {
 
         activeLoadingCount--
 
-        if (activeLoadingCount === 0) restoreLoadingState()
+        if (activeLoadingCount === 0) abortDelay(restoreLoadingState)
     }
 
-    let startLoadingWithDelay = applyDelay(directive, startLoading, endLoading)
+    let cleanupA = whenTargetsArePartOfRequest(component, el, targets, inverted, [
+        startLoading,
+        endLoading,
+    ])
 
-    let cleanupA = whenTargetsArePartOfRequest(component, el, targets, inverted, startLoadingWithDelay)
-
-    let cleanupB = whenTargetsArePartOfFileUpload(component, targets, startLoadingWithDelay)
+    let cleanupB = whenTargetsArePartOfFileUpload(component, targets, [
+        startLoading,
+        endLoading,
+    ])
 
     cleanup(() => {
         cleanupA()
@@ -48,14 +54,8 @@ directive('loading', ({ el, directive, component, cleanup }) => {
     })
 })
 
-function applyDelay(directive, startLoading, endLoading) {
-    if (! directive.modifiers.includes('delay') || directive.modifiers.includes('none')) {
-        return () => {
-            startLoading()
-
-            return endLoading
-        }
-    }
+function applyDelay(directive) {
+    if (! directive.modifiers.includes('delay') || directive.modifiers.includes('none')) return [i => i(), i => i()]
 
     let duration = 200
 
@@ -77,26 +77,29 @@ function applyDelay(directive, startLoading, endLoading) {
         }
     })
 
-    return () => {
-        let started = false
+    let timeout
+    let started = false
 
-        let timeout = setTimeout(() => {
-            startLoading()
+    return [
+        (callback) => { // Initiate delay...
+            timeout = setTimeout(() => {
+                callback()
 
-            started = true
-        }, duration)
-
-        return () => {
+                started = true
+            }, duration)
+        },
+        async (callback) => { // Execute or abort...
             if (started) {
-                endLoading()
+                await callback()
+                started = false
             } else {
                 clearTimeout(timeout)
             }
-        }
-    }
+        },
+    ]
 }
 
-function whenTargetsArePartOfRequest(component, el, targets, inverted, startLoading) {
+function whenTargetsArePartOfRequest(component, el, targets, inverted, [ startLoading, endLoading ]) {
     return interceptMessage(({ message, onSend, onSuccess, onFinish }) => {
         if (component !== message.component) return
 
@@ -121,8 +124,6 @@ function whenTargetsArePartOfRequest(component, el, targets, inverted, startLoad
         let cleared = false
         let navigationWasStarted = false
         let stopWaitingForNavigation = () => {}
-        let endLoading = () => {}
-
         let finishLoading = () => {
             if (! matches || cleared) return
 
@@ -139,7 +140,7 @@ function whenTargetsArePartOfRequest(component, el, targets, inverted, startLoad
 
             if (! matches) return
 
-            endLoading = startLoading()
+            startLoading()
         })
 
         // Clear loading before morph on success
@@ -171,9 +172,7 @@ function whenTargetsArePartOfRequest(component, el, targets, inverted, startLoad
     })
 }
 
-function whenTargetsArePartOfFileUpload(component, targets, startLoading) {
-    let endLoadingByProperty = new Map
-
+function whenTargetsArePartOfFileUpload(component, targets, [ startLoading, endLoading ]) {
     let eventMismatch = e => {
         let { id, property } = e.detail
 
@@ -183,31 +182,23 @@ function whenTargetsArePartOfFileUpload(component, targets, startLoading) {
         return false
     }
 
-    let finishLoading = e => {
-        if (eventMismatch(e)) return
-
-        let { property } = e.detail
-        let pending = endLoadingByProperty.get(property)
-        let endLoading = pending?.shift()
-
-        endLoading?.()
-
-        if (pending?.length === 0) endLoadingByProperty.delete(property)
-    }
-
     let cleanupA = listen(window, 'livewire-upload-start', e => {
         if (eventMismatch(e)) return
 
-        let { property } = e.detail
-        let pending = endLoadingByProperty.get(property) ?? []
-
-        pending.push(startLoading())
-        endLoadingByProperty.set(property, pending)
+        startLoading()
     })
 
-    let cleanupB = listen(window, 'livewire-upload-finish', finishLoading)
+    let cleanupB = listen(window, 'livewire-upload-finish', e => {
+        if (eventMismatch(e)) return
 
-    let cleanupC = listen(window, 'livewire-upload-error', finishLoading)
+        endLoading()
+    })
+
+    let cleanupC = listen(window, 'livewire-upload-error', e => {
+        if (eventMismatch(e)) return
+
+        endLoading()
+    })
 
     return () => {
         cleanupA()

--- a/src/Features/SupportWireLoading/BrowserTest.php
+++ b/src/Features/SupportWireLoading/BrowserTest.php
@@ -104,6 +104,40 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    function test_wire_loading_attr_restores_existing_attribute_after_renderless_action()
+    {
+        Livewire::visit(new class extends Component {
+            public bool $disabled = true;
+
+            #[\Livewire\Attributes\Renderless]
+            public function renderlessAction() {
+                usleep(250000);
+            }
+
+            public function render() {
+                return <<<'HTML'
+                    <div>
+                        <button type="button" wire:click="renderlessAction" dusk="renderless">
+                            Renderless action
+                        </button>
+
+                        <button
+                            type="button"
+                            x-bind:disabled="$wire.$get('disabled')"
+                            wire:loading.attr="disabled"
+                            dusk="target">
+                            Target
+                        </button>
+                    </div>
+                HTML;
+            }
+        })
+        ->waitUntil('document.querySelector(\'[dusk="target"]\').disabled === true')
+        ->waitForLivewire()->click('@renderless')
+        ->assertScript('document.querySelector(\'[dusk="target"]\').disabled', true)
+        ;
+    }
+
     function test_wire_loading_attr_doesnt_conflict_with_exist_one()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportWireLoading/BrowserTest.php
+++ b/src/Features/SupportWireLoading/BrowserTest.php
@@ -138,6 +138,59 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    function test_wire_loading_attr_restores_after_all_overlapping_requests_finish()
+    {
+        Livewire::visit(new class extends Component {
+            #[\Livewire\Attributes\Renderless]
+            public function slowAction() {
+                usleep(500000);
+
+                $this->dispatch('slow-finished');
+            }
+
+            #[\Livewire\Attributes\Renderless]
+            public function fastAction() {
+                usleep(100000);
+
+                $this->dispatch('fast-finished');
+            }
+
+            public function render() {
+                return <<<'HTML'
+                    <div
+                        x-data="{ fastFinished: false, slowFinished: false }"
+                        x-on:fast-finished.window="fastFinished = true"
+                        x-on:slow-finished.window="slowFinished = true"
+                    >
+                        <button type="button" wire:click.async="slowAction" dusk="slow">
+                            Slow action
+                        </button>
+
+                        <button type="button" wire:click.async="fastAction" dusk="fast">
+                            Fast action
+                        </button>
+
+                        <button type="button" wire:loading.attr="disabled" dusk="target">
+                            Target
+                        </button>
+
+                        <span x-show="fastFinished">Fast finished</span>
+                        <span x-show="slowFinished">Slow finished</span>
+                    </div>
+                HTML;
+            }
+        })
+        ->waitForLivewireToLoad()
+        ->assertAttributeMissing('@target', 'disabled')
+        ->click('@fast')
+        ->click('@slow')
+        ->waitForText('Fast finished')
+        ->assertAttribute('@target', 'disabled', 'true')
+        ->waitForText('Slow finished')
+        ->assertAttributeMissing('@target', 'disabled')
+        ;
+    }
+
     function test_wire_loading_attr_doesnt_conflict_with_exist_one()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportWireLoading/BrowserTest.php
+++ b/src/Features/SupportWireLoading/BrowserTest.php
@@ -191,6 +191,59 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    function test_wire_loading_delay_restores_after_all_overlapping_requests_finish()
+    {
+        Livewire::visit(new class extends Component {
+            #[\Livewire\Attributes\Renderless]
+            public function slowAction() {
+                usleep(500000);
+
+                $this->dispatch('slow-finished');
+            }
+
+            #[\Livewire\Attributes\Renderless]
+            public function fastAction() {
+                usleep(100000);
+
+                $this->dispatch('fast-finished');
+            }
+
+            public function render() {
+                return <<<'HTML'
+                    <div
+                        x-data="{ fastFinished: false, slowFinished: false }"
+                        x-on:fast-finished.window="fastFinished = true"
+                        x-on:slow-finished.window="slowFinished = true"
+                    >
+                        <button type="button" wire:click.async="slowAction" dusk="slow">
+                            Slow action
+                        </button>
+
+                        <button type="button" wire:click.async="fastAction" dusk="fast">
+                            Fast action
+                        </button>
+
+                        <button type="button" wire:loading.delay.shortest.attr="disabled" dusk="target">
+                            Target
+                        </button>
+
+                        <span x-show="fastFinished">Fast finished</span>
+                        <span x-show="slowFinished">Slow finished</span>
+                    </div>
+                HTML;
+            }
+        })
+        ->waitForLivewireToLoad()
+        ->assertAttributeMissing('@target', 'disabled')
+        ->click('@fast')
+        ->click('@slow')
+        ->waitForText('Fast finished')
+        ->assertAttribute('@target', 'disabled', 'true')
+        ->waitForText('Slow finished')
+        ->assertAttributeMissing('@target', 'disabled')
+        ;
+    }
+
     function test_wire_loading_attr_doesnt_conflict_with_exist_one()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportWireLoading/BrowserTest.php
+++ b/src/Features/SupportWireLoading/BrowserTest.php
@@ -138,6 +138,50 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    function test_wire_loading_class_restores_existing_class_state_after_renderless_action()
+    {
+        Livewire::visit(new class extends Component {
+            #[\Livewire\Attributes\Renderless]
+            public function renderlessAction() {
+                usleep(250000);
+            }
+
+            public function render() {
+                return <<<'HTML'
+                    <div>
+                        <button type="button" wire:click="renderlessAction" dusk="renderless">
+                            Renderless action
+                        </button>
+
+                        <div
+                            class="existing"
+                            wire:loading.class="existing added"
+                            dusk="add">
+                            Add classes
+                        </div>
+
+                        <div
+                            class="existing"
+                            wire:loading.class.remove="existing absent"
+                            dusk="remove">
+                            Remove classes
+                        </div>
+                    </div>
+                HTML;
+            }
+        })
+        ->assertHasClass('@add', 'existing')
+        ->assertScript('document.querySelector(\'[dusk="add"]\').classList.contains(\'added\')', false)
+        ->assertHasClass('@remove', 'existing')
+        ->assertScript('document.querySelector(\'[dusk="remove"]\').classList.contains(\'absent\')', false)
+        ->waitForLivewire()->click('@renderless')
+        ->assertHasClass('@add', 'existing')
+        ->assertScript('document.querySelector(\'[dusk="add"]\').classList.contains(\'added\')', false)
+        ->assertHasClass('@remove', 'existing')
+        ->assertScript('document.querySelector(\'[dusk="remove"]\').classList.contains(\'absent\')', false)
+        ;
+    }
+
     function test_wire_loading_attr_restores_after_all_overlapping_requests_finish()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
When an attribute is already controlled by Alpine and the same attribute is temporarily set by `wire:loading.attr`, Livewire removes the attribute when loading ends. A renderless action exposes this because no morph follows to reapply Alpine's binding.

```blade
<button wire:click="renderlessAction">Renderless action</button>

<button
    x-bind:disabled="$wire.$get('disabled')"
    wire:loading.attr="disabled"
>
    Submit
</button>
```

Fixes #10332.

## Current solution: Levels 1–4

The implementation is being built in independently reviewable steps:

- capture the attribute's current value before `wire:loading` changes it;
- restore that value when loading ends, or remove the attribute if it was originally absent;
- keep the behavior local to `wire:loading` rather than changing the shared directive helper;
- capture only on the first overlapping loading start;
- restore only after the final overlapping loading cycle finishes;
- treat overlapping requests as one continuous loading period, including when delay is used;
- restore each class named by `wire:loading.class` to its original presence or absence.

## Levels

- [x] **Level 1 — Immediate problem:** restore an existing attribute after a renderless loading cycle.
- [x] **Level 2 — Overlapping ownership:** preserve the first snapshot and restore only after the final active request finishes.
- [x] **Level 3 — Delays and out-of-order completion:** start delay on the first request and cancel or restore it only after the final request finishes.
- [x] **Level 4 — Loading classes:** preserve original class membership for both `.class` and `.class.remove`.

## Remaining scope

This remains local to `wire:loading`. Display restoration and the separate `wire:dirty` / `wire:offline` lifecycles are intentionally left for follow-up evaluation rather than broadening the shared directive helper here.

## Verification

- `composer test:browser -- src/Features/SupportWireLoading/BrowserTest.php` — 26 tests, 174 assertions
- focused overlapping-delay browser test — confirmed failing before Level 3, passing with the single-busy-period implementation
- focused class restoration browser test — confirmed failing before Level 4, passing for both `.class` and `.class.remove`
- `npm run test:run` — 110 passed, 1 skipped
- real Laravel playground — target remains disabled before and after the renderless request; no browser errors
