### PR TITLE
Use Alpine deferred initialization for component script modules

### DIFF
--- a/js/features/supportJsModules.js
+++ b/js/features/supportJsModules.js
@@ -1,5 +1,6 @@
 import { on } from '@/hooks'
 import { getModuleUrl } from '@/utils'
+import Alpine from 'alpinejs'
 
 let pendingComponentAssets = new WeakMap()
 
@@ -14,18 +15,30 @@ on('effect', ({ component, effects }) => {
         let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
         let path = `${getModuleUrl()}/js/${encodedName}.js?v=${scriptModuleHash}`
 
-        pendingComponentAssets.set(component, Alpine.reactive({
+        let pendingAsset = Alpine.reactive({
             loading: true,
             afterLoaded: [],
-        }))
+        })
 
-        import(/* @vite-ignore */ path).then(module => {
-            module.run.call(component.$wire, component.$wire, component.$wire.js);
+        pendingComponentAssets.set(component, pendingAsset)
 
-            pendingComponentAssets.get(component).loading = false
-            pendingComponentAssets.get(component).afterLoaded.forEach(callback => callback())
-            pendingComponentAssets.delete(component)
-        });
+        let promise = import(/* @vite-ignore */ path).then(module => {
+            module.run.call(component.$wire, component.$wire, component.$wire.js)
+        })
+
+        let finish = () => {
+            pendingAsset.loading = false
+
+            if (pendingComponentAssets.get(component) === pendingAsset) {
+                pendingComponentAssets.delete(component)
+            }
+
+            let callbacks = pendingAsset.afterLoaded.splice(0)
+
+            callbacks.forEach(callback => callback())
+        }
+
+        Alpine.deferInit(component.el, promise.finally(finish))
     }
 })
 

--- a/src/Features/SupportJsModules/BrowserTest.php
+++ b/src/Features/SupportJsModules/BrowserTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportJsModules;
 
 use Illuminate\Support\Facades\Route;
+use Livewire\Component;
 use Livewire\Livewire;
 
 class BrowserTest extends \Tests\BrowserTestCase
@@ -17,6 +18,22 @@ class BrowserTest extends \Tests\BrowserTestCase
                     'Content-Type' => 'application/javascript',
                 ]);
             });
+
+            Route::get('/slow-slot-module.js', function () {
+                usleep(2_000_000);
+
+                return response("export let greeting = 'slot-alpine-data-loaded'", 200, [
+                    'Content-Type' => 'application/javascript',
+                ]);
+            });
+
+            Route::get('/alpine-data-page', function () {
+                return app('livewire')->new('testns::alpine-data.index')();
+            })->middleware('web');
+
+            Route::get('/alpine-data-page-2', function () {
+                return app('livewire')->new('testns::alpine-data.index')();
+            })->middleware('web');
         };
     }
 
@@ -50,6 +67,108 @@ class BrowserTest extends \Tests\BrowserTestCase
         Livewire::visit('testns::mfc-with-imports')
             ->waitForLivewireToLoad()
             ->waitForTextIn('@target', 'js-import-loaded');
+    }
+
+    public function test_alpine_data_is_available_during_initial_component_initialization()
+    {
+        Livewire::visit('testns::alpine-data.index')
+            ->waitForLivewireToLoad()
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertSeeIn('@js-action', 'js-action-loaded')
+            ->assertSeeIn('@js-action-state', 'ready')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_is_available_when_a_lazy_component_hydrates()
+    {
+        Livewire::visit('testns::lazy-with-alpine-data')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_is_available_when_a_component_is_added_dynamically()
+    {
+        Livewire::visit([new class extends Component {
+            public $show = false;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$toggle('show')" dusk="toggle">Toggle</button>
+
+                    @if ($show)
+                        <livewire:testns::alpine-data.index />
+                    @endif
+                </div>
+                HTML;
+            }
+        }])
+            ->assertDontSee('alpine-data-loaded')
+            ->waitForLivewire()->click('@toggle')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_is_available_in_a_slot_forwarded_through_a_lazy_component()
+    {
+        Livewire::visit('testns::lazy-with-alpine-data-in-slot.parent')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_is_available_when_an_existing_child_morphs_forwarded_slot_content()
+    {
+        Livewire::visit('testns::lazy-slot-with-existing-wrapper.parent')
+            ->assertSeeIn('@target', 'Loading...')
+            ->waitForTextIn('@target', 'slot-alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_is_available_in_a_component_added_to_an_island()
+    {
+        Livewire::visit('testns::island-with-alpine-data')
+            ->assertSeeIn('@placeholder', 'No child yet')
+            ->waitForLivewire()->click('@toggle')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_is_available_after_wire_navigate()
+    {
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <div dusk="source-page">Source page</div>
+                    <a href="/alpine-data-page" wire:navigate dusk="link">Go to alpine data page</a>
+                </div>
+                HTML;
+            }
+        }])
+            ->assertSeeIn('@source-page', 'Source page')
+            ->waitForNavigate()->click('@link')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_module_remains_available_across_wire_navigate()
+    {
+        Livewire::visit('testns::navigate-with-alpine-data')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->waitForNavigate()->click('@link')
+            ->waitUntilMissing('@first-page')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_component_initialization_recovers_when_a_script_module_fails_to_import()
+    {
+        Livewire::visit('testns::failed-module')
+            ->waitForTextIn('@ready', 'ready')
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '1');
     }
 
     public function test_script_module_survives_a_back_navigation()

--- a/src/Features/SupportJsModules/fixtures/alpine-data/index.blade.php
+++ b/src/Features/SupportJsModules/fixtures/alpine-data/index.blade.php
@@ -1,0 +1,20 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div x-data="testAlpineData">
+    <div dusk="target" x-text="message"></div>
+    <div dusk="js-action" x-text="$wire.$js.moduleGreeting()"></div>
+    <div dusk="js-action-state" x-text="$wire.$js.moduleGreeting() instanceof Promise ? 'pending' : 'ready'"></div>
+</div>
+
+<script>
+    $js('moduleGreeting', () => 'js-action-loaded')
+
+    Alpine.data('testAlpineData', () => ({
+        message: 'alpine-data-loaded',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/failed-module.blade.php
+++ b/src/Features/SupportJsModules/fixtures/failed-module.blade.php
@@ -1,0 +1,17 @@
+<?php
+
+new class extends Livewire\Component {
+    public $count = 0;
+};
+?>
+
+<div x-data="{ ready: false }" x-init="ready = true">
+    <span dusk="ready" x-text="ready ? 'ready' : 'waiting'">waiting</span>
+
+    <button wire:click="$set('count', {{ $count + 1 }})" dusk="increment">Increment</button>
+    <span dusk="count">{{ $count }}</span>
+</div>
+
+<script>
+    import '/missing-component-module.js'
+</script>

--- a/src/Features/SupportJsModules/fixtures/island-with-alpine-data.blade.php
+++ b/src/Features/SupportJsModules/fixtures/island-with-alpine-data.blade.php
@@ -1,0 +1,18 @@
+<?php
+
+new class extends Livewire\Component {
+    public $show = false;
+};
+?>
+
+<div>
+    @island(name: 'content')
+        @if ($show)
+            <livewire:testns::alpine-data.index />
+        @else
+            <div dusk="placeholder">No child yet</div>
+        @endif
+    @endisland
+
+    <button wire:click="$toggle('show')" wire:island="content" dusk="toggle">Toggle</button>
+</div>

--- a/src/Features/SupportJsModules/fixtures/lazy-slot-with-existing-wrapper/parent.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-slot-with-existing-wrapper/parent.blade.php
@@ -1,0 +1,30 @@
+<?php
+
+use Livewire\Attributes\Lazy;
+
+new #[Lazy] class extends Livewire\Component {
+    //
+};
+?>
+
+@placeholder
+    <div>
+        <livewire:testns::lazy-slot-with-existing-wrapper.wrapper>
+            <div dusk="target">Loading...</div>
+        </livewire:testns::lazy-slot-with-existing-wrapper.wrapper>
+    </div>
+@endplaceholder
+
+<div>
+    <livewire:testns::lazy-slot-with-existing-wrapper.wrapper>
+        <div dusk="target" x-data="testSlotAlpineData" x-text="message"></div>
+    </livewire:testns::lazy-slot-with-existing-wrapper.wrapper>
+</div>
+
+<script>
+    import { greeting } from '/slow-slot-module.js'
+
+    Alpine.data('testSlotAlpineData', () => ({
+        message: greeting,
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/lazy-slot-with-existing-wrapper/wrapper.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-slot-with-existing-wrapper/wrapper.blade.php
@@ -1,0 +1,10 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div dusk="wrapper">
+    {{ $slot }}
+</div>

--- a/src/Features/SupportJsModules/fixtures/lazy-with-alpine-data-in-slot/parent.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-with-alpine-data-in-slot/parent.blade.php
@@ -1,0 +1,20 @@
+<?php
+
+use Livewire\Attributes\Lazy;
+
+new #[Lazy] class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <livewire:testns::lazy-with-alpine-data-in-slot.wrapper>
+        <div dusk="target" x-data="testAlpineData" x-text="message"></div>
+    </livewire:testns::lazy-with-alpine-data-in-slot.wrapper>
+</div>
+
+<script>
+    Alpine.data('testAlpineData', () => ({
+        message: 'alpine-data-loaded',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/lazy-with-alpine-data-in-slot/wrapper.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-with-alpine-data-in-slot/wrapper.blade.php
@@ -1,0 +1,10 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div dusk="wrapper">
+    {{ $slot }}
+</div>

--- a/src/Features/SupportJsModules/fixtures/lazy-with-alpine-data.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-with-alpine-data.blade.php
@@ -1,0 +1,18 @@
+<?php
+
+use Livewire\Attributes\Lazy;
+
+new #[Lazy] class extends Livewire\Component {
+    //
+};
+?>
+
+<div x-data="testAlpineData">
+    <div dusk="target" x-text="message"></div>
+</div>
+
+<script>
+    Alpine.data('testAlpineData', () => ({
+        message: 'alpine-data-loaded',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/navigate-with-alpine-data.blade.php
+++ b/src/Features/SupportJsModules/fixtures/navigate-with-alpine-data.blade.php
@@ -1,0 +1,14 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <div dusk="first-page">First page</div>
+
+    <livewire:testns::alpine-data.index />
+
+    <a href="/alpine-data-page-2" wire:navigate dusk="link">Go to second page</a>
+</div>


### PR DESCRIPTION
## Problem

- **What users experience:** Alpine expressions inside a Livewire component can fail during initial render, lazy hydration, morphing, islands, or navigation when they reference `Alpine.data()` or `$js` actions registered by that component's `<script>` module. The browser reports that the registration is undefined, or a directive sees Livewire's temporary Promise proxy instead of the loaded action.
- **What users expected:** A component-local script module should finish registering its Alpine data and JavaScript actions before Alpine initializes that component's DOM.
- **Why reality differs:** Component script modules are dynamic imports, while Alpine initializes DOM trees synchronously. Livewire had a way to observe a pending asset, but Alpine had no supported way to suspend only the affected tree. The earlier patch worked around that gap by toggling private Alpine ignore/marker state and manually re-running `initTree()`.

## Solution

- [Level 1: consume Alpine's deferred-init boundary](https://github.com/livewire/livewire/commit/d15e61d0) — passes the module promise to `Alpine.deferInit()` and clears Livewire's pending-module state before Alpine resumes. This removes the need to manipulate `_x_ignore`, `_x_marker`, clone interceptors, or call `initTree()` manually.
- [Level 2: prove the full lifecycle matrix](https://github.com/livewire/livewire/commit/488def53) — adds browser coverage for initial, lazy, dynamic, forwarded-slot morph, island, `wire:navigate`, navigation persistence, `$js` readiness, and failed-import behavior.

This is the balanced path: Alpine owns Alpine initialization, while Livewire only declares the promise its component depends on.

## Dependency / release order

Draft until [alpinejs/alpine#4886](https://github.com/alpinejs/alpine/pull/4886) is merged, released, and Livewire's Alpine lock is updated to that release. A clean install of Alpine 3.16.3 does not contain `deferInit()` yet.

This is intended as the fundamental successor to #10619; that PR should remain available for comparison until this dependency is resolved.

## Verification

- `npm run build`
- Focused Livewire browser tests: 9 passing, 42 assertions
- Real Laravel application reproduction: component-local `Alpine.data()` renders successfully
- Level 1 also builds independently
