### PR TITLE
[4.x] Surface TypeErrors from Livewire tests across Laravel versions

### DIFF
--- a/src/Features/SupportTesting/RequestBroker.php
+++ b/src/Features/SupportTesting/RequestBroker.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\Concerns\MakesHttpRequests;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Livewire\Mechanisms\HandleRequests\HandleRequests;
 
 class RequestBroker
 {
@@ -27,15 +28,17 @@ class RequestBroker
 
         $this->withoutExceptionHandling([HttpException::class, AuthorizationException::class])->withoutMiddleware();
 
-        $result = $callback($this);
+        try {
+            return app(HandleRequests::class)->temporarilyPropagateExceptions(
+                fn () => $callback($this),
+            );
+        } finally {
+            $this->app->instance(ExceptionHandler::class, $cachedHandler);
 
-        $this->app->instance(ExceptionHandler::class, $cachedHandler);
-
-        if (! $cachedShouldSkipMiddleware) {
-            unset($this->app['middleware.disable']);
+            if (! $cachedShouldSkipMiddleware) {
+                unset($this->app['middleware.disable']);
+            }
         }
-
-        return $result;
     }
 
     function withoutHandling($except = [])

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -560,6 +560,17 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             ->assertReturned(fn ($data) => $data === 'bar');
     }
 
+    function test_type_errors_thrown_from_component_actions_are_rethrown()
+    {
+        config()->set('app.debug', false);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('array_merge(): Argument #1 must be of type array, Illuminate\\Support\\Collection given');
+
+        Livewire::test(ComponentWithActionThatThrowsTypeError::class)
+            ->call('save');
+    }
+
     public function test_can_set_cookies_for_use_with_testing()
     {
         // Test both the `withCookies` and `withCookie` methods that Laravel normally provides
@@ -804,6 +815,14 @@ class ComponentWithMethodThatReturnsData extends TestComponent
     function foo()
     {
         return 'bar';
+    }
+}
+
+class ComponentWithActionThatThrowsTypeError extends TestComponent
+{
+    function save()
+    {
+        array_merge(collect(), []);
     }
 }
 

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportTesting;
 
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Validation\ValidationRule;
 use PHPUnit\Framework\ExpectationFailedException;
 use Illuminate\Support\Facades\Artisan;
@@ -571,6 +572,41 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             ->call('save');
     }
 
+    function test_type_errors_thrown_while_binding_component_action_parameters_are_rethrown()
+    {
+        config()->set('app.debug', false);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('must be of type array, string given');
+
+        Livewire::test(ComponentWithActionThatThrowsTypeError::class)
+            ->call('saveItems', 'not-an-array');
+    }
+
+    function test_exception_handling_and_middleware_are_restored_after_component_exceptions()
+    {
+        config()->set('app.debug', false);
+
+        $cachedHandler = app(ExceptionHandler::class);
+        $cachedShouldSkipMiddleware = app()->shouldSkipMiddleware();
+
+        try {
+            Livewire::test(ComponentWithActionThatThrowsTypeError::class)
+                ->call('save');
+
+            $this->fail('The component TypeError was not rethrown.');
+        } catch (\TypeError $e) {
+            $this->assertStringContainsString('array_merge()', $e->getMessage());
+        }
+
+        $this->assertSame($cachedHandler, app(ExceptionHandler::class));
+        $this->assertSame($cachedShouldSkipMiddleware, app()->shouldSkipMiddleware());
+
+        Livewire::test(ComponentWithMethodThatReturnsData::class)
+            ->call('foo')
+            ->assertReturned('bar');
+    }
+
     public function test_can_set_cookies_for_use_with_testing()
     {
         // Test both the `withCookies` and `withCookie` methods that Laravel normally provides
@@ -823,6 +859,10 @@ class ComponentWithActionThatThrowsTypeError extends TestComponent
     function save()
     {
         array_merge(collect(), []);
+    }
+
+    function saveItems(array $items)
+    {
     }
 }
 

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -18,6 +18,8 @@ class HandleRequests extends Mechanism
 {
     protected $updateRoute;
 
+    protected $shouldPropagateExceptions = false;
+
     function boot()
     {
         // Register the default route immediately (before routes files load)
@@ -135,6 +137,19 @@ class HandleRequests extends Mechanism
         return $route->named('*livewire.update');
     }
 
+    function temporarilyPropagateExceptions($callback)
+    {
+        $cachedShouldPropagateExceptions = $this->shouldPropagateExceptions;
+
+        $this->shouldPropagateExceptions = true;
+
+        try {
+            return $callback();
+        } finally {
+            $this->shouldPropagateExceptions = $cachedShouldPropagateExceptions;
+        }
+    }
+
     function handleUpdate()
     {
         // When a custom update route is registered, reject requests that arrive
@@ -206,7 +221,7 @@ class HandleRequests extends Mechanism
             } catch (\TypeError $e) {
                 report($e);
 
-                if (config('app.debug')) throw $e;
+                if (config('app.debug') || $this->shouldPropagateExceptions) throw $e;
 
                 abort(419);
             }


### PR DESCRIPTION
## Problem

- **Experience:** When a component action or its parameter binding throws a TypeError under Livewire::test() with debug mode disabled, the call returns an empty 419-backed component state and hides the original exception and stack trace.
- **Expectation:** The original TypeError should be rethrown to PHPUnit because the Livewire test broker disables exception handling for component requests.
- **Cause:** HandleRequests catches every TypeError escaping an update and converts it to a 419 before the Laravel test handler can rethrow it. RequestBroker intentionally renders HttpExceptions, so the synthesized 419 reaches SubsequentRender and the original exception is lost.

## Solution

1. [Level 1 — Propagate TypeErrors from Livewire tests](https://github.com/livewire/livewire/commit/80fc458e05db19afe09fc1194796eadd025395ea) — adds a nest-safe internal propagation scope around the Livewire test broker, restores the exception handler and middleware state in finally, and covers TypeErrors thrown inside action bodies. Production requests still report the exception and return 419.
2. [Level 2 — Cover parameter binding and broker cleanup](https://github.com/livewire/livewire/commit/8cc7c8ae001d80b5276aa4dcdfa952c87734af8e) — covers TypeErrors raised by PHP action-parameter binding and proves the broker leaves no exception-handling or middleware state behind after an exception escapes.

This uses an explicit Livewire-owned test scope rather than the Laravel WithoutExceptionHandlingHandler marker used by #10407. That marker is unavailable on supported Laravel 10, while this path works across the declared Laravel 10–13 range without adding a public API.

Fixes #10385.