### PR TITLE
[4.x] Add a trusted-storage codec for synthesized values

### DIFF
--- a/src/Mechanisms/HandleSynths/CorruptPersistedValueException.php
+++ b/src/Mechanisms/HandleSynths/CorruptPersistedValueException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleSynths;
+
+class CorruptPersistedValueException extends \Exception
+{
+    public function __construct($previous = null)
+    {
+        parent::__construct('Livewire encountered corrupt persisted property data.', previous: $previous);
+    }
+}

--- a/src/Mechanisms/HandleSynths/PersistedValueCodec.php
+++ b/src/Mechanisms/HandleSynths/PersistedValueCodec.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleSynths;
+
+use Livewire\Drawer\Utils;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+
+class PersistedValueCodec
+{
+    const KEY = '__livewire_persisted';
+
+    const VERSION = 1;
+
+    public function __construct(protected HandleSynths $synths) {}
+
+    public function encodeForStorage($value, $component, $path, $key)
+    {
+        if (! $this->requiresSynthesis($value)) return $value;
+
+        $encoded = $this->synths->dehydrate(
+            $value,
+            new ComponentContext($component),
+            $path,
+        );
+
+        return [
+            static::KEY => [
+                'version' => static::VERSION,
+                'value' => $encoded,
+                'signature' => $this->signatureFor($encoded, $key),
+            ],
+        ];
+    }
+
+    public function decodeFromStorage($value, $component, $path, $key)
+    {
+        if (! $this->isEnvelope($value)) return $value;
+
+        $envelope = $value[static::KEY];
+
+        if (! $this->isValidEnvelope($envelope, $key)) {
+            throw new CorruptPersistedValueException;
+        }
+
+        try {
+            return $this->synths->hydrate(
+                $envelope['value'],
+                new ComponentContext($component),
+                $path,
+            );
+        } catch (\Throwable $e) {
+            throw new CorruptPersistedValueException($e);
+        }
+    }
+
+    protected function isEnvelope($value)
+    {
+        return is_array($value)
+            && count($value) === 1
+            && array_key_exists(static::KEY, $value);
+    }
+
+    protected function isValidEnvelope($envelope, $key)
+    {
+        if (! is_array($envelope) || count($envelope) !== 3) return false;
+
+        if (($envelope['version'] ?? null) !== static::VERSION) return false;
+
+        if (! array_key_exists('value', $envelope)) return false;
+
+        if (! Utils::isSyntheticTuple($envelope['value'])) return false;
+
+        if (! is_string($signature = $envelope['signature'] ?? null)) return false;
+
+        return hash_equals(
+            $this->signatureFor($envelope['value'], $key),
+            $signature,
+        );
+    }
+
+    protected function signatureFor($value, $key)
+    {
+        $payload = json_encode([
+            'type' => 'livewire-persisted-value',
+            'version' => static::VERSION,
+            'key' => $key,
+            'value' => $value,
+        ], JSON_THROW_ON_ERROR);
+
+        return hash_hmac('sha256', $payload, app('encrypter')->getKey());
+    }
+
+    protected function requiresSynthesis($value)
+    {
+        if (Utils::isAPrimitive($value)) return false;
+
+        if (! is_array($value)) return true;
+
+        foreach ($value as $child) {
+            if ($this->requiresSynthesis($child)) return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Mechanisms/HandleSynths/PersistedValueCodecUnitTest.php
+++ b/src/Mechanisms/HandleSynths/PersistedValueCodecUnitTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleSynths;
+
+use Illuminate\Support\Collection;
+use Tests\TestComponent;
+
+class PersistedValueCodecUnitTest extends \Tests\TestCase
+{
+    public function test_a_collection_round_trips_through_json_storage()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+
+        $encoded = $codec->encodeForStorage(collect([1, 2, 3]), $component, 'items', 'session.items');
+        $stored = json_decode(json_encode($encoded), true);
+        $decoded = $codec->decodeFromStorage($stored, $component, 'items', 'session.items');
+
+        $this->assertInstanceOf(Collection::class, $decoded);
+        $this->assertSame([1, 2, 3], $decoded->all());
+    }
+
+    public function test_json_safe_values_are_not_encoded()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $value = ['search' => '', 'tags' => [1, 2], 'enabled' => true];
+
+        $this->assertSame($value, $codec->encodeForStorage($value, $component, 'filters', 'session.filters'));
+        $this->assertSame($value, $codec->decodeFromStorage($value, $component, 'filters', 'session.filters'));
+    }
+
+    public function test_an_unsigned_envelope_is_never_hydrated()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $forged = [
+            PersistedValueCodec::KEY => [
+                'version' => PersistedValueCodec::VERSION,
+                'value' => [['secret'], ['s' => 'clctn', 'class' => Collection::class]],
+            ],
+        ];
+
+        $this->expectException(CorruptPersistedValueException::class);
+
+        $codec->decodeFromStorage($forged, $component, 'items', 'session.items');
+    }
+}

--- a/src/Mechanisms/HandleSynths/PersistedValueCodecUnitTest.php
+++ b/src/Mechanisms/HandleSynths/PersistedValueCodecUnitTest.php
@@ -2,7 +2,9 @@
 
 namespace Livewire\Mechanisms\HandleSynths;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Tests\TestComponent;
 
 class PersistedValueCodecUnitTest extends \Tests\TestCase
@@ -44,5 +46,152 @@ class PersistedValueCodecUnitTest extends \Tests\TestCase
         $this->expectException(CorruptPersistedValueException::class);
 
         $codec->decodeFromStorage($forged, $component, 'items', 'session.items');
+    }
+
+    public function test_nested_synthesized_values_round_trip_through_json_storage()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $date = Carbon::parse('2026-01-15 10:00:00');
+        $value = ['items' => collect([1, 2]), 'createdAt' => $date];
+
+        $encoded = $codec->encodeForStorage($value, $component, 'state', 'session.state');
+        $stored = json_decode(json_encode($encoded), true);
+        $decoded = $codec->decodeFromStorage($stored, $component, 'state', 'session.state');
+
+        $this->assertInstanceOf(Collection::class, $decoded['items']);
+        $this->assertSame([1, 2], $decoded['items']->all());
+        $this->assertInstanceOf(Carbon::class, $decoded['createdAt']);
+        $this->assertTrue($decoded['createdAt']->equalTo($date));
+    }
+
+    public function test_registered_custom_synths_round_trip_through_json_storage()
+    {
+        app(HandleSynths::class)->registerSynth(PersistedValueSynth::class);
+
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+
+        $encoded = $codec->encodeForStorage(new PersistedValue('stored'), $component, 'value', 'session.value');
+        $stored = json_decode(json_encode($encoded), true);
+        $decoded = $codec->decodeFromStorage($stored, $component, 'value', 'session.value');
+
+        $this->assertInstanceOf(PersistedValue::class, $decoded);
+        $this->assertSame('stored', $decoded->value);
+    }
+
+    public function test_bare_synth_tuples_are_not_decoded()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $tuple = [['one', 'two'], ['s' => 'clctn', 'class' => Collection::class]];
+
+        $this->assertSame($tuple, $codec->decodeFromStorage($tuple, $component, 'items', 'session.items'));
+    }
+
+    public function test_envelopes_with_sibling_application_data_are_not_decoded()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $encoded = $codec->encodeForStorage(collect([1, 2]), $component, 'items', 'session.items');
+        $withSiblingData = [...$encoded, 'application' => 'value'];
+
+        $this->assertSame($withSiblingData, $codec->decodeFromStorage($withSiblingData, $component, 'items', 'session.items'));
+    }
+
+    public function test_unsupported_envelope_versions_are_rejected()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $encoded = $codec->encodeForStorage(collect([1, 2]), $component, 'items', 'session.items');
+        $encoded[PersistedValueCodec::KEY]['version']++;
+
+        $this->expectException(CorruptPersistedValueException::class);
+
+        $codec->decodeFromStorage($encoded, $component, 'items', 'session.items');
+    }
+
+    public function test_tampered_envelopes_are_rejected_before_hydration()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $encoded = $codec->encodeForStorage(collect([1, 2]), $component, 'items', 'session.items');
+        $encoded[PersistedValueCodec::KEY]['value'][0][] = 3;
+
+        $this->expectException(CorruptPersistedValueException::class);
+
+        $codec->decodeFromStorage($encoded, $component, 'items', 'session.items');
+    }
+
+    public function test_signatures_are_bound_to_the_storage_key()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $encoded = $codec->encodeForStorage(collect([1, 2]), $component, 'items', 'session.items');
+
+        $this->expectException(CorruptPersistedValueException::class);
+
+        $codec->decodeFromStorage($encoded, $component, 'items', 'session.other');
+    }
+
+    public function test_a_shared_storage_key_can_be_decoded_by_another_component_property()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $encoded = $codec->encodeForStorage(collect([1, 2]), new TestComponent, 'items', 'shared');
+
+        $decoded = $codec->decodeFromStorage($encoded, new OtherTestComponent, 'renamed', 'shared');
+
+        $this->assertInstanceOf(Collection::class, $decoded);
+        $this->assertSame([1, 2], $decoded->all());
+    }
+
+    public function test_hydration_failures_are_reported_as_corrupt_persisted_values()
+    {
+        app(HandleSynths::class)->registerSynth(PersistedValueSynth::class);
+
+        $component = new TestComponent;
+        $encoded = app(PersistedValueCodec::class)
+            ->encodeForStorage(new PersistedValue('stored'), $component, 'value', 'session.value');
+        $codecWithoutCustomSynth = new PersistedValueCodec(new HandleSynths);
+
+        try {
+            $codecWithoutCustomSynth->decodeFromStorage($encoded, $component, 'value', 'session.value');
+        } catch (CorruptPersistedValueException $e) {
+            $this->assertStringContainsString('No synthesizer found', $e->getPrevious()->getMessage());
+
+            return;
+        }
+
+        $this->fail('The outdated persisted value was hydrated.');
+    }
+}
+
+class OtherTestComponent extends TestComponent
+{
+    //
+}
+
+class PersistedValue
+{
+    public function __construct(public string $value) {}
+}
+
+class PersistedValueSynth extends Synth
+{
+    public static $key = 'persisted-value';
+
+    public static function match($target)
+    {
+        return $target instanceof PersistedValue;
+    }
+
+    public function dehydrate($target)
+    {
+        return [$target->value, []];
+    }
+
+    public function hydrate($value)
+    {
+        return new PersistedValue($value);
     }
 }


### PR DESCRIPTION
## Why

Features that persist Livewire property values outside the normal browser snapshot need the synth system, but should not each learn about `ComponentContext`, recursive synth tuples, collision-resistant envelopes, or storage trust.

That plumbing leaked into the first version of #10628 while solving #10250. #10276 gave us the reusable low-level synth mechanism; this PR adds the missing storage-facing layer so the session fix can become the easy change.

## What

Add a small `PersistedValueCodec` over `HandleSynths`:

```php
$stored = $codec->encodeForStorage($value, $component, $path, $storageKey);
$value = $codec->decodeFromStorage($stored, $component, $path, $storageKey);
```

The codec:

- leaves primitives and JSON-native arrays untouched;
- recursively dehydrates values that require a registered Livewire synth;
- owns a strict, versioned envelope so ordinary synth-shaped arrays are never interpreted as metadata;
- signs encoded envelopes with the application encryption key and binds the signature to the caller's resolved storage key;
- reconstructs `ComponentContext` internally;
- preserves nested values and registered custom synths;
- rejects unsigned, modified, wrong-version, or wrong-scope envelopes before `HandleSynths::hydrate()` is reachable.
- converts authentic values whose synthesizer is no longer available into recoverable corrupt state.

## Trust boundary

This is intentionally not a general-purpose hydrator. Persisted values can originate from client-writable Livewire properties even when the eventual storage backend is trusted, so storage trust alone is insufficient. The codec authenticates its own output before hydration, using the same application-key security boundary as Livewire snapshots.

Browser snapshots retain their existing checksum, while URLs and request updates remain on the narrower type-directed `hydrateForUpdate()` path. No arbitrary request value can manufacture a decodable persisted synth envelope.

## Progressive commits

1. 🛹 [`19ea33ec`](https://github.com/livewire/livewire/commit/19ea33ec) — round-trip a Collection through an authenticated JSON envelope and prove unsigned envelopes never hydrate.
2. 🚲 [`224029ab`](https://github.com/livewire/livewire/commit/224029ab) — define nested/custom synth behavior, strict envelope compatibility, storage-key sharing/scoping, tamper rejection, and outdated-synth recovery.

## Verification

- Focused codec coverage: 12 tests, 19 assertions.
- Full stacked unit suite: 1,504 tests, 4,251 assertions; 13 existing skips and 3 existing incomplete tests.
- Independent review confirmed the original unsigned design was exploitable through a client-authored `ModelSynth` envelope; the signed design rejects that path before hydration under both JSON and PHP serializers.
- Built production assets before the complete unit run.

No user-facing behavior changes in this prerequisite PR. #10628 is the first consumer and retains the original implementation credit to @joshhanley.
