### PR TITLE
[4.x] Start fetching script modules before the page needs them

### DIFF
--- a/js/features/supportJsModules.js
+++ b/js/features/supportJsModules.js
@@ -15,6 +15,16 @@ let morphGates = new WeakMap()
 // page carries on. Scripts therefore always run with the component's markup
 // in the DOM, but before Alpine has initialized it...
 on('effect', ({ component, effects, request }) => {
+    // A response that's about to mount new children with script modules names
+    // them ahead of the morph — start fetching so their modules are warm (or
+    // already loaded) by the time the children hit the page. Purely a latency
+    // optimization: each child still imports its own module when it mounts...
+    if (effects.childScriptModules) {
+        effects.childScriptModules.forEach(({ name, hash }) => {
+            import(/* @vite-ignore */ modulePath(name, hash)).catch(() => {})
+        })
+    }
+
     let scriptModuleHash
 
     if (Object.prototype.hasOwnProperty.call(effects, 'scriptModule')) {
@@ -23,8 +33,7 @@ on('effect', ({ component, effects, request }) => {
 
     if (! scriptModuleHash) return
 
-    let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
-    let path = `${getModuleUrl()}/js/${encodedName}.js?v=${scriptModuleHash}`
+    let path = modulePath(component.name, scriptModuleHash)
 
     let pending = Alpine.reactive({
         loading: true,
@@ -70,6 +79,12 @@ on('effect', ({ component, effects, request }) => {
 // breaking outright...
 function deferInit(el, promise) {
     if (Alpine.deferInit) Alpine.deferInit(el, promise)
+}
+
+function modulePath(name, hash) {
+    let encodedName = name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
+
+    return `${getModuleUrl()}/js/${encodedName}.js?v=${hash}`
 }
 
 // The morph gate answers "is this component's markup in the DOM yet?". With

--- a/src/Features/SupportJsModules/BrowserTest.php
+++ b/src/Features/SupportJsModules/BrowserTest.php
@@ -242,6 +242,35 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertConsoleLogHasNoErrors();
     }
 
+    public function test_a_module_preload_link_is_injected_into_the_head()
+    {
+        // The initial page render emits a modulepreload link so the browser
+        // starts fetching the module while parsing — before Livewire boots...
+        Livewire::visit('testns::alpine-data')
+            ->assertScript('!! document.head.querySelector(\'link[rel="modulepreload"][href*="testns---alpine-data.js"]\')', true)
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_a_module_preload_link_is_injected_for_lazy_components()
+    {
+        // Even though a lazy placeholder mounts without its scriptModule
+        // effect, the page render still warms the module it will need...
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <livewire:testns::alpine-data lazy />
+                </div>
+                HTML;
+            }
+        }])
+            ->assertScript('!! document.head.querySelector(\'link[rel="modulepreload"][href*="testns---alpine-data.js"]\')', true)
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
     public function test_x_cloak_is_honored_while_the_module_is_loading()
     {
         // The /slow-module.js import keeps the component's module pending

--- a/src/Features/SupportJsModules/SupportJsModules.php
+++ b/src/Features/SupportJsModules/SupportJsModules.php
@@ -5,12 +5,21 @@ namespace Livewire\Features\SupportJsModules;
 use Illuminate\Support\Facades\Route;
 use Livewire\ComponentHook;
 use Livewire\Drawer\Utils;
+use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
+
+use function Livewire\on;
 
 class SupportJsModules extends ComponentHook
 {
+    protected static $modulesMountedThisRequest = [];
+
     static function provide()
     {
+        on('flush-state', function () {
+            static::$modulesMountedThisRequest = [];
+        });
+
         Route::get(EndpointResolver::componentJsPath(), function ($component) {
             $component = str_replace('----', ':', $component);
             $component = str_replace('---', '::', $component);
@@ -42,10 +51,15 @@ class SupportJsModules extends ComponentHook
 
     public function dehydrate($context)
     {
-        // Don't add scriptModule effect during lazy-loading placeholder mount.
-        // The component's view isn't rendered yet, so @assets won't have run.
-        // The scriptModule will be added when __lazyLoad triggers the real mount.
-        if ($this->storeGet('isLazyLoadMounting') === true) return;
+        // The placeholder mount of a lazy component doesn't get a scriptModule
+        // effect (its view hasn't rendered yet), but the full-page render can
+        // still start the module's fetch from the head so it's warm by the
+        // time the real mount arrives...
+        if ($this->storeGet('isLazyLoadMounting') === true) {
+            $this->registerModulePreloadAsset();
+
+            return;
+        }
 
         // Add scriptModule effect during:
         // 1. Normal component mounting ($context->isMounting())
@@ -53,7 +67,15 @@ class SupportJsModules extends ComponentHook
         $isNormalMount = $context->isMounting();
         $isLazyLoadHydration = $this->storeGet('isLazyLoadHydrating') === true;
 
-        if (! $isNormalMount && ! $isLazyLoadHydration) return;
+        if (! $isNormalMount && ! $isLazyLoadHydration) {
+            // This component is being updated rather than mounted. If any
+            // children with script modules mounted during this request, tell
+            // the client now so it can start fetching their modules before
+            // the morph that adds them to the page...
+            $this->flushModulesMountedThisRequest($context);
+
+            return;
+        }
 
         if (method_exists($this->component, 'scriptModuleSrc')) {
             $path = $this->component->scriptModuleSrc();
@@ -63,6 +85,68 @@ class SupportJsModules extends ComponentHook
             $hash = crc32($filemtime);
 
             $context->addEffect('scriptModule', $hash);
+
+            if ($isNormalMount) {
+                // On an initial page load, a modulepreload link in the head
+                // starts the fetch during HTML parsing — long before Livewire
+                // boots and discovers the module itself...
+                $this->registerModulePreloadAsset();
+
+                // During an update request, the mount belongs to a new child —
+                // collect it so the update's root component can announce it...
+                static::$modulesMountedThisRequest[$this->component->getName()] = $hash;
+            }
         }
+
+        // A hydrating lazy component's children mount during its render —
+        // announce their modules the same way an updating component does...
+        if ($isLazyLoadHydration) {
+            $this->flushModulesMountedThisRequest($context);
+        }
+    }
+
+    protected function registerModulePreloadAsset()
+    {
+        // Preloading is for full-page renders, where the link lands in the
+        // head during HTML parsing. Rendered assets also ride along in update
+        // payloads, so skip update requests entirely — new children there are
+        // announced through the childScriptModules effect instead...
+        if (app('livewire')->isLivewireRequest()) return;
+
+        if (! method_exists($this->component, 'scriptModuleSrc')) return;
+
+        $path = $this->component->scriptModuleSrc();
+
+        if (! file_exists($path)) return;
+
+        $hash = crc32(filemtime($path));
+
+        $url = static::moduleUrl($this->component->getName(), $hash);
+
+        SupportScriptsAndAssets::$renderedAssets['module-preload:'.$url] = '<link rel="modulepreload" href="'.$url.'">';
+    }
+
+    protected function flushModulesMountedThisRequest($context)
+    {
+        if (empty(static::$modulesMountedThisRequest)) return;
+
+        $modules = [];
+
+        foreach (static::$modulesMountedThisRequest as $name => $hash) {
+            $modules[] = ['name' => $name, 'hash' => $hash];
+        }
+
+        static::$modulesMountedThisRequest = [];
+
+        $context->addEffect('childScriptModules', $modules);
+    }
+
+    public static function moduleUrl($name, $hash)
+    {
+        $encodedName = str_replace('.', '--', $name);
+        $encodedName = str_replace('::', '---', $encodedName);
+        $encodedName = str_replace(':', '----', $encodedName);
+
+        return url(app('livewire')->getUriPrefix()).'/js/'.$encodedName.'.js?v='.$hash;
     }
 }

--- a/src/Features/SupportJsModules/UnitTest.php
+++ b/src/Features/SupportJsModules/UnitTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Livewire\Features\SupportJsModules;
+
+use Illuminate\Support\Facades\Route;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class UnitTest extends \Tests\TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Statics like the rendered-assets bucket survive between tests in
+        // the same process...
+        Livewire::flushState();
+
+        app('livewire.finder')->addNamespace('testns', viewPath: __DIR__.'/fixtures');
+    }
+
+    public function test_an_initial_render_injects_a_module_preload_link_into_the_head()
+    {
+        Route::get('/module-preload-test', fn () => app('livewire')->new('testns::alpine-data')());
+
+        $response = $this->get('/module-preload-test');
+
+        $response->assertSee('<link rel="modulepreload"', false);
+        $response->assertSee('testns---alpine-data.js?v=', false);
+    }
+
+    public function test_a_component_without_a_script_module_injects_no_preload_link()
+    {
+        Route::get('/no-module-preload-test', fn () => app('livewire')->new('testns::no-module')());
+
+        $response = $this->get('/no-module-preload-test');
+
+        $response->assertDontSee('modulepreload');
+    }
+
+    public function test_an_update_that_mounts_a_child_announces_the_childs_script_module()
+    {
+        $component = Livewire::test(new class extends Component {
+            public $show = false;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @if ($show)
+                        <livewire:testns::alpine-data />
+                    @endif
+                </div>
+                HTML;
+            }
+        });
+
+        $this->assertArrayNotHasKey('childScriptModules', $component->effects);
+
+        $component->set('show', true);
+
+        $modules = $component->effects['childScriptModules'] ?? null;
+
+        $this->assertNotNull($modules);
+        $this->assertCount(1, $modules);
+        $this->assertSame('testns::alpine-data', $modules[0]['name']);
+        $this->assertArrayHasKey('hash', $modules[0]);
+    }
+
+    public function test_child_module_announcements_are_not_repeated_on_the_next_update()
+    {
+        $component = Livewire::test(new class extends Component {
+            public $show = false;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @if ($show)
+                        <livewire:testns::alpine-data />
+                    @endif
+                </div>
+                HTML;
+            }
+        });
+
+        $component->set('show', true);
+
+        $this->assertArrayHasKey('childScriptModules', $component->effects);
+
+        // The collector drains on announcement — the next update mounts
+        // nothing new and must announce nothing...
+        $component->call('$refresh');
+
+        $this->assertArrayNotHasKey('childScriptModules', $component->effects);
+    }
+
+    public function test_lazy_hydration_announces_the_script_modules_of_children_it_mounts()
+    {
+        \Livewire\Features\SupportLazyLoading\SupportLazyLoading::$disableWhileTesting = false;
+
+        try {
+            $component = Livewire::test('testns::lazy-wrapper');
+
+            preg_match("/__lazyLoad\('([^']+)'\)/", html_entity_decode($component->html()), $matches);
+
+            $this->assertNotEmpty($matches[1] ?? null);
+
+            $component->call('__lazyLoad', $matches[1]);
+
+            $modules = $component->effects['childScriptModules'] ?? null;
+
+            $this->assertNotNull($modules);
+            $this->assertCount(1, $modules);
+            $this->assertSame('testns::alpine-data', $modules[0]['name']);
+        } finally {
+            \Livewire\Features\SupportLazyLoading\SupportLazyLoading::$disableWhileTesting = true;
+        }
+    }
+
+    public function test_an_update_that_mounts_no_new_children_announces_nothing()
+    {
+        $component = Livewire::test(new class extends Component {
+            public $count = 0;
+
+            public function render()
+            {
+                return '<div>{{ $count }}</div>';
+            }
+        });
+
+        $component->set('count', 1);
+
+        $this->assertArrayNotHasKey('childScriptModules', $component->effects);
+    }
+}

--- a/src/Features/SupportJsModules/fixtures/lazy-wrapper.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-wrapper.blade.php
@@ -1,0 +1,10 @@
+<?php
+
+new #[\Livewire\Attributes\Lazy] class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <livewire:testns::alpine-data />
+</div>

--- a/src/Features/SupportJsModules/fixtures/no-module.blade.php
+++ b/src/Features/SupportJsModules/fixtures/no-module.blade.php
@@ -1,0 +1,10 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <span>no module here</span>
+</div>


### PR DESCRIPTION
Follow-up to #10631, now rebased directly onto `4.x`. That PR makes script-module loading *correct* — a component's tree suspends until its module has run. This one makes the suspended window *invisible* by starting fetches as early as the server knows they're coming. Everything here is a pure latency optimization: each component still imports and runs its own module when it mounts, so nothing in this PR is load-bearing — a missed preload just means a slightly longer window, never incorrect behavior.

## 1. `modulepreload` links on initial page loads

`SupportJsModules::dehydrate()` already knows a mounting component's module URL and hash. On full-page renders it now registers

```html
<link rel="modulepreload" href="/livewire/js/audio-uploader.js?v=88fca3e1">
```

through the existing rendered-assets head injection. The browser's preload scanner starts the fetch while parsing HTML — long before `livewire.js` boots, discovers the effect, and calls `import()`. Today's waterfall (parse → boot → discover → fetch) becomes a parallel fetch, and the module is typically fetched and compiled before `DOMContentLoaded`, so the deferred window collapses to microtasks — resumed before first paint in the common case.

Two extra wins for free:

- **Lazy placeholders** skip the `scriptModule` effect (the real view hasn't rendered), but the page render still knows the module is coming — the placeholder mount emits the preload link, so the module is warm by the time hydration needs it.
- **`wire:navigate`** merges new head assets before initializing the new page, so preload links ride along automatically.

Update requests are unaffected: the rendered-assets bucket is only injected into full-page HTML responses.

## 2. `childScriptModules` on update responses

For children mounted by an update there's nothing to preload ahead of time — the response *is* the discovery. But the server knows which children with modules mounted during the request before the client sees any HTML. Each such mount is collected into a request-scoped static (cleared on `flush-state`), and the responding component's dehydrate drains it into an effect:

```json
{ "childScriptModules": [{ "name": "testns::alpine-data", "hash": 3939658634 }] }
```

The client fire-and-forgets `import()` for each the moment the response arrives — overlapping the fetch with state sync and the morph, instead of starting it only when the child's root is encountered mid-morph. Lazy-hydrating components drain the same way, which also covers the nested case (a module component inside a lazy module component) that would otherwise fetch as a waterfall.

## Tests

- `UnitTest.php` (6 tests): initial render injects the preload link into the head (asserted through the real `RequestHandled` injection), no link for module-less components, `childScriptModules` announced when an update mounts a child and absent when it doesn't, the collector draining so the next update announces nothing, and lazy hydration announcing the modules of the children it mounts.
- `BrowserTest.php`: preload link present in the head on an initial render and on a page that only renders a lazy placeholder — both pages still load their modules and log no console errors.

Full `SupportJsModules` browser suite (17) green on top of the defer branch.


Notes from adversarial review: preload registration explicitly skips Livewire update requests (new children there are covered by `childScriptModules`, and rendered assets would otherwise ride along in update payloads); and if a module file changes between a lazy placeholder's page render and its hydration, the two hashes produce two fetches — harmless, and inherent to hash-versioned URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxEoar4u3NVYop2jweewwf

