### PR TITLE
[4.x] Support container-resolvable for `EndpointResolver`

### DIFF
--- a/src/LivewireServiceProvider.php
+++ b/src/LivewireServiceProvider.php
@@ -7,6 +7,8 @@ use Livewire\Compiler\Compiler;
 use Illuminate\Foundation\Console\AboutCommand;
 use Composer\InstalledVersions;
 use Livewire\Compiler\CacheManager;
+use Livewire\Mechanisms\HandleRequests\DefaultEndpointResolver;
+use Livewire\Mechanisms\HandleRequests\EndpointResolverInterface;
 
 class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
 {
@@ -31,6 +33,8 @@ class LivewireServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->app->singleton(LivewireManager::class);
 
         app('livewire')->setProvider($this);
+
+        $this->app->singletonIf(EndpointResolverInterface::class, DefaultEndpointResolver::class);
 
         $this->app->singleton('livewire.finder', function () {
             $finder = new Finder;

--- a/src/Mechanisms/FrontendAssets/EndpointResolverIntegrationUnitTest.php
+++ b/src/Mechanisms/FrontendAssets/EndpointResolverIntegrationUnitTest.php
@@ -2,12 +2,46 @@
 
 namespace Livewire\Mechanisms\FrontendAssets;
 
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+use Livewire\LivewireServiceProvider;
 use Livewire\Mechanisms\FrontendAssets\FrontendAssets;
 use Livewire\Mechanisms\HandleRequests\EndpointResolver;
+use Livewire\Mechanisms\HandleRequests\EndpointResolverInterface;
 use Tests\TestCase;
 
 class EndpointResolverIntegrationUnitTest extends TestCase
 {
+    protected function getPackageProviders($app)
+    {
+        return [
+            LivewireServiceProvider::class,
+            CustomEndpointResolverServiceProvider::class,
+        ];
+    }
+
+    public function test_livewire_routes_use_custom_endpoint_resolver()
+    {
+        $routes = collect(Route::getRoutes()->getRoutes());
+
+        foreach ([
+            'custom-livewire/update',
+            config('app.debug') ? 'custom-livewire/livewire.js' : 'custom-livewire/livewire.min.js',
+            'custom-livewire/livewire.min.js.map',
+            'custom-livewire/livewire.csp.min.js.map',
+            'custom-livewire/upload-file',
+            'custom-livewire/preview-file/{filename}',
+            'custom-livewire/js/{component}.js',
+            'custom-livewire/css/{component}.css',
+            'custom-livewire/css/{component}.global.css',
+        ] as $uri) {
+            $this->assertTrue(
+                $routes->contains(fn ($route) => $route->uri() === $uri),
+                "Expected Livewire route [{$uri}] to be registered."
+            );
+        }
+    }
+
     public function test_script_route_uses_endpoint_resolver_path()
     {
         $expectedPath = EndpointResolver::scriptPath(minified: !config('app.debug'));
@@ -46,7 +80,74 @@ class EndpointResolverIntegrationUnitTest extends TestCase
         $prefix = EndpointResolver::prefix();
 
         $this->assertStringStartsWith($prefix, EndpointResolver::updatePath());
-        $this->assertStringStartsWith($prefix, EndpointResolver::scriptPath());
+        $this->assertStringStartsWith($prefix, EndpointResolver::scriptPath(false));
+        $this->assertStringStartsWith($prefix, EndpointResolver::scriptPath(true));
+        $this->assertStringStartsWith($prefix, EndpointResolver::mapPath(false));
+        $this->assertStringStartsWith($prefix, EndpointResolver::mapPath(true));
         $this->assertStringStartsWith($prefix, EndpointResolver::uploadPath());
+        $this->assertStringStartsWith($prefix, EndpointResolver::previewPath());
+    }
+}
+
+class CustomEndpointResolverServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->singleton(
+            EndpointResolverInterface::class,
+            CustomEndpointResolver::class,
+        );
+    }
+}
+
+class CustomEndpointResolver implements EndpointResolverInterface
+{
+    public function prefix(): string
+    {
+        return '/custom-livewire';
+    }
+
+    public function updatePath(): string
+    {
+        return $this->prefix() . '/update';
+    }
+
+    public function scriptPath(bool $minified = false): string
+    {
+        $file = $minified ? 'livewire.min.js' : 'livewire.js';
+
+        return $this->prefix() . '/' . $file;
+    }
+
+    public function mapPath(bool $csp = false): string
+    {
+        $file = $csp ? 'livewire.csp.min.js.map' : 'livewire.min.js.map';
+
+        return $this->prefix() . '/' . $file;
+    }
+
+    public function uploadPath(): string
+    {
+        return $this->prefix() . '/upload-file';
+    }
+
+    public function previewPath(): string
+    {
+        return $this->prefix() . '/preview-file/{filename}';
+    }
+
+    public function componentJsPath(): string
+    {
+        return $this->prefix() . '/js/{component}.js';
+    }
+
+    public function componentCssPath(): string
+    {
+        return $this->prefix() . '/css/{component}.css';
+    }
+
+    public function componentGlobalCssPath(): string
+    {
+        return $this->prefix() . '/css/{component}.global.css';
     }
 }

--- a/src/Mechanisms/HandleRequests/DefaultEndpointResolver.php
+++ b/src/Mechanisms/HandleRequests/DefaultEndpointResolver.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleRequests;
+
+/**
+ * Default implementation of the endpoint resolver.
+ */
+class DefaultEndpointResolver implements EndpointResolverInterface
+{
+    /**
+     * Get the base path prefix for all Livewire endpoints.
+     *
+     * Uses APP_KEY to generate a unique prefix per installation,
+     * making it harder to target Livewire apps with universal scanners.
+     */
+    public function prefix(): string
+    {
+        $hash = substr(hash('sha256', config('app.key') . 'livewire-endpoint'), 0, 8);
+
+        return '/livewire-' . $hash;
+    }
+
+    /**
+     * Get the path for the update endpoint.
+     */
+    public function updatePath(): string
+    {
+        return $this->prefix() . '/update';
+    }
+
+    /**
+     * Get the path for the JavaScript asset endpoint.
+     */
+    public function scriptPath(bool $minified = false): string
+    {
+        $file = $minified ? 'livewire.min.js' : 'livewire.js';
+
+        return $this->prefix() . '/' . $file;
+    }
+
+    /**
+     * Get the path for the source map endpoint.
+     */
+    public function mapPath(bool $csp = false): string
+    {
+        $file = $csp ? 'livewire.csp.min.js.map' : 'livewire.min.js.map';
+
+        return $this->prefix() . '/' . $file;
+    }
+
+    /**
+     * Get the path for the file upload endpoint.
+     */
+    public function uploadPath(): string
+    {
+        return $this->prefix() . '/upload-file';
+    }
+
+    /**
+     * Get the path for the file preview endpoint.
+     */
+    public function previewPath(): string
+    {
+        return $this->prefix() . '/preview-file/{filename}';
+    }
+
+    /**
+     * Get the path for component JavaScript modules.
+     */
+    public function componentJsPath(): string
+    {
+        return $this->prefix() . '/js/{component}.js';
+    }
+
+    /**
+     * Get the path for component CSS modules (scoped styles).
+     */
+    public function componentCssPath(): string
+    {
+        return $this->prefix() . '/css/{component}.css';
+    }
+
+    /**
+     * Get the path for component global CSS modules.
+     */
+    public function componentGlobalCssPath(): string
+    {
+        return $this->prefix() . '/css/{component}.global.css';
+    }
+}

--- a/src/Mechanisms/HandleRequests/DefaultEndpointResolver.php
+++ b/src/Mechanisms/HandleRequests/DefaultEndpointResolver.php
@@ -5,7 +5,7 @@ namespace Livewire\Mechanisms\HandleRequests;
 /**
  * Default implementation of the endpoint resolver.
  */
-class DefaultEndpointResolver implements EndpointResolverInterface
+final class DefaultEndpointResolver implements EndpointResolverInterface
 {
     /**
      * Get the base path prefix for all Livewire endpoints.

--- a/src/Mechanisms/HandleRequests/EndpointResolver.php
+++ b/src/Mechanisms/HandleRequests/EndpointResolver.php
@@ -5,6 +5,14 @@ namespace Livewire\Mechanisms\HandleRequests;
 class EndpointResolver
 {
     /**
+     * Get the concrete implementation from container
+     */
+    protected static function resolver(): EndpointResolverInterface
+    {
+        return app(EndpointResolverInterface::class);
+    }
+
+    /**
      * Get the base path prefix for all Livewire endpoints.
      *
      * Uses APP_KEY to generate a unique prefix per installation,
@@ -12,9 +20,7 @@ class EndpointResolver
      */
     public static function prefix(): string
     {
-        $hash = substr(hash('sha256', config('app.key') . 'livewire-endpoint'), 0, 8);
-
-        return '/livewire-' . $hash;
+        return static::resolver()->prefix();
     }
 
     /**
@@ -22,7 +28,7 @@ class EndpointResolver
      */
     public static function updatePath(): string
     {
-        return static::prefix() . '/update';
+        return static::resolver()->updatePath();
     }
 
     /**
@@ -30,9 +36,7 @@ class EndpointResolver
      */
     public static function scriptPath(bool $minified = false): string
     {
-        $file = $minified ? 'livewire.min.js' : 'livewire.js';
-
-        return static::prefix() . '/' . $file;
+        return static::resolver()->scriptPath($minified);
     }
 
     /**
@@ -40,9 +44,7 @@ class EndpointResolver
      */
     public static function mapPath(bool $csp = false): string
     {
-        $file = $csp ? 'livewire.csp.min.js.map' : 'livewire.min.js.map';
-
-        return static::prefix() . '/' . $file;
+        return static::resolver()->mapPath($csp);
     }
 
     /**
@@ -50,7 +52,7 @@ class EndpointResolver
      */
     public static function uploadPath(): string
     {
-        return static::prefix() . '/upload-file';
+        return static::resolver()->uploadPath();
     }
 
     /**
@@ -58,7 +60,7 @@ class EndpointResolver
      */
     public static function previewPath(): string
     {
-        return static::prefix() . '/preview-file/{filename}';
+        return static::resolver()->previewPath();
     }
 
     /**
@@ -66,7 +68,7 @@ class EndpointResolver
      */
     public static function componentJsPath(): string
     {
-        return static::prefix() . '/js/{component}.js';
+        return static::resolver()->componentJsPath();
     }
 
     /**
@@ -74,7 +76,7 @@ class EndpointResolver
      */
     public static function componentCssPath(): string
     {
-        return static::prefix() . '/css/{component}.css';
+        return static::resolver()->componentCssPath();
     }
 
     /**
@@ -82,6 +84,6 @@ class EndpointResolver
      */
     public static function componentGlobalCssPath(): string
     {
-        return static::prefix() . '/css/{component}.global.css';
+        return static::resolver()->componentGlobalCssPath();
     }
 }

--- a/src/Mechanisms/HandleRequests/EndpointResolverInterface.php
+++ b/src/Mechanisms/HandleRequests/EndpointResolverInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleRequests;
+
+interface EndpointResolverInterface
+{
+    public function prefix(): string;
+
+    public function updatePath(): string;
+
+    public function scriptPath(bool $minified = false): string;
+
+    public function mapPath(bool $csp = false): string;
+
+    public function uploadPath(): string;
+
+    public function previewPath(): string;
+
+    public function componentJsPath(): string;
+
+    public function componentCssPath(): string;
+
+    public function componentGlobalCssPath(): string;
+}

--- a/src/Mechanisms/HandleRequests/EndpointResolverUnitTest.php
+++ b/src/Mechanisms/HandleRequests/EndpointResolverUnitTest.php
@@ -24,6 +24,16 @@ class EndpointResolverUnitTest extends TestCase
         $this->assertSame('/custom-livewire/css/{component}.global.css', EndpointResolver::componentGlobalCssPath());
     }
 
+    public function test_endpoint_resolver_retains_static_api(): void
+    {
+        $this->assertTrue(method_exists(EndpointResolver::class, 'prefix'));
+        $this->assertTrue(method_exists(EndpointResolver::class, 'updatePath'));
+        $this->assertTrue(method_exists(EndpointResolver::class, 'scriptPath'));
+        $this->assertTrue(method_exists(EndpointResolver::class, 'mapPath'));
+        $this->assertTrue(method_exists(EndpointResolver::class, 'uploadPath'));
+        $this->assertTrue(method_exists(EndpointResolver::class, 'previewPath'));
+    }
+
     public function test_generates_unique_prefix_from_app_key()
     {
         $prefix = EndpointResolver::prefix();

--- a/src/Mechanisms/HandleRequests/EndpointResolverUnitTest.php
+++ b/src/Mechanisms/HandleRequests/EndpointResolverUnitTest.php
@@ -7,6 +7,23 @@ use Tests\TestCase;
 
 class EndpointResolverUnitTest extends TestCase
 {
+    public function test_endpoint_resolver_can_be_overridden()
+    {
+        $this->app->singleton(EndpointResolverInterface::class, CustomEndpointResolver::class);
+
+        $this->assertSame('/custom-livewire', EndpointResolver::prefix());
+        $this->assertSame('/custom-livewire/update', EndpointResolver::updatePath());
+        $this->assertSame('/custom-livewire/livewire.js', EndpointResolver::scriptPath(config('app.debug')));
+        $this->assertSame('/custom-livewire/livewire.min.js', EndpointResolver::scriptPath(! config('app.debug')));
+        $this->assertSame('/custom-livewire/livewire.min.js.map', EndpointResolver::mapPath());
+        $this->assertSame('/custom-livewire/livewire.csp.min.js.map', EndpointResolver::mapPath(csp: true));
+        $this->assertSame('/custom-livewire/upload-file', EndpointResolver::uploadPath());
+        $this->assertSame('/custom-livewire/preview-file/{filename}', EndpointResolver::previewPath());
+        $this->assertSame('/custom-livewire/js/{component}.js', EndpointResolver::componentJsPath());
+        $this->assertSame('/custom-livewire/css/{component}.css', EndpointResolver::componentCssPath());
+        $this->assertSame('/custom-livewire/css/{component}.global.css', EndpointResolver::componentGlobalCssPath());
+    }
+
     public function test_generates_unique_prefix_from_app_key()
     {
         $prefix = EndpointResolver::prefix();
@@ -99,5 +116,57 @@ class EndpointResolverUnitTest extends TestCase
         $this->assertStringStartsWith($prefix, EndpointResolver::uploadPath());
         $this->assertStringStartsWith($prefix, EndpointResolver::previewPath());
         $this->assertStringStartsWith($prefix, EndpointResolver::componentJsPath());
+    }
+}
+
+class CustomEndpointResolver implements EndpointResolverInterface
+{
+    public function prefix(): string
+    {
+        return '/custom-livewire';
+    }
+
+    public function updatePath(): string
+    {
+        return $this->prefix() . '/update';
+    }
+
+    public function scriptPath(bool $minified = false): string
+    {
+        $file = $minified ? 'livewire.min.js' : 'livewire.js';
+
+        return $this->prefix() . '/' . $file;
+    }
+
+    public function mapPath(bool $csp = false): string
+    {
+        $file = $csp ? 'livewire.csp.min.js.map' : 'livewire.min.js.map';
+
+        return $this->prefix() . '/' . $file;
+    }
+
+    public function uploadPath(): string
+    {
+        return $this->prefix() . '/upload-file';
+    }
+
+    public function previewPath(): string
+    {
+        return $this->prefix() . '/preview-file/{filename}';
+    }
+
+    public function componentJsPath(): string
+    {
+        return $this->prefix() . '/js/{component}.js';
+    }
+
+    public function componentCssPath(): string
+    {
+        return $this->prefix() . '/css/{component}.css';
+    }
+
+    public function componentGlobalCssPath(): string
+    {
+        return $this->prefix() . '/css/{component}.global.css';
     }
 }

--- a/src/Tests/LivewireRouteCachingUnitTest.php
+++ b/src/Tests/LivewireRouteCachingUnitTest.php
@@ -5,10 +5,37 @@ namespace Livewire\Tests;
 use Error;
 use Exception;
 use Illuminate\Routing\Route;
+use Illuminate\Support\ServiceProvider;
+use Livewire\LivewireServiceProvider;
+use Livewire\Mechanisms\HandleRequests\EndpointResolverInterface;
 use Tests\TestCase;
 
 class LivewireRouteCachingUnitTest extends TestCase
 {
+    protected function getPackageProviders($app)
+    {
+        return [
+            CustomEndpointResolverServiceProvider::class,
+            LivewireServiceProvider::class,
+        ];
+    }
+
+    public function test_custom_livewire_script_route_is_cacheable(): void
+    {
+        $uri = config('app.debug') ? 'custom-livewire/livewire.js' : 'custom-livewire/livewire.min.js';
+        $route = $this->getRoute($uri);
+
+        $this->cacheRoute($route, 'Livewire\Mechanisms\FrontendAssets\FrontendAssets@returnJavaScriptAsFile', "Failed to cache route '$uri'");
+    }
+
+    public function test_custom_livewire_update_route_is_cacheable(): void
+    {
+        $uri = 'custom-livewire/update';
+        $route = $this->getRoute($uri);
+
+        $this->cacheRoute($route, 'Livewire\Mechanisms\HandleRequests\HandleRequests@handleUpdate', "Failed to cache route '$uri'");
+    }
+
     public function test_livewire_script_route_is_cacheable(): void
     {
         // The route changes based on debug mode
@@ -49,5 +76,68 @@ class LivewireRouteCachingUnitTest extends TestCase
         }
 
         $this->assertTrue(true);
+    }
+}
+
+class CustomEndpointResolverServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->singleton(
+            EndpointResolverInterface::class,
+            CustomEndpointResolver::class,
+        );
+    }
+}
+
+class CustomEndpointResolver implements EndpointResolverInterface
+{
+    public function prefix(): string
+    {
+        return '/custom-livewire';
+    }
+
+    public function updatePath(): string
+    {
+        return $this->prefix() . '/update';
+    }
+
+    public function scriptPath(bool $minified = false): string
+    {
+        $file = $minified ? 'livewire.min.js' : 'livewire.js';
+
+        return $this->prefix() . '/' . $file;
+    }
+
+    public function mapPath(bool $csp = false): string
+    {
+        $file = $csp ? 'livewire.csp.min.js.map' : 'livewire.min.js.map';
+
+        return $this->prefix() . '/' . $file;
+    }
+
+    public function uploadPath(): string
+    {
+        return $this->prefix() . '/upload-file';
+    }
+
+    public function previewPath(): string
+    {
+        return $this->prefix() . '/preview-file/{filename}';
+    }
+
+    public function componentJsPath(): string
+    {
+        return $this->prefix() . '/js/{component}.js';
+    }
+
+    public function componentCssPath(): string
+    {
+        return $this->prefix() . '/css/{component}.css';
+    }
+
+    public function componentGlobalCssPath(): string
+    {
+        return $this->prefix() . '/css/{component}.global.css';
     }
 }


### PR DESCRIPTION
This is an alternative for https://github.com/livewire/livewire/pull/10658 where the concern is `EndpointResolver` class already used by consumers in their internal codebase.

This change from facade to direct container resolver

**#10658**
```php
use Illuminate\Support\Facade;

class EndpointResolver extends Facade
{
    public static function getFacadeAccessor()
    {
        return \Livewire\Mechanisms\HandleRequests\EndpointResolverInterface::class;
    }
}
```

**This PR**
```php
class EndpointResolver
{
    protected static function resolver(): EndpointResolverInterface
    {
        return app(EndpointResolverInterface::class);
    }

    public static function prefix(): string
    {
        return static::resolver()->prefix();
    }
    
    // ...
}
```