### PR TITLE
[4.x] Fix wire transition skipped after flux toast auto-dismissed

### DIFF
--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -29,23 +29,6 @@ function clearTransitionNames(root) {
     })
 }
 
-function hasBlockingTopLayer() {
-    if (document.querySelector('dialog:modal')) return true
-
-    for (let el of document.querySelectorAll(':popover-open')) {
-        // Flux toast hosts: only block while a real toast panel is present
-        if (el.localName === 'ui-toast' || el.localName === 'ui-toast-group') {
-            if (el.querySelector('[data-flux-toast-dialog]')) return true
-            continue // open host, no panel → do not block transitions
-        }
-
-        // Other popovers (menus, dropdowns, etc.): still block
-        return true
-    }
-
-    return false
-}
-
 export async function transitionDomMutation(fromEl, toEl, callback, options = {}) {
     // Skip transitions entirely if requested...
     if (options.skip) return callback()
@@ -61,7 +44,13 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
     // Skip entirely if a top-layer element is already open (transitions behind
     // it are invisible to the user and the ::view-transition pseudo-elements
     // would paint above it during animation)...
-    if (hasBlockingTopLayer()) return callback()
+    if (document.querySelector('dialog:modal')) return callback()
+
+    for (let el of document.querySelectorAll(':popover-open')) {
+        if ([...el.querySelectorAll('*')].some(el => el.checkVisibility())) {
+            return callback()
+        }
+    }
 
     // Set transition names right before the transition starts (not permanently)...
     setTransitionNames(fromEl, options)

--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -29,6 +29,23 @@ function clearTransitionNames(root) {
     })
 }
 
+function hasBlockingTopLayer() {
+    if (document.querySelector('dialog:modal')) return true
+
+    for (let el of document.querySelectorAll(':popover-open')) {
+        // Flux toast hosts: only block while a real toast panel is present
+        if (el.localName === 'ui-toast' || el.localName === 'ui-toast-group') {
+            if (el.querySelector('[data-flux-toast-dialog]')) return true
+            continue // open host, no panel → do not block transitions
+        }
+
+        // Other popovers (menus, dropdowns, etc.): still block
+        return true
+    }
+
+    return false
+}
+
 export async function transitionDomMutation(fromEl, toEl, callback, options = {}) {
     // Skip transitions entirely if requested...
     if (options.skip) return callback()
@@ -44,7 +61,7 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
     // Skip entirely if a top-layer element is already open (transitions behind
     // it are invisible to the user and the ::view-transition pseudo-elements
     // would paint above it during animation)...
-    if (document.querySelector('dialog:modal, :popover-open')) return callback()
+    if (hasBlockingTopLayer()) return callback()
 
     // Set transition names right before the transition starts (not permanently)...
     setTransitionNames(fromEl, options)

--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -46,9 +46,14 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
     // would paint above it during animation)...
     if (document.querySelector('dialog:modal')) return callback()
 
-    for (let el of document.querySelectorAll(':popover-open')) {
-        if ([...el.querySelectorAll('*')].some(el => el.checkVisibility())) {
-            return callback()
+    // An open popover only blocks the transition if it has visible descendants.
+    // Some components (e.g. toast hosts) keep an empty popover open as a
+    // persistent container — the host element itself always passes
+    // checkVisibility() while open, so visible *descendants* are the proxy
+    // for "this popover is actually showing UI"...
+    for (let popover of document.querySelectorAll(':popover-open')) {
+        for (let el of popover.querySelectorAll('*')) {
+            if (el.checkVisibility()) return callback()
         }
     }
 

--- a/src/Features/SupportTransitions/BrowserTest.php
+++ b/src/Features/SupportTransitions/BrowserTest.php
@@ -501,7 +501,7 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
-    public function test_transition_runs_when_popover_stays_open_without_panel()
+    public function test_transition_runs_when_popover_stays_open_without_visible_content()
     {
         Livewire::visit(
             new class extends \Livewire\Component {
@@ -522,11 +522,11 @@ class BrowserTest extends \Tests\BrowserTestCase
                             <div wire:transition dusk="target">Hello</div>
                         @endif
 
-                        <div
-                            popover="manual"
-                            dusk="toast-host"
-                            x-init="$el.showPopover()"
-                        ></div>
+                        <div popover="manual" dusk="toast-host" x-init="$el.showPopover()">
+                            <template>
+                                <div>Hidden popover content</div>
+                            </template>
+                        </div>
                     </div>
                     HTML;
                 }
@@ -543,7 +543,49 @@ class BrowserTest extends \Tests\BrowserTestCase
         "))
         ->waitForLivewire()->click('@toggle')
         ->waitFor('@target')
-        ->assertScript('window.__startViewTransitionCalled', true)
-        ;
+        ->assertScript('window.__startViewTransitionCalled', true);
+    }
+
+    public function test_transition_does_not_run_when_popover_has_visible_content()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $show = false;
+
+                public function toggle()
+                {
+                    $this->show = ! $this->show;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="toggle" dusk="toggle">Toggle</button>
+
+                        @if ($show)
+                            <div wire:transition dusk="target">Hello</div>
+                        @endif
+
+                        <div popover="manual" dusk="toast-host" x-init="$el.showPopover()">
+                            <div>Visible popover content</div>
+                        </div>
+                    </div>
+                    HTML;
+                }
+            }
+        )
+        ->waitUntil("document.querySelector('[dusk=toast-host]').matches(':popover-open')")
+        ->tap(fn ($browser) => $browser->script("
+            window.__startViewTransitionCalled = false
+            let original = document.startViewTransition.bind(document)
+            document.startViewTransition = function (...args) {
+                window.__startViewTransitionCalled = true
+                return original(...args)
+            }
+        "))
+        ->waitForLivewire()->click('@toggle')
+        ->waitFor('@target')
+        ->assertScript('window.__startViewTransitionCalled', false);
     }
 }

--- a/src/Features/SupportTransitions/BrowserTest.php
+++ b/src/Features/SupportTransitions/BrowserTest.php
@@ -500,4 +500,50 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->waitUntil("!$animationsRunning")
         ;
     }
+
+    public function test_transition_runs_when_popover_stays_open_without_panel()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $show = false;
+
+                public function toggle()
+                {
+                    $this->show = ! $this->show;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="toggle" dusk="toggle">Toggle</button>
+
+                        @if ($show)
+                            <div wire:transition dusk="target">Hello</div>
+                        @endif
+
+                        <div
+                            popover="manual"
+                            dusk="toast-host"
+                            x-init="$el.showPopover()"
+                        ></div>
+                    </div>
+                    HTML;
+                }
+            }
+        )
+        ->waitUntil("document.querySelector('[dusk=toast-host]').matches(':popover-open')")
+        ->tap(fn ($browser) => $browser->script("
+            window.__startViewTransitionCalled = false
+            let original = document.startViewTransition.bind(document)
+            document.startViewTransition = function (...args) {
+                window.__startViewTransitionCalled = true
+                return original(...args)
+            }
+        "))
+        ->waitForLivewire()->click('@toggle')
+        ->waitFor('@target')
+        ->assertScript('window.__startViewTransitionCalled', true)
+        ;
+    }
 }


### PR DESCRIPTION
### Problem

`wire:transition` currently skips a View Transition whenever there is an open modal dialog or popover:

```js
if (document.querySelector('dialog:modal, :popover-open')) {
    return callback()
}
```

This is necessary for open popovers because View Transition pseudo-elements can paint above the top layer. Starting a transition while a popover is open can cause the transition to render over the popover.

However, `:popover-open` only tells us that the popover itself is open. It does not tell us whether the popover currently has any **visible UI**.

Some components keep a popover open as a persistent container while its contents are hidden. In that case, `:popover-open` still matches even though there is nothing visible that needs to be protected from the View Transition.

This causes subsequent Livewire transitions to be skipped unnecessarily.

### Solution

Keep the existing behavior for modal dialogs, but for popovers only skip the transition when the popover contains a visible element:

```js
if (document.querySelector('dialog:modal')) return callback()

for (let popover of document.querySelectorAll(':popover-open')) { 
    for (let el of popover.querySelectorAll('*')) { 
        if (el.checkVisibility()) return callback() 
    } 
}
```

`checkVisibility()` lets us determine whether the open popover actually contains visible UI without relying on any framework- or component-specific selectors.

This keeps the behavior generic and avoids coupling Livewire's transition implementation to a particular component library or DOM structure.

### Why not just check `:popover-open`?

An open popover can remain mounted and open while its contents are hidden. Treating every `:popover-open` element as blocking would therefore incorrectly skip transitions when there is no visible popover.

At the same time, removing the `:popover-open` check entirely would reintroduce the issue where an actually visible popover can be covered by View Transition pseudo-elements.

The new check handles both cases:

* **Visible popover** → skip the transition.
* **Open but visually inactive popover** → allow the transition.
* **Modal dialog** → skip the transition as before.

### Why `checkVisibility()`?

Checking text content, child count, or specific element names would be unreliable:

* A popover can contain non-textual UI.
* A popover can contain DOM nodes that are hidden.
* Empty/non-empty DOM structure does not necessarily correspond to visible UI.
* Component-specific selectors would couple Livewire to another package's implementation details.

`checkVisibility()` directly answers the relevant question: whether there is currently a visible element inside the open popover.

Fixes: https://github.com/livewire/flux/issues/2783