### PR TITLE
[4.x] Guard array-shaped synthetizers against non-array update values

### DIFF
--- a/docs/synthesizers.md
+++ b/docs/synthesizers.md
@@ -244,3 +244,30 @@ class AddressSynth extends Synth
     }
 }
 ```
+
+## Array-shaped synthesizers
+
+If your synthesizer's `hydrate()` method assumes the wire value is an array
+(e.g. it runs `foreach`, builds a collection, or calls `fromLivewire()` on
+array data), implement the `ArrayShapedSynth` marker interface:
+
+```php
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+
+class MoneySynth extends Synth implements ArrayShapedSynth
+{
+    public static $key = 'money';
+
+    public function hydrate($value, $meta, $hydrateChild)
+    {
+        // $value is guaranteed to be an array on the update path when
+        // this interface is implemented; non-arrays are returned as-is
+        // by HandleSynths before hydrate() is called.
+        // ...
+    }
+}
+```
+> [!important]
+> Do not implement this interface on synths that legitimately hydrate scalars
+(dates, enums, ints, floats, strings).

--- a/src/Features/SupportFormObjects/FormObjectSynth.php
+++ b/src/Features/SupportFormObjects/FormObjectSynth.php
@@ -5,10 +5,11 @@ namespace Livewire\Features\SupportFormObjects;
 use Livewire\Drawer\Utils;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Livewire\Features\SupportAttributes\AttributeCollection;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 
 use function Livewire\wrap;
 
-class FormObjectSynth extends Synth {
+class FormObjectSynth extends Synth implements ArrayShapedSynth {
     public static $key = 'form';
 
     static function match($target)

--- a/src/Features/SupportWireables/WireableSynth.php
+++ b/src/Features/SupportWireables/WireableSynth.php
@@ -36,7 +36,7 @@ class WireableSynth extends Synth
     function hydrate($value, $meta, $hydrateChild)
     {
         // Same guard as ArraySynth: updates can replace a Wireable with a
-        // scalar (or __rm__). Previous meta must not foreach a non-array
+        // scalar (or __rm__). Previous meta must not loop a non-array
         if (! is_array($value)) return $value;
 
         // Verify class implements Wireable even though checksum protects this...

--- a/src/Features/SupportWireables/WireableSynth.php
+++ b/src/Features/SupportWireables/WireableSynth.php
@@ -33,12 +33,7 @@ class WireableSynth extends Synth
         ];
     }
 
-    function hydrate($value, $meta, $hydrateChild)
-    {
-        // Same guard as ArraySynth: updates can replace a Wireable with a
-        // scalar (or __rm__). Previous meta must not loop a non-array
-        if (! is_array($value)) return $value;
-
+    function hydrate($value, $meta, $hydrateChild) {
         // Verify class implements Wireable even though checksum protects this...
         if (! isset($meta['class']) || ! is_a($meta['class'], Wireable::class, true)) {
             throw new \Exception('Livewire: Invalid wireable class.');

--- a/src/Features/SupportWireables/WireableSynth.php
+++ b/src/Features/SupportWireables/WireableSynth.php
@@ -33,7 +33,12 @@ class WireableSynth extends Synth
         ];
     }
 
-    function hydrate($value, $meta, $hydrateChild) {
+    function hydrate($value, $meta, $hydrateChild)
+    {
+        // Same guard as ArraySynth: updates can replace a Wireable with a
+        // scalar (or __rm__). Previous meta must not foreach a non-array
+        if (! is_array($value)) return $value;
+
         // Verify class implements Wireable even though checksum protects this...
         if (! isset($meta['class']) || ! is_a($meta['class'], Wireable::class, true)) {
             throw new \Exception('Livewire: Invalid wireable class.');

--- a/src/Features/SupportWireables/WireableSynth.php
+++ b/src/Features/SupportWireables/WireableSynth.php
@@ -2,10 +2,11 @@
 
 namespace Livewire\Features\SupportWireables;
 
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use Livewire\Wireable;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 
-class WireableSynth extends Synth
+class WireableSynth extends Synth implements ArrayShapedSynth
 {
     public static $key = 'wrbl';
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/ArrayShapedSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/ArrayShapedSynth.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
+
+/**
+ * Marker for synthesizers whose hydrate() assumes an array wire value.
+ *
+ * On property updates, Livewire reuses synthesizer meta from the previous
+ * checksum-verified snapshot (#10489). The update payload can still change
+ * shape at that path (scalar, null, or "__rm__"). Implementors are skipped
+ * when the incoming value is not an array, matching the guard ArraySynth
+ * has always applied.
+ *
+ * Implement this if your hydrate() does foreach / array construction /
+ * fromLivewire() on array data. Scalar-friendly synths (Carbon, Enum, Int,
+ * Float, Stringable) must not implement it.
+ *
+ * @see \Livewire\Mechanisms\HandleSynths\HandleSynths::hydratePropertyUpdate()
+ */
+interface ArrayShapedSynth
+{
+    //
+}

--- a/src/Mechanisms/HandleComponents/Synthesizers/ArraySynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/ArraySynth.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
 
-class ArraySynth extends Synth {
+class ArraySynth extends Synth implements ArrayShapedSynth {
     public static $key = 'arr';
 
     static function match($target) {

--- a/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
@@ -27,7 +27,7 @@ class CollectionSynth extends ArraySynth {
     function hydrate($value, $meta, $hydrateChild)
     {
         // Same guard as ArraySynth: updates can replace a Wireable with a
-        // scalar (or __rm__). Previous meta must not foreach a non-array
+        // scalar (or __rm__). Previous meta must not loop a non-array
         if (! is_array($value)) return $value;
 
         if (! isset($meta['class']) || ! is_a($meta['class'], Collection::class, true)) {

--- a/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
@@ -24,7 +24,12 @@ class CollectionSynth extends ArraySynth {
         ];
     }
 
-    function hydrate($value, $meta, $hydrateChild) {
+    function hydrate($value, $meta, $hydrateChild)
+    {
+        // Same guard as ArraySynth: updates can replace a Wireable with a
+        // scalar (or __rm__). Previous meta must not foreach a non-array
+        if (! is_array($value)) return $value;
+
         if (! isset($meta['class']) || ! is_a($meta['class'], Collection::class, true)) {
             throw new \Exception("Livewire: Class [{$meta['class']}] is not a valid Collection type.");
         }

--- a/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
@@ -24,12 +24,7 @@ class CollectionSynth extends ArraySynth {
         ];
     }
 
-    function hydrate($value, $meta, $hydrateChild)
-    {
-        // Same guard as ArraySynth: updates can replace a Wireable with a
-        // scalar (or __rm__). Previous meta must not loop a non-array
-        if (! is_array($value)) return $value;
-
+    function hydrate($value, $meta, $hydrateChild) {
         if (! isset($meta['class']) || ! is_a($meta['class'], Collection::class, true)) {
             throw new \Exception("Livewire: Class [{$meta['class']}] is not a valid Collection type.");
         }

--- a/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
@@ -4,7 +4,7 @@ namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
 
 use stdClass;
 
-class StdClassSynth extends Synth {
+class StdClassSynth extends Synth implements ArrayShapedSynth {
     public static $key = 'std';
 
     static function match($target) {

--- a/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
@@ -21,7 +21,12 @@ class StdClassSynth extends Synth {
         return [$data, []];
     }
 
-    function hydrate($value, $meta, $hydrateChild) {
+    function hydrate($value, $meta, $hydrateChild)
+    {
+        // Same guard as ArraySynth: updates can replace a Wireable with a
+        // scalar (or __rm__). Previous meta must not foreach a non-array
+        if (! is_array($value)) return $value;
+
         $obj = new stdClass;
 
         foreach ($value as $key => $child) {

--- a/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
@@ -21,12 +21,7 @@ class StdClassSynth extends Synth {
         return [$data, []];
     }
 
-    function hydrate($value, $meta, $hydrateChild)
-    {
-        // Same guard as ArraySynth: updates can replace a Wireable with a
-        // scalar (or __rm__). Previous meta must not loop a non-array
-        if (! is_array($value)) return $value;
-
+    function hydrate($value, $meta, $hydrateChild) {
         $obj = new stdClass;
 
         foreach ($value as $key => $child) {

--- a/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
@@ -24,7 +24,7 @@ class StdClassSynth extends Synth {
     function hydrate($value, $meta, $hydrateChild)
     {
         // Same guard as ArraySynth: updates can replace a Wireable with a
-        // scalar (or __rm__). Previous meta must not foreach a non-array
+        // scalar (or __rm__). Previous meta must not loop a non-array
         if (! is_array($value)) return $value;
 
         $obj = new stdClass;

--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -23,6 +23,14 @@ class HandleSynths extends Mechanism
         Synthesizers\FloatSynth::class,
     ];
 
+    protected array $arrayShapedSynthKeys = [
+        'arr',      // ArraySynth
+        'clctn',    // CollectionSynth
+        'std',      // StdClassSynth
+        'wrbl',     // WireableSynth
+        'form',     // FormObjectSynth
+    ];
+
     // Performance optimization: Cache which synthesizer matches which type
     protected array $typeCache = [];
 
@@ -90,6 +98,12 @@ class HandleSynths extends Mechanism
         // Validate class against denylist before any synthesizer can instantiate it...
         if (isset($meta['class'])) {
             SecurityPolicy::validateClass($meta['class']);
+        }
+
+        // Central guard: array-shaped synths must not receive non-arrays
+        // (scalars, __rm__, null, etc.) when meta is reused from the snapshot.
+        if ($this->isArrayShapedSynth($meta['s'] ?? '') && ! is_array($value)) {
+            return $value;
         }
 
         $synth = $this->resolve($meta['s'], $context, $path);
@@ -231,5 +245,10 @@ class HandleSynths extends Mechanism
         }
 
         return $meta;
+    }
+
+    protected function isArrayShapedSynth(string $key): bool
+    {
+        return in_array($key, $this->arrayShapedSynthKeys, true);
     }
 }

--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -8,6 +8,7 @@ use Livewire\Mechanisms\HandleComponents\SecurityPolicy;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers;
 use Livewire\Drawer\Utils;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use ReflectionUnionType;
 
 class HandleSynths extends Mechanism
@@ -21,14 +22,6 @@ class HandleSynths extends Mechanism
         Synthesizers\ArraySynth::class,
         Synthesizers\IntSynth::class,
         Synthesizers\FloatSynth::class,
-    ];
-
-    protected array $arrayShapedSynthKeys = [
-        'arr',      // ArraySynth
-        'clctn',    // CollectionSynth
-        'std',      // StdClassSynth
-        'wrbl',     // WireableSynth
-        'form',     // FormObjectSynth
     ];
 
     // Performance optimization: Cache which synthesizer matches which type
@@ -100,13 +93,15 @@ class HandleSynths extends Mechanism
             SecurityPolicy::validateClass($meta['class']);
         }
 
-        // Central guard: array-shaped synths must not receive non-arrays
-        // (scalars, __rm__, null, etc.) when meta is reused from the snapshot.
-        if ($this->isArrayShapedSynth($meta['s'] ?? '') && ! is_array($value)) {
+        $synth = $this->resolve($meta['s'], $context, $path);
+
+        // Array-shaped synths must not receive non-arrays when meta is reused
+        // from the snapshot (shape change or __rm__). Same rule ArraySynth
+        // already applies locally; enforced here for all implementors of
+        // ArrayShapedSynth (built-in and third-party).
+        if ($synth instanceof ArrayShapedSynth && ! is_array($value)) {
             return $value;
         }
-
-        $synth = $this->resolve($meta['s'], $context, $path);
 
         return $synth->hydrate($value, $meta, function ($name, $child) use ($context, $path, $raw) {
             // Updates carry values only — the browser strips synthesizer meta out
@@ -245,10 +240,5 @@ class HandleSynths extends Mechanism
         }
 
         return $meta;
-    }
-
-    protected function isArrayShapedSynth(string $key): bool
-    {
-        return in_array($key, $this->arrayShapedSynthKeys, true);
     }
 }

--- a/src/Mechanisms/HandleSynths/UnitTest.php
+++ b/src/Mechanisms/HandleSynths/UnitTest.php
@@ -290,6 +290,65 @@ class UnitTest extends \Tests\TestCase
 
         $component->set('data.section', ['tags' => ['attacker-controlled']]);
     }
+
+    public function test_hydrate_for_update_leaves_children_whose_shape_changed_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => ['tags' => collect(['a']), 'other' => collect(['b'])],
+        ], $context, 'data')];
+
+        // Collection meta must not be applied to a scalar...
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', [
+            'tags' => 1,
+            'other' => ['b'],
+        ], $context);
+
+        $this->assertSame(1, $updated['tags']);
+        $this->assertInstanceOf(Collection::class, $updated['other']);
+    }
+
+    public function test_hydrate_for_update_leaves_wireable_children_replaced_with_scalars_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $wireable = new class implements \Livewire\Wireable {
+            public function toLivewire()
+            {
+                return [];
+            }
+
+            public static function fromLivewire($value)
+            {
+                return new static;
+            }
+        };
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => ['item' => $wireable],
+        ], $context, 'data')];
+
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', [
+            'item' => 1,
+        ], $context);
+
+        $this->assertSame(1, $updated['item']);
+    }
+
+    public function test_hydrate_for_update_leaves_a_property_whose_shape_changed_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['item' => $synths->dehydrate(collect(['a']), $context, 'item')];
+
+        $updated = $synths->hydrateForUpdate($raw, 'item', 1, $context);
+
+        $this->assertSame(1, $updated);
+    }
 }
 
 class CustomThing

--- a/src/Mechanisms/HandleSynths/UnitTest.php
+++ b/src/Mechanisms/HandleSynths/UnitTest.php
@@ -315,20 +315,8 @@ class UnitTest extends \Tests\TestCase
         $synths = app(HandleSynths::class);
         $context = new ComponentContext(new TestComponent);
 
-        $wireable = new class implements \Livewire\Wireable {
-            public function toLivewire()
-            {
-                return [];
-            }
-
-            public static function fromLivewire($value)
-            {
-                return new static;
-            }
-        };
-
         $raw = ['data' => $synths->dehydrate([
-            'section' => ['item' => $wireable],
+            'section' => ['item' => new EmptyWireable],
         ], $context, 'data')];
 
         $updated = $synths->hydrateForUpdate($raw, 'data.section', [
@@ -344,6 +332,64 @@ class UnitTest extends \Tests\TestCase
         $context = new ComponentContext(new TestComponent);
 
         $raw = ['item' => $synths->dehydrate(collect(['a']), $context, 'item')];
+
+        $updated = $synths->hydrateForUpdate($raw, 'item', 1, $context);
+
+        $this->assertSame(1, $updated);
+    }
+    
+    public function test_replacing_a_wireable_array_item_with_a_scalar_does_not_throw()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public $array = [];
+        });
+
+        $component->set('array', [0 => new EmptyWireable]);
+        $component->set('array', [0 => 1]);
+
+        $this->assertSame([0 => 1], $component->get('array'));
+    }
+
+    public function test_hydrate_for_update_leaves_stdclass_children_replaced_with_scalars_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => [
+                'item' => (object) ['name' => 'a'],
+                'other' => (object) ['name' => 'b'],
+            ],
+        ], $context, 'data')];
+
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', [
+            'item' => 1,
+            'other' => ['name' => 'b'],
+        ], $context);
+
+        $this->assertSame(1, $updated['item']);
+        $this->assertInstanceOf(\stdClass::class, $updated['other']);
+        $this->assertSame('b', $updated['other']->name);
+    }
+
+    public function test_hydrate_for_update_leaves_a_top_level_stdclass_whose_shape_changed_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['item' => $synths->dehydrate((object) ['name' => 'a'], $context, 'item')];
+
+        $updated = $synths->hydrateForUpdate($raw, 'item', 1, $context);
+
+        $this->assertSame(1, $updated);
+    }
+
+    public function test_hydrate_for_update_leaves_a_top_level_wireable_whose_shape_changed_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['item' => $synths->dehydrate(new EmptyWireable, $context, 'item')];
 
         $updated = $synths->hydrateForUpdate($raw, 'item', 1, $context);
 
@@ -373,5 +419,20 @@ class CustomThingSynth extends Synth
     public function hydrate($value)
     {
         return new CustomThing($value['value']);
+    }
+}
+
+class EmptyWireable implements \Livewire\Wireable
+{
+    public function __construct(public mixed $v = null) {}
+
+    public function toLivewire()
+    {
+        return ['v' => $this->v];
+    }
+
+    public static function fromLivewire($value)
+    {
+        return new static($value['v'] ?? null);
     }
 }


### PR DESCRIPTION
Alternative approaches from #10607 but more likely as simple guard against recursive hydrate nested synthesizers which targeting array-shaped synths.

## Problem

Since v4.4.1 (#10489), recursive update hydration re-applies synthesizer meta from the previous snapshot to nested values. That correctly keeps Collections / uploads / etc. intact when an ancestor path is updated.

It breaks when a nested (or top-level) value **changes shape** — e.g. an array item that was a `Wireable` is later set to a scalar:

```php
$component->set('array', [0 => new EmptyObject]); // Wireable
$component->set('array', [0 => 1]);               // int
// foreach() argument must be of type array|object, int given
// at WireableSynth.php
```

`WireableSynth`, `CollectionSynth`, `StdClassSynth`, and `FormObjectSynth` always loop the value. After #10489 they can receive a scalar (or `__rm__`) while still carrying the old meta.

`ArraySynth` already handled this case:

```php
// If we are "hydrating" a value about to be used in an update,
// Let's make sure it's actually an array before try to set it.
// This is most common in the case of "__rm__" values, but also
// applies to any non-array value...
if (! is_array($value)) {
    return $value;
}
```

The other array-shaped synthesizers did not. #10489 only exposed the gap by reusing snapshot meta on updates.

## Solution

Introduce a marker interface and enforce the rule once in `HandleSynths`:

```php
interface ArrayShapedSynth
{
    //
}
```

Synths that implement it: `ArraySynth`, `CollectionSynth` (via inheritance), `StdClassSynth`, `WireableSynth`, `FormObjectSynth`.

In `hydratePropertyUpdate`, after resolving the synth from snapshot meta:

```php
if ($synth instanceof ArrayShapedSynth && ! is_array($value)) {
    return $value;
}
```

- Snapshot meta is still attached exactly as today (security contract unchanged: meta only from the checksum-verified snapshot).
- Array-shaped synths are skipped when the incoming value is not an array; scalar-friendly synths (Carbon, Enum, Int, Float, Stringable) are unaffected.
- Third-party / userland synths that assume array wire data implement the same interface — no central key list and no special `registerSynth()` path.

`ArraySynth`’s existing local guard is left in place for non-update paths. No per-synth one-liners are added on the other classes.

No changes to the #10489 recursion path. Nested Collections and uploads still re-hydrate when the wire value remains array-shaped; type swaps and `__rm__` fall through cleanly.

This is an alternative to per-synth guards and to approaches that compare the incoming value’s shape against the previous value before attaching meta. Here, meta is always taken from the snapshot; we only refuse to apply it when the value cannot be what that meta describes.

## Tests

- Nested Collection replaced with a scalar is left alone; siblings still re-hydrate
- Nested Wireable / stdClass replaced with a scalar is left alone
- Top-level Collection / Wireable / stdClass replaced with a scalar is left alone
- Replacing a Wireable array item with a scalar via `Livewire::test()->set()` does not throw
- Form object shape change is left alone

## Docs

Add the information about this in [Synthetizers](https://livewire.laravel.com/docs/4.x/synthesizers)

Fixes: https://github.com/livewire/livewire/issues/10606