### PR TITLE
[4.x] Fix stale wire:navigate.hover prefetches after Livewire requests

### DIFF
--- a/js/plugins/navigate/prefetch.js
+++ b/js/plugins/navigate/prefetch.js
@@ -28,7 +28,13 @@ export function prefetchHtml(destination, callback, errorCallback) {
 
     if (prefetches[uri]) return
 
-    prefetches[uri] = { finished: false, html: null, whenFinished: () => setTimeout(() => delete prefetches[uri], cacheDuration), whenFailed: () => {} }
+    let state = { finished: false, html: null, whenFinished: () => {}, whenFailed: () => {} }
+
+    state.whenFinished = () => setTimeout(() => {
+        if (prefetches[uri] === state) delete prefetches[uri]
+    }, cacheDuration)
+
+    prefetches[uri] = state
 
     performFetch(uri, (html, routedUri, status) => {
         let state = prefetches[uri]

--- a/js/plugins/navigate/prefetch.js
+++ b/js/plugins/navigate/prefetch.js
@@ -37,10 +37,8 @@ export function prefetchHtml(destination, callback, errorCallback) {
     prefetches[uri] = state
 
     performFetch(uri, (html, routedUri, status) => {
-        let state = prefetches[uri]
-
         // The prefetch may have been invalidated while its request was in flight.
-        if (! state) return
+        if (prefetches[uri] !== state) return
 
         storeCurrentPageStatus(status)
 
@@ -59,10 +57,8 @@ export function prefetchHtml(destination, callback, errorCallback) {
 
         callback(html, routedUri)
     }, () => {
-        let state = prefetches[uri]
-
         // The prefetch may have been invalidated while its request was in flight.
-        if (! state) return
+        if (prefetches[uri] !== state) return
 
         let whenFailed = state.whenFailed
 

--- a/js/plugins/navigate/prefetch.js
+++ b/js/plugins/navigate/prefetch.js
@@ -13,12 +13,14 @@ let cacheDuration = 30000
 // so discard all prefetched HTML before the request is sent.
 // If a navigation is already waiting on an in-flight prefetch, fail it so it
 // falls back to a fresh navigation request.
-interceptRequest(() => {
-    Object.values(prefetches).forEach(state => {
-        if (! state.finished) state.whenFailed()
-    })
+interceptRequest(({ onSend }) => {
+    onSend(() => {
+        Object.values(prefetches).forEach(state => {
+            if (! state.finished) state.whenFailed()
+        })
 
-    prefetches = {}
+        prefetches = {}
+    })
 })
 
 export function prefetchHtml(destination, callback, errorCallback) {
@@ -69,6 +71,10 @@ export function prefetchHtml(destination, callback, errorCallback) {
 
 export function storeThePrefetchedHtmlForWhenALinkIsClicked(html, destination, finalDestination) {
     let state = prefetches[getUriStringFromUrlObject(destination)]
+
+    // The prefetch may have been invalidated while its request was in flight.
+    if (! state) return
+
     state.html = html
     state.finished = true
     state.finalDestination = finalDestination

--- a/js/plugins/navigate/prefetch.js
+++ b/js/plugins/navigate/prefetch.js
@@ -1,12 +1,25 @@
 import { performFetch } from "@/plugins/navigate/fetch";
 import { getUriStringFromUrlObject } from "./links";
 import { storeCurrentPageStatus } from "./history";
+import { interceptRequest } from "@/request";
 
 // Warning: this could cause some memory leaks
 let prefetches = {}
 
 // Default prefetch cache duration is 30 seconds...
 let cacheDuration = 30000
+
+// A Livewire request can change the application state,
+// so discard all prefetched HTML before the request is sent.
+// If a navigation is already waiting on an in-flight prefetch, fail it so it
+// falls back to a fresh navigation request.
+interceptRequest(() => {
+    Object.values(prefetches).forEach(state => {
+        if (! state.finished) state.whenFailed()
+    })
+
+    prefetches = {}
+})
 
 export function prefetchHtml(destination, callback, errorCallback) {
     let uri = getUriStringFromUrlObject(destination)
@@ -16,11 +29,34 @@ export function prefetchHtml(destination, callback, errorCallback) {
     prefetches[uri] = { finished: false, html: null, whenFinished: () => setTimeout(() => delete prefetches[uri], cacheDuration), whenFailed: () => {} }
 
     performFetch(uri, (html, routedUri, status) => {
+        let state = prefetches[uri]
+
+        // The prefetch may have been invalidated while its request was in flight.
+        if (! state) return
+
         storeCurrentPageStatus(status)
+
+        // Don't cache redirected responses. The prefetch is keyed by the original
+        // URL, so caching the redirected response could cause a later navigation
+        // to use stale or unauthorized HTML.
+        if (getUriStringFromUrlObject(routedUri) !== uri) {
+            let whenFailed = state.whenFailed
+
+            delete prefetches[uri]
+
+            whenFailed()
+
+            return
+        }
 
         callback(html, routedUri)
     }, () => {
-        let whenFailed = prefetches[uri].whenFailed
+        let state = prefetches[uri]
+
+        // The prefetch may have been invalidated while its request was in flight.
+        if (! state) return
+
+        let whenFailed = state.whenFailed
 
         // If the fetch failed, remove the prefetch so it gets attempted again...
         delete prefetches[uri]

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -1980,6 +1980,35 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->waitUntil('window.__redirectedPrefetchRequests === 2');
     }
 
+    public function test_prefetch_invalidation_callback_does_not_expire_a_new_prefetch_early()
+    {
+        Livewire::visit(PageWithPrefetchOnHover::class)
+            ->assertSee('Prefetch clear page')
+
+            // A: create the first cached prefetch.
+            ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+            ->mouseover('@title')
+
+            // Give A's expiry timer a definite head start over B's.
+            ->pause(5000)
+
+            // Invalidate A through the Livewire-request hook.
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '1')
+
+            // B: create a new prefetch for the same URI.
+            ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+            ->mouseover('@title')
+
+            // A is now at least 31s old, while B is only 26s old.
+            // A's timer should have expired, but B's timer should still be active.
+            ->pause(26000)
+
+            // B must still be served from the cache.
+            ->waitForNoNavigatePrefetchRequest()->mouseover('@link.to.second')
+            ->mouseover('@title');
+    }
+
     protected function registerComponentTestRoutes($routes)
     {
         $registered = 0;

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -1784,6 +1784,158 @@ class BrowserTest extends \Tests\BrowserTestCase
         });
     }
 
+    public function test_livewire_action_clears_navigate_prefetch_cache()
+    {
+        Livewire::visit(PageWithPrefetchOnHover::class)
+            ->assertSee('Prefetch clear page')
+
+            // Hover → prefetch stored
+            ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+            ->mouseover('@title')
+
+            // Still cached
+            ->waitForNoNavigatePrefetchRequest()->mouseover('@link.to.second')
+            ->mouseover('@title')
+
+            // Real MessageRequest → interceptor clears cache
+            ->waitForLivewire()->click('@increment')
+            ->assertSeeIn('@count', '1')
+
+            // Cache cleared → new prefetch must fire
+            ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+            ->assertSee('Prefetch clear page');
+    }
+
+    public function test_livewire_action_clears_prefetch_so_protected_route_is_refetched()
+    {
+        $this->registerComponentTestRoutes([
+            '/protected' => new class extends Component {
+                public function render()
+                {
+                    if (! session('authorized')) {
+                        return redirect('/create-password');
+                    }
+
+                    return <<<'HTML'
+                        <div dusk="protected-page">On protected page</div>
+                    HTML;
+                }
+            },
+            '/create-password' => new class extends Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                        <div dusk="create-password-page">Create a password</div>
+                    HTML;
+                }
+            },
+        ]);
+
+        Livewire::visit(new class extends Component {
+            public $authorized = false;
+
+            public function save()
+            {
+                session(['authorized' => true]);
+
+                $this->authorized = true;
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <div dusk="gate-page">{{ $authorized ? 'Authorized' : 'Forbidden' }}</div>
+
+                        <a href="/protected" wire:navigate.hover dusk="link.to.protected">
+                            Go to protected
+                        </a>
+
+                        <button type="button" wire:click="save" dusk="authorize">
+                            Authorize
+                        </button>
+                    </div>
+                HTML;
+            }
+        })
+        ->assertSee('Forbidden')
+
+        // Simulate prefetch destination on hover when its still protected
+        ->waitForNavigatePrefetchRequest()->mouseover('@link.to.protected')
+
+        // Second hover should not prefetch destination
+        ->waitForNoNavigatePrefetchRequest()->mouseover('@link.to.protected')
+
+        ->waitForLivewire()->click('@authorize')
+        ->assertSee('Authorized')
+
+        // Livewire action should clear all prefetch destination so hovering should prefetch again
+        ->waitForNavigatePrefetchRequest()->mouseover('@link.to.protected')
+
+        // Clicking the link should not trigger navigate request again
+        ->waitForNoNavigateRequest()->click('@link.to.protected')
+        ->assertSee('On protected page')
+        ->assertDontSee('Create a password')
+        ->assertPathIs('/protected')
+        ;
+    }
+
+    public function test_navigate_fallback_when_in_flight_prefetch_cleared_by_livewire_request()
+    {
+        Livewire::visit(PageWithPrefetchOnHover::class)
+            ->assertSee('Prefetch clear page')
+            ->tap(fn (Browser $browser) => $browser->script(<<<'JS'
+                window.__originalFetch = window.fetch
+                window.__releasePrefetch = null
+                window.__requestCount = 0
+
+                window.fetch = function (url, options) {
+                    let pathname = new URL(url, window.location.origin).pathname
+
+                    if (pathname === '/second') {
+                        window.__requestCount++
+
+                        // Hold only the speculative prefetch.
+                        if (window.__requestCount === 1) {
+                            return new Promise((resolve, reject) => {
+                                window.__releasePrefetch = () => {
+                                    window.__originalFetch(url, options)
+                                        .then(resolve)
+                                        .catch(reject)
+                                }
+                            })
+                        }
+                    }
+
+                    return window.__originalFetch(url, options)
+                }
+            JS))
+
+            // Hover starts the first request, which we deliberately keep open.
+            ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+
+            ->waitUntil('window.__releasePrefetch !== null')
+
+            // Click while navigation is waiting for the in-flight prefetch.
+            ->click('@link.to.second')
+
+            // Let the navigate click handler attach its callbacks to the prefetch.
+            ->pause(50)
+
+            // MessageRequest invalidates the prefetch while navigation is waiting.
+            ->waitForLivewire()->click('@increment')
+
+            // Correct behavior is a second request for the navigation fallback.
+            ->waitUntil('window.__requestCount === 2')
+            ->waitForText('On second')
+
+            // Original prefetch can finish afterwards without resurrecting stale prefetched HTML.
+            ->tap(fn (Browser $browser) => $browser->script('window.__releasePrefetch()'))
+
+            ->assertPathIs('/second')
+            ->assertScript('return window.__requestCount', 2);
+    }
+
     protected function registerComponentTestRoutes($routes)
     {
         $registered = 0;
@@ -2541,6 +2693,35 @@ class PageWithLinkToAnErrorPage extends Component
             })
         </script>
         @endscript
+        HTML;
+    }
+}
+
+class PageWithPrefetchOnHover extends Component
+{
+    public $count = 0;
+
+    public function increment()
+    {
+        $this->count++;
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+            <div>
+                <div dusk="title">Prefetch clear page</div>
+
+                <span dusk="count">{{ $count }}</span>
+
+                <button type="button" wire:click="increment" dusk="increment">
+                    Increment
+                </button>
+
+                <a href="/second" wire:navigate.hover dusk="link.to.second">
+                    Go to second page
+                </a>
+            </div>
         HTML;
     }
 }

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -1936,6 +1936,50 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->assertScript('return window.__requestCount', 2);
     }
 
+    public function test_redirected_navigate_prefetch_is_not_cached()
+    {
+        Livewire::visit(new class extends Component {
+            public function render()
+            {
+                return <<<'HTML'
+                    <div>
+                        <div dusk="title">Redirect prefetch page</div>
+                        <a href="/redirect-to-second" wire:navigate.hover dusk="link.to.redirected">
+                            Go to redirected
+                        </a>
+                    </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@title', 'Redirect prefetch page')
+            ->tap(fn (Browser $browser) => $browser->script(<<<'JS'
+                window.__redirectedPrefetchRequests = 0
+                window.__redirectedPrefetchCompleted = 0
+                window.__originalFetch = window.fetch
+
+                window.fetch = function (url, options) {
+                    let pathname = new URL(url, window.location.origin).pathname
+
+                    // Count the *original* URL only (before follow)
+                    if (pathname === '/redirect-to-second') {
+                        window.__redirectedPrefetchRequests++
+                        return window.__originalFetch(url, options).then(response => {
+                            window.__redirectedPrefetchCompleted++
+                            return response
+                        })
+                    }
+
+                    return window.__originalFetch(url, options)
+                }
+            JS))
+            ->waitForNavigatePrefetchRequest()->mouseover('@link.to.redirected')
+            ->waitUntil('window.__redirectedPrefetchCompleted === 1')
+            ->mouseover('@title')
+            // Must prefetch again: redirectd response must not sit under /redirect-to-second
+            ->waitForNavigatePrefetchRequest()->mouseover('@link.to.redirected')
+            ->waitUntil('window.__redirectedPrefetchRequests === 2');
+    }
+
     protected function registerComponentTestRoutes($routes)
     {
         $registered = 0;

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -2009,6 +2009,71 @@ class BrowserTest extends \Tests\BrowserTestCase
             ->mouseover('@title');
     }
 
+    public function test_invalidated_prefetch_response_does_not_complete_a_new_prefetch_for_the_same_uri()
+    {
+        Livewire::visit(PageWithPrefetchOnHover::class)
+            ->assertSee('Prefetch clear page')
+            ->tap(fn (Browser $browser) => $browser->script(<<<'JS'
+                window.__originalFetch = window.fetch
+                window.__releasePrefetch = {}
+                window.__requestCount = 0
+
+                window.fetch = function (url, options) {
+                    let pathname = new URL(url, window.location.origin).pathname
+
+                    if (pathname === '/second') {
+                        window.__requestCount++
+
+                        let request = window.__requestCount
+
+                        return new Promise((resolve, reject) => {
+                            window.__releasePrefetch[request] = () => {
+                                window.__originalFetch(url, options)
+                                    .then(resolve)
+                                    .catch(reject)
+                            }
+                        })
+                    }
+
+                    return window.__originalFetch(url, options)
+                }
+            JS))
+
+            // A.
+            ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+            ->waitUntil('window.__releasePrefetch[1] !== undefined')
+            ->mouseover('@title')
+
+            // Invalidate A.
+            ->waitForLivewire()->click('@increment')
+
+            // B.
+            ->waitForNavigatePrefetchRequest()->mouseover('@link.to.second')
+            ->waitUntil('window.__releasePrefetch[2] !== undefined')
+            ->mouseover('@title')
+
+            // A completes after B replaced it.
+            ->tap(fn (Browser $browser) => $browser->script(
+                'window.__releasePrefetch[1]()'
+            ))
+
+            // Start navigation. It should be waiting on B.
+            ->click('@link.to.second')
+
+            // Give A's callback time to run.
+            ->pause(250)
+
+            // We must still be on the original page.
+            ->assertSee('Prefetch clear page')
+
+            // B is the request that should unblock navigation.
+            ->tap(fn (Browser $browser) => $browser->script(
+                'window.__releasePrefetch[2]()'
+            ))
+
+            ->waitForText('On second');
+    }
+
     protected function registerComponentTestRoutes($routes)
     {
         $registered = 0;


### PR DESCRIPTION
> [!NOTE]
> Based on https://github.com/livewire/livewire/pull/10668 with a minimal fix.

## Affected version
- 3.x (backport)
- 4.x (current PR)

## Problem

`wire:navigate.hover` prefetches and caches the destination HTML for up to 30 seconds.

If a Livewire request changes application state during that period, the cached HTML can become stale. Subsequent navigation may then use the stale prefetched response instead of making a fresh request.

This is particularly problematic for protected routes. For example, a route may initially redirect to a password-creation page when prefetched, but become accessible after a Livewire action updates the session. Without invalidating the prefetch, navigating to the route can continue using the stale prefetched response.

Prefetches that redirect also must not be cached under the original URL. The response belongs to the redirected destination, while the cache entry is keyed by the original URL.

## Changes

* Invalidate all navigation prefetches when a Livewire request is sent.
* Fall back to a normal navigation request when an in-flight prefetch is invalidated while navigation is waiting for it.
* Ignore responses from prefetch requests that were invalidated while they were in flight.
* Do not cache prefetched responses when the request was redirected to a different URL.
* Ensure an invalidated prefetch's expiry timer cannot expire a newer prefetch for the same URL.
* Ignore responses from invalidated prefetch requests, including when a newer prefetch for the same URL has already replaced them.

## Why

A prefetched page represents application state at the time the prefetch was made. A subsequent Livewire request can change that state, including session state, authorization state, or other data used to render the destination.

Discarding the prefetch when a Livewire request is sent ensures that the next navigation gets a fresh response.

Because an in-flight prefetch cannot necessarily be cancelled, its response may arrive after the prefetch has been invalidated. If a new prefetch for the same URL has started in the meantime, the old response must not complete or modify the newer prefetch. Each prefetch therefore verifies that it is still the current prefetch for the URL before handling its response.

When an invalidated prefetch is replaced by a new prefetch for the same URL, the old prefetch's 30-second expiry timer must not remove the new cache entry. Each prefetch should retain its own cache lifetime.

The existing `whenFailed` fallback is used for in-flight prefetches, so no additional navigation-tracking mechanism is required.

This intentionally keeps the existing 30s cache timer mechanism (no broader prefetch lifecycle rewrite).

## Trade-off

Every sent Livewire request clears the hover prefetch cache. That is intentional: correctness for auth/session/state takes priority over keeping speculative prefetches.

Clearing runs on `onSend` so cancelled-before-send requests do not discard the cache.

## Tests

Added coverage for:

* Clearing a cached navigation prefetch after a Livewire action.
* Refetching a previously protected route after its authorization state changes.
* Falling back to a fresh navigation request when an in-flight prefetch is invalidated by a Livewire request.
* Ensuring an invalidated prefetch response cannot complete or interfere with a newer prefetch for the same URL.
* Ensuring an invalidated prefetch cannot expire a newer prefetch for the same URL before the newer prefetch's 30-second cache lifetime has elapsed.
* Redirected prefetch responses are not cached for the original URL.

Fixes: https://github.com/livewire/livewire/discussions/9386