### PR TITLE
[4.x] Fix stale `wire:navigate.hover` prefetch HTML after a component action

### DIFF
--- a/js/plugins/navigate/prefetch.js
+++ b/js/plugins/navigate/prefetch.js
@@ -18,24 +18,24 @@ export function prefetchHtml(destination, callback, errorCallback) {
 
     if (prefetches[uri]) return
 
-    prefetches[uri] = { finished: false, html: null, whenFinished: () => {}, whenFailed: () => {}, expiry: null }
+    let state = { finished: false, html: null, whenFinished: () => {}, whenFailed: () => {}, expiry: null }
+
+    prefetches[uri] = state
 
     // Bound the lifetime of an in-flight prefetch. If it takes too long,
     // invalidate it and allow any waiting navigation to fall back.
-    prefetches[uri].expiry = setTimeout(() => {
-        invalidatePrefetch(uri)
+    state.expiry = setTimeout(() => {
+        invalidatePrefetch(uri, state)
     }, cacheDuration)
 
     performFetch(uri, (html, routedUri, status) => {
+        if (prefetches[uri] !== state) return
+
         storeCurrentPageStatus(status)
 
         callback(html, routedUri)
     }, () => {
-        let state = prefetches[uri]
-
-        // The prefetch may already have been invalidated while the request
-        // was in flight. In that case there is nothing left to update.
-        if (! state) return
+        if (prefetches[uri] !== state) return
 
         if (state.expiry) clearTimeout(state.expiry)
 
@@ -64,7 +64,7 @@ export function storeThePrefetchedHtmlForWhenALinkIsClicked(html, destination, f
     if (state.expiry) clearTimeout(state.expiry)
 
     state.expiry = setTimeout(() => {
-        invalidatePrefetch(uri)
+        invalidatePrefetch(uri, state)
     }, cacheDuration)
 
     state.whenFinished()
@@ -116,10 +116,11 @@ function clearPrefetches() {
     }
 }
 
-function invalidatePrefetch(uri) {
-    let state = prefetches[uri]
-
+function invalidatePrefetch(uri, state = prefetches[uri]) {
     if (! state) return
+
+    // Don't let an old prefetch invalidate a newer one for the same URI.
+    if (prefetches[uri] !== state) return
 
     if (state.expiry) clearTimeout(state.expiry)
 

--- a/js/plugins/navigate/prefetch.js
+++ b/js/plugins/navigate/prefetch.js
@@ -18,29 +18,59 @@ export function prefetchHtml(destination, callback, errorCallback) {
 
     if (prefetches[uri]) return
 
-    prefetches[uri] = { finished: false, html: null, whenFinished: () => setTimeout(() => delete prefetches[uri], cacheDuration), whenFailed: () => {} }
+    prefetches[uri] = { finished: false, html: null, whenFinished: () => {}, whenFailed: () => {}, expiry: null }
+
+    // Bound the lifetime of an in-flight prefetch. If it takes too long,
+    // invalidate it and allow any waiting navigation to fall back.
+    prefetches[uri].expiry = setTimeout(() => {
+        invalidatePrefetch(uri)
+    }, cacheDuration)
 
     performFetch(uri, (html, routedUri, status) => {
         storeCurrentPageStatus(status)
 
         callback(html, routedUri)
     }, () => {
-        let whenFailed = prefetches[uri].whenFailed
+        let state = prefetches[uri]
 
-        // If the fetch failed, remove the prefetch so it gets attempted again...
+        // The prefetch may already have been invalidated while the request
+        // was in flight. In that case there is nothing left to update.
+        if (! state) {
+            errorCallback()
+
+            return
+        }
+
+        if (state.expiry) clearTimeout(state.expiry)
+
         delete prefetches[uri]
 
         errorCallback()
 
-        whenFailed()
+        // If navigation was waiting for this in-flight prefetch,
+        // fall back to the normal navigation request.
+        state.whenFailed()
     })
 }
 
 export function storeThePrefetchedHtmlForWhenALinkIsClicked(html, destination, finalDestination) {
-    let state = prefetches[getUriStringFromUrlObject(destination)]
+    let uri = getUriStringFromUrlObject(destination)
+    let state = prefetches[uri]
+
+    // If it takes too long, invalidate it and allow any waiting navigation to fall back.
+    if (! state) return
+
     state.html = html
     state.finished = true
     state.finalDestination = finalDestination
+
+    // The cache lifetime begins once the HTML is available.
+    if (state.expiry) clearTimeout(state.expiry)
+
+    state.expiry = setTimeout(() => {
+        invalidatePrefetch(uri)
+    }, cacheDuration)
+
     state.whenFinished()
 }
 
@@ -50,31 +80,54 @@ export function getPretchedHtmlOr(destination, receive, ifNoPrefetchExists) {
     if (! prefetches[uri]) return ifNoPrefetchExists()
 
     if (prefetches[uri].finished) {
-        let html = prefetches[uri].html
-        let finalDestination = prefetches[uri].finalDestination
+        let state = prefetches[uri]
+        let html = state.html
+        let finalDestination = state.finalDestination
+
+        if (state.expiry) clearTimeout(state.expiry)
 
         delete prefetches[uri]
 
         return receive(html, finalDestination)
-    } else {
-        prefetches[uri].whenFinished = () => {
-            let html = prefetches[uri].html
-            let finalDestination = prefetches[uri].finalDestination
-
-            delete prefetches[uri]
-
-            receive(html, finalDestination)
-        }
-
-        // Someone is waiting on this in-flight prefetch. If it fails, they're
-        // left hanging with no navigation at all, so send them down the normal
-        // request path instead where a failure can be handled properly...
-        prefetches[uri].whenFailed = ifNoPrefetchExists
     }
+
+    // Navigation is waiting for the in-flight prefetch.
+    prefetches[uri].whenFinished = () => {
+        // The prefetch may have been invalidated before completion.
+        let state = prefetches[uri]
+
+        if (! state) return ifNoPrefetchExists()
+
+        let html = state.html
+        let finalDestination = state.finalDestination
+
+        if (state.expiry) clearTimeout(state.expiry)
+
+        delete prefetches[uri]
+
+        receive(html, finalDestination)
+    }
+
+    // Someone is waiting on this in-flight prefetch. If it fails, they're
+    // left hanging with no navigation at all, so send them down the normal
+    // request path instead where a failure can be handled properly...
+    prefetches[uri].whenFailed = ifNoPrefetchExists
 }
 
 function clearPrefetches() {
     for (let uri in prefetches) {
-        delete prefetches[uri]
+        invalidatePrefetch(uri)
     }
+}
+
+function invalidatePrefetch(uri) {
+    let state = prefetches[uri]
+
+    if (! state) return
+
+    if (state.expiry) clearTimeout(state.expiry)
+
+    delete prefetches[uri]
+
+    state.whenFailed()
 }

--- a/js/plugins/navigate/prefetch.js
+++ b/js/plugins/navigate/prefetch.js
@@ -35,11 +35,7 @@ export function prefetchHtml(destination, callback, errorCallback) {
 
         // The prefetch may already have been invalidated while the request
         // was in flight. In that case there is nothing left to update.
-        if (! state) {
-            errorCallback()
-
-            return
-        }
+        if (! state) return
 
         if (state.expiry) clearTimeout(state.expiry)
 

--- a/js/plugins/navigate/prefetch.js
+++ b/js/plugins/navigate/prefetch.js
@@ -1,12 +1,17 @@
 import { performFetch } from "@/plugins/navigate/fetch";
 import { getUriStringFromUrlObject } from "./links";
 import { storeCurrentPageStatus } from "./history";
+import { interceptRequest } from "@/request";
 
 // Warning: this could cause some memory leaks
 let prefetches = {}
 
 // Default prefetch cache duration is 30 seconds...
 let cacheDuration = 30000
+
+interceptRequest(({ onSend }) => {
+    onSend(() => clearPrefetches())
+})
 
 export function prefetchHtml(destination, callback, errorCallback) {
     let uri = getUriStringFromUrlObject(destination)
@@ -68,3 +73,8 @@ export function getPretchedHtmlOr(destination, receive, ifNoPrefetchExists) {
     }
 }
 
+function clearPrefetches() {
+    for (let uri in prefetches) {
+        delete prefetches[uri]
+    }
+}

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -6,7 +6,6 @@ use Laravel\Dusk\Browser;
 use Livewire\Attributes\On;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\View;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Url;
@@ -1633,49 +1632,24 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_livewire_action_clears_navigate_prefetch_cache()
     {
-        Livewire::visit(new class extends Component {
-            public $count = 0;
+        Livewire::visit(PageWithPrefetchOnHover::class)
+            ->assertSee('Prefetch clear page')
 
-            public function increment()
-            {
-                $this->count++;
-            }
+            // Hover → prefetch stored
+            ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+            ->mouseover('@title')
 
-            public function render()
-            {
-                return <<<'HTML'
-                    <div>
-                        <div dusk="title">Prefetch clear page</div>
+            // Still cached
+            ->waitForNoNavigatePrefetchRequest()->mouseover('@link.to.second')
+            ->mouseover('@title')
 
-                        <span dusk="count">{{ $count }}</span>
+            // Real MessageRequest → interceptor clears cache
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '1')
 
-                        <button type="button" wire:click="increment" dusk="increment">+</button>
-
-                        <a href="/second" wire:navigate.hover dusk="link.to.second">
-                            Go to second page
-                        </a>
-                    </div>
-                HTML;
-            }
-        })
-        ->assertSee('Prefetch clear page')
-
-        // Hover → prefetch stored
-        ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
-        ->mouseover('@title')
-
-        // Still cached
-        ->waitForNoNavigatePrefetchRequest()->mouseover('@link.to.second')
-        ->mouseover('@title')
-
-        // Real MessageRequest → interceptor clears cache
-        ->waitForLivewire()->click('@increment')
-        ->assertSeeIn('@count', '1')
-
-        // Cache cleared → new prefetch must fire
-        ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
-        ->assertSee('Prefetch clear page')
-        ;
+            // Cache cleared → new prefetch must fire
+            ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+            ->assertSee('Prefetch clear page');
     }
 
     public function test_livewire_action_clears_prefetch_so_protected_route_is_refetched()
@@ -1734,17 +1708,16 @@ class BrowserTest extends \Tests\BrowserTestCase
 
         // Simulate prefetch destination on hover when its still protected
         ->waitForNavigatePrefetchRequest()->mouseover('@link.to.protected')
-        ->mouseover('@gate-page')
 
         // Second hover should not prefetch destination
         ->waitForNoNavigatePrefetchRequest()->mouseover('@link.to.protected')
-        ->mouseover('@gate-page')
 
         ->waitForLivewire()->click('@authorize')
         ->assertSee('Authorized')
 
         // Livewire action should clear all prefetch destination so hovering should prefetch again
         ->waitForNavigatePrefetchRequest()->mouseover('@link.to.protected')
+
         // Clicking the link should not trigger navigate request again
         ->waitForNoNavigateRequest()->click('@link.to.protected')
         ->assertSee('On protected page')
@@ -1755,90 +1728,59 @@ class BrowserTest extends \Tests\BrowserTestCase
 
     public function test_navigate_fallback_when_in_flight_prefetch_cleared_by_livewire_request()
     {
-        Livewire::visit(new class extends Component {
-            public $count = 0;
+        Livewire::visit(PageWithPrefetchOnHover::class)
+            ->assertSee('Prefetch clear page')
+            ->tap(fn (Browser $browser) => $browser->script(<<<'JS'
+                window.__originalFetch = window.fetch
+                window.__releasePrefetch = null
+                window.__requestCount = 0
 
-            public function increment()
-            {
-                $this->count++;
-            }
+                window.fetch = function (url, options) {
+                    let pathname = new URL(url, window.location.origin).pathname
 
-            public function render()
-            {
-                return <<<'HTML'
-                    <div>
-                        <div dusk="title">On first</div>
-                        <span dusk="count">{{ $count }}</span>
-                        <button type="button" wire:click="increment" dusk="increment">
-                            Increment
-                        </button>
-                        <a href="/second" wire:navigate.hover dusk="link.to.second">
-                            Go to second page
-                        </a>
-                    </div>
-                HTML;
-            }
-        })
-        ->assertSee('On first')
+                    if (pathname === '/second') {
+                        window.__requestCount++
 
-        ->tap(fn (Browser $browser) => $browser->script(<<<'JS'
-            window.__originalFetch = window.fetch
-            window.__releaseProtectedPrefetch = null
-            window.__secondRequestCount = 0
-
-            window.fetch = function (url, options) {
-                let pathname = new URL(
-                    url,
-                    window.location.origin
-                ).pathname
-
-                if (pathname === '/second') {
-                    window.__secondRequestCount++
-
-                    // Hold only the speculative prefetch.
-                    if (window.__secondRequestCount === 1) {
-                        return new Promise((resolve, reject) => {
-                            window.__releaseProtectedPrefetch = () => {
-                                window.__originalFetch(url, options)
-                                    .then(resolve)
-                                    .catch(reject)
-                            }
-                        })
+                        // Hold only the speculative prefetch.
+                        if (window.__requestCount === 1) {
+                            return new Promise((resolve, reject) => {
+                                window.__releasePrefetch = () => {
+                                    window.__originalFetch(url, options)
+                                        .then(resolve)
+                                        .catch(reject)
+                                }
+                            })
+                        }
                     }
+
+                    return window.__originalFetch(url, options)
                 }
+            JS))
 
-                return window.__originalFetch(url, options)
-            }
-        JS))
+            // Hover starts the first request, which we deliberately keep open.
+            ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
 
-        // Hover starts the first request, which we deliberately keep open.
-        ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+            ->waitUntil('window.__releasePrefetch !== null')
 
-        ->waitUntil('window.__releaseProtectedPrefetch !== null')
+            // Click while navigation is waiting for the in-flight prefetch.
+            ->click('@link.to.second')
 
-        // Click while navigation is waiting for the in-flight prefetch.
-        ->click('@link.to.second')
+            // Let the navigate click handler attach its callbacks to the prefetch.
+            ->pause(50)
 
-        // Let the navigate click handler attach its callbacks to the prefetch.
-        ->pause(50)
+            // MessageRequest invalidates the prefetch while navigation is waiting.
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '1')
 
-        // A MessageRequest invalidates the prefetch while navigation is waiting.
-        ->waitForLivewire()->click('@increment')
-        ->assertSeeIn('@count', '1')
+            // Correct behavior is a second request for the navigation fallback.
+            ->waitUntil('window.__requestCount === 2')
+            ->waitForText('On second')
 
-        // Correct behavior is a second request for the navigation fallback.
-        ->waitUntil('window.__secondRequestCount === 2')
-        ->waitForText('On second')
+            // Original prefetch can finish afterwards without resurrecting stale prefetched HTML.
+            ->tap(fn (Browser $browser) => $browser->script('window.__releasePrefetch()'))
 
-        // The original prefetch can finish afterwards without resurrecting
-        // stale prefetched HTML.
-        ->tap(fn (Browser $browser) => $browser->script(
-            'window.__releaseProtectedPrefetch()'
-        ))
-
-        ->assertPathIs('/second')
-        ->assertScript('return window.__secondRequestCount', 2)
-        ;
+            ->assertPathIs('/second')
+            ->assertScript('return window.__requestCount', 2);
     }
 
     protected function registerComponentTestRoutes($routes)
@@ -2503,6 +2445,35 @@ class PageWithLinkToAnErrorPage extends Component
             })
         </script>
         @endscript
+        HTML;
+    }
+}
+
+class PageWithPrefetchOnHover extends Component
+{
+    public $count = 0;
+
+    public function increment()
+    {
+        $this->count++;
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+            <div>
+                <div dusk="title">Prefetch clear page</div>
+
+                <span dusk="count">{{ $count }}</span>
+
+                <button type="button" wire:click="increment" dusk="increment">
+                    Increment
+                </button>
+
+                <a href="/second" wire:navigate.hover dusk="link.to.second">
+                    Go to second page
+                </a>
+            </div>
         HTML;
     }
 }

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -1753,6 +1753,94 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_navigate_fallback_when_in_flight_prefetch_cleared_by_livewire_request()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <div dusk="title">On first</div>
+                        <span dusk="count">{{ $count }}</span>
+                        <button type="button" wire:click="increment" dusk="increment">
+                            Increment
+                        </button>
+                        <a href="/second" wire:navigate.hover dusk="link.to.second">
+                            Go to second page
+                        </a>
+                    </div>
+                HTML;
+            }
+        })
+        ->assertSee('On first')
+
+        ->tap(fn (Browser $browser) => $browser->script(<<<'JS'
+            window.__originalFetch = window.fetch
+            window.__releaseProtectedPrefetch = null
+            window.__secondRequestCount = 0
+
+            window.fetch = function (url, options) {
+                let pathname = new URL(
+                    url,
+                    window.location.origin
+                ).pathname
+
+                if (pathname === '/second') {
+                    window.__secondRequestCount++
+
+                    // Hold only the speculative prefetch.
+                    if (window.__secondRequestCount === 1) {
+                        return new Promise((resolve, reject) => {
+                            window.__releaseProtectedPrefetch = () => {
+                                window.__originalFetch(url, options)
+                                    .then(resolve)
+                                    .catch(reject)
+                            }
+                        })
+                    }
+                }
+
+                return window.__originalFetch(url, options)
+            }
+        JS))
+
+        // Hover starts the first request, which we deliberately keep open.
+        ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+
+        ->waitUntil('window.__releaseProtectedPrefetch !== null')
+
+        // Click while navigation is waiting for the in-flight prefetch.
+        ->click('@link.to.second')
+
+        // Let the navigate click handler attach its callbacks to the prefetch.
+        ->pause(50)
+
+        // A MessageRequest invalidates the prefetch while navigation is waiting.
+        ->waitForLivewire()->click('@increment')
+        ->assertSeeIn('@count', '1')
+
+        // Correct behavior is a second request for the navigation fallback.
+        ->waitUntil('window.__secondRequestCount === 2')
+        ->waitForText('On second')
+
+        // The original prefetch can finish afterwards without resurrecting
+        // stale prefetched HTML.
+        ->tap(fn (Browser $browser) => $browser->script(
+            'window.__releaseProtectedPrefetch()'
+        ))
+
+        ->assertPathIs('/second')
+        ->assertScript('return window.__secondRequestCount', 2)
+        ;
+    }
+
     protected function registerComponentTestRoutes($routes)
     {
         $registered = 0;

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -6,6 +6,7 @@ use Laravel\Dusk\Browser;
 use Livewire\Attributes\On;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\View;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Url;
@@ -1628,6 +1629,128 @@ class BrowserTest extends \Tests\BrowserTestCase
 
             $browser->driver->switchTo()->window($initialHandles[0]);
         });
+    }
+
+    public function test_livewire_action_clears_navigate_prefetch_cache()
+    {
+        Livewire::visit(new class extends Component {
+            public $count = 0;
+
+            public function increment()
+            {
+                $this->count++;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <div dusk="title">Prefetch clear page</div>
+
+                        <span dusk="count">{{ $count }}</span>
+
+                        <button type="button" wire:click="increment" dusk="increment">+</button>
+
+                        <a href="/second" wire:navigate.hover dusk="link.to.second">
+                            Go to second page
+                        </a>
+                    </div>
+                HTML;
+            }
+        })
+        ->assertSee('Prefetch clear page')
+
+        // Hover → prefetch stored
+        ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+        ->mouseover('@title')
+
+        // Still cached
+        ->waitForNoNavigatePrefetchRequest()->mouseover('@link.to.second')
+        ->mouseover('@title')
+
+        // Real MessageRequest → interceptor clears cache
+        ->waitForLivewire()->click('@increment')
+        ->assertSeeIn('@count', '1')
+
+        // Cache cleared → new prefetch must fire
+        ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+        ->assertSee('Prefetch clear page')
+        ;
+    }
+
+    public function test_livewire_action_clears_prefetch_so_protected_route_is_refetched()
+    {
+        $this->registerComponentTestRoutes([
+            '/protected' => new class extends Component {
+                public function render()
+                {
+                    if (! session('authorized')) {
+                        return redirect('/create-password');
+                    }
+
+                    return <<<'HTML'
+                        <div dusk="protected-page">On protected page</div>
+                    HTML;
+                }
+            },
+            '/create-password' => new class extends Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                        <div dusk="create-password-page">Create a password</div>
+                    HTML;
+                }
+            },
+        ]);
+
+        Livewire::visit(new class extends Component {
+            public $authorized = false;
+
+            public function save()
+            {
+                session(['authorized' => true]);
+
+                $this->authorized = true;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <div dusk="gate-page">{{ $authorized ? 'Authorized' : 'Forbidden' }}</div>
+
+                        <a href="/protected" wire:navigate.hover dusk="link.to.protected">
+                            Go to protected
+                        </a>
+
+                        <button type="button" wire:click="save" dusk="authorize">
+                            Authorize
+                        </button>
+                    </div>
+                HTML;
+            }
+        })
+        ->assertSee('Forbidden')
+
+        // Simulate prefetch destination on hover when its still protected
+        ->waitForNavigatePrefetchRequest()->mouseover('@link.to.protected')
+        ->mouseover('@gate-page')
+
+        // Second hover should not prefetch destination
+        ->waitForNoNavigatePrefetchRequest()->mouseover('@link.to.protected')
+        ->mouseover('@gate-page')
+
+        ->waitForLivewire()->click('@authorize')
+        ->assertSee('Authorized')
+
+        // Livewire action should clear all prefetch destination so hovering should prefetch again
+        ->waitForNavigatePrefetchRequest()->mouseover('@link.to.protected')
+        // Clicking the link should not trigger navigate request again
+        ->waitForNoNavigateRequest()->click('@link.to.protected')
+        ->assertSee('On protected page')
+        ->assertDontSee('Create a password')
+        ->assertPathIs('/protected')
+        ;
     }
 
     protected function registerComponentTestRoutes($routes)

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -1770,7 +1770,6 @@ class BrowserTest extends \Tests\BrowserTestCase
 
             // MessageRequest invalidates the prefetch while navigation is waiting.
             ->waitForLivewire()->click('@increment')
-            ->assertSeeIn('@count', '1')
 
             // Correct behavior is a second request for the navigation fallback.
             ->waitUntil('window.__requestCount === 2')


### PR DESCRIPTION
## Summary

This PR fixes an issue where HTML prefetched by `wire:navigate.hover` could become stale after a Livewire component action modified the requirement to visit destination page.

### Problem

`wire:navigate.hover` can prefetch a destination page before the user clicks a navigation link. That prefetched HTML is then cached and reused when the navigation actually occurs.

However, if a Livewire component action runs after the prefetch completes, the current page state may change before the user navigates. In this situation, the previously prefetched navigation response can no longer reliably represent the correct state of the application.

Because the stale prefetched HTML remained cached, a subsequent `wire:navigate` navigation or `$this->redirect(..., navigate: true)` could incorrectly reuse that outdated response instead of fetching fresh HTML.

```blade
<a href="{{ route('profile.show') }}" wire:navigate.hover>Profile</a>
```
```php
Route::get('/profile', ShowProfile::class)
    ->middleware(HavePassword::class)
    ->name('profile.show');

Route::get('/create-password', CreatePassword::class)
    ->middleware(HaveNoPassword::class)
    ->name('password.create');
```

In this situation, user hover the profile link (prefetch) then click then link to create a password less than `30s` which is prefetched html time limit stored. Because the stored html is `/create-password`, it will navigate there however user already create a password so it will redirect back again to original page.

Related discussion: https://github.com/livewire/livewire/discussions/9386

### Solution

This PR ensures that prefetched navigation HTML is invalidated when a component action is called.

As a result, after a Livewire action changes the application state, a later `wire:navigate` navigation will no longer use a prefetch response created before that action. Instead, navigation can proceed using up-to-date HTML.

This prevents stale prefetched content from being rendered after the state of the current page has changed.

### Tests

* `test_livewire_action_clears_navigate_prefetch_cache`
* `test_livewire_action_clears_prefetch_so_protected_route_is_refetched`
* `test_navigate_fallback_when_in_flight_prefetch_cleared_by_livewire_request`