### PR TITLE
[4.x] Reuse resolved models across properties

### DIFF
--- a/src/Features/SupportModels/EloquentCollectionSynth.php
+++ b/src/Features/SupportModels/EloquentCollectionSynth.php
@@ -76,16 +76,36 @@ class EloquentCollectionSynth extends Synth {
         }
 
         return $this->makeLazyProxy($class, $meta, function () use ($modelClass, $keys, $meta) {
-            // We are using Laravel's method here for restoring the collection, which ensures
-            // that all models in the collection are restored in one query, preventing n+1
-            // issues and also only restores models that exist.
-            $collection = (new $modelClass)->newQueryForRestoration($keys)->useWritePdo()->get();
+            $models = [];
+            $missingKeys = [];
 
-            $collection = $collection->keyBy->getKey();
+            // Reuse any models already resolved this request — by route binding (via
+            // SubstituteBindings middleware) or by another hydrated property — so
+            // that only the remaining models need to be queried.
+            foreach (array_unique($keys) as $key) {
+                if ($model = SupportModels::getResolvedModel($modelClass, $key)) {
+                    $models[$key] = $model;
+                } else {
+                    $missingKeys[] = $key;
+                }
+            }
+
+            if (count($missingKeys) > 0) {
+                // We are using Laravel's method here for restoring the collection, which ensures
+                // that all models in the collection are restored in one query, preventing n+1
+                // issues and also only restores models that exist.
+                $collection = (new $modelClass)->newQueryForRestoration($missingKeys)->useWritePdo()->get();
+
+                foreach ($collection as $model) {
+                    $models[$model->getKey()] = $model;
+
+                    SupportModels::rememberResolvedModel($model);
+                }
+            }
 
             return new $meta['class'](
-                collect($meta['keys'])->map(function ($id) use ($collection) {
-                    return $collection[$id] ?? null;
+                collect($meta['keys'])->map(function ($id) use ($models) {
+                    return $models[$id] ?? null;
                 })->filter()
             );
         });

--- a/src/Features/SupportModels/ModelSynth.php
+++ b/src/Features/SupportModels/ModelSynth.php
@@ -4,7 +4,6 @@ namespace Livewire\Features\SupportModels;
 
 use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Livewire\Mechanisms\HandleComponents\ComponentContext;
-use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Model;
@@ -74,16 +73,29 @@ class ModelSynth extends Synth {
 
         $key = $meta['key'];
 
-        // If this model was already resolved by route binding (via
-        // SubstituteBindings middleware), reuse it to avoid a duplicate query.
-        $resolvedModel = app(PersistentMiddleware::class)->getResolvedRouteModel($class, $key);
+        // If this model was already resolved this request — by route binding (via
+        // SubstituteBindings middleware) or by another hydrated property — then
+        // reuse it to avoid a duplicate query.
+        $resolvedModel = SupportModels::getResolvedModel($class, $key);
 
         if ($resolvedModel) {
             return $resolvedModel;
         }
 
         return $this->makeLazyProxy($class, $meta, function () use ($class, $key) {
-            return (new $class)->newQueryForRestoration($key)->useWritePdo()->firstOrFail();
+            // Another property (like a collection containing this model) may have
+            // resolved since hydration, so check for a match one more time...
+            $resolvedModel = SupportModels::getResolvedModel($class, $key);
+
+            if ($resolvedModel) {
+                return $resolvedModel;
+            }
+
+            $model = (new $class)->newQueryForRestoration($key)->useWritePdo()->firstOrFail();
+
+            SupportModels::rememberResolvedModel($model);
+
+            return $model;
         });
     }
 

--- a/src/Features/SupportModels/SupportModels.php
+++ b/src/Features/SupportModels/SupportModels.php
@@ -2,15 +2,62 @@
 
 namespace Livewire\Features\SupportModels;
 
+use function Livewire\on;
+use Livewire\Mechanisms\PersistentMiddleware\PersistentMiddleware;
 use Livewire\ComponentHook;
 
 class SupportModels extends ComponentHook
 {
+    public static $resolvedModels = [];
+
+    public static $staleModels = [];
+
     static function provide()
     {
         app('livewire')->propertySynthesizer([
             ModelSynth::class,
             EloquentCollectionSynth::class,
         ]);
+
+        on('flush-state', function () {
+            static::$resolvedModels = [];
+            static::$staleModels = [];
+        });
+    }
+
+    static function rememberResolvedModel($model)
+    {
+        $hash = get_class($model).':'.$model->getKey();
+
+        // Don't track models that have gone stale, otherwise a deletion or an
+        // update made through the original instance couldn't be detected...
+        if (isset(static::$staleModels[$hash])) return;
+
+        static::$resolvedModels[$hash] = $model;
+    }
+
+    static function getResolvedModel($class, $key)
+    {
+        $hash = $class.':'.$key;
+
+        if (isset(static::$staleModels[$hash])) return null;
+
+        $model = static::$resolvedModels[$hash]
+            ?? app(PersistentMiddleware::class)->getResolvedRouteModel($class, $key);
+
+        if (! $model) return null;
+
+        // Only reuse an instance that is indistinguishable from a freshly queried
+        // one. Once an instance has been deleted or mutated, stop sharing that
+        // model for the rest of the request and fall back to fresh queries...
+        if (! $model->exists || $model->isDirty() || $model->wasChanged()) {
+            static::$staleModels[$hash] = true;
+
+            unset(static::$resolvedModels[$hash]);
+
+            return null;
+        }
+
+        return $model;
     }
 }

--- a/src/Features/SupportModels/UnitTest.php
+++ b/src/Features/SupportModels/UnitTest.php
@@ -325,6 +325,406 @@ class UnitTest extends \Tests\TestCase
         $this->assertCount(1, array_values($articleQueries));
     }
 
+    public function test_a_model_property_reuses_a_model_already_hydrated_by_a_collection_property()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public Collection $articles;
+
+            public Article $selected;
+
+            public function mount() {
+                $this->articles = Article::all();
+                $this->selected = $this->articles->first();
+            }
+
+            public function render() { return <<<'HTML'
+                <div>
+                    @foreach($articles as $article)
+                    {{ $article->title.'-'.$loop->index }}
+                    @endforeach
+                    {{ 'Selected: '.$selected->title }}
+                </div>
+            HTML; }
+        });
+
+        Article::resolveConnection()->enableQueryLog();
+        Article::resolveConnection()->flushQueryLog();
+
+        $component->call('$refresh')
+            ->assertSee('First-0')
+            ->assertSee('Second-1')
+            ->assertSee('Selected: First');
+
+        $this->assertCount(1, Article::resolveConnection()->getQueryLog());
+    }
+
+    public function test_a_collection_property_only_queries_models_not_already_hydrated_by_a_model_property()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public Article $selected;
+
+            public Collection $articles;
+
+            public function mount() {
+                $this->selected = Article::first();
+                $this->articles = Article::all();
+            }
+
+            public function render() { return <<<'HTML'
+                <div>
+                    {{ 'Selected: '.$selected->title }}
+                    @foreach($articles as $article)
+                    {{ $article->title.'-'.$loop->index }}
+                    @endforeach
+                </div>
+            HTML; }
+        });
+
+        Article::resolveConnection()->enableQueryLog();
+        Article::resolveConnection()->flushQueryLog();
+
+        $component->call('$refresh')
+            ->assertSee('Selected: First')
+            ->assertSee('First-0')
+            ->assertSee('Second-1');
+
+        $queryLog = Article::resolveConnection()->getQueryLog();
+
+        $this->assertCount(2, $queryLog);
+
+        // The collection query should only restore the model that wasn't already
+        // resolved by the model property. Integer keys may be inlined into the
+        // SQL or passed as bindings depending on the Laravel version...
+        [$modelQuery, $collectionQuery] = $queryLog;
+
+        $this->assertTrue(
+            str_contains($collectionQuery['query'], 'in (2)') || $collectionQuery['bindings'] === [2],
+            'The collection should only have queried for the unresolved model',
+        );
+    }
+
+    public function test_two_model_properties_with_the_same_key_are_hydrated_with_one_query()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public Article $first;
+
+            public Article $second;
+
+            public function mount() {
+                $this->first = Article::first();
+                $this->second = Article::first();
+            }
+
+            public function render() { return <<<'HTML'
+                <div>{{ 'a:'.$first->title }} {{ 'b:'.$second->title }}</div>
+            HTML; }
+        });
+
+        Article::resolveConnection()->enableQueryLog();
+        Article::resolveConnection()->flushQueryLog();
+
+        $component->call('$refresh')
+            ->assertSee('a:First')
+            ->assertSee('b:First');
+
+        $this->assertCount(1, Article::resolveConnection()->getQueryLog());
+    }
+
+    public function test_reused_model_instances_are_shared_within_a_request()
+    {
+        Livewire::test(new class extends \Livewire\Component {
+            public Collection $articles;
+
+            public Article $selected;
+
+            public function mount() {
+                $this->articles = Article::all();
+                $this->selected = $this->articles->first();
+            }
+
+            public function rename() {
+                $this->articles->count();
+
+                $this->selected->title = 'Renamed';
+            }
+
+            public function render() { return <<<'HTML'
+                <div>
+                    @foreach($articles as $article)
+                    {{ $article->title.'-'.$loop->index }}
+                    @endforeach
+                </div>
+            HTML; }
+        })
+        ->call('rename')
+        ->assertSee('Renamed-0')
+        ->assertSee('Second-1');
+    }
+
+    public function test_a_collection_is_not_queried_when_all_its_models_are_already_resolved()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public Article $one;
+
+            public Article $two;
+
+            public Collection $articles;
+
+            public function mount() {
+                $this->one = Article::find(1);
+                $this->two = Article::find(2);
+                $this->articles = new Collection([Article::find(1), Article::find(1), Article::find(2)]);
+            }
+
+            public function render() { return <<<'HTML'
+                <div>
+                    {{ 'a:'.$one->title }} {{ 'b:'.$two->title }}
+                    @foreach($articles as $article)
+                    {{ $article->title.'-'.$loop->index }}
+                    @endforeach
+                </div>
+            HTML; }
+        });
+
+        Article::resolveConnection()->enableQueryLog();
+        Article::resolveConnection()->flushQueryLog();
+
+        $component->call('$refresh')
+            ->assertSee('a:First')
+            ->assertSee('b:Second')
+            ->assertSee('First-0')
+            ->assertSee('First-1')
+            ->assertSee('Second-2');
+
+        $this->assertCount(2, Article::resolveConnection()->getQueryLog());
+    }
+
+    public function test_resolved_models_are_not_reused_across_requests()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public Article $article;
+
+            public function mount() {
+                $this->article = Article::first();
+            }
+
+            public function render() { return <<<'HTML'
+                <div>{{ $article->title }}</div>
+            HTML; }
+        });
+
+        Article::resolveConnection()->enableQueryLog();
+        Article::resolveConnection()->flushQueryLog();
+
+        $component->call('$refresh')->assertSee('First');
+        $component->call('$refresh')->assertSee('First');
+
+        $this->assertCount(2, Article::resolveConnection()->getQueryLog());
+    }
+
+    public function test_a_mutated_model_is_not_reused_by_other_properties()
+    {
+        // On earlier versions there are no lazy proxies, so properties hydrate
+        // eagerly before any mutations and share the still-clean instance...
+        if (PHP_VERSION_ID < 80400) $this->markTestSkipped('Requires lazy model proxies');
+
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public Article $first;
+
+            public Article $second;
+
+            public function mount() {
+                $this->first = Article::first();
+                $this->second = Article::first();
+            }
+
+            public function rename() {
+                $this->first->title = 'Draft';
+            }
+
+            public function render() { return <<<'HTML'
+                <div>{{ 'a:'.$first->title }} {{ 'b:'.$second->title }}</div>
+            HTML; }
+        });
+
+        Article::resolveConnection()->enableQueryLog();
+        Article::resolveConnection()->flushQueryLog();
+
+        // The unsaved mutation on $first shouldn't leak into $second — it
+        // should fall through to a fresh query instead...
+        $component->call('rename')
+            ->assertSee('a:Draft')
+            ->assertSee('b:First');
+
+        $this->assertCount(2, Article::resolveConnection()->getQueryLog());
+    }
+
+    public function test_a_deleted_model_is_not_reused_when_hydrating_a_collection()
+    {
+        // On earlier versions there are no lazy proxies, so the collection is
+        // hydrated eagerly before the deletion, like it is on main...
+        if (PHP_VERSION_ID < 80400) $this->markTestSkipped('Requires lazy model proxies');
+
+        $this->resetMutableArticles();
+
+        Livewire::test(new class extends \Livewire\Component {
+            public Collection $articles;
+
+            public MutableArticle $selected;
+
+            public function mount() {
+                $this->articles = MutableArticle::all();
+                $this->selected = $this->articles->first();
+            }
+
+            public function deleteSelected() {
+                $this->selected->delete();
+            }
+
+            public function render() { return <<<'HTML'
+                <div>
+                    @foreach($articles as $article)
+                    {{ $article->title.'-'.$loop->index }}
+                    @endforeach
+                </div>
+            HTML; }
+        })
+        ->call('deleteSelected')
+        ->assertDontSee('First-')
+        ->assertSee('Second-0');
+    }
+
+    public function test_a_saved_model_is_not_reused_by_other_properties()
+    {
+        if (PHP_VERSION_ID < 80400) $this->markTestSkipped('Requires lazy model proxies');
+
+        $this->resetMutableArticles();
+
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public MutableArticle $first;
+
+            public MutableArticle $second;
+
+            public function mount() {
+                $this->first = MutableArticle::find(1);
+                $this->second = MutableArticle::find(1);
+            }
+
+            public function rename() {
+                $this->first->update(['title' => 'Renamed']);
+            }
+
+            public function render() { return <<<'HTML'
+                <div>{{ 'a:'.$first->title }} {{ 'b:'.$second->title }}</div>
+            HTML; }
+        });
+
+        MutableArticle::resolveConnection()->enableQueryLog();
+        MutableArticle::resolveConnection()->flushQueryLog();
+
+        // The saved model shouldn't be reused for $second — it should fall
+        // through to a fresh query, which reads the same saved title...
+        $component->call('rename')
+            ->assertSee('a:Renamed')
+            ->assertSee('b:Renamed');
+
+        $selects = array_filter(
+            MutableArticle::resolveConnection()->getQueryLog(),
+            fn ($q) => str_starts_with($q['query'], 'select'),
+        );
+
+        $this->assertCount(2, $selects);
+    }
+
+    public function test_a_model_saved_after_its_reuse_was_rejected_is_not_served_stale()
+    {
+        if (PHP_VERSION_ID < 80400) $this->markTestSkipped('Requires lazy model proxies');
+
+        $this->resetMutableArticles();
+
+        Livewire::test(new class extends \Livewire\Component {
+            public MutableArticle $first;
+
+            public MutableArticle $second;
+
+            public Collection $articles;
+
+            public function mount() {
+                $this->first = MutableArticle::find(1);
+                $this->second = MutableArticle::find(1);
+                $this->articles = MutableArticle::all();
+            }
+
+            public function rename() {
+                // Once a mutated instance is encountered, the model shouldn't be
+                // shared for the rest of the request — even after the collection
+                // resolves a clean instance while the mutation is unsaved...
+                $this->first->title = 'Renamed';
+
+                $this->articles->count();
+
+                $this->first->save();
+            }
+
+            public function render() { return <<<'HTML'
+                <div>{{ 'b:'.$second->title }}</div>
+            HTML; }
+        })
+        ->call('rename')
+        ->assertSee('b:Renamed');
+    }
+
+    public function test_a_model_deleted_after_its_reuse_was_rejected_is_not_resurrected()
+    {
+        if (PHP_VERSION_ID < 80400) $this->markTestSkipped('Requires lazy model proxies');
+
+        $this->resetMutableArticles();
+
+        Livewire::test(new class extends \Livewire\Component {
+            public MutableArticle $selected;
+
+            public Collection $articles;
+
+            public Collection $others;
+
+            public function mount() {
+                $this->selected = MutableArticle::find(1);
+                $this->articles = MutableArticle::all();
+                $this->others = MutableArticle::all();
+            }
+
+            public function deleteSelected() {
+                $this->selected->title = 'Doomed';
+
+                $this->articles->count();
+
+                $this->selected->delete();
+            }
+
+            public function render() { return <<<'HTML'
+                <div>
+                    @foreach($others as $article)
+                    {{ $article->title.'-'.$loop->index }}
+                    @endforeach
+                </div>
+            HTML; }
+        })
+        ->call('deleteSelected')
+        ->assertDontSee('First-')
+        ->assertDontSee('Doomed-')
+        ->assertSee('Second-0');
+    }
+
+    protected function resetMutableArticles()
+    {
+        // Reset the table as these tests modify or delete its rows...
+        MutableArticle::query()->delete();
+        MutableArticle::insert([
+            ['id' => 1, 'title' => 'First'],
+            ['id' => 2, 'title' => 'Second'],
+        ]);
+    }
+
     public function test_hydrating_an_empty_eloquent_collection_does_not_trigger_deprecations()
     {
         $component = Livewire::test(new class extends \Livewire\Component {
@@ -377,6 +777,19 @@ class ArticleComponent extends \Livewire\Component
 class Article extends Model
 {
     use Sushi;
+
+    protected $rows = [
+        ['title' => 'First'],
+        ['title' => 'Second'],
+    ];
+}
+
+// Uses its own table so modifying or deleting rows doesn't affect other tests...
+class MutableArticle extends Model
+{
+    use Sushi;
+
+    protected $guarded = [];
 
     protected $rows = [
         ['title' => 'First'],


### PR DESCRIPTION
Backports #10633 from main to 4.x by cherry-pick. This avoids duplicate model queries during update hydration while retaining 4.x model synth architecture.

Verification:
- Focused SupportModels suite: 27 tests, 64 assertions, 1 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced duplicate model lookups when the same records are used across multiple properties or collections.
  - Improved collection hydration by reusing records already loaded during a request.

- **Reliability**
  - Ensured updated or deleted records are not incorrectly reused.
  - Preserved request isolation so cached records do not carry over between requests.

- **Bug Fixes**
  - Improved consistency when models are saved, modified, or removed during request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->