### PR TITLE
[4.x] Share the component instance with views during an island render

### DIFF
--- a/src/Features/SupportIslands/HandlesIslands.php
+++ b/src/Features/SupportIslands/HandlesIslands.php
@@ -217,9 +217,16 @@ trait HandlesIslands
 
         $view->with($data);
 
+        // Blade components and third-party packages detect the Livewire context
+        // through the shared "__livewire" variable, so an island render has to
+        // share it the same way a full component render does...
+        $revertShare = Utils::shareWithViews('__livewire', $this);
+
         $finish = trigger('renderIsland', $this, $name, $view, $properties);
 
         $html = $view->render();
+
+        $revertShare();
 
         $replaceHtml = function ($newHtml) use (&$html) {
             $html = $newHtml;

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -536,6 +536,34 @@ class UnitTest extends TestCase
         $this->assertCount(1, $fragments, 'Expected only one island fragment but got ' . count($fragments));
     }
 
+    public function test_island_render_shares_the_component_with_views()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public function repaint()
+            {
+                $this->renderIsland('probe');
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    @island(name: 'probe')
+                        <div>shared: {{ app('view')->shared('__livewire') ? 'yes' : 'no' }}</div>
+                    @endisland
+                </div>
+                HTML;
+            }
+        });
+
+        $component->assertSee('shared: yes');
+
+        $component->call('repaint');
+
+        $fragments = implode('', $component->effects['islandFragments'] ?? []);
+
+        $this->assertStringContainsString('shared: yes', $fragments);
+    }
+
     public function test_island_directive_supports_nested_parentheses_in_expression()
     {
         Livewire::test(new class extends \Livewire\Component {


### PR DESCRIPTION
1️⃣ **Is this something that is wanted/needed?** It fixes a bug: a bound Blade component inside an island loses its binding when that island is rendered on its own. No discussion was opened first, happy to move this to one if preferred.

2️⃣ **Did you create a branch for your fix?** Yes, `fix/share-livewire-instance-during-island-render` against `4.x`.

3️⃣ **Does it contain multiple, unrelated changes?** No, one change plus its test.

4️⃣ **Does it include tests?** Yes, a unit test in `SupportIslands/UnitTest.php` that fails without the change.

5️⃣ **Description**

A Blade component with a `wire:model` binding loses that binding when the island around it is rendered on its own through `renderIsland()`. The server still holds the value, but the re-rendered markup comes back unbound, so the control shows up empty until the next full page load.

The cause is an asymmetry between the two render paths. `HandleComponents::render()` shares the component instance with every view for the duration of the render:

```php
$revertA = Utils::shareWithViews('__livewire', $component);
```

`HandlesIslands::renderIslandView()` only puts it into the view's own data:

```php
$scope = array_merge(['__livewire' => $this], $properties);

$view->with($scope);
```

That difference matters for any package that detects the Livewire context through `View::shared('__livewire')` rather than through a variable inside the view being rendered. Blade components render in their own view instance, so the `with()` data never reaches them, and during a standalone island render they conclude they are outside Livewire and drop their `wire:model` handling.

**The change**

Share the instance for the duration of the island render and revert afterwards, which is what `SupportValidation::renderIsland()` already does for the error bag a few lines away:

```php
$revertShare = Utils::shareWithViews('__livewire', $this);

$finish = trigger('renderIsland', $this, $name, $view, $properties);

$html = $view->render();

$revertShare();
```

`shareWithViews()` remembers the previous value and restores it, so nested islands and nested component renders stay correct.

**Reproduction**

```php
Livewire::test(new class extends Component {
    public function repaint()
    {
        $this->renderIsland('probe');
    }

    public function render()
    {
        return <<<'HTML'
        <div>
            @island(name: 'probe')
                <div>shared: {{ app('view')->shared('__livewire') ? 'yes' : 'no' }}</div>
            @endisland
        </div>
        HTML;
    }
});
```

The initial render prints `shared: yes`, the island fragment produced by `repaint()` prints `shared: no`. The added test covers exactly that. The rest of the island unit tests pass unchanged.