### PR TITLE
[4.x] Fix `wire:sort` not working when sortable item contains link with `wire:navigate`

### DIFF
--- a/js/features/supportWireSort.js
+++ b/js/features/supportWireSort.js
@@ -94,3 +94,22 @@ function bindSortItem(el, directive) {
         }
     })
 }
+
+export function isSortableElement(el) {
+    let item = el.closest('[wire\\:sort\\:item],[x-sort\\:item]')
+
+    if (! item) return false
+
+    // Ignored elements are never draggable...
+    if (el.closest('[wire\\:sort\\:ignore],[x-sort\\:ignore]')) return false
+
+    let handleSelector = '[wire\\:sort\\:handle],[x-sort\\:handle]'
+    let list = item.parentElement
+
+    // If the list uses a drag handle, only the handle can start a drag...
+    if (list && list.querySelector(handleSelector)) {
+        return el.closest(handleSelector) !== null
+    }
+
+    return true
+}

--- a/js/plugins/navigate/links.js
+++ b/js/plugins/navigate/links.js
@@ -1,3 +1,4 @@
+import { isSortableElement } from '@/features/supportWireSort'
 
 export function whenThisLinkIsPressed(el, callback) {
     let isProgrammaticClick = e => ! e.isTrusted
@@ -21,6 +22,20 @@ export function whenThisLinkIsPressed(el, callback) {
 
         if (linkShouldBeHandledNatively(el)) return;
 
+        // Sortable item: activate only on a real click.
+        // After a drag, SortableJS prevents this click → no prefetch, no navigate.
+        if (isSortableElement(el)) {
+            e.preventDefault()
+
+            callback(whenReleased => {
+                requestAnimationFrame(() => {
+                    whenReleased()
+                })
+            })
+
+            return
+        }
+
         // If it's a plain left click, we want to prevent "click" and let "mouseup" do its thing...
         e.preventDefault()
     })
@@ -30,6 +45,10 @@ export function whenThisLinkIsPressed(el, callback) {
         if (isNotPlainLeftClick(e)) return;
 
         if (linkShouldBeHandledNatively(el)) return;
+
+        // Do not call callback() here for sortable items.
+        // callback() starts prefetch immediately in navigate/index.js.
+        if (isSortableElement(el)) return
 
         e.preventDefault()
 

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -53,6 +53,18 @@ class BrowserTest extends \Tests\BrowserTestCase
             Livewire::component('first-noscript-page', FirstNoscriptPage::class);
             Livewire::component('second-noscript-page', SecondNoscriptPage::class);
 
+            Livewire::component('sort-nav-first', SortNavFirstPage::class);
+            Livewire::component('sort-nav-second', SortNavSecondPage::class);
+
+            Livewire::component('sort-nav-handle', SortNavHandleNavPage::class);
+            Livewire::component('sort-nav-ignore', SortNavIgnorePage::class);
+
+            Route::get('/sort-nav-handle', SortNavHandleNavPage::class)->middleware('web');
+            Route::get('/sort-nav-ignore', SortNavIgnorePage::class)->middleware('web');
+
+            Route::get('/sort-nav-first', SortNavFirstPage::class)->middleware('web');
+            Route::get('/sort-nav-second', SortNavSecondPage::class)->middleware('web');
+
             Route::get('/navbar/{page}', NavBarComponent::class)->middleware('web');
 
             Route::get('/query-page', QueryPage::class)->middleware('web');
@@ -1630,6 +1642,43 @@ class BrowserTest extends \Tests\BrowserTestCase
         });
     }
 
+    public function test_wire_navigate_still_works_when_link_also_has_sortable_item()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/sort-nav-first')
+                ->assertSeeIn('@item-1', 'Page 1')
+                ->assertSeeIn('@item-2', 'Page 2')
+                ->waitForNavigate()->click('@item-2')
+                ->assertPathIs('/sort-nav-second')
+                ->assertSeeIn('@item-1', 'Page 1')
+                ->assertSeeIn('@item-2', 'Page 2')
+                ;
+        });
+    }
+
+    public function test_wire_navigate_still_works_when_link_is_outside_sort_handle()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/sort-nav-handle')
+                ->assertSee('On first')
+                ->waitForNavigate()->click('@nav-link')
+                ->assertPathIs('/sort-nav-second');
+        });
+    }
+
+    public function test_wire_navigate_still_works_when_link_has_sort_ignore()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/sort-nav-ignore')
+                ->assertSee('On first')
+                ->waitForNavigate()->click('@ignored-link')
+                ->assertPathIs('/sort-nav-second');
+        });
+    }
+
     protected function registerComponentTestRoutes($routes)
     {
         $registered = 0;
@@ -2292,6 +2341,86 @@ class PageWithLinkToAnErrorPage extends Component
             })
         </script>
         @endscript
+        HTML;
+    }
+}
+
+class SortNavFirstPage extends Component
+{
+    public function sortItem($item, $position)
+    {
+        //
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <ul wire:sort="sortItem">
+                <li>
+                    <a href="/sort-nav-first" dusk="item-1" wire:navigate wire:sort:item="item-1">Page 1</a>
+                </li>
+                <li>
+                    <a href="/sort-nav-second" dusk="item-2" wire:navigate wire:sort:item="item-2">Page 2</a>
+                </li>
+            </ul>
+        </div>
+        HTML;
+    }
+}
+
+class SortNavSecondPage extends SortNavFirstPage {}
+
+class SortNavHandleNavPage extends Component
+{
+    public function sortItem($item, $position)
+    {
+        //
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <div>On first</div>
+
+            <ul wire:sort="sortItem">
+                <li wire:sort:item="item-1">
+                    <a href="/sort-nav-second" dusk="nav-link" wire:navigate>Go</a>
+                    <span wire:sort:handle>Drag</span>
+                </li>
+                <li wire:sort:item="item-2">
+                    <a href="/" wire:navigate>Other</a>
+                    <span wire:sort:handle>Drag</span>
+                </li>
+            </ul>
+        </div>
+        HTML;
+    }
+}
+
+class SortNavIgnorePage extends Component
+{
+    public function sortItem($item, $position)
+    {
+        //
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <div>On first</div>
+
+            <ul wire:sort="sortItem">
+                <li wire:sort:item="item-1">
+                    <a href="/sort-nav-second" dusk="ignored-link" wire:navigate wire:sort:ignore>Go</a>
+                </li>
+                <li wire:sort:item="item-2">
+                    <a href="/" wire:navigate>Other</a>
+                </li>
+            </ul>
+        </div>
         HTML;
     }
 }

--- a/src/Features/SupportWireSort/BrowserTest.php
+++ b/src/Features/SupportWireSort/BrowserTest.php
@@ -2,12 +2,29 @@
 
 namespace Livewire\Features\SupportWireSort;
 
+use Illuminate\Support\Facades\Route;
 use Tests\BrowserTestCase;
 use Livewire\Component;
 use Livewire\Livewire;
 
 class BrowserTest extends BrowserTestCase
 {
+    public static function tweakApplicationHook()
+    {
+        return function () {
+            Livewire::component('sort-nav-first', SortNavFirstPage::class);
+            Livewire::component('sort-nav-second', SortNavSecondPage::class);
+
+            Livewire::component('sort-nav-handle-first', SortNavHandleFirstPage::class);
+            Livewire::component('sort-nav-handle-second', SortNavHandleSecondPage::class);
+
+            Route::get('/sort-nav-first', SortNavFirstPage::class)->middleware('web');
+            Route::get('/sort-nav-second', SortNavSecondPage::class)->middleware('web');
+
+            Route::get('/sort-nav-handle-first', SortNavHandleFirstPage::class)->middleware('web');
+            Route::get('/sort-nav-handle-second', SortNavHandleSecondPage::class)->middleware('web');
+        };
+    }
     public function test_wire_sort_id_is_passed_as_third_parameter_to_sort_handler()
     {
         Livewire::visit(new class extends Component {
@@ -296,4 +313,113 @@ class BrowserTest extends BrowserTestCase
         ->waitForTextIn('@result', 'item:item-2,position:0')
         ->assertSeeIn('@result', 'item:item-2,position:0');
     }
+
+    public function test_wire_sort_works_when_sort_item_also_has_wire_navigate()
+    {
+        $this->browse(function ($browser) {
+            $browser->visit('/sort-nav-first')
+                // Dragging sortable item shouldn't sending network request
+                ->waitForNoNavigateRequest()->drag('@item-2', '@item-1')
+                ->waitForTextIn('@result', 'item:item-2,position:0')
+                ->assertPresent('@sortable')
+                ->assertSeeIn('@item-1', 'Item 1')
+                ->assertSeeIn('@item-2', 'Item 2')
+                ->assertPathIs('/sort-nav-first')
+                // Navigate should still work after sorting
+                ->waitForNavigate()->click('@item-2')
+                ->assertPathIs('/sort-nav-second')
+                ->waitForNoNavigateRequest()->drag('@item-1', '@item-2')
+                ->waitForTextIn('@result', 'item:item-1,position:1')
+                ->assertPresent('@sortable')
+                ->assertSeeIn('@item-1', 'Item 1')
+                ->assertSeeIn('@item-2', 'Item 2')
+                ;
+        });
+    }
+
+    public function test_wire_sort_works_via_handle_when_item_contains_wire_navigate_link()
+    {
+        $this->browse(function ($browser) {
+            $browser->visit('/sort-nav-handle-first')
+                // Dragging sortable item shouldn't sending network request
+                ->waitForNoNavigateRequest()->drag('@handle-2', '@handle-1')
+                ->waitForTextIn('@result', 'item:item-2,position:0')
+                ->assertPresent('@sortable')
+                ->assertSeeIn('@handle-1', 'Handle 1')
+                ->assertSeeIn('@handle-2', 'Handle 2')
+                ->assertPathIs('/sort-nav-handle-first')
+                // Clicking sort handler should not trigger navigate
+                ->waitForNoNavigateRequest()->click('@handle-2')
+                // Navigate should still work after sorting
+                ->waitForNavigate()->click('@link-2')
+                ->assertPathIs('/sort-nav-handle-second')
+                ->waitForNoNavigateRequest()->drag('@handle-1', '@handle-2')
+                ->waitForTextIn('@result', 'item:item-1,position:1')
+                ->assertPresent('@sortable')
+                ->assertSeeIn('@handle-1', 'Handle 1')
+                ->assertSeeIn('@handle-2', 'Handle 2')
+                ;
+        });
+    }
 }
+
+class SortNavFirstPage extends Component
+{
+    public $result = '';
+
+    public function sortItem($item, $position)
+    {
+        $this->result = "item:{$item},position:{$position}";
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <ul dusk="sortable" wire:sort="sortItem">
+                <li>
+                    <a href="/sort-nav-first" dusk="item-1" wire:navigate wire:sort:item="item-1">Item 1</a>
+                </li>
+                <li>
+                    <a href="/sort-nav-second" dusk="item-2" wire:navigate wire:sort:item="item-2">Item 2</a>
+                </li>
+            </ul>
+
+            <div dusk="result">{{ $result }}</div>
+        </div>
+        HTML;
+    }
+}
+
+class SortNavHandleFirstPage extends Component
+{
+    public $result = '';
+
+    public function sortItem($item, $position)
+    {
+        $this->result = "item:{$item},position:{$position}";
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <ul dusk="sortable" wire:sort="sortItem">
+                <li wire:sort:item="item-1">
+                    <a href="/sort-nav-handle-first" dusk="link-1" wire:navigate>Item 1</a>
+                    <span dusk="handle-1" wire:sort:handle>Handle 1</span>
+                </li>
+                <li wire:sort:item="item-2">
+                    <a href="/sort-nav-handle-second" dusk="link-2" wire:navigate>Item 2</a>
+                    <span dusk="handle-2" wire:sort:handle>Handle 2</span>
+                </li>
+            </ul>
+
+            <div dusk="result">{{ $result }}</div>
+        </div>
+        HTML;
+    }
+}
+
+class SortNavSecondPage extends SortNavFirstPage {}
+class SortNavHandleSecondPage extends SortNavHandleFirstPage {}


### PR DESCRIPTION
## Summary

Fix an interaction between `wire:navigate` and `wire:sort` that prevents sortable items from being dragged when the item is also a navigable link.

## Problem

`wire:navigate` calls `preventDefault()` on `mousedown` events before handling navigation on `mouseup`.

`wire:sort` relies on the native `mousedown` event to allow SortableJS to start a drag. When a sortable item also uses `wire:navigate`, preventing the event stops SortableJS from initiating the drag.

This means an element such as:

```html
<ul wire:sort="save">
    <li wire:sort:item="1">
        <a href="/x" wire:navigate>Item 1</a>
    </li>
    <li wire:sort:item="2">
        <a href="/y" wire:navigate>Item 2</a>
    </li>
</ul>
```

can no longer be dragged as expected.

## Solution

`wire:navigate` was intercepting `mousedown` on links and calling `preventDefault()`, which blocked SortableJS from starting a drag when the same element also had `wire:sort:item` (or `x-sort:item`).

The fix changes how navigate handles **sortable** links:

1. **Detect sortable items**  
   Treat the link as a sort item if it has `wire:sort:item` / `x-sort:item`, or is inside such an element.

2. **Do not hijack the press path for sort items**  
   On `mousedown`, skip navigate’s usual flow for those elements:
   - no `preventDefault()` (Sortable can start the drag)
   - no `callback()` (avoids immediate **prefetch** and the mouseup → navigate path)

3. **Navigate on real clicks only**  
   For sort items, run navigate from the `click` handler instead. SortableJS already suppresses `click` after a successful drag, so:
   - **drag** → sort runs, no navigate/prefetch request  
   - **click** → navigate runs as usual  

Normal `wire:navigate` links are unchanged (mousedown → prefetch, mouseup → navigate).

## Tests

* Verify a sortable item that also has `wire:navigate` can still be dragged and sorted without navigating away / network sent from prefetching
* Verify `wire:navigate` continues to work when used together with `wire:sort:item`.

Fixes: https://github.com/livewire/livewire/issues/10662