### PR TITLE
[4.x] Allow original filenames for temporary preview downloads

### DIFF
--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -179,6 +179,12 @@ However, Livewire solves this issue by providing a temporary, signed URL that pr
 
 This URL is protected against showing files in directories above the temporary directory. And, because it's signed, users can't abuse this URL to preview other files on your system.
 
+If users can download the preview, you may use the original upload name as the suggested filename by passing `useOriginalFilename: true`:
+
+```blade
+<a href="{{ $photo->temporaryUrl(useOriginalFilename: true) }}">Download preview</a>
+```
+
 > [!tip] S3 temporary signed URLs
 > If you've configured Livewire to use S3 for temporary file storage, calling `->temporaryUrl()` will generate a temporary, signed URL to S3 directly so that image previews aren't loaded from your Laravel application server.
 

--- a/src/Drawer/Utils.php
+++ b/src/Drawer/Utils.php
@@ -65,7 +65,7 @@ class Utils extends BaseUtils
             fn ($headers) => response($content, 200, $headers));
     }
 
-    static function pretendPreviewResponseIsPreviewFile($filename)
+    static function pretendPreviewResponseIsPreviewFile($filename, $downloadName = null)
     {
         $file = FileUploadConfiguration::path($filename);
         $storage = FileUploadConfiguration::storage();
@@ -73,7 +73,7 @@ class Utils extends BaseUtils
         $lastModified = FileUploadConfiguration::lastModified($file);
 
         return self::cachedFileResponse($filename, $mimeType, $lastModified,
-            fn ($headers) => $storage->download($file, $filename, $headers));
+            fn ($headers) => $storage->download($file, $downloadName ?? $filename, $headers));
     }
 
     static private function cachedFileResponse($filename, $contentType, $lastModified, $downloadCallback)

--- a/src/Features/SupportFileUploads/FilePreviewController.php
+++ b/src/Features/SupportFileUploads/FilePreviewController.php
@@ -19,7 +19,9 @@ class FilePreviewController implements HasMiddleware
     {
         abort_unless(request()->hasValidRelativeSignature(), 401);
 
-        $downloadName = (new TemporaryUploadedFile($filename, FileUploadConfiguration::disk()))->getClientOriginalName();
+        $downloadName = request()->boolean('useOriginalFilename')
+            ? (new TemporaryUploadedFile($filename, FileUploadConfiguration::disk()))->getClientOriginalName()
+            : null;
 
         return Utils::pretendPreviewResponseIsPreviewFile($filename, $downloadName);
     }

--- a/src/Features/SupportFileUploads/FilePreviewController.php
+++ b/src/Features/SupportFileUploads/FilePreviewController.php
@@ -19,6 +19,8 @@ class FilePreviewController implements HasMiddleware
     {
         abort_unless(request()->hasValidRelativeSignature(), 401);
 
-        return Utils::pretendPreviewResponseIsPreviewFile($filename);
+        $downloadName = (new TemporaryUploadedFile($filename, FileUploadConfiguration::disk()))->getClientOriginalName();
+
+        return Utils::pretendPreviewResponseIsPreviewFile($filename, $downloadName);
     }
 }

--- a/src/Features/SupportFileUploads/TemporaryUploadedFile.php
+++ b/src/Features/SupportFileUploads/TemporaryUploadedFile.php
@@ -131,7 +131,7 @@ class TemporaryUploadedFile extends UploadedFile
         return @getimagesize(stream_get_meta_data($tmpFile)['uri']);
     }
 
-    public function temporaryUrl()
+    public function temporaryUrl(bool $useOriginalFilename = false)
     {
         if (!$this->isPreviewable()) {
             throw new FileNotPreviewableException($this);
@@ -150,8 +150,14 @@ class TemporaryUploadedFile extends UploadedFile
             return $this->storage->temporaryUrl($this->path, now()->addDay());
         }
 
+        $parameters = ['filename' => $this->getFilename()];
+
+        if ($useOriginalFilename) {
+            $parameters['useOriginalFilename'] = true;
+        }
+
         return GenerateSignedUploadUrlFacade::signedRoute(
-            'livewire.preview-file', now()->addMinutes(30)->endOfHour(), ['filename' => $this->getFilename()]
+            'livewire.preview-file', now()->addMinutes(30)->endOfHour(), $parameters
         );
     }
 

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -552,7 +552,7 @@ class UnitTest extends \Tests\TestCase
         $this->assertTrue($photo->isPreviewable());
     }
 
-    public function test_temporary_preview_uses_the_original_filename_for_downloads()
+    public function test_temporary_preview_uses_the_temporary_filename_for_downloads_by_default()
     {
         Storage::fake('avatars');
 
@@ -563,6 +563,20 @@ class UnitTest extends \Tests\TestCase
         SupportDisablingBackButtonCache::$disableBackButtonCache = false;
 
         $this->get($photo->temporaryUrl())
+            ->assertDownload($photo->getFilename());
+    }
+
+    public function test_temporary_preview_can_use_the_original_filename_for_downloads()
+    {
+        Storage::fake('avatars');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', UploadedFile::fake()->image('avatar.jpg'))
+            ->viewData('photo');
+
+        SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+
+        $this->get($photo->temporaryUrl(useOriginalFilename: true))
             ->assertDownload('avatar.jpg');
     }
 

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -685,6 +685,16 @@ class UnitTest extends \Tests\TestCase
         $this->get(str($photo->temporaryUrl())->before('&signature='))->assertStatus(401);
     }
 
+    public function test_original_filename_preview_option_must_be_part_of_the_signed_url()
+    {
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', UploadedFile::fake()->image('avatar.jpg'))
+            ->viewData('photo');
+
+        $this->get($photo->temporaryUrl().'&useOriginalFilename=1')
+            ->assertStatus(401);
+    }
+
     public function test_file_paths_cant_include_slashes_which_would_allow_them_to_access_other_private_directories()
     {
         $this->expectException(PathTraversalDetected::class);

--- a/src/Features/SupportFileUploads/UnitTest.php
+++ b/src/Features/SupportFileUploads/UnitTest.php
@@ -552,6 +552,20 @@ class UnitTest extends \Tests\TestCase
         $this->assertTrue($photo->isPreviewable());
     }
 
+    public function test_temporary_preview_uses_the_original_filename_for_downloads()
+    {
+        Storage::fake('avatars');
+
+        $photo = Livewire::test(FileUploadComponent::class)
+            ->set('photo', UploadedFile::fake()->image('avatar.jpg'))
+            ->viewData('photo');
+
+        SupportDisablingBackButtonCache::$disableBackButtonCache = false;
+
+        $this->get($photo->temporaryUrl())
+            ->assertDownload('avatar.jpg');
+    }
+
     public function test_file_is_not_sent_on_cache_hit()
     {
         Storage::fake('avatars');


### PR DESCRIPTION
This follows up on #10381 and applies the opt-in approach to the current `4.x` signed-preview URL flow.

## Problem

- **What the user experiences:** Downloading a locally served temporary preview uses Livewire's opaque temporary hash as the suggested filename.
- **What they expected:** The download should be suggested with the name of the file they uploaded, such as `avatar.jpg`.
- **What caused the difference:** The local preview response uses the same value as both the private storage lookup key and the public `Content-Disposition` filename. S3/GCS already distinguish these concerns and return the original upload name.

## Solution

The final API preserves existing behavior by default and opts into the original name with `temporaryUrl(useOriginalFilename: true)`. The option travels inside the signed URL and is only honored after signature validation.

- [Level 1 — separate the storage key from the download name](https://github.com/livewire/livewire/commit/b82645a5cb8ccf51e66d035e06249acb70145fae): the smallest readable fix, using the original name for every local preview download.
- [Level 2 — make the behavior opt-in](https://github.com/livewire/livewire/commit/7df879ea27e28268a7c23911189ae18a00a108e0): preserve the current default, add the named argument, and carry the choice through the signed preview URL.
- [Level 3 — verify and document the boundary](https://github.com/livewire/livewire/commit/6ba30d9dce6bfb1fbc4e22591ba4042ffa08bb79): prove the option cannot be appended after signing and document the user-facing API.

```blade
<a href="{{ $photo->temporaryUrl(useOriginalFilename: true) }}">Download preview</a>
```

## Verification

- Reproduced the hashed filename against unmodified `4.x`.
- Passed all 1,397 unit tests (3 incomplete, 13 skipped).
- Passed all 65 `SupportFileUploads` unit tests.
- Verified in a real Laravel app that the default URL returns the temporary name, the opt-in URL returns the original name, and a tampered URL returns 401.
