### PR TITLE
[4.x] Preserve islands after nested Blade directives

### DIFF
--- a/src/Features/SupportIslands/BrowserTest.php
+++ b/src/Features/SupportIslands/BrowserTest.php
@@ -47,6 +47,38 @@ class BrowserTest extends BrowserTestCase
             ;
     }
 
+    public function test_island_after_repeated_nested_blade_directives()
+    {
+        Livewire::visit([new class extends \Livewire\Component {
+            public $count = 0;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @if (auth()->check())
+                        first
+                    @endif
+
+                    @if (auth()->check() && request()->isMethod('get'))
+                        second
+                    @endif
+
+                    @island
+                        <div dusk="island">Count: {{ $count }}</div>
+                    @endisland
+
+                    @if (auth()->check())
+                        third
+                    @endif
+                </div>
+                HTML;
+            }
+        }])
+            ->assertSeeIn('@island', 'Count: 0')
+            ;
+    }
+
     public function test_sibling_islands()
     {
         Livewire::visit([new class extends \Livewire\Component {

--- a/src/Features/SupportIslands/BrowserTest.php
+++ b/src/Features/SupportIslands/BrowserTest.php
@@ -71,11 +71,14 @@ class BrowserTest extends BrowserTestCase
                     @if (auth()->check())
                         third
                     @endif
+
+                    <div dusk="literal">[LIVEWIRE_DIRECTIVE_AT]</div>
                 </div>
                 HTML;
             }
         }])
             ->assertSeeIn('@island', 'Count: 0')
+            ->assertSeeIn('@literal', '[LIVEWIRE_DIRECTIVE_AT]')
             ;
     }
 

--- a/src/Features/SupportIslands/BrowserTest.php
+++ b/src/Features/SupportIslands/BrowserTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportIslands;
 
+use Illuminate\Support\Facades\Blade;
 use Tests\BrowserTestCase;
 use Livewire\Livewire;
 
@@ -79,6 +80,36 @@ class BrowserTest extends BrowserTestCase
         }])
             ->assertSeeIn('@island', 'Count: 0')
             ->assertSeeIn('@literal', '[LIVEWIRE_DIRECTIVE_AT]')
+            ;
+    }
+
+    public function test_island_compilation_preserves_foreign_directives_and_marker_like_content()
+    {
+        Blade::directive('islandGreeting', fn ($expression) => '<div dusk="custom-directive">Hello from Blade</div>');
+
+        Livewire::visit([new class extends \Livewire\Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @islandGreeting
+
+                    <div dusk="marker-like-content">[LIVEWIRE_DIRECTIVE:0]</div>
+                    <div dusk="escaped-directive">@@if (true)</div>
+
+                    @island
+                        <div dusk="island-with-foreign-directives">Island rendered</div>
+                        <div dusk="escaped-directive-inside-island">@@if (true)</div>
+                    @endisland
+                </div>
+                HTML;
+            }
+        }])
+            ->assertSeeIn('@custom-directive', 'Hello from Blade')
+            ->assertSeeIn('@marker-like-content', '[LIVEWIRE_DIRECTIVE:0]')
+            ->assertSeeIn('@escaped-directive', '@if(true)')
+            ->assertSeeIn('@island-with-foreign-directives', 'Island rendered')
+            ->assertSeeIn('@escaped-directive-inside-island', '@if(true)')
             ;
     }
 

--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -57,6 +57,8 @@ class IslandCompiler
 
         $result = $compiler->compileStatementsMadePublic($contents);
 
+        $result = str_replace('[LIVEWIRE_DIRECTIVE_AT]', '@', $result);
+
         $result = $this->restoreBladeComments($result, $comments);
 
         for ($i=$maxNestingLevel; $i >= $currentNestingLevel; $i--) {
@@ -238,10 +240,9 @@ PHP;
                     // Don't process through built-in directive methods...
                     // $match[0] = $this->$method(Arr::get($match, 3));
 
-                    // Just return the original match...
-                    return $match[0];
+                    return str_replace('@', '[LIVEWIRE_DIRECTIVE_AT]', $match[0]);
                 } else {
-                    return $match[0];
+                    return str_replace('@', '[LIVEWIRE_DIRECTIVE_AT]', $match[0]);
                 }
 
                 return isset($match[3]) ? $match[0] : $match[0].$match[2];

--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -214,9 +214,7 @@ PHP;
 
     protected function restoreSetAsideDirectives(string $contents, array $directives): string
     {
-        return preg_replace_callback('/\[LIVEWIRE_DIRECTIVE:(\d+)\]/', function ($match) use ($directives) {
-            return $directives[(int) $match[1]];
-        }, $contents);
+        return strtr($contents, $directives);
     }
 
     public function getHackedBladeCompiler()
@@ -225,21 +223,30 @@ PHP;
             app('files'),
             rtrim(config('view.compiled'), '/\\') . '/livewire',
         ) extends \Illuminate\View\Compilers\BladeCompiler {
-            public $setAsideDirectives = [];
+            public array $setAsideDirectives = [];
+
+            protected string $setAsideDirectivePrefix = '[LIVEWIRE_DIRECTIVE:';
 
             /**
-             * Make this method public...
+             * Make statement compilation public and reserve a placeholder prefix
+             * that does not collide with authored view content...
              */
             public function compileStatementsMadePublic($template)
             {
+                while (str_contains($template, $this->setAsideDirectivePrefix)) {
+                    $this->setAsideDirectivePrefix .= '_';
+                }
+
                 return $this->compileStatements($template);
             }
 
             protected function setAside($directive)
             {
-                $this->setAsideDirectives[] = $directive;
+                $placeholder = $this->setAsideDirectivePrefix . count($this->setAsideDirectives) . ']';
 
-                return '[LIVEWIRE_DIRECTIVE:' . (count($this->setAsideDirectives) - 1) . ']';
+                $this->setAsideDirectives[$placeholder] = $directive;
+
+                return $placeholder;
             }
 
             /**
@@ -248,20 +255,15 @@ PHP;
              */
             protected function compileStatement($match)
             {
-                if (str_contains($match[1], '@')) {
-                    $match[0] = isset($match[3]) ? $match[1].$match[3] : $match[1];
-                } elseif (isset($this->customDirectives[$match[1]])) {
-                    $match[0] = $this->callCustomDirective($match[1], Arr::get($match, 3));
-                } elseif (method_exists($this, $method = 'compile'.ucfirst($match[1]))) {
-                    // Don't process through built-in directive methods...
-                    // $match[0] = $this->$method(Arr::get($match, 3));
+                if (isset($this->customDirectives[$match[1]])) {
+                    $compiled = $this->callCustomDirective($match[1], Arr::get($match, 3));
 
-                    return $this->setAside($match[0]);
-                } else {
-                    return $this->setAside($match[0]);
+                    return isset($match[3]) ? $compiled : $compiled.$match[2];
                 }
 
-                return isset($match[3]) ? $match[0] : $match[0].$match[2];
+                // Blade moves forward as it replaces statements, so foreign directives
+                // must be consumed during this island-only pass and restored afterward...
+                return $this->setAside($match[0]);
             }
         };
 

--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -57,7 +57,7 @@ class IslandCompiler
 
         $result = $compiler->compileStatementsMadePublic($contents);
 
-        $result = str_replace('[LIVEWIRE_DIRECTIVE_AT]', '@', $result);
+        $result = $this->restoreSetAsideDirectives($result, $compiler->setAsideDirectives);
 
         $result = $this->restoreBladeComments($result, $comments);
 
@@ -212,18 +212,34 @@ PHP;
         }, $contents);
     }
 
+    protected function restoreSetAsideDirectives(string $contents, array $directives): string
+    {
+        return preg_replace_callback('/\[LIVEWIRE_DIRECTIVE:(\d+)\]/', function ($match) use ($directives) {
+            return $directives[(int) $match[1]];
+        }, $contents);
+    }
+
     public function getHackedBladeCompiler()
     {
         $instance = new class (
             app('files'),
             rtrim(config('view.compiled'), '/\\') . '/livewire',
         ) extends \Illuminate\View\Compilers\BladeCompiler {
+            public $setAsideDirectives = [];
+
             /**
              * Make this method public...
              */
             public function compileStatementsMadePublic($template)
             {
                 return $this->compileStatements($template);
+            }
+
+            protected function setAside($directive)
+            {
+                $this->setAsideDirectives[] = $directive;
+
+                return '[LIVEWIRE_DIRECTIVE:' . (count($this->setAsideDirectives) - 1) . ']';
             }
 
             /**
@@ -240,9 +256,9 @@ PHP;
                     // Don't process through built-in directive methods...
                     // $match[0] = $this->$method(Arr::get($match, 3));
 
-                    return str_replace('@', '[LIVEWIRE_DIRECTIVE_AT]', $match[0]);
+                    return $this->setAside($match[0]);
                 } else {
-                    return str_replace('@', '[LIVEWIRE_DIRECTIVE_AT]', $match[0]);
+                    return $this->setAside($match[0]);
                 }
 
                 return isset($match[3]) ? $match[0] : $match[0].$match[2];

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -580,6 +580,50 @@ class UnitTest extends TestCase
             ->assertSee('value: HELLO');
     }
 
+    public function test_island_keeps_its_token_when_a_directive_above_it_has_an_unbalanced_expression()
+    {
+        $compiledPath = sys_get_temp_dir() . '/laravel-island-offset-' . uniqid();
+
+        config()->set('view.compiled', $compiledPath);
+        app()->forgetInstance('livewire.compiler');
+        app()->forgetInstance('livewire.factory');
+
+        $compiled = IslandCompiler::compile(__FILE__, <<<'HTML'
+        <div>
+            @if (auth()->check())
+                first
+            @endif
+
+            @if (auth()->check() && request()->isMethod('get'))
+                second
+            @endif
+
+            @island(name: 'counter')
+                @if (request()->isMethod('get'))
+                    <div>count: {{ $count }}</div>
+                @endif
+            @endisland
+
+            @if (auth()->check())
+                third
+            @endif
+        </div>
+        HTML);
+
+        $token = app('livewire.compiler')->cacheManager->getHash(__FILE__) . '-1';
+        $cachedPath = IslandCompiler::getCachedPathFromToken($token);
+
+        $this->assertStringContainsString("token: '{$token}'", $compiled);
+        $this->assertStringNotContainsString('[ENDISLAND', $compiled);
+        $this->assertStringNotContainsString('[LIVEWIRE_DIRECTIVE:', $compiled);
+        $this->assertStringContainsString("@if (auth()->check() && request()->isMethod('get'))", $compiled);
+        $this->assertFileExists($cachedPath);
+        $this->assertStringContainsString("@if (request()->isMethod('get'))", File::get($cachedPath));
+        $this->assertStringNotContainsString('[LIVEWIRE_DIRECTIVE:', File::get($cachedPath));
+
+        File::deleteDirectory($compiledPath);
+    }
+
     public function test_island_tokens_are_stable_across_different_base_paths()
     {
         $path = '/resources/views/components/foo.blade.php';


### PR DESCRIPTION
Closes the compiler failure reported and diagnosed by @stebrl in #10624.

An island can be skipped during Livewire's island-only Blade pass when earlier directives share a nested-call prefix. The compiled view keeps an `@island` without Livewire's generated token, so every request fails with `IslandCompiler::getCachedPathFromToken(): Argument #1 ($token) must be of type string, null given`.

## User experience

Given two ordinary directives before an island:

```blade
@if (auth()->check())
    first
@endif

@if (auth()->check() && request()->isMethod('get'))
    second
@endif

@island
    <div>...</div>
@endisland
```

- **Actual:** the page deterministically returns 500 because the island token was dropped during compilation.
- **Expected:** directives before an island remain ordinary Blade and the island renders with its generated token.

## Findings

- Confirmed demand is narrow: #10624 is the only exact report, from one application with two affected views. The failure is nevertheless production-fatal and uses supported syntax.
- The related #10277 / #10282 fixed nested parentheses on the island directive itself; this failure happens earlier, while foreign directives are passing through the island compiler.
- Laravel's `BladeCompiler::compileStatements()` repairs an initially unbalanced regex match with a search from the start of the template. Livewire's island pass returned foreign directives unchanged, leaving earlier identical prefixes visible to that repair. Blade could then reconstruct a later directive from an earlier one, advance its forward-only replacement offset beyond the island, and silently drop the tokenized replacement.
- Livewire has already fixed the same position-vs-value lookup class in a separate compiler path in #9921. Existing Blade-comment shielding in #9838 also provides local precedent for temporarily setting source aside.

## Directions considered

- **Minimal:** mask the leading `@` in foreign directives during this pass. It fixes the reported case but a fixed marker can collide with authored content.
- **Maximal:** replace the hacked Blade compiler with a dedicated island parser and nested syntax tree. This removes the coupling entirely, but makes Livewire own a partial Blade lexer for escapes, comments, quotes, and malformed syntax.
- **Evaporative:** fix Laravel's global parenthesis-repair lookup upstream. Worth pursuing, but Livewire still needs a bridge across supported Laravel versions.
- **Userland:** hoist nested calls into variables/properties before the island. This works today, but is obscure, per-view, and not an appropriate framework answer.

This PR chooses the small compatibility bridge: every non-island directive is replaced with a collision-safe, per-pass placeholder, then restored byte-for-byte before islands are extracted. Escaped directives are also preserved until Blade's real compilation pass.

## Built as working slices

Each commit is independently testable and evolves the same user-visible fix:

1. **Skateboard — [fix the reported page](https://github.com/livewire/livewire/commit/b580a362):** one obvious marker consumes foreign directives so Blade cannot skip the island; adds the browser regression.
2. **Bicycle — [preserve complete directives](https://github.com/livewire/livewire/commit/c198b354):** stores and restores each foreign directive instead of globally replacing marker text.
3. **Car — [make preservation collision-safe](https://github.com/livewire/livewire/commit/f73c8e51):** selects a placeholder prefix absent from the view and covers compiler fingerprints, custom directives, escaped directives, and marker-like authored content.

## Verification

- Reproduced current `4.x` in a real Laravel app: HTTP 500 with the null-token exception.
- Verified the final branch in the same app: HTTP 200, `count: 0` rendered, generated island token present, no internal island/directive markers leaked.
- Full unit suite: 1,408 tests / 4,017 assertions passing (13 skipped, 3 incomplete).
- Full islands browser suite: 35 tests / 192 assertions passing.
- No documentation change: this restores existing documented behavior and introduces no public API.
- No new execution surface: foreign directives remain inert source during the island pre-pass and are restored exactly for Blade's normal compiler.

## Follow-up

Laravel's position lookup should still be repaired upstream so other source-preserving compiler clients cannot hit the same class of failure. Livewire can remove this bridge once every supported Laravel line contains that fix.

A separate island-parser failure remains possible when raw or verbatim content contains an unbalanced `(` or a literal `@island`: this pre-pass calls `compileStatements()` directly, before Blade stores raw/verbatim blocks. It can produce the same missing-token symptom through a different path and should be handled separately rather than folded into this targeted fix.
