### PR TITLE
Synchronize eligible 4.x changes into main for release prep

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -349,6 +349,16 @@ $this->reset('title');
 $this->reset(['title', 'content']);
 ```
 
+`reset()` restores each property to the state declared on the form class. If a typed property has no default value, it will be uninitialized after it is reset. Give fields a default value when they need to be read or rendered immediately after resetting:
+
+```php
+public string $title = '';
+
+public ?string $subtitle = null;
+```
+
+Alternatively, assign the property after calling `reset()` before reading it.
+
 ### Pulling form fields
 
 Alternatively, you can use the `pull()` method to both retrieve a form's properties and reset them in one operation.

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -50,6 +50,31 @@ Here's a more full example where you can do something like register a JavaScript
 
 To learn more about JavaScript actions, [visit the actions documentation](/docs/4.x/actions#javascript-actions).
 
+### When scripts run
+
+A component's script runs when its markup is in the DOM, but before Alpine has initialized it. Livewire suspends initialization of the component's tree until the script has finished, so anything the script registers—`Alpine.data()` providers, `$js` actions, custom directives—is guaranteed to exist before any expression in the component's markup evaluates:
+
+```blade
+<div x-data="audioUploader">
+    <span x-text="message"></span>
+</div>
+
+<script>
+    Alpine.data('audioUploader', () => ({
+        message: 'Loaded',
+    }))
+</script>
+```
+
+This holds on the initial page load and every other way a component enters the page: lazy loading, dynamic mounting from a parent update, islands, and `wire:navigate`.
+
+A few consequences of this timing worth knowing:
+
+* `$wire.$el` and plain DOM queries work—the markup is present when the script runs.
+* Anything produced by initializing the markup—`$refs`, Alpine component state—doesn't exist yet. Reach for it from an `init()` hook on your Alpine component, or after `await $wire.$nextTick()`.
+* While a script is loading, the component's markup is visible but not yet interactive. This window is normally imperceptible, but for a heavy module you can put [`x-cloak`](https://alpinejs.dev/directives/cloak) on elements that shouldn't appear until the script is ready—it's honored until the component initializes.
+* If a script fails to load or throws, Livewire logs the error and initializes the component anyway so the page keeps working.
+
 ### Using `$wire` from scripts
 
 When you add `<script>` tags inside your component, you automatically have access to your Livewire component's `$wire` object.

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -49,6 +49,8 @@ The best way to reduce requests in this scenario is simply to make the polling i
 You can manually control how often the component will poll by appending the desired duration to `wire:poll` like so:
 
 ```blade
+<div wire:poll.1m> <!-- In minutes... -->
+
 <div wire:poll.15s> <!-- In seconds... -->
 
 <div wire:poll.15000ms> <!-- In milliseconds... -->

--- a/docs/synthesizers.md
+++ b/docs/synthesizers.md
@@ -400,3 +400,21 @@ JavaScript proxies can't intercept a `Date`'s internal methods, so Alpine (like 
 * **Binding inputs directly to a rich property** (`wire:model="publishedAt"`) sets the input's raw string value onto the property. The string is sent to the server as-is and re-hydrated there, but the input will display the browser's string representation of the rich object — for form inputs, prefer binding to nested fields or handling conversion yourself.
 
 For reference, these are the keys of Livewire's built-in synthesizers: `arr` (arrays), `cbn` (Carbon/DateTime), `clctn` (Collections), `str` (Stringables), `enm` (Enums), `std` (stdClass), `mdl` (Eloquent models), `elcln` (Eloquent collections), `wrbl` (Wireables), `form` (Form objects), and `fil` (file uploads).
+
+## Array-shaped synthesizers
+
+During property updates, Livewire may reuse synthesizer metadata from the previous snapshot to hydrate nested values. If your synthesizer always serializes its value as an array, implement the `ArrayShapedSynth` interface:
+
+```php
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+
+class AddressSynth extends Synth implements ArrayShapedSynth
+{
+    // ...
+}
+```
+
+This tells Livewire not to run your synthesizer when a top-level or nested update replaces the previous value with any non-array value. Instead, Livewire treats the incoming value as the replacement. Array updates continue through your synthesizer as usual.
+
+Only implement this interface when your synthesizer's `hydrate()` method requires an array. Synthesizers that hydrate scalar values, such as dates, enums, integers, floats, or strings, should not implement it. Without the interface, Livewire continues applying the previous synthesizer metadata to non-array updates for backwards compatibility.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -737,18 +737,25 @@ Run actions when elements enter or leave the viewport, similar to Alpine's [`x-i
 <div wire:intersect:leave="pauseVideo">...</div>
 <div wire:intersect.half="loadMore">...</div>
 <div wire:intersect.full="startAnimation">...</div>
+<div wire:intersect.half.dwell.500ms="trackImpression">...</div>
 
 <!-- With options -->
 <div wire:intersect.margin.200px="loadMore">...</div>
 <div wire:intersect.threshold.50="trackScroll">...</div>
+<div wire:intersect.parent="loadWithinScroller">...</div>
 ```
 
 Available modifiers:
 - `.once` - Fire only once
+- `.dwell.Xms` - Require continuous intersection for a duration (250ms by default)
 - `.half` - Wait until half is visible
 - `.full` - Wait until fully visible
 - `.threshold.X` - Custom visibility percentage (0-100)
 - `.margin.Xpx` or `.margin.X%` - Intersection margin
+- `.parent` - Observe relative to the element's parent
+- `.renderless` - Skip rendering after the action
+- `.async` - Run the action in parallel
+- `.preserve-scroll` - Preserve the page scroll position
 
 [Learn more about wire:intersect →](/docs/4.x/wire-intersect)
 

--- a/docs/wire-intersect.md
+++ b/docs/wire-intersect.md
@@ -72,6 +72,35 @@ Use the `.once` modifier to ensure the action only fires on the first intersecti
 
 This is particularly useful for analytics or tracking when you only want to record the first time a user sees something.
 
+## Require continuous visibility
+
+Use `.dwell` when an element must remain visible before the action runs. The default dwell time is 250 milliseconds:
+
+```blade
+<div wire:intersect.dwell="trackView">...</div>
+```
+
+Add a duration modifier to choose a different interval:
+
+```blade
+<!-- Run after 500 milliseconds of continuous visibility -->
+<div wire:intersect.dwell.500ms="trackView">...</div>
+```
+
+The dwell timer resets if the element stops meeting its visibility threshold or the page moves to the background. It starts again when the element becomes eligible in a visible page.
+
+For `wire:intersect:leave`, the dwell interval instead begins after visibility falls below the configured threshold:
+
+```blade
+<div wire:intersect:leave.half.dwell.500ms="pauseVideo">...</div>
+```
+
+Combine `.dwell` with a visibility threshold and `.once` to record a qualified impression:
+
+```blade
+<div wire:intersect.once.half.dwell.1000ms="trackImpression">...</div>
+```
+
 ## Combining modifiers
 
 You can combine multiple modifiers to create precise behaviors:
@@ -178,7 +207,12 @@ wire:intersect:leave="action"
 | Modifier | Description |
 |----------|-------------|
 | `.once` | Only fire the action on the first intersection |
+| `.dwell.[duration]` | Require continuous visibility before firing (defaults to `250ms`) |
 | `.half` | Trigger when half of the element is visible |
 | `.full` | Trigger when the entire element is visible |
 | `.threshold.[0-100]` | Trigger at a custom visibility threshold percentage |
 | `.margin.[value]` | Add margin around the viewport (e.g., `.margin.200px`, `.margin.10%`) |
+| `.parent` | Observe visibility within the element's parent instead of the browser viewport |
+| `.renderless` | Run the action without rendering the component |
+| `.async` | Run the action in a parallel request |
+| `.preserve-scroll` | Preserve the page's scroll position through the action |

--- a/docs/wire-poll.md
+++ b/docs/wire-poll.md
@@ -52,6 +52,8 @@ The best way to reduce requests in this scenario is simply to make the polling i
 You can manually control how often the component will poll by appending the desired duration to `wire:poll` like so:
 
 ```blade
+<div wire:poll.1m> <!-- In minutes... -->
+
 <div wire:poll.15s> <!-- In seconds... -->
 
 <div wire:poll.15000ms> <!-- In milliseconds... -->
@@ -88,6 +90,7 @@ wire:poll="action"
 
 | Modifier | Description |
 |----------|-------------|
+| `.[number]m` | Poll interval in minutes (e.g., `.1m`) |
 | `.[number]s` | Poll interval in seconds (e.g., `.15s`) |
 | `.[number]ms` | Poll interval in milliseconds (e.g., `.15000ms`) |
 | `.keep-alive` | Continue polling even when the tab is in the background |

--- a/js/directives/wire-dirty.js
+++ b/js/directives/wire-dirty.js
@@ -48,11 +48,11 @@ export function checkDirty(component, targets) {
         isDirty = ! deeplyEqual(component.canonical, component.reactive)
     } else if (Array.isArray(targets)) {
         for (let i = 0; i < targets.length; i++) {
-            if (isDirty) break;
-
             let target = targets[i]
 
-            isDirty = ! deeplyEqual(dataGet(component.canonical, target), dataGet(component.reactive, target))
+            if (! deeplyEqual(dataGet(component.canonical, target), dataGet(component.reactive, target))) {
+                isDirty = true
+            }
         }
     } else {
         isDirty = ! deeplyEqual(dataGet(component.canonical, targets), dataGet(component.reactive, targets))

--- a/js/directives/wire-loading.js
+++ b/js/directives/wire-loading.js
@@ -10,14 +10,49 @@ directive('loading', ({ el, directive, component, cleanup }) => {
 
     let [delay, abortDelay] = applyDelay(directive)
 
+    let restoreLoadingState = () => toggleBooleanStateDirective(el, directive, false)
+    let activeLoadingCount = 0
+
+    let startLoading = () => {
+        if (activeLoadingCount === 0) {
+            if (directive.modifiers.includes('class')) {
+                let classes = directive.expression.split(' ').filter(String)
+                let classStates = classes.map(className => [className, el.classList.contains(className)])
+
+                restoreLoadingState = () => classStates.forEach(([className, wasPresent]) => {
+                    el.classList.toggle(className, wasPresent)
+                })
+            } else if (directive.modifiers.includes('attr')) {
+                let attribute = directive.expression
+                let value = el.getAttribute(attribute)
+
+                restoreLoadingState = value === null
+                    ? () => el.removeAttribute(attribute)
+                    : () => el.setAttribute(attribute, value)
+            }
+
+            delay(() => toggleBooleanStateDirective(el, directive, true))
+        }
+
+        activeLoadingCount++
+    }
+
+    let endLoading = () => {
+        if (activeLoadingCount === 0) return
+
+        activeLoadingCount--
+
+        if (activeLoadingCount === 0) abortDelay(restoreLoadingState)
+    }
+
     let cleanupA = whenTargetsArePartOfRequest(component, el, targets, inverted, [
-        () => delay(() => toggleBooleanStateDirective(el, directive, true)),
-        () => abortDelay(() => toggleBooleanStateDirective(el, directive, false)),
+        startLoading,
+        endLoading,
     ])
 
     let cleanupB = whenTargetsArePartOfFileUpload(component, targets, [
-        () => delay(() => toggleBooleanStateDirective(el, directive, true)),
-        () => abortDelay(() => toggleBooleanStateDirective(el, directive, false)),
+        startLoading,
+        endLoading,
     ])
 
     cleanup(() => {

--- a/js/directives/wire-poll.js
+++ b/js/directives/wire-poll.js
@@ -128,11 +128,14 @@ export function extractDurationFrom(modifiers, defaultDuration) {
     let durationInMilliSeconds
     let durationInMilliSecondsString = modifiers.find(mod => mod.match(/([0-9]+)ms/))
     let durationInSecondsString = modifiers.find(mod => mod.match(/([0-9]+)s/))
+    let durationInMinutesString = modifiers.find(mod => mod.match(/([0-9]+)m/))
 
     if (durationInMilliSecondsString) {
         durationInMilliSeconds = Number(durationInMilliSecondsString.replace('ms', ''))
     } else if (durationInSecondsString) {
         durationInMilliSeconds = Number(durationInSecondsString.replace('s', '')) * 1000
+    } else if (durationInMinutesString) {
+        durationInMilliSeconds = Number(durationInMinutesString.replace('m', '')) * 60 * 1000
     }
 
     return durationInMilliSeconds || defaultDuration

--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -125,7 +125,18 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
     // Skip entirely if a top-layer element is already open (transitions behind
     // it are invisible to the user and the ::view-transition pseudo-elements
     // would paint above it during animation)...
-    if (document.querySelector('dialog:modal, :popover-open')) return callback()
+    if (document.querySelector('dialog:modal')) return callback()
+
+    // An open popover only blocks the transition if it has visible descendants.
+    // Some components (e.g. toast hosts) keep an empty popover open as a
+    // persistent container — the host element itself always passes
+    // checkVisibility() while open, so visible *descendants* are the proxy
+    // for "this popover is actually showing UI"...
+    for (let popover of document.querySelectorAll(':popover-open')) {
+        for (let el of popover.querySelectorAll('*')) {
+            if (el.checkVisibility()) return callback()
+        }
+    }
 
     // Set transition names right before the transition starts (not permanently)...
     setTransitionNames(fromEl, options)

--- a/js/features/supportJsModules.js
+++ b/js/features/supportJsModules.js
@@ -15,6 +15,16 @@ let morphGates = new WeakMap()
 // page carries on. Scripts therefore always run with the component's markup
 // in the DOM, but before Alpine has initialized it...
 on('effect', ({ component, effects, request }) => {
+    // A response that's about to mount new children with script modules names
+    // them ahead of the morph — start fetching so their modules are warm (or
+    // already loaded) by the time the children hit the page. Purely a latency
+    // optimization: each child still imports its own module when it mounts...
+    if (effects.childScriptModules) {
+        effects.childScriptModules.forEach(({ name, hash }) => {
+            import(/* @vite-ignore */ modulePath(name, hash)).catch(() => {})
+        })
+    }
+
     let scriptModuleHash
 
     if (Object.prototype.hasOwnProperty.call(effects, 'scriptModule')) {
@@ -23,8 +33,7 @@ on('effect', ({ component, effects, request }) => {
 
     if (! scriptModuleHash) return
 
-    let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
-    let path = `${getModuleUrl()}/js/${encodedName}.js?v=${scriptModuleHash}`
+    let path = modulePath(component.name, scriptModuleHash)
 
     let pending = Alpine.reactive({
         loading: true,
@@ -70,6 +79,12 @@ on('effect', ({ component, effects, request }) => {
 // breaking outright...
 function deferInit(el, promise) {
     if (Alpine.deferInit) Alpine.deferInit(el, promise)
+}
+
+function modulePath(name, hash) {
+    let encodedName = name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
+
+    return `${getModuleUrl()}/js/${encodedName}.js?v=${hash}`
 }
 
 // The morph gate answers "is this component's markup in the DOM yet?". With

--- a/js/features/supportJsModules.js
+++ b/js/features/supportJsModules.js
@@ -1,36 +1,147 @@
 import { on } from '@/hooks'
+import { interceptMessage } from '@/request'
 import { getModuleUrl } from '@/utils'
+import Alpine from 'alpinejs'
 
 let pendingComponentAssets = new WeakMap()
 
-on('effect', ({ component, effects }) => {
+let morphGates = new WeakMap()
+
+// A component's script module is fetched asynchronously, but Alpine walks the
+// DOM synchronously — left alone, Alpine evaluates the component's markup
+// before the module's Alpine.data() and $js registrations exist. So while the
+// module loads, the component's tree is suspended via Alpine.deferInit():
+// nothing inside initializes until the module has run, and the rest of the
+// page carries on. Scripts therefore always run with the component's markup
+// in the DOM, but before Alpine has initialized it...
+on('effect', ({ component, effects, request }) => {
     let scriptModuleHash
 
     if (Object.prototype.hasOwnProperty.call(effects, 'scriptModule')) {
         scriptModuleHash = effects.scriptModule
     }
 
-    if (scriptModuleHash) {
-        let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
-        let path = `${getModuleUrl()}/js/${encodedName}.js?v=${scriptModuleHash}`
+    if (! scriptModuleHash) return
 
-        pendingComponentAssets.set(component, Alpine.reactive({
-            loading: true,
-            afterLoaded: [],
-        }))
+    let encodedName = component.name.replace(/\./g, '--').replace(/::/g, '---').replace(/:/g, '----')
+    let path = `${getModuleUrl()}/js/${encodedName}.js?v=${scriptModuleHash}`
 
-        import(/* @vite-ignore */ path).then(module => {
-            module.run.call(component.$wire, component.$wire, component.$wire.js);
+    let pending = Alpine.reactive({
+        loading: true,
+        afterLoaded: [],
+    })
 
-            pendingComponentAssets.get(component).loading = false
-            pendingComponentAssets.get(component).afterLoaded.forEach(callback => callback())
+    pendingComponentAssets.set(component, pending)
+
+    // Start fetching immediately, but hold the module's execution until this
+    // response's morph has landed (a lazy component's real markup arrives in
+    // the same response as its scriptModule effect)...
+    let modulePromise = import(/* @vite-ignore */ path)
+
+    let ready = Promise.all([modulePromise, morphGateFor(component, request)])
+        .then(([module]) => {
+            // The component may have been removed while its module was in
+            // flight — don't run the script for a component that's no longer
+            // on the page...
+            if (! component.el.isConnected) return
+
+            module.run.call(component.$wire, component.$wire, component.$wire.js)
+
+            pending.loading = false
+            pending.afterLoaded.forEach(callback => callback())
+        })
+        .catch(error => {
+            // A module that fails to load or run must not leave the component's
+            // tree suspended forever. Surface the error, then let the tree
+            // initialize without it...
+            console.error(`Livewire: The script module for the [${component.name}] component failed:`, error)
+        })
+        .finally(() => {
+            pending.loading = false
+
             pendingComponentAssets.delete(component)
-        });
+        })
+
+    deferInit(component.el, ready)
+})
+
+// Alpine.deferInit() ships in Alpine v3.17. If an older Alpine is bundled,
+// degrade to loading the module without suspending the tree rather than
+// breaking outright...
+function deferInit(el, promise) {
+    if (Alpine.deferInit) Alpine.deferInit(el, promise)
+}
+
+// The morph gate answers "is this component's markup in the DOM yet?". With
+// no in-flight request there's nothing to wait for: on the initial page load,
+// a back/forward restore, or a child rendered by its parent's update, the
+// markup is already present when the effect fires. For a message-driven
+// effect (lazy hydration), the gate binds to the exact message that carried
+// the effect — a concurrent message for the same component finishing first
+// must not open it early...
+let processingMessages = new WeakMap()
+
+function morphGateFor(component, request) {
+    if (! request) return Promise.resolve()
+
+    let message = processingMessages.get(component)
+
+    if (! message) return Promise.resolve()
+
+    if (! morphGates.has(message)) {
+        let resolve
+
+        let promise = new Promise(r => resolve = r)
+
+        morphGates.set(message, { promise, resolve })
     }
+
+    return morphGates.get(message).promise
+}
+
+function releaseMorphGate(message) {
+    let gate = morphGates.get(message)
+
+    if (! gate) return
+
+    morphGates.delete(message)
+
+    gate.resolve()
+}
+
+interceptMessage(({ message, onSuccess, onCancel, onFailure, onError, onFinish }) => {
+    onSuccess(({ onSync, onMorphed }) => {
+        // Effects are processed between sync and morph — remember which
+        // message is applying its response so the effect hook can bind the
+        // gate to it...
+        onSync(() => processingMessages.set(message.component, message))
+
+        onMorphed(() => releaseMorphGate(message))
+    })
+
+    // However the message ends, its gate must open — a component would
+    // otherwise stay suspended forever...
+    onCancel(() => releaseMorphGate(message))
+    onFailure(() => releaseMorphGate(message))
+    onError(() => releaseMorphGate(message))
+    onFinish(() => {
+        if (processingMessages.get(message.component) === message) {
+            processingMessages.delete(message.component)
+        }
+
+        releaseMorphGate(message)
+    })
 })
 
 export function assetIsPendingFor(component) {
     return pendingComponentAssets.has(component) && pendingComponentAssets.get(component).loading
+}
+
+// True only when the component's tree was actually suspended — a pending
+// module on an Alpine without deferInit() loads the old (racy) way, and the
+// component initializes on the first pass like it always did...
+export function treeIsSuspendedFor(component) {
+    return !! Alpine.deferInit && assetIsPendingFor(component)
 }
 
 export function runAfterAssetIsLoadedFor(component, callback) {

--- a/js/features/supportWireSort.js
+++ b/js/features/supportWireSort.js
@@ -2,21 +2,23 @@ import { setNextActionOrigin } from '@/request'
 import { evaluateActionExpression } from '../evaluator'
 import Alpine from 'alpinejs'
 import { extractDirective } from '@/directives'
+import { on } from '@/hooks'
+
+on('directive.init', ({ el, directive }) => {
+    if (! directive.rawName.startsWith('wire:sort:item')) return
+
+    // This directive was already initialized by interceptInit...
+    if (el._x_sort_key !== undefined) return
+
+    bindSortItem(el, directive)
+})
 
 Alpine.interceptInit(el => {
     for (let i = 0; i < el.attributes.length; i++) {
         if (el.attributes[i].name.startsWith('wire:sort:item')) {
             let directive = extractDirective(el, el.attributes[i].name)
 
-            let modifierString = directive.modifiers.join('.')
-
-            let expression = directive.expression
-
-            Alpine.bind(el, {
-                ['x-sort:item' + modifierString]() {
-                    return expression
-                }
-            })
+            bindSortItem(el, directive)
         } else if (el.attributes[i].name.startsWith('wire:sort:group-id')) {
             // This will get read by the wire:sort handler below...
             continue
@@ -80,3 +82,15 @@ Alpine.interceptInit(el => {
         }
     }
 })
+
+function bindSortItem(el, directive) {
+    let modifierString = directive.modifiers.join('.')
+
+    let expression = directive.expression
+
+    Alpine.bind(el, {
+        ['x-sort:item' + modifierString]() {
+            return expression
+        }
+    })
+}

--- a/js/lifecycle.js
+++ b/js/lifecycle.js
@@ -1,4 +1,5 @@
 import { findComponentByEl, destroyComponent, initComponent, hasComponent } from './store'
+import { treeIsSuspendedFor } from './features/supportJsModules'
 import { matchesForLivewireDirective, extractDirective } from './directives'
 import { trigger } from './hooks'
 import collapse from '@alpinejs/collapse'
@@ -40,6 +41,12 @@ export function start() {
         // This prevents Livewire from causing general slowness for other Alpine elements on the page...
         if (! Array.from(attributes).some(attribute => matchesForLivewireDirective(attribute.name))) return
 
+        // An element Alpine hasn't initialized sits inside an ignored or
+        // suspended tree. Its directives will be picked up by the tree walk
+        // when (and if) it initializes — triggering them now would double
+        // them up...
+        if (! el._x_marker) return
+
         let component = findComponentByEl(el, false)
 
         if (! component) return
@@ -67,6 +74,12 @@ export function start() {
                 Alpine.onAttributeRemoved(el, 'wire:id', () => {
                     destroyComponent(component.id)
                 })
+
+                // If the component's tree was just suspended while its script module
+                // loads (initComponent's effect processing registered it with
+                // Alpine.deferInit), bail out here so directive triggers fire once
+                // on the resume pass instead of on both passes...
+                if (treeIsSuspendedFor(component)) return
             }
 
             let directives = Array.from(el.getAttributeNames())

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,18 @@
             "name": "laravel-livewire",
             "license": "MIT",
             "dependencies": {
-                "@alpinejs/anchor": "^3.16.3",
-                "@alpinejs/collapse": "^3.16.3",
-                "@alpinejs/csp": "^3.16.3",
-                "@alpinejs/focus": "^3.16.3",
-                "@alpinejs/intersect": "^3.16.3",
-                "@alpinejs/mask": "^3.16.3",
-                "@alpinejs/morph": "^3.16.3",
-                "@alpinejs/persist": "^3.16.3",
-                "@alpinejs/resize": "^3.16.3",
-                "@alpinejs/sort": "^3.16.3",
+                "@alpinejs/anchor": "^3.17.0",
+                "@alpinejs/collapse": "^3.17.0",
+                "@alpinejs/csp": "^3.17.0",
+                "@alpinejs/focus": "^3.17.0",
+                "@alpinejs/intersect": "^3.17.0",
+                "@alpinejs/mask": "^3.17.0",
+                "@alpinejs/morph": "^3.17.0",
+                "@alpinejs/persist": "^3.17.0",
+                "@alpinejs/resize": "^3.17.0",
+                "@alpinejs/sort": "^3.17.0",
                 "@vue/reactivity": "^3.2.45",
-                "alpinejs": "^3.16.3",
+                "alpinejs": "^3.17.0",
                 "nprogress": "^0.2.0"
             },
             "devDependencies": {
@@ -29,33 +29,33 @@
             }
         },
         "node_modules/@alpinejs/anchor": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.16.3.tgz",
-            "integrity": "sha512-l53MqW/ZNzR+0jmQ6WhRWEb0K3ZxXhWxgjnLTA+GDX99wCO47lYaD8SIPjxXRARfcrRKPzrpj1llKa0pfwg1kw==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.17.0.tgz",
+            "integrity": "sha512-TCY8DnyMWIWdAECjTEzBsDnh4gfiKuZq2wjmS0eHY0F38i5s4k2iOphxt5cWAytLI9yw6FKqbCytXNmjHOZjDQ==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.5.3"
             }
         },
         "node_modules/@alpinejs/collapse": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.16.3.tgz",
-            "integrity": "sha512-ekH5VBTpMBNnffAfvL+3mqFLIWNW4bUmCExEl+1WdGPewtVYBI2kMWNd2lVOsrvsDRSij7VGmAG0AK5s8WD03g==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.17.0.tgz",
+            "integrity": "sha512-Dwjb8cEjUYdHy0FCKCfmmq/RGOotSm116w/fQBXTrX2HPw5rrJ3ZUgUhO1JOgtgkOw+vTlBERPtjJViIrMZn0w==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/csp": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.16.3.tgz",
-            "integrity": "sha512-eqz6rpWDXuJOGp3YvsXQqZljjBz7ZWAkEmJUt3zTJyK9SEjUcInfOx7sRLzEUlrU+o9r2UhxCVhFBc5eJAUMdA==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.17.0.tgz",
+            "integrity": "sha512-D6W+RbUfkU1SyAYM0GHNF84jEHtx77HQq5CdOBvlBwDzKqbdTqjITPRLNihZ/EcUqoLgqebFzHd/v55rpP0Jhw==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.5.40"
             }
         },
         "node_modules/@alpinejs/focus": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.16.3.tgz",
-            "integrity": "sha512-MwEeux0W+/DP4B3FyNHPs+kzqMmgfWRf25WsJLBH1kahBqiVHNLewSJotbO+9345A8WsHz3yx8XkaeNnepDv3Q==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.17.0.tgz",
+            "integrity": "sha512-tqkE2Pj4WgSXXujs3eCLxiS2ZODgNcDsKvG5lCZKlDozeRO6WFeSAjV5EKi4p+BFNIwm1937O4xwuV7hQ0Q+jA==",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^8.0.0",
@@ -63,39 +63,39 @@
             }
         },
         "node_modules/@alpinejs/intersect": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.16.3.tgz",
-            "integrity": "sha512-hGiwxwfuRjiYpxnuZOD5ymQAPhyxspVfhwuSEg/TdJhfqmfacJd4Z42LIKIdXoDE8JaexXvrUeg5MBxzLVgMmQ==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.17.0.tgz",
+            "integrity": "sha512-6vvZFWmPo/+Vu+vSWjKkE2KFw7HF4SLS8TaGZqnLXhrwOc3UOoYdjz798lQSYhNp1W1Z0+s/Boi4kAczt5BOkA==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/mask": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.16.3.tgz",
-            "integrity": "sha512-BKu3IT4kk1GqgH8Lsn8ekV6nrbbMJgjOuI6zC+rJ+m/iPxBstH80ELauD23a7OiJAVQZjdS+lmYFfCVAbk3Rqg==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.17.0.tgz",
+            "integrity": "sha512-/VL4Sc4T3V/gzuqurOhvsO3FqUKC6RzGrNV4UJUYzv3i+tip/LXTKJIPjPKdw/qzto8c2pRFJ0lpEWPyVcYFBw==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/morph": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.16.3.tgz",
-            "integrity": "sha512-JUrZ9tCXTgdQRoHAIdCDzdrkyEC8ffXwFlynEQ7it0jFy2UW4X0jpcRRBUhvyD94OiMpN6bd82eWhd+3PaqP+g==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.17.0.tgz",
+            "integrity": "sha512-Jucn2wQObrNFnz8m2JR6W2G6fiYpnVu9C2Y1VWfuLDfmD1mv6tHowBevISBxQ459gL/1Iyec3jSZl3hWbyN/Mw==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/persist": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.16.3.tgz",
-            "integrity": "sha512-VyhG3C1CKTvGwHQICw1GLfqIuUt++q54oSRGstX+Y30yjj+JK6HrWj50yzAS+C2K8SXnR99ipY6SQevLaHAgog==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.17.0.tgz",
+            "integrity": "sha512-sS4raHKnSnqfQrVgMAJhc/9cRDZ6ZiLlJqhNhboaiU986JQSOOtfKSM2n23EVmMtm/RcqDR6HqVjDjgyQyuvxg==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/resize": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.16.3.tgz",
-            "integrity": "sha512-3GG13wnOqdYduvT1DPpdJolY254cT8eHw32bx3Ibay2v9HnPzRTDZ9BiZe4iI+1rEcH4E6IKsM7RsEjAaSO0Og==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.17.0.tgz",
+            "integrity": "sha512-5kVl5975Ob6O22RomUqqMnM+azIX51ckHS1eW+1y/xv0UiXFDa7V16jTz+pCRlDH9EHr9mE+wF1DbGIleI7xhg==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/sort": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.16.3.tgz",
-            "integrity": "sha512-LEmI3oE+oIrWmAWoA4PhkA0/kvbrlAr5hBrAvreWU63U4oleTDpgp0LS0qzxBMLOzoEJKwupWuq9l2j6fz2erg==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.17.0.tgz",
+            "integrity": "sha512-yruO0mcORzZEXWg8JSaOEKyw770x5Iu2ssi9sYnPacwJaU+R0e7rXn7VDrbg2DvevnpeKg7dZZtR3VUykF3tOA==",
             "license": "MIT",
             "dependencies": {
                 "sortablejs": "^1.15.2"
@@ -1266,9 +1266,9 @@
             }
         },
         "node_modules/alpinejs": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.16.3.tgz",
-            "integrity": "sha512-kLIO2JOPs5ZY3mHPH+CHHPzp89Y6Gb2luLRy+RDIb1oG9y6N5Vfc75kkEoaSOPhJqvakuPiAsnd9paNPNSZyVg==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.17.0.tgz",
+            "integrity": "sha512-LDLcfqFsiQrdFCNqK7zWyfjx2QE2sjPw0bIPThLVHMIQATAp1dNRKga1xPSqC+71UYFiosIYblLszzzo9r9k6A==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.5.40"

--- a/package.json
+++ b/package.json
@@ -17,18 +17,18 @@
         "vitest": "^3.2.4"
     },
     "dependencies": {
-        "@alpinejs/anchor": "^3.16.3",
-        "@alpinejs/collapse": "^3.16.3",
-        "@alpinejs/csp": "^3.16.3",
-        "@alpinejs/focus": "^3.16.3",
-        "@alpinejs/intersect": "^3.16.3",
-        "@alpinejs/mask": "^3.16.3",
-        "@alpinejs/morph": "^3.16.3",
-        "@alpinejs/persist": "^3.16.3",
-        "@alpinejs/resize": "^3.16.3",
-        "@alpinejs/sort": "^3.16.3",
+        "@alpinejs/anchor": "^3.17.0",
+        "@alpinejs/collapse": "^3.17.0",
+        "@alpinejs/csp": "^3.17.0",
+        "@alpinejs/focus": "^3.17.0",
+        "@alpinejs/intersect": "^3.17.0",
+        "@alpinejs/mask": "^3.17.0",
+        "@alpinejs/morph": "^3.17.0",
+        "@alpinejs/persist": "^3.17.0",
+        "@alpinejs/resize": "^3.17.0",
+        "@alpinejs/sort": "^3.17.0",
         "@vue/reactivity": "^3.2.45",
-        "alpinejs": "^3.16.3",
+        "alpinejs": "^3.17.0",
         "nprogress": "^0.2.0"
     }
 }

--- a/src/ComponentHook.php
+++ b/src/ComponentHook.php
@@ -71,6 +71,18 @@ abstract class ComponentHook
         };
     }
 
+    function callRenderPlaceholder(...$params) {
+        $callbacks = [];
+
+        if (method_exists($this, 'renderPlaceholder')) $callbacks[] = $this->renderPlaceholder(...$params);
+
+        return function (...$params) use ($callbacks) {
+            foreach ($callbacks as $callback) {
+                if (is_callable($callback)) $callback(...$params);
+            }
+        };
+    }
+
     function callDehydrate(...$params) {
         if (method_exists($this, 'dehydrate')) $this->dehydrate(...$params);
     }

--- a/src/ComponentHookRegistry.php
+++ b/src/ComponentHookRegistry.php
@@ -73,6 +73,10 @@ class ComponentHookRegistry
             return static::proxyCallToHooks($component, 'callRenderIsland')($name, $view, $data);
         });
 
+        on('render.placeholder', function ($component, $view, $data) {
+            return static::proxyCallToHooks($component, 'callRenderPlaceholder')($view, $data);
+        });
+
         on('dehydrate', function ($component, $context) {
             static::proxyCallToHooks($component, 'callDehydrate')($context);
         });

--- a/src/Drawer/BaseUtils.php
+++ b/src/Drawer/BaseUtils.php
@@ -147,4 +147,60 @@ class BaseUtils
 
         return $property->hasType() && (! $property->isInitialized($target));
     }
+
+    /**
+     * Compare a value's native PHP type with a property's declared type.
+     *
+     * This deliberately does not apply PHP's weak scalar coercion. It returns
+     * null when the property is missing or untyped because there is no declared
+     * type contract to compare the value against.
+     */
+    static function propertyTypeMatchesValue($target, $property, $value): ?bool {
+        if (! $property || ! property_exists($target, $property)) return null;
+
+        $reflectionProperty = static::getProperty($target, $property);
+
+        if (! $type = $reflectionProperty->getType()) return null;
+
+        return static::typeMatchesValue($type, $value, $reflectionProperty->getDeclaringClass());
+    }
+
+    protected static function typeMatchesValue($type, $value, $declaringClass): bool {
+        if ($value === null) return $type->allowsNull();
+
+        if ($type instanceof \ReflectionUnionType) {
+            foreach ($type->getTypes() as $unionType) {
+                if (static::typeMatchesValue($unionType, $value, $declaringClass)) return true;
+            }
+
+            return false;
+        }
+
+        if ($type instanceof \ReflectionIntersectionType) {
+            foreach ($type->getTypes() as $intersectionType) {
+                if (! static::typeMatchesValue($intersectionType, $value, $declaringClass)) return false;
+            }
+
+            return true;
+        }
+
+        $name = $type->getName();
+
+        return match ($name) {
+            'mixed' => true,
+            'string' => is_string($value),
+            'int' => is_int($value),
+            'float' => is_float($value),
+            'bool' => is_bool($value),
+            'array' => is_array($value),
+            'object' => is_object($value),
+            'iterable' => is_iterable($value),
+            'callable' => is_callable($value),
+            'false' => $value === false,
+            'true' => $value === true,
+            'self', 'static' => $value instanceof ($declaringClass->getName()),
+            'parent' => ($parent = $declaringClass->getParentClass()) && $value instanceof ($parent->getName()),
+            default => $value instanceof $name,
+        };
+    }
 }

--- a/src/Drawer/PropertyTypeUnitTest.php
+++ b/src/Drawer/PropertyTypeUnitTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Livewire\Drawer;
+
+class PropertyTypeUnitTest extends \Tests\TestCase
+{
+    function test_it_matches_values_against_named_property_types()
+    {
+        $target = new PropertyTypeFixture;
+
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'string', 'value'));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'string', 1));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'integer', 1));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'integer', '1'));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'float', 1.5));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'float', 1));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'boolean', true));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'array', []));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'object', new \stdClass));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'iterable', []));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'mixed', new \stdClass));
+    }
+
+    function test_it_matches_nullable_and_union_property_types()
+    {
+        $target = new PropertyTypeFixture;
+
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'nullableString', null));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'nullableString', 'value'));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'nullableString', []));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'stringOrArray', 'value'));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'stringOrArray', []));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'stringOrArray', 1));
+    }
+
+    function test_it_matches_class_and_interface_property_types()
+    {
+        $target = new PropertyTypeFixture;
+
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'objectType', new PropertyTypeObject));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'objectType', new \stdClass));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'interfaceType', new PropertyTypeObject));
+        $this->assertTrue(Utils::propertyTypeMatchesValue($target, 'intersectionType', new PropertyTypeObject));
+        $this->assertFalse(Utils::propertyTypeMatchesValue($target, 'intersectionType', new PropertyTypeInterfaceOnlyObject));
+    }
+
+    function test_it_reports_when_there_is_no_declared_type_to_match_against()
+    {
+        $target = new PropertyTypeFixture;
+
+        $this->assertNull(Utils::propertyTypeMatchesValue($target, 'untyped', 'value'));
+        $this->assertNull(Utils::propertyTypeMatchesValue($target, 'missing', 'value'));
+    }
+}
+
+interface PropertyTypeInterface
+{
+}
+
+class PropertyTypeObject implements PropertyTypeInterface, \Stringable
+{
+    public function __toString(): string
+    {
+        return '';
+    }
+}
+
+class PropertyTypeInterfaceOnlyObject implements PropertyTypeInterface
+{
+}
+
+class PropertyTypeFixture
+{
+    public string $string;
+    public int $integer;
+    public float $float;
+    public bool $boolean;
+    public array $array;
+    public object $object;
+    public iterable $iterable;
+    public mixed $mixed;
+    public ?string $nullableString;
+    public string|array $stringOrArray;
+    public PropertyTypeObject $objectType;
+    public PropertyTypeInterface $interfaceType;
+    public PropertyTypeInterface&\Stringable $intersectionType;
+    public $untyped;
+}

--- a/src/Features/SupportComputed/BaseComputed.php
+++ b/src/Features/SupportComputed/BaseComputed.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Features\SupportComputed;
 
-use function Livewire\{ invade, wrap };
+use function Livewire\invade;
 
 use Livewire\Features\SupportAttributes\Attribute;
 use Illuminate\Support\Facades\Cache;
@@ -158,13 +158,7 @@ class BaseComputed extends Attribute
 
     protected function evaluateComputed()
     {
-        $value = null;
-
-        wrap($this->component)->tap(function ($component) use (&$value) {
-            $value = invade($component)->{parent::getName()}();
-        });
-
-        return $value;
+        return invade($this->component)->{parent::getName()}();
     }
 
     public function getName()
@@ -176,4 +170,6 @@ class BaseComputed extends Attribute
     {
         return str($value)->camel()->toString();
     }
+
+
 }

--- a/src/Features/SupportComputed/UnitTest.php
+++ b/src/Features/SupportComputed/UnitTest.php
@@ -735,36 +735,6 @@ class UnitTest extends TestCase
             ->dispatch('bar', 'baz')
             ->assertSetStrict('foo', 'baz');
     }
-
-    public function test_computed_attribute_can_trigger_component_exception_hook()
-    {
-        Livewire::test(new class extends TestComponent {
-            #[Computed]
-            public function foo(): string
-            {
-                throw new ComputedPropertyException('Exception from computed property');
-            }
-
-            public function exception($e, $stopPropagation)
-            {
-                if ($e instanceof ComputedPropertyException) {
-                    $stopPropagation();
-
-                    session()->put('exception-hook-triggered', true);
-                }
-            }
-
-            public function render()
-            {
-                return <<<'HTML'
-                    <div>{{ $this->foo }}</div>
-                HTML;
-            }
-        })
-            ->assertOk();
-
-        $this->assertTrue(session()->has('exception-hook-triggered'));
-    }
 }
 
 class ComputedPropertyStub extends Component
@@ -908,16 +878,5 @@ class NullIssetComputedPropertyStub extends Component{
             {{ var_dump(isset($this->foo)) }}
         </div>
         HTML;
-    }
-}
-
-class ComputedPropertyException extends \Exception
-{
-    public function __construct(
-        string $message = '',
-        int $code = 0,
-        \Throwable|null $previous = null
-    ) {
-        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -152,7 +152,40 @@ class BrowserTest extends BrowserTestCase
             ->pause(50)
             ->assertVisible('@dirty-indicator')
         ;
-}
+    }
+
+    function test_wire_dirty_keeps_tracking_every_target_after_a_commit()
+    {
+        Livewire::visit(new class extends Component {
+            public $first = false;
+
+            public $second = '';
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <input dusk="first" type="checkbox" wire:model="first" />
+                        <input dusk="second" type="text" wire:model="second" />
+
+                        <button dusk="commit" type="button" wire:click="$commit">Commit</button>
+
+                        <div dusk="dirty" wire:dirty.class="dirty" wire:target="first, second"></div>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertAttributeDoesntContain('@dirty', 'class', 'dirty')
+            ->check('@first')
+            ->pause(50)
+            ->assertAttributeContains('@dirty', 'class', 'dirty')
+            ->waitForLivewire()->click('@commit')
+            ->waitUntil("!document.querySelector('[dusk=\"dirty\"]').classList.contains('dirty')")
+            ->type('@second', 'Later target')
+            ->pause(50)
+            ->assertAttributeContains('@dirty', 'class', 'dirty')
+        ;
+    }
 
     function test_can_update_bound_value_from_lifecyle_hook()
     {

--- a/src/Features/SupportFormObjects/BrowserTest.php
+++ b/src/Features/SupportFormObjects/BrowserTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Livewire\Features\SupportFormObjects;
+
+use Livewire\Component;
+use Livewire\Form;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    public function test_resetting_required_typed_form_properties_completes_the_next_render()
+    {
+        Livewire::visit(new class extends Component {
+            public BrowserRequiredPostForm $form;
+
+            public string $state = 'initialized';
+
+            public function mount()
+            {
+                $this->form->title = 'Some Title';
+            }
+
+            public function resetForm()
+            {
+                $this->form->reset();
+
+                $property = new \ReflectionProperty($this->form, 'title');
+
+                $this->state = $property->isInitialized($this->form)
+                    ? 'initialized'
+                    : 'uninitialized';
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <button dusk="reset" wire:click="resetForm">Reset</button>
+
+                        <span dusk="state">{{ $state }}</span>
+                    </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@state', 'initialized')
+            ->click('@reset')
+            ->waitForTextIn('@state', 'uninitialized');
+    }
+}
+
+class BrowserRequiredPostForm extends Form
+{
+    public string $title;
+}

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -110,6 +110,17 @@ class Form implements Arrayable
         $freshInstance = new static($this->getComponent(), $this->getPropertyName());
 
         foreach ($properties as $property) {
+            $property = str($property);
+
+            if (! $property->contains('.') && property_exists($freshInstance, (string) $property)) {
+                $isInitialized = (new \ReflectionProperty($freshInstance, (string) $property))->isInitialized($freshInstance);
+
+                if (! $isInitialized) {
+                    data_forget($this, (string) $property);
+                    continue;
+                }
+            }
+
             data_set($this, $property, data_get($freshInstance, $property));
         }
     }

--- a/src/Features/SupportFormObjects/FormObjectSynth.php
+++ b/src/Features/SupportFormObjects/FormObjectSynth.php
@@ -3,12 +3,13 @@
 namespace Livewire\Features\SupportFormObjects;
 
 use Livewire\Drawer\Utils;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Livewire\Features\SupportAttributes\AttributeCollection;
 
 use function Livewire\wrap;
 
-class FormObjectSynth extends Synth {
+class FormObjectSynth extends Synth implements ArrayShapedSynth {
     public static $key = 'form';
 
     static function match($target)

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -1148,6 +1148,72 @@ class UnitTest extends \Tests\TestCase
             ->assertSetStrict('form', fn ($form) => $form instanceof PostFormStubWithDefaults)
         ;
     }
+
+    public function test_reset_restores_required_typed_properties_to_their_uninitialized_state()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public PostFormStubWithRequiredTypedProperties $form;
+
+            public function mount()
+            {
+                $this->form->title = 'Some Title';
+                $this->form->content = 'Some content...';
+            }
+
+            public function resetForm()
+            {
+                $this->form->reset();
+            }
+        })
+            ->call('resetForm')
+            ->assertOk();
+
+        $form = $component->instance()->form;
+
+        $this->assertFalse((new \ReflectionProperty($form, 'title'))->isInitialized($form));
+        $this->assertFalse((new \ReflectionProperty($form, 'content'))->isInitialized($form));
+    }
+
+    public function test_resetting_one_required_typed_property_preserves_sibling_values()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public PostFormStubWithRequiredTypedProperties $form;
+
+            public function mount()
+            {
+                $this->form->title = 'Some Title';
+                $this->form->content = 'Some content...';
+            }
+
+            public function resetTitle()
+            {
+                $this->form->reset('title');
+            }
+        })
+            ->call('resetTitle')
+            ->assertSetStrict('form.content', 'Some content...')
+            ->assertOk();
+
+        $form = $component->instance()->form;
+
+        $this->assertFalse((new \ReflectionProperty($form, 'title'))->isInitialized($form));
+    }
+
+    public function test_resetting_a_nested_path_continues_to_use_its_declared_default()
+    {
+        Livewire::test(new class extends TestComponent {
+            public PostFormStubWithNestedDefaults $form;
+
+            public function resetName()
+            {
+                $this->form->reset('profile.name');
+            }
+        })
+            ->set('form.profile.name', 'Taylor')
+            ->call('resetName')
+            ->assertSetStrict('form.profile.name', '')
+            ->assertOk();
+    }
 }
 
 class PostFormStub extends Form
@@ -1172,6 +1238,20 @@ class PostFormStubWithArrayDefaults extends Form
         1 => true,
         2 => false,
         'foo' => ['bar' => 'baz'],
+    ];
+}
+
+class PostFormStubWithRequiredTypedProperties extends Form
+{
+    public string $title;
+
+    public string $content;
+}
+
+class PostFormStubWithNestedDefaults extends Form
+{
+    public array $profile = [
+        'name' => '',
     ];
 }
 

--- a/src/Features/SupportFormObjects/UnitTest.php
+++ b/src/Features/SupportFormObjects/UnitTest.php
@@ -1070,6 +1070,20 @@ class UnitTest extends \Tests\TestCase
         $synth->hydrate(['title' => 'test'], ['class' => \stdClass::class], fn($k, $v) => $v);
     }
 
+    function test_an_untyped_form_object_property_can_be_replaced_with_a_scalar_during_an_update()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $form;
+
+            public function mount()
+            {
+                $this->form = new PostFormStub($this, 'form');
+            }
+        })
+            ->set('form', 1)
+            ->assertSetStrict('form', 1);
+    }
+
     public function test_can_fill_a_form_object_from_eloquent_model_with_enum_cast()
     {
         Livewire::test(new class extends TestComponent {

--- a/src/Features/SupportHtmlAttributeForwarding/BrowserTest.php
+++ b/src/Features/SupportHtmlAttributeForwarding/BrowserTest.php
@@ -125,4 +125,71 @@ class BrowserTest extends BrowserTestCase
             ->assertAttribute('@parent-component > div', 'data-testid', 'my-alert')
             ->assertAttribute('@parent-component > div', 'wire:sort:item', '1');
     }
+
+    public function test_html_attributes_are_forwarded_to_a_lazy_components_placeholder_when_it_opts_in()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div dusk="parent-component">
+                        <h1>Parent Component</h1>
+
+                        <livewire:alert
+                            type="error"
+                            class="mb-4"
+                            id="error-alert"
+                            data-testid="my-alert"
+                            dusk="alert-component"
+                            wire:sort:item="1"
+                            lazy
+                        >
+                            Something went wrong!
+                        </livewire:alert>
+                    </div>
+                    HTML;
+                }
+            },
+            'alert' => new class extends Component {
+                public string $type = 'info';
+
+                public function mount()
+                {
+                    usleep(200 * 1000); // 200ms
+                }
+
+                public function placeholder()
+                {
+                    return <<<'HTML'
+                    <div {{ $attributes }}>Loading...</div>
+                    HTML;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div {{ $attributes->merge(['class' => 'alert alert-'.$type]) }}>
+                        <h2>Alert Component</h2>
+
+                        {{ $slot }}
+
+                        <button type="button" wire:click="$refresh" dusk="refresh">Refresh</button>
+                    </div>
+                    HTML;
+                }
+            }
+        ])
+            ->waitForLivewireToLoad()
+            ->assertDontSee('Alert Component')
+            ->assertAttribute('@parent-component > div', 'id', 'error-alert')
+            ->assertAttribute('@parent-component > div', 'data-testid', 'my-alert')
+            ->assertAttribute('@parent-component > div', 'wire:sort:item', '1')
+
+            ->waitForText('Alert Component') // Wait for the lazy component to load
+            ->assertAttribute('@parent-component > div', 'class', 'alert alert-error mb-4')
+            ->assertAttribute('@parent-component > div', 'id', 'error-alert')
+            ->assertAttribute('@parent-component > div', 'data-testid', 'my-alert')
+            ->assertAttribute('@parent-component > div', 'wire:sort:item', '1');
+    }
 }

--- a/src/Features/SupportHtmlAttributeForwarding/SupportHtmlAttributeForwarding.php
+++ b/src/Features/SupportHtmlAttributeForwarding/SupportHtmlAttributeForwarding.php
@@ -21,6 +21,13 @@ class SupportHtmlAttributeForwarding extends ComponentHook
         $view->with(['attributes' => new ComponentAttributeBag($attributes)]);
     }
 
+    public function renderPlaceholder($view, $properties)
+    {
+        $attributes = $this->component->getHtmlAttributes();
+
+        $view->with(['attributes' => new ComponentAttributeBag($attributes)]);
+    }
+
     function hydrate($memo)
     {
         $attributes = $memo['attributes'] ?? [];

--- a/src/Features/SupportIslands/BrowserTest.php
+++ b/src/Features/SupportIslands/BrowserTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportIslands;
 
+use Illuminate\Support\Facades\Blade;
 use Tests\BrowserTestCase;
 use Livewire\Livewire;
 
@@ -44,6 +45,71 @@ class BrowserTest extends BrowserTestCase
             ->waitForLivewire()->click('@root-increment')
             ->assertSeeIn('@island-increment', 'Count: 1')
             ->assertSeeIn('@root-increment', 'Root count: 2')
+            ;
+    }
+
+    public function test_island_after_repeated_nested_blade_directives()
+    {
+        Livewire::visit([new class extends \Livewire\Component {
+            public $count = 0;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @if (auth()->check())
+                        first
+                    @endif
+
+                    @if (auth()->check() && request()->isMethod('get'))
+                        second
+                    @endif
+
+                    @island
+                        <div dusk="island">Count: {{ $count }}</div>
+                    @endisland
+
+                    @if (auth()->check())
+                        third
+                    @endif
+
+                    <div dusk="literal">[LIVEWIRE_DIRECTIVE_AT]</div>
+                </div>
+                HTML;
+            }
+        }])
+            ->assertSeeIn('@island', 'Count: 0')
+            ->assertSeeIn('@literal', '[LIVEWIRE_DIRECTIVE_AT]')
+            ;
+    }
+
+    public function test_island_compilation_preserves_foreign_directives_and_marker_like_content()
+    {
+        Blade::directive('islandGreeting', fn ($expression) => '<div dusk="custom-directive">Hello from Blade</div>');
+
+        Livewire::visit([new class extends \Livewire\Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @islandGreeting
+
+                    <div dusk="marker-like-content">[LIVEWIRE_DIRECTIVE:0]</div>
+                    <div dusk="escaped-directive">@@if (true)</div>
+
+                    @island
+                        <div dusk="island-with-foreign-directives">Island rendered</div>
+                        <div dusk="escaped-directive-inside-island">@@if (true)</div>
+                    @endisland
+                </div>
+                HTML;
+            }
+        }])
+            ->assertSeeIn('@custom-directive', 'Hello from Blade')
+            ->assertSeeIn('@marker-like-content', '[LIVEWIRE_DIRECTIVE:0]')
+            ->assertSeeIn('@escaped-directive', '@if(true)')
+            ->assertSeeIn('@island-with-foreign-directives', 'Island rendered')
+            ->assertSeeIn('@escaped-directive-inside-island', '@if(true)')
             ;
     }
 

--- a/src/Features/SupportIslands/Compiler/IslandCompiler.php
+++ b/src/Features/SupportIslands/Compiler/IslandCompiler.php
@@ -57,6 +57,8 @@ class IslandCompiler
 
         $result = $compiler->compileStatementsMadePublic($contents);
 
+        $result = $this->restoreSetAsideDirectives($result, $compiler->setAsideDirectives);
+
         $result = $this->restoreBladeComments($result, $comments);
 
         for ($i=$maxNestingLevel; $i >= $currentNestingLevel; $i--) {
@@ -210,18 +212,41 @@ PHP;
         }, $contents);
     }
 
+    protected function restoreSetAsideDirectives(string $contents, array $directives): string
+    {
+        return strtr($contents, $directives);
+    }
+
     public function getHackedBladeCompiler()
     {
         $instance = new class (
             app('files'),
             rtrim(config('view.compiled'), '/\\') . '/livewire',
         ) extends \Illuminate\View\Compilers\BladeCompiler {
+            public array $setAsideDirectives = [];
+
+            protected string $setAsideDirectivePrefix = '[LIVEWIRE_DIRECTIVE:';
+
             /**
-             * Make this method public...
+             * Make statement compilation public and reserve a placeholder prefix
+             * that does not collide with authored view content...
              */
             public function compileStatementsMadePublic($template)
             {
+                while (str_contains($template, $this->setAsideDirectivePrefix)) {
+                    $this->setAsideDirectivePrefix .= '_';
+                }
+
                 return $this->compileStatements($template);
+            }
+
+            protected function setAside($directive)
+            {
+                $placeholder = $this->setAsideDirectivePrefix . count($this->setAsideDirectives) . ']';
+
+                $this->setAsideDirectives[$placeholder] = $directive;
+
+                return $placeholder;
             }
 
             /**
@@ -230,21 +255,15 @@ PHP;
              */
             protected function compileStatement($match)
             {
-                if (str_contains($match[1], '@')) {
-                    $match[0] = isset($match[3]) ? $match[1].$match[3] : $match[1];
-                } elseif (isset($this->customDirectives[$match[1]])) {
-                    $match[0] = $this->callCustomDirective($match[1], Arr::get($match, 3));
-                } elseif (method_exists($this, $method = 'compile'.ucfirst($match[1]))) {
-                    // Don't process through built-in directive methods...
-                    // $match[0] = $this->$method(Arr::get($match, 3));
+                if (isset($this->customDirectives[$match[1]])) {
+                    $compiled = $this->callCustomDirective($match[1], Arr::get($match, 3));
 
-                    // Just return the original match...
-                    return $match[0];
-                } else {
-                    return $match[0];
+                    return isset($match[3]) ? $compiled : $compiled.$match[2];
                 }
 
-                return isset($match[3]) ? $match[0] : $match[0].$match[2];
+                // Blade moves forward as it replaces statements, so foreign directives
+                // must be consumed during this island-only pass and restored afterward...
+                return $this->setAside($match[0]);
             }
         };
 

--- a/src/Features/SupportIslands/HandlesIslands.php
+++ b/src/Features/SupportIslands/HandlesIslands.php
@@ -217,9 +217,16 @@ trait HandlesIslands
 
         $view->with($data);
 
+        // Blade components and third-party packages detect the Livewire context
+        // through the shared "__livewire" variable, so an island render has to
+        // share it the same way a full component render does...
+        $revertShare = Utils::shareWithViews('__livewire', $this);
+
         $finish = trigger('renderIsland', $this, $name, $view, $properties);
 
         $html = $view->render();
+
+        $revertShare();
 
         $replaceHtml = function ($newHtml) use (&$html) {
             $html = $newHtml;

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -536,6 +536,34 @@ class UnitTest extends TestCase
         $this->assertCount(1, $fragments, 'Expected only one island fragment but got ' . count($fragments));
     }
 
+    public function test_island_render_shares_the_component_with_views()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public function repaint()
+            {
+                $this->renderIsland('probe');
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    @island(name: 'probe')
+                        <div>shared: {{ app('view')->shared('__livewire') ? 'yes' : 'no' }}</div>
+                    @endisland
+                </div>
+                HTML;
+            }
+        });
+
+        $component->assertSee('shared: yes');
+
+        $component->call('repaint');
+
+        $fragments = implode('', $component->effects['islandFragments'] ?? []);
+
+        $this->assertStringContainsString('shared: yes', $fragments);
+    }
+
     public function test_island_directive_supports_nested_parentheses_in_expression()
     {
         Livewire::test(new class extends \Livewire\Component {

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -580,6 +580,50 @@ class UnitTest extends TestCase
             ->assertSee('value: HELLO');
     }
 
+    public function test_island_keeps_its_token_when_a_directive_above_it_has_an_unbalanced_expression()
+    {
+        $compiledPath = sys_get_temp_dir() . '/laravel-island-offset-' . uniqid();
+
+        config()->set('view.compiled', $compiledPath);
+        app()->forgetInstance('livewire.compiler');
+        app()->forgetInstance('livewire.factory');
+
+        $compiled = IslandCompiler::compile(__FILE__, <<<'HTML'
+        <div>
+            @if (auth()->check())
+                first
+            @endif
+
+            @if (auth()->check() && request()->isMethod('get'))
+                second
+            @endif
+
+            @island(name: 'counter')
+                @if (request()->isMethod('get'))
+                    <div>count: {{ $count }}</div>
+                @endif
+            @endisland
+
+            @if (auth()->check())
+                third
+            @endif
+        </div>
+        HTML);
+
+        $token = app('livewire.compiler')->cacheManager->getHash(__FILE__) . '-1';
+        $cachedPath = IslandCompiler::getCachedPathFromToken($token);
+
+        $this->assertStringContainsString("token: '{$token}'", $compiled);
+        $this->assertStringNotContainsString('[ENDISLAND', $compiled);
+        $this->assertStringNotContainsString('[LIVEWIRE_DIRECTIVE:', $compiled);
+        $this->assertStringContainsString("@if (auth()->check() && request()->isMethod('get'))", $compiled);
+        $this->assertFileExists($cachedPath);
+        $this->assertStringContainsString("@if (request()->isMethod('get'))", File::get($cachedPath));
+        $this->assertStringNotContainsString('[LIVEWIRE_DIRECTIVE:', File::get($cachedPath));
+
+        File::deleteDirectory($compiledPath);
+    }
+
     public function test_island_tokens_are_stable_across_different_base_paths()
     {
         $path = '/resources/views/components/foo.blade.php';

--- a/src/Features/SupportJsModules/BrowserTest.php
+++ b/src/Features/SupportJsModules/BrowserTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportJsModules;
 
 use Illuminate\Support\Facades\Route;
+use Livewire\Component;
 use Livewire\Livewire;
 
 class BrowserTest extends \Tests\BrowserTestCase
@@ -17,6 +18,21 @@ class BrowserTest extends \Tests\BrowserTestCase
                     'Content-Type' => 'application/javascript',
                 ]);
             });
+
+            // A module that stays pending until the test releases it. Gating
+            // client-side keeps the (single-threaded) test server free to
+            // handle Livewire updates while the module is "loading"...
+            Route::get('/slow-module.js', function () {
+                return response(
+                    'await new Promise(resolve => { window.releaseSlowModule = resolve })' . "\n\n" . 'export default true',
+                    200,
+                    ['Content-Type' => 'application/javascript'],
+                );
+            });
+
+            Route::get('/navigate-page', function () {
+                return app('livewire')->new('testns::navigate-page')();
+            })->middleware('web');
         };
     }
 
@@ -84,5 +100,234 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->pause(100)
             ->click('@mark-again')
             ->assertSeeIn('@target', 'js-action-called-again');
+    }
+
+    public function test_alpine_data_works_in_single_file_component_script()
+    {
+        // Alpine walks the DOM synchronously while script modules load
+        // asynchronously. The component's tree must be suspended until its
+        // module has registered Alpine.data() providers, or `x-data` on the
+        // component's own root evaluates against nothing.
+        // Regression test for: https://github.com/livewire/livewire/discussions/9591
+        Livewire::visit('testns::alpine-data')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_keeps_working_after_a_morph()
+    {
+        Livewire::visit('testns::alpine-data')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->waitForLivewire()->click('@refresh')
+            ->assertSeeIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_works_with_two_instances_on_one_page()
+    {
+        // The first instance is the one that historically failed: later
+        // instances only worked because the first one's module had already
+        // registered the shared Alpine.data() name globally.
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <livewire:testns::alpine-data key="first" />
+                    <livewire:testns::alpine-data key="second" />
+                </div>
+                HTML;
+            }
+        }])
+            ->waitUntil("[...document.querySelectorAll('[dusk=\"target\"]')].filter(el => el.textContent === 'alpine-data-loaded').length === 2")
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_works_in_dynamically_added_component()
+    {
+        Livewire::visit([new class extends Component {
+            public $show = false;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$toggle('show')" dusk="toggle">Toggle</button>
+
+                    @if ($show)
+                        <livewire:testns::alpine-data />
+                    @endif
+                </div>
+                HTML;
+            }
+        }])
+            ->assertConsoleLogHasNoErrors()
+            ->assertDontSee('alpine-data-loaded')
+            ->waitForLivewire()->click('@toggle')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_works_in_lazy_loaded_component()
+    {
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <livewire:testns::alpine-data lazy />
+                </div>
+                HTML;
+            }
+        }])
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_works_in_component_inside_island()
+    {
+        Livewire::visit('testns::island-with-alpine-data')
+            ->assertConsoleLogHasNoErrors()
+            ->assertSeeIn('@placeholder', 'No child yet')
+            ->assertDontSee('alpine-data-loaded')
+            ->waitForLivewire()->click('@toggle')
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_alpine_data_works_after_wire_navigate()
+    {
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <div dusk="source-page">Source page</div>
+
+                    <a href="/navigate-page" wire:navigate dusk="link">Go to the alpine data page</a>
+                </div>
+                HTML;
+            }
+        }])
+            ->assertSeeIn('@source-page', 'Source page')
+            ->assertConsoleLogHasNoErrors()
+            ->waitForNavigate()->click('@link')
+            ->waitForTextIn('@target', 'navigate-data-loaded')
+            ->assertConsoleLogHasNoErrors()
+            // Navigating on to another page containing the same component
+            // reuses the cached module and still initializes correctly...
+            ->waitForNavigate()->click('@next-link')
+            ->waitForTextIn('@page-marker', 'page-two')
+            ->waitForTextIn('@target', 'navigate-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_a_lazy_components_script_runs_against_its_real_markup_not_the_placeholder()
+    {
+        // The non-lazy instance warms the module cache, so the lazy instance's
+        // import resolves instantly — before the hydration morph, without the
+        // morph gate. The script records whether it saw the real markup...
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <livewire:testns::lazy-probe key="eager" />
+                    <livewire:testns::lazy-probe key="lazy" lazy />
+                </div>
+                HTML;
+            }
+        }])
+            ->waitUntil("window.lazyProbeResults && window.lazyProbeResults.length === 2")
+            ->assertScript('window.lazyProbeResults.every(sawRealMarkup => sawRealMarkup)', true)
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_x_cloak_is_honored_while_the_module_is_loading()
+    {
+        // The /slow-module.js import keeps the component's module pending
+        // until the test releases it, holding the suspended window open...
+        Livewire::visit('testns::slow-alpine-data')
+            ->waitUntil('typeof window.releaseSlowModule === "function"')
+            ->assertScript('document.querySelector(\'[dusk="wrapper"]\').hasAttribute(\'x-cloak\')', true)
+            ->tap(fn ($b) => $b->script('window.releaseSlowModule()'))
+            ->waitForTextIn('@target', 'slow-data-loaded')
+            ->assertScript('document.querySelector(\'[dusk="wrapper"]\').hasAttribute(\'x-cloak\')', false)
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_a_component_removed_while_its_module_loads_never_runs_its_script()
+    {
+        Livewire::visit([new class extends Component {
+            public $show = false;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="$toggle('show')" dusk="toggle">Toggle</button>
+
+                    @if ($show)
+                        <livewire:testns::slow-alpine-data />
+                    @endif
+                </div>
+                HTML;
+            }
+        }])
+            ->waitForLivewire()->click('@toggle')
+            ->waitUntil('typeof window.releaseSlowModule === "function"')
+            // Remove the component before its module resolves...
+            ->waitForLivewire()->click('@toggle')
+            ->tap(fn ($b) => $b->script('window.releaseSlowModule()'))
+            ->pause(300)
+            ->assertScript('window.slowModuleRan === undefined', true)
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_a_failed_module_import_still_initializes_the_component_and_the_rest_of_the_page()
+    {
+        // The /missing-module.js import 404s, so the module never loads. The
+        // component's tree must initialize anyway (fail open), and other
+        // components on the page must be unaffected...
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <livewire:testns::broken-import />
+
+                    <div x-data="{ message: 'sibling-works' }">
+                        <span dusk="sibling" x-text="message"></span>
+                    </div>
+                </div>
+                HTML;
+            }
+        }])
+            ->waitForTextIn('@sibling', 'sibling-works')
+            ->assertSeeIn('@broken-target', 'server-rendered')
+            // The failed component's own tree still initializes (fail open):
+            // an Alpine binding inside it that doesn't need the module renders...
+            ->waitForTextIn('@broken-fail-open', 'initialized-anyway');
+    }
+
+    public function test_a_script_that_throws_still_initializes_the_component_and_the_rest_of_the_page()
+    {
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <livewire:testns::run-throws />
+
+                    <div x-data="{ message: 'sibling-works' }">
+                        <span dusk="sibling" x-text="message"></span>
+                    </div>
+                </div>
+                HTML;
+            }
+        }])
+            ->waitForTextIn('@sibling', 'sibling-works')
+            ->assertSeeIn('@throws-target', 'server-rendered')
+            ->waitForTextIn('@throws-fail-open', 'initialized-anyway');
     }
 }

--- a/src/Features/SupportJsModules/BrowserTest.php
+++ b/src/Features/SupportJsModules/BrowserTest.php
@@ -243,6 +243,35 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertConsoleLogHasNoErrors();
     }
 
+    public function test_a_module_preload_link_is_injected_into_the_head()
+    {
+        // The initial page render emits a modulepreload link so the browser
+        // starts fetching the module while parsing — before Livewire boots...
+        Livewire::visit('testns::alpine-data')
+            ->assertScript('!! document.head.querySelector(\'link[rel="modulepreload"][href*="testns---alpine-data.js"]\')', true)
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
+    public function test_a_module_preload_link_is_injected_for_lazy_components()
+    {
+        // Even though a lazy placeholder mounts without its scriptModule
+        // effect, the page render still warms the module it will need...
+        Livewire::visit([new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <livewire:testns::alpine-data lazy />
+                </div>
+                HTML;
+            }
+        }])
+            ->assertScript('!! document.head.querySelector(\'link[rel="modulepreload"][href*="testns---alpine-data.js"]\')', true)
+            ->waitForTextIn('@target', 'alpine-data-loaded')
+            ->assertConsoleLogHasNoErrors();
+    }
+
     public function test_x_cloak_is_honored_while_the_module_is_loading()
     {
         // The /slow-module.js import keeps the component's module pending

--- a/src/Features/SupportJsModules/SupportJsModules.php
+++ b/src/Features/SupportJsModules/SupportJsModules.php
@@ -5,12 +5,21 @@ namespace Livewire\Features\SupportJsModules;
 use Illuminate\Support\Facades\Route;
 use Livewire\ComponentHook;
 use Livewire\Drawer\Utils;
+use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
+
+use function Livewire\on;
 
 class SupportJsModules extends ComponentHook
 {
+    protected static $modulesMountedThisRequest = [];
+
     static function provide()
     {
+        on('flush-state', function () {
+            static::$modulesMountedThisRequest = [];
+        });
+
         Route::get(EndpointResolver::componentJsPath(), function ($component) {
             $component = str_replace('----', ':', $component);
             $component = str_replace('---', '::', $component);
@@ -42,10 +51,15 @@ class SupportJsModules extends ComponentHook
 
     public function dehydrate($context)
     {
-        // Don't add scriptModule effect during lazy-loading placeholder mount.
-        // The component's view isn't rendered yet, so @assets won't have run.
-        // The scriptModule will be added when __lazyLoad triggers the real mount.
-        if ($this->storeGet('isLazyLoadMounting') === true) return;
+        // The placeholder mount of a lazy component doesn't get a scriptModule
+        // effect (its view hasn't rendered yet), but the full-page render can
+        // still start the module's fetch from the head so it's warm by the
+        // time the real mount arrives...
+        if ($this->storeGet('isLazyLoadMounting') === true) {
+            $this->registerModulePreloadAsset();
+
+            return;
+        }
 
         // Add scriptModule effect during:
         // 1. Normal component mounting ($context->isMounting())
@@ -53,7 +67,15 @@ class SupportJsModules extends ComponentHook
         $isNormalMount = $context->isMounting();
         $isLazyLoadHydration = $this->storeGet('isLazyLoadHydrating') === true;
 
-        if (! $isNormalMount && ! $isLazyLoadHydration) return;
+        if (! $isNormalMount && ! $isLazyLoadHydration) {
+            // This component is being updated rather than mounted. If any
+            // children with script modules mounted during this request, tell
+            // the client now so it can start fetching their modules before
+            // the morph that adds them to the page...
+            $this->flushModulesMountedThisRequest($context);
+
+            return;
+        }
 
         if (method_exists($this->component, 'scriptModuleSrc')) {
             $path = $this->component->scriptModuleSrc();
@@ -63,6 +85,68 @@ class SupportJsModules extends ComponentHook
             $hash = crc32($filemtime);
 
             $context->addEffect('scriptModule', $hash);
+
+            if ($isNormalMount) {
+                // On an initial page load, a modulepreload link in the head
+                // starts the fetch during HTML parsing — long before Livewire
+                // boots and discovers the module itself...
+                $this->registerModulePreloadAsset();
+
+                // During an update request, the mount belongs to a new child —
+                // collect it so the update's root component can announce it...
+                static::$modulesMountedThisRequest[$this->component->getName()] = $hash;
+            }
         }
+
+        // A hydrating lazy component's children mount during its render —
+        // announce their modules the same way an updating component does...
+        if ($isLazyLoadHydration) {
+            $this->flushModulesMountedThisRequest($context);
+        }
+    }
+
+    protected function registerModulePreloadAsset()
+    {
+        // Preloading is for full-page renders, where the link lands in the
+        // head during HTML parsing. Rendered assets also ride along in update
+        // payloads, so skip update requests entirely — new children there are
+        // announced through the childScriptModules effect instead...
+        if (app('livewire')->isLivewireRequest()) return;
+
+        if (! method_exists($this->component, 'scriptModuleSrc')) return;
+
+        $path = $this->component->scriptModuleSrc();
+
+        if (! file_exists($path)) return;
+
+        $hash = crc32(filemtime($path));
+
+        $url = static::moduleUrl($this->component->getName(), $hash);
+
+        SupportScriptsAndAssets::$renderedAssets['module-preload:'.$url] = '<link rel="modulepreload" href="'.$url.'">';
+    }
+
+    protected function flushModulesMountedThisRequest($context)
+    {
+        if (empty(static::$modulesMountedThisRequest)) return;
+
+        $modules = [];
+
+        foreach (static::$modulesMountedThisRequest as $name => $hash) {
+            $modules[] = ['name' => $name, 'hash' => $hash];
+        }
+
+        static::$modulesMountedThisRequest = [];
+
+        $context->addEffect('childScriptModules', $modules);
+    }
+
+    public static function moduleUrl($name, $hash)
+    {
+        $encodedName = str_replace('.', '--', $name);
+        $encodedName = str_replace('::', '---', $encodedName);
+        $encodedName = str_replace(':', '----', $encodedName);
+
+        return url(app('livewire')->getUriPrefix()).'/js/'.$encodedName.'.js?v='.$hash;
     }
 }

--- a/src/Features/SupportJsModules/UnitTest.php
+++ b/src/Features/SupportJsModules/UnitTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Livewire\Features\SupportJsModules;
+
+use Illuminate\Support\Facades\Route;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class UnitTest extends \Tests\TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Statics like the rendered-assets bucket survive between tests in
+        // the same process...
+        Livewire::flushState();
+
+        app('livewire.finder')->addNamespace('testns', viewPath: __DIR__.'/fixtures');
+    }
+
+    public function test_an_initial_render_injects_a_module_preload_link_into_the_head()
+    {
+        Route::get('/module-preload-test', fn () => app('livewire')->new('testns::alpine-data')());
+
+        $response = $this->get('/module-preload-test');
+
+        $response->assertSee('<link rel="modulepreload"', false);
+        $response->assertSee('testns---alpine-data.js?v=', false);
+    }
+
+    public function test_a_component_without_a_script_module_injects_no_preload_link()
+    {
+        Route::get('/no-module-preload-test', fn () => app('livewire')->new('testns::no-module')());
+
+        $response = $this->get('/no-module-preload-test');
+
+        $response->assertDontSee('modulepreload');
+    }
+
+    public function test_an_update_that_mounts_a_child_announces_the_childs_script_module()
+    {
+        $component = Livewire::test(new class extends Component {
+            public $show = false;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @if ($show)
+                        <livewire:testns::alpine-data />
+                    @endif
+                </div>
+                HTML;
+            }
+        });
+
+        $this->assertArrayNotHasKey('childScriptModules', $component->effects);
+
+        $component->set('show', true);
+
+        $modules = $component->effects['childScriptModules'] ?? null;
+
+        $this->assertNotNull($modules);
+        $this->assertCount(1, $modules);
+        $this->assertSame('testns::alpine-data', $modules[0]['name']);
+        $this->assertArrayHasKey('hash', $modules[0]);
+    }
+
+    public function test_child_module_announcements_are_not_repeated_on_the_next_update()
+    {
+        $component = Livewire::test(new class extends Component {
+            public $show = false;
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @if ($show)
+                        <livewire:testns::alpine-data />
+                    @endif
+                </div>
+                HTML;
+            }
+        });
+
+        $component->set('show', true);
+
+        $this->assertArrayHasKey('childScriptModules', $component->effects);
+
+        // The collector drains on announcement — the next update mounts
+        // nothing new and must announce nothing...
+        $component->call('$refresh');
+
+        $this->assertArrayNotHasKey('childScriptModules', $component->effects);
+    }
+
+    public function test_lazy_hydration_announces_the_script_modules_of_children_it_mounts()
+    {
+        \Livewire\Features\SupportLazyLoading\SupportLazyLoading::$disableWhileTesting = false;
+
+        try {
+            $component = Livewire::test('testns::lazy-wrapper');
+
+            preg_match("/__lazyLoad\('([^']+)'\)/", html_entity_decode($component->html()), $matches);
+
+            $this->assertNotEmpty($matches[1] ?? null);
+
+            $component->call('__lazyLoad', $matches[1]);
+
+            $modules = $component->effects['childScriptModules'] ?? null;
+
+            $this->assertNotNull($modules);
+            $this->assertCount(1, $modules);
+            $this->assertSame('testns::alpine-data', $modules[0]['name']);
+        } finally {
+            \Livewire\Features\SupportLazyLoading\SupportLazyLoading::$disableWhileTesting = true;
+        }
+    }
+
+    public function test_an_update_that_mounts_no_new_children_announces_nothing()
+    {
+        $component = Livewire::test(new class extends Component {
+            public $count = 0;
+
+            public function render()
+            {
+                return '<div>{{ $count }}</div>';
+            }
+        });
+
+        $component->set('count', 1);
+
+        $this->assertArrayNotHasKey('childScriptModules', $component->effects);
+    }
+}

--- a/src/Features/SupportJsModules/fixtures/alpine-data.blade.php
+++ b/src/Features/SupportJsModules/fixtures/alpine-data.blade.php
@@ -1,0 +1,18 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div x-data="testAlpineData">
+    <span dusk="target" x-text="message"></span>
+
+    <button dusk="refresh" wire:click="$refresh">refresh</button>
+</div>
+
+<script>
+    Alpine.data('testAlpineData', () => ({
+        message: 'alpine-data-loaded',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/broken-import.blade.php
+++ b/src/Features/SupportJsModules/fixtures/broken-import.blade.php
@@ -1,0 +1,22 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <span dusk="broken-target">server-rendered</span>
+
+    <span dusk="broken-binding" x-data="brokenImportData" x-text="message"></span>
+
+    <span dusk="broken-fail-open" x-data="{ message: 'initialized-anyway' }" x-text="message"></span>
+</div>
+
+<script>
+    import '/missing-module.js'
+
+    Alpine.data('brokenImportData', () => ({
+        message: 'never',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/island-with-alpine-data.blade.php
+++ b/src/Features/SupportJsModules/fixtures/island-with-alpine-data.blade.php
@@ -1,0 +1,23 @@
+<?php
+
+new class extends Livewire\Component {
+    public bool $show = false;
+
+    public function toggle()
+    {
+        $this->show = ! $this->show;
+    }
+};
+?>
+
+<div>
+    @island
+        <div dusk="placeholder">No child yet</div>
+
+        @if ($show)
+            <livewire:testns::alpine-data />
+        @endif
+
+        <button dusk="toggle" wire:click="toggle">toggle</button>
+    @endisland
+</div>

--- a/src/Features/SupportJsModules/fixtures/lazy-probe.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-probe.blade.php
@@ -1,0 +1,22 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div x-data="lazyProbe">
+    <span data-real dusk="probe-target" x-text="message"></span>
+</div>
+
+<script>
+    window.lazyProbeResults = window.lazyProbeResults || []
+
+    // Records whether this component's REAL markup (not a lazy placeholder)
+    // was in the DOM when its script ran...
+    window.lazyProbeResults.push(!! $wire.$el.querySelector('[data-real]'))
+
+    Alpine.data('lazyProbe', () => ({
+        message: 'probe-loaded',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/lazy-wrapper.blade.php
+++ b/src/Features/SupportJsModules/fixtures/lazy-wrapper.blade.php
@@ -1,0 +1,10 @@
+<?php
+
+new #[\Livewire\Attributes\Lazy] class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <livewire:testns::alpine-data />
+</div>

--- a/src/Features/SupportJsModules/fixtures/navigate-page.blade.php
+++ b/src/Features/SupportJsModules/fixtures/navigate-page.blade.php
@@ -1,0 +1,20 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div x-data="navigateAlpineData">
+    <div dusk="page-marker">page-{{ request()->query('page', 'one') }}</div>
+
+    <span dusk="target" x-text="message"></span>
+
+    <a href="/navigate-page?page=two" wire:navigate dusk="next-link">next</a>
+</div>
+
+<script>
+    Alpine.data('navigateAlpineData', () => ({
+        message: 'navigate-data-loaded',
+    }))
+</script>

--- a/src/Features/SupportJsModules/fixtures/no-module.blade.php
+++ b/src/Features/SupportJsModules/fixtures/no-module.blade.php
@@ -1,0 +1,10 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <span>no module here</span>
+</div>

--- a/src/Features/SupportJsModules/fixtures/run-throws.blade.php
+++ b/src/Features/SupportJsModules/fixtures/run-throws.blade.php
@@ -1,0 +1,16 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div>
+    <span dusk="throws-target">server-rendered</span>
+
+    <span dusk="throws-fail-open" x-data="{ message: 'initialized-anyway' }" x-text="message"></span>
+</div>
+
+<script>
+    throw new Error('boom')
+</script>

--- a/src/Features/SupportJsModules/fixtures/slow-alpine-data.blade.php
+++ b/src/Features/SupportJsModules/fixtures/slow-alpine-data.blade.php
@@ -1,0 +1,20 @@
+<?php
+
+new class extends Livewire\Component {
+    //
+};
+?>
+
+<div dusk="wrapper" x-data="slowAlpineData" x-cloak>
+    <span dusk="target" x-text="message"></span>
+</div>
+
+<script>
+    import '/slow-module.js'
+
+    window.slowModuleRan = true
+
+    Alpine.data('slowAlpineData', () => ({
+        message: 'slow-data-loaded',
+    }))
+</script>

--- a/src/Features/SupportLegacyModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentCollectionSynth.php
@@ -3,10 +3,11 @@
 namespace Livewire\Features\SupportLegacyModels;
 
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use LogicException;
 
-class EloquentCollectionSynth extends Synth
+class EloquentCollectionSynth extends Synth implements ArrayShapedSynth
 {
     public static $key = 'elcl';
 

--- a/src/Features/SupportLegacyModels/EloquentModelSynth.php
+++ b/src/Features/SupportLegacyModels/EloquentModelSynth.php
@@ -4,11 +4,12 @@ namespace Livewire\Features\SupportLegacyModels;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\ClassMorphViolationException;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
-class EloquentModelSynth extends Synth
+class EloquentModelSynth extends Synth implements ArrayShapedSynth
 {
     public static $key = 'elmdl';
 

--- a/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
+++ b/src/Features/SupportLegacyModels/Tests/PublicPropertyHydrationAndDehydrationUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportLegacyModels\Tests;
 
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Livewire\Livewire;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -56,6 +57,26 @@ class PublicPropertyHydrationAndDehydrationUnitTest extends \Tests\TestCase
 
         $component = Livewire::test(PostComponent::class);
         $this->assertEquals('Livewire\Features\SupportLegacyModels\Tests\Post', $component->snapshot['data']['post'][1]['class']);
+    }
+
+    public function test_legacy_models_and_collections_can_be_replaced_with_scalars_during_an_update()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public $model;
+            public $models;
+
+            public function mount()
+            {
+                $this->model = new Post;
+                $this->models = new EloquentCollection([new Post]);
+            }
+        });
+
+        $component->set('model', 1);
+        $component->set('models', 2);
+
+        $this->assertSame(1, $component->get('model'));
+        $this->assertSame(2, $component->get('models'));
     }
 
     public function test_it_uses_class_name_if_laravels_morph_map_not_available_when_hydrating()

--- a/src/Features/SupportPageComponents/SupportPageComponents.php
+++ b/src/Features/SupportPageComponents/SupportPageComponents.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Features\SupportPageComponents;
 
-use function Livewire\{on, off, once};
+use function Livewire\{on, once};
 use Livewire\Drawer\ImplicitRouteBinding;
 use Livewire\ComponentHook;
 use Livewire\Mechanisms\HandleRouting\LivewirePageController;
@@ -112,13 +112,15 @@ class SupportPageComponents extends ComponentHook
             };
         });
 
-        on('render', $handler);
-        on('render.placeholder', $handler);
+        $render = on('render', $handler);
+        $renderPlaceholder = on('render.placeholder', $handler);
 
-        $callback();
-
-        off('render', $handler);
-        off('render.placeholder', $handler);
+        try {
+            $callback();
+        } finally {
+            $render();
+            $renderPlaceholder();
+        }
 
         return $layoutConfig;
     }

--- a/src/Features/SupportPageComponents/UnitTest.php
+++ b/src/Features/SupportPageComponents/UnitTest.php
@@ -9,7 +9,10 @@ use Illuminate\Http\Response;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Blade;
 use Livewire\Component;
+use Livewire\EventBus;
 use Livewire\Livewire;
+
+use function Livewire\invade;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -477,6 +480,48 @@ class UnitTest extends \Tests\TestCase
             ->get('/teams/99/projects/42')
             ->assertSee('project:42')
             ->assertSee('team:none');
+    }
+
+    public function test_render_interceptor_removes_listeners_when_callback_throws()
+    {
+        $eventBus = invade(app(EventBus::class));
+
+        $renderListenersBefore = $eventBus->listeners['render'] ?? [];
+        $placeholderListenersBefore = $eventBus->listeners['render.placeholder'] ?? [];
+
+        try {
+            SupportPageComponents::interceptTheRenderOfTheComponentAndRetreiveTheLayoutConfiguration(function () {
+                throw new \RuntimeException;
+            });
+        } catch (\RuntimeException) {
+            //
+        }
+
+        $this->assertSame(
+            $renderListenersBefore,
+            $eventBus->listeners['render'] ?? [],
+        );
+
+        $this->assertSame(
+            $placeholderListenersBefore,
+            $eventBus->listeners['render.placeholder'] ?? [],
+        );
+    }
+
+    public function test_page_component_falls_back_to_default_layout_when_no_layout_is_captured()
+    {
+        config()->set('livewire.component_layout', 'layouts::panel');
+
+        $layoutConfig = SupportPageComponents::interceptTheRenderOfTheComponentAndRetreiveTheLayoutConfiguration(function () {
+            // Intentionally do nothing – no render / render.placeholder is fired
+        });
+
+        $this->assertNull($layoutConfig);
+
+        // Exact fallback used by HandlesPageComponents::__invoke
+        $fallback = $layoutConfig ?: new PageComponentConfig;
+
+        $this->assertSame('layouts::panel', $fallback->view);
     }
 }
 

--- a/src/Features/SupportPolling/BrowserTest.php
+++ b/src/Features/SupportPolling/BrowserTest.php
@@ -27,6 +27,48 @@ class BrowserTest extends BrowserTestCase
             ;
     }
 
+    public function test_poll_duration_can_be_in_minutes()
+    {
+        Livewire::visit(new class extends Component {
+            public $pollCount = 0;
+            public $polling = false;
+
+            public function startPolling()
+            {
+                $this->polling = true;
+            }
+
+            public function poll()
+            {
+                $this->pollCount++;
+            }
+
+            public function render() { return <<<'HTML'
+            <div>
+                <button wire:click="startPolling" dusk="start-polling">Start polling</button>
+                <span dusk="poll-count">{{ $pollCount }}</span>
+
+                @if ($polling)
+                    <div wire:poll.1m="poll"></div>
+                @endif
+            </div>
+            HTML; }
+        })
+        ->tap(fn ($b) => $b->script(<<<'JS'
+            window.originalSetInterval = window.setInterval
+            window.setInterval = (callback, duration) => {
+                window.pollDuration = duration
+                window.setInterval = window.originalSetInterval
+
+                return window.setTimeout(callback)
+            }
+            JS))
+        ->waitForLivewire()->click('@start-polling')
+        ->assertScript('window.pollDuration', 60000)
+        ->waitForTextIn('@poll-count', '1')
+        ;
+    }
+
     public function test_polling_requests_are_batched_by_default()
     {
         Livewire::visit([new class extends Component {

--- a/src/Features/SupportQueryString/BaseUrl.php
+++ b/src/Features/SupportQueryString/BaseUrl.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportQueryString;
 
 use Illuminate\Support\Arr;
+use Livewire\Drawer\Utils;
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
 use Livewire\Features\SupportFormObjects\Form;
 use Livewire\Mechanisms\HandleComponents\ComponentContext;
@@ -67,9 +68,34 @@ class BaseUrl extends LivewireAttribute
             ? json_decode(json_encode($initialValue, flags: JSON_BIGINT_AS_STRING), true, flags: JSON_BIGINT_AS_STRING)
             : json_decode($initialValue ?? '', true, flags: JSON_BIGINT_AS_STRING);
 
+        $original = $this->getValue();
+
+        if (is_string($initialValue) && is_array($decoded)) {
+            $target = $this->getSubTarget() ?? $this->getComponent();
+            $property = $this->getSubName() ?? $this->getName();
+
+            $decodedMatchesPropertyType = Utils::propertyTypeMatchesValue(
+                $target,
+                $property,
+                $decoded,
+            );
+            $initialValueMatchesPropertyType = Utils::propertyTypeMatchesValue(
+                $target,
+                $property,
+                $initialValue,
+            );
+
+            $propertyTypePrefersInitialValue = $decodedMatchesPropertyType === false && $initialValueMatchesPropertyType === true;
+            $untypedPropertyCurrentlyContainsString = $decodedMatchesPropertyType === null && is_string($original);
+
+            if ($propertyTypePrefersInitialValue || $untypedPropertyCurrentlyContainsString) {
+                $decoded = null;
+            }
+        }
+
         // If only part of an array is present in the query string,
         // we want to merge instead of override the value...
-        if (is_array($decoded) && is_array($original = $this->getValue())) {
+        if (is_array($decoded) && is_array($original)) {
             $decoded = $this->recursivelyMergeArraysWithoutAppendingDuplicateValues($original, $decoded);
         }
 

--- a/src/Features/SupportQueryString/BrowserTest.php
+++ b/src/Features/SupportQueryString/BrowserTest.php
@@ -11,6 +11,30 @@ use Illuminate\Support\Facades\Route;
 
 class BrowserTest extends \Tests\BrowserTestCase
 {
+    public function test_structured_string_query_parameters_remain_strings()
+    {
+        Livewire::withQueryParams([
+            'search' => '[123]',
+        ])->visit([
+            new class extends Component
+            {
+                #[Url]
+                public $search = '';
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <span dusk="search">{{ $search }}</span>
+                    </div>
+                    HTML;
+                }
+            },
+        ])
+            ->assertSeeIn('@search', '[123]')
+            ->assertQueryStringHas('search', '[123]');
+    }
+
     public function test_it_does_not_add_null_values_to_the_query_string_array()
     {
         Livewire::visit([

--- a/src/Features/SupportQueryString/UnitTest.php
+++ b/src/Features/SupportQueryString/UnitTest.php
@@ -109,6 +109,82 @@ class UnitTest extends \Tests\TestCase
         $this->assertSame($largeNumber, $component->instance()->tableSearch);
     }
 
+    function test_structured_strings_are_preserved_from_query_string()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => '[123]',
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public $search = '';
+        });
+
+        $this->assertSame('[123]', $component->instance()->search);
+    }
+
+    function test_structured_strings_are_preserved_by_the_public_url_attribute()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => '[123]',
+        ])->test(new class extends TestComponent {
+            #[\Livewire\Attributes\Url]
+            public $search = '';
+        });
+
+        $this->assertSame('[123]', $component->instance()->search);
+    }
+
+    function test_structured_strings_are_preserved_for_uninitialized_nullable_string_properties()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => '[123]',
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public ?string $search;
+        });
+
+        $this->assertSame('[123]', $component->instance()->search);
+    }
+
+    function test_structured_strings_are_preserved_for_legacy_query_string_properties()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => '[123]',
+        ])->test(new class extends TestComponent {
+            public ?string $search;
+
+            protected function queryString()
+            {
+                return ['search'];
+            }
+        });
+
+        $this->assertSame('[123]', $component->instance()->search);
+    }
+
+    function test_structured_values_are_decoded_when_a_union_type_accepts_arrays()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => '{"id":123}',
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public string|array|null $search;
+        });
+
+        $this->assertSame(['id' => 123], $component->instance()->search);
+    }
+
+    function test_bracketed_query_string_arrays_remain_arrays_when_a_union_type_accepts_them()
+    {
+        $component = Livewire::withQueryParams([
+            'search' => [123],
+        ])->test(new class extends TestComponent {
+            #[BaseUrl]
+            public string|array|null $search;
+        });
+
+        $this->assertSame([123], $component->instance()->search);
+    }
+
     function test_large_numbers_in_arrays_are_preserved_from_query_string()
     {
         $largeNumber = '74350194073086909398128';

--- a/src/Features/SupportRedirects/UnitTest.php
+++ b/src/Features/SupportRedirects/UnitTest.php
@@ -288,6 +288,15 @@ class UnitTest extends \Tests\TestCase
         $this->assertEquals('livewire-is-awesome', Session::get('success'));
     }
 
+    public function test_redirect_response_is_not_included_in_returns()
+    {
+        $component = Livewire::test(TriggersRedirectStub::class);
+
+        $component->runAction('triggerRedirectHelper');
+
+        $this->assertNull($component->effects['returns'][0]);
+    }
+
     protected function registerNamedRoute()
     {
         Route::get('foo', function () {

--- a/src/Features/SupportTesting/RequestBroker.php
+++ b/src/Features/SupportTesting/RequestBroker.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\Concerns\MakesHttpRequests;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Livewire\Mechanisms\HandleRequests\HandleRequests;
 
 class RequestBroker
 {
@@ -27,15 +28,17 @@ class RequestBroker
 
         $this->withoutExceptionHandling([HttpException::class, AuthorizationException::class])->withoutMiddleware();
 
-        $result = $callback($this);
+        try {
+            return app(HandleRequests::class)->temporarilyPropagateExceptions(
+                fn () => $callback($this),
+            );
+        } finally {
+            $this->app->instance(ExceptionHandler::class, $cachedHandler);
 
-        $this->app->instance(ExceptionHandler::class, $cachedHandler);
-
-        if (! $cachedShouldSkipMiddleware) {
-            unset($this->app['middleware.disable']);
+            if (! $cachedShouldSkipMiddleware) {
+                unset($this->app['middleware.disable']);
+            }
         }
-
-        return $result;
     }
 
     function withoutHandling($except = [])

--- a/src/Features/SupportTesting/UnitTest.php
+++ b/src/Features/SupportTesting/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportTesting;
 
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Validation\ValidationRule;
 use PHPUnit\Framework\ExpectationFailedException;
 use Illuminate\Support\Facades\Artisan;
@@ -560,6 +561,52 @@ class UnitTest extends \LegacyTests\Unit\TestCase
             ->assertReturned(fn ($data) => $data === 'bar');
     }
 
+    function test_type_errors_thrown_from_component_actions_are_rethrown()
+    {
+        config()->set('app.debug', false);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('array_merge(): Argument #1 must be of type array, Illuminate\\Support\\Collection given');
+
+        Livewire::test(ComponentWithActionThatThrowsTypeError::class)
+            ->call('save');
+    }
+
+    function test_type_errors_thrown_while_binding_component_action_parameters_are_rethrown()
+    {
+        config()->set('app.debug', false);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('must be of type array, string given');
+
+        Livewire::test(ComponentWithActionThatThrowsTypeError::class)
+            ->call('saveItems', 'not-an-array');
+    }
+
+    function test_exception_handling_and_middleware_are_restored_after_component_exceptions()
+    {
+        config()->set('app.debug', false);
+
+        $cachedHandler = app(ExceptionHandler::class);
+        $cachedShouldSkipMiddleware = app()->shouldSkipMiddleware();
+
+        try {
+            Livewire::test(ComponentWithActionThatThrowsTypeError::class)
+                ->call('save');
+
+            $this->fail('The component TypeError was not rethrown.');
+        } catch (\TypeError $e) {
+            $this->assertStringContainsString('array_merge()', $e->getMessage());
+        }
+
+        $this->assertSame($cachedHandler, app(ExceptionHandler::class));
+        $this->assertSame($cachedShouldSkipMiddleware, app()->shouldSkipMiddleware());
+
+        Livewire::test(ComponentWithMethodThatReturnsData::class)
+            ->call('foo')
+            ->assertReturned('bar');
+    }
+
     public function test_can_set_cookies_for_use_with_testing()
     {
         // Test both the `withCookies` and `withCookie` methods that Laravel normally provides
@@ -804,6 +851,18 @@ class ComponentWithMethodThatReturnsData extends TestComponent
     function foo()
     {
         return 'bar';
+    }
+}
+
+class ComponentWithActionThatThrowsTypeError extends TestComponent
+{
+    function save()
+    {
+        array_merge(collect(), []);
+    }
+
+    function saveItems(array $items)
+    {
     }
 }
 

--- a/src/Features/SupportTransitions/BrowserTest.php
+++ b/src/Features/SupportTransitions/BrowserTest.php
@@ -500,4 +500,92 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->waitUntil("!$animationsRunning")
         ;
     }
+
+    public function test_transition_runs_when_popover_stays_open_without_visible_content()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $show = false;
+
+                public function toggle()
+                {
+                    $this->show = ! $this->show;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="toggle" dusk="toggle">Toggle</button>
+
+                        @if ($show)
+                            <div wire:transition dusk="target">Hello</div>
+                        @endif
+
+                        <div popover="manual" dusk="toast-host" x-init="$el.showPopover()">
+                            <template>
+                                <div>Hidden popover content</div>
+                            </template>
+                        </div>
+                    </div>
+                    HTML;
+                }
+            }
+        )
+        ->waitUntil("document.querySelector('[dusk=toast-host]').matches(':popover-open')")
+        ->tap(fn ($browser) => $browser->script("
+            window.__startViewTransitionCalled = false
+            let original = document.startViewTransition.bind(document)
+            document.startViewTransition = function (...args) {
+                window.__startViewTransitionCalled = true
+                return original(...args)
+            }
+        "))
+        ->waitForLivewire()->click('@toggle')
+        ->waitFor('@target')
+        ->assertScript('window.__startViewTransitionCalled', true);
+    }
+
+    public function test_transition_does_not_run_when_popover_has_visible_content()
+    {
+        Livewire::visit(
+            new class extends \Livewire\Component {
+                public $show = false;
+
+                public function toggle()
+                {
+                    $this->show = ! $this->show;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button wire:click="toggle" dusk="toggle">Toggle</button>
+
+                        @if ($show)
+                            <div wire:transition dusk="target">Hello</div>
+                        @endif
+
+                        <div popover="manual" dusk="toast-host" x-init="$el.showPopover()">
+                            <div>Visible popover content</div>
+                        </div>
+                    </div>
+                    HTML;
+                }
+            }
+        )
+        ->waitUntil("document.querySelector('[dusk=toast-host]').matches(':popover-open')")
+        ->tap(fn ($browser) => $browser->script("
+            window.__startViewTransitionCalled = false
+            let original = document.startViewTransition.bind(document)
+            document.startViewTransition = function (...args) {
+                window.__startViewTransitionCalled = true
+                return original(...args)
+            }
+        "))
+        ->waitForLivewire()->click('@toggle')
+        ->waitFor('@target')
+        ->assertScript('window.__startViewTransitionCalled', false);
+    }
 }

--- a/src/Features/SupportValidation/HandlesValidation.php
+++ b/src/Features/SupportValidation/HandlesValidation.php
@@ -512,6 +512,8 @@ trait HandlesValidation
     protected function unwrapDataForValidation($data)
     {
         return collect($data)->map(function ($value) {
+            // Scalars and arrays are already valid Laravel validation data...
+            if (! is_object($value)) return $value;
 
             $synth = app('livewire')->findSynth($value, $this);
 

--- a/src/Features/SupportValidation/UnitTest.php
+++ b/src/Features/SupportValidation/UnitTest.php
@@ -15,7 +15,9 @@ use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\AssertionFailedError;
+use Sushi\Sushi;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -1036,6 +1038,300 @@ class UnitTest extends \Tests\TestCase
 
         $component->assertOnlyHasErrors(['foo' => 'min', 'bar' => 'min']);
     }
+
+    public function test_validation_ready_data_is_not_resolved_by_synthesizers()
+    {
+        $livewire = new class {
+            public int $findSynthCalls = 0;
+
+            public function findSynth($value, $component)
+            {
+                $this->findSynthCalls++;
+            }
+        };
+
+        app()->instance('livewire', $livewire);
+
+        $component = new class extends TestComponent {
+            public function unwrap($data)
+            {
+                return $this->unwrapDataForValidation($data);
+            }
+        };
+
+        $data = [
+            'string' => 'Livewire',
+            'integer' => 4,
+            'float' => 4.0,
+            'boolean' => true,
+            'null' => null,
+            'array' => ['already', 'valid'],
+        ];
+
+        $this->assertSame($data, $component->unwrap($data));
+        $this->assertSame(0, $livewire->findSynthCalls);
+    }
+
+    public function test_validate_only_unwraps_an_array_access_sibling_used_in_a_dependent_rule()
+    {
+        ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
+
+        Livewire::test(new class extends TestComponent {
+            public $title = 'Livewire';
+
+            public $settings;
+
+            public function mount()
+            {
+                $this->settings = new ValidationUnwrappingSpyCollection([
+                    'required_title' => 'Livewire',
+                ]);
+            }
+
+            public function validateTitle()
+            {
+                $this->validateOnly('title', [
+                    'title' => 'same:settings.required_title',
+                ]);
+            }
+        })->call('validateTitle')->assertHasNoErrors();
+
+        $this->assertSame(1, ValidationUnwrappingSpyCollection::$toArrayCalls);
+    }
+
+    public function test_validate_only_dependent_rule_against_a_sibling_still_fails_when_it_should()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $title = 'Different';
+
+            public $settings;
+
+            public function mount()
+            {
+                $this->settings = new ValidationUnwrappingSpyCollection([
+                    'required_title' => 'Livewire',
+                ]);
+            }
+
+            public function validateTitle()
+            {
+                $this->validateOnly('title', [
+                    'title' => 'same:settings.required_title',
+                ]);
+            }
+        })->call('validateTitle')->assertHasErrors(['title' => 'same']);
+    }
+
+    public function test_validate_only_supports_wildcard_dependent_rule_parameters_against_a_collection_sibling()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $chosen = 2;
+
+            public $options;
+
+            public function mount()
+            {
+                $this->options = collect([['id' => 1], ['id' => 2]]);
+            }
+
+            public function validateChosen()
+            {
+                $this->validateOnly('chosen', [
+                    'chosen' => 'in_array:options.*.id',
+                ]);
+            }
+        })->call('validateChosen')->assertHasNoErrors()
+            ->set('chosen', 99)
+            ->call('validateChosen')->assertHasErrors(['chosen' => 'in_array']);
+    }
+
+    public function test_validate_only_can_compare_against_a_whole_collection_sibling()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $copy = ['a'];
+
+            public $original;
+
+            public function mount()
+            {
+                $this->original = collect(['a']);
+            }
+
+            public function validateCopy()
+            {
+                $this->validateOnly('copy', [
+                    'copy' => 'same:original',
+                ]);
+            }
+        })->call('validateCopy')->assertHasNoErrors();
+    }
+
+    public function test_validate_only_dependent_rules_read_a_model_sibling_the_same_as_full_validation()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $reason = '';
+
+            public $article;
+
+            public function mount()
+            {
+                $this->article = ArticleForValidationUnwrappingTesting::first();
+            }
+
+            public function validateReason()
+            {
+                $this->validateOnly('reason', [
+                    'reason' => 'required_if:article.status,published',
+                ]);
+            }
+        })->call('validateReason')->assertHasErrors(['reason' => 'required_if']);
+    }
+
+    public function test_validate_only_with_validator_callbacks_see_unwrapped_siblings()
+    {
+        ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
+
+        Livewire::test(new class extends TestComponent {
+            public $title = '';
+
+            public $settings;
+
+            public function mount()
+            {
+                $this->settings = new ValidationUnwrappingSpyCollection([
+                    'strict' => true,
+                ]);
+            }
+
+            public function validateTitle()
+            {
+                $this->withValidator(function ($validator) {
+                    $validator->sometimes('title', 'required', fn ($input) => $input->settings['strict'] === true);
+                })->validateOnly('title', [
+                    'title' => 'string',
+                ]);
+            }
+        })->call('validateTitle')->assertHasErrors(['title' => 'required']);
+
+        $this->assertSame(1, ValidationUnwrappingSpyCollection::$toArrayCalls);
+    }
+
+    public function test_can_validate_a_string_property_whose_value_matches_a_synth_key()
+    {
+        // The raw string used to be passed to findSynth, match the Wireable
+        // synth's key, and fatal calling toLivewire() on a string...
+        Livewire::test(new class extends TestComponent {
+            public $title = 'wrbl';
+
+            public function save()
+            {
+                $this->validate(['title' => 'required|string|min:3']);
+            }
+        })->call('save')->assertHasNoErrors();
+    }
+
+    public function test_validate_only_still_unwraps_a_wireable_sibling_for_dependent_rules()
+    {
+        Livewire::test(new class extends TestComponent {
+            public $title;
+
+            public $settings;
+
+            public function mount()
+            {
+                $this->settings = new CustomWireableValidationDTO(50);
+            }
+
+            public function validateTitle()
+            {
+                $this->validateOnly('title', [
+                    'title' => 'required_if:settings.amount,50',
+                ]);
+            }
+        })->call('validateTitle')->assertHasErrors(['title' => 'required_if']);
+    }
+
+    public function test_validate_only_still_unwraps_the_property_being_validated()
+    {
+        ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
+
+        Livewire::test(new class extends TestComponent {
+            public $rows;
+
+            public function mount()
+            {
+                $this->rows = new ValidationUnwrappingSpyCollection([
+                    ['id' => 1],
+                ]);
+            }
+
+            public function validateRow()
+            {
+                $this->validateOnly('rows.0.id', [
+                    'rows.*.id' => 'required|integer',
+                ]);
+            }
+        })->call('validateRow')->assertHasNoErrors();
+
+        $this->assertSame(1, ValidationUnwrappingSpyCollection::$toArrayCalls);
+    }
+
+    public function test_validate_still_unwraps_all_arrayable_properties()
+    {
+        ValidationUnwrappingSpyCollection::$toArrayCalls = 0;
+
+        Livewire::test(new class extends TestComponent {
+            public $title = 'Livewire';
+
+            public $rows;
+
+            public function mount()
+            {
+                $this->rows = new ValidationUnwrappingSpyCollection([
+                    ['id' => 1],
+                ]);
+            }
+
+            public function validateAll()
+            {
+                $this->validate([
+                    'title' => 'required',
+                    'rows.*.id' => 'required|integer',
+                ]);
+            }
+        })->call('validateAll')->assertHasNoErrors();
+
+        $this->assertSame(1, ValidationUnwrappingSpyCollection::$toArrayCalls);
+    }
+}
+
+class ValidationUnwrappingSpyCollection extends Collection
+{
+    public static int $toArrayCalls = 0;
+
+    public function toArray()
+    {
+        static::$toArrayCalls++;
+
+        return parent::toArray();
+    }
+}
+
+class ArticleForValidationUnwrappingTesting extends Model
+{
+    use Sushi;
+
+    protected $casts = ['status' => ArticleStatusForValidationUnwrappingTesting::class];
+
+    protected $rows = [
+        ['status' => 'published'],
+    ];
+}
+
+enum ArticleStatusForValidationUnwrappingTesting: string
+{
+    case Published = 'published';
+    case Draft = 'draft';
 }
 
 class ComponentWithRulesProperty extends TestComponent

--- a/src/Features/SupportWireIntersect/BrowserTest.php
+++ b/src/Features/SupportWireIntersect/BrowserTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Livewire\Features\SupportWireIntersect;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class BrowserTest extends BrowserTestCase
+{
+    public function test_dwell_modifier_is_forwarded_to_alpine()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            public function track()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <p dusk="count">Count: {{ $count }}</p>
+
+                    <div dusk="viewport" style="height: 200px; overflow-y: auto;">
+                        <div style="height: 200px;"></div>
+                        <div wire:intersect.once.parent.dwell.1000ms="track" style="height: 200px;">Target</div>
+                    </div>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@count', 'Count: 0')
+        ->tap(fn ($browser) => $browser->script("document.querySelector('[dusk=viewport]').scrollTop = 200"))
+        ->pause(200)
+        ->assertSeeIn('@count', 'Count: 0')
+        ->waitForText('Count: 1');
+    }
+
+    public function test_dwell_initializes_on_elements_added_during_a_morph()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            public $targetVisible = false;
+
+            public function revealTarget()
+            {
+                $this->targetVisible = true;
+            }
+
+            public function track()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button wire:click="revealTarget" dusk="show">Show target</button>
+                    <p dusk="count">Count: {{ $count }}</p>
+
+                    @if ($targetVisible)
+                        <div dusk="viewport" style="height: 200px; overflow-y: auto;">
+                            <div style="height: 200px;"></div>
+                            <div wire:intersect.once.half.parent.dwell.300ms="track" style="height: 200px;">Target</div>
+                        </div>
+                    @endif
+                </div>
+                HTML;
+            }
+        })
+        ->assertNotPresent('@viewport')
+        ->waitForLivewire()->click('@show')
+        ->assertPresent('@viewport')
+        ->tap(fn ($browser) => $browser->script("document.querySelector('[dusk=viewport]').scrollTop = 110"))
+        ->waitForText('Count: 1');
+    }
+
+    public function test_dwell_supports_renderless_actions()
+    {
+        Livewire::visit(new class extends Component {
+            public $renders = 0;
+
+            public function track()
+            {
+                $this->js('window.livewireIntersectTracked = true');
+            }
+
+            public function render()
+            {
+                $this->renders++;
+
+                return <<<'HTML'
+                <div x-init="window.livewireIntersectTracked = false">
+                    <p dusk="renders">Renders: {{ $renders }}</p>
+
+                    <div dusk="viewport" style="height: 200px; overflow-y: auto;">
+                        <div style="height: 200px;"></div>
+                        <div wire:intersect.once.half.parent.dwell.300ms.renderless="track" style="height: 200px;">Target</div>
+                    </div>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@renders', 'Renders: 1')
+        ->tap(fn ($browser) => $browser->script("document.querySelector('[dusk=viewport]').scrollTop = 110"))
+        ->waitUntil('window.livewireIntersectTracked === true')
+        ->assertSeeIn('@renders', 'Renders: 1');
+    }
+}

--- a/src/Features/SupportWireLoading/BrowserTest.php
+++ b/src/Features/SupportWireLoading/BrowserTest.php
@@ -104,6 +104,190 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    function test_wire_loading_attr_restores_existing_attribute_after_renderless_action()
+    {
+        Livewire::visit(new class extends Component {
+            public bool $disabled = true;
+
+            #[\Livewire\Attributes\Renderless]
+            public function renderlessAction() {
+                usleep(250000);
+            }
+
+            public function render() {
+                return <<<'HTML'
+                    <div>
+                        <button type="button" wire:click="renderlessAction" dusk="renderless">
+                            Renderless action
+                        </button>
+
+                        <button
+                            type="button"
+                            x-bind:disabled="$wire.$get('disabled')"
+                            wire:loading.attr="disabled"
+                            dusk="target">
+                            Target
+                        </button>
+                    </div>
+                HTML;
+            }
+        })
+        ->waitUntil('document.querySelector(\'[dusk="target"]\').disabled === true')
+        ->waitForLivewire()->click('@renderless')
+        ->assertScript('document.querySelector(\'[dusk="target"]\').disabled', true)
+        ;
+    }
+
+    function test_wire_loading_class_restores_existing_class_state_after_renderless_action()
+    {
+        Livewire::visit(new class extends Component {
+            #[\Livewire\Attributes\Renderless]
+            public function renderlessAction() {
+                usleep(250000);
+            }
+
+            public function render() {
+                return <<<'HTML'
+                    <div>
+                        <button type="button" wire:click="renderlessAction" dusk="renderless">
+                            Renderless action
+                        </button>
+
+                        <div
+                            class="existing"
+                            wire:loading.class="existing added"
+                            dusk="add">
+                            Add classes
+                        </div>
+
+                        <div
+                            class="existing"
+                            wire:loading.class.remove="existing absent"
+                            dusk="remove">
+                            Remove classes
+                        </div>
+                    </div>
+                HTML;
+            }
+        })
+        ->assertHasClass('@add', 'existing')
+        ->assertScript('document.querySelector(\'[dusk="add"]\').classList.contains(\'added\')', false)
+        ->assertHasClass('@remove', 'existing')
+        ->assertScript('document.querySelector(\'[dusk="remove"]\').classList.contains(\'absent\')', false)
+        ->waitForLivewire()->click('@renderless')
+        ->assertHasClass('@add', 'existing')
+        ->assertScript('document.querySelector(\'[dusk="add"]\').classList.contains(\'added\')', false)
+        ->assertHasClass('@remove', 'existing')
+        ->assertScript('document.querySelector(\'[dusk="remove"]\').classList.contains(\'absent\')', false)
+        ;
+    }
+
+    function test_wire_loading_attr_restores_after_all_overlapping_requests_finish()
+    {
+        Livewire::visit(new class extends Component {
+            #[\Livewire\Attributes\Renderless]
+            public function slowAction() {
+                usleep(500000);
+
+                $this->dispatch('slow-finished');
+            }
+
+            #[\Livewire\Attributes\Renderless]
+            public function fastAction() {
+                usleep(100000);
+
+                $this->dispatch('fast-finished');
+            }
+
+            public function render() {
+                return <<<'HTML'
+                    <div
+                        x-data="{ fastFinished: false, slowFinished: false }"
+                        x-on:fast-finished.window="fastFinished = true"
+                        x-on:slow-finished.window="slowFinished = true"
+                    >
+                        <button type="button" wire:click.async="slowAction" dusk="slow">
+                            Slow action
+                        </button>
+
+                        <button type="button" wire:click.async="fastAction" dusk="fast">
+                            Fast action
+                        </button>
+
+                        <button type="button" wire:loading.attr="disabled" dusk="target">
+                            Target
+                        </button>
+
+                        <span x-show="fastFinished">Fast finished</span>
+                        <span x-show="slowFinished">Slow finished</span>
+                    </div>
+                HTML;
+            }
+        })
+        ->waitForLivewireToLoad()
+        ->assertAttributeMissing('@target', 'disabled')
+        ->click('@fast')
+        ->click('@slow')
+        ->waitForText('Fast finished')
+        ->assertAttribute('@target', 'disabled', 'true')
+        ->waitForText('Slow finished')
+        ->assertAttributeMissing('@target', 'disabled')
+        ;
+    }
+
+    function test_wire_loading_delay_restores_after_all_overlapping_requests_finish()
+    {
+        Livewire::visit(new class extends Component {
+            #[\Livewire\Attributes\Renderless]
+            public function slowAction() {
+                usleep(500000);
+
+                $this->dispatch('slow-finished');
+            }
+
+            #[\Livewire\Attributes\Renderless]
+            public function fastAction() {
+                usleep(100000);
+
+                $this->dispatch('fast-finished');
+            }
+
+            public function render() {
+                return <<<'HTML'
+                    <div
+                        x-data="{ fastFinished: false, slowFinished: false }"
+                        x-on:fast-finished.window="fastFinished = true"
+                        x-on:slow-finished.window="slowFinished = true"
+                    >
+                        <button type="button" wire:click.async="slowAction" dusk="slow">
+                            Slow action
+                        </button>
+
+                        <button type="button" wire:click.async="fastAction" dusk="fast">
+                            Fast action
+                        </button>
+
+                        <button type="button" wire:loading.delay.shortest.attr="disabled" dusk="target">
+                            Target
+                        </button>
+
+                        <span x-show="fastFinished">Fast finished</span>
+                        <span x-show="slowFinished">Slow finished</span>
+                    </div>
+                HTML;
+            }
+        })
+        ->waitForLivewireToLoad()
+        ->assertAttributeMissing('@target', 'disabled')
+        ->click('@fast')
+        ->click('@slow')
+        ->waitForText('Fast finished')
+        ->assertAttribute('@target', 'disabled', 'true')
+        ->waitForText('Slow finished')
+        ->assertAttributeMissing('@target', 'disabled')
+        ;
+    }
+
     function test_wire_loading_attr_doesnt_conflict_with_exist_one()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportWireSort/BrowserTest.php
+++ b/src/Features/SupportWireSort/BrowserTest.php
@@ -116,6 +116,139 @@ class BrowserTest extends BrowserTestCase
         ->assertSeeIn('@result', 'item:item-1,position:2');
     }
 
+    public function test_wire_sort_item_id_works_when_added_to_an_already_rendered_element()
+    {
+        Livewire::visit(new class extends Component {
+            public $enabled = false;
+            public $result = '';
+
+            public function enable()
+            {
+                $this->enabled = true;
+            }
+
+            public function sortItem($item, $position)
+            {
+                $this->result = "item:{$item},position:{$position}";
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button type="button" dusk="enable" wire:click="enable">Enable</button>
+
+                    <ul dusk="sortable" wire:sort="sortItem">
+                        <li dusk="item-1" wire:key="item-1" @if ($enabled) wire:sort:item="item-1" @endif>Item 1</li>
+                        <li dusk="item-2" wire:key="item-2" @if ($enabled) wire:sort:item="item-2" @endif>Item 2</li>
+                    </ul>
+
+                    <div dusk="result">{{ $result }}</div>
+                </div>
+                HTML;
+            }
+        })
+        ->click('@enable')
+        ->waitForTextIn('[wire\\:key="item-2"]', 'Item 2')
+        ->drag('@item-2', '@item-1')
+        ->waitForTextIn('@result', 'item:item-2,position:0')
+        ->assertSeeIn('@result', 'item:item-2,position:0');
+    }
+
+    public function test_wire_sort_item_id_is_passed_for_lazy_child_components()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public $result = '';
+
+                public function sortItem($item, $position)
+                {
+                    $this->result = "item:{$item},position:{$position}";
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <ul dusk="sortable" wire:sort="sortItem">
+                            <livewire:child dusk="item-1" wire:key="item-1" wire:sort:item="item-1" lazy>
+                                Item 1
+                            </livewire:child>
+
+                            <livewire:child dusk="item-2" wire:key="item-2" wire:sort:item="item-2" lazy>
+                                Item 2
+                            </livewire:child>
+                        </ul>
+
+                        <div dusk="result">{{ $result }}</div>
+                    </div>
+                    HTML;
+                }
+            },
+            'child' => new class extends Component {
+                public function placeholder()
+                {
+                    return <<<'HTML'
+                    <li>Loading...</li>
+                    HTML;
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <li {{ $attributes }}>
+                        Child {{ $slot }}
+                    </li>
+                    HTML;
+                }
+            },
+        ])
+        ->waitForText('Child Item 2')
+        ->drag('@item-2', '@item-1')
+        ->waitForTextIn('@result', 'item:item-2,position:0')
+        ->assertSeeIn('@result', 'item:item-2,position:0');
+    }
+
+    public function test_removing_a_sortable_element_after_wire_sort_is_removed_does_not_error()
+    {
+        Livewire::visit(new class extends Component {
+            public $sorting = true;
+            public $showList = true;
+
+            public function disableSorting()
+            {
+                $this->sorting = false;
+            }
+
+            public function removeList()
+            {
+                $this->showList = false;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button dusk="disable" wire:click="disableSorting">Disable sorting</button>
+                    <button dusk="remove" wire:click="removeList">Remove list</button>
+
+                    @if ($showList)
+                        <ul dusk="sortable" @if ($sorting) wire:sort="sortItem" @endif>
+                            <li wire:sort:item="item-1">Item 1</li>
+                            <li wire:sort:item="item-2">Item 2</li>
+                        </ul>
+                    @endif
+                </div>
+                HTML;
+            }
+        })
+        ->waitForLivewire()->click('@disable')
+        ->assertAttributeMissing('@sortable', 'wire:sort')
+        ->waitForLivewire()->click('@remove')
+        ->waitUntilMissing('@sortable')
+        ->assertConsoleLogHasNoErrors();
+    }
+
     public function test_wire_sort_works_without_sort_id()
     {
         Livewire::visit(new class extends Component {

--- a/src/Features/SupportWireables/BrowserTest.php
+++ b/src/Features/SupportWireables/BrowserTest.php
@@ -59,6 +59,31 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->waitForText('43')
         ->assertSee('43');
     }
+
+    public function test_a_wireable_can_be_replaced_with_a_scalar()
+    {
+        Livewire::visit(new class () extends \Livewire\Component {
+            public array $items = [];
+
+            public function mount(): void
+            {
+                $this->items = [new Person('Jæja', 42)];
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <button type="button" x-on:click="$wire.set('items', [1])" dusk="replace">Replace</button>
+                    <span>{{ json_encode($items) }}</span>
+                </div>
+                HTML;
+            }
+        })
+        ->assertSee('42')
+        ->waitForLivewire()->click('@replace')
+        ->assertSee('[1]');
+    }
 }
 
 class Person implements Wireable

--- a/src/Features/SupportWireables/UnitTest.php
+++ b/src/Features/SupportWireables/UnitTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use Livewire\Component;
 use Livewire\Livewire;
 use Livewire\Wireable;
+use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
 {
@@ -36,6 +37,18 @@ class UnitTest extends \Tests\TestCase
             ->call("\$set", 'wireable', ['message' => 'bar', 'embeddedWireable' => ['message' => '42']])
             ->call("\$set", 'wireable.message', 'bar')
             ->assertSee('bar');
+    }
+
+    public function test_a_wireable_can_be_replaced_with_a_scalar_during_an_update()
+    {
+        $component = Livewire::test(new class extends TestComponent {
+            public $items = [];
+        });
+
+        $component->set('items', [new WireableClass('foo', '42')]);
+        $component->set('items', [1]);
+
+        $this->assertSame([1], $component->get('items'));
     }
 
     public function test_a_wireable_can_be_set_as_a_public_property_and_validates_only()

--- a/src/Features/SupportWireables/WireableSynth.php
+++ b/src/Features/SupportWireables/WireableSynth.php
@@ -3,9 +3,10 @@
 namespace Livewire\Features\SupportWireables;
 
 use Livewire\Wireable;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 
-class WireableSynth extends Synth
+class WireableSynth extends Synth implements ArrayShapedSynth
 {
     public static $key = 'wrbl';
 

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -63,17 +63,17 @@ class FrontendAssets extends Mechanism
         $this->javaScriptRoute = $route;
     }
 
-    public static function livewireScripts($expression)
+    public static function livewireScripts($expression): string
     {
         return '{!! \Livewire\Mechanisms\FrontendAssets\FrontendAssets::scripts('.$expression.') !!}';
     }
 
-    public static function livewireScriptConfig($expression)
+    public static function livewireScriptConfig($expression): string
     {
         return '{!! \Livewire\Mechanisms\FrontendAssets\FrontendAssets::scriptConfig('.$expression.') !!}';
     }
 
-    public static function livewireStyles($expression)
+    public static function livewireStyles($expression): string
     {
         return '{!! \Livewire\Mechanisms\FrontendAssets\FrontendAssets::styles('.$expression.') !!}';
     }
@@ -105,10 +105,7 @@ class FrontendAssets extends Mechanism
         return Utils::pretendResponseIsFile(__DIR__.'/../../../dist/livewire.csp.min.js.map');
     }
 
-    /**
-     * @return string
-     */
-    public static function styles($options = [])
+    public static function styles($options = []): string
     {
         if (app(static::class)->hasRenderedStyles) return '';
 
@@ -161,10 +158,7 @@ class FrontendAssets extends Mechanism
         return static::minify($html);
     }
 
-    /**
-     * @return string
-     */
-    public static function scripts($options = [])
+    public static function scripts($options = []): string
     {
         if (app(static::class)->hasRenderedScripts) return '';
 
@@ -182,7 +176,7 @@ class FrontendAssets extends Mechanism
         return implode("\n", $html);
     }
 
-    public static function js($options)
+    public static function js($options): string
     {
         // Use the default endpoint...
         $url = url(app(static::class)->javaScriptRoute->uri);
@@ -233,7 +227,7 @@ class FrontendAssets extends Mechanism
         HTML;
     }
 
-    public static function scriptConfig($options = [])
+    public static function scriptConfig($options = []): string
     {
         app(static::class)->hasRenderedScripts = true;
 

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -14,6 +14,7 @@ use Livewire\Features\SupportEvents\SupportEvents;
 use Livewire\Features\SupportFormObjects\Form;
 use Illuminate\Support\Facades\View;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class HandleComponents extends Mechanism
@@ -576,10 +577,10 @@ class HandleComponents extends Mechanism
             if ($earlyReturnCalled) {
                 $return = $finish($earlyReturn);
 
-                // File downloads are sent to the browser through the download effect, so we shouldn't add
-                // the response object as a return here. But we need to keep it's position in `returns`
-                // so we will just set it to `null` instead...
-                if ($return instanceof StreamedResponse || $return instanceof BinaryFileResponse) {
+                // File downloads and redirects are sent to the browser through their own effects, so we
+                // shouldn't add the response object as a return here. But we need to keep it's position
+                // in `returns` so we will just set it to `null` instead...
+                if ($return instanceof StreamedResponse || $return instanceof BinaryFileResponse || $return instanceof RedirectResponse) {
                     $return = null;
                 }
 
@@ -608,10 +609,10 @@ class HandleComponents extends Mechanism
 
             $return = $finish($return);
 
-            // File downloads are sent to the browser through the download effect, so we shouldn't add
-            // the response object as a return here. But we need to keep it's position in `returns`
-            // so we will just set it to `null` instead...
-            if ($return instanceof StreamedResponse || $return instanceof BinaryFileResponse) {
+            // File downloads and redirects are sent to the browser through their own effects, so we
+            // shouldn't add the response object as a return here. But we need to keep it's position
+            // in `returns` so we will just set it to `null` instead...
+            if ($return instanceof StreamedResponse || $return instanceof BinaryFileResponse || $return instanceof RedirectResponse) {
                 $return = null;
             }
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/ArrayShapedSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/ArrayShapedSynth.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
+
+/**
+ * Marks synthesizers whose hydrate method requires an array wire value.
+ */
+interface ArrayShapedSynth
+{
+    //
+}

--- a/src/Mechanisms/HandleComponents/Synthesizers/ArraySynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/ArraySynth.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
 
-class ArraySynth extends Synth {
+class ArraySynth extends Synth implements ArrayShapedSynth {
     public static $key = 'arr';
 
     static function match($target) {
@@ -18,10 +18,7 @@ class ArraySynth extends Synth {
     }
 
     function hydrate($value, $meta, $hydrateChild) {
-        // If we are "hydrating" a value about to be used in an update,
-        // Let's make sure it's actually an array before try to set it.
-        // This is most common in the case of "__rm__" values, but also
-        // applies to any non-array value...
+        // Keep direct callers from attempting to iterate a non-array value.
         if (! is_array($value)) {
             return $value;
         }

--- a/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CollectionSynth.php
@@ -4,7 +4,7 @@ namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
 
 use Illuminate\Support\Collection;
 
-class CollectionSynth extends ArraySynth {
+class CollectionSynth extends ArraySynth implements ArrayShapedSynth {
     public static $key = 'clctn';
 
     static function match($target) {

--- a/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/StdClassSynth.php
@@ -4,7 +4,7 @@ namespace Livewire\Mechanisms\HandleComponents\Synthesizers;
 
 use stdClass;
 
-class StdClassSynth extends Synth {
+class StdClassSynth extends Synth implements ArrayShapedSynth {
     public static $key = 'std';
 
     static function match($target) {

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -18,6 +18,8 @@ class HandleRequests extends Mechanism
 {
     protected $updateRoute;
 
+    protected $shouldPropagateExceptions = false;
+
     function boot()
     {
         // Register the default route immediately (before routes files load)
@@ -135,6 +137,19 @@ class HandleRequests extends Mechanism
         return $route->named('*livewire.update');
     }
 
+    function temporarilyPropagateExceptions($callback)
+    {
+        $cachedShouldPropagateExceptions = $this->shouldPropagateExceptions;
+
+        $this->shouldPropagateExceptions = true;
+
+        try {
+            return $callback();
+        } finally {
+            $this->shouldPropagateExceptions = $cachedShouldPropagateExceptions;
+        }
+    }
+
     function handleUpdate()
     {
         // When a custom update route is registered, reject requests that arrive
@@ -206,7 +221,7 @@ class HandleRequests extends Mechanism
             } catch (\TypeError $e) {
                 report($e);
 
-                if (config('app.debug')) throw $e;
+                if (config('app.debug') || $this->shouldPropagateExceptions) throw $e;
 
                 abort(419);
             }

--- a/src/Mechanisms/HandleSynths/HandleSynths.php
+++ b/src/Mechanisms/HandleSynths/HandleSynths.php
@@ -5,6 +5,7 @@ namespace Livewire\Mechanisms\HandleSynths;
 use Livewire\Mechanisms\Mechanism;
 use Livewire\Mechanisms\HandleComponents\ComponentContext;
 use Livewire\Mechanisms\HandleComponents\SecurityPolicy;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers;
 use Livewire\Drawer\Utils;
@@ -95,6 +96,12 @@ class HandleSynths extends Mechanism
         }
 
         $synth = $this->resolve($meta['s'], $context, $path);
+
+        // Snapshot meta describes the previous value. If an update replaces an
+        // array-shaped value with a scalar, the previous synth no longer applies.
+        if ($synth instanceof ArrayShapedSynth && ! is_array($value)) {
+            return $value;
+        }
 
         return $synth->hydrate($value, $meta, function ($name, $child) use ($context, $path, $raw) {
             if ($raw === null || is_object($child)) return $child;

--- a/src/Mechanisms/HandleSynths/UnitTest.php
+++ b/src/Mechanisms/HandleSynths/UnitTest.php
@@ -8,6 +8,7 @@ use Livewire\Attributes\Validate;
 use Livewire\Form;
 use Livewire\Livewire;
 use Livewire\Mechanisms\HandleComponents\ComponentContext;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\ArrayShapedSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\CollectionSynth;
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Livewire\Selection;
@@ -136,6 +137,28 @@ class UnitTest extends \Tests\TestCase
         $synths->hydratePropertyUpdate($tuple, $context, 'evil');
     }
 
+    public function test_hydrate_property_update_validates_classes_before_skipping_array_shaped_synths()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not allowed to be instantiated');
+
+        $synths->hydratePropertyUpdate([
+            1,
+            ['s' => 'arr', 'class' => \Symfony\Component\Process\Process::class],
+        ], $context, 'evil');
+    }
+
+    /*
+     * An update sends values without synthesizer meta — the browser strips
+     * it. When the updated path sits ABOVE a synthesized value (updating
+     * `data.section` when `data.section.row.tags` is a collection), the
+     * nested values can only be reconstructed from the meta in the previous,
+     * checksum-verified snapshot. See hydratePropertyUpdate().
+     */
+
     public function test_hydrate_for_update_recursively_hydrates_nested_synthetic_values()
     {
         $synths = app(HandleSynths::class);
@@ -168,6 +191,113 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertInstanceOf(Collection::class, $updated['tags']);
         $this->assertSame(['some' => 'array'], $updated['brandNew']);
+    }
+
+    public function test_hydrate_for_update_leaves_collection_children_replaced_with_scalars_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => ['tags' => collect(['a']), 'other' => collect(['b'])],
+        ], $context, 'data')];
+
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', [
+            'tags' => 1,
+            'other' => ['b'],
+        ], $context);
+
+        $this->assertSame(1, $updated['tags']);
+        $this->assertInstanceOf(Collection::class, $updated['other']);
+    }
+
+    public function test_hydrate_for_update_leaves_stdclass_children_replaced_with_scalars_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => [
+                'item' => (object) ['name' => 'a'],
+                'other' => (object) ['name' => 'b'],
+            ],
+        ], $context, 'data')];
+
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', [
+            'item' => 1,
+            'other' => ['name' => 'b'],
+        ], $context);
+
+        $this->assertSame(1, $updated['item']);
+        $this->assertInstanceOf(\stdClass::class, $updated['other']);
+        $this->assertSame('b', $updated['other']->name);
+    }
+
+    public function test_hydrate_for_update_leaves_top_level_array_shaped_values_replaced_with_scalars_alone()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $collection = ['item' => $synths->dehydrate(collect(['a']), $context, 'item')];
+        $stdClass = ['item' => $synths->dehydrate((object) ['name' => 'a'], $context, 'item')];
+
+        $this->assertSame(1, $synths->hydrateForUpdate($collection, 'item', 1, $context));
+        $this->assertSame(1, $synths->hydrateForUpdate($stdClass, 'item', 1, $context));
+        $this->assertNull($synths->hydrateForUpdate($collection, 'item', null, $context));
+    }
+
+    public function test_hydrate_for_update_still_applies_scalar_shaped_synths()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['date' => $synths->dehydrate(Carbon::parse('2026-01-01'), $context, 'date')];
+        $updated = $synths->hydrateForUpdate($raw, 'date', '2026-08-29T12:00:00+00:00', $context);
+
+        $this->assertInstanceOf(Carbon::class, $updated);
+        $this->assertSame('2026-08-29T12:00:00+00:00', $updated->format(\DateTimeInterface::ATOM));
+    }
+
+    public function test_userland_array_shaped_synths_can_allow_scalar_replacements()
+    {
+        $synths = app(HandleSynths::class);
+        $synths->registerSynth(CustomThingSynth::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['thing' => $synths->dehydrate(new CustomThing('original'), $context, 'thing')];
+
+        $this->assertSame(1, $synths->hydrateForUpdate($raw, 'thing', 1, $context));
+    }
+
+    public function test_unmarked_userland_synths_keep_hydrating_non_array_updates()
+    {
+        $synths = app(HandleSynths::class);
+        $synths->registerSynth(ScalarFriendlyThingSynth::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['thing' => $synths->dehydrate(new ScalarFriendlyThing('original'), $context, 'thing')];
+        $updated = $synths->hydrateForUpdate($raw, 'thing', 1, $context);
+
+        $this->assertInstanceOf(ScalarFriendlyThing::class, $updated);
+        $this->assertSame(1, $updated->value);
+    }
+
+    public function test_hydrate_for_update_passes_nested_removals_through_untouched()
+    {
+        $synths = app(HandleSynths::class);
+        $context = new ComponentContext(new TestComponent);
+
+        $raw = ['data' => $synths->dehydrate([
+            'section' => ['tags' => collect(['a']), 'other' => collect(['b'])],
+        ], $context, 'data')];
+
+        $updated = $synths->hydrateForUpdate($raw, 'data.section', [
+            'tags' => '__rm__',
+            'other' => ['b'],
+        ], $context);
+
+        $this->assertSame('__rm__', $updated['tags']);
+        $this->assertInstanceOf(Collection::class, $updated['other']);
     }
 
     public function test_hydrate_for_update_leaves_already_hydrated_children_alone()
@@ -282,7 +412,7 @@ class CustomThing
     public function __construct(public string $value = 'default') {}
 }
 
-class CustomThingSynth extends Synth
+class CustomThingSynth extends Synth implements ArrayShapedSynth
 {
     public static $key = 'custom-thing';
 
@@ -299,5 +429,30 @@ class CustomThingSynth extends Synth
     public function hydrate($value)
     {
         return new CustomThing($value['value']);
+    }
+}
+
+class ScalarFriendlyThing
+{
+    public function __construct(public mixed $value) {}
+}
+
+class ScalarFriendlyThingSynth extends Synth
+{
+    public static $key = 'scalar-friendly-thing';
+
+    public static function match($target)
+    {
+        return $target instanceof ScalarFriendlyThing;
+    }
+
+    public function dehydrate($target)
+    {
+        return [['value' => $target->value], []];
+    }
+
+    public function hydrate($value)
+    {
+        return new ScalarFriendlyThing($value);
     }
 }


### PR DESCRIPTION
Synchronizes the final eligible 4.x post-v4.4.2 changes into main, plus the 3.x multi-target wire:dirty fix being prepared for 4.x.

The superseded TypeError change/revert pair (#10407 and #10625) is omitted while its version-safe replacement #10621 is retained. Main-only persisted-value/session and navigate-transition architecture remains untouched.

Verification:
- Production asset build
- Vitest: 164 passed, 1 skipped
- Focused PHP suites: 111 tests, 369 assertions, 1 skipped
- Focused wire:dirty browser regression: 1 test, 5 assertions