### PR TITLE
[4.x] Fix #[Session] non-primitives under JSON sessions

### DIFF
--- a/src/Features/SupportSession/BaseSession.php
+++ b/src/Features/SupportSession/BaseSession.php
@@ -29,9 +29,13 @@ class BaseSession extends LivewireAttribute
             return;
         }
 
+        // A stored value can become unassignable after it was persisted: its
+        // type no longer matches the property (\TypeError), or it's a scalar
+        // backing a since-removed enum case (\ValueError from Enum::from()).
+        // Either way the stale value is forgotten and the default preserved.
         try {
             $this->setValue($fromSession);
-        } catch (\TypeError) {
+        } catch (\TypeError|\ValueError) {
             Session::forget($this->key());
         }
     }

--- a/src/Features/SupportSession/BaseSession.php
+++ b/src/Features/SupportSession/BaseSession.php
@@ -3,12 +3,16 @@
 namespace Livewire\Features\SupportSession;
 
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+use Livewire\Mechanisms\HandleSynths\CorruptPersistedValueException;
+use Livewire\Mechanisms\HandleSynths\PersistedValueCodec;
 use Illuminate\Support\Facades\Session;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class BaseSession extends LivewireAttribute
 {
+    protected $codec;
+
     function __construct(
         protected $key = null,
     ) {}
@@ -17,9 +21,19 @@ class BaseSession extends LivewireAttribute
     {
         if (! $this->exists()) return;
 
-        $fromSession = $this->read();
+        try {
+            $fromSession = $this->read();
+        } catch (CorruptPersistedValueException) {
+            Session::forget($this->key());
 
-        $this->setValue($fromSession);
+            return;
+        }
+
+        try {
+            $this->setValue($fromSession);
+        } catch (\TypeError) {
+            Session::forget($this->key());
+        }
     }
 
     public function dehydrate($context)
@@ -34,12 +48,43 @@ class BaseSession extends LivewireAttribute
 
     protected function read()
     {
-        return Session::get($this->key());
+        // Always decode so changing session serializers doesn't strand values
+        // that Livewire encoded before the configuration changed.
+        $key = $this->key();
+
+        return $this->codec()->decodeFromStorage(
+            Session::get($key),
+            $this->component,
+            $this->getName(),
+            $key,
+        );
     }
 
     protected function write()
     {
-        Session::put($this->key(), $this->getValue());
+        $value = $this->getValue();
+        $key = $this->key();
+
+        if ($this->sessionIsJsonSerialized()) {
+            $value = $this->codec()->encodeForStorage(
+                $value,
+                $this->component,
+                $this->getName(),
+                $key,
+            );
+        }
+
+        Session::put($key, $value);
+    }
+
+    protected function sessionIsJsonSerialized()
+    {
+        return config('session.serialization', 'php') === 'json';
+    }
+
+    protected function codec()
+    {
+        return $this->codec ??= app(PersistedValueCodec::class);
     }
 
     protected function key()

--- a/src/Features/SupportSession/JsonSerializationBrowserTest.php
+++ b/src/Features/SupportSession/JsonSerializationBrowserTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Livewire\Features\SupportSession;
+
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Session;
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class JsonSerializationBrowserTest extends BrowserTestCase
+{
+    public static function tweakApplicationHook()
+    {
+        return function () {
+            config(['session.serialization' => 'json']);
+        };
+    }
+
+    public function test_collection_properties_survive_a_full_page_refresh()
+    {
+        Livewire::visit(new class extends Component {
+            #[Session]
+            public ?Collection $list = null;
+
+            public function mount(): void
+            {
+                $this->list ??= collect();
+            }
+
+            public function add(): void
+            {
+                $this->list->push($this->list->count() + 1);
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <span dusk="serialization">{{ config('session.serialization') }}</span>
+                    <button dusk="button" wire:click="add">Add</button>
+                    <span dusk="list">{{ $list->implode(', ') }}</span>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@serialization', 'json')
+            ->assertSeeIn('@list', '')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@list', '1')
+            ->refresh()
+            ->assertSeeIn('@list', '1')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@list', '1, 2');
+    }
+}

--- a/src/Features/SupportSession/UnitTest.php
+++ b/src/Features/SupportSession/UnitTest.php
@@ -2,8 +2,10 @@
 
 namespace Livewire\Features\SupportSession;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Session as FacadesSession;
 use Livewire\Attributes\Session;
+use Livewire\Component;
 use Tests\TestCase;
 use Livewire\Livewire;
 use Tests\TestComponent;
@@ -42,5 +44,42 @@ class UnitTest extends TestCase
         });
 
         $this->assertTrue(FacadesSession::has('baz.2'));
+    }
+
+    public function test_collection_properties_survive_json_session_serialization()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->call('add');
+
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->assertSet('list', fn ($list) => $list instanceof Collection && $list->all() === [1]);
+    }
+}
+
+class ComponentWithSessionCollection extends Component
+{
+    #[Session]
+    public ?Collection $list = null;
+
+    public function mount(): void
+    {
+        $this->list ??= collect();
+    }
+
+    public function add(): void
+    {
+        $this->list->push($this->list->count() + 1);
+    }
+
+    public function render()
+    {
+        return '<div>{{ $list->implode(", ") }}</div>';
     }
 }

--- a/src/Features/SupportSession/UnitTest.php
+++ b/src/Features/SupportSession/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportSession;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Session as FacadesSession;
 use Livewire\Attributes\Session;
@@ -61,6 +62,29 @@ class UnitTest extends TestCase
         Livewire::test(ComponentWithSessionCollection::class)
             ->assertSet('list', fn ($list) => $list instanceof Collection && $list->all() === [1]);
     }
+
+    public function test_synthesized_properties_survive_json_session_serialization()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        $date = Carbon::parse('2026-01-15 10:00:00');
+
+        Livewire::test(ComponentWithSynthesizedSessionProperties::class)
+            ->set('when', $date)
+            ->set('nested', ['list' => collect([1, 2]), 'when' => $date]);
+
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentWithSynthesizedSessionProperties::class)
+            ->assertSet('when', fn ($when) => $when instanceof Carbon && $when->equalTo($date))
+            ->assertSet('nested', fn ($nested) => $nested['list'] instanceof Collection
+                && $nested['list']->all() === [1, 2]
+                && $nested['when'] instanceof Carbon
+                && $nested['when']->equalTo($date));
+    }
 }
 
 class ComponentWithSessionCollection extends Component
@@ -81,5 +105,19 @@ class ComponentWithSessionCollection extends Component
     public function render()
     {
         return '<div>{{ $list->implode(", ") }}</div>';
+    }
+}
+
+class ComponentWithSynthesizedSessionProperties extends Component
+{
+    #[Session]
+    public ?Carbon $when = null;
+
+    #[Session]
+    public array $nested = [];
+
+    public function render()
+    {
+        return '<div></div>';
     }
 }

--- a/src/Features/SupportSession/UnitTest.php
+++ b/src/Features/SupportSession/UnitTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Session as FacadesSession;
 use Livewire\Attributes\Session;
 use Livewire\Component;
+use Livewire\Mechanisms\HandleSynths\PersistedValueCodec;
 use Tests\TestCase;
 use Livewire\Livewire;
 use Tests\TestComponent;
@@ -85,11 +86,167 @@ class UnitTest extends TestCase
                 && $nested['when'] instanceof Carbon
                 && $nested['when']->equalTo($date));
     }
+
+    public function test_php_sessions_continue_to_store_values_raw()
+    {
+        config(['session.serialization' => 'php']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->call('add');
+
+        $stored = session('collection');
+
+        $this->assertInstanceOf(Collection::class, $stored);
+        $this->assertSame([1], $stored->all());
+    }
+
+    public function test_json_sessions_continue_to_store_primitive_values_raw()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithPrimitiveSessionProperty::class)
+            ->set('count', 1);
+
+        $this->assertSame(1, session('primitive'));
+    }
+
+    public function test_legacy_tuple_shaped_arrays_are_not_treated_as_synthetic_values()
+    {
+        $tuple = [['one', 'two'], ['s' => 'clctn', 'class' => Collection::class]];
+
+        FacadesSession::put('legacy-tuple', $tuple);
+
+        Livewire::test(ComponentWithRawSessionArray::class)
+            ->assertSet('value', $tuple);
+    }
+
+    public function test_session_envelopes_are_decoded_even_after_switching_to_php_serialization()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->call('add');
+
+        config(['session.serialization' => 'php']);
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->assertSet('list', fn ($list) => $list instanceof Collection && $list->all() === [1]);
+    }
+
+    public function test_client_authored_synth_envelopes_are_discarded_in_json_sessions()
+    {
+        $this->assertClientAuthoredSynthEnvelopeIsDiscarded('json');
+    }
+
+    public function test_client_authored_synth_envelopes_are_discarded_in_php_sessions()
+    {
+        $this->assertClientAuthoredSynthEnvelopeIsDiscarded('php');
+    }
+
+    public function test_unreadable_persisted_envelopes_are_discarded()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->call('add');
+
+        $stored = session('collection');
+        $stored[PersistedValueCodec::KEY]['version']++;
+
+        FacadesSession::put('collection', $stored);
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->assertSet('list', fn ($list) => $list instanceof Collection && $list->isEmpty());
+    }
+
+    public function test_components_can_share_an_explicit_session_key()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->call('add');
+
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentReadingSharedSessionCollection::class)
+            ->assertSet('items', fn ($items) => $items instanceof Collection && $items->all() === [1]);
+    }
+
+    public function test_values_for_synths_that_are_no_longer_registered_are_discarded()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        $encoded = app(PersistedValueCodec::class)->encodeForStorage(
+            new \Illuminate\Foundation\Auth\User,
+            new TestComponent,
+            'value',
+            'dangerous-value',
+        );
+
+        FacadesSession::put('dangerous-value', $encoded);
+
+        app()->instance(
+            \Livewire\Mechanisms\HandleSynths\HandleSynths::class,
+            new \Livewire\Mechanisms\HandleSynths\HandleSynths,
+        );
+
+        Livewire::test(ComponentWithDangerousSessionProperty::class)
+            ->assertSet('value', 'safe');
+    }
+
+    public function test_json_arrays_left_by_older_versions_are_discarded_from_typed_properties()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+        FacadesSession::put('stale-collection', [1, 2]);
+
+        Livewire::test(ComponentWithStaleSessionCollection::class)
+            ->assertSet('list', null);
+    }
+
+    protected function assertClientAuthoredSynthEnvelopeIsDiscarded($serialization)
+    {
+        config(['session.serialization' => $serialization]);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithDangerousSessionProperty::class)
+            ->set('value', [
+                PersistedValueCodec::KEY => [
+                    'version' => PersistedValueCodec::VERSION,
+                    'value' => [null, [
+                        's' => 'mdl',
+                        'class' => \Illuminate\Foundation\Auth\User::class,
+                        'key' => 1,
+                    ]],
+                ],
+            ]);
+
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentWithDangerousSessionProperty::class)
+            ->assertSet('value', 'safe');
+    }
 }
 
 class ComponentWithSessionCollection extends Component
 {
-    #[Session]
+    #[Session(key: 'collection')]
     public ?Collection $list = null;
 
     public function mount(): void
@@ -108,6 +265,22 @@ class ComponentWithSessionCollection extends Component
     }
 }
 
+class ComponentReadingSharedSessionCollection extends Component
+{
+    #[Session(key: 'collection')]
+    public ?Collection $items = null;
+
+    public function mount(): void
+    {
+        $this->items ??= collect();
+    }
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
 class ComponentWithSynthesizedSessionProperties extends Component
 {
     #[Session]
@@ -115,6 +288,50 @@ class ComponentWithSynthesizedSessionProperties extends Component
 
     #[Session]
     public array $nested = [];
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class ComponentWithPrimitiveSessionProperty extends Component
+{
+    #[Session(key: 'primitive')]
+    public int $count = 0;
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class ComponentWithRawSessionArray extends Component
+{
+    #[Session(key: 'legacy-tuple')]
+    public array $value = [];
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class ComponentWithDangerousSessionProperty extends Component
+{
+    #[Session(key: 'dangerous-value')]
+    public $value = 'safe';
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class ComponentWithStaleSessionCollection extends Component
+{
+    #[Session(key: 'stale-collection')]
+    public ?Collection $list = null;
 
     public function render()
     {

--- a/src/Features/SupportSession/UnitTest.php
+++ b/src/Features/SupportSession/UnitTest.php
@@ -255,6 +255,21 @@ class UnitTest extends TestCase
             ->assertSet('list', null);
     }
 
+    public function test_stale_enum_backing_values_are_discarded_from_typed_properties()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        // A scalar backing an enum case that no longer exists (a removed or
+        // renamed case, or a value written before the enum changed). Coercing
+        // it throws a ValueError that must be recovered from, not surfaced.
+        FacadesSession::put('stale-enum', 'archived');
+
+        Livewire::test(ComponentWithSessionEnum::class)
+            ->assertSet('status', null);
+    }
+
     protected function assertClientAuthoredSynthEnvelopeIsDiscarded($serialization)
     {
         config(['session.serialization' => $serialization]);
@@ -438,6 +453,23 @@ class ComponentWithStaleSessionCollection extends Component
 {
     #[Session(key: 'stale-collection')]
     public ?Collection $list = null;
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+enum SessionStatus: string
+{
+    case Draft = 'draft';
+    case Published = 'published';
+}
+
+class ComponentWithSessionEnum extends Component
+{
+    #[Session(key: 'stale-enum')]
+    public ?SessionStatus $status = null;
 
     public function render()
     {

--- a/src/Features/SupportSession/UnitTest.php
+++ b/src/Features/SupportSession/UnitTest.php
@@ -2,15 +2,19 @@
 
 namespace Livewire\Features\SupportSession;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Session as FacadesSession;
 use Livewire\Attributes\Session;
 use Livewire\Component;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+use Livewire\Mechanisms\HandleSynths\HandleSynths;
 use Livewire\Mechanisms\HandleSynths\PersistedValueCodec;
 use Tests\TestCase;
 use Livewire\Livewire;
 use Tests\TestComponent;
+use Sushi\Sushi;
 
 class UnitTest extends TestCase
 {
@@ -87,6 +91,38 @@ class UnitTest extends TestCase
                 && $nested['when']->equalTo($date));
     }
 
+    public function test_custom_synthesized_properties_survive_json_session_serialization()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+        app(HandleSynths::class)->registerSynth(CustomSessionValueSynth::class);
+
+        Livewire::test(ComponentWithCustomSynthesizedSessionProperty::class);
+
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentWithCustomSynthesizedSessionProperty::class)
+            ->assertSet('value', fn ($value) => $value instanceof CustomSessionValue && $value->value === 'persisted');
+    }
+
+    public function test_model_properties_survive_json_session_serialization()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithSessionModel::class)
+            ->assertSet('article', fn ($article) => $article instanceof SessionArticle && $article->title === 'First');
+
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentWithSessionModel::class)
+            ->assertSet('article', fn ($article) => $article instanceof SessionArticle && $article->title === 'First');
+    }
+
     public function test_php_sessions_continue_to_store_values_raw()
     {
         config(['session.serialization' => 'php']);
@@ -112,6 +148,7 @@ class UnitTest extends TestCase
             ->set('count', 1);
 
         $this->assertSame(1, session('primitive'));
+        $this->assertSame(['search' => '', 'tags' => [1, 2]], session('json-native'));
     }
 
     public function test_legacy_tuple_shaped_arrays_are_not_treated_as_synthetic_values()
@@ -295,10 +332,79 @@ class ComponentWithSynthesizedSessionProperties extends Component
     }
 }
 
+class ComponentWithCustomSynthesizedSessionProperty extends Component
+{
+    #[Session]
+    public ?CustomSessionValue $value = null;
+
+    public function mount()
+    {
+        $this->value ??= new CustomSessionValue('persisted');
+    }
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class ComponentWithSessionModel extends Component
+{
+    #[Session(key: 'article')]
+    public ?SessionArticle $article = null;
+
+    public function mount()
+    {
+        $this->article ??= SessionArticle::first();
+    }
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class SessionArticle extends Model
+{
+    use Sushi;
+
+    protected $rows = [
+        ['title' => 'First'],
+    ];
+}
+
+class CustomSessionValue
+{
+    public function __construct(public string $value) {}
+}
+
+class CustomSessionValueSynth extends Synth
+{
+    public static $key = 'session-value';
+
+    public static function match($target)
+    {
+        return $target instanceof CustomSessionValue;
+    }
+
+    public function dehydrate($target)
+    {
+        return [$target->value, []];
+    }
+
+    public function hydrate($value)
+    {
+        return new CustomSessionValue($value);
+    }
+}
+
 class ComponentWithPrimitiveSessionProperty extends Component
 {
     #[Session(key: 'primitive')]
     public int $count = 0;
+
+    #[Session(key: 'json-native')]
+    public array $filters = ['search' => '', 'tags' => [1, 2]];
 
     public function render()
     {


### PR DESCRIPTION
## Decision brief

Fresh Laravel applications now default to JSON session serialization ([laravel/laravel@75cef50](https://github.com/laravel/laravel/commit/75cef503c6edc3447dd79053a648ea981857e15b)). That makes `#[Session]` fail for typed non-primitive properties: a `Collection` survives Livewire updates through the snapshot synth pipeline, but after a full page refresh Laravel reads the JSON session value as a plain array and PHP rejects assigning it to `?Collection`.

```text
Cannot assign array to property ...::$list of type ?Illuminate\Support\Collection
```

Fixes #10250. Supersedes #10386.

### Demand and product call

- Confirmed demand is one reporter and one explicit beneficiary, with no duplicate reports or independent “me too” comments found.
- The affected surface is broader than that count: Laravel's new default exposes every new app that combines `#[Session]` with Collection, Carbon, enum, model, nested, or custom synthesized values.
- This should be fixed in core rather than documented away. The complete userland escape hatch is switching session serialization back to `php`, but that undoes Laravel's security-motivated default. Array-backed state is a safe narrow workaround, not a satisfactory `#[Session]` contract.

### Prior decisions

- #10252 was the original fix from @joshhanley. Review identified three constraints: don't create a careless hydration pathway, don't leak `HandleComponents` internals, and don't add cost or behavior changes to PHP-serialized sessions.
- #10276 extracted and secured `HandleSynths` specifically so features like `#[Session]` can reuse the registered synth pipeline without reaching into `HandleComponents`.
- #10630 added the missing storage-facing abstraction over `HandleSynths`: an authenticated, versioned `PersistedValueCodec`. It is now merged, and this PR builds directly on that core abstraction.
- #10386 applied that mechanism, but stored bare synth tuples. Any pre-existing session array shaped like `[data, ['s' => ...]]` could therefore be mistaken for Livewire metadata.
- Laravel solved its analogous JSON-session `ViewErrorBag` type loss with a narrowly owned codec in [framework #42090](https://github.com/laravel/framework/pull/42090). This PR follows the same boundary while reusing Livewire's general synth registry.

## Solution

Under `session.serialization=json`, `BaseSession` delegates its value to the `PersistedValueCodec` introduced in #10630. The codec decides whether synthesis is necessary and owns recursive traversal, component context, the strict versioned envelope, authentication, and synth security checks.

`BaseSession` now knows only that JSON sessions require storage encoding. It no longer understands synth tuples or calls `hydrate()` directly. Reads are decoded regardless of the current serializer so configuration changes do not strand encoded state; corrupt or stale values are forgotten and the property's default is preserved.

Consequences:

- Collections, Carbon, nested synthesized values, and registered custom synths round-trip through JSON sessions.
- JSON primitives remain raw.
- PHP-serialized sessions remain raw and pay no synth cost.
- Legacy tuple-shaped arrays remain ordinary arrays.
- Every encoded envelope is signed with the application key and scoped to its resolved session key.
- Client-authored, tampered, unsupported-version, and wrong-scope envelopes are rejected before synth hydration.
- Components intentionally using the same explicit session key can continue to share values.
- Authentic values for removed synthesizers are discarded safely instead of permanently failing every request.
- Class metadata still passes through `SecurityPolicy::validateClass()` before any synth can instantiate it.
- No `unserialize()` path is introduced.
- Forging a decodable persisted value requires `APP_KEY`, the same trust failure that permits forging Livewire snapshot checksums.

## Progressive implementation

Each commit is a usable stage rather than a disconnected piece:

The prerequisite first makes the change easy in [#10630](https://github.com/livewire/livewire/pull/10630). This PR then builds the user-facing fix in usable stages:

1. 🛹 [Fix session-backed Collections under JSON serialization](https://github.com/livewire/livewire/commit/74cdc617) — `BaseSession` delegates to the authenticated codec and solves the reporter's exact typed-Collection refresh failure.
2. 🛴 [Persist every synthesized value in JSON sessions](https://github.com/livewire/livewire/commit/b9151770) — proves the same path for Carbon and nested synthesized values.
3. 🚲 [Lock in session compatibility and security boundaries](https://github.com/livewire/livewire/commit/f823d846) — proves raw PHP/primitives, explicit-key sharing, legacy tuple safety, stale-state recovery, and rejection of client-authored model envelopes under both serializers.
4. 🚗 [Complete JSON session compatibility across the browser lifecycle](https://github.com/livewire/livewire/commit/762dd09c) — preserves JSON-native arrays, proves registered custom synths and Eloquent models, asserts JSON mode, and exercises add → full refresh → add.

## Reproduction and verification

Confirmed before the fix on the reporter's exact Livewire `v4.2.4` (`7d0bfa46`):

1. Load the component successfully.
2. Click **Add**; `1` renders.
3. Refresh the page; Laravel returns HTTP 500 with the typed-property error above.

Confirmed after the fix in the same Laravel 13 playground:

1. Click **Add**; `1` renders.
2. Refresh; `1` is restored with no error.
3. Click **Add** again; `1, 2` renders.

Automated verification:

- Persisted-value codec: 12 tests, 19 assertions.
- SupportSession feature suite: 16 tests, 20 assertions.
- Full unit suite: 1,504 tests, 4,251 assertions; 13 existing skips and 3 existing incomplete tests.
- Focused browser regression: 1 test, 5 assertions.
- Real Laravel 13 playground: `1` after update → `1` after full refresh → `1, 2` after the next update.
- Independent review reproduced an unsigned-envelope `ModelSynth` exploit against the first design; the final signed design directly tests and rejects that path under JSON and PHP sessions.

Session-backed Eloquent values retain normal `ModelSynth` lazy-loading semantics; this PR does not force model queries during `BaseSession::mount()`.

## Immediate userland workaround

Apps unable to upgrade can keep JSON-native data in the session and derive a Collection:

```php
#[Session]
public array $listData = [];

#[Computed]
public function list(): Collection
{
    return collect($this->listData);
}
```

This works for JSON-safe items but does not preserve arbitrary nested object types.

Implementation credit: this is rebuilt from @joshhanley's original work in #10252; Josh is credited as a co-author in the first commit.
