### PR TITLE
[4.x] Persist dirty state until explicitly marked clean

### DIFF
--- a/docs/wire-dirty.md
+++ b/docs/wire-dirty.md
@@ -3,9 +3,9 @@ In a traditional HTML page containing a form, the form is only ever submitted wh
 
 However, Livewire is capable of much more than traditional form submissions. You can validate form inputs in real-time or even save the form as a user types.
 
-In these "real-time" update scenarios, it can be helpful to signal to your users when a form or subset of a form has been changed, but hasn't been saved to the database.
+In these "real-time" update scenarios, it can be helpful to signal when a form or subset of a form has changed but hasn't reached the server.
 
-When a form contains un-saved input, that form is considered "dirty". It only becomes "clean" when a network request has been triggered to synchronize the server state with the client-side state.
+When the browser contains input that differs from the server state, that input is considered "dirty". It becomes "clean" when a message synchronizes the browser and server state.
 
 ## Basic usage
 
@@ -110,6 +110,53 @@ Or apply conditional classes with Alpine:
 >
 ```
 
+## Persisting dirty state across messages
+
+By default, dirty state describes whether the server has received the browser's latest changes. Any message can therefore make the component clean, even when that message didn't save anything to a database.
+
+For an unsaved-changes indicator, add the `.persist` modifier and mark the state as clean after it has been saved:
+
+```php
+<?php // resources/views/components/post/⚡create.blade.php
+
+use Livewire\Component;
+use App\Models\Post;
+
+new class extends Component {
+    public $title = '';
+
+    public function save()
+    {
+        Post::create($this->only(['title']));
+
+        $this->markAsClean(); // [tl! highlight]
+    }
+};
+?>
+
+<form wire:submit="save">
+    <input type="text" wire:model="title">
+
+    <button type="submit">Save</button>
+
+    <div wire:dirty.persist>Unsaved changes...</div> <!-- [tl! highlight] -->
+</form>
+```
+
+Persistent dirty state survives polling, live model updates, and unrelated actions. Clean server-side changes are accepted into its baseline automatically, while local edits remain dirty until `markAsClean()` runs.
+
+The `$dirty` expression accepts the same option:
+
+```blade
+<div x-show="$wire.$dirty('title', { persist: true })">Unsaved title...</div>
+```
+
+From Alpine, `$wire.$markAsClean()` marks the current browser state as clean without sending a message:
+
+```blade
+<button type="button" x-on:click="$wire.$markAsClean()">Accept changes</button>
+```
+
 ## Reference
 
 ```blade
@@ -123,6 +170,7 @@ wire:target="property"
 |----------|-------------|
 | `.remove` | Show element by default, hide when dirty |
 | `.class="class-name"` | Add a CSS class when dirty |
+| `.persist` | Compare against the last state marked as clean instead of the latest server state |
 
 ### `$dirty` expression
 
@@ -131,5 +179,13 @@ wire:target="property"
 | `$dirty` | Returns `true` if any property has unsaved changes |
 | `$dirty('property')` | Returns `true` if the specified property has unsaved changes |
 | `$dirty(['title', 'description'])` | Returns `true` if any of the specified properties have unsaved changes |
+| `$dirty('title', { persist: true })` | Compares the property against the last state marked as clean |
 
 Can be used in Livewire directives like `wire:show="$dirty"` or in Alpine as `$wire.$dirty()`.
+
+### Marking state as clean
+
+| Call | Description |
+|------|-------------|
+| `$this->markAsClean()` | Marks the state returned by the current message as clean |
+| `$wire.$markAsClean()` | Marks the current browser state as clean |

--- a/js/$wire.js
+++ b/js/$wire.js
@@ -37,6 +37,7 @@ let aliases = {
     'hook': '$hook',
     'watch': '$watch',
     'dirty': '$dirty',
+    'markAsClean': '$markAsClean',
     'effect': '$effect',
     'commit': '$commit',
     'errors': '$errors',
@@ -222,22 +223,27 @@ wireProperty('$refs', (component) => {
     })
 })
 
-wireProperty('$dirty', (component) => (property) => {
+wireProperty('$dirty', (component) => (property, options = {}) => {
+    let persist = options.persist ?? false
     let reactive = Alpine.reactive({ dirty: false })
+
+    let refresh = () => {
+        reactive.dirty = checkDirty(component, property, persist)
+    }
 
     interceptComponentMessage(component, ({ onFinish }) => {
         onFinish(() => {
-            queueMicrotask(() => {
-                reactive.dirty = checkDirty(component, property)
-            })
+            queueMicrotask(refresh)
         })
     })
 
-    Alpine.effect(() => {
-        reactive.dirty = checkDirty(component, property)
-    })
+    Alpine.effect(refresh)
 
     return reactive.dirty
+})
+
+wireProperty('$markAsClean', (component) => () => {
+    component.markAsClean()
 })
 
 wireProperty('$intercept', (component) => (actionNameOrCallback, maybeCallback) => {

--- a/js/component.js
+++ b/js/component.js
@@ -3,6 +3,7 @@ import { generateWireObject } from '@/$wire'
 import { findComponentByEl, findComponent, hasComponent } from '@/store'
 import { trigger } from '@/hooks'
 import { setNextActionOrigin } from '@/request'
+import { mergeCleanState } from '@/utils/mergeCleanState'
 
 export class Component {
     constructor(el) {
@@ -86,6 +87,9 @@ export class Component {
         let newCanonical = extractData(deepClone(snapshot.data))
 
         let dirty = diff(updatedOldCanonical, newCanonical)
+
+        this.baseline = mergeCleanState(this.baseline, this.reactive, newCanonical)
+        this.baselineVersion.value++
 
         this.snapshotEncoded = snapshotEncoded
 

--- a/js/component.js
+++ b/js/component.js
@@ -33,6 +33,9 @@ export class Component {
 
         // "canonical" data represents the last known server state.
         this.canonical = extractData(deepClone(this.snapshot.data))
+        // "baseline" data represents the last state marked as clean.
+        this.baseline = extractData(deepClone(this.snapshot.data))
+        this.baselineVersion = Alpine.reactive({ value: 0 })
         // "ephemeral" represents the most current state. (This can be freely manipulated by end users)
         this.ephemeral = extractData(deepClone(this.snapshot.data))
         // "reactive" is just ephemeral, except when you mutate it, front-ends like Vue react.
@@ -66,6 +69,12 @@ export class Component {
 
     intercept(action, callback = null) {
         return this.$wire.$intercept(action, callback)
+    }
+
+    markAsClean(state = this.reactive) {
+        this.baseline = deepClone(state)
+
+        this.baselineVersion.value++
     }
 
     mergeNewSnapshot(snapshotEncoded, effects, updates = {}) {

--- a/js/directives/wire-dirty.js
+++ b/js/directives/wire-dirty.js
@@ -8,13 +8,14 @@ let refreshDirtyStatesByComponent = new WeakBag
 on('commit', ({ component, succeed }) => {
     succeed(() => {
         setTimeout(() => { // Doing a "setTimeout" to let morphdom do its thing first...
-            refreshDirtyStatesByComponent.each(component, i => i(false))
+            refreshDirtyStatesByComponent.each(component, recompute => recompute(true))
         })
     })
 })
 
 directive('dirty', ({ el, directive, component }) => {
     let targets = dirtyTargets(el)
+    let persist = directive.modifiers.includes('persist')
 
     let oldIsDirty = false
 
@@ -26,36 +27,43 @@ directive('dirty', ({ el, directive, component }) => {
         oldIsDirty = isDirty
     }
 
-    refreshDirtyStatesByComponent.add(component, refreshDirtyState)
+    let recompute = (force = false) => {
+        let isDirty = checkDirty(component, targets.length === 0 ? undefined : targets, persist)
 
-    Alpine.effect(() => {
-        let isDirty = false
-
-        isDirty = checkDirty(component, targets.length === 0 ? undefined : targets)
-
-        if (oldIsDirty !== isDirty) {
+        if (force || oldIsDirty !== isDirty) {
             refreshDirtyState(isDirty)
         }
 
         oldIsDirty = isDirty
-    })
+    }
+
+    refreshDirtyStatesByComponent.add(component, recompute)
+
+    Alpine.effect(() => recompute())
 })
 
-export function checkDirty(component, targets) {
+export function checkDirty(component, targets, persist = false) {
     let isDirty = false
+    let reference = component.canonical
+
+    if (persist) {
+        component.baselineVersion.value
+
+        reference = component.baseline
+    }
 
     if (targets === undefined) {
-        isDirty = JSON.stringify(component.canonical) !== JSON.stringify(component.reactive)
+        isDirty = JSON.stringify(reference) !== JSON.stringify(component.reactive)
     } else if (Array.isArray(targets)) {
         for (let i = 0; i < targets.length; i++) {
             if (isDirty) break;
 
             let target = targets[i]
 
-            isDirty = JSON.stringify(dataGet(component.canonical, target)) !== JSON.stringify(dataGet(component.reactive, target))
+            isDirty = JSON.stringify(dataGet(reference, target)) !== JSON.stringify(dataGet(component.reactive, target))
         }
     } else {
-        isDirty = JSON.stringify(dataGet(component.canonical, targets)) !== JSON.stringify(dataGet(component.reactive, targets))
+        isDirty = JSON.stringify(dataGet(reference, targets)) !== JSON.stringify(dataGet(component.reactive, targets))
     }
 
     return isDirty

--- a/js/features/index.js
+++ b/js/features/index.js
@@ -24,6 +24,7 @@ import './supportSlots';
 import './supportDataLoading';
 import './supportDataCurrent';
 import './supportPreserveScroll';
+import './supportDirty';
 import './supportWireIntersect';
 import './supportWireSort';
 import './supportJsModules'

--- a/js/features/supportDirty.js
+++ b/js/features/supportDirty.js
@@ -1,0 +1,7 @@
+import { on } from '@/hooks'
+
+on('effect', ({ component, effects }) => {
+    if (! effects['markClean']) return
+
+    component.markAsClean(component.canonical)
+})

--- a/js/utils/mergeCleanState.js
+++ b/js/utils/mergeCleanState.js
@@ -1,0 +1,42 @@
+import { deepClone, deeplyEqual, isObject } from '@/utils'
+
+export function mergeCleanState(baseline, reactive, canonical) {
+    if (deeplyEqual(baseline, reactive)) return deepClone(canonical)
+
+    if (! isObject(baseline) || ! isObject(reactive) || ! isObject(canonical)) {
+        return deepClone(baseline)
+    }
+
+    let merged = {}
+    let keys = new Set([
+        ...Object.keys(baseline),
+        ...Object.keys(reactive),
+        ...Object.keys(canonical),
+    ])
+
+    keys.forEach(key => {
+        let baselineHasKey = Object.hasOwn(baseline, key)
+        let reactiveHasKey = Object.hasOwn(reactive, key)
+        let canonicalHasKey = Object.hasOwn(canonical, key)
+
+        let isClean = baselineHasKey === reactiveHasKey
+            && (! baselineHasKey || deeplyEqual(baseline[key], reactive[key]))
+
+        if (isClean) {
+            if (canonicalHasKey) merged[key] = deepClone(canonical[key])
+
+            return
+        }
+
+        if (baselineHasKey && reactiveHasKey && canonicalHasKey
+            && isObject(baseline[key]) && isObject(reactive[key]) && isObject(canonical[key])) {
+            merged[key] = mergeCleanState(baseline[key], reactive[key], canonical[key])
+
+            return
+        }
+
+        if (baselineHasKey) merged[key] = deepClone(baseline[key])
+    })
+
+    return merged
+}

--- a/js/utils/mergeCleanState.spec.js
+++ b/js/utils/mergeCleanState.spec.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { mergeCleanState } from './mergeCleanState'
+
+describe('mergeCleanState', () => {
+    it('accepts server changes to clean properties', () => {
+        expect(mergeCleanState(
+            { title: 'Original', count: 0 },
+            { title: 'Original', count: 0 },
+            { title: 'Original', count: 1 },
+        )).toEqual({ title: 'Original', count: 1 })
+    })
+
+    it('preserves baselines for local changes while accepting clean siblings', () => {
+        expect(mergeCleanState(
+            { form: { title: 'Original', status: 'draft' }, count: 0 },
+            { form: { title: 'Changed', status: 'draft' }, count: 0 },
+            { form: { title: 'Changed', status: 'published' }, count: 1 },
+        )).toEqual({
+            form: { title: 'Original', status: 'published' },
+            count: 1,
+        })
+    })
+
+    it('preserves a locally changed array as one value', () => {
+        expect(mergeCleanState(
+            { tags: ['one'], count: 0 },
+            { tags: ['one', 'two'], count: 0 },
+            { tags: ['one', 'two'], count: 1 },
+        )).toEqual({ tags: ['one'], count: 1 })
+    })
+
+    it('preserves local additions and removals', () => {
+        expect(mergeCleanState(
+            { form: { kept: 'yes', removed: 'saved' } },
+            { form: { kept: 'yes', added: 'draft' } },
+            { form: { kept: 'changed', added: 'draft' } },
+        )).toEqual({ form: { kept: 'changed', removed: 'saved' } })
+    })
+})

--- a/src/Component.php
+++ b/src/Component.php
@@ -13,6 +13,7 @@ use Livewire\Features\SupportJsEvaluation\HandlesJsEvaluation;
 use Livewire\Features\SupportIslands\HandlesIslands;
 use Livewire\Features\SupportFormObjects\HandlesFormObjects;
 use Livewire\Features\SupportEvents\HandlesEvents;
+use Livewire\Features\SupportDirty\HandlesDirty;
 use Livewire\Features\SupportHtmlAttributeForwarding\HandlesHtmlAttributeForwarding;
 use Livewire\Features\SupportDisablingBackButtonCache\HandlesDisablingBackButtonCache;
 use Livewire\Features\SupportAttributes\HandlesAttributes;
@@ -30,6 +31,7 @@ abstract class Component
     use AuthorizesRequests;
     use InteractsWithProperties;
     use HandlesEvents;
+    use HandlesDirty;
     use HandlesIslands;
     use HandlesRedirects;
     use HandlesTransitions;

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -37,6 +37,46 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    function test_wire_dirty_can_persist_across_messages_until_marked_as_clean()
+    {
+        Livewire::visit(new class extends Component {
+            public $title = '';
+
+            public $count = 0;
+
+            public function increment() { $this->count++; }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <input dusk="input" type="text" wire:model="title" />
+                        <button dusk="unrelated" type="button" wire:click="increment">{{ $count }}</button>
+                        <button dusk="clean" type="button" x-on:click="$wire.$markAsClean()">Mark clean</button>
+
+                        <div dusk="dirty" wire:dirty.persist wire:target="title">Unsaved changes...</div>
+                        <div dusk="expression" x-show="$wire.$dirty('title', { persist: true })">Expression is dirty...</div>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertNotVisible('@dirty')
+            ->assertNotVisible('@expression')
+            ->type('@input', 'Hello')
+            ->pause(50)
+            ->assertVisible('@dirty')
+            ->assertVisible('@expression')
+            ->waitForLivewire()->click('@unrelated')
+            ->pause(50)
+            ->assertVisible('@dirty')
+            ->assertVisible('@expression')
+            ->click('@clean')
+            ->pause(50)
+            ->assertNotVisible('@dirty')
+            ->assertNotVisible('@expression')
+        ;
+    }
+
     function test_can_use_dollar_dirty_to_check_if_component_is_dirty()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -77,6 +77,39 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    function test_persistent_dirty_state_ignores_clean_server_changes()
+    {
+        Livewire::visit(new class extends Component {
+            public $title = '';
+
+            public $count = 0;
+
+            public function increment() { $this->count++; }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <input dusk="input" type="text" wire:model="title" />
+                        <button dusk="unrelated" type="button" wire:click="increment">{{ $count }}</button>
+
+                        <div dusk="dirty" wire:dirty.persist>Unsaved changes...</div>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertNotVisible('@dirty')
+            ->waitForLivewire()->click('@unrelated')
+            ->assertNotVisible('@dirty')
+            ->type('@input', 'Hello')
+            ->pause(50)
+            ->assertVisible('@dirty')
+            ->waitForLivewire()->click('@unrelated')
+            ->pause(50)
+            ->assertVisible('@dirty')
+        ;
+    }
+
     function test_can_use_dollar_dirty_to_check_if_component_is_dirty()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -110,6 +110,77 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    function test_persistent_dirty_state_can_be_marked_as_clean_by_the_server()
+    {
+        Livewire::visit(new class extends Component {
+            public $title = '';
+
+            public function save()
+            {
+                $this->markAsClean();
+            }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <input dusk="input" type="text" wire:model="title" />
+                        <button dusk="save" type="button" wire:click="save">Save</button>
+
+                        <div dusk="dirty" wire:dirty.persist>Unsaved changes...</div>
+                    </div>
+                BLADE;
+            }
+        })
+            ->type('@input', 'Hello')
+            ->pause(50)
+            ->assertVisible('@dirty')
+            ->waitForLivewire()->click('@save')
+            ->pause(50)
+            ->assertNotVisible('@dirty')
+        ;
+    }
+
+    function test_marking_as_clean_preserves_a_newer_local_edit()
+    {
+        Livewire::visit(new class extends Component {
+            public $title = '';
+
+            public $saves = 0;
+
+            public function save()
+            {
+                usleep(300_000);
+
+                $this->saves++;
+                $this->markAsClean();
+            }
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <input dusk="input" type="text" wire:model="title" />
+                        <button dusk="save" type="button" wire:click="save">Save</button>
+                        <span dusk="saves">{{ $saves }}</span>
+
+                        <div dusk="dirty" wire:dirty.persist>Unsaved changes...</div>
+                    </div>
+                BLADE;
+            }
+        })
+            ->type('@input', 'First edit')
+            ->pause(50)
+            ->assertVisible('@dirty')
+            ->click('@save')
+            ->pause(50)
+            ->type('@input', 'Newer edit')
+            ->waitUntil("document.querySelector('[dusk=\"saves\"]').textContent.trim() === '1'")
+            ->pause(50)
+            ->assertVisible('@dirty')
+        ;
+    }
+
     function test_can_use_dollar_dirty_to_check_if_component_is_dirty()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportDirty/HandlesDirty.php
+++ b/src/Features/SupportDirty/HandlesDirty.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Livewire\Features\SupportDirty;
+
+use function Livewire\store;
+
+trait HandlesDirty
+{
+    public function markAsClean()
+    {
+        store($this)->set('markClean', true);
+    }
+}

--- a/src/Features/SupportDirty/SupportDirty.php
+++ b/src/Features/SupportDirty/SupportDirty.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Livewire\Features\SupportDirty;
+
+use Livewire\ComponentHook;
+
+class SupportDirty extends ComponentHook
+{
+    public function dehydrate($context)
+    {
+        if (! $this->storeGet('markClean')) return;
+
+        $context->addEffect('markClean', true);
+    }
+}

--- a/src/Features/SupportDirty/UnitTest.php
+++ b/src/Features/SupportDirty/UnitTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Livewire\Features\SupportDirty;
+
+use Tests\TestComponent;
+use Livewire\Livewire;
+
+class UnitTest extends \Tests\TestCase
+{
+    function test_mark_as_clean_adds_an_effect_to_the_current_message()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public function save()
+            {
+                $this->markAsClean();
+            }
+
+            public function touch() {}
+        });
+
+        $this->assertArrayNotHasKey('markClean', $component->effects);
+
+        $component->call('save');
+
+        $this->assertTrue($component->effects['markClean']);
+
+        $component->call('touch');
+
+        $this->assertArrayNotHasKey('markClean', $component->effects);
+    }
+}

--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -181,6 +181,7 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
             Features\SupportJsEvaluation\SupportJsEvaluation::class,
             Features\SupportMagicActions\SupportMagicActions::class,
             Features\SupportQueryString\SupportQueryString::class,
+            Features\SupportDirty\SupportDirty::class,
             Features\SupportFileUploads\SupportFileUploads::class,
             Features\SupportTeleporting\SupportTeleporting::class,
             Features\SupportLazyLoading\SupportLazyLoading::class,

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -136,7 +136,7 @@ class FrontendAssets extends Mechanism
                 display: none;
             }
 
-            [wire\:dirty]:not(textarea):not(input):not(select) {
+            [wire\:dirty]:not(textarea):not(input):not(select), [wire\:dirty\.persist]:not(textarea):not(input):not(select) {
                 display: none;
             }
 


### PR DESCRIPTION
Builds on the underlying need identified in #10600 with a baseline that distinguishes local edits from clean server-originated changes.

## Problem

- **What does the user experience?** An unsaved-changes indicator powered by `wire:dirty` appears while typing, then disappears after any unrelated message such as `wire:poll`, even though the save action never ran.
- **What did they expect?** The indicator should remain dirty until the edited state is explicitly accepted as saved.
- **What caused the difference?** `wire:dirty` compares the browser's reactive state to `component.canonical`, and every successful server response replaces `canonical`. It therefore measures “has the server received this state?” rather than “has this state been saved?”

## Solution

This adds an opt-in persistent baseline through `wire:dirty.persist` and `$dirty(..., { persist: true })`. Persistent baselines survive unrelated messages, absorb clean server-originated changes, and advance only when the application explicitly calls `markAsClean()`.

The implementation is deliberately staged so each commit is a workable level of the solution:

1. **[Level 1 — persistent baseline](https://github.com/livewire/livewire/commit/d6d6f9edbaf13bee117392dd6e4b5ececfcdb6b3):** Adds `.persist`, the `$dirty` option, and `$wire.$markAsClean()` as the smallest client-side expression of the idea.
2. **[Level 2 — reconcile clean server changes](https://github.com/livewire/livewire/commit/573b981fc6df6b37f019e8434864cc9ebb051ce2):** Advances clean portions of the baseline during snapshot merges, so polling and server-owned sibling updates do not become false unsaved edits.
3. **[Level 3 — authoritative save checkpoint](https://github.com/livewire/livewire/commit/19903f776cd02573359ea6493ca5ef828ee951a0):** Adds `$this->markAsClean()`, applies the returned canonical snapshot as the saved checkpoint, preserves newer in-flight browser edits, and documents the API.

## Other paths considered

- **Minimum:** Keep an initial client snapshot and reset it manually. Small, but server changes become false positives and successful saves have no authoritative checkpoint.
- **Maximum:** Introduce a first-class edit-session tracker with path-level save acknowledgements, partial saves, and concurrency metadata. Complete, but much larger than this opt-in feature needs.
- **Evaporative:** Move persistence semantics into a dedicated form transaction API that automatically owns save boundaries. Harmonious, but requires reconstructing the form/action model.
- **Userland:** Store selected initial values in Alpine, compare them manually, and reset after a successful save event. No framework change, but every application must rebuild lifecycle and concurrency handling.

## Verification

- 114 JavaScript tests pass (1 existing skipped), including four new baseline reconciliation cases.
- Focused server-effect unit test passes (3 assertions).
- Four focused browser tests pass (16 assertions), covering unrelated messages, clean server changes, server-side checkpoints, and a newer edit made while save is in flight.
- Both Livewire browser bundles build successfully.
- A real Laravel playground confirms clean polls stay clean, edits remain dirty across polls, save clears the indicator, and the following poll remains clean.
