### PR TITLE
[4.x] Fix wire:navigate breaking when a teleport targets an element inside @persist

### DIFF
--- a/js/plugins/navigate/persist.js
+++ b/js/plugins/navigate/persist.js
@@ -29,11 +29,11 @@ export function putPersistantElementsBack(callback) {
 
         old._x_wasPersisted = true
 
-        callback(old, i)
-
         Alpine.mutateDom(() => {
             i.replaceWith(old)
         })
+
+        callback(old, i)
     })
 
     Object.entries(els).forEach(([key, el]) => {

--- a/js/plugins/navigate/persist.js
+++ b/js/plugins/navigate/persist.js
@@ -18,6 +18,7 @@ export function storePersistantElementsForLater(callback) {
 
 export function putPersistantElementsBack(callback) {
     let usedPersists = []
+    let putBacks = []
 
     document.querySelectorAll('[x-persist]').forEach(i => {
         let old = els[i.getAttribute('x-persist')]
@@ -33,8 +34,12 @@ export function putPersistantElementsBack(callback) {
             i.replaceWith(old)
         })
 
-        callback(old, i)
+        putBacks.push([old, i])
     })
+
+    // Wait until every persisted element is back on the page before running the
+    // callbacks, otherwise a teleport can't resolve a target inside one of them...
+    putBacks.forEach(([old, i]) => callback(old, i))
 
     Object.entries(els).forEach(([key, el]) => {
         if (usedPersists.includes(key)) return

--- a/js/plugins/navigate/teleport.js
+++ b/js/plugins/navigate/teleport.js
@@ -17,7 +17,7 @@ export function removeAnyLeftOverStaleTeleportTargets(body) {
 }
 
 export function unPackPersistedTeleports(persistedEl) {
-    // Before we put back any persisted elements, we're going to
+    // Now that the persisted elements are back on the page, we're going to
     // find any "x-teleports" and put their targets back on the page...
     Alpine.walk(persistedEl, (el, skip) => {
         if (! el._x_teleport) return;

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -254,6 +254,61 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_teleports_targeting_an_element_inside_a_persist_are_put_back()
+    {
+        $this->registerComponentTestRoutes([
+            '/second' => new class extends Component {
+                public function render(){ return <<<'HTML'
+                    <div>
+                        <div>
+                            On second page
+                        </div>
+
+                        @persist('header')
+                            <div>Loading...</div>
+                        @endpersist
+                    </div>
+                HTML; }
+            },
+        ]);
+
+        Livewire::visit(new class extends Component {
+            public function render(){
+                return <<<'HTML'
+                    <div>
+                        <div>
+                            On first page
+                        </div>
+
+                        @persist('header')
+                            <div x-data="{ outerScopeCount: 0 }">
+                                <div id="labels"></div>
+
+                                <template x-teleport="#labels">
+                                    <div>
+                                        <span x-text="outerScopeCount" dusk="target"></span>
+                                        <button x-on:click="outerScopeCount++" dusk="button">inc</button>
+                                    </div>
+                                </template>
+                            </div>
+                        @endpersist
+
+                        <a href="/second" wire:navigate dusk="link">Go to second page</a>
+                    </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@target', '0')
+        ->click('@button')
+        ->assertSeeIn('@target', '1')
+        ->click('@link')
+        ->waitForText('On second page')
+        ->assertSeeIn('@target', '1')
+        ->click('@button')
+        ->assertSeeIn('@target', '2')
+        ;
+    }
+
     public function test_can_configure_progress_bar()
     {
         $this->browse(function ($browser) {

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -254,7 +254,7 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
-    public function test_teleports_targeting_an_element_inside_a_persist_are_put_back()
+    public function test_navigate_works_with_teleports_targeting_inside_a_persist()
     {
         $this->registerComponentTestRoutes([
             '/second' => new class extends Component {
@@ -265,7 +265,7 @@ class BrowserTest extends \Tests\BrowserTestCase
                         </div>
 
                         @persist('header')
-                            <div>Loading...</div>
+                            <div>Placeholder</div>
                         @endpersist
                     </div>
                 HTML; }
@@ -291,6 +291,67 @@ class BrowserTest extends \Tests\BrowserTestCase
                                     </div>
                                 </template>
                             </div>
+                        @endpersist
+
+                        <a href="/second" wire:navigate dusk="link">Go to second page</a>
+                    </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@target', '0')
+        ->click('@button')
+        ->assertSeeIn('@target', '1')
+        ->click('@link')
+        ->waitForText('On second page')
+        ->assertSeeIn('@target', '1')
+        ->click('@button')
+        ->assertSeeIn('@target', '2')
+        ;
+    }
+
+    public function test_navigate_works_with_teleports_targeting_inside_another_persist()
+    {
+        $this->registerComponentTestRoutes([
+            '/second' => new class extends Component {
+                public function render(){ return <<<'HTML'
+                    <div>
+                        <div>
+                            On second page
+                        </div>
+
+                        @persist('header')
+                            <div>Placeholder</div>
+                        @endpersist
+
+                        @persist('sidebar')
+                            <div>Placeholder</div>
+                        @endpersist
+                    </div>
+                HTML; }
+            },
+        ]);
+
+        Livewire::visit(new class extends Component {
+            public function render(){
+                return <<<'HTML'
+                    <div>
+                        <div>
+                            On first page
+                        </div>
+
+                        @persist('header')
+                            <div x-data="{ outerScopeCount: 0 }">
+                                <template x-teleport="#labels">
+                                    <div>
+                                        <span x-text="outerScopeCount" dusk="target"></span>
+                                        <button x-on:click="outerScopeCount++" dusk="button">inc</button>
+                                    </div>
+                                </template>
+                            </div>
+                        @endpersist
+
+                        @persist('sidebar')
+                            <div id="labels"></div>
                         @endpersist
 
                         <a href="/second" wire:navigate dusk="link">Go to second page</a>


### PR DESCRIPTION
Clicking a `wire:navigate` link can leave the destination page completely inert. No Livewire, no Alpine, nothing until a manual refresh. It happens when a persisted element holds an `x-teleport` pointing at a target inside itself and the destination page ships no matching target, which is what you get when the persisted component is `#[Lazy]` and only its placeholder comes down.

```blade
@persist('sidebar')
    <div id="labels"></div>

    <template x-teleport="#labels">
        <span>Label</span>
    </template>
@endpersist
```

`putPersistantElementsBack()` ran its put-back callback before re-attaching the persisted element, so `unPackPersistedTeleports()` resolved teleport targets through `document.querySelector()` while that element was still detached. The target could not be found, `placeInDom` threw on `null.appendChild(...)`, and since the exception escaped `swapCurrentPageWithNewHtml`, `nowInitializeAlpineOnTheNewPage` never ran.

Every persisted element now goes back on the page first and the callbacks run afterwards, so a teleport can also resolve a target that lives inside a different persist. That also mirrors `storePersistantElementsForLater()`, which already packs up while the element is still attached.

Fixes #10652
