### PR TITLE
[3.x] Keep wire:dirty subscribed to every target

### DIFF
--- a/js/directives/wire-dirty.js
+++ b/js/directives/wire-dirty.js
@@ -35,11 +35,9 @@ directive('dirty', ({ el, directive, component }) => {
             isDirty = JSON.stringify(component.canonical) !== JSON.stringify(component.reactive)
         } else {
             for (let i = 0; i < targets.length; i++) {
-                if (isDirty) break;
-
                 let target = targets[i]
 
-                isDirty = JSON.stringify(dataGet(component.canonical, target)) !== JSON.stringify(dataGet(component.reactive, target))
+                isDirty = JSON.stringify(dataGet(component.canonical, target)) !== JSON.stringify(dataGet(component.reactive, target)) || isDirty
             }
         }
 

--- a/js/directives/wire-dirty.js
+++ b/js/directives/wire-dirty.js
@@ -37,7 +37,12 @@ directive('dirty', ({ el, directive, component }) => {
             for (let i = 0; i < targets.length; i++) {
                 let target = targets[i]
 
-                isDirty = JSON.stringify(dataGet(component.canonical, target)) !== JSON.stringify(dataGet(component.reactive, target)) || isDirty
+                let canonical = JSON.stringify(dataGet(component.canonical, target))
+                let reactive = JSON.stringify(dataGet(component.reactive, target))
+
+                if (canonical !== reactive) {
+                    isDirty = true
+                }
             }
         }
 

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -36,6 +36,39 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    function test_wire_dirty_keeps_tracking_every_target_after_a_commit()
+    {
+        Livewire::visit(new class extends Component {
+            public $first = false;
+
+            public $second = '';
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <input dusk="first" type="checkbox" wire:model="first" />
+                        <input dusk="second" type="text" wire:model="second" />
+
+                        <button dusk="commit" type="button" wire:click="$commit">Commit</button>
+
+                        <div dusk="dirty" wire:dirty.class="dirty" wire:target="first, second"></div>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertAttributeDoesntContain('@dirty', 'class', 'dirty')
+            ->check('@first')
+            ->pause(50)
+            ->assertAttributeContains('@dirty', 'class', 'dirty')
+            ->waitForLivewire()->click('@commit')
+            ->waitUntil("!document.querySelector('[dusk=\"dirty\"]').classList.contains('dirty')")
+            ->type('@second', 'Later target')
+            ->pause(50)
+            ->assertAttributeContains('@dirty', 'class', 'dirty')
+        ;
+    }
+
     function test_can_update_bound_value_from_lifecyle_hook()
     {
         Livewire::visit(new class extends Component {


### PR DESCRIPTION
This is a staged alternative to #10604.

## Problem

- **What the user experiences:** After a `wire:dirty` indicator sees an earlier target become dirty and that change is committed, editing a later target no longer shows the dirty indicator. In the reported app, the unsaved-changes bar and Save button stay missing until a page refresh.
- **What the user expected:** Every property listed in `wire:target` should remain observable, so editing any of them immediately shows the unsaved state—even after another target has already been committed.
- **Why reality differs:** Alpine rebuilds an effect's dependencies from the reactive values read during its latest run. The dirty-target loop exits after the first dirty target, so later targets are not read and their subscriptions are dropped. The commit hook then clears the visible dirty state outside the effect, leaving those subscriptions missing.

## Solution

Keep the fix local to `wire:dirty`: read every declared target on every effect run while remembering whether any target differs.

- [Level 1 — minimal runtime fix](https://github.com/livewire/livewire/commit/e80355b26b83304d2163161d847894c69a7981fd): remove the early exit and accumulate dirty state without short-circuiting reactive reads.
- [Level 2 — explicit invariant](https://github.com/livewire/livewire/commit/b49137f779932032f9a3620fa29e8ae3f0c0ae99): make each canonical/reactive comparison explicit so it is clear that every target must be evaluated.
- [Level 3 — behavioral coverage](https://github.com/livewire/livewire/commit/a3bd4a6882f993b89687737d7e57f22e651bf02e): reproduce an earlier target becoming dirty and committing, then prove a later target still activates `wire:dirty` in the browser.

## Verification

- `npm run build`
- `DUSK_DRIVER_URL=http://localhost:9516 DUSK_SERVE_PORT=8002 FORCE_RUN=1 vendor/bin/phpunit src/Features/SupportDataBinding/BrowserTest.php` — 9 tests, 29 assertions
- Real Laravel browser reproduction against the exact PR base and final branch
