### PR TITLE
[4.x] Avoid unnecessary validation data unwrapping

### DIFF
--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -512,6 +512,8 @@ trait HandlesValidation
     protected function unwrapDataForValidation($data)
     {
         return collect($data)->map(function ($value) {
+            // Scalars and arrays are already valid Laravel validation data...
+            if (! is_object($value)) return $value;
 
             $synth = app('livewire')->findSynth($value, $this);
 

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -2,7 +2,6 @@
 
 namespace Livewire\Features\SupportValidation;
 
-use ArrayAccess;
 use function Livewire\invade;
 use function Livewire\store;
 use Illuminate\Contracts\Support\Arrayable;
@@ -382,7 +381,7 @@ trait HandlesValidation
 
         $ruleKeysToShorten = $this->getModelAttributeRuleKeysToShorten($data, $rules);
 
-        $data = $this->unwrapDataForValidation($data, $property, $rulesForField);
+        $data = $this->unwrapDataForValidation($data);
 
         // If a matching rule is found, then filter collections down to keys specified in the field,
         // while leaving all other data intact. If a key isn't specified and instead there is a
@@ -510,17 +509,11 @@ trait HandlesValidation
         return Utils::getPublicPropertiesDefinedOnSubclass($this);
     }
 
-    protected function unwrapDataForValidation($data, $property = null, $rules = [])
+    protected function unwrapDataForValidation($data)
     {
-        $untouched = $this->siblingsUntouchedByRules($data, $property, $rules);
-
-        return collect($data)->map(function ($value, $key) use ($untouched) {
+        return collect($data)->map(function ($value) {
             // Scalars and arrays are already valid Laravel validation data...
             if (! is_object($value)) return $value;
-
-            // Laravel can traverse ArrayAccess values without materializing them,
-            // so siblings that no rule references are safe to leave wrapped...
-            if (in_array($key, $untouched, true)) return $value;
 
             $synth = app('livewire')->findSynth($value, $this);
 
@@ -529,41 +522,6 @@ trait HandlesValidation
 
             return $value;
         })->all();
-    }
-
-    protected function siblingsUntouchedByRules($data, $property, $rules)
-    {
-        if (is_null($property)) return [];
-
-        // Rule objects, closures, and withValidator() callbacks can read any
-        // value on the validator, so every sibling has to be unwrapped...
-        if ($this->withValidatorCallback) return [];
-
-        $referenced = [$property];
-
-        foreach ($rules as $key => $ruleSet) {
-            foreach (is_string($ruleSet) ? explode('|', $ruleSet) : Arr::wrap($ruleSet) as $rule) {
-                if ($rule instanceof \Stringable) $rule = (string) $rule;
-
-                if (! is_string($rule)) return [];
-
-                // A bare "confirmed" rule implicitly reads a "{field}_confirmation" sibling...
-                if ($rule === 'confirmed') $referenced[] = Utils::beforeFirstDot($key.'_confirmation');
-
-                if (! str_contains($rule, ':')) continue;
-
-                // Dependent rules like "same:settings.title" read sibling properties
-                // through their parameters...
-                foreach (explode(',', (string) str($rule)->after(':')) as $parameter) {
-                    $referenced[] = Utils::beforeFirstDot(trim($parameter));
-                }
-            }
-        }
-
-        return collect($data)
-            ->filter(fn ($value, $key) => $value instanceof ArrayAccess && ! in_array($key, $referenced, true))
-            ->keys()
-            ->all();
     }
 
     protected function prepareForValidation($attributes)

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -382,7 +382,7 @@ trait HandlesValidation
 
         $ruleKeysToShorten = $this->getModelAttributeRuleKeysToShorten($data, $rules);
 
-        $data = $this->unwrapDataForValidation($data, $property);
+        $data = $this->unwrapDataForValidation($data, $property, $rulesForField);
 
         // If a matching rule is found, then filter collections down to keys specified in the field,
         // while leaving all other data intact. If a key isn't specified and instead there is a
@@ -510,20 +510,17 @@ trait HandlesValidation
         return Utils::getPublicPropertiesDefinedOnSubclass($this);
     }
 
-    protected function unwrapDataForValidation($data, $property = null)
+    protected function unwrapDataForValidation($data, $property = null, $rules = [])
     {
-        return collect($data)->map(function ($value, $key) use ($property) {
+        $untouched = $this->siblingsUntouchedByRules($data, $property, $rules);
+
+        return collect($data)->map(function ($value, $key) use ($untouched) {
             // Scalars and arrays are already valid Laravel validation data...
             if (! is_object($value)) return $value;
 
-            if (
-                ! is_null($property)
-                && $key !== $property
-                && $value instanceof ArrayAccess
-            ) {
-                // Laravel can traverse ArrayAccess values without materializing them...
-                return $value;
-            }
+            // Laravel can traverse ArrayAccess values without materializing them,
+            // so siblings that no rule references are safe to leave wrapped...
+            if (in_array($key, $untouched, true)) return $value;
 
             $synth = app('livewire')->findSynth($value, $this);
 
@@ -532,6 +529,41 @@ trait HandlesValidation
 
             return $value;
         })->all();
+    }
+
+    protected function siblingsUntouchedByRules($data, $property, $rules)
+    {
+        if (is_null($property)) return [];
+
+        // Rule objects, closures, and withValidator() callbacks can read any
+        // value on the validator, so every sibling has to be unwrapped...
+        if ($this->withValidatorCallback) return [];
+
+        $referenced = [$property];
+
+        foreach ($rules as $key => $ruleSet) {
+            foreach (is_string($ruleSet) ? explode('|', $ruleSet) : Arr::wrap($ruleSet) as $rule) {
+                if ($rule instanceof \Stringable) $rule = (string) $rule;
+
+                if (! is_string($rule)) return [];
+
+                // A bare "confirmed" rule implicitly reads a "{field}_confirmation" sibling...
+                if ($rule === 'confirmed') $referenced[] = Utils::beforeFirstDot($key.'_confirmation');
+
+                if (! str_contains($rule, ':')) continue;
+
+                // Dependent rules like "same:settings.title" read sibling properties
+                // through their parameters...
+                foreach (explode(',', (string) str($rule)->after(':')) as $parameter) {
+                    $referenced[] = Utils::beforeFirstDot(trim($parameter));
+                }
+            }
+        }
+
+        return collect($data)
+            ->filter(fn ($value, $key) => $value instanceof ArrayAccess && ! in_array($key, $referenced, true))
+            ->keys()
+            ->all();
     }
 
     protected function prepareForValidation($attributes)

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportValidation;
 
+use ArrayAccess;
 use function Livewire\invade;
 use function Livewire\store;
 use Illuminate\Contracts\Support\Arrayable;
@@ -381,7 +382,7 @@ trait HandlesValidation
 
         $ruleKeysToShorten = $this->getModelAttributeRuleKeysToShorten($data, $rules);
 
-        $data = $this->unwrapDataForValidation($data);
+        $data = $this->unwrapDataForValidation($data, $property);
 
         // If a matching rule is found, then filter collections down to keys specified in the field,
         // while leaving all other data intact. If a key isn't specified and instead there is a
@@ -509,11 +510,20 @@ trait HandlesValidation
         return Utils::getPublicPropertiesDefinedOnSubclass($this);
     }
 
-    protected function unwrapDataForValidation($data)
+    protected function unwrapDataForValidation($data, $property = null)
     {
-        return collect($data)->map(function ($value) {
+        return collect($data)->map(function ($value, $key) use ($property) {
             // Scalars and arrays are already valid Laravel validation data...
             if (! is_object($value)) return $value;
+
+            if (
+                ! is_null($property)
+                && $key !== $property
+                && $value instanceof ArrayAccess
+            ) {
+                // Laravel can traverse ArrayAccess values without materializing them...
+                return $value;
+            }
 
             $synth = app('livewire')->findSynth($value, $this);
 

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -1123,6 +1123,80 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertSame(0, ValidationUnwrappingSpyCollection::$toArrayCalls);
     }
+
+    public function test_validate_only_still_unwraps_a_wireable_sibling_for_dependent_rules()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $title;
+
+            public $settings;
+
+            public function mount()
+            {
+                $this->settings = new CustomWireableValidationDTO(50);
+            }
+
+            public function validateTitle()
+            {
+                $this->validateOnly('title', [
+                    'title' => 'required_if:settings.amount,50',
+                ]);
+            }
+        })->call('validateTitle')->assertHasErrors(['title' => 'required_if']);
+    }
+
+    public function test_validate_only_still_unwraps_the_property_being_validated()
+    {
+        ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
+
+        Livewire::test(new class extends TestComponent {
+            public $rows;
+
+            public function mount()
+            {
+                $this->rows = new ValidationUnwrappingSpyCollection([
+                    ['id' => 1],
+                ]);
+            }
+
+            public function validateRow()
+            {
+                $this->validateOnly('rows.0.id', [
+                    'rows.*.id' => 'required|integer',
+                ]);
+            }
+        })->call('validateRow')->assertHasNoErrors();
+
+        $this->assertSame(1, ValidationUnwrappingSpyCollection::$toArrayCalls);
+    }
+
+    public function test_validate_still_unwraps_all_arrayable_properties()
+    {
+        ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
+
+        Livewire::test(new class extends TestComponent {
+            public $title = 'Livewire';
+
+            public $rows;
+
+            public function mount()
+            {
+                $this->rows = new ValidationUnwrappingSpyCollection([
+                    ['id' => 1],
+                ]);
+            }
+
+            public function validateAll()
+            {
+                $this->validate([
+                    'title' => 'required',
+                    'rows.*.id' => 'required|integer',
+                ]);
+            }
+        })->call('validateAll')->assertHasNoErrors();
+
+        $this->assertSame(1, ValidationUnwrappingSpyCollection::$toArrayCalls);
+    }
 }
 
 class ValidationUnwrappingSpyCollection extends Collection

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -15,7 +15,10 @@ use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Livewire\Form;
 use PHPUnit\Framework\AssertionFailedError;
+use Sushi\Sushi;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -1097,7 +1100,7 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame(0, ValidationUnwrappingSpyCollection::$toArrayCalls);
     }
 
-    public function test_validate_only_can_use_an_array_access_sibling_in_a_dependent_rule_without_unwrapping_it()
+    public function test_validate_only_unwraps_an_array_access_sibling_referenced_by_a_dependent_rule()
     {
         ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
 
@@ -1121,7 +1124,161 @@ class UnitTest extends \Tests\TestCase
             }
         })->call('validateTitle')->assertHasNoErrors();
 
+        $this->assertSame(1, ValidationUnwrappingSpyCollection::$toArrayCalls);
+    }
+
+    public function test_validate_only_dependent_rule_against_a_sibling_still_fails_when_it_should()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $title = 'Different';
+
+            public $settings;
+
+            public function mount()
+            {
+                $this->settings = new ValidationUnwrappingSpyCollection([
+                    'required_title' => 'Livewire',
+                ]);
+            }
+
+            public function validateTitle()
+            {
+                $this->validateOnly('title', [
+                    'title' => 'same:settings.required_title',
+                ]);
+            }
+        })->call('validateTitle')->assertHasErrors(['title' => 'same']);
+    }
+
+    public function test_validate_only_supports_wildcard_dependent_rule_parameters_against_a_collection_sibling()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $chosen = 2;
+
+            public $options;
+
+            public function mount()
+            {
+                $this->options = collect([['id' => 1], ['id' => 2]]);
+            }
+
+            public function validateChosen()
+            {
+                $this->validateOnly('chosen', [
+                    'chosen' => 'in_array:options.*.id',
+                ]);
+            }
+        })->call('validateChosen')->assertHasNoErrors()
+            ->set('chosen', 99)
+            ->call('validateChosen')->assertHasErrors(['chosen' => 'in_array']);
+    }
+
+    public function test_validate_only_can_compare_against_a_whole_collection_sibling()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $copy = ['a'];
+
+            public $original;
+
+            public function mount()
+            {
+                $this->original = collect(['a']);
+            }
+
+            public function validateCopy()
+            {
+                $this->validateOnly('copy', [
+                    'copy' => 'same:original',
+                ]);
+            }
+        })->call('validateCopy')->assertHasNoErrors();
+    }
+
+    public function test_validate_only_dependent_rules_read_a_model_sibling_the_same_as_full_validation()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $reason = '';
+
+            public $article;
+
+            public function mount()
+            {
+                $this->article = ArticleForValidationUnwrappingTesting::first();
+            }
+
+            public function validateReason()
+            {
+                $this->validateOnly('reason', [
+                    'reason' => 'required_if:article.status,published',
+                ]);
+            }
+        })->call('validateReason')->assertHasErrors(['reason' => 'required_if']);
+    }
+
+    public function test_validate_only_with_validator_callbacks_see_unwrapped_siblings()
+    {
+        ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
+
+        Livewire::test(new class extends TestComponent {
+            public $title = '';
+
+            public $settings;
+
+            public function mount()
+            {
+                $this->settings = new ValidationUnwrappingSpyCollection([
+                    'strict' => true,
+                ]);
+            }
+
+            public function validateTitle()
+            {
+                $this->withValidator(function ($validator) {
+                    $validator->sometimes('title', 'required', fn ($input) => $input->settings['strict'] === true);
+                })->validateOnly('title', [
+                    'title' => 'string',
+                ]);
+            }
+        })->call('validateTitle')->assertHasErrors(['title' => 'required']);
+
+        $this->assertSame(1, ValidationUnwrappingSpyCollection::$toArrayCalls);
+    }
+
+    public function test_validate_only_keeps_unreferenced_form_object_siblings_wrapped()
+    {
+        ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
+
+        Livewire::test(new class extends TestComponent {
+            public ValidationUnwrappingTestForm $form;
+
+            public function mount()
+            {
+                $this->form->rows = new ValidationUnwrappingSpyCollection([
+                    ['id' => 1],
+                ]);
+            }
+
+            public function validateTitle()
+            {
+                $this->validateOnly('form.title');
+            }
+        })->call('validateTitle')->assertHasNoErrors();
+
         $this->assertSame(0, ValidationUnwrappingSpyCollection::$toArrayCalls);
+    }
+
+    public function test_can_validate_a_string_property_whose_value_matches_a_synth_key()
+    {
+        // The raw string used to be passed to findSynth, match the Wireable
+        // synth's key, and fatal calling toLivewire() on a string...
+        Livewire::test(new class extends TestComponent {
+            public $title = 'wrbl';
+
+            public function save()
+            {
+                $this->validate(['title' => 'required|string|min:3']);
+            }
+        })->call('save')->assertHasNoErrors();
     }
 
     public function test_validate_only_still_unwraps_a_wireable_sibling_for_dependent_rules()
@@ -1209,6 +1366,31 @@ class ValidationUnwrappingSpyCollection extends Collection
 
         return parent::toArray();
     }
+}
+
+class ValidationUnwrappingTestForm extends Form
+{
+    #[Validate('required')]
+    public $title = 'Livewire';
+
+    public $rows;
+}
+
+class ArticleForValidationUnwrappingTesting extends Model
+{
+    use Sushi;
+
+    protected $casts = ['status' => ArticleStatusForValidationUnwrappingTesting::class];
+
+    protected $rows = [
+        ['status' => 'published'],
+    ];
+}
+
+enum ArticleStatusForValidationUnwrappingTesting: string
+{
+    case Published = 'published';
+    case Draft = 'draft';
 }
 
 class ComponentWithRulesProperty extends TestComponent

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -16,7 +16,6 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Livewire\Form;
 use PHPUnit\Framework\AssertionFailedError;
 use Sushi\Sushi;
 
@@ -1073,34 +1072,7 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame(0, $livewire->findSynthCalls);
     }
 
-    public function test_validate_only_does_not_unwrap_unrelated_arrayable_properties()
-    {
-        ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
-
-        Livewire::test(new class extends TestComponent {
-            public $title = 'Livewire';
-
-            public $rows;
-
-            public function mount()
-            {
-                $this->rows = new ValidationUnwrappingSpyCollection([
-                    ['id' => 1],
-                ]);
-            }
-
-            public function validateTitle()
-            {
-                $this->validateOnly('title', [
-                    'title' => 'required',
-                ]);
-            }
-        })->call('validateTitle')->assertHasNoErrors();
-
-        $this->assertSame(0, ValidationUnwrappingSpyCollection::$toArrayCalls);
-    }
-
-    public function test_validate_only_unwraps_an_array_access_sibling_referenced_by_a_dependent_rule()
+    public function test_validate_only_unwraps_an_array_access_sibling_used_in_a_dependent_rule()
     {
         ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
 
@@ -1244,29 +1216,6 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame(1, ValidationUnwrappingSpyCollection::$toArrayCalls);
     }
 
-    public function test_validate_only_keeps_unreferenced_form_object_siblings_wrapped()
-    {
-        ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
-
-        Livewire::test(new class extends TestComponent {
-            public ValidationUnwrappingTestForm $form;
-
-            public function mount()
-            {
-                $this->form->rows = new ValidationUnwrappingSpyCollection([
-                    ['id' => 1],
-                ]);
-            }
-
-            public function validateTitle()
-            {
-                $this->validateOnly('form.title');
-            }
-        })->call('validateTitle')->assertHasNoErrors();
-
-        $this->assertSame(0, ValidationUnwrappingSpyCollection::$toArrayCalls);
-    }
-
     public function test_can_validate_a_string_property_whose_value_matches_a_synth_key()
     {
         // The raw string used to be passed to findSynth, match the Wireable
@@ -1366,14 +1315,6 @@ class ValidationUnwrappingSpyCollection extends Collection
 
         return parent::toArray();
     }
-}
-
-class ValidationUnwrappingTestForm extends Form
-{
-    #[Validate('required')]
-    public $title = 'Livewire';
-
-    public $rows;
 }
 
 class ArticleForValidationUnwrappingTesting extends Model

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -1036,6 +1036,40 @@ class UnitTest extends \Tests\TestCase
 
         $component->assertOnlyHasErrors(['foo' => 'min', 'bar' => 'min']);
     }
+
+    public function test_validation_ready_data_is_not_resolved_by_synthesizers()
+    {
+        $livewire = new class {
+            public int $findSynthCalls = 0;
+
+            public function findSynth($value, $component)
+            {
+                $this->findSynthCalls++;
+            }
+        };
+
+        app()->instance('livewire', $livewire);
+
+        $component = new class extends TestComponent {
+            public function unwrap($data)
+            {
+                return $this->unwrapDataForValidation($data);
+            }
+        };
+
+        $data = [
+            'string' => 'Livewire',
+            'integer' => 4,
+            'float' => 4.0,
+            'boolean' => true,
+            'null' => null,
+            'array' => ['already', 'valid'],
+        ];
+
+        $this->assertSame($data, $component->unwrap($data));
+        $this->assertSame(0, $livewire->findSynthCalls);
+    }
+
 }
 
 class ComponentWithRulesProperty extends TestComponent

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -1070,6 +1070,71 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame(0, $livewire->findSynthCalls);
     }
 
+    public function test_validate_only_does_not_unwrap_unrelated_arrayable_properties()
+    {
+        ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
+
+        Livewire::test(new class extends TestComponent {
+            public $title = 'Livewire';
+
+            public $rows;
+
+            public function mount()
+            {
+                $this->rows = new ValidationUnwrappingSpyCollection([
+                    ['id' => 1],
+                ]);
+            }
+
+            public function validateTitle()
+            {
+                $this->validateOnly('title', [
+                    'title' => 'required',
+                ]);
+            }
+        })->call('validateTitle')->assertHasNoErrors();
+
+        $this->assertSame(0, ValidationUnwrappingSpyCollection::$toArrayCalls);
+    }
+
+    public function test_validate_only_can_use_an_array_access_sibling_in_a_dependent_rule_without_unwrapping_it()
+    {
+        ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
+
+        Livewire::test(new class extends TestComponent {
+            public $title = 'Livewire';
+
+            public $settings;
+
+            public function mount()
+            {
+                $this->settings = new ValidationUnwrappingSpyCollection([
+                    'required_title' => 'Livewire',
+                ]);
+            }
+
+            public function validateTitle()
+            {
+                $this->validateOnly('title', [
+                    'title' => 'same:settings.required_title',
+                ]);
+            }
+        })->call('validateTitle')->assertHasNoErrors();
+
+        $this->assertSame(0, ValidationUnwrappingSpyCollection::$toArrayCalls);
+    }
+}
+
+class ValidationUnwrappingSpyCollection extends Collection
+{
+    public static int $toArrayCalls = 0;
+
+    public function toArray()
+    {
+        static::$toArrayCalls++;
+
+        return parent::toArray();
+    }
 }
 
 class ComponentWithRulesProperty extends TestComponent


### PR DESCRIPTION
## Problem

`validateOnly()` gets slower as a form grows, even though it validates a single field: every top-level public property — plain scalars and arrays included — is pushed through `findSynth()` during validation prep. For string values this routes through `findByKey()`, costing ~15µs per property *per call*, so large scalar forms pay a real tax on every keystroke validation (#9416, and the dominant cost in #10565's report).

## Findings

- Scalars and arrays are already valid Laravel validation data — the synth lookup on them is pure waste. No built-in synth matches a non-object value, so nothing is skipped that could have mattered.
- Skipping it also fixes a latent fatal: a string property whose *value* equals a synth key (e.g. `'wrbl'`) was routed through `findByKey()`, resolved the Wireable synth, and fataled calling `->toLivewire()` on a string.

## Potential solutions

- **Bail early for non-objects** — two lines, cannot change validation results, captures the reported cost.
- **Also keep `Arrayable`/`ArrayAccess` siblings lazy during `validateOnly()`** — explored and rejected: dependent rules that reference a wrapped sibling break silently (wildcard parameters never match objects through `Arr::dot()`, whole-object `same:`/`gt:` comparisons fail on type mismatch, model siblings leak live cast/hidden/lazy-load semantics), and guarding all of that requires a rule-parameter–scanning heuristic that isn't worth its weight.

## Proposed solution

The non-object bail alone:

```php
// Scalars and arrays are already valid Laravel validation data...
if (! is_object($value)) return $value;
```

Objects take exactly the same path as before — synth `unwrapForValidation()`, then `Arrayable::toArray()` — so validation behavior is byte-for-byte identical; the only observable change is the `'wrbl'` fatal becoming a passing validation.

## Verification

- 10,000 preparation passes over 38 scalar fields: **5,385ms → 17ms**. Re-measured through a real browser round trip (`wire:model.live.blur` → `updated()` → `validateOnly()`) on a 16-property component: 1,000 unwrap passes dropped **624ms → 1.1ms**.
- New tests pin the fast path (a synth spy proving scalars never hit `findSynth()`), the eager-sibling semantics any future laziness attempt must preserve (wildcard `in_array:options.*.id`, whole-Collection `same:`, enum-cast model `required_if`, `withValidator()` + `sometimes()`, and a negative-path dependent rule), and the synth-key string fatal.
- Full unit suite: 1,432 tests, 4,068 assertions; 13 skipped, 3 incomplete. Branch is merged with the current `4.x` head.

No documentation change is needed: the public validation API is unchanged.
