### PR TITLE
[4.x] Ensure temporary render state is cleaned up when rendering throws an exception.

### DIFF
--- a/src/Features/SupportIslands/HandlesIslands.php
+++ b/src/Features/SupportIslands/HandlesIslands.php
@@ -224,17 +224,19 @@ trait HandlesIslands
 
         $finish = trigger('renderIsland', $this, $name, $view, $properties);
 
-        $html = $view->render();
+        try {
+            $html = $view->render();
+        } finally {
+            $revertShare();
 
-        $revertShare();
-
-        $replaceHtml = function ($newHtml) use (&$html) {
-            $html = $newHtml;
-        };
-
-        $finish($html, $replaceHtml);
-
-        app(ExtendBlade::class)->endLivewireRendering();
+            $replaceHtml = function ($newHtml) use (&$html) {
+                $html = $newHtml;
+            };
+    
+            $finish($html, $replaceHtml);
+    
+            app(ExtendBlade::class)->endLivewireRendering();
+        }
 
         return $html;
     }

--- a/src/Features/SupportIslands/HandlesIslands.php
+++ b/src/Features/SupportIslands/HandlesIslands.php
@@ -228,15 +228,15 @@ trait HandlesIslands
             $html = $view->render();
         } finally {
             $revertShare();
-
-            $replaceHtml = function ($newHtml) use (&$html) {
-                $html = $newHtml;
-            };
-    
-            $finish($html, $replaceHtml);
-    
-            app(ExtendBlade::class)->endLivewireRendering();
         }
+        
+        $replaceHtml = function ($newHtml) use (&$html) {
+            $html = $newHtml;
+        };
+    
+        $finish($html, $replaceHtml);
+    
+        app(ExtendBlade::class)->endLivewireRendering();
 
         return $html;
     }

--- a/src/Features/SupportIslands/HandlesIslands.php
+++ b/src/Features/SupportIslands/HandlesIslands.php
@@ -229,13 +229,13 @@ trait HandlesIslands
         } finally {
             $revertShare();
         }
-        
+
         $replaceHtml = function ($newHtml) use (&$html) {
             $html = $newHtml;
         };
-    
+
         $finish($html, $replaceHtml);
-    
+
         app(ExtendBlade::class)->endLivewireRendering();
 
         return $html;

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -381,9 +381,11 @@ class HandleComponents extends Mechanism
     {
         array_push(static::$renderStack, $component);
 
-        return tap($callback(), function () {
+        try {
+            return $callback();
+        } finally {
             array_pop(static::$renderStack);
-        });
+        }
     }
 
     protected function updateProperties($component, $updates, $data, $context)

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -330,12 +330,14 @@ class HandleComponents extends Mechanism
 
             $viewContext = new ViewContext;
 
-            $html = $view->render(function ($view) use ($viewContext) {
-                // Extract leftover slots, sections, and pushes before they get flushed...
-                $viewContext->extractFromEnvironment($view->getFactory());
-            });
-
-            $revertA(); $revertB();
+            try {
+                $html = $view->render(function ($view) use ($viewContext) {
+                    // Extract leftover slots, sections, and pushes before they get flushed...
+                    $viewContext->extractFromEnvironment($view->getFactory());
+                });
+            } finally {
+                $revertA(); $revertB();
+            }
 
             $html = Utils::insertAttributesIntoHtmlRoot($html, [
                 'wire:id' => $component->getId(),

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -285,6 +285,25 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertEmpty(HandleComponents::$renderStack);
     }
+
+    public function test_view_sharing_is_reverted_when_render_throws()
+    {
+        try {
+            Livewire::test(new class extends Component {
+                public function render()
+                {
+                    return '<div>{{ $foo }}</div>';
+                }
+            });
+
+            $this->fail('Expected a ViewException to be thrown.');
+        } catch (\Illuminate\View\ViewException $e) {
+            // Expected...
+        }
+
+        $this->assertNull(view()->shared('__livewire'));
+        $this->assertNull(view()->shared('_instance'));
+    }
 }
 
 class BasicComponent extends TestComponent

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -6,8 +6,10 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Stringable;
 use Livewire\Component;
+use Livewire\Features\SupportIslands\Compiler\IslandCompiler;
 use Livewire\Form;
 use Livewire\Livewire;
+use Livewire\Mechanisms\ExtendBlade\ExtendBlade;
 use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
@@ -303,6 +305,47 @@ class UnitTest extends \Tests\TestCase
 
         $this->assertNull(view()->shared('__livewire'));
         $this->assertNull(view()->shared('_instance'));
+    }
+
+    public function test_island_view_sharing_is_reverted_when_render_island_throws()
+    {
+        try {
+            Livewire::test(new class extends Component {
+                public bool $fail = false;
+
+                public function breakIsland()
+                {
+                    $this->fail = true;
+                    $this->skipRender();
+                    $this->renderIsland('probe');
+                }
+
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        @island(name: 'probe')
+                            <div>
+                                @if ($fail)
+                                    {{ $foo }}
+                                @else
+                                    ok
+                                @endif
+                            </div>
+                        @endisland
+                    </div>
+                    HTML;
+                }
+            })
+                ->call('breakIsland');
+
+            $this->fail('Expected a ViewException to be thrown.');
+        } catch (\Illuminate\View\ViewException $e) {
+            // Expected...
+        }
+
+        $this->assertNull(view()->shared('__livewire'));
+        $this->assertFalse(ExtendBlade::isRenderingLivewireComponent());
     }
 }
 

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -270,18 +270,20 @@ class UnitTest extends \Tests\TestCase
 
     public function test_render_stack_is_cleaned_up_when_render_callback_throws()
     {
-        $this->expectException(\Illuminate\View\ViewException::class);
-
-        Livewire::test(ComponentWithUndefinedProperty::class);
+        try {
+            Livewire::test(ComponentWithUndefinedProperty::class);
+            $this->fail('Expected ViewException to be thrown.');
+        } catch (\Illuminate\View\ViewException) {}
 
         $this->assertEmpty(HandleComponents::$renderStack);
     }
 
     public function test_view_sharing_is_reverted_when_render_throws()
     {
-        $this->expectException(\Illuminate\View\ViewException::class);
-
-        Livewire::test(ComponentWithUndefinedProperty::class);
+        try {
+            Livewire::test(ComponentWithUndefinedProperty::class);
+            $this->fail('Expected ViewException to be thrown.');
+        } catch (\Illuminate\View\ViewException) {}
 
         $this->assertNull(view()->shared('__livewire'));
         $this->assertNull(view()->shared('_instance'));
@@ -289,9 +291,7 @@ class UnitTest extends \Tests\TestCase
 
     public function test_island_view_sharing_is_reverted_when_render_island_throws()
     {
-        $this->expectException(\Illuminate\View\ViewException::class);
-
-        Livewire::test(new class extends Component {
+        $component = Livewire::test(new class extends Component {
             public bool $fail = false;
 
             public function breakIsland()
@@ -320,9 +320,12 @@ class UnitTest extends \Tests\TestCase
         })
             ->assertOk()
             ->assertSetStrict('fail', false)
-            ->assertSee('Island rendered')
-            ->call('breakIsland')
-            ->assertSetStrict('fail', true);
+            ->assertSee('Island rendered');
+
+        try {
+            $component->call('breakIsland')->assertSetStrict('fail', true);
+            $this->fail('Expected ViewException to be thrown');
+        } catch (\Illuminate\View\ViewException) {}
 
         $this->assertNull(view()->shared('__livewire'));
     }

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -6,10 +6,8 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Stringable;
 use Livewire\Component;
-use Livewire\Features\SupportIslands\Compiler\IslandCompiler;
 use Livewire\Form;
 use Livewire\Livewire;
-use Livewire\Mechanisms\ExtendBlade\ExtendBlade;
 use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
@@ -345,7 +343,6 @@ class UnitTest extends \Tests\TestCase
         }
 
         $this->assertNull(view()->shared('__livewire'));
-        $this->assertFalse(ExtendBlade::isRenderingLivewireComponent());
     }
 }
 

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -267,6 +267,37 @@ class UnitTest extends \Tests\TestCase
         ->call('refresh')
         ->assertSetStrict('refreshed', true);
     }
+
+    public function test_render_stack_is_cleaned_up_when_render_callback_throws()
+    {
+        $component = new class extends Component {};
+
+        $handleComponents = app(HandleComponents::class);
+
+        $trackInRenderStack = (new \ReflectionMethod(
+            HandleComponents::class,
+            'trackInRenderStack'
+        ));
+
+        try {
+            $trackInRenderStack->invoke(
+                $handleComponents,
+                $component,
+                function () {
+                    throw new \RuntimeException('Render failed.');
+                },
+            );
+
+            $this->fail('Expected render callback to throw.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Render failed.', $e->getMessage());
+        }
+
+        $this->assertTrue(
+            empty(HandleComponents::$renderStack),
+            'Render stack should be empty on exception'
+        );
+    }
 }
 
 class BasicComponent extends TestComponent

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -270,36 +270,18 @@ class UnitTest extends \Tests\TestCase
 
     public function test_render_stack_is_cleaned_up_when_render_callback_throws()
     {
-        try {
-            Livewire::test(new class extends Component {
-                public function render()
-                {
-                    return '<div>{{ $foo }}</div>';
-                }
-            });
+        $this->expectException(\Illuminate\View\ViewException::class);
 
-            $this->fail('Expected a ViewException to be thrown.');
-        } catch (\Illuminate\View\ViewException $e) {
-            // Expected...
-        }
+        Livewire::test(ComponentWithUndefinedProperty::class);
 
         $this->assertEmpty(HandleComponents::$renderStack);
     }
 
     public function test_view_sharing_is_reverted_when_render_throws()
     {
-        try {
-            Livewire::test(new class extends Component {
-                public function render()
-                {
-                    return '<div>{{ $foo }}</div>';
-                }
-            });
+        $this->expectException(\Illuminate\View\ViewException::class);
 
-            $this->fail('Expected a ViewException to be thrown.');
-        } catch (\Illuminate\View\ViewException $e) {
-            // Expected...
-        }
+        Livewire::test(ComponentWithUndefinedProperty::class);
 
         $this->assertNull(view()->shared('__livewire'));
         $this->assertNull(view()->shared('_instance'));
@@ -307,42 +289,50 @@ class UnitTest extends \Tests\TestCase
 
     public function test_island_view_sharing_is_reverted_when_render_island_throws()
     {
-        try {
-            Livewire::test(new class extends Component {
-                public bool $fail = false;
+        $this->expectException(\Illuminate\View\ViewException::class);
 
-                public function breakIsland()
-                {
-                    $this->fail = true;
-                    $this->skipRender();
-                    $this->renderIsland('probe');
-                }
+        Livewire::test(new class extends Component {
+            public bool $fail = false;
 
-                public function render()
-                {
-                    return <<<'HTML'
-                    <div>
-                        @island(name: 'probe')
-                            <div>
-                                @if ($fail)
-                                    {{ $foo }}
-                                @else
-                                    ok
-                                @endif
-                            </div>
-                        @endisland
-                    </div>
-                    HTML;
-                }
-            })
-                ->call('breakIsland');
+            public function breakIsland()
+            {
+                $this->fail = true;
+                $this->skipRender();
+                $this->renderIsland('probe');
+            }
 
-            $this->fail('Expected a ViewException to be thrown.');
-        } catch (\Illuminate\View\ViewException $e) {
-            // Expected...
-        }
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @island(name: 'probe')
+                        <div>
+                            @if ($fail)
+                                {{ $undefinedProperty }}
+                            @else
+                                Island rendered
+                            @endif
+                        </div>
+                    @endisland
+                </div>
+                HTML;
+            }
+        })
+            ->assertOk()
+            ->assertSetStrict('fail', false)
+            ->assertSee('Island rendered')
+            ->call('breakIsland')
+            ->assertSetStrict('fail', true);
 
         $this->assertNull(view()->shared('__livewire'));
+    }
+}
+
+class ComponentWithUndefinedProperty extends Component
+{
+    public function render()
+    {
+        return '<div>{{ $undefinedProperty }}</div>';
     }
 }
 

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -270,33 +270,20 @@ class UnitTest extends \Tests\TestCase
 
     public function test_render_stack_is_cleaned_up_when_render_callback_throws()
     {
-        $component = new class extends Component {};
-
-        $handleComponents = app(HandleComponents::class);
-
-        $trackInRenderStack = (new \ReflectionMethod(
-            HandleComponents::class,
-            'trackInRenderStack'
-        ));
-
         try {
-            $trackInRenderStack->invoke(
-                $handleComponents,
-                $component,
-                function () {
-                    throw new \RuntimeException('Render failed.');
-                },
-            );
+            Livewire::test(new class extends Component {
+                public function render()
+                {
+                    return '<div>{{ $foo }}</div>';
+                }
+            });
 
-            $this->fail('Expected render callback to throw.');
-        } catch (\RuntimeException $e) {
-            $this->assertSame('Render failed.', $e->getMessage());
+            $this->fail('Expected a ViewException to be thrown.');
+        } catch (\Illuminate\View\ViewException $e) {
+            // Expected...
         }
 
-        $this->assertTrue(
-            empty(HandleComponents::$renderStack),
-            'Render stack should be empty on exception'
-        );
+        $this->assertEmpty(HandleComponents::$renderStack);
     }
 }
 


### PR DESCRIPTION
## Summary

Ensure temporary render state is cleaned up when rendering throws an exception.

## Problem

There are two places in the render path where cleanup currently only happens after successful execution:

**`HandleComponents::render()`**
* `trackInRenderStack()` relies on `tap()` to pop the render stack.
* `$revertA` and `$revertB` state is reverted only after `$view->render()` completes.

**`HandleIslands::renderIslandView()`**
- `$revertShare` only runs after `$view->render()` completes.

If rendering throws, these cleanup callbacks are skipped, leaving temporary render state behind.

## Solution

Use `try/finally` for both cleanup paths so the state is restored regardless of whether rendering succeeds or throws.

Regression tests cover both cases.

This keeps the normal rendering behavior unchanged while making the cleanup defensive against exceptions during view rendering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup after failed view rendering.
  - Prevented stale component state and render-stack entries from persisting when rendering encounters an error.

- **Tests**
  - Added regression coverage confirming render state and shared view values are cleared after rendering failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->