### PR TITLE
[4.x] Only mark a lazy component loaded once it has actually resumed

### DIFF
--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -118,18 +118,22 @@ class SupportLazyLoading extends ComponentHook
         $this->component->skipHydrate();
 
         $this->storeSet('isLazyLoadHydrating', true);
+        $this->storeSet('isLazyIsolated', $memo['lazyIsolated'] ?? false);
     }
 
     function dehydrate($context)
     {
-        if ($this->storeGet('isLazyLoadMounting') === true) {
-            $context->addMemo('lazyLoaded', false);
-            $context->addMemo('lazyIsolated', $this->storeGet('isLazyIsolated'));
-        } elseif (
-            $this->storeGet('isLazyLoadHydrating') === true
+        if (
+            $this->storeGet('isLazyLoadResumed') === true
             || $this->storeGet('isLazyLoadAlreadyLoaded') === true
         ) {
             $context->addMemo('lazyLoaded', true);
+        } elseif (
+            $this->storeGet('isLazyLoadMounting') === true
+            || $this->storeGet('isLazyLoadHydrating') === true
+        ) {
+            $context->addMemo('lazyLoaded', false);
+            $context->addMemo('lazyIsolated', $this->storeGet('isLazyIsolated'));
         }
     }
 
@@ -153,6 +157,8 @@ class SupportLazyLoading extends ComponentHook
         $mountParams = $this->resurrectMountParams($encoded);
 
         $this->callMountLifecycleMethod($mountParams);
+
+        $this->storeSet('isLazyLoadResumed', true);
 
         $returnEarly();
     }

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -182,6 +182,17 @@ class LazyAlpha extends Component {
 }
 
 #[Lazy]
+class LazyBeta extends Component {
+    public function placeholder() {
+        return '<div>Loading...</div>';
+    }
+
+    public function render() {
+        return '<div>beta</div>';
+    }
+}
+
+#[Lazy]
 class LazyGamma extends Component {
     public $level = 0;
     public $mounts = 0;
@@ -200,17 +211,6 @@ class LazyGamma extends Component {
 
     public function render() {
         return '<div>level:'.$this->level.' mounts:'.$this->mounts.'</div>';
-    }
-}
-
-#[Lazy]
-class LazyBeta extends Component {
-    public function placeholder() {
-        return '<div>Loading...</div>';
-    }
-
-    public function render() {
-        return '<div>beta</div>';
     }
 }
 

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Route;
 use Livewire\Attributes\Defer;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Lazy;
+use Livewire\Attributes\On;
 use Livewire\Component;
 use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Livewire;
@@ -112,6 +113,26 @@ class UnitTest extends \Tests\TestCase
             ->assertSee('mounts:1');
     }
 
+    public function test_a_lazy_component_reached_before_it_loads_still_mounts()
+    {
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        Livewire::component('lazy-gamma', LazyGamma::class);
+
+        $component = Livewire::test('lazy-gamma', ['level' => 5]);
+
+        preg_match("/__lazyLoad\('([^']+)'\)/", html_entity_decode($component->html()), $matches);
+
+        $this->assertFalse($component->snapshot['memo']['lazyLoaded']);
+
+        $component->dispatch('refresh-panels');
+
+        $component
+            ->call('__lazyLoad', $matches[1])
+            ->assertSee('level:5')
+            ->assertSee('mounts:1');
+    }
+
     public function test_a_lazy_load_call_on_a_non_lazy_component_is_not_claimed()
     {
         $this->expectException(MethodNotFoundException::class);
@@ -150,6 +171,28 @@ class LazyAlpha extends Component {
         $this->level = $level;
         $this->mounts++;
     }
+
+    public function placeholder() {
+        return '<div>Loading...</div>';
+    }
+
+    public function render() {
+        return '<div>level:'.$this->level.' mounts:'.$this->mounts.'</div>';
+    }
+}
+
+#[Lazy]
+class LazyGamma extends Component {
+    public $level = 0;
+    public $mounts = 0;
+
+    public function mount($level = 0) {
+        $this->level = $level;
+        $this->mounts++;
+    }
+
+    #[On('refresh-panels')]
+    public function refreshPanels() {}
 
     public function placeholder() {
         return '<div>Loading...</div>';


### PR DESCRIPTION
## Problem

`SupportLazyLoading::hydrate()` sets `isLazyLoadHydrating` whenever the memo says `lazyLoaded === false`, which is every request that hydrates a lazy component that has not loaded yet, not just the `__lazyLoad` resume. `dehydrate()` then reads that same flag as "finished loading" and writes `lazyLoaded: true`.

Nothing checks whether `callMountLifecycleMethod()` ran. So any request that reaches an unloaded lazy component before `__lazyLoad` does, a dispatched event for instance, stamps the snapshot as loaded. The later `__lazyLoad` is then ignored by the guard added in #10562, and the component renders with `mount()` never having run.

It is easy to miss in the wild because mount params are still applied straight to matching public properties, so the component looks half initialized rather than blank. Anything assigned inside `mount()` is not there: a typed property throws "must not be accessed before initialization", an array property throws on key access.

#10589 removed the original trigger by no longer registering client-side listeners for a placeholder, but the mismarking itself is untouched, and any request that reaches the component still hits it.

### Solution

Key `lazyLoaded: true` off whether the lazy load was actually resumed rather than off `isLazyLoadHydrating`. `call()` sets `isLazyLoadResumed` right after `callMountLifecycleMethod()` runs, and `dehydrate()` requires that flag or the existing `isLazyLoadAlreadyLoaded` check before marking the snapshot loaded.

A component merely hydrated while still unloaded now keeps `lazyLoaded: false` and carries its `lazyIsolated` flag forward, so a later `__lazyLoad` mounts it normally.

Scoped to the memo only. Such a request still renders the component rather than falling back to its placeholder, which is the broader behavioral question raised in the issue and left for a separate call.

Verification:

- `test_a_lazy_component_reached_before_it_loads_still_mounts` dispatches an event at the component before its resume request and asserts the resume still mounts it. Without the change it renders `level:5 mounts:0`
- Lazy-loading unit suite: 11 tests, 26 assertions
- Full unit suite: 1450 tests, no new failures

Fixes #10643
