### PR TITLE
[4.x] Replace 'noneset' string sentinel used by `__get()` with unique object sentinel

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -113,7 +113,8 @@ abstract class Component
 
     function __get($property)
     {
-        $value = 'noneset';
+        $noneset = new \stdClass();
+        $value = $noneset;
 
         $returnValue = function ($newValue) use (&$value) {
             $value = $newValue;
@@ -123,7 +124,7 @@ abstract class Component
 
         $value = $finish($value);
 
-        if ($value === 'noneset') {
+        if ($value === $noneset) {
             throw new PropertyNotFoundException($property, $this->getName());
         }
 

--- a/src/Component.php
+++ b/src/Component.php
@@ -122,7 +122,9 @@ abstract class Component
 
         $finish = trigger('__get', $this, $property, $returnValue);
 
-        $value = $finish($value);
+        if ($value !== $noneset) {
+            $value = $finish($value);
+        }
 
         if ($value === $noneset) {
             throw new PropertyNotFoundException($property, $this->getName());

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -9,7 +9,10 @@ use Livewire\EventBus;
 use Livewire\Livewire;
 use Livewire\Component;
 use Livewire\Attributes\Computed;
+use Livewire\Exceptions\PropertyNotFoundException;
 use Livewire\Features\SupportEvents\BaseOn;
+
+use function Livewire\on;
 
 class UnitTest extends TestCase
 {
@@ -769,6 +772,28 @@ class UnitTest extends TestCase
         })
             ->assertSetStrict('foo', 'noneset')
             ->assertSee('noneset');
+    }
+
+    public function test_get_finisher_does_not_receive_stdclass()
+    {
+        $seen = null;
+
+        on('__get', function () use (&$seen) {
+            return function ($value) use (&$seen) {
+                $seen = $value;
+
+                return $value;
+            };
+        });
+
+        try {
+            $component = Livewire::test(TestComponent::class);
+            $component->instance()->missingProperty;
+        } catch (PropertyNotFoundException $e) {
+            // expected
+        }
+
+        $this->assertNotInstanceOf(\stdClass::class, $seen);
     }
 }
 

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -735,6 +735,41 @@ class UnitTest extends TestCase
             ->dispatch('bar', 'baz')
             ->assertSetStrict('foo', 'baz');
     }
+
+    public function test_computed_property_can_return_the_string_noneset()
+    {
+        Livewire::test(new class extends TestComponent {
+            #[Computed]
+            public function foo()
+            {
+                return 'noneset';
+            }
+
+            public function render()
+            {
+                return '<div>{{ $this->foo }}</div>';
+            }
+        })
+            ->assertSetStrict('foo', 'noneset')
+            ->assertSee('noneset');
+    }
+
+    public function test_legacy_computed_property_can_return_the_string_noneset()
+    {
+        Livewire::test(new class extends TestComponent {
+            public function getFooProperty()
+            {
+                return 'noneset';
+            }
+
+            public function render()
+            {
+                return '<div>{{ $this->foo }}</div>';
+            }
+        })
+            ->assertSetStrict('foo', 'noneset')
+            ->assertSee('noneset');
+    }
 }
 
 class ComputedPropertyStub extends Component


### PR DESCRIPTION
## Summary

This is a small defensive change that removes an unnecessary assumption from the property resolution path: that `'noneset'` can never be a legitimate resolved value.

While it is very unlikely that a property will actually resolve to `'noneset'`, the current implementation makes that value implicitly reserved. There is no reason for a particular user value to have special meaning here when PHP gives us a simple way to represent an internal "unset" state without colliding with application values.

## Motivation

`__get()` currently uses a string as both:

- a possible property value, and
- an internal marker meaning "no value was resolved."

Conceptually, these are different states:

`property was not resolved`
`property was resolved to "noneset"`

but the current implementation represents both states with the same value.

That means the correctness of the property resolution mechanism depends on an undocumented assumption that `'noneset'` will never be returned.

This is unlikely to cause a real-world issue, but it is still an avoidable ambiguity in the implementation. Using a unique object gives us an explicit sentinel that cannot collide with a legitimate property value:

```php
$unset = new \stdClass();
$value = $unset;
```

The check then becomes:
```php
if ($value === $unset) { throw new PropertyNotFoundException($property, $this->getName()); }
```

The sentinel has no meaning outside this method and cannot be confused with a value supplied by an application.

## Why make this change if the collision is unlikely?

Because the benefit isn't primarily about fixing a frequently occurring bug.

The important distinction is that `'noneset'` is **not actually an invalid property value**. The implementation simply happens to use it as an internal marker.

That creates a hidden contract where a completely ordinary application value becomes reserved by framework internals.

A sentinel object expresses the intent much more precisely:

> "This specific object means no value was resolved."

rather than:

> "This particular string means no value was resolved, so hopefully nobody ever needs to return it."

This also makes the implementation resilient to future changes. If a new property resolver, synthesizer, hook, or extension happens to produce `'noneset'`, it does not silently change the control flow of `__get()`.

## Tests

Add a regression test demonstrating that a property explicitly resolved to the previous sentinel value is returned rather than treated as missing.