### PR TITLE
[4.x] Don't forward array attributes to a lazy placeholder

### DIFF
--- a/src/Features/SupportHtmlAttributeForwarding/SupportHtmlAttributeForwarding.php
+++ b/src/Features/SupportHtmlAttributeForwarding/SupportHtmlAttributeForwarding.php
@@ -23,7 +23,7 @@ class SupportHtmlAttributeForwarding extends ComponentHook
 
     public function renderPlaceholder($view, $properties)
     {
-        $attributes = $this->component->getHtmlAttributes();
+        $attributes = array_filter($this->component->getHtmlAttributes(), fn ($value) => ! is_array($value));
 
         $view->with(['attributes' => new ComponentAttributeBag($attributes)]);
     }

--- a/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
+++ b/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
@@ -4,7 +4,9 @@ namespace Livewire\Features\SupportHtmlAttributeForwarding;
 
 use Tests\TestCase;
 use Livewire\Livewire;
+use Livewire\Features\SupportLazyLoading\SupportLazyLoading;
 use Livewire\Component;
+use Livewire\Attributes\Lazy;
 
 class UnitTest extends TestCase
 {
@@ -46,5 +48,28 @@ class UnitTest extends TestCase
         ->assertSeeHtml('id="error-alert"')
         ->assertSeeHtml('data-testid="my-alert"')
         ;
+    }
+
+    public function test_array_html_attributes_are_not_forwarded_to_a_placeholder()
+    {
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        Livewire::component('alert', LazyAlert::class);
+
+        $html = Livewire::mount('alert', ['lazy' => true, 'pageFilters' => ['status' => 'active'], 'id' => 'error-alert']);
+
+        $this->assertStringContainsString('id="error-alert"', $html);
+        $this->assertStringNotContainsString('pageFilters=', $html);
+    }
+}
+
+#[Lazy]
+class LazyAlert extends Component {
+    public function placeholder() {
+        return '<div {{ $attributes }}>Loading...</div>';
+    }
+
+    public function render() {
+        return '<div {{ $attributes }}>Alert</div>';
     }
 }

--- a/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
+++ b/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
@@ -70,6 +70,6 @@ class LazyAlert extends Component {
     }
 
     public function render() {
-        return '<div {{ $attributes }}>Alert</div>';
+        return '<div>Alert</div>';
     }
 }


### PR DESCRIPTION
A lazy component's placeholder crashes with `trim(): Argument #1 ($string) must be of type string, array given` when a non-property mount param holds an array. #10392 started passing forwarded HTML attributes into the placeholder view, and `ComponentAttributeBag::__toString()` has no array handling, so an array-valued param breaks the render even when the placeholder never touches that key. Filament v5 hits this on every lazy widget, since it forwards a `pageFilters` array.

Array values are now skipped when building the placeholder's bag. `->class()` and `->style()` already flatten arrays to strings before they reach the bag, so nothing renderable is lost.

Fixes #10646