### PR TITLE
[4.x] Fix `@assets` and `@scripts` blocks inside implicit rendered islands not available

### DIFF
--- a/src/Features/SupportIslands/SupportIslands.php
+++ b/src/Features/SupportIslands/SupportIslands.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportIslands;
 use Livewire\Features\SupportIslands\Compiler\IslandCompiler;
 use Illuminate\Support\Facades\Blade;
 use Livewire\ComponentHook;
+use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
 
 class SupportIslands extends ComponentHook
 {
@@ -74,6 +75,10 @@ class SupportIslands extends ComponentHook
     public function dehydrate($context)
     {
         $this->component->renderImplicitIslandMorphs();
+
+        // Collect assets/scripts immediately after island rendering,
+        // as SupportScriptsAndAssets::dehydrate runs before this hook.
+        SupportScriptsAndAssets::collectComponentPendingAssetsAndScripts($this->component, $context);
 
         $context->addMemo('islands', $this->component->getIslands());
 

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -7,6 +7,8 @@ use Livewire\Livewire;
 use Livewire\Features\SupportIslands\Compiler\IslandCompiler;
 use Illuminate\Support\Facades\File;
 
+use function Livewire\invade;
+
 class UnitTest extends TestCase
 {
     public function test_class_component_island_recovers_when_cached_file_is_deleted_between_requests()
@@ -738,5 +740,128 @@ class UnitTest extends TestCase
         $this->assertStringContainsString('wire:id="'.$appendedChildId.'" wire:name="island-child" wire:key="row-2"', $component->html());
         $this->assertStringNotContainsString('child 1', $component->html());
         $this->assertStringNotContainsString('child 2', $component->html());
+    }
+
+    public function test_assets_inside_implicitly_rendered_deferred_island_are_shipped(): void
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @island(name: 'panel', defer: true)
+                        @placeholder <div>loading</div> @endplaceholder
+                        <div data-loaded>ready</div>
+                        @assets
+                            <script src="/island-asset.js" data-island-asset></script>
+                        @endassets
+                        @script
+                            <script data-island-script>window.__islandScript = true</script>
+                        @endscript
+                    @endisland
+                </div>
+                HTML;
+            }
+        });
+
+        $component->assertDontSee('data-loaded');
+
+        $component->update(calls: [
+            [
+                'method' => '__lazyLoadIsland',
+                'params' => [],
+                'path' => '',
+                'metadata' => [
+                    'island' => [
+                        'name' => 'panel',
+                        'mode' => 'morph',
+                    ],
+                ],
+            ],
+        ]);
+
+        // 1) Island really mounted (implicit morph path)
+        $fragments = implode('', $component->effects['islandFragments'] ?? []);
+        $this->assertStringContainsString('data-loaded', $fragments);
+
+        // 2) Assets from the payload (NOT static getAssets() after flushState)
+        $payload = invade($component)->lastState->getResponse()->json();
+        $assets = $payload['assets'] ?? [];
+
+        $this->assertTrue(
+            collect($assets)->contains(fn ($script) => str_contains($script, 'data-island-asset')),
+            'Assets from an implicitly rendered deferred island must appear in the response assets payload'
+        );
+
+        // 3) Scripts are component effects (still valid after flush)
+        $scripts = $component->effects['scripts'] ?? [];
+        $this->assertTrue(
+            collect($scripts)->contains(fn ($script) => str_contains($script, 'data-island-script')),
+            'Scripts from an implicitly rendered deferred island must appear in effects'
+        );
+    }
+
+    public function test_assets_inside_an_explicitly_rendered_island_are_still_shipped()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public function refreshPanel()
+            {
+                $this->renderIsland('panel');
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    @island(name: 'panel', defer: true)
+                        @placeholder <div>loading</div> @endplaceholder
+                        <div data-loaded>ready</div>
+                        @assets
+                            <script src="/island-asset.js" data-island-asset></script>
+                        @endassets
+                        @script
+                            <script data-island-script>window.__islandScript = true</script>
+                        @endscript
+                    @endisland
+                </div>
+                HTML;
+            }
+        });
+
+        $component->assertDontSee('data-loaded');
+
+        $component->update(calls: [
+            [
+                'method' => 'refreshPanel',
+                'params' => [],
+                'path' => '',
+                'metadata' => [
+                    'island' => [
+                        'name' => 'panel',
+                        'mode' => 'morph',
+                    ],
+                ],
+            ],
+        ]);
+
+        // 1) Island really mounted (implicit morph path)
+        $fragments = implode('', $component->effects['islandFragments'] ?? []);
+        $this->assertStringContainsString('data-loaded', $fragments);
+
+        // 2) Assets from the payload (NOT static getAssets() after flushState)
+        $payload = invade($component)->lastState->getResponse()->json();
+        $assets = $payload['assets'] ?? [];
+
+        $this->assertTrue(
+            collect($assets)->contains(fn ($script) => str_contains($script, 'data-island-asset')),
+            'Assets from an implicitly rendered deferred island must appear in the response assets payload'
+        );
+
+        // 3) Scripts are component effects (still valid after flush)
+        $scripts = $component->effects['scripts'] ?? [];
+        $this->assertTrue(
+            collect($scripts)->contains(fn ($script) => str_contains($script, 'data-island-script')),
+            'Scripts from an implicitly rendered deferred island must appear in effects'
+        );
     }
 }

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -742,7 +742,7 @@ class UnitTest extends TestCase
         $this->assertStringNotContainsString('child 2', $component->html());
     }
 
-    public function test_assets_inside_implicitly_rendered_deferred_island_are_shipped(): void
+    public function test_assets_and_scripts_inside_implicitly_rendered_island_are_available(): void
     {
         $component = Livewire::test(new class extends \Livewire\Component {
             public function render()
@@ -790,18 +790,18 @@ class UnitTest extends TestCase
 
         $this->assertTrue(
             collect($assets)->contains(fn ($script) => str_contains($script, 'data-island-asset')),
-            'Assets from an implicitly rendered deferred island must appear in the response assets payload'
+            'Assets from an implicitly rendered island must appear in the response assets payload'
         );
 
         // 3) Scripts are component effects (still valid after flush)
         $scripts = $component->effects['scripts'] ?? [];
         $this->assertTrue(
             collect($scripts)->contains(fn ($script) => str_contains($script, 'data-island-script')),
-            'Scripts from an implicitly rendered deferred island must appear in effects'
+            'Scripts from an implicitly rendered island must appear in effects'
         );
     }
 
-    public function test_assets_inside_an_explicitly_rendered_island_are_still_shipped()
+    public function test_assets_and_scripts_inside_an_explicitly_rendered_island_are_available()
     {
         $component = Livewire::test(new class extends \Livewire\Component {
             public function refreshPanel()
@@ -828,23 +828,9 @@ class UnitTest extends TestCase
             }
         });
 
-        $component->assertDontSee('data-loaded');
+        $component->assertDontSee('data-loaded')->call('refreshPanel');
 
-        $component->update(calls: [
-            [
-                'method' => 'refreshPanel',
-                'params' => [],
-                'path' => '',
-                'metadata' => [
-                    'island' => [
-                        'name' => 'panel',
-                        'mode' => 'morph',
-                    ],
-                ],
-            ],
-        ]);
-
-        // 1) Island really mounted (implicit morph path)
+        // 1) Island really mounted (explicit morph path)
         $fragments = implode('', $component->effects['islandFragments'] ?? []);
         $this->assertStringContainsString('data-loaded', $fragments);
 
@@ -854,14 +840,14 @@ class UnitTest extends TestCase
 
         $this->assertTrue(
             collect($assets)->contains(fn ($script) => str_contains($script, 'data-island-asset')),
-            'Assets from an implicitly rendered deferred island must appear in the response assets payload'
+            'Assets from an explicitly rendered island must appear in the response assets payload'
         );
 
         // 3) Scripts are component effects (still valid after flush)
         $scripts = $component->effects['scripts'] ?? [];
         $this->assertTrue(
             collect($scripts)->contains(fn ($script) => str_contains($script, 'data-island-script')),
-            'Scripts from an implicitly rendered deferred island must appear in effects'
+            'Scripts from an explicitly rendered island must appear in effects'
         );
     }
 }

--- a/src/Features/SupportScriptsAndAssets/BrowserTest.php
+++ b/src/Features/SupportScriptsAndAssets/BrowserTest.php
@@ -504,4 +504,38 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->waitUntil('!! window.datePicker === true')
         ;
     }
+
+    public function test_assets_and_scripts_can_be_loaded_from_an_implicitly_rendered_deferred_island()
+    {
+        Route::get('/test.js', function () {
+            return Utils::pretendResponseIsFile(__DIR__.'/test.js');
+        });
+
+        Livewire::visit(new class extends \Livewire\Component {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <span dusk="foo"></span>
+                    <span dusk="bar"></span>
+                    @island(defer: true)
+                        <div dusk="island">Island loaded</div>
+                        @assets
+                            <script src="/test.js" defer></script>
+                        @endassets
+                        @script
+                            <script>
+                                document.querySelector('[dusk="bar"]').textContent = 'script loaded'
+                            </script>
+                        @endscript
+                    @endisland
+                </div>
+                HTML;
+            }
+        })
+            ->assertNotPresent('@island')
+            ->waitForTextIn('@island', 'Island loaded')
+            ->assertSeeIn('@foo', 'evaluated')
+            ->assertSeeIn('@bar', 'script loaded');
+    }
 }

--- a/src/Features/SupportScriptsAndAssets/SupportScriptsAndAssets.php
+++ b/src/Features/SupportScriptsAndAssets/SupportScriptsAndAssets.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportScriptsAndAssets;
 use Livewire\ComponentHook;
 
 use function Livewire\on;
+use function Livewire\store;
 
 class SupportScriptsAndAssets extends ComponentHook
 {
@@ -138,10 +139,15 @@ class SupportScriptsAndAssets extends ComponentHook
 
     function dehydrate($context)
     {
-        $alreadyRunScriptKeys = $this->storeGet('forwardScriptsToDehydrateMemo', []);
+        static::collectComponentPendingAssetsAndScripts($this->component, $context);
+    }
+
+    public static function collectComponentPendingAssetsAndScripts($component, $context)
+    {
+        $alreadyRunScriptKeys = store($component)->get('forwardScriptsToDehydrateMemo', []);
 
         // Add any scripts to the payload that haven't been run yet for this component....
-        foreach ($this->storeGet('scripts', []) as $key => $script) {
+        foreach (store($component)->get('scripts', []) as $key => $script) {
             if (! in_array($key, $alreadyRunScriptKeys)) {
                 $context->pushEffect('scripts', $script, $key);
                 $alreadyRunScriptKeys[] = $key;
@@ -150,11 +156,10 @@ class SupportScriptsAndAssets extends ComponentHook
 
         $context->addMemo('scripts', $alreadyRunScriptKeys);
 
+        $alreadyRunAssetKeys = store($component)->get('forwardAssetsToDehydrateMemo', []);
+        
         // Add any assets to the payload that haven't been run yet for the entire page...
-
-        $alreadyRunAssetKeys = $this->storeGet('forwardAssetsToDehydrateMemo', []);
-
-        foreach ($this->storeGet('assets', []) as $key => $assets) {
+        foreach (store($component)->get('assets', []) as $key => $assets) {
             if (! in_array($key, $alreadyRunAssetKeys)) {
 
                 // These will either get injected into the HTML if it's an initial page load


### PR DESCRIPTION
> [!NOTE]
> This is an alternative for https://github.com/livewire/livewire/pull/10666

## Problem

Assets and scripts registered inside an implicitly rendered deferred island are not included in the response.

Implicit island morphs are rendered during `SupportIslands::dehydrate()`, which runs after `SupportScriptsAndAssets::dehydrate()`. This means `@assets` and `@script` blocks registered while rendering the island are added too late to be picked up by the normal scripts/assets dehydration step.

As a result, the island itself is rendered correctly, but assets and scripts declared inside it are missing from the response.

## Solution

Collect any scripts and assets registered during implicit island rendering after the island morphs have been rendered.

The existing scripts/assets state and memo are used to avoid re-registering anything that was already processed during the request. Newly registered scripts are pushed onto the response effects, while newly registered assets are added back to the rendered assets collection.

This keeps the existing scripts/assets handling intact and only accounts for registrations that happen during implicit island rendering.

## Tests

Added a regression test covering a deferred implicit island containing both:

* `@assets` with an external script
* `@script` with an inline script

The test verifies that:

* the deferred island is rendered when it is loaded;
* the asset is included in the response assets payload;
* the script is included in the component effects.

Fixes: https://github.com/livewire/livewire/issues/10665
