### PR TITLE
[4.x] Keep wire:dirty subscribed to every target

### DIFF
--- a/js/directives/wire-dirty.js
+++ b/js/directives/wire-dirty.js
@@ -48,11 +48,14 @@ export function checkDirty(component, targets) {
         isDirty = JSON.stringify(component.canonical) !== JSON.stringify(component.reactive)
     } else if (Array.isArray(targets)) {
         for (let i = 0; i < targets.length; i++) {
-            if (isDirty) break;
-
             let target = targets[i]
 
-            isDirty = JSON.stringify(dataGet(component.canonical, target)) !== JSON.stringify(dataGet(component.reactive, target))
+            let canonical = JSON.stringify(dataGet(component.canonical, target))
+            let reactive = JSON.stringify(dataGet(component.reactive, target))
+
+            if (canonical !== reactive) {
+                isDirty = true
+            }
         }
     } else {
         isDirty = JSON.stringify(dataGet(component.canonical, targets)) !== JSON.stringify(dataGet(component.reactive, targets))

--- a/src/Features/SupportDataBinding/BrowserTest.php
+++ b/src/Features/SupportDataBinding/BrowserTest.php
@@ -152,7 +152,40 @@ class BrowserTest extends BrowserTestCase
             ->pause(50)
             ->assertVisible('@dirty-indicator')
         ;
-}
+    }
+
+    function test_wire_dirty_keeps_tracking_every_target_after_a_commit()
+    {
+        Livewire::visit(new class extends Component {
+            public $first = false;
+
+            public $second = '';
+
+            public function render()
+            {
+                return <<<'BLADE'
+                    <div>
+                        <input dusk="first" type="checkbox" wire:model="first" />
+                        <input dusk="second" type="text" wire:model="second" />
+
+                        <button dusk="commit" type="button" wire:click="$commit">Commit</button>
+
+                        <div dusk="dirty" wire:dirty.class="dirty" wire:target="first, second"></div>
+                    </div>
+                BLADE;
+            }
+        })
+            ->assertAttributeDoesntContain('@dirty', 'class', 'dirty')
+            ->check('@first')
+            ->pause(50)
+            ->assertAttributeContains('@dirty', 'class', 'dirty')
+            ->waitForLivewire()->click('@commit')
+            ->waitUntil("!document.querySelector('[dusk=\"dirty\"]').classList.contains('dirty')")
+            ->type('@second', 'Later target')
+            ->pause(50)
+            ->assertAttributeContains('@dirty', 'class', 'dirty')
+        ;
+    }
 
     function test_can_update_bound_value_from_lifecyle_hook()
     {


### PR DESCRIPTION
Ports #10616 from 3.x to 4.x for release synchronization.

The 4.x helper now evaluates every target on every reactive pass so Alpine remains subscribed after an earlier target becomes clean. The original multi-target browser regression was adapted to the 4.x helper architecture.

Verification:
- Production asset build
- Vitest: 110 passed, 1 skipped
- Focused browser regression: 1 test, 5 assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dirty-state tracking when multiple targets are monitored.
  * Dirty indicators now update correctly after a commit when changes occur in any tracked target.

* **Tests**
  * Added coverage verifying dirty-state behavior across multiple targets and successive changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->