### PR TITLE
[4.x] Revert #10407 in favor of version-safe exception propagation

### DIFF
--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -560,28 +560,6 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             ->assertReturned(fn ($data) => $data === 'bar');
     }
 
-    function test_type_errors_thrown_from_component_actions_are_rethrown()
-    {
-        config()->set('app.debug', false);
-
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('array_merge(): Argument #1 must be of type array, Illuminate\Support\Collection given');
-
-        Livewire::test(ComponentWithActionThatThrowsTypeError::class)
-            ->call('save');
-    }
-
-    function test_type_errors_thrown_while_binding_component_action_parameters_are_rethrown()
-    {
-        config()->set('app.debug', false);
-
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('must be of type array, string given');
-
-        Livewire::test(ComponentWithActionThatThrowsTypeError::class)
-            ->call('saveItems', 'not-an-array');
-    }
-
     public function test_can_set_cookies_for_use_with_testing()
     {
         // Test both the `withCookies` and `withCookie` methods that Laravel normally provides
@@ -826,18 +804,6 @@ class ComponentWithMethodThatReturnsData extends TestComponent
     function foo()
     {
         return 'bar';
-    }
-}
-
-class ComponentWithActionThatThrowsTypeError extends TestComponent
-{
-    function save()
-    {
-        array_merge(collect(), []);
-    }
-
-    function saveItems(array $items)
-    {
     }
 }
 

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -2,8 +2,6 @@
 
 namespace Livewire\Mechanisms\HandleRequests;
 
-use Illuminate\Contracts\Debug\ExceptionHandler;
-use Illuminate\Foundation\Testing\Concerns\WithoutExceptionHandlingHandler;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
 use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
@@ -208,7 +206,7 @@ class HandleRequests extends Mechanism
             } catch (\TypeError $e) {
                 report($e);
 
-                if (config('app.debug') || app(ExceptionHandler::class) instanceof WithoutExceptionHandlingHandler) throw $e;
+                if (config('app.debug')) throw $e;
 
                 abort(419);
             }


### PR DESCRIPTION
## Reason

Reverts #10407 so it can be replaced by #10621.

The merged handler-marker approach does not cover declared Laravel 10 support because WithoutExceptionHandlingHandler is only available from Laravel 11 onward. It also lets RequestBroker skip exception-handler and middleware restoration when a TypeError escapes.

#10621 carries the same user-facing fix through an internal Livewire-owned propagation scope that works across Laravel 10–13 and restores broker state in finally.