### PR TITLE
[4.x] Keep an island's token when a directive above it is unbalanced

### DIFF
--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -57,6 +57,8 @@ class IslandCompiler
 
         $result = $compiler->compileStatementsMadePublic($contents);
 
+        $result = $this->restoreSetAsideDirectives($result, $compiler->setAsideDirectives);
+
         $result = $this->restoreBladeComments($result, $comments);
 
         for ($i=$maxNestingLevel; $i >= $currentNestingLevel; $i--) {
@@ -203,6 +205,20 @@ PHP;
         return [$contents, $comments];
     }
 
+    /**
+     * @param  array<int, string>  $directives
+     */
+    protected function restoreSetAsideDirectives(string $contents, array $directives): string
+    {
+        if ($directives === []) {
+            return $contents;
+        }
+
+        return preg_replace_callback('/\[BLADE_DIRECTIVE:(\d+)\]/', function ($match) use ($directives) {
+            return $directives[(int) $match[1]];
+        }, $contents);
+    }
+
     protected function restoreBladeComments(string $contents, array $comments): string
     {
         return preg_replace_callback('/\[BLADE_COMMENT:(\d+)\]/', function ($match) use ($comments) {
@@ -217,11 +233,39 @@ PHP;
             rtrim(config('view.compiled'), '/\\') . '/livewire',
         ) extends \Illuminate\View\Compilers\BladeCompiler {
             /**
+             * Foreign directives, keyed by the placeholder standing in for them.
+             *
+             * @var array<int, string>
+             */
+            public $setAsideDirectives = [];
+
+            /**
              * Make this method public...
              */
             public function compileStatementsMadePublic($template)
             {
                 return $this->compileStatements($template);
+            }
+
+            /**
+             * Swap a foreign directive for a placeholder instead of returning it unchanged.
+             *
+             * compileStatements() locates every directive by text, with a search offset that
+             * only moves forward - which assumes a replacement consumes the source it matched.
+             * Handing a directive back untouched breaks that assumption: its text stays in the
+             * template, and the paren-balancing loop (which resolves an unbalanced match with
+             * Str::after(), searching from position 0) can rebuild a later directive out of an
+             * earlier, identical prefix. The offset then jumps past directives that follow, or
+             * lands on text that no longer exists ahead of it, and replaceFirstStatement()
+             * silently drops their compiled output. An @island caught by that keeps a bare
+             * `@island(...)` with no token, so every render throws from
+             * getCachedPathFromToken(). A unique placeholder keeps the invariant intact...
+             */
+            protected function setAside($directive)
+            {
+                $this->setAsideDirectives[] = $directive;
+
+                return '[BLADE_DIRECTIVE:' . (count($this->setAsideDirectives) - 1) . ']';
             }
 
             /**
@@ -238,10 +282,9 @@ PHP;
                     // Don't process through built-in directive methods...
                     // $match[0] = $this->$method(Arr::get($match, 3));
 
-                    // Just return the original match...
-                    return $match[0];
+                    return $this->setAside($match[0]);
                 } else {
-                    return $match[0];
+                    return $this->setAside($match[0]);
                 }
 
                 return isset($match[3]) ? $match[0] : $match[0].$match[2];

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -605,4 +605,51 @@ class UnitTest extends TestCase
 
         File::deleteDirectory($compiledPath);
     }
+
+    public function test_island_keeps_its_token_when_a_directive_above_it_has_an_unbalanced_expression()
+    {
+        $compiledPath = sys_get_temp_dir() . '/laravel-island-offset-' . uniqid();
+
+        config()->set('view.compiled', $compiledPath);
+        app()->forgetInstance('livewire.compiler');
+        app()->forgetInstance('livewire.factory');
+
+        // Blade's directive regex is non-greedy, so the second condition below first matches
+        // as `@if (auth()` - unbalanced. Resolving that used to rebuild the match out of the
+        // first identical prefix in the template (the condition above it), which pushed the
+        // compiler's search offset past the @island and dropped its replacement silently...
+        $compiled = IslandCompiler::compile(__FILE__, <<<'HTML'
+        <div>
+            @if (auth()->check())
+                first
+            @endif
+
+            @if (auth()->check() && request()->isMethod('get'))
+                second
+            @endif
+
+            @island(name: 'counter')
+                <div>count: {{ $count }}</div>
+            @endisland
+
+            @if (auth()->check())
+                third
+            @endif
+        </div>
+        HTML);
+
+        $token = app('livewire.compiler')->cacheManager->getHash(__FILE__) . '-1';
+
+        $this->assertStringContainsString("token: '{$token}'", $compiled);
+        $this->assertFileExists(IslandCompiler::getCachedPathFromToken($token));
+
+        // A dropped @island leaves its closing marker behind, because the failed lookup
+        // resets the offset and the @endisland is then found again...
+        $this->assertStringNotContainsString('[ENDISLAND', $compiled);
+
+        // Foreign directives come back exactly as they went in...
+        $this->assertStringContainsString("@if (auth()->check() && request()->isMethod('get'))", $compiled);
+
+        File::deleteDirectory($compiledPath);
+    }
 }


### PR DESCRIPTION
## Problem

An `@island` sometimes ends up in the compiled view without its `token:` argument. Every render of that view then throws:

```
IslandCompiler::getCachedPathFromToken(): Argument #1 ($token) must be of type string, null given
```

This view triggers it:

```blade
<div>
    @if (auth()->check())
        first
    @endif

    @if (auth()->check() && request()->isMethod('get'))
        second
    @endif

    @island(name: 'counter')
        <div>count: {{ $count }}</div>
    @endisland

    @if (auth()->check())
        third
    @endif
</div>
```

Both `@if`s compile fine. The island does not. It comes out of the island pass untouched, with a stray closing marker where its content ended:

```blade
    @island(name: 'counter')
        <div>count: {{ $count }}</div>
    [ENDISLAND:1]
```

It happens while the view is compiled, and it is not random: recompiling gives the same broken result, so `view:clear` does not fix it.

Whether it happens depends on what sits above the island. Three things have to line up:

1. A directive above the island has a nested call in its condition, like `@if (auth()->check())`.
2. The text `@if (auth()` also appears somewhere earlier in the file.
3. The island sits in the stretch that Blade then skips.

That is why it looks arbitrary. Move the same island above the first `@if` and it works.

## Cause

Blade compiles directives one after another. To replace one, it searches the template for its text, starting from a marker that only moves forward.

That works because a replacement removes the text it matched. Whatever has been handled is gone, so a later search cannot land on it again.

The island pass breaks that rule. Its compiler hands foreign directives back untouched:

```php
} else {
    return $match[0];
}
```

Now nothing is removed. The whole template stays as it was, and later searches can still reach text that was already dealt with.

That matters because of how Blade matches a directive to begin with:

```php
preg_match_all('/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( [\S\s]*? ) \))?/x', $template, $matches);
```

`[\S\s]*?` is lazy, so it stops at the first `)` it can reach:

```php
'@if (auth()->check())'  =>  '@if (auth()'
```

Blade knows this and repairs it. If the parentheses do not balance, it goes looking for the rest of the directive:

```php
$after = Str::after($template, $match[0]);
$rest  = Str::before($after, ')');
```

`Str::after()` searches from the start of the template. Not from the directive being repaired.

So in the view above, repairing the second `@if` picks up the rest from the first one. Blade ends up holding `@if (auth()->check())`, the text of a different directive.

It then searches for that text, starting at the marker. The text is not where it should be. Either Blade finds it further down and skips everything in between, or it does not find it at all and loses this directive. Both end on the same line:

```php
return [$subject, 0];
```

The replacement has already been built at that point. For an `@island`, it is the one carrying the token. It is dropped, and nothing is logged.

The stray `[ENDISLAND:1]` above comes from the same line: the failed search resets the marker to `0`, so the `@endisland` is found again and replaced.

## Fix

Replace foreign directives with a placeholder instead of returning them untouched, then put them back once the statements are compiled and before the islands are extracted.

`stripBladeComments()` and `restoreBladeComments()`, a few lines above in the same class, already do exactly this for Blade comments.

With a placeholder, every replacement removes the text it matched. Blade's rule holds again, and `Str::after()` can no longer reach into text that was already handled.

## Tests

`test_island_keeps_its_token_when_a_directive_above_it_has_an_unbalanced_expression` in `src/Features/SupportIslands/UnitTest.php` compiles the view above. On `4.x` it fails: no `token:`, and a stray `[ENDISLAND:1]` left behind. With the fix it passes.

## What we do until then

We rewrite the conditions above an island so the expression is balanced at its first `)`, usually by hoisting it:

```blade
@php
    $canImport = user()->can('manage products') && company()->hasFeature('bulk_import');
@endphp

@if ($canImport)
```

`@if (count($payments) === 0)` needs the same treatment, since its first `)` closes `count(`. It became `@if ($payments === [])`.

To keep it from coming back silently, we added an architecture test that runs the island pass over every view containing `@endisland` and fails if an island directive does not survive it. Two views in our app needed one rewrite each.

## The underlying line

`Str::after($template, $match[0])` in `BladeCompiler::compileStatements()` searches from the start of the template rather than from the current offset. I could not reach that from a plain Blade run, since a normal replacement consumes its source, so this PR fixes it on the Livewire side only.