### PR TITLE
[4.x] Suspend component trees until their script modules load

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -50,6 +50,31 @@ Here's a more full example where you can do something like register a JavaScript
 
 To learn more about JavaScript actions, [visit the actions documentation](/docs/4.x/actions#javascript-actions).
 
+### When scripts run
+
+A component's script runs when its markup is in the DOM, but before Alpine has initialized it. Livewire suspends initialization of the component's tree until the script has finished, so anything the script registers—`Alpine.data()` providers, `$js` actions, custom directives—is guaranteed to exist before any expression in the component's markup evaluates:
+
+```blade
+<div x-data="audioUploader">
+    <span x-text="message"></span>
+</div>
+
+<script>
+    Alpine.data('audioUploader', () => ({
+        message: 'Loaded',
+    }))
+</script>
+```
+
+This holds on the initial page load and every other way a component enters the page: lazy loading, dynamic mounting from a parent update, islands, and `wire:navigate`.
+
+A few consequences of this timing worth knowing:
+
+* `$wire.$el` and plain DOM queries work—the markup is present when the script runs.
+* Anything produced by initializing the markup—`$refs`, Alpine component state—doesn't exist yet. Reach for it from an `init()` hook on your Alpine component, or after `await $wire.$nextTick()`.
+* While a script is loading, the component's markup is visible but not yet interactive. This window is normally imperceptible, but for a heavy module you can put [`x-cloak`](https://alpinejs.dev/directives/cloak) on elements that shouldn't appear until the script is ready—it's honored until the component initializes.
+* If a script fails to load or throws, Livewire logs the error and initializes the component anyway so the page keeps working.
+
 ### Using `$wire` from scripts
 
 When you add `<script>` tags inside your component, you automatically have access to your Livewire component's `$wire` object.

--- a/js/features/supportJsModules.js
+++ b/js/features/supportJsModules.js
@@ -1,36 +1,147 @@
 import { on } from '@/hooks'
+import { interceptMessage } from '@/request'
 import { getModuleUrl } from '@/utils'
+import Alpine from 'alpinejs'
 
 let pendingComponentAssets = new WeakMap()
 
-on('effect', ({ component, effects }) => {
+let morphGates = new WeakMap()
+
+// A component's script module is fetched asynchronously, but Alpine walks the
+// DOM synchronously — left alone, Alpine evaluates the component's markup
+// before the module's Alpine.data() and $js registrations exist. So while the
+// module loads, the component's tree is suspended via Alpine.deferInit():
+// nothing inside initializes until the module has run, and the rest of the
+// page carries on. Scripts therefore always run with the component's markup
+// in the DOM, but before Alpine has initialized it...
+on('effect', ({ component, effects, request }) => {
     let scriptModuleHash
 
     if (Object.prototype.hasOwnProperty.call(effects, 'scriptModule')) {
         scriptModuleHash = effects.scriptModule
     }
 
-    if (scriptModuleHash) {
-        let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
-        let path = `${getModuleUrl()}/js/${encodedName}.js?v=${scriptModuleHash}`
+    if (! scriptModuleHash) return
 
-        pendingComponentAssets.set(component, Alpine.reactive({
-            loading: true,
-            afterLoaded: [],
-        }))
+    let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
+    let path = `${getModuleUrl()}/js/${encodedName}.js?v=${scriptModuleHash}`
 
-        import(/* @vite-ignore */ path).then(module => {
-            module.run.call(component.$wire, component.$wire, component.$wire.js);
+    let pending = Alpine.reactive({
+        loading: true,
+        afterLoaded: [],
+    })
 
-            pendingComponentAssets.get(component).loading = false
-            pendingComponentAssets.get(component).afterLoaded.forEach(callback => callback())
+    pendingComponentAssets.set(component, pending)
+
+    // Start fetching immediately, but hold the module's execution until this
+    // response's morph has landed (a lazy component's real markup arrives in
+    // the same response as its scriptModule effect)...
+    let modulePromise = import(/* @vite-ignore */ path)
+
+    let ready = Promise.all([modulePromise, morphGateFor(component, request)])
+        .then(([module]) => {
+            // The component may have been removed while its module was in
+            // flight — don't run the script for a component that's no longer
+            // on the page...
+            if (! component.el.isConnected) return
+
+            module.run.call(component.$wire, component.$wire, component.$wire.js)
+
+            pending.loading = false
+            pending.afterLoaded.forEach(callback => callback())
+        })
+        .catch(error => {
+            // A module that fails to load or run must not leave the component's
+            // tree suspended forever. Surface the error, then let the tree
+            // initialize without it...
+            console.error(`Livewire: The script module for the [${component.name}] component failed:`, error)
+        })
+        .finally(() => {
+            pending.loading = false
+
             pendingComponentAssets.delete(component)
-        });
+        })
+
+    deferInit(component.el, ready)
+})
+
+// Alpine.deferInit() ships in Alpine v3.17. If an older Alpine is bundled,
+// degrade to loading the module without suspending the tree rather than
+// breaking outright...
+function deferInit(el, promise) {
+    if (Alpine.deferInit) Alpine.deferInit(el, promise)
+}
+
+// The morph gate answers "is this component's markup in the DOM yet?". With
+// no in-flight request there's nothing to wait for: on the initial page load,
+// a back/forward restore, or a child rendered by its parent's update, the
+// markup is already present when the effect fires. For a message-driven
+// effect (lazy hydration), the gate binds to the exact message that carried
+// the effect — a concurrent message for the same component finishing first
+// must not open it early...
+let processingMessages = new WeakMap()
+
+function morphGateFor(component, request) {
+    if (! request) return Promise.resolve()
+
+    let message = processingMessages.get(component)
+
+    if (! message) return Promise.resolve()
+
+    if (! morphGates.has(message)) {
+        let resolve
+
+        let promise = new Promise(r => resolve = r)
+
+        morphGates.set(message, { promise, resolve })
     }
+
+    return morphGates.get(message).promise
+}
+
+function releaseMorphGate(message) {
+    let gate = morphGates.get(message)
+
+    if (! gate) return
+
+    morphGates.delete(message)
+
+    gate.resolve()
+}
+
+interceptMessage(({ message, onSuccess, onCancel, onFailure, onError, onFinish }) => {
+    onSuccess(({ onSync, onMorphed }) => {
+        // Effects are processed between sync and morph — remember which
+        // message is applying its response so the effect hook can bind the
+        // gate to it...
+        onSync(() => processingMessages.set(message.component, message))
+
+        onMorphed(() => releaseMorphGate(message))
+    })
+
+    // However the message ends, its gate must open — a component would
+    // otherwise stay suspended forever...
+    onCancel(() => releaseMorphGate(message))
+    onFailure(() => releaseMorphGate(message))
+    onError(() => releaseMorphGate(message))
+    onFinish(() => {
+        if (processingMessages.get(message.component) === message) {
+            processingMessages.delete(message.component)
+        }
+
+        releaseMorphGate(message)
+    })
 })
 
 export function assetIsPendingFor(component) {
     return pendingComponentAssets.has(component) && pendingComponentAssets.get(component).loading
+}
+
+// True only when the component's tree was actually suspended — a pending
+// module on an Alpine without deferInit() loads the old (racy) way, and the
+// component initializes on the first pass like it always did...
+export function treeIsSuspendedFor(component) {
+    return !! Alpine.deferInit && assetIsPendingFor(component)
 }
 
 export function runAfterAssetIsLoadedFor(component, callback) {

--- a/js/lifecycle.js
+++ b/js/lifecycle.js
@@ -1,4 +1,5 @@
 import { findComponentByEl, destroyComponent, initComponent, hasComponent } from './store'
+import { treeIsSuspendedFor } from './features/supportJsModules'
 import { matchesForLivewireDirective, extractDirective } from './directives'
 import { trigger } from './hooks'
 import collapse from '@alpinejs/collapse'
@@ -40,6 +41,12 @@ export function start() {
         // This prevents Livewire from causing general slowness for other Alpine elements on the page...
         if (! Array.from(attributes).some(attribute => matchesForLivewireDirective(attribute.name))) return
 
+        // An element Alpine hasn't initialized sits inside an ignored or
+        // suspended tree. Its directives will be picked up by the tree walk
+        // when (and if) it initializes — triggering them now would double
+        // them up...
+        if (! el._x_marker) return
+
         let component = findComponentByEl(el, false)
 
         if (! component) return
@@ -67,6 +74,12 @@ export function start() {
                 Alpine.onAttributeRemoved(el, 'wire:id', () => {
                     destroyComponent(component.id)
                 })
+
+                // If the component's tree was just suspended while its script module
+                // loads (initComponent's effect processing registered it with
+                // Alpine.deferInit), bail out here so directive triggers fire once
+                // on the resume pass instead of on both passes...
+                if (treeIsSuspendedFor(component)) return
             }
 
             let directives = Array.from(el.getAttributeNames())

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,18 @@
             "name": "laravel-livewire",
             "license": "MIT",
             "dependencies": {
-                "@alpinejs/anchor": "^3.16.3",
-                "@alpinejs/collapse": "^3.16.3",
-                "@alpinejs/csp": "^3.16.3",
-                "@alpinejs/focus": "^3.16.3",
-                "@alpinejs/intersect": "^3.16.3",
-                "@alpinejs/mask": "^3.16.3",
-                "@alpinejs/morph": "^3.16.3",
-                "@alpinejs/persist": "^3.16.3",
-                "@alpinejs/resize": "^3.16.3",
-                "@alpinejs/sort": "^3.16.3",
+                "@alpinejs/anchor": "^3.17.0",
+                "@alpinejs/collapse": "^3.17.0",
+                "@alpinejs/csp": "^3.17.0",
+                "@alpinejs/focus": "^3.17.0",
+                "@alpinejs/intersect": "^3.17.0",
+                "@alpinejs/mask": "^3.17.0",
+                "@alpinejs/morph": "^3.17.0",
+                "@alpinejs/persist": "^3.17.0",
+                "@alpinejs/resize": "^3.17.0",
+                "@alpinejs/sort": "^3.17.0",
                 "@vue/reactivity": "^3.2.45",
-                "alpinejs": "^3.16.3",
+                "alpinejs": "^3.17.0",
                 "nprogress": "^0.2.0"
             },
             "devDependencies": {
@@ -29,33 +29,33 @@
             }
         },
         "node_modules/@alpinejs/anchor": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.16.3.tgz",
-            "integrity": "sha512-l53MqW/ZNzR+0jmQ6WhRWEb0K3ZxXhWxgjnLTA+GDX99wCO47lYaD8SIPjxXRARfcrRKPzrpj1llKa0pfwg1kw==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.17.0.tgz",
+            "integrity": "sha512-TCY8DnyMWIWdAECjTEzBsDnh4gfiKuZq2wjmS0eHY0F38i5s4k2iOphxt5cWAytLI9yw6FKqbCytXNmjHOZjDQ==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.5.3"
             }
         },
         "node_modules/@alpinejs/collapse": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.16.3.tgz",
-            "integrity": "sha512-ekH5VBTpMBNnffAfvL+3mqFLIWNW4bUmCExEl+1WdGPewtVYBI2kMWNd2lVOsrvsDRSij7VGmAG0AK5s8WD03g==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.17.0.tgz",
+            "integrity": "sha512-Dwjb8cEjUYdHy0FCKCfmmq/RGOotSm116w/fQBXTrX2HPw5rrJ3ZUgUhO1JOgtgkOw+vTlBERPtjJViIrMZn0w==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/csp": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.16.3.tgz",
-            "integrity": "sha512-eqz6rpWDXuJOGp3YvsXQqZljjBz7ZWAkEmJUt3zTJyK9SEjUcInfOx7sRLzEUlrU+o9r2UhxCVhFBc5eJAUMdA==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.17.0.tgz",
+            "integrity": "sha512-D6W+RbUfkU1SyAYM0GHNF84jEHtx77HQq5CdOBvlBwDzKqbdTqjITPRLNihZ/EcUqoLgqebFzHd/v55rpP0Jhw==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.5.40"
             }
         },
         "node_modules/@alpinejs/focus": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.16.3.tgz",
-            "integrity": "sha512-MwEeux0W+/DP4B3FyNHPs+kzqMmgfWRf25WsJLBH1kahBqiVHNLewSJotbO+9345A8WsHz3yx8XkaeNnepDv3Q==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.17.0.tgz",
+            "integrity": "sha512-tqkE2Pj4WgSXXujs3eCLxiS2ZODgNcDsKvG5lCZKlDozeRO6WFeSAjV5EKi4p+BFNIwm1937O4xwuV7hQ0Q+jA==",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^8.0.0",
@@ -63,39 +63,39 @@
             }
         },
         "node_modules/@alpinejs/intersect": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.16.3.tgz",
-            "integrity": "sha512-hGiwxwfuRjiYpxnuZOD5ymQAPhyxspVfhwuSEg/TdJhfqmfacJd4Z42LIKIdXoDE8JaexXvrUeg5MBxzLVgMmQ==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.17.0.tgz",
+            "integrity": "sha512-6vvZFWmPo/+Vu+vSWjKkE2KFw7HF4SLS8TaGZqnLXhrwOc3UOoYdjz798lQSYhNp1W1Z0+s/Boi4kAczt5BOkA==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/mask": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.16.3.tgz",
-            "integrity": "sha512-BKu3IT4kk1GqgH8Lsn8ekV6nrbbMJgjOuI6zC+rJ+m/iPxBstH80ELauD23a7OiJAVQZjdS+lmYFfCVAbk3Rqg==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.17.0.tgz",
+            "integrity": "sha512-/VL4Sc4T3V/gzuqurOhvsO3FqUKC6RzGrNV4UJUYzv3i+tip/LXTKJIPjPKdw/qzto8c2pRFJ0lpEWPyVcYFBw==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/morph": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.16.3.tgz",
-            "integrity": "sha512-JUrZ9tCXTgdQRoHAIdCDzdrkyEC8ffXwFlynEQ7it0jFy2UW4X0jpcRRBUhvyD94OiMpN6bd82eWhd+3PaqP+g==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.17.0.tgz",
+            "integrity": "sha512-Jucn2wQObrNFnz8m2JR6W2G6fiYpnVu9C2Y1VWfuLDfmD1mv6tHowBevISBxQ459gL/1Iyec3jSZl3hWbyN/Mw==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/persist": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.16.3.tgz",
-            "integrity": "sha512-VyhG3C1CKTvGwHQICw1GLfqIuUt++q54oSRGstX+Y30yjj+JK6HrWj50yzAS+C2K8SXnR99ipY6SQevLaHAgog==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.17.0.tgz",
+            "integrity": "sha512-sS4raHKnSnqfQrVgMAJhc/9cRDZ6ZiLlJqhNhboaiU986JQSOOtfKSM2n23EVmMtm/RcqDR6HqVjDjgyQyuvxg==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/resize": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.16.3.tgz",
-            "integrity": "sha512-3GG13wnOqdYduvT1DPpdJolY254cT8eHw32bx3Ibay2v9HnPzRTDZ9BiZe4iI+1rEcH4E6IKsM7RsEjAaSO0Og==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.17.0.tgz",
+            "integrity": "sha512-5kVl5975Ob6O22RomUqqMnM+azIX51ckHS1eW+1y/xv0UiXFDa7V16jTz+pCRlDH9EHr9mE+wF1DbGIleI7xhg==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/sort": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.16.3.tgz",
-            "integrity": "sha512-LEmI3oE+oIrWmAWoA4PhkA0/kvbrlAr5hBrAvreWU63U4oleTDpgp0LS0qzxBMLOzoEJKwupWuq9l2j6fz2erg==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.17.0.tgz",
+            "integrity": "sha512-yruO0mcORzZEXWg8JSaOEKyw770x5Iu2ssi9sYnPacwJaU+R0e7rXn7VDrbg2DvevnpeKg7dZZtR3VUykF3tOA==",
             "license": "MIT",
             "dependencies": {
                 "sortablejs": "^1.15.2"
@@ -1266,9 +1266,9 @@
             }
         },
         "node_modules/alpinejs": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.16.3.tgz",
-            "integrity": "sha512-kLIO2JOPs5ZY3mHPH+CHHPzp89Y6Gb2luLRy+RDIb1oG9y6N5Vfc75kkEoaSOPhJqvakuPiAsnd9paNPNSZyVg==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.17.0.tgz",
+            "integrity": "sha512-LDLcfqFsiQrdFCNqK7zWyfjx2QE2sjPw0bIPThLVHMIQATAp1dNRKga1xPSqC+71UYFiosIYblLszzzo9r9k6A==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.5.40"

--- a/package.json
+++ b/package.json
@@ -17,18 +17,18 @@
         "vitest": "^3.2.4"
     },
     "dependencies": {
-        "@alpinejs/anchor": "^3.16.3",
-        "@alpinejs/collapse": "^3.16.3",
-        "@alpinejs/csp": "^3.16.3",
-        "@alpinejs/focus": "^3.16.3",
-        "@alpinejs/intersect": "^3.16.3",
-        "@alpinejs/mask": "^3.16.3",
-        "@alpinejs/morph": "^3.16.3",
-        "@alpinejs/persist": "^3.16.3",
-        "@alpinejs/resize": "^3.16.3",
-        "@alpinejs/sort": "^3.16.3",
+        "@alpinejs/anchor": "^3.17.0",
+        "@alpinejs/collapse": "^3.17.0",
+        "@alpinejs/csp": "^3.17.0",
+        "@alpinejs/focus": "^3.17.0",
+        "@alpinejs/intersect": "^3.17.0",
+        "@alpinejs/mask": "^3.17.0",
+        "@alpinejs/morph": "^3.17.0",
+        "@alpinejs/persist": "^3.17.0",
+        "@alpinejs/resize": "^3.17.0",
+        "@alpinejs/sort": "^3.17.0",
         "@vue/reactivity": "^3.2.45",
-        "alpinejs": "^3.16.3",
+        "alpinejs": "^3.17.0",
         "nprogress": "^0.2.0"
     }
 }

--- a/src/Features/SupportJsModules/BrowserTest.php
+++ b/src/Features/SupportJsModules/BrowserTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportJsModules;
 
 use Illuminate\Support\Facades\Route;
+use Livewire\Component;
 use Livewire\Livewire;
 
 class BrowserTest extends \Tests\BrowserTestCase
@@ -17,6 +18,21 @@ class BrowserTest extends \Tests\BrowserTestCase
                     'Content-Type' => 'application/javascript',
                 ]);
             });
+
+            // A module that stays pending until the test releases it. Gating
+            // client-side keeps the (single-threaded) test server free to
+            // handle Livewire updates while the module is "loading"...
+            Route::get('/slow-module.js', function () {
+                return response(
+                    'await new Promise(resolve => { window.releaseSlowModule = resolve })' . "\n\n" . 'export default true',
+                    200,
+                    ['Content-Type' => 'application/javascript'],
+                );
+            });
+
+            Route::get('/navigate-page', function () {
+                return app('livewire')->new('testns::navigate-page')();
+            })->middleware('web');
         };
     }
 
@@ -83,5 +99,234 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->pause(100)
             ->click('@mark-again')
             ->assertSeeIn('@target', 'js-action-called-again');
+    }
+
+    public function test_alpine_data_works_in_single_file_component_script()
+    {
+        // Alpine walks the DOM synchronously while script modules load
+        // asynchronously. The component's tree must be suspended until its
+        // module has registered Alpine.data() providers, or `x-data` on the
+        // component's own root evaluates against nothing.
+        // Regression test for: https://github.com/livewire/livewire/discussions/9591
+        Livewire::visit('testns::alpine-data')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_keeps_working_after_a_morph()
+    {
+        Livewire::visit('testns::alpine-data')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->waitForLivewire()->click('@refresh')
+            ->assertSeeIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_works_with_two_instances_on_one_page()
+    {
+        // The first instance is the one that historically failed: later
+        // instances only worked because the first one's module had already
+        // registered the shared Alpine.data() name globally.
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <livewire:testns::alpine-data key="first" />
+                    <livewire:testns::alpine-data key="second" />
+                </div>
+                HTML;
+            }
+        }])
+            ->waitUntil("[...document.querySelectorAll('[dusk=\"target\"]')].filter(el => el.textContent === 'alpine-data-loaded').length === 2")
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_works_in_dynamically_added_component()
+    {
+        Livewire::visit([new class extends Component {
+            public $show = false;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$toggle('show')" dusk="toggle">Toggle</button>
+
+                    @if ($show)
+                        <livewire:testns::alpine-data />
+                    @endif
+                </div>
+                HTML;
+            }
+        }])
+            ->assertConsoleLogHasNoErrors()
+            ->assertDontSee('alpine-data-loaded')
+            ->waitForLivewire()->click('@toggle')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_works_in_lazy_loaded_component()
+    {
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <livewire:testns::alpine-data lazy />
+                </div>
+                HTML;
+            }
+        }])
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_works_in_component_inside_island()
+    {
+        Livewire::visit('testns::island-with-alpine-data')
+            ->assertConsoleLogHasNoErrors()
+            ->assertSeeIn('@placeholder', 'No child yet')
+            ->assertDontSee('alpine-data-loaded')
+            ->waitForLivewire()->click('@toggle')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_works_after_wire_navigate()
+    {
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <div dusk="source-page">Source page</div>
+
+                    <a href="/navigate-page" wire:navigate dusk="link">Go to the alpine data page</a>
+                </div>
+                HTML;
+            }
+        }])
+            ->assertSeeIn('@source-page', 'Source page')
+            ->assertConsoleLogHasNoErrors()
+            ->waitForNavigate()->click('@link')
+            ->waitForTextIn('@target', 'navigate-data-loaded')
+            ->assertConsoleLogHasNoErrors()
+            // Navigating on to another page containing the same component
+            // reuses the cached module and still initializes correctly...
+            ->waitForNavigate()->click('@next-link')
+            ->waitForTextIn('@page-marker', 'page-two')
+            ->waitForTextIn('@target', 'navigate-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_a_lazy_components_script_runs_against_its_real_markup_not_the_placeholder()
+    {
+        // The non-lazy instance warms the module cache, so the lazy instance's
+        // import resolves instantly — before the hydration morph, without the
+        // morph gate. The script records whether it saw the real markup...
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <livewire:testns::lazy-probe key="eager" />
+                    <livewire:testns::lazy-probe key="lazy" lazy />
+                </div>
+                HTML;
+            }
+        }])
+            ->waitUntil("window.lazyProbeResults && window.lazyProbeResults.length === 2")
+            ->assertScript('window.lazyProbeResults.every(sawRealMarkup => sawRealMarkup)', true)
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_x_cloak_is_honored_while_the_module_is_loading()
+    {
+        // The /slow-module.js import keeps the component's module pending
+        // until the test releases it, holding the suspended window open...
+        Livewire::visit('testns::slow-alpine-data')
+            ->waitUntil('typeof window.releaseSlowModule === "function"')
+            ->assertScript('document.querySelector(\'[dusk="wrapper"]\').hasAttribute(\'x-cloak\')', true)
+            ->tap(fn ($b) => $b->script('window.releaseSlowModule()'))
+            ->waitForTextIn('@target', 'slow-data-loaded')
+            ->assertScript('document.querySelector(\'[dusk="wrapper"]\').hasAttribute(\'x-cloak\')', false)
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_a_component_removed_while_its_module_loads_never_runs_its_script()
+    {
+        Livewire::visit([new class extends Component {
+            public $show = false;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$toggle('show')" dusk="toggle">Toggle</button>
+
+                    @if ($show)
+                        <livewire:testns::slow-alpine-data />
+                    @endif
+                </div>
+                HTML;
+            }
+        }])
+            ->waitForLivewire()->click('@toggle')
+            ->waitUntil('typeof window.releaseSlowModule === "function"')
+            // Remove the component before its module resolves...
+            ->waitForLivewire()->click('@toggle')
+            ->tap(fn ($b) => $b->script('window.releaseSlowModule()'))
+            ->pause(300)
+            ->assertScript('window.slowModuleRan === undefined', true)
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_a_failed_module_import_still_initializes_the_component_and_the_rest_of_the_page()
+    {
+        // The /missing-module.js import 404s, so the module never loads. The
+        // component's tree must initialize anyway (fail open), and other
+        // components on the page must be unaffected...
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <livewire:testns::broken-import />
+
+                    <div x-data="{ message: 'sibling-works' }">
+                        <span dusk="sibling" x-text="message"></span>
+                    </div>
+                </div>
+                HTML;
+            }
+        }])
+            ->waitForTextIn('@sibling', 'sibling-works')
+            ->assertSeeIn('@broken-target', 'server-rendered')
+            // The failed component's own tree still initializes (fail open):
+            // an Alpine binding inside it that doesn't need the module renders...
+            ->waitForTextIn('@broken-fail-open', 'initialized-anyway');
+    }
+
+    public function test_a_script_that_throws_still_initializes_the_component_and_the_rest_of_the_page()
+    {
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <livewire:testns::run-throws />
+
+                    <div x-data="{ message: 'sibling-works' }">
+                        <span dusk="sibling" x-text="message"></span>
+                    </div>
+                </div>
+                HTML;
+            }
+        }])
+            ->waitForTextIn('@sibling', 'sibling-works')
+            ->assertSeeIn('@throws-target', 'server-rendered')
+            ->waitForTextIn('@throws-fail-open', 'initialized-anyway');
     }
 }

--- a/src/Features/SupportJsModules/fixtures/alpine-data.blade.php
+++ b/src/Features/SupportJsModules/fixtures/alpine-data.blade.php
@@ -1,0 +1,18 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div x-data="testAlpineData">
+    <span dusk="target" x-text="message"></span>
+
+    <button dusk="refresh" wire:click="$refresh">refresh</button>
+</div>
+
+<script>
+    Alpine.data('testAlpineData', () => ({
+        message: 'alpine-data-loaded',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/broken-import.blade.php
+++ b/src/Features/SupportJsModules/fixtures/broken-import.blade.php
@@ -1,0 +1,22 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <span dusk="broken-target">server-rendered</span>
+
+    <span dusk="broken-binding" x-data="brokenImportData" x-text="message"></span>
+
+    <span dusk="broken-fail-open" x-data="{ message: 'initialized-anyway' }" x-text="message"></span>
+</div>
+
+<script>
+    import '/missing-module.js'
+
+    Alpine.data('brokenImportData', () => ({
+        message: 'never',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/island-with-alpine-data.blade.php
+++ b/src/Features/SupportJsModules/fixtures/island-with-alpine-data.blade.php
@@ -1,0 +1,23 @@
+<?php
+
+new class extends Livewire\Component {
+    public bool $show = false;
+
+    public function toggle()
+    {
+        $this->show = ! $this->show;
+    }
+};
+?>
+
+<div>
+    @island
+        <div dusk="placeholder">No child yet</div>
+
+        @if ($show)
+            <livewire:testns::alpine-data />
+        @endif
+
+        <button dusk="toggle" wire:click="toggle">toggle</button>
+    @endisland
+</div>

--- a/src/Features/SupportJsModules/fixtures/lazy-probe.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-probe.blade.php
@@ -1,0 +1,22 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div x-data="lazyProbe">
+    <span data-real dusk="probe-target" x-text="message"></span>
+</div>
+
+<script>
+    window.lazyProbeResults = window.lazyProbeResults || []
+
+    // Records whether this component's REAL markup (not a lazy placeholder)
+    // was in the DOM when its script ran...
+    window.lazyProbeResults.push(!! $wire.$el.querySelector('[data-real]'))
+
+    Alpine.data('lazyProbe', () => ({
+        message: 'probe-loaded',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/navigate-page.blade.php
+++ b/src/Features/SupportJsModules/fixtures/navigate-page.blade.php
@@ -1,0 +1,20 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div x-data="navigateAlpineData">
+    <div dusk="page-marker">page-{{ request()->query('page', 'one') }}</div>
+
+    <span dusk="target" x-text="message"></span>
+
+    <a href="/navigate-page?page=two" wire:navigate dusk="next-link">next</a>
+</div>
+
+<script>
+    Alpine.data('navigateAlpineData', () => ({
+        message: 'navigate-data-loaded',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/run-throws.blade.php
+++ b/src/Features/SupportJsModules/fixtures/run-throws.blade.php
@@ -1,0 +1,16 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <span dusk="throws-target">server-rendered</span>
+
+    <span dusk="throws-fail-open" x-data="{ message: 'initialized-anyway' }" x-text="message"></span>
+</div>
+
+<script>
+    throw new Error('boom')
+</script>

--- a/src/Features/SupportJsModules/fixtures/slow-alpine-data.blade.php
+++ b/src/Features/SupportJsModules/fixtures/slow-alpine-data.blade.php
@@ -1,0 +1,20 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div dusk="wrapper" x-data="slowAlpineData" x-cloak>
+    <span dusk="target" x-text="message"></span>
+</div>
+
+<script>
+    import '/slow-module.js'
+
+    window.slowModuleRan = true
+
+    Alpine.data('slowAlpineData', () => ({
+        message: 'slow-data-loaded',
+    }))
+</script>


### PR DESCRIPTION
## The problem

A component's co-located `<script>` compiles to an ES module fetched with a dynamic `import()`. Alpine walks the DOM synchronously. That race is unwinnable as stated: even a byte-for-byte cached module settles no earlier than the next microtask, which is after the walk has already evaluated the component's markup. So:

```blade
<div x-data="audioUploader">
    <span x-text="message"></span>
</div>

<script>
    Alpine.data('audioUploader', () => ({ message: 'Loaded' }))
</script>
```

throws `Alpine Expression Error: audioUploader is not defined` — on initial load, dynamic mounts, lazy hydration, islands, and `wire:navigate`. The "first instance always breaks, later instances work" signature in the reports comes from the first instance's late `run()` registering the name globally for everyone after it.

This is the successor to #10295/#10619/#10623 (and #9861 before them), reimplemented from scratch. Fixes #9591, #9737, #9830.

## The fix

One invariant, enforced at one choke point: **a component's subtree never Alpine-initializes before its script module has settled (executed or failed).**

The effect hook starts the `import()` immediately, then hands a readiness promise to `Alpine.deferInit(component.el, ready)` — the new upstream primitive (alpinejs/alpine#4887) that suspends exactly that tree, visible but uninitialized, while the rest of the page carries on. Alpine owns the suspension mechanics (clone mirroring, mutation replay, removal, nesting); Livewire only declares the prerequisite.

Because the same choke point sits under every entry path, all of them are fixed by the same few lines: initial load and back/forward (fresh roots in the start walk), dynamic children (fresh roots mid-morph), lazy hydration (live root suspended before the awaited morph applies), islands and slots (fresh roots in fragment morphs), and `wire:navigate` (fresh roots after the swap).

### The script-timing contract

The fix forces a uniform, documentable contract that previously existed only as an accident of racing — a component's script runs **when its markup is in the DOM, but before Alpine initializes it**:

- Registrations (`Alpine.data()`, `$js` actions, directives) are guaranteed to exist before any expression in the component's markup evaluates.
- `$wire.$el` and DOM queries work — for updates, `run()` is gated on the response's morph landing (`morphGateFor`), so a lazy component's script sees its real markup, not the placeholder.
- Anything produced by initializing the markup (`$refs`, Alpine state) doesn't exist yet — use an `init()` hook or `$wire.$nextTick()`. This is the one behavioral edge relative to scripts that "worked" before, and it's documented in `docs/javascript.md`.
- `x-cloak` is honored through the loading window.

### Failure and interruption semantics

- **Fail open.** A module that 404s or a script that throws logs a `console.error` naming the component, then the tree initializes without it. The page stays alive; sibling components are untouched. `finally` guarantees the suspension always releases.
- **The morph gate always opens.** It resolves on `onMorphed`, and as a backstop on `onCancel`/`onFailure`/`onError`/`onFinish` — however a message ends, no component stays suspended.
- **Removal mid-flight.** A component removed while its module loads never runs its script (connectivity check before `run()`), and Alpine skips initializing the disconnected tree.
- The early return in `lifecycle.js` after `initComponent` makes `wire:` directive triggers fire once, on the resume pass, instead of doubling up across both passes.

## Compatibility

- Components without co-located JS: every new branch is guarded on the `scriptModule` effect — behavior is byte-identical.
- `Alpine.deferInit` is feature-detected: with an older bundled Alpine the loader degrades to today's (racy) behavior instead of breaking. **This PR needs the Alpine release containing `deferInit` plus a `npm run bump-alpine` to go green in CI** — see dependency note below.
- The `$js` promise-proxy in `$wire.js` stays as a safety net for late `$js` access from outside the component.
- CSP builds pick the primitive up automatically once Alpine ships it (`@alpinejs/csp` shares Alpine's core API surface).

## Tests

`src/Features/SupportJsModules/BrowserTest.php` — 16 tests: the 4 existing module tests, plus initial load (`x-data` on the component's own root — the hardest case), two instances on one page (the first-instance race), post-morph survival, dynamic child, lazy hydration, island-mounted child, `wire:navigate` (including a second navigation reusing the cached module), `x-cloak` through a deterministically-held loading window (client-gated module via top-level `await`, so the single-threaded test server never serializes the timeline), removal mid-flight, failed import and throwing script fail-open (each asserting the broken component's own tree still initializes), and a lazy DOM-probe that pins the morph-gate contract: a lazy component whose module is already cached records whether its script saw real markup or the placeholder.

Regression batches run green: SupportLazyLoading (23), SupportIslands (33), SupportNavigate (59), SupportScriptsAndAssets (16), SupportSlots, SupportEvents (22), plus the JS unit suite (110) — all against a locally built Alpine including `deferInit`, and the full Alpine Cypress suite passes with the primitive in place.

## Dependency

Merge order: alpinejs/alpine deferInit PR → Alpine release → `npm run bump-alpine` here → this PR goes green. Until the bump, the feature-detect keeps the bundle safe but the new browser tests fail (they assert the fixed behavior).

A follow-up PR (`claude/eager-script-module-delivery`) layers eager module delivery on top — `modulepreload` head links and a `childScriptModules` prefetch — shrinking the suspended window to near zero. It's split out because it's pure latency work; this PR is the correctness story.


## Hardening from adversarial review

Three defects found in review are fixed here beyond the original design:

- **Degraded-path regression**: the early return after `initComponent` now checks `treeIsSuspendedFor()` (deferInit present AND module pending) instead of just "module pending" — otherwise, on an Alpine without `deferInit`, the root's `wire:` directive triggers would be skipped on the only pass that ever runs.
- **Message-keyed morph gate**: the gate binds to the exact message that carried the `scriptModule` effect (tracked via `onSync`), so a concurrent message for the same component finishing first can't open it early and run the script against placeholder markup.
- **No double directive triggers**: Livewire's own attributes-added handler now skips elements Alpine hasn't initialized (no `_x_marker`) — their directives are picked up exactly once by the tree walk when the suspended tree resumes.

Known, accepted edge: `$js` promise-proxy calls made *before* a module that then fails to load remain unsettled (same as today's failure mode); the failure itself is loudly logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxEoar4u3NVYop2jweewwf
