### PR TITLE
[4.x] Preserve structured strings in URL properties

### DIFF
--- a/src/Drawer/BaseUtils.php
+++ b/src/Drawer/BaseUtils.php
@@ -147,4 +147,60 @@ class BaseUtils
 
         return $property->hasType() && (! $property->isInitialized($target));
     }
+
+    /**
+     * Compare a value's native PHP type with a property's declared type.
+     *
+     * This deliberately does not apply PHP's weak scalar coercion. It returns
+     * null when the property is missing or untyped because there is no declared
+     * type contract to compare the value against.
+     */
+    static function propertyTypeMatchesValue($target, $property, $value): ?bool {
+        if (! $property || ! property_exists($target, $property)) return null;
+
+        $reflectionProperty = static::getProperty($target, $property);
+
+        if (! $type = $reflectionProperty->getType()) return null;
+
+        return static::typeMatchesValue($type, $value, $reflectionProperty->getDeclaringClass());
+    }
+
+    protected static function typeMatchesValue($type, $value, $declaringClass): bool {
+        if ($value === null) return $type->allowsNull();
+
+        if ($type instanceof \ReflectionUnionType) {
+            foreach ($type->getTypes() as $unionType) {
+                if (static::typeMatchesValue($unionType, $value, $declaringClass)) return true;
+            }
+
+            return false;
+        }
+
+        if ($type instanceof \ReflectionIntersectionType) {
+            foreach ($type->getTypes() as $intersectionType) {
+                if (! static::typeMatchesValue($intersectionType, $value, $declaringClass)) return false;
+            }
+
+            return true;
+        }
+
+        $name = $type->getName();
+
+        return match ($name) {
+            'mixed' => true,
+            'string' => is_string($value),
+            'int' => is_int($value),
+            'float' => is_float($value),
+            'bool' => is_bool($value),
+            'array' => is_array($value),
+            'object' => is_object($value),
+            'iterable' => is_iterable($value),
+            'callable' => is_callable($value),
+            'false' => $value === false,
+            'true' => $value === true,
+            'self', 'static' => $value instanceof ($declaringClass->getName()),
+            'parent' => ($parent = $declaringClass->getParentClass()) && $value instanceof ($parent->getName()),
+            default => $value instanceof $name,
+        };
+    }
 }

--- a/src/Drawer/PropertyTypeUnitTest.php
+++ b/src/Drawer/PropertyTypeUnitTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Livewire\Drawer;
+
+class PropertyTypeUnitTest extends \Tests\TestCase
+{
+    function test_it_matches_values_against_named_property_types()
+    {
+        $target = new PropertyTypeFixture;
+
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'string', 'value'));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'string', 1));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'integer', 1));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'integer', '1'));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'float', 1.5));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'float', 1));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'boolean', true));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'array', []));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'object', new \stdClass));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'iterable', []));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'mixed', new \stdClass));
+    }
+
+    function test_it_matches_nullable_and_union_property_types()
+    {
+        $target = new PropertyTypeFixture;
+
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'nullableString', null));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'nullableString', 'value'));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'nullableString', []));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'stringOrArray', 'value'));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'stringOrArray', []));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'stringOrArray', 1));
+    }
+
+    function test_it_matches_class_and_interface_property_types()
+    {
+        $target = new PropertyTypeFixture;
+
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'objectType', new PropertyTypeObject));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'objectType', new \stdClass));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'interfaceType', new PropertyTypeObject));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'intersectionType', new PropertyTypeObject));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'intersectionType', new PropertyTypeInterfaceOnlyObject));
+    }
+
+    function test_it_reports_when_there_is_no_declared_type_to_match_against()
+    {
+        $target = new PropertyTypeFixture;
+
+        $this->assertNull(Utils::propertyTypeMatchesValue($target, 'untyped', 'value'));
+        $this->assertNull(Utils::propertyTypeMatchesValue($target, 'missing', 'value'));
+    }
+}
+
+interface PropertyTypeInterface
+{
+}
+
+class PropertyTypeObject implements PropertyTypeInterface, \Stringable
+{
+    public function __toString(): string
+    {
+        return '';
+    }
+}
+
+class PropertyTypeInterfaceOnlyObject implements PropertyTypeInterface
+{
+}
+
+class PropertyTypeFixture
+{
+    public string $string;
+    public int $integer;
+    public float $float;
+    public bool $boolean;
+    public array $array;
+    public object $object;
+    public iterable $iterable;
+    public mixed $mixed;
+    public ?string $nullableString;
+    public string|array $stringOrArray;
+    public PropertyTypeObject $objectType;
+    public PropertyTypeInterface $interfaceType;
+    public PropertyTypeInterface&\Stringable $intersectionType;
+    public $untyped;
+}

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -7,6 +7,7 @@ use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\Features\SupportFormObjects\Form;
 use ReflectionClass;
 use ReflectionNamedType;
+use ReflectionUnionType;
 
 #[\Attribute]
 class BaseUrl extends LivewireAttribute
@@ -50,14 +51,25 @@ class BaseUrl extends LivewireAttribute
         return false;
     }
 
-    protected function propertyIsTypedAsString()
+    protected function propertySupportsStringValues($value)
     {
+        if (is_string($value)) return true;
+
         $reflectionClass = new ReflectionClass($this->getSubTarget() ?? $this->getComponent());
+        $propertyName = $this->getSubName() ?? $this->getName();
 
-        if ($this->getSubName() && $reflectionClass->hasProperty($this->getSubName())) {
-            $type = $reflectionClass->getProperty($this->getSubName())->getType();
+        if (! $propertyName || ! $reflectionClass->hasProperty($propertyName)) return false;
 
-            return $type instanceof ReflectionNamedType && $type->getName() === 'string';
+        $type = $reflectionClass->getProperty($propertyName)->getType();
+
+        if ($type instanceof ReflectionNamedType) {
+            return $type->getName() === 'string';
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            foreach ($type->getTypes() as $type) {
+                if ($type->getName() === 'string') return true;
+            }
         }
 
         return false;
@@ -81,7 +93,7 @@ class BaseUrl extends LivewireAttribute
 
         $original = $this->getValue();
 
-        if (is_string($initialValue) && is_array($decoded) && (is_string($original) || $this->propertyIsTypedAsString())) {
+        if (is_string($initialValue) && is_array($decoded) && $this->propertySupportsStringValues($original)) {
             $decoded = null;
         }
 

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\Features\SupportFormObjects\Form;
 use ReflectionClass;
+use ReflectionNamedType;
 
 #[\Attribute]
 class BaseUrl extends LivewireAttribute
@@ -49,6 +50,19 @@ class BaseUrl extends LivewireAttribute
         return false;
     }
 
+    protected function propertyIsTypedAsString()
+    {
+        $reflectionClass = new ReflectionClass($this->getSubTarget() ?? $this->getComponent());
+
+        if ($this->getSubName() && $reflectionClass->hasProperty($this->getSubName())) {
+            $type = $reflectionClass->getProperty($this->getSubName())->getType();
+
+            return $type instanceof ReflectionNamedType && $type->getName() === 'string';
+        }
+
+        return false;
+    }
+
     public function setPropertyFromQueryString()
     {
         if ($this->as === null && $this->isOnFormObjectProperty()) {
@@ -65,13 +79,15 @@ class BaseUrl extends LivewireAttribute
             ? json_decode(json_encode($initialValue, flags: JSON_BIGINT_AS_STRING), true, flags: JSON_BIGINT_AS_STRING)
             : json_decode($initialValue ?? '', true, flags: JSON_BIGINT_AS_STRING);
 
-        if (is_string($initialValue) && is_array($decoded) && is_string($this->getValue())) {
+        $original = $this->getValue();
+
+        if (is_string($initialValue) && is_array($decoded) && (is_string($original) || $this->propertyIsTypedAsString())) {
             $decoded = null;
         }
 
         // If only part of an array is present in the query string,
         // we want to merge instead of override the value...
-        if (is_array($decoded) && is_array($original = $this->getValue())) {
+        if (is_array($decoded) && is_array($original)) {
             $decoded = $this->recursivelyMergeArraysWithoutAppendingDuplicateValues($original, $decoded);
         }
 

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -65,6 +65,10 @@ class BaseUrl extends LivewireAttribute
             ? json_decode(json_encode($initialValue, flags: JSON_BIGINT_AS_STRING), true, flags: JSON_BIGINT_AS_STRING)
             : json_decode($initialValue ?? '', true, flags: JSON_BIGINT_AS_STRING);
 
+        if (is_string($initialValue) && is_array($decoded) && is_string($this->getValue())) {
+            $decoded = null;
+        }
+
         // If only part of an array is present in the query string,
         // we want to merge instead of override the value...
         if (is_array($decoded) && is_array($original = $this->getValue())) {

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -3,11 +3,10 @@
 namespace Livewire\Features\SupportQueryString;
 
 use Illuminate\Support\Arr;
+use Livewire\Drawer\Utils;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\Features\SupportFormObjects\Form;
 use ReflectionClass;
-use ReflectionNamedType;
-use ReflectionUnionType;
 
 #[\Attribute]
 class BaseUrl extends LivewireAttribute
@@ -51,30 +50,6 @@ class BaseUrl extends LivewireAttribute
         return false;
     }
 
-    protected function propertySupportsStringValues($value)
-    {
-        if (is_string($value)) return true;
-
-        $reflectionClass = new ReflectionClass($this->getSubTarget() ?? $this->getComponent());
-        $propertyName = $this->getSubName() ?? $this->getName();
-
-        if (! $propertyName || ! $reflectionClass->hasProperty($propertyName)) return false;
-
-        $type = $reflectionClass->getProperty($propertyName)->getType();
-
-        if ($type instanceof ReflectionNamedType) {
-            return $type->getName() === 'string';
-        }
-
-        if ($type instanceof ReflectionUnionType) {
-            foreach ($type->getTypes() as $type) {
-                if ($type->getName() === 'string') return true;
-            }
-        }
-
-        return false;
-    }
-
     public function setPropertyFromQueryString()
     {
         if ($this->as === null && $this->isOnFormObjectProperty()) {
@@ -93,8 +68,27 @@ class BaseUrl extends LivewireAttribute
 
         $original = $this->getValue();
 
-        if (is_string($initialValue) && is_array($decoded) && $this->propertySupportsStringValues($original)) {
-            $decoded = null;
+        if (is_string($initialValue) && is_array($decoded)) {
+            $target = $this->getSubTarget() ?? $this->getComponent();
+            $property = $this->getSubName() ?? $this->getName();
+
+            $decodedMatchesPropertyType = Utils::propertyTypeMatchesValue(
+                $target,
+                $property,
+                $decoded,
+            );
+            $initialValueMatchesPropertyType = Utils::propertyTypeMatchesValue(
+                $target,
+                $property,
+                $initialValue,
+            );
+
+            $propertyTypePrefersInitialValue = $decodedMatchesPropertyType === false && $initialValueMatchesPropertyType === true;
+            $untypedPropertyCurrentlyContainsString = $decodedMatchesPropertyType === null && is_string($original);
+
+            if ($propertyTypePrefersInitialValue || $untypedPropertyCurrentlyContainsString) {
+                $decoded = null;
+            }
         }
 
         // If only part of an array is present in the query string,

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -11,6 +11,30 @@ use Illuminate\Support\Facades\Route;
 
 class BrowserTest extends \Tests\BrowserTestCase
 {
+    public function test_structured_string_query_parameters_remain_strings()
+    {
+        Livewire::withQueryParams([
+            'search' => '[123]',
+        ])->visit([
+            new class extends Component
+            {
+                #[Url]
+                public $search = '';
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <span dusk="search">{{ $search }}</span>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->assertSeeIn('@search', '[123]')
+            ->assertQueryStringHas('search', '[123]');
+    }
+
     public function test_it_does_not_add_null_values_to_the_query_string_array()
     {
         Livewire::visit([

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -121,6 +121,18 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame('[123]', $component->instance()->search);
     }
 
+    function test_structured_strings_are_preserved_for_uninitialized_nullable_string_properties()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => '[123]',
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public ?string $search;
+        });
+
+        $this->assertSame('[123]', $component->instance()->search);
+    }
+
     function test_large_numbers_in_arrays_are_preserved_from_query_string()
     {
         $largeNumber = '74350194073086909398128';

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -121,6 +121,18 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame('[123]', $component->instance()->search);
     }
 
+    function test_structured_strings_are_preserved_by_the_public_url_attribute()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => '[123]',
+        ])->test(new class extends TestComponent {
+            #[\Livewire\Attributes\Url]
+            public $search = '';
+        });
+
+        $this->assertSame('[123]', $component->instance()->search);
+    }
+
     function test_structured_strings_are_preserved_for_uninitialized_nullable_string_properties()
     {
         $component = Livewire::withQueryParams([
@@ -131,6 +143,46 @@ class UnitTest extends \Tests\TestCase
         });
 
         $this->assertSame('[123]', $component->instance()->search);
+    }
+
+    function test_structured_strings_are_preserved_for_legacy_query_string_properties()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => '[123]',
+        ])->test(new class extends TestComponent {
+            public ?string $search;
+
+            protected function queryString()
+            {
+                return ['search'];
+            }
+        });
+
+        $this->assertSame('[123]', $component->instance()->search);
+    }
+
+    function test_structured_strings_are_preserved_when_a_union_type_accepts_strings()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => '{"id":123}',
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public string|array|null $search;
+        });
+
+        $this->assertSame('{"id":123}', $component->instance()->search);
+    }
+
+    function test_bracketed_query_string_arrays_remain_arrays_when_a_union_type_accepts_them()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => [123],
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public string|array|null $search;
+        });
+
+        $this->assertSame([123], $component->instance()->search);
     }
 
     function test_large_numbers_in_arrays_are_preserved_from_query_string()

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -109,6 +109,18 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame($largeNumber, $component->instance()->tableSearch);
     }
 
+    function test_structured_strings_are_preserved_from_query_string()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => '[123]',
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public $search = '';
+        });
+
+        $this->assertSame('[123]', $component->instance()->search);
+    }
+
     function test_large_numbers_in_arrays_are_preserved_from_query_string()
     {
         $largeNumber = '74350194073086909398128';

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -161,7 +161,7 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame('[123]', $component->instance()->search);
     }
 
-    function test_structured_strings_are_preserved_when_a_union_type_accepts_strings()
+    function test_structured_values_are_decoded_when_a_union_type_accepts_arrays()
     {
         $component = Livewire::withQueryParams([
             'search' => '{"id":123}',
@@ -170,7 +170,7 @@ class UnitTest extends \Tests\TestCase
             public string|array|null $search;
         });
 
-        $this->assertSame('{"id":123}', $component->instance()->search);
+        $this->assertSame(['id' => 123], $component->instance()->search);
     }
 
     function test_bracketed_query_string_arrays_remain_arrays_when_a_union_type_accepts_them()


### PR DESCRIPTION
## Problem

- **What does the user experience?** Visiting a page with a scalar query value such as `?search=[123]` changes a string-backed `#[Url]` property into an array. Consumers such as Filament then hit an `Array to string conversion` error and the page fails to load.
- **What did they expect?** The scalar query value should remain the literal string `[123]`, so searching and rendering continue normally. Actual query arrays written with bracket notation, such as `?search[0]=123`, should still become arrays.
- **What caused the difference?** `BaseUrl` runs every scalar query value through `json_decode()`. Structured-looking text decodes into an array before the property is assigned, even though PHP's query parser had already distinguished a scalar value from a bracket-notation array.

This is an alternative implementation of the problem reported in [#10602](https://github.com/livewire/livewire/pull/10602) and [filamentphp/filament#20372](https://github.com/filamentphp/filament/issues/20372).

## Solution

`Utils::propertyTypeMatchesValue()` now owns the general rule for strictly comparing a value's native PHP type with named, nullable, union, intersection, class, and interface property types. It deliberately reports an unknown result for missing or untyped properties instead of guessing.

`BaseUrl` uses that utility to compare both the decoded structured value and the original scalar. It preserves the original only when the property type prefers it; legacy untyped properties fall back to the type of their current value. Existing scalar coercion for numbers and booleans remains unchanged, while real bracket-notation arrays continue through the existing array path.

The solution is intentionally built in independently workable levels:

- [**Level 1 — initialized values**](https://github.com/livewire/livewire/commit/10ebfb0b4ac9b0ad2e0c990970611192908e001c): the smallest readable guard; preserves structured-looking scalar text when the current property value is a string.
- [**Level 2 — uninitialized typed values**](https://github.com/livewire/livewire/commit/0745efaaef95fa5925efa58db026f544a8d177a0): extends the guard to uninitialized nullable string properties by consulting their declared type.
- [**Level 3 — complete string-capable coverage**](https://github.com/livewire/livewire/commit/ca0eb1879bd2181f3f56f31cb95d4b65a1872ac0): covers the public `#[Url]` attribute, legacy query-string declarations, union types, JSON object strings, and verifies in a browser that bracket-notation arrays remain arrays.
- [**Level 4 — global property type matching**](https://github.com/livewire/livewire/commit/3f3251d4d12d5b58f08de8b3f54787804e101cce): extracts the policy into a documented global utility with a dedicated type matrix, then makes `BaseUrl` select between original and decoded values through that utility.

## Verification

- `vendor/bin/phpunit --testsuite Unit` — 1,404 tests, 3,985 assertions
- `vendor/bin/phpunit src/Features/SupportQueryString/BrowserTest.php` — 36 tests, 288 assertions
