### PR TITLE
[4.x] Keep children mounted during an island render

### DIFF
--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -677,4 +677,64 @@ class UnitTest extends TestCase
 
         File::deleteDirectory($compiledPath);
     }
+
+    public function test_children_mounted_during_an_island_render_are_kept_in_the_children_memo()
+    {
+        Livewire::component('island-child', new class extends \Livewire\Component {
+            public $number = 0;
+
+            public function render() {
+                return '<div>child {{ $number }}</div>';
+            }
+        });
+
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public $from = 0;
+
+            public $to = 1;
+
+            public function loadMore()
+            {
+                $this->from = $this->to + 1;
+                $this->to++;
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    @island(name: 'rows', always: true)
+                        @foreach (range($from ?: 1, $to) as $number)
+                            <livewire:island-child :$number :wire:key="'row-'.$number" />
+                        @endforeach
+                    @endisland
+                </div>
+                HTML;
+            }
+        });
+
+        $this->assertSame(['row-1'], array_keys($component->snapshot['memo']['children']));
+
+        $component->update(calls: [
+            [
+                'method' => 'loadMore',
+                'params' => [],
+                'path' => '',
+                'metadata' => [
+                    'island' => [
+                        'name' => 'rows',
+                        'mode' => 'append',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(['row-1', 'row-2'], array_keys($component->snapshot['memo']['children']));
+
+        $appendedChildId = $component->snapshot['memo']['children']['row-2'][1];
+
+        $component->call('$refresh');
+
+        $this->assertStringContainsString('wire:id="'.$appendedChildId.'" wire:name="island-child" wire:key="row-2"', $component->html());
+        $this->assertStringNotContainsString('child 2', $component->html());
+    }
 }

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -689,8 +689,7 @@ class UnitTest extends TestCase
         });
 
         $component = Livewire::test(new class extends \Livewire\Component {
-            public $from = 0;
-
+            public $from = 1;
             public $to = 1;
 
             public function loadMore()
@@ -703,7 +702,7 @@ class UnitTest extends TestCase
                 return <<<'HTML'
                 <div>
                     @island(name: 'rows', always: true)
-                        @foreach (range($from ?: 1, $to) as $number)
+                        @foreach (range($from, $to) as $number)
                             <livewire:island-child :$number :wire:key="'row-'.$number" />
                         @endforeach
                     @endisland
@@ -714,6 +713,7 @@ class UnitTest extends TestCase
 
         $this->assertSame(['row-1'], array_keys($component->snapshot['memo']['children']));
 
+        // Simulate an append-mode island render, like a "load more" button would...
         $component->update(calls: [
             [
                 'method' => 'loadMore',
@@ -734,7 +734,9 @@ class UnitTest extends TestCase
 
         $component->call('$refresh');
 
+        // The appended child should come back as a stub, not mount again from scratch...
         $this->assertStringContainsString('wire:id="'.$appendedChildId.'" wire:name="island-child" wire:key="row-2"', $component->html());
+        $this->assertStringNotContainsString('child 1', $component->html());
         $this->assertStringNotContainsString('child 2', $component->html());
     }
 }

--- a/src/Features/SupportNestingComponents/SupportNestingComponents.php
+++ b/src/Features/SupportNestingComponents/SupportNestingComponents.php
@@ -112,10 +112,7 @@ class SupportNestingComponents extends ComponentHook
 
     function keepRenderedChildren()
     {
-        $this->storeSet('children', array_replace(
-            $this->storeGet('previousChildren', []),
-            $this->storeGet('children', []),
-        ));
+        $this->storeSet('children', array_replace($this->storeGet('previousChildren', []), $this->getChildren()));
     }
 
     static function setParametersToMatchingProperties($component, $params)

--- a/src/Features/SupportNestingComponents/SupportNestingComponents.php
+++ b/src/Features/SupportNestingComponents/SupportNestingComponents.php
@@ -112,7 +112,10 @@ class SupportNestingComponents extends ComponentHook
 
     function keepRenderedChildren()
     {
-        $this->storeSet('children', $this->storeGet('previousChildren'));
+        $this->storeSet('children', array_replace(
+            $this->storeGet('previousChildren', []),
+            $this->storeGet('children', []),
+        ));
     }
 
     static function setParametersToMatchingProperties($component, $params)


### PR DESCRIPTION
A `<livewire:child>` mounted during an island render never makes it into the parent's `children` memo. The next ordinary render of the parent treats those children as if they had never rendered, mounts them again with new ids and full HTML, and the morph throws away the live components along with their state.

An island-scoped action (`wire:island`, `wire:island.append`, `$wire.$island(...)`) calls `skipRender()` and renders only the island. Children mounted inside that island push themselves into the parent's `children` store as usual, and then dehydrate discards them:

```php
function dehydrate($context)
{
    if ($this->component->shouldSkipRender()) {
        $this->keepRenderedChildren(); // children = previousChildren
    }
    ...
    $context->addMemo('children', $this->getChildren());
}
```

`keepRenderedChildren()` was written for `#[Renderless]`, where nothing can have been mounted, so overwriting was safe. With islands it drops whatever the island just mounted.

The practical cost is that `wire:island.append` can't be used for infinite scroll when the appended rows are components: every append works, and then the next render of the parent rebuilds all of them.

The fix keeps the previously rendered children and layers this request's children over the top, so an entry mounted during the island render survives and a key rendered in both requests still resolves to the newer child.

Two notes on the details:

`array_replace` rather than the `array_merge` suggested in the issue. `array_merge` renumbers integer-like keys, and a numeric `wire:key` reaches this array as a real integer key, so merging turns keys `[1, 2]` into `[0, 1]` and breaks the lookup for every numeric-keyed child, including ones that work today. `array_replace` preserves the keys.

This covers append mode, which is what the issue reports. Morph-mode islands lose children too, but for a different reason: `SupportNestingComponents` is registered ahead of `SupportIslands`, so the children memo is written before `SupportIslands::dehydrate()` runs `renderImplicitIslandMorphs()`, which is where morph children mount. That looks fixable by re-adding the memo after the morph render, and it passes the suite locally, but it's a separate cause and touches hook ordering, so I left it out rather than widen this PR. Happy to add it here or open a follow-up, whichever you prefer.

Reported and diagnosed in #10657, along with the proposed fix.

Fixes #10657
