### PR TITLE
[4.x] Fix `$wire.$watch` crash from lazy placeholder node conflict

### DIFF
--- a/js/$wire.js
+++ b/js/$wire.js
@@ -1,6 +1,7 @@
 import { cancelUpload, removeUpload, upload, uploadMultiple } from './features/supportFileUploads'
 import { dispatch, dispatchEl, dispatchRef, dispatchSelf, dispatchTo, listen } from '@/events'
 import { generateEntangleFunction } from '@/features/supportEntangle'
+import { generateWatchFunction } from '@/features/supportWatch'
 import { findComponentByEl } from '@/store'
 import { dataGet, dataSet } from '@/utils'
 import Alpine from 'alpinejs'
@@ -119,6 +120,8 @@ Alpine.magic('wire', (el, { cleanup }) => {
 
             if (['$entangle', 'entangle'].includes(property)) {
                 return generateEntangleFunction(component, cleanup)
+            } else if (['$watch', 'watch'].includes(property)) {
+                return generateWatchFunction(component, cleanup)
             }
 
             return component.$wire[property]
@@ -277,18 +280,7 @@ wireProperty('$toggle', (component) => (name, live = true) => {
 })
 
 wireProperty('$watch', (component) => (path, callback) => {
-    let getter = () => {
-        return dataGet(component.reactive, path)
-    }
-
-    let unwatch = Alpine.watch(getter, callback)
-
-    let removeCleanup = component.addCleanup(unwatch)
-
-    return () => {
-        removeCleanup()
-        unwatch()
-    }
+    return generateWatchFunction(component)(path, callback)
 })
 
 wireProperty('$effect', (component) => (callback) => {

--- a/js/features/supportWatch.js
+++ b/js/features/supportWatch.js
@@ -1,0 +1,23 @@
+import { dataGet } from '@/utils'
+import Alpine from 'alpinejs'
+
+export function generateWatchFunction(component, cleanup) {
+    return (path, callback) => {
+        let getter = () => dataGet(component.reactive, path)
+
+        let unwatch = Alpine.watch(getter, callback)
+
+        if (cleanup) {
+            cleanup(unwatch)
+
+            return unwatch
+        }
+
+        let removeCleanup = component.addCleanup(unwatch)
+
+        return () => {
+            removeCleanup()
+            unwatch()
+        }
+    }
+}

--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -827,6 +827,46 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_conflicting_placeholder_node_does_not_break_watch_cleanup_or_leak_memory_on_lazy_component()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public bool $childShown = false;
+
+                public function render() { return <<<HTML
+                <div>
+                    <button type="button" wire:click="\$toggle('childShown')">Toggle</button>
+
+                    @if (\$this->childShown)
+                        <livewire:child lazy />
+                    @endif
+                </div>
+                HTML; }
+            }, 'child' => new class extends Component {
+                public function placeholder() { return <<<HTML
+                    <div id="child">
+                        <div>Loading...</div>
+                        <div>Dummy placeholder</div>
+                    </div>
+                    HTML; }
+
+                public function render() { return <<<HTML
+                    <div id="child">
+                        <div x-data="{ init() { \$wire.\$watch('search', () => {}) } }">
+                            Children component
+                        </div>
+                    </div>
+                    HTML; }
+            }
+        ])
+        ->waitForText('Toggle')
+        ->click('button')
+        ->waitForText('Children component')
+        ->click('button')
+        ->waitUntilMissing('#child')
+        ->assertConsoleLogHasNoErrors()
+        ->assertScript("window.Livewire.all().some(c => c.name === 'child')", false);
+    }
 }
 
 class Page extends Component {


### PR DESCRIPTION
## The problem

`$wire.$watch` ties its cleanup to the component, not the element calling it. Alpine's morph "clone" pass runs `x-data` `init()` on a throwaway node before diffing, with its reactivity neutered, this happens whenever a lazy placeholder shares node positions with its real markup. The resulting broken watcher gets stuck in `component.cleanups` and throws when the component is destroyed, aborting the rest of the cleanup and leaving the component registered in `window.Livewire.all()` forever.

More details and reproduction here : #10655 

## The fix

Tie `$wire.$watch`'s cleanup to the calling element when possible, like `$wire.$entangle` already does. Direct usage (`@script`, file uploads) falls back to the component's lifetime, unchanged. Extracted into `js/features/supportWatch.js`.

## Tests

- [x] Added a regression test: lazy component, placeholder/real markup share node positions, `$wire.$watch` in `x-data`
- [x] Fails before the fix (same error), passes after
- [x] `SupportLazyLoading` (24 tests) pass
- [x] `SupportFileUploads` (10 tests) pass, no collision with file upload's own watcher cleanup
- [x] `JavascriptUnwatchBrowserTest` passes, manual unwatch from `x-data` still works
- [x] `SupportJsModules`/`SupportWireIntersect` failures are pre-existing on `4.x` (confirmed unrelated to this change)

Fixes #10655