### PR TITLE
[4.x] Guard array-shaped synthesizers during property updates

### DIFF
--- a/docs/synthesizers.md
+++ b/docs/synthesizers.md
@@ -259,6 +259,6 @@ class AddressSynth extends Synth implements ArrayShapedSynth
 }
 ```
 
-This tells Livewire not to run your synthesizer when an update replaces the previous value with a scalar, `null`, or a removal marker. Instead, Livewire treats the incoming value as the replacement.
+This tells Livewire not to run your synthesizer when a top-level or nested update replaces the previous value with any non-array value. Instead, Livewire treats the incoming value as the replacement. Array updates continue through your synthesizer as usual.
 
-Only implement this interface when your synthesizer's `hydrate()` method requires an array. Synthesizers that hydrate scalar values, such as dates, enums, integers, floats, or strings, should not implement it.
+Only implement this interface when your synthesizer's `hydrate()` method requires an array. Synthesizers that hydrate scalar values, such as dates, enums, integers, floats, or strings, should not implement it. Without the interface, Livewire continues applying the previous synthesizer metadata to non-array updates for backwards compatibility.

--- a/docs/synthesizers.md
+++ b/docs/synthesizers.md
@@ -244,3 +244,21 @@ class AddressSynth extends Synth
     }
 }
 ```
+
+## Array-shaped synthesizers
+
+During property updates, Livewire may reuse synthesizer metadata from the previous snapshot to hydrate nested values. If your synthesizer always serializes its value as an array, implement the `ArrayShapedSynth` interface:
+
+```php
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+
+class AddressSynth extends Synth implements ArrayShapedSynth
+{
+    // ...
+}
+```
+
+This tells Livewire not to run your synthesizer when an update replaces the previous value with a scalar, `null`, or a removal marker. Instead, Livewire treats the incoming value as the replacement.
+
+Only implement this interface when your synthesizer's `hydrate()` method requires an array. Synthesizers that hydrate scalar values, such as dates, enums, integers, floats, or strings, should not implement it.

--- a/src/Features/SupportFormObjects/FormObjectSynth.php
+++ b/src/Features/SupportFormObjects/FormObjectSynth.php
@@ -3,12 +3,13 @@
 namespace Livewire\Features\SupportFormObjects;
 
 use Livewire\Drawer\Utils;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Livewire\Features\SupportAttributes\AttributeCollection;
 
 use function Livewire\wrap;
 
-class FormObjectSynth extends Synth {
+class FormObjectSynth extends Synth implements ArrayShapedSynth {
     public static $key = 'form';
 
     static function match($target)
@@ -32,10 +33,6 @@ class FormObjectSynth extends Synth {
         // Verify class extends Form even though checksum protects this...
         if (! isset($meta['class']) || ! is_a($meta['class'], Form::class, true)) {
             throw new \Exception('Livewire: Invalid form object class.');
-        }
-
-        if (! is_array($data)) {
-            return $data;
         }
 
         // If the form object already exists on the component (e.g. during a

--- a/src/Features/SupportFormObjects/FormObjectSynth.php
+++ b/src/Features/SupportFormObjects/FormObjectSynth.php
@@ -34,6 +34,10 @@ class FormObjectSynth extends Synth {
             throw new \Exception('Livewire: Invalid form object class.');
         }
 
+        if (! is_array($data)) {
+            return $data;
+        }
+
         // If the form object already exists on the component (e.g. during a
         // consolidated property update where the entire form is sent as one
         // update), reuse it. Creating a new instance would discard the booted

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -1076,12 +1076,15 @@ class UnitTest extends \Tests\TestCase
             public PostFormStub $form;
         });
 
-        $synth = new FormObjectSynth(
-            new \Livewire\Mechanisms\HandleComponents\ComponentContext($component->instance()),
-            'form'
-        );
+        $synths = app(\Livewire\Mechanisms\HandleSynths\HandleSynths::class);
+        $context = new \Livewire\Mechanisms\HandleComponents\ComponentContext($component->instance());
 
-        $this->assertSame(1, $synth->hydrate(1, ['class' => PostFormStub::class], fn($k, $v) => $v));
+        $this->assertSame(1, $synths->hydrateForUpdate(
+            $component->snapshot['data'],
+            'form',
+            1,
+            $context,
+        ));
     }
 
     public function test_can_fill_a_form_object_from_eloquent_model_with_enum_cast()

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -1070,21 +1070,18 @@ class UnitTest extends \Tests\TestCase
         $synth->hydrate(['title' => 'test'], ['class' => \stdClass::class], fn($k, $v) => $v);
     }
 
-    function test_form_object_synth_allows_a_scalar_replacement_during_an_update()
+    function test_an_untyped_form_object_property_can_be_replaced_with_a_scalar_during_an_update()
     {
-        $component = Livewire::test(new class extends TestComponent {
-            public PostFormStub $form;
-        });
+        Livewire::test(new class extends TestComponent {
+            public $form;
 
-        $synths = app(\Livewire\Mechanisms\HandleSynths\HandleSynths::class);
-        $context = new \Livewire\Mechanisms\HandleComponents\ComponentContext($component->instance());
-
-        $this->assertSame(1, $synths->hydrateForUpdate(
-            $component->snapshot['data'],
-            'form',
-            1,
-            $context,
-        ));
+            public function mount()
+            {
+                $this->form = new PostFormStub($this, 'form');
+            }
+        })
+            ->set('form', 1)
+            ->assertSetStrict('form', 1);
     }
 
     public function test_can_fill_a_form_object_from_eloquent_model_with_enum_cast()

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -1070,6 +1070,20 @@ class UnitTest extends \Tests\TestCase
         $synth->hydrate(['title' => 'test'], ['class' => \stdClass::class], fn($k, $v) => $v);
     }
 
+    function test_form_object_synth_allows_a_scalar_replacement_during_an_update()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public PostFormStub $form;
+        });
+
+        $synth = new FormObjectSynth(
+            new \Livewire\Mechanisms\HandleComponents\ComponentContext($component->instance()),
+            'form'
+        );
+
+        $this->assertSame(1, $synth->hydrate(1, ['class' => PostFormStub::class], fn($k, $v) => $v));
+    }
+
     public function test_can_fill_a_form_object_from_eloquent_model_with_enum_cast()
     {
         Livewire::test(new class extends TestComponent {

--- a/src/Features/SupportLegacyModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentCollectionSynth.php
@@ -3,10 +3,11 @@
 namespace Livewire\Features\SupportLegacyModels;
 
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use LogicException;
 
-class EloquentCollectionSynth extends Synth
+class EloquentCollectionSynth extends Synth implements ArrayShapedSynth
 {
     public static $key = 'elcl';
 

--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -4,11 +4,12 @@ namespace Livewire\Features\SupportLegacyModels;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\ClassMorphViolationException;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
-class EloquentModelSynth extends Synth
+class EloquentModelSynth extends Synth implements ArrayShapedSynth
 {
     public static $key = 'elmdl';
 

--- a/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportLegacyModels\Tests;
 
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Livewire\Livewire;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -56,6 +57,26 @@ class PublicPropertyHydrationAndDehydrationUnitTest extends \Tests\TestCase
 
         $component = Livewire::test(PostComponent::class);
         $this->assertEquals('Livewire\Features\SupportLegacyModels\Tests\Post', $component->snapshot['data']['post'][1]['class']);
+    }
+
+    public function test_legacy_models_and_collections_can_be_replaced_with_scalars_during_an_update()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public $model;
+            public $models;
+
+            public function mount()
+            {
+                $this->model = new Post;
+                $this->models = new EloquentCollection([new Post]);
+            }
+        });
+
+        $component->set('model', 1);
+        $component->set('models', 2);
+
+        $this->assertSame(1, $component->get('model'));
+        $this->assertSame(2, $component->get('models'));
     }
 
     public function test_it_uses_class_name_if_laravels_morph_map_not_available_when_hydrating()

--- a/src/Features/SupportWireables/BrowserTest.php
+++ b/src/Features/SupportWireables/BrowserTest.php
@@ -59,6 +59,31 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->waitForText('43')
         ->assertSee('43');
     }
+
+    public function test_a_wireable_can_be_replaced_with_a_scalar()
+    {
+        Livewire::visit(new class () extends \Livewire\Component {
+            public array $items = [];
+
+            public function mount(): void
+            {
+                $this->items = [new Person('Jæja', 42)];
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <button type="button" x-on:click="$wire.set('items', [1])" dusk="replace">Replace</button>
+                    <span>{{ json_encode($items) }}</span>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSee('42')
+        ->waitForLivewire()->click('@replace')
+        ->assertSee('[1]');
+    }
 }
 
 class Person implements Wireable

--- a/src/Features/SupportWireables/UnitTest.php
+++ b/src/Features/SupportWireables/UnitTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use Livewire\Component;
 use Livewire\Livewire;
 use Livewire\Wireable;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -36,6 +37,18 @@ class UnitTest extends \Tests\TestCase
             ->call("\$set", 'wireable', ['message' => 'bar', 'embeddedWireable' => ['message' => '42']])
             ->call("\$set", 'wireable.message', 'bar')
             ->assertSee('bar');
+    }
+
+    public function test_a_wireable_can_be_replaced_with_a_scalar_during_an_update()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public $items = [];
+        });
+
+        $component->set('items', [new WireableClass('foo', '42')]);
+        $component->set('items', [1]);
+
+        $this->assertSame([1], $component->get('items'));
     }
 
     public function test_a_wireable_can_be_set_as_a_public_property_and_validates_only()

--- a/src/Features/SupportWireables/WireableSynth.php
+++ b/src/Features/SupportWireables/WireableSynth.php
@@ -3,9 +3,10 @@
 namespace Livewire\Features\SupportWireables;
 
 use Livewire\Wireable;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 
-class WireableSynth extends Synth
+class WireableSynth extends Synth implements ArrayShapedSynth
 {
     public static $key = 'wrbl';
 
@@ -37,10 +38,6 @@ class WireableSynth extends Synth
         // Verify class implements Wireable even though checksum protects this...
         if (! isset($meta['class']) || ! is_a($meta['class'], Wireable::class, true)) {
             throw new \Exception('Livewire: Invalid wireable class.');
-        }
-
-        if (! is_array($value)) {
-            return $value;
         }
 
         foreach ($value as $key => $child) {

--- a/src/Features/SupportWireables/WireableSynth.php
+++ b/src/Features/SupportWireables/WireableSynth.php
@@ -39,6 +39,10 @@ class WireableSynth extends Synth
             throw new \Exception('Livewire: Invalid wireable class.');
         }
 
+        if (! is_array($value)) {
+            return $value;
+        }
+
         foreach ($value as $key => $child) {
             $value[$key] = $hydrateChild($key, $child);
         }

--- a/src/Mechanisms/HandleComponents/Synthesizers/ArrayShapedSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/ArrayShapedSynth.php
@@ -2,6 +2,9 @@
 
 namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
 
+/**
+ * Marks synthesizers whose hydrate method requires an array wire value.
+ */
 interface ArrayShapedSynth
 {
     //

--- a/src/Mechanisms/HandleComponents/Synthesizers/ArrayShapedSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/ArrayShapedSynth.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
+
+interface ArrayShapedSynth
+{
+    //
+}

--- a/src/Mechanisms/HandleComponents/Synthesizers/ArraySynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/ArraySynth.php
@@ -18,10 +18,7 @@ class ArraySynth extends Synth implements ArrayShapedSynth {
     }
 
     function hydrate($value, $meta, $hydrateChild) {
-        // If we are "hydrating" a value about to be used in an update,
-        // Let's make sure it's actually an array before try to set it.
-        // This is most common in the case of "__rm__" values, but also
-        // applies to any non-array value...
+        // Keep direct callers from attempting to iterate a non-array value.
         if (! is_array($value)) {
             return $value;
         }

--- a/src/Mechanisms/HandleComponents/Synthesizers/ArraySynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/ArraySynth.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
 
-class ArraySynth extends Synth {
+class ArraySynth extends Synth implements ArrayShapedSynth {
     public static $key = 'arr';
 
     static function match($target) {

--- a/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
@@ -4,7 +4,7 @@ namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
 
 use Illuminate\Support\Collection;
 
-class CollectionSynth extends ArraySynth {
+class CollectionSynth extends ArraySynth implements ArrayShapedSynth {
     public static $key = 'clctn';
 
     static function match($target) {

--- a/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
@@ -29,10 +29,6 @@ class CollectionSynth extends ArraySynth {
             throw new \Exception("Livewire: Class [{$meta['class']}] is not a valid Collection type.");
         }
 
-        if (! is_array($value)) {
-            return $value;
-        }
-
         foreach ($value as $key => $child) {
             $value[$key] = $hydrateChild($key, $child);
         }

--- a/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
@@ -29,6 +29,10 @@ class CollectionSynth extends ArraySynth {
             throw new \Exception("Livewire: Class [{$meta['class']}] is not a valid Collection type.");
         }
 
+        if (! is_array($value)) {
+            return $value;
+        }
+
         foreach ($value as $key => $child) {
             $value[$key] = $hydrateChild($key, $child);
         }

--- a/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
@@ -22,6 +22,10 @@ class StdClassSynth extends Synth {
     }
 
     function hydrate($value, $meta, $hydrateChild) {
+        if (! is_array($value)) {
+            return $value;
+        }
+
         $obj = new stdClass;
 
         foreach ($value as $key => $child) {

--- a/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
@@ -4,7 +4,7 @@ namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
 
 use stdClass;
 
-class StdClassSynth extends Synth {
+class StdClassSynth extends Synth implements ArrayShapedSynth {
     public static $key = 'std';
 
     static function match($target) {
@@ -22,10 +22,6 @@ class StdClassSynth extends Synth {
     }
 
     function hydrate($value, $meta, $hydrateChild) {
-        if (! is_array($value)) {
-            return $value;
-        }
-
         $obj = new stdClass;
 
         foreach ($value as $key => $child) {

--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -5,6 +5,7 @@ namespace Livewire\Mechanisms\HandleSynths;
 use Livewire\Mechanisms\Mechanism;
 use Livewire\Mechanisms\HandleComponents\ComponentContext;
 use Livewire\Mechanisms\HandleComponents\SecurityPolicy;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers;
 use Livewire\Drawer\Utils;
@@ -93,6 +94,12 @@ class HandleSynths extends Mechanism
         }
 
         $synth = $this->resolve($meta['s'], $context, $path);
+
+        // Snapshot meta describes the previous value. If an update replaces an
+        // array-shaped value with a scalar, the previous synth no longer applies.
+        if ($synth instanceof ArrayShapedSynth && ! is_array($value)) {
+            return $value;
+        }
 
         return $synth->hydrate($value, $meta, function ($name, $child) use ($context, $path, $raw) {
             // Updates carry values only — the browser strips synthesizer meta out

--- a/src/Mechanisms/HandleSynths/UnitTest.php
+++ b/src/Mechanisms/HandleSynths/UnitTest.php
@@ -181,6 +181,58 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame(['some' => 'array'], $updated['brandNew']);
     }
 
+    public function test_hydrate_for_update_leaves_collection_children_replaced_with_scalars_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => ['tags' => collect(['a']), 'other' => collect(['b'])],
+        ], $context, 'data')];
+
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', [
+            'tags' => 1,
+            'other' => ['b'],
+        ], $context);
+
+        $this->assertSame(1, $updated['tags']);
+        $this->assertInstanceOf(Collection::class, $updated['other']);
+    }
+
+    public function test_hydrate_for_update_leaves_stdclass_children_replaced_with_scalars_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => [
+                'item' => (object) ['name' => 'a'],
+                'other' => (object) ['name' => 'b'],
+            ],
+        ], $context, 'data')];
+
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', [
+            'item' => 1,
+            'other' => ['name' => 'b'],
+        ], $context);
+
+        $this->assertSame(1, $updated['item']);
+        $this->assertInstanceOf(\stdClass::class, $updated['other']);
+        $this->assertSame('b', $updated['other']->name);
+    }
+
+    public function test_hydrate_for_update_leaves_top_level_array_shaped_values_replaced_with_scalars_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $collection = ['item' => $synths->dehydrate(collect(['a']), $context, 'item')];
+        $stdClass = ['item' => $synths->dehydrate((object) ['name' => 'a'], $context, 'item')];
+
+        $this->assertSame(1, $synths->hydrateForUpdate($collection, 'item', 1, $context));
+        $this->assertSame(1, $synths->hydrateForUpdate($stdClass, 'item', 1, $context));
+    }
+
     public function test_hydrate_for_update_passes_nested_removals_through_untouched()
     {
         $synths = app(HandleSynths::class);

--- a/src/Mechanisms/HandleSynths/UnitTest.php
+++ b/src/Mechanisms/HandleSynths/UnitTest.php
@@ -247,7 +247,6 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame(1, $synths->hydrateForUpdate($collection, 'item', 1, $context));
         $this->assertSame(1, $synths->hydrateForUpdate($stdClass, 'item', 1, $context));
         $this->assertNull($synths->hydrateForUpdate($collection, 'item', null, $context));
-        $this->assertSame('__rm__', $synths->hydrateForUpdate($collection, 'item', '__rm__', $context));
     }
 
     public function test_hydrate_for_update_still_applies_scalar_shaped_synths()
@@ -271,6 +270,19 @@ class UnitTest extends \Tests\TestCase
         $raw = ['thing' => $synths->dehydrate(new CustomThing('original'), $context, 'thing')];
 
         $this->assertSame(1, $synths->hydrateForUpdate($raw, 'thing', 1, $context));
+    }
+
+    public function test_unmarked_userland_synths_keep_hydrating_non_array_updates()
+    {
+        $synths = app(HandleSynths::class);
+        $synths->registerSynth(ScalarFriendlyThingSynth::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['thing' => $synths->dehydrate(new ScalarFriendlyThing('original'), $context, 'thing')];
+        $updated = $synths->hydrateForUpdate($raw, 'thing', 1, $context);
+
+        $this->assertInstanceOf(ScalarFriendlyThing::class, $updated);
+        $this->assertSame(1, $updated->value);
     }
 
     public function test_hydrate_for_update_passes_nested_removals_through_untouched()
@@ -406,5 +418,30 @@ class CustomThingSynth extends Synth implements ArrayShapedSynth
     public function hydrate($value)
     {
         return new CustomThing($value['value']);
+    }
+}
+
+class ScalarFriendlyThing
+{
+    public function __construct(public mixed $value) {}
+}
+
+class ScalarFriendlyThingSynth extends Synth
+{
+    public static $key = 'scalar-friendly-thing';
+
+    public static function match($target)
+    {
+        return $target instanceof ScalarFriendlyThing;
+    }
+
+    public function dehydrate($target)
+    {
+        return [['value' => $target->value], []];
+    }
+
+    public function hydrate($value)
+    {
+        return new ScalarFriendlyThing($value);
     }
 }

--- a/src/Mechanisms/HandleSynths/UnitTest.php
+++ b/src/Mechanisms/HandleSynths/UnitTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use Livewire\Livewire;
 use Livewire\Mechanisms\HandleComponents\ComponentContext;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\CollectionSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Tests\TestComponent;
@@ -134,6 +135,20 @@ class UnitTest extends \Tests\TestCase
         $synths->hydratePropertyUpdate($tuple, $context, 'evil');
     }
 
+    public function test_hydrate_property_update_validates_classes_before_skipping_array_shaped_synths()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not allowed to be instantiated');
+
+        $synths->hydratePropertyUpdate([
+            1,
+            ['s' => 'arr', 'class' => \Symfony\Component\Process\Process::class],
+        ], $context, 'evil');
+    }
+
     /*
      * An update sends values without synthesizer meta — the browser strips
      * it. When the updated path sits ABOVE a synthesized value (updating
@@ -231,6 +246,31 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertSame(1, $synths->hydrateForUpdate($collection, 'item', 1, $context));
         $this->assertSame(1, $synths->hydrateForUpdate($stdClass, 'item', 1, $context));
+        $this->assertNull($synths->hydrateForUpdate($collection, 'item', null, $context));
+        $this->assertSame('__rm__', $synths->hydrateForUpdate($collection, 'item', '__rm__', $context));
+    }
+
+    public function test_hydrate_for_update_still_applies_scalar_shaped_synths()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['date' => $synths->dehydrate(Carbon::parse('2026-01-01'), $context, 'date')];
+        $updated = $synths->hydrateForUpdate($raw, 'date', '2026-08-29T12:00:00+00:00', $context);
+
+        $this->assertInstanceOf(Carbon::class, $updated);
+        $this->assertSame('2026-08-29T12:00:00+00:00', $updated->format(\DateTimeInterface::ATOM));
+    }
+
+    public function test_userland_array_shaped_synths_can_allow_scalar_replacements()
+    {
+        $synths = app(HandleSynths::class);
+        $synths->registerSynth(CustomThingSynth::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['thing' => $synths->dehydrate(new CustomThing('original'), $context, 'thing')];
+
+        $this->assertSame(1, $synths->hydrateForUpdate($raw, 'thing', 1, $context));
     }
 
     public function test_hydrate_for_update_passes_nested_removals_through_untouched()
@@ -349,7 +389,7 @@ class CustomThing
     public function __construct(public string $value = 'default') {}
 }
 
-class CustomThingSynth extends Synth
+class CustomThingSynth extends Synth implements ArrayShapedSynth
 {
     public static $key = 'custom-thing';
 


### PR DESCRIPTION
## Decision

Fix this now as a narrow 4.x regression, but do not merge the original implementation verbatim.

This replaces #10611 with the same central idea—array-shaped synths should decline non-array replacements—built up in reviewable vertical commits and finished as an explicit userland contract.

Fixes #10606.

## Problem

#10489 correctly taught ancestor property updates to recursively hydrate nested synthesized values from the previous checksum-verified snapshot. The regression is that the old synth metadata is also reused when an update *replaces* that value with a different wire shape.

Given an array item containing a `Wireable`, replacing it with an integer through a direct property update sends the integer to `WireableSynth::hydrate()`, which expects an array and throws while iterating it. The user sees a 500 instead of the new scalar value being accepted.

```php
$component->set('items', [new EmptyWireable]);
$component->set('items', [1]);

// Expected: [1]
// Before: foreach() argument must be of type array|object, int given
```

## Evidence and scope

- **Demand:** one confirmed production reporter in #10606. This is low measured demand, but it is a deterministic regression introduced in 4.4.1 rather than a speculative feature.
- **No-for-now:** not recommended. The only reliable workaround is to perform the type swap inside a server action instead of using `$wire.set`, `wire:model`, entanglement, or another direct property update.
- **Prior art:** `ArraySynth` has used the same non-array early-return rule since #6190. #10431 reduces problematic client-side diff consolidation, but cannot see server-only/custom synths or cover explicit parent `$wire.set` calls. #10607 explores a generic wire-shape comparison; this PR deliberately avoids changing scalar synth semantics.
- **Long-term direction:** a future protocol could distinguish `patch`, `replace`, and `remove` explicitly. That is a major-version design, not a 4.x regression fix.

## Solution

Introduce `ArrayShapedSynth` as an opt-in contract. After resolving and security-checking authenticated snapshot metadata, update hydration returns a non-array incoming value as the replacement instead of invoking an array-oriented synth.

Built-in coverage: Array/Collection, Wireable, stdClass, FormObject, and the opt-in legacy Eloquent model/collection synths. Scalar-shaped synths such as Carbon, Enum, Int, Float, and Stringable remain unchanged. Custom synths can opt in when their `hydrate()` method requires array wire data; existing unmarked synths retain their previous behavior.

This rule is intentionally limited to non-array replacements. An array-shaped synth still receives array updates, even when an application intends that array to represent a different value. Model synths that reconstruct entirely from metadata and ignore wire data also retain their existing semantics.

## Commit ladder

Each commit is independently useful and tested:

1. [Skateboard: fix the exact Wireable → scalar regression](https://github.com/livewire/livewire/commit/730846bafbebccace1a68da07d728eeaa286b7fa)
2. [Scooter: cover the other built-in array-oriented synths](https://github.com/livewire/livewire/commit/3399d03aafaa93d0a84e649c981c7f9d989afc4a)
3. [Bike: centralize the rule behind the array-shaped contract](https://github.com/livewire/livewire/commit/54182a89f69b239fbb9bb585a040c9c47e3153f7)
4. [Motorcycle: finish userland, edge-case, security, and documentation coverage](https://github.com/livewire/livewire/commit/ede656a8d8589d3b6b6f43ffe767e08109a4670a)
5. [Car: integrate review feedback across legacy, browser, FormObject, compatibility, and docs coverage](https://github.com/livewire/livewire/commit/1947f850d73219fcf6353077b51493b4a5c805b4)

## Verification

- `vendor/bin/phpunit --testsuite Unit` — 1,400 tests, 3,981 assertions; 13 skipped and 3 incomplete, no failures
- Focused HandleSynths, Wireable, FormObject, and legacy model tests — 109 tests, 533 assertions
- `vendor/bin/phpunit src/Features/SupportWireables/BrowserTest.php` — 3 browser tests, 6 assertions, no failures
- Real Laravel/Livewire browser reproduction on exact base SHA `9696751077f3a74d289db97d877e4a3ef2491aa3`: confirmed the pre-fix 500 at `WireableSynth.php:42`; final branch completes the same two-request flow with `[1]` and no console warnings/errors

## Independent review

The final branch was reviewed with the requested Claude CLI pass. Its core mechanism and security ordering were independently verified. The actionable feedback was incorporated in the final commit: legacy synth coverage, an end-to-end FormObject case, explicit unmarked-custom-synth compatibility, automated browser coverage, precise non-array docs, and removal of an unreachable top-level removal assertion.

## Credit

The contract and core direction come from #10611 by @ghabriel25, who is credited as a co-author in the commits so GitHub preserves authorship. #10607 by @lazerg supplied a useful competing shape-comparison design and edge-case context.
