### PR TITLE
Add failing test for lazy islands with a reactive child

### DIFF
--- a/src/Features/SupportIslands/BrowserTest.php
+++ b/src/Features/SupportIslands/BrowserTest.php
@@ -807,6 +807,35 @@ class BrowserTest extends BrowserTestCase
             ;
     }
 
+    public function test_visible_lazy_islands_with_a_reactive_nested_component_hydrate()
+    {
+        Livewire::visit([new class extends \Livewire\Component {
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    @island(name: 'one', lazy: true, always: true)
+                        @placeholder <div dusk="one-placeholder">Loading one</div> @endplaceholder
+                        <div dusk="one-mounted">One mounted</div>
+                    @endisland
+                    @island(name: 'two', lazy: true, always: true)
+                        @placeholder <div dusk="two-placeholder">Loading two</div> @endplaceholder
+                        <div dusk="two-mounted">Two mounted</div>
+                    @endisland
+                    <livewire:nested />
+                </div>
+                HTML;
+            }
+        }, 'nested' => new class extends \Livewire\Component {
+            #[\Livewire\Attributes\Reactive]
+            public bool $editing = false;
+            public function render() { return '<div></div>'; }
+        }])
+            ->waitFor('@one-mounted')
+            ->waitFor('@two-mounted')
+            ->assertNotPresent('@one-placeholder')
+            ->assertNotPresent('@two-placeholder');
+    }
+
     public function test_island_with_lazy_and_always_updates_with_the_component_when_the_component_makes_a_request()
     {
         Livewire::visit([new class extends \Livewire\Component {


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

This is a verified regression introduced by `785465b76d78`. There is no discussion yet; this draft documents the minimized reproduction before work begins on the fix.

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

Yes: `codex/reproduce-lazy-island-reactive-child-regression`.

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No. It contains only the focused browser regression test.

4️⃣ Does it include tests? (Required)

Yes. This draft intentionally adds a failing browser test; no production fix is included yet.

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

When a component renders multiple visible lazy islands alongside a nested component with a reactive property, only the first island hydrates. The remaining islands stay as loading placeholders indefinitely.

The minimized reproduction uses two plain `lazy: true, always: true` islands and one empty nested component with a default `#[Reactive]` boolean. It does not require a deferred parent, scrolling, Flux, Blaze, layout markup, or application-specific code.

Boundary validation with freshly built browser assets:

- Parent `6be2790f`: 3/3 passing
- Regression commit `785465b7`: 3/3 failing
- Livewire v4.4.3: 3/3 failing

Each failure hydrates the first island and times out waiting for the second. This draft leaves the failure in place so the fix can be developed against it separately.