### PR TITLE
[4.x] Allow custom x-cloak variants by targeting empty x-cloak attributes

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -141,11 +141,11 @@ class FrontendAssets extends Mechanism
                 --livewire-progress-bar-color: {$progressBarColor};
             }
 
-            [x-cloak] {
+            [x-cloak=""] {
                 display: none !important;
             }
 
-            [wire\:cloak] {
+            [wire\:cloak=""] {
                 display: none !important;
             }
 


### PR DESCRIPTION
## What does this PR do?

This PR changes Livewire's default `x-cloak` CSS selector from:

```css
[x-cloak] {
    display: none !important;
}
```

to:

```css
[x-cloak=""] {
    display: none !important;
}
```

## Why is this needed?

The current `[x-cloak]` selector matches any element containing the `x-cloak` attribute, regardless of its value. This makes it impossible to introduce value-based `x-cloak` variants without Livewire's default style also applying to them.

For example, an application may want to cloak an element only below a specific responsive breakpoint:

```html
<div x-cloak="lg">
    ...
</div>
```

```css
@media (width < theme(--breakpoint-lg)) {
    [x-cloak="lg"] {
        display: none !important;
    }
}
```

With Livewire's current `[x-cloak]` rule, `x-cloak="lg"` is always hidden until Alpine initializes, including on screens at or above the `lg` breakpoint. This defeats the purpose of the responsive variant.

Using `[x-cloak=""]` restricts Livewire's default style to the standard empty `x-cloak` attribute:

```html
<div x-cloak>
    ...
</div>
```

It therefore preserves the existing behavior for regular `x-cloak` usage while allowing applications to define their own value-based variants such as `x-cloak="lg"`.

Alpine still removes the `x-cloak` attribute normally when it initializes, regardless of its value, so this change only makes Livewire's CSS selector more specific and extensible.
