### PR TITLE
Require Alpine 3.17.2 on main

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,18 +17,18 @@
         "vitest": "^3.2.4"
     },
     "dependencies": {
-        "@alpinejs/anchor": "^3.17.1",
-        "@alpinejs/collapse": "^3.17.1",
-        "@alpinejs/csp": "^3.17.1",
-        "@alpinejs/focus": "^3.17.1",
-        "@alpinejs/intersect": "^3.17.1",
-        "@alpinejs/mask": "^3.17.1",
-        "@alpinejs/morph": "^3.17.1",
-        "@alpinejs/persist": "^3.17.1",
-        "@alpinejs/resize": "^3.17.1",
-        "@alpinejs/sort": "^3.17.1",
+        "@alpinejs/anchor": "^3.17.2",
+        "@alpinejs/collapse": "^3.17.2",
+        "@alpinejs/csp": "^3.17.2",
+        "@alpinejs/focus": "^3.17.2",
+        "@alpinejs/intersect": "^3.17.2",
+        "@alpinejs/mask": "^3.17.2",
+        "@alpinejs/morph": "^3.17.2",
+        "@alpinejs/persist": "^3.17.2",
+        "@alpinejs/resize": "^3.17.2",
+        "@alpinejs/sort": "^3.17.2",
         "@vue/reactivity": "^3.2.45",
-        "alpinejs": "^3.17.1",
+        "alpinejs": "^3.17.2",
         "nprogress": "^0.2.0"
     }
 }


### PR DESCRIPTION
Prepare main to consume Alpine 3.17.2.

The package constraints are updated now; the lockfile remains intentionally unchanged until Alpine v3.17.2 is published to npm. After publication, regenerate the lockfile from the real registry and run the JavaScript/build verification before marking ready.