### PR TITLE
Preserve browser event origins for listener requests

### DIFF
--- a/js/features/supportListeners.js
+++ b/js/features/supportListeners.js
@@ -1,4 +1,5 @@
 import { on as hook } from '@/hooks'
+import { setNextActionOrigin } from '@/request'
 
 hook('effect', ({ component, effects }) => {
     let listeners = []
@@ -17,6 +18,14 @@ function registerListeners(component, listeners) {
             if (component.isLazy && ! component.hasBeenLazyLoaded) return
 
             if (e.__livewire) e.__livewire.receivedBy.push(component)
+
+            // Event listeners may live in a completely different component than
+            // the element that dispatched the event (for example, a global toast).
+            // Preserve that element as the action origin so it receives data-loading
+            // for the listener's request.
+            if (e.target instanceof Element) {
+                setNextActionOrigin({ el: e.target })
+            }
 
             component.$wire.call('__dispatch', name, e.detail || {})
         }
@@ -41,5 +50,4 @@ function registerListeners(component, listeners) {
         })
     })
 }
-
 

--- a/src/Features/SupportDataLoading/BrowserTest.php
+++ b/src/Features/SupportDataLoading/BrowserTest.php
@@ -6,6 +6,43 @@ use Livewire\Livewire;
 
 class BrowserTest extends \Tests\BrowserTestCase
 {
+    public function test_data_loading_follows_an_event_origin_into_a_different_listener_component()
+    {
+        Livewire::visit([
+            new class extends \Livewire\Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button x-on:click="$el.dispatchEvent(new CustomEvent('toast-action', { bubbles: true }))" dusk="toast-action">Retry</button>
+                        <livewire:receiver />
+                    </div>
+                    HTML;
+                }
+            },
+            'receiver' => new class extends \Livewire\Component {
+                #[\Livewire\Attributes\On('toast-action')]
+                public function handleToastAction()
+                {
+                    usleep(250 * 1000);
+                }
+
+                public function render()
+                {
+                    return '<div dusk="receiver">Receiver</div>';
+                }
+            },
+        ])
+        ->waitForLivewireToLoad()
+        ->assertAttributeMissing('@toast-action', 'data-loading')
+        ->click('@toast-action')
+        ->pause(10)
+        ->assertAttribute('@toast-action', 'data-loading', 'true')
+        ->pause(350)
+        ->assertAttributeMissing('@toast-action', 'data-loading')
+        ;
+    }
+
     public function test_data_loading_attribute_is_added_to_an_element_when_it_triggers_a_request()
     {
         Livewire::visit([


### PR DESCRIPTION
When a bubbling browser event is handled by a Livewire listener, preserve the event target as the origin of the listener request.

This matters when the event starts outside the listening component—for example, a global toast action. Features such as data-loading can then decorate the control the user actually activated while another component performs the work.

## Coordinated PRs

- livewire/flux#2791 — public API and toast markup
- livewire/flux-pro#567 — action runtime and browser coverage
- livewire/livewire#10648 — cross-component request loading origin
- livewire/flux-docs#211 — documentation and interactive example

## Verification

- npm run build
- composer test:browser -- --filter="test_data_loading_follows_an_event_origin_into_a_different_listener_component"
- 1 browser test passed with 4 assertions