### PR TITLE
[4.x] Defer Alpine init until component modules load

### DIFF
--- a/js/features/supportJsModules.js
+++ b/js/features/supportJsModules.js
@@ -1,7 +1,20 @@
 import { on } from '@/hooks'
 import { getModuleUrl } from '@/utils'
+import Alpine from 'alpinejs'
 
 let pendingComponentAssets = new WeakMap()
+let pendingComponentCount = 0
+
+Alpine.interceptClone((from, to) => {
+    if (pendingComponentCount === 0) return
+    if (! from || from.nodeType !== 1) return
+
+    let component = from.closest('[wire\\:id]')?.__livewire
+
+    if (component && assetIsPendingFor(component)) {
+        to._x_ignore = true
+    }
+})
 
 on('effect', ({ component, effects }) => {
     let scriptModuleHash
@@ -13,19 +26,36 @@ on('effect', ({ component, effects }) => {
     if (scriptModuleHash) {
         let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
         let path = `${getModuleUrl()}/js/${encodedName}.js?v=${scriptModuleHash}`
+        let alreadyInitialised = component.el._x_marker
+
+        if (alreadyInitialised) {
+            component.el._x_ignore = true
+        }
 
         pendingComponentAssets.set(component, Alpine.reactive({
             loading: true,
             afterLoaded: [],
         }))
 
-        import(/* @vite-ignore */ path).then(module => {
-            module.run.call(component.$wire, component.$wire, component.$wire.js);
+        pendingComponentCount++
 
-            pendingComponentAssets.get(component).loading = false
-            pendingComponentAssets.get(component).afterLoaded.forEach(callback => callback())
+        import(/* @vite-ignore */ path).then(module => {
+            module.run.call(component.$wire, component.$wire, component.$wire.js)
+
+            let pendingAsset = pendingComponentAssets.get(component)
+
+            pendingAsset.loading = false
             pendingComponentAssets.delete(component)
-        });
+            pendingComponentCount--
+
+            if (alreadyInitialised && component.el.isConnected) {
+                delete component.el._x_ignore
+                delete component.el._x_marker
+                Alpine.initTree(component.el)
+            }
+
+            pendingAsset.afterLoaded.forEach(callback => callback())
+        })
     }
 })
 

--- a/js/features/supportJsModules.js
+++ b/js/features/supportJsModules.js
@@ -1,15 +1,18 @@
 import { on } from '@/hooks'
+import { findComponentByEl } from '@/store'
 import { getModuleUrl } from '@/utils'
 import Alpine from 'alpinejs'
 
 let pendingComponentAssets = new WeakMap()
 let pendingComponentCount = 0
 
+// Morph initializes detached clones before swapping them into the document, so
+// carry the pending component's ignore state onto each clone in that subtree.
 Alpine.interceptClone((from, to) => {
     if (pendingComponentCount === 0) return
     if (! from || from.nodeType !== 1) return
 
-    let component = from.closest('[wire\\:id]')?.__livewire
+    let component = findComponentByEl(from, false)
 
     if (component && assetIsPendingFor(component)) {
         to._x_ignore = true
@@ -41,7 +44,7 @@ on('effect', ({ component, effects }) => {
 
         import(/* @vite-ignore */ path).then(module => {
             module.run.call(component.$wire, component.$wire, component.$wire.js)
-
+        }).finally(() => {
             let pendingAsset = pendingComponentAssets.get(component)
 
             pendingAsset.loading = false

--- a/js/lifecycle.js
+++ b/js/lifecycle.js
@@ -1,5 +1,6 @@
 import { findComponentByEl, destroyComponent, initComponent, hasComponent } from './store'
 import { matchesForLivewireDirective, extractDirective } from './directives'
+import { assetIsPendingFor, runAfterAssetIsLoadedFor } from './features/supportJsModules'
 import { trigger } from './hooks'
 import collapse from '@alpinejs/collapse'
 import focus from '@alpinejs/focus'
@@ -67,6 +68,19 @@ export function start() {
                 Alpine.onAttributeRemoved(el, 'wire:id', () => {
                     destroyComponent(component.id)
                 })
+
+                if (assetIsPendingFor(component)) {
+                    el._x_ignore = true
+
+                    runAfterAssetIsLoadedFor(component, () => {
+                        if (! el.isConnected) return
+
+                        delete el._x_ignore
+                        Alpine.initTree(el)
+                    })
+
+                    return
+                }
             }
 
             let directives = Array.from(el.getAttributeNames())

--- a/src/Features/SupportJsModules/BrowserTest.php
+++ b/src/Features/SupportJsModules/BrowserTest.php
@@ -60,6 +60,13 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertConsoleLogHasNoErrors();
     }
 
+    public function test_alpine_data_is_available_when_a_lazy_component_hydrates()
+    {
+        Livewire::visit('testns::lazy-with-alpine-data')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
     public function test_script_module_survives_a_back_navigation()
     {
         // The `scriptModule` effect is only sent while mounting, so navigating

--- a/src/Features/SupportJsModules/BrowserTest.php
+++ b/src/Features/SupportJsModules/BrowserTest.php
@@ -52,6 +52,14 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->waitForTextIn('@target', 'js-import-loaded');
     }
 
+    public function test_alpine_data_is_available_during_initial_component_initialization()
+    {
+        Livewire::visit('testns::alpine-data.index')
+            ->waitForLivewireToLoad()
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
     public function test_script_module_survives_a_back_navigation()
     {
         // The `scriptModule` effect is only sent while mounting, so navigating

--- a/src/Features/SupportJsModules/BrowserTest.php
+++ b/src/Features/SupportJsModules/BrowserTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportJsModules;
 
 use Illuminate\Support\Facades\Route;
+use Livewire\Component;
 use Livewire\Livewire;
 
 class BrowserTest extends \Tests\BrowserTestCase
@@ -17,6 +18,22 @@ class BrowserTest extends \Tests\BrowserTestCase
                     'Content-Type' => 'application/javascript',
                 ]);
             });
+
+            Route::get('/slow-slot-module.js', function () {
+                usleep(2_000_000);
+
+                return response("export let greeting = 'slot-alpine-data-loaded'", 200, [
+                    'Content-Type' => 'application/javascript',
+                ]);
+            });
+
+            Route::get('/alpine-data-page', function () {
+                return app('livewire')->new('testns::alpine-data.index')();
+            })->middleware('web');
+
+            Route::get('/alpine-data-page-2', function () {
+                return app('livewire')->new('testns::alpine-data.index')();
+            })->middleware('web');
         };
     }
 
@@ -65,6 +82,91 @@ class BrowserTest extends \Tests\BrowserTestCase
         Livewire::visit('testns::lazy-with-alpine-data')
             ->waitForTextIn('@target', 'alpine-data-loaded')
             ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_is_available_when_a_component_is_added_dynamically()
+    {
+        Livewire::visit([new class extends Component {
+            public $show = false;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$toggle('show')" dusk="toggle">Toggle</button>
+
+                    @if ($show)
+                        <livewire:testns::alpine-data.index />
+                    @endif
+                </div>
+                HTML;
+            }
+        }])
+            ->assertDontSee('alpine-data-loaded')
+            ->waitForLivewire()->click('@toggle')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_is_available_in_a_slot_forwarded_through_a_lazy_component()
+    {
+        Livewire::visit('testns::lazy-with-alpine-data-in-slot.parent')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_is_available_when_an_existing_child_morphs_forwarded_slot_content()
+    {
+        Livewire::visit('testns::lazy-slot-with-existing-wrapper.parent')
+            ->assertSeeIn('@target', 'Loading...')
+            ->waitForTextIn('@target', 'slot-alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_is_available_in_a_component_added_to_an_island()
+    {
+        Livewire::visit('testns::island-with-alpine-data')
+            ->assertSeeIn('@placeholder', 'No child yet')
+            ->waitForLivewire()->click('@toggle')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_is_available_after_wire_navigate()
+    {
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <div dusk="source-page">Source page</div>
+                    <a href="/alpine-data-page" wire:navigate dusk="link">Go to alpine data page</a>
+                </div>
+                HTML;
+            }
+        }])
+            ->assertSeeIn('@source-page', 'Source page')
+            ->waitForNavigate()->click('@link')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_module_remains_available_across_wire_navigate()
+    {
+        Livewire::visit('testns::navigate-with-alpine-data')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->waitForNavigate()->click('@link')
+            ->waitUntilMissing('@first-page')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_component_initialization_recovers_when_a_script_module_fails_to_import()
+    {
+        Livewire::visit('testns::failed-module')
+            ->waitForTextIn('@ready', 'ready')
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '1');
     }
 
     public function test_script_module_survives_a_back_navigation()

--- a/src/Features/SupportJsModules/fixtures/alpine-data/index.blade.php
+++ b/src/Features/SupportJsModules/fixtures/alpine-data/index.blade.php
@@ -1,0 +1,16 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div x-data="testAlpineData">
+    <div dusk="target" x-text="message"></div>
+</div>
+
+<script>
+    Alpine.data('testAlpineData', () => ({
+        message: 'alpine-data-loaded',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/failed-module.blade.php
+++ b/src/Features/SupportJsModules/fixtures/failed-module.blade.php
@@ -1,0 +1,17 @@
+<?php
+
+new class extends Livewire\Component {
+    public $count = 0;
+};
+?>
+
+<div x-data="{ ready: false }" x-init="ready = true">
+    <span dusk="ready" x-text="ready ? 'ready' : 'waiting'">waiting</span>
+
+    <button wire:click="$set('count', {{ $count + 1 }})" dusk="increment">Increment</button>
+    <span dusk="count">{{ $count }}</span>
+</div>
+
+<script>
+    import '/missing-component-module.js'
+</script>

--- a/src/Features/SupportJsModules/fixtures/island-with-alpine-data.blade.php
+++ b/src/Features/SupportJsModules/fixtures/island-with-alpine-data.blade.php
@@ -1,0 +1,18 @@
+<?php
+
+new class extends Livewire\Component {
+    public $show = false;
+};
+?>
+
+<div>
+    @island(name: 'content')
+        @if ($show)
+            <livewire:testns::alpine-data.index />
+        @else
+            <div dusk="placeholder">No child yet</div>
+        @endif
+    @endisland
+
+    <button wire:click="$toggle('show')" wire:island="content" dusk="toggle">Toggle</button>
+</div>

--- a/src/Features/SupportJsModules/fixtures/lazy-slot-with-existing-wrapper/parent.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-slot-with-existing-wrapper/parent.blade.php
@@ -1,0 +1,30 @@
+<?php
+
+use Livewire\Attributes\Lazy;
+
+new #[Lazy] class extends Livewire\Component {
+    //
+};
+?>
+
+@placeholder
+    <div>
+        <livewire:testns::lazy-slot-with-existing-wrapper.wrapper>
+            <div dusk="target">Loading...</div>
+        </livewire:testns::lazy-slot-with-existing-wrapper.wrapper>
+    </div>
+@endplaceholder
+
+<div>
+    <livewire:testns::lazy-slot-with-existing-wrapper.wrapper>
+        <div dusk="target" x-data="testSlotAlpineData" x-text="message"></div>
+    </livewire:testns::lazy-slot-with-existing-wrapper.wrapper>
+</div>
+
+<script>
+    import { greeting } from '/slow-slot-module.js'
+
+    Alpine.data('testSlotAlpineData', () => ({
+        message: greeting,
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/lazy-slot-with-existing-wrapper/wrapper.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-slot-with-existing-wrapper/wrapper.blade.php
@@ -1,0 +1,10 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div dusk="wrapper">
+    {{ $slot }}
+</div>

--- a/src/Features/SupportJsModules/fixtures/lazy-with-alpine-data-in-slot/parent.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-with-alpine-data-in-slot/parent.blade.php
@@ -1,0 +1,20 @@
+<?php
+
+use Livewire\Attributes\Lazy;
+
+new #[Lazy] class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <livewire:testns::lazy-with-alpine-data-in-slot.wrapper>
+        <div dusk="target" x-data="testAlpineData" x-text="message"></div>
+    </livewire:testns::lazy-with-alpine-data-in-slot.wrapper>
+</div>
+
+<script>
+    Alpine.data('testAlpineData', () => ({
+        message: 'alpine-data-loaded',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/lazy-with-alpine-data-in-slot/wrapper.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-with-alpine-data-in-slot/wrapper.blade.php
@@ -1,0 +1,10 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div dusk="wrapper">
+    {{ $slot }}
+</div>

--- a/src/Features/SupportJsModules/fixtures/lazy-with-alpine-data.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-with-alpine-data.blade.php
@@ -1,0 +1,18 @@
+<?php
+
+use Livewire\Attributes\Lazy;
+
+new #[Lazy] class extends Livewire\Component {
+    //
+};
+?>
+
+<div x-data="testAlpineData">
+    <div dusk="target" x-text="message"></div>
+</div>
+
+<script>
+    Alpine.data('testAlpineData', () => ({
+        message: 'alpine-data-loaded',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/navigate-with-alpine-data.blade.php
+++ b/src/Features/SupportJsModules/fixtures/navigate-with-alpine-data.blade.php
@@ -1,0 +1,14 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <div dusk="first-page">First page</div>
+
+    <livewire:testns::alpine-data.index />
+
+    <a href="/alpine-data-page-2" wire:navigate dusk="link">Go to second page</a>
+</div>


### PR DESCRIPTION
Rebased and reorganized replacement for #10295. The core approach and original regression coverage were developed with @joshhanley, who is credited on each commit.

## Problem

- **What does the user experience?** A single- or multi-file component registers `Alpine.data()` in its co-located script module, but Alpine evaluates the component's `x-data` first. The browser logs `Alpine Expression Error: ... is not defined`, and the dependent UI is blank or non-interactive. This can happen on initial render, dynamic mounts, lazy hydration, islands, and `wire:navigate`.
- **What did they expect instead?** A component's own script module should finish registering its Alpine data provider before Alpine evaluates directives in that component's DOM.
- **What caused the difference?** The `scriptModule` effect starts an asynchronous `import()`, while Alpine continues its synchronous `start()`/`initTree()` traversal. The async registration loses that race.

## Solution

Keep `Livewire.start()` synchronous and defer Alpine initialization only for a component whose script module is pending.

- [**Level 1 — initial component initialization**](https://github.com/livewire/livewire/commit/cc92a602979ca86e34396b4a333d179911d2c2dd): mark a newly discovered component root ignored, then initialize its tree after its module loads. This is the smallest diff that exposes the heart of the fix.
- [**Level 2 — lazy hydration and morphs**](https://github.com/livewire/livewire/commit/590a21818067140ae74221bdbad4d7bda634e84f): carry the ignored state through Alpine's detached morph clones and reinitialize already-active component roots after their module loads.
- [**Level 3 — ownership and failure hardening**](https://github.com/livewire/livewire/commit/c3d709313c44d2c99f536a67d8b983df2e331d0a): resolve the actual Livewire owner for forwarded slots, always release deferred initialization when imports fail, and cover dynamic children, lazy slots, islands, and navigation.

The trade-off is a brief uninitialized state for only the affected component while its module downloads. That is narrower than making Livewire's global boot and message lifecycles asynchronous.

## Alternatives considered

- **Minimum:** stop after Level 1. Tiny and useful, but incomplete for already-initialized roots such as lazy hydration.
- **Maximum:** add a global async preparation phase that discovers and preloads every component module before Alpine boot, morph, navigation, and island processing. More uniform, but it turns broad lifecycle APIs async and increases the blast radius.
- **Evaporative:** compile or hoist component registrations into an eagerly available bundle so runtime component-module imports no longer race Alpine at all. Architecturally clean, but it changes the component compilation and asset model.
- **Userland:** move `Alpine.data()` into a global `@assets`/`alpine:init` script or use an inline `x-data` object. This avoids a framework contribution, but sacrifices co-location and does not make component-local modules correctly ordered.

## Verification

- `DUSK_SERVE_PORT=8011 vendor/bin/phpunit --configuration phpunit.xml.dist src/Features/SupportJsModules/BrowserTest.php` — 13 tests, 46 assertions
- `npm run test:run` — 110 passed, 1 skipped
- `npm run build` — both Livewire bundles built successfully
- Real Laravel app comparison: affected `4.x` rendered a blank status with two Alpine reference errors; this branch renders `Alpine data loaded` with no console errors

Context: #10295, #9861, discussions #9591, #9737, and #9830.
