### PR TITLE
[4.x] Fix skip render always fallback to default layout

### DIFF
--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -91,7 +91,7 @@ class SupportPageComponents extends ComponentHook
 
         // Only run this handler once for the parent-most component. Otherwise child components
         // will run this handler too and override the configured layout...
-        $handler = once(function ($target, $view, $data) use (&$layoutConfig, &$slots) {
+        $handler = once(function ($target, $view, $data = []) use (&$layoutConfig, &$slots) {
             $layoutAttr = $target->getAttributes()->whereInstanceOf(BaseLayout::class)->first();
             $titleAttr = $target->getAttributes()->whereInstanceOf(BaseTitle::class)->first();
 
@@ -114,12 +114,14 @@ class SupportPageComponents extends ComponentHook
 
         $render = on('render', $handler);
         $renderPlaceholder = on('render.placeholder', $handler);
+        $skipRender = on('skip.render', $handler);
 
         try {
             $callback();
         } finally {
             $render();
             $renderPlaceholder();
+            $skipRender();
         }
 
         return $layoutConfig;

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -91,7 +91,7 @@ class SupportPageComponents extends ComponentHook
 
         // Only run this handler once for the parent-most component. Otherwise child components
         // will run this handler too and override the configured layout...
-        $handler = once(function ($target, $view, $data = []) use (&$layoutConfig, &$slots) {
+        $handler = once(function ($target, $view, $data) use (&$layoutConfig, &$slots) {
             $layoutAttr = $target->getAttributes()->whereInstanceOf(BaseLayout::class)->first();
             $titleAttr = $target->getAttributes()->whereInstanceOf(BaseTitle::class)->first();
 

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -114,7 +114,9 @@ class SupportPageComponents extends ComponentHook
 
         $render = on('render', $handler);
         $renderPlaceholder = on('render.placeholder', $handler);
-        $skipRender = on('skip.render', $handler);
+        $skipRender = on('skip.render', function ($target, $resolveView) use ($handler) {
+            return $handler($target, ...$resolveView());
+        });
 
         try {
             $callback();

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -11,8 +11,10 @@ use Illuminate\Support\Facades\Blade;
 use Livewire\Component;
 use Livewire\EventBus;
 use Livewire\Livewire;
+use Livewire\Mechanisms\HandleComponents\HandleComponents;
 
 use function Livewire\invade;
+use function Livewire\trigger;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -523,6 +525,42 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertSame('layouts::panel', $fallback->view);
     }
+
+    public function test_layout_from_view_macro_is_captured_when_render_is_skipped(): void
+    {
+        Livewire::component(ComponentWithLayoutMacroAndSkipRender::class);
+
+        Route::get('/foo', ComponentWithLayoutMacroAndSkipRender::class);
+
+        $this
+            ->withoutExceptionHandling()
+            ->get('/foo')
+            ->assertSee('baz');
+    }
+
+    public function test_layout_from_attribute_is_captured_when_render_is_skipped()
+    {
+        Livewire::component(ComponentWithLayoutAttributeAndSkipRender::class);
+
+        Route::get('/foo', ComponentWithLayoutAttributeAndSkipRender::class);
+
+        $this
+            ->withoutExceptionHandling()
+            ->get('/foo')
+            ->assertSee('baz');
+    }
+
+    public function test_title_from_attribute_is_captured_when_render_is_skipped()
+    {
+        Livewire::component(ComponentWithTitleAttributeAndSkipRender::class);
+
+        Route::get('/foo', ComponentWithTitleAttributeAndSkipRender::class);
+
+        $this
+            ->withoutExceptionHandling()
+            ->get('/foo')
+            ->assertSee('some-title');
+    }
 }
 
 class ComponentForRouteWithoutMountParametersTest extends Component
@@ -929,5 +967,49 @@ class ComponentWithOptionalMountParamAndTrait extends Component
         return <<<'HTML'
         <div>{{ $postId }} {{ $tab }}</div>
         HTML;
+    }
+}
+
+class ComponentWithLayoutMacroAndSkipRender extends Component
+{
+    public function mount()
+    {
+        $this->skipRender('<div>skip-placeholder</div>');
+    }
+
+    public function render()
+    {
+        return view('null-view')->layout('layouts.app-with-bar', [
+            'bar' => 'baz',
+        ]);
+    }
+}
+
+#[BaseLayout('layouts.app-with-bar', ['bar' => 'baz'])]
+class ComponentWithLayoutAttributeAndSkipRender extends Component
+{
+    public function mount()
+    {
+        $this->skipRender('<div>skip-placeholder</div>');
+    }
+
+    public function render()
+    {
+        return view('null-view');
+    }
+}
+
+#[BaseLayout('layouts.app-with-title')]
+#[BaseTitle('some-title')]
+class ComponentWithTitleAttributeAndSkipRender extends Component
+{
+    public function mount()
+    {
+        $this->skipRender('<div>skip-placeholder</div>');
+    }
+
+    public function render()
+    {
+        return view('null-view');
     }
 }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -316,11 +316,9 @@ class HandleComponents extends Mechanism
 
             // We only need to set layout configuration if its not redirecting
             if (! store($component)->get('redirect', false)) {
-                [$view] = $this->getView($component);
-
                 // Trigger skip.render event without calling the finisher
                 // to respect component layout macro/attribute
-                trigger('skip.render', $component, $view, []);
+                trigger('skip.render', $component, fn () => $this->getView($component));
             }
 
             return Utils::insertAttributesIntoHtmlRoot($html, [

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -320,7 +320,7 @@ class HandleComponents extends Mechanism
 
                 // Trigger skip.render event without calling the finisher
                 // to respect component layout macro/attribute
-                trigger('skip.render', $component, $view);
+                trigger('skip.render', $component, $view, []);
             }
 
             return Utils::insertAttributesIntoHtmlRoot($html, [

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Mechanisms\HandleComponents;
 
-use function Livewire\{on, trigger, wrap };
+use function Livewire\{on, store, trigger, wrap };
 use Livewire\Mechanisms\Mechanism;
 use Livewire\Mechanisms\HandleSynths\HandleSynths;
 use Livewire\Exceptions\PublicPropertyNotFoundException;
@@ -309,22 +309,27 @@ class HandleComponents extends Mechanism
 
     protected function render($component, $default = null)
     {
-        [ $view, $properties ] = $this->getView($component);
-
         if ($html = $component->shouldSkipRender()) {
             $html = value(is_string($html) ? $html : $default);
 
             if (! $html) return;
 
-            // Trigger skip.render event without calling the finisher
-            // to respect component layout macro/attribute
-            trigger('skip.render', $component, $view);
+            // We only need to set layout configuration if its not redirecting
+            if (! store($component)->get('redirect', false)) {
+                [$view] = $this->getView($component);
+
+                // Trigger skip.render event without calling the finisher
+                // to respect component layout macro/attribute
+                trigger('skip.render', $component, $view);
+            }
 
             return Utils::insertAttributesIntoHtmlRoot($html, [
                 'wire:id' => $component->getId(),
                 'wire:name' => $component->getName(),
             ]);
         }
+
+        [ $view, $properties ] = $this->getView($component);
 
         return $this->trackInRenderStack($component, function () use ($component, $view, $properties) {
             $finish = trigger('render', $component, $view, $properties);

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -309,18 +309,22 @@ class HandleComponents extends Mechanism
 
     protected function render($component, $default = null)
     {
+        [ $view, $properties ] = $this->getView($component);
+
         if ($html = $component->shouldSkipRender()) {
             $html = value(is_string($html) ? $html : $default);
 
             if (! $html) return;
+
+            // Trigger skip.render event without calling the finisher
+            // to respect component layout macro/attribute
+            trigger('skip.render', $component, $view);
 
             return Utils::insertAttributesIntoHtmlRoot($html, [
                 'wire:id' => $component->getId(),
                 'wire:name' => $component->getName(),
             ]);
         }
-
-        [ $view, $properties ] = $this->getView($component);
 
         return $this->trackInRenderStack($component, function () use ($component, $view, $properties) {
             $finish = trigger('render', $component, $view, $properties);


### PR DESCRIPTION
### Summary

This PR fixes an issue where page components that call `skipRender()` always fall back to the default layout, even when the component defines its own layout using a view `->layout()` macro or the `#[Layout]` attribute.

The problem occurs because `skipRender()` bypasses the normal `render` event, which is currently responsible for allowing the page-component layout handler to inspect the component's rendered view and capture its layout configuration.

This change ensures the component's view is resolved before handling `skipRender()` and introduces a dedicated `skip.render` event so the page-component layout configuration can still be captured when rendering is skipped.

### Problem

When a page component calls `skipRender()` during its lifecycle, Livewire skips the normal rendering flow.

For example:

```php
class MyPage extends Component
{
    public function mount()
    {
        $this->skipRender();
    }

    public function render()
    {
        return view('my-page')
            ->layout('layouts.app');
    }
}
```

Previously, because the `render` event was never triggered for the skipped render, the page-component layout interceptor never had an opportunity to capture the layout configuration.

As a result, the page component could incorrectly fall back to the default layout instead of using the layout explicitly configured by the component.

The same issue affected layout and title attributes.

### What changed

#### 1. Introduce a `skip.render` event

When `skipRender()` is active, Livewire now triggers a `skip.render` event with the component and resolved view.

This allows consumers that need to inspect render metadata to behave consistently whether the component is actually rendered or skipped.

The existing `render` event remains unchanged for the normal rendering path.

#### 2. Capture layout configuration during skipped renders

The page-component layout interceptor now listens to:

* `render`
* `render.placeholder`
* `skip.render`

This ensures layouts and titles are captured regardless of whether the component produces normal HTML or skips its render.

### Expected behavior

With this change, a page component such as:

```php
class MyPage extends Component
{
    public function mount()
    {
        $this->skipRender();
    }

    public function render()
    {
        return view('my-page')
            ->layout('layouts.custom');
    }
}
```

will continue to use `layouts.custom` rather than falling back to the application's default layout.

### Tests

Added regression coverage for the different ways a page component can configure its layout while skipping rendering:

* Layout configured through the view `->layout()` macro.
* Layout configured through the `#[Layout]` attribute.
* Title configured through the `#[Title]` attribute.

The tests verify that the configured layout/title information is still respected when `skipRender()` is called.

All existing behavior for normal rendering remains unchanged.
