### PR TITLE
Prepare Alpine 3.17.1 on main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,18 @@
             "name": "laravel-livewire",
             "license": "MIT",
             "dependencies": {
-                "@alpinejs/anchor": "^3.17.0",
-                "@alpinejs/collapse": "^3.17.0",
-                "@alpinejs/csp": "^3.17.0",
-                "@alpinejs/focus": "^3.17.0",
-                "@alpinejs/intersect": "^3.17.0",
-                "@alpinejs/mask": "^3.17.0",
-                "@alpinejs/morph": "^3.17.0",
-                "@alpinejs/persist": "^3.17.0",
-                "@alpinejs/resize": "^3.17.0",
-                "@alpinejs/sort": "^3.17.0",
+                "@alpinejs/anchor": "^3.17.1",
+                "@alpinejs/collapse": "^3.17.1",
+                "@alpinejs/csp": "^3.17.1",
+                "@alpinejs/focus": "^3.17.1",
+                "@alpinejs/intersect": "^3.17.1",
+                "@alpinejs/mask": "^3.17.1",
+                "@alpinejs/morph": "^3.17.1",
+                "@alpinejs/persist": "^3.17.1",
+                "@alpinejs/resize": "^3.17.1",
+                "@alpinejs/sort": "^3.17.1",
                 "@vue/reactivity": "^3.2.45",
-                "alpinejs": "^3.17.0",
+                "alpinejs": "^3.17.1",
                 "nprogress": "^0.2.0"
             },
             "devDependencies": {
@@ -29,33 +29,33 @@
             }
         },
         "node_modules/@alpinejs/anchor": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.17.0.tgz",
-            "integrity": "sha512-TCY8DnyMWIWdAECjTEzBsDnh4gfiKuZq2wjmS0eHY0F38i5s4k2iOphxt5cWAytLI9yw6FKqbCytXNmjHOZjDQ==",
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.17.1.tgz",
+            "integrity": "sha512-x6mVH3CAUKLMMh1jEgJ7pWi9DzKEgTq6pK391wN1MvSLndjr0RYOyfCakS1Y6SqHZbTyRtwfp3zG3ECoFYILKw==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.5.3"
             }
         },
         "node_modules/@alpinejs/collapse": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.17.0.tgz",
-            "integrity": "sha512-Dwjb8cEjUYdHy0FCKCfmmq/RGOotSm116w/fQBXTrX2HPw5rrJ3ZUgUhO1JOgtgkOw+vTlBERPtjJViIrMZn0w==",
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.17.1.tgz",
+            "integrity": "sha512-ygf0kJ2I+1TgBUjS+V1Dx2KlT/y/AatyfavzL7b2T3qrPx7WRGI4yxvFB0h6J5OZVO08dhtDTVk/Z1GIC6ME/w==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/csp": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.17.0.tgz",
-            "integrity": "sha512-D6W+RbUfkU1SyAYM0GHNF84jEHtx77HQq5CdOBvlBwDzKqbdTqjITPRLNihZ/EcUqoLgqebFzHd/v55rpP0Jhw==",
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.17.1.tgz",
+            "integrity": "sha512-HDrY0ZxvJWSmeUYqtHVSsitaqy1es3VDCNodPpdQRX4nHhHiRoeib+rOzRFFStFRD/6x0KmQzJVJ4FCLAI/DUQ==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.5.40"
             }
         },
         "node_modules/@alpinejs/focus": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.17.0.tgz",
-            "integrity": "sha512-tqkE2Pj4WgSXXujs3eCLxiS2ZODgNcDsKvG5lCZKlDozeRO6WFeSAjV5EKi4p+BFNIwm1937O4xwuV7hQ0Q+jA==",
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.17.1.tgz",
+            "integrity": "sha512-23+9xUfPMhuqIm6xeqLQmQTBjNY/yHtJ5np05WrFZLdKXOXCLktpAE7ZAgmPoD/s7F2banEiJzTSFDO6GnWUIg==",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^8.0.0",
@@ -63,39 +63,39 @@
             }
         },
         "node_modules/@alpinejs/intersect": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.17.0.tgz",
-            "integrity": "sha512-6vvZFWmPo/+Vu+vSWjKkE2KFw7HF4SLS8TaGZqnLXhrwOc3UOoYdjz798lQSYhNp1W1Z0+s/Boi4kAczt5BOkA==",
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.17.1.tgz",
+            "integrity": "sha512-60UZyk6BNGocHgEvKxBfgqPXq9Y1tuQ363/FjdlXc1eNI8Q0arelStWLhEyd0u8JJp7FTr50S/CmaYXMijTQYQ==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/mask": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.17.0.tgz",
-            "integrity": "sha512-/VL4Sc4T3V/gzuqurOhvsO3FqUKC6RzGrNV4UJUYzv3i+tip/LXTKJIPjPKdw/qzto8c2pRFJ0lpEWPyVcYFBw==",
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.17.1.tgz",
+            "integrity": "sha512-EK/6nkVdO0kyLM/xYag6oJ2jEbQevEfsdRdjUnwJnzCcLLulUpTLo0JVRBml9XBobM614pVOEMzdbXPPI0wB9w==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/morph": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.17.0.tgz",
-            "integrity": "sha512-Jucn2wQObrNFnz8m2JR6W2G6fiYpnVu9C2Y1VWfuLDfmD1mv6tHowBevISBxQ459gL/1Iyec3jSZl3hWbyN/Mw==",
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.17.1.tgz",
+            "integrity": "sha512-RVafJn9fsF1mrxbQniSgTyneV4ybEFPgBGsjwpxko1g0WPdctTewgnxxO86gy5VztpjNvpjRW1bcpq39WtMt8w==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/persist": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.17.0.tgz",
-            "integrity": "sha512-sS4raHKnSnqfQrVgMAJhc/9cRDZ6ZiLlJqhNhboaiU986JQSOOtfKSM2n23EVmMtm/RcqDR6HqVjDjgyQyuvxg==",
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.17.1.tgz",
+            "integrity": "sha512-PN/93FIWakZYY4zB/VGDlFtx2LOoa318huflgLMo2jsk+pkjLlDkX1qmuUFh5xhI7Uj3vSvU1Eu1WIA3TN3PTA==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/resize": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.17.0.tgz",
-            "integrity": "sha512-5kVl5975Ob6O22RomUqqMnM+azIX51ckHS1eW+1y/xv0UiXFDa7V16jTz+pCRlDH9EHr9mE+wF1DbGIleI7xhg==",
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.17.1.tgz",
+            "integrity": "sha512-TyHYMY6DQBh9P/hOFH3KGLE7ilyfR3u3qsYtJfpsE6Fq8eKobkjudahmhHmdiGurohx8YaVbWBNilDcnAjLOTw==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/sort": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.17.0.tgz",
-            "integrity": "sha512-yruO0mcORzZEXWg8JSaOEKyw770x5Iu2ssi9sYnPacwJaU+R0e7rXn7VDrbg2DvevnpeKg7dZZtR3VUykF3tOA==",
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.17.1.tgz",
+            "integrity": "sha512-Q6qF00WI4cQAZdIxPgbsHnxZIiIv4T1kfSPyEy2QB/SLhLdISuIjzTBa3TQAe1P45BkRtNk5Y8fQuDZuKhN/6w==",
             "license": "MIT",
             "dependencies": {
                 "sortablejs": "^1.15.2"
@@ -1266,9 +1266,9 @@
             }
         },
         "node_modules/alpinejs": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.17.0.tgz",
-            "integrity": "sha512-LDLcfqFsiQrdFCNqK7zWyfjx2QE2sjPw0bIPThLVHMIQATAp1dNRKga1xPSqC+71UYFiosIYblLszzzo9r9k6A==",
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.17.1.tgz",
+            "integrity": "sha512-HDUhA9juSA/pNYZ5FAAlW4qNsdeVORFSVONEIu0hVasqCOqLitf15R9tCr5GBCV0ZxiZW2Qx6BYdMSF7iGLT/Q==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.5.40"

--- a/package.json
+++ b/package.json
@@ -17,18 +17,18 @@
         "vitest": "^3.2.4"
     },
     "dependencies": {
-        "@alpinejs/anchor": "^3.17.0",
-        "@alpinejs/collapse": "^3.17.0",
-        "@alpinejs/csp": "^3.17.0",
-        "@alpinejs/focus": "^3.17.0",
-        "@alpinejs/intersect": "^3.17.0",
-        "@alpinejs/mask": "^3.17.0",
-        "@alpinejs/morph": "^3.17.0",
-        "@alpinejs/persist": "^3.17.0",
-        "@alpinejs/resize": "^3.17.0",
-        "@alpinejs/sort": "^3.17.0",
+        "@alpinejs/anchor": "^3.17.1",
+        "@alpinejs/collapse": "^3.17.1",
+        "@alpinejs/csp": "^3.17.1",
+        "@alpinejs/focus": "^3.17.1",
+        "@alpinejs/intersect": "^3.17.1",
+        "@alpinejs/mask": "^3.17.1",
+        "@alpinejs/morph": "^3.17.1",
+        "@alpinejs/persist": "^3.17.1",
+        "@alpinejs/resize": "^3.17.1",
+        "@alpinejs/sort": "^3.17.1",
         "@vue/reactivity": "^3.2.45",
-        "alpinejs": "^3.17.0",
+        "alpinejs": "^3.17.1",
         "nprogress": "^0.2.0"
     }
 }


### PR DESCRIPTION
Updates main to Alpine v3.17.1 from the published npm packages.

Verified with a clean npm install, the full JavaScript suite (164 passed, 1 skipped), and a production build. The lockfile resolves Alpine and all bundled plugins to 3.17.1.