### PR TITLE
[4.x] Fix @assets inside implicitly rendered islands not shipping

### DIFF
--- a/src/Features/SupportIslands/SupportIslands.php
+++ b/src/Features/SupportIslands/SupportIslands.php
@@ -6,12 +6,19 @@ use Livewire\Features\SupportIslands\Compiler\IslandCompiler;
 use Illuminate\Support\Facades\Blade;
 use Livewire\ComponentHook;
 
+use function Livewire\before;
+
 class SupportIslands extends ComponentHook
 {
     public static function provide()
     {
         static::registerInlineIslandPrecompiler();
         static::registerIslandDirective();
+
+        // Flush implicit island renders before any dehydrate hook, so other hooks (e.g. assets) see their output...
+        before('dehydrate', function ($component) {
+            $component->renderImplicitIslandMorphs();
+        });
     }
 
     public static function registerIslandDirective()

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportIslands;
 use Tests\TestCase;
 use Livewire\Livewire;
 use Livewire\Features\SupportIslands\Compiler\IslandCompiler;
+use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
 use Illuminate\Support\Facades\File;
 
 class UnitTest extends TestCase
@@ -738,5 +739,69 @@ class UnitTest extends TestCase
         $this->assertStringContainsString('wire:id="'.$appendedChildId.'" wire:name="island-child" wire:key="row-2"', $component->html());
         $this->assertStringNotContainsString('child 1', $component->html());
         $this->assertStringNotContainsString('child 2', $component->html());
+    }
+
+    public function test_assets_inside_an_implicitly_rendered_island_are_shipped()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    @island(defer: true)
+                        @placeholder <div>loading</div> @endplaceholder
+                        <div data-loaded>ready</div>
+                        @assets <script src="/x.js" data-x></script> @endassets
+                    @endisland
+                </div>
+                HTML;
+            }
+        });
+
+        $name = $component->instance()->getIslands()[0]['name'];
+
+        app('livewire')->update($component->snapshot, [], [
+            [
+                'method' => '__lazyLoadIsland',
+                'params' => [],
+                'path' => '',
+                'metadata' => [
+                    'island' => ['name' => $name, 'mode' => 'morph'],
+                ],
+            ],
+        ]);
+
+        $this->assertStringContainsString('/x.js', json_encode(SupportScriptsAndAssets::getAssets()));
+    }
+
+    public function test_assets_inside_an_explicitly_rendered_island_are_still_shipped()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public function refresh()
+            {
+                $this->renderIsland('counter');
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    @island(defer: true, name: 'counter')
+                        @placeholder <div>loading</div> @endplaceholder
+                        <div data-loaded>ready</div>
+                        @assets <script src="/y.js" data-y></script> @endassets
+                    @endisland
+                </div>
+                HTML;
+            }
+        });
+
+        app('livewire')->update($component->snapshot, [], [
+            [
+                'method' => 'refresh',
+                'params' => [],
+                'path' => '',
+            ],
+        ]);
+
+        $this->assertStringContainsString('/y.js', json_encode(SupportScriptsAndAssets::getAssets()));
     }
 }


### PR DESCRIPTION
`@assets` inside an implicitly rendered island (deferred, lazy, `skip` + `wire:intersect`, or any `wire:*` action fired from inside an island) stopped shipping after #10529 batched implicit island morphs into `SupportIslands::dehydrate()`. `SupportScriptsAndAssets` is registered earlier in the service provider, so its `dehydrate()` already copies the component's asset store into the response before the island actually renders and pushes its `@assets` block.

This adds a `before('dehydrate', ...)` hook from `SupportIslands::provide()` that flushes queued implicit island renders ahead of every other feature's `dehydrate()`, regardless of registration order, so the pushed assets are already in the store by the time they're collected. An explicit `$this->renderIsland()` call from an action runs synchronously during the action itself, so it was never affected and stays unaffected.

Fixes #10665

Verification:
- Focused SupportIslands unit suite: 27 tests, 54 assertions
- Focused SupportIslands + SupportScriptsAndAssets browser suites: 53 tests
- Full unit suite: 1462 tests
