### PR TITLE
Fix Livewire updates from route binding error pages

### DIFF
--- a/src/Mechanisms/PersistentMiddleware/BrowserTest.php
+++ b/src/Mechanisms/PersistentMiddleware/BrowserTest.php
@@ -35,6 +35,11 @@ class BrowserTest extends BrowserTestCase
 
     public static function tweakApplicationHook() {
         return function() {
+            config()->set('view.paths', [
+                __DIR__.'/fixtures/views',
+                ...config('view.paths'),
+            ]);
+
             Livewire::addPersistentMiddleware([AllowListedMiddleware::class, IsBanned::class]);
 
             // Overwrite the default route for these tests, so the middleware is included
@@ -85,6 +90,8 @@ class BrowserTest extends BrowserTestCase
             Livewire::component('child-with-modelable', ChildComponentWithModelable::class);
             Livewire::component('page-with-explicit-binding', PageComponentWithExplicitBinding::class);
             Livewire::component('child-for-explicit-binding', ChildForExplicitBinding::class);
+            Livewire::component('error-page-counter', ErrorPageCounter::class);
+            Livewire::component('error-page-child', ErrorPageChild::class);
 
             Route::get('/page-with-reactive-child/{post}', PageComponentWithReactiveChild::class)
                 ->middleware('web');
@@ -96,8 +103,29 @@ class BrowserTest extends BrowserTestCase
 
             Route::get('/explicit-binding/{bound_model}', PageComponentWithExplicitBinding::class)
                 ->middleware('web');
+
+            Route::get('/model-binding-error/{post}', fn (Post $post) => 'Found')
+                ->middleware('web');
         };
     }
+
+    public function test_component_on_route_model_binding_404_can_make_repeated_livewire_requests()
+    {
+        Livewire::visit(Component::class)
+            ->visit('/model-binding-error/40472')
+            ->assertSee('Count: 0')
+            ->waitForLivewire()->click('@error-page-increment')
+            ->assertSee('Count: 1')
+            ->waitForLivewire()->click('@error-page-increment')
+            ->assertSee('Count: 2')
+            ->waitForLivewire()->click('@show-error-page-child')
+            ->assertSee('Child count: 0')
+            ->waitForLivewire()->click('@error-page-child-increment')
+            ->assertSee('Child count: 1')
+            ->assertMissing('#livewire-error')
+        ;
+    }
+
     public function test_that_persistent_middleware_is_applied_to_subsequent_livewire_requests()
     {
         // @todo: Copy implementation from V2 for persistent middleware and ensure localisation and subdirectory hosting are supported. https://github.com/livewire/livewire/pull/5490
@@ -724,6 +752,49 @@ class ChildForExplicitBinding extends BaseComponent
         <div>
             <span dusk="child-output">child loaded</span>
         </div>
+        HTML;
+    }
+}
+
+class ErrorPageCounter extends BaseComponent
+{
+    public $count = 0;
+
+    public $showChild = false;
+
+    public function increment()
+    {
+        $this->count++;
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <button wire:click="increment" dusk="error-page-increment">Count: {{ $count }}</button>
+            <button wire:click="$set('showChild', true)" dusk="show-error-page-child">Show child</button>
+
+            @if ($showChild)
+                <livewire:error-page-child />
+            @endif
+        </div>
+        HTML;
+    }
+}
+
+class ErrorPageChild extends BaseComponent
+{
+    public $count = 0;
+
+    public function increment()
+    {
+        $this->count++;
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <button wire:click="increment" dusk="error-page-child-increment">Child count: {{ $count }}</button>
         HTML;
     }
 }

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -8,12 +8,17 @@ use Illuminate\Routing\Router;
 use Livewire\Mechanisms\Mechanism;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use function Livewire\on;
+use function Livewire\store;
 use Illuminate\Support\Str;
 use Livewire\Drawer\Utils;
 use Livewire\Mechanisms\HandleRequests\HandleRequests;
 
 class PersistentMiddleware extends Mechanism
 {
+    protected const ROUTE_BINDING_ERROR_PAGE = 'routeBindingErrorPage';
+
+    protected const ROUTE_BINDING_ERROR_PAGE_ATTRIBUTE = 'livewire_route_binding_error_page';
+
     protected static $persistentMiddleware = [
         \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
         \Laravel\Jetstream\Http\Middleware\AuthenticateSession::class,
@@ -32,7 +37,42 @@ class PersistentMiddleware extends Mechanism
 
     function boot()
     {
+        app('view')->composer('errors::*', function ($view) {
+            $exception = $view->getData()['exception'] ?? null;
+
+            if (
+                $exception instanceof NotFoundHttpException
+                && $exception->getPrevious() instanceof ModelNotFoundException
+            ) {
+                request()->attributes->set(static::ROUTE_BINDING_ERROR_PAGE_ATTRIBUTE, true);
+            }
+        });
+
+        on('mount', function ($component, $params, $key, $parent) {
+            if (
+                request()->attributes->get(static::ROUTE_BINDING_ERROR_PAGE_ATTRIBUTE)
+                || ($parent && store($parent)->get(static::ROUTE_BINDING_ERROR_PAGE))
+            ) {
+                store($component)->set(static::ROUTE_BINDING_ERROR_PAGE, true);
+            }
+        });
+
+        on('hydrate', function ($component, $memo) {
+            if ($memo[static::ROUTE_BINDING_ERROR_PAGE] ?? false) {
+                store($component)->set(static::ROUTE_BINDING_ERROR_PAGE, true);
+            }
+        });
+
         on('dehydrate', function ($component, $context) {
+            // Components rendered by a route model binding 404 never made it
+            // through the original route's middleware, so there is no
+            // successful middleware context to replay on their updates.
+            if (store($component)->get(static::ROUTE_BINDING_ERROR_PAGE)) {
+                $context->addMemo(static::ROUTE_BINDING_ERROR_PAGE, true);
+
+                return;
+            }
+
             [$path, $method] = $this->extractPathAndMethodFromRequest();
 
             $context->addMemo('path', $path);
@@ -42,6 +82,10 @@ class PersistentMiddleware extends Mechanism
         on('snapshot-verified', function ($snapshot) {
             // Only apply middleware to requests hitting the Livewire update endpoint, and not any fake requests such as a test.
             if (! app(HandleRequests::class)->isLivewireRoute()) return;
+
+            // This flag was added to the checksummed snapshot while Laravel
+            // rendered a route model binding 404 response.
+            if ($snapshot['memo'][static::ROUTE_BINDING_ERROR_PAGE] ?? false) return;
 
             $this->extractPathAndMethodFromSnapshot($snapshot);
 
@@ -119,11 +163,7 @@ class PersistentMiddleware extends Mechanism
         // Only send through pipeline if there are middleware found
         if (is_null($middleware) || $middleware === []) return;
 
-        try {
-            Utils::applyMiddleware($request, $middleware);
-        } catch (ModelNotFoundException $e) {
-            return;
-        }
+        Utils::applyMiddleware($request, $middleware);
 
         $this->middlewareAppliedFor[$routeKey] = true;
 

--- a/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
+++ b/src/Mechanisms/PersistentMiddleware/PersistentMiddleware.php
@@ -3,6 +3,7 @@
 namespace Livewire\Mechanisms\PersistentMiddleware;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Routing\Router;
 use Livewire\Mechanisms\Mechanism;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -118,7 +119,11 @@ class PersistentMiddleware extends Mechanism
         // Only send through pipeline if there are middleware found
         if (is_null($middleware) || $middleware === []) return;
 
-        Utils::applyMiddleware($request, $middleware);
+        try {
+            Utils::applyMiddleware($request, $middleware);
+        } catch (ModelNotFoundException $e) {
+            return;
+        }
 
         $this->middlewareAppliedFor[$routeKey] = true;
 

--- a/src/Mechanisms/PersistentMiddleware/UnitTest.php
+++ b/src/Mechanisms/PersistentMiddleware/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Mechanisms\PersistentMiddleware;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Facades\Facade;
@@ -150,6 +151,45 @@ class UnitTest extends \LegacyTests\Unit\TestCase
         $response->assertJsonPath('components.0.snapshot', $snapshot);
     }
 
+    public function test_model_not_found_during_middleware_replay_does_not_run_the_component_action()
+    {
+        $base = Livewire::getPersistentMiddleware();
+
+        try {
+            Livewire::addPersistentMiddleware(ThrowingMiddleware::class);
+
+            $component = Livewire::test(SensitiveActionComponent::class);
+            $snapshot = json_encode($component->snapshot);
+
+            foreach (app('router')->getRoutes() as $route) {
+                if (str_contains($route->uri(), 'livewire-unit-test-endpoint')) {
+                    $route->middleware([ThrowingMiddleware::class]);
+                    break;
+                }
+            }
+
+            SensitiveActionComponent::$actionRan = false;
+
+            $response = $this->withHeaders(['X-Livewire' => 'true'])
+                ->postJson(EndpointResolver::updatePath(), [
+                    'components' => [[
+                        'calls' => [[
+                            'method' => 'performSensitiveAction',
+                            'params' => [],
+                            'metadata' => [],
+                        ]],
+                        'updates' => [],
+                        'snapshot' => $snapshot,
+                    ]],
+                ]);
+
+            $response->assertNotFound();
+            $this->assertFalse(SensitiveActionComponent::$actionRan);
+        } finally {
+            Livewire::setPersistentMiddleware($base);
+        }
+    }
+
 }
 
 class EmptyComponent extends BaseComponent
@@ -161,5 +201,23 @@ class EmptyComponent extends BaseComponent
 
         </div>
         HTML;
+    }
+}
+
+class SensitiveActionComponent extends EmptyComponent
+{
+    public static $actionRan = false;
+
+    public function performSensitiveAction()
+    {
+        static::$actionRan = true;
+    }
+}
+
+class ThrowingMiddleware
+{
+    public function handle(Request $request, \Closure $next): \Symfony\Component\HttpFoundation\Response
+    {
+        throw (new ModelNotFoundException)->setModel('App\\MissingModel', ['missing']);
     }
 }

--- a/src/Mechanisms/PersistentMiddleware/fixtures/views/errors/404.blade.php
+++ b/src/Mechanisms/PersistentMiddleware/fixtures/views/errors/404.blade.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        @livewireStyles
+    </head>
+    <body>
+        <livewire:error-page-counter />
+
+        @livewireScripts
+    </body>
+</html>


### PR DESCRIPTION
## Problem

When route model binding renders a custom 404 page containing a Livewire component, interacting with that component opens a second 404 in Livewire's error modal instead of running the action.

The component's snapshot records the failed route's path and method even though that route's middleware pipeline never completed. On update, Livewire treats those values as a successful middleware context, rematches the route, and hits the same missing binding before the component action can run.

## Approaches considered

- **Minimum:** catch `ModelNotFoundException` during persistent middleware replay. This is tiny, but it fails open: middleware after `SubstituteBindings`, including authorization, can be skipped.
- **Maximum:** record the exact middleware context that completed during every initial request and replay only that context. This is conceptually pure, but it redesigns the persistent middleware lifecycle for a narrow error-page bug.
- **Evaporate:** render exception pages through a separate internal/fallback route, or make them non-Livewire, so the failed route never becomes the component's update context. That moves the problem into Laravel/application error-page architecture or removes the desired interactivity.

## Chosen path

Capture the provenance on the original request: when Laravel renders `errors::*` because route model binding failed, mark each component in its checksummed snapshot. Only those verified snapshots skip persistent middleware replay.

The marker is restored per component on hydration and inherited by children mounted later, so it survives repeated interactions without leaking across bundled components. A component rendered from a valid route receives no marker; if its model disappears later, the update still fails closed before its action runs.

## Levels

1. [Level 1: Ignore missing models during middleware replay](https://github.com/livewire/livewire/commit/9e651f5179715d6cc407b2657e7a4e1984f30c80) — the smallest readable patch and the heart of the original proposal.
2. [Level 2: Preserve verified error-page context](https://github.com/livewire/livewire/commit/260ee4c45b552672b42a6ee618cb01a61a9c8676) — replaces the broad catch with the balanced, fail-closed solution and adds end-to-end and security regressions.

## Verification

- Reproduced the original behavior in a real Laravel app: `Count: 0` opened a second 404 in Livewire's modal.
- Verified the final playground behavior through `Count: 0 → 1 → 2` with no error modal.
- `./vendor/bin/phpunit --configuration phpunit.xml.dist src/Mechanisms/PersistentMiddleware/UnitTest.php` — 5 tests, 9 assertions.
- `composer test:browser -- --filter=PersistentMiddleware` — 9 tests, 35 assertions.

This supersedes #10592 and addresses the report and minimal proposal in #10572.

## Contribution checklist

1. This behavior is wanted and already demonstrated by #10572 and #10592; no separate discussion was opened.
2. The change is on a dedicated branch.
3. The PR contains one focused fix.
4. It includes unit and browser coverage.
