### PR TITLE
Backport eligible 4.x fixes to 3.x

### DIFF
--- a/docs/component-hooks.md
+++ b/docs/component-hooks.md
@@ -144,4 +144,4 @@ class SupportCsvDownloads extends ComponentHook
 }
 ```
 
-You can 
+The callback returned from `call()` runs after the component method has finished. In this example, it can inspect each method's return value and handle `Csv` instances in one place.

--- a/js/plugins/navigate/persist.js
+++ b/js/plugins/navigate/persist.js
@@ -18,6 +18,7 @@ export function storePersistantElementsForLater(callback) {
 
 export function putPersistantElementsBack(callback) {
     let usedPersists = []
+    let putBacks = []
 
     document.querySelectorAll('[x-persist]').forEach(i => {
         let old = els[i.getAttribute('x-persist')]
@@ -29,12 +30,16 @@ export function putPersistantElementsBack(callback) {
 
         old._x_wasPersisted = true
 
-        callback(old, i)
-
         Alpine.mutateDom(() => {
             i.replaceWith(old)
         })
+
+        putBacks.push([old, i])
     })
+
+    // Wait until every persisted element is back on the page before running the
+    // callbacks, otherwise a teleport can't resolve a target inside one of them...
+    putBacks.forEach(([old, i]) => callback(old, i))
 
     Object.entries(els).forEach(([key, el]) => {
         if (usedPersists.includes(key)) return

--- a/js/plugins/navigate/teleport.js
+++ b/js/plugins/navigate/teleport.js
@@ -17,7 +17,7 @@ export function removeAnyLeftOverStaleTeleportTargets(body) {
 }
 
 export function unPackPersistedTeleports(persistedEl) {
-    // Before we put back any persisted elements, we're going to
+    // Now that the persisted elements are back on the page, we're going to
     // find any "x-teleports" and put their targets back on the page...
     Alpine.walk(persistedEl, (el, skip) => {
         if (! el._x_teleport) return;

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -243,6 +243,122 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_navigate_works_with_teleports_targeting_inside_a_persist()
+    {
+        $this->registerComponentTestRoutes([
+            '/second' => new class extends Component {
+                public function render(){ return <<<'HTML'
+                    <div>
+                        <div>
+                            On second page
+                        </div>
+
+                        @persist('header')
+                            <div>Placeholder</div>
+                        @endpersist
+                    </div>
+                HTML; }
+            },
+        ]);
+
+        Livewire::visit(new class extends Component {
+            public function render(){
+                return <<<'HTML'
+                    <div>
+                        <div>
+                            On first page
+                        </div>
+
+                        @persist('header')
+                            <div x-data="{ outerScopeCount: 0 }">
+                                <div id="labels"></div>
+
+                                <template x-teleport="#labels">
+                                    <div>
+                                        <span x-text="outerScopeCount" dusk="target"></span>
+                                        <button x-on:click="outerScopeCount++" dusk="button">inc</button>
+                                    </div>
+                                </template>
+                            </div>
+                        @endpersist
+
+                        <a href="/second" wire:navigate dusk="link">Go to second page</a>
+                    </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@target', '0')
+        ->click('@button')
+        ->assertSeeIn('@target', '1')
+        ->click('@link')
+        ->waitForText('On second page')
+        ->assertSeeIn('@target', '1')
+        ->click('@button')
+        ->assertSeeIn('@target', '2')
+        ;
+    }
+
+    public function test_navigate_works_with_teleports_targeting_inside_another_persist()
+    {
+        $this->registerComponentTestRoutes([
+            '/second' => new class extends Component {
+                public function render(){ return <<<'HTML'
+                    <div>
+                        <div>
+                            On second page
+                        </div>
+
+                        @persist('header')
+                            <div>Placeholder</div>
+                        @endpersist
+
+                        @persist('sidebar')
+                            <div>Placeholder</div>
+                        @endpersist
+                    </div>
+                HTML; }
+            },
+        ]);
+
+        Livewire::visit(new class extends Component {
+            public function render(){
+                return <<<'HTML'
+                    <div>
+                        <div>
+                            On first page
+                        </div>
+
+                        @persist('header')
+                            <div x-data="{ outerScopeCount: 0 }">
+                                <template x-teleport="#labels">
+                                    <div>
+                                        <span x-text="outerScopeCount" dusk="target"></span>
+                                        <button x-on:click="outerScopeCount++" dusk="button">inc</button>
+                                    </div>
+                                </template>
+                            </div>
+                        @endpersist
+
+                        @persist('sidebar')
+                            <div id="labels"></div>
+                        @endpersist
+
+                        <a href="/second" wire:navigate dusk="link">Go to second page</a>
+                    </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@target', '0')
+        ->click('@button')
+        ->assertSeeIn('@target', '1')
+        ->click('@link')
+        ->waitForText('On second page')
+        ->assertSeeIn('@target', '1')
+        ->click('@button')
+        ->assertSeeIn('@target', '2')
+        ;
+    }
+
     public function test_can_configure_progress_bar()
     {
         $this->browse(function ($browser) {

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -127,10 +127,12 @@ class FrontendAssets extends Mechanism
                 --livewire-progress-bar-color: {$progressBarColor};
             }
 
+            [x-cloak="x-cloak"],
             [x-cloak=""] {
                 display: none !important;
             }
 
+            [wire\:cloak="wire:cloak"],
             [wire\:cloak=""] {
                 display: none !important;
             }

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -127,11 +127,11 @@ class FrontendAssets extends Mechanism
                 --livewire-progress-bar-color: {$progressBarColor};
             }
 
-            [x-cloak] {
+            [x-cloak=""] {
                 display: none !important;
             }
 
-            [wire\:cloak] {
+            [wire\:cloak=""] {
                 display: none !important;
             }
 


### PR DESCRIPTION
Backport the 4.x fixes that apply to the 3.x architecture:

- #10653 restores persisted elements before teleport callbacks run
- #10664 allows value-based `x-cloak` variants
- #10674 completes the truncated component-hook documentation
- #10675 supports Blade-rendered cloak attribute values

The new island-assets change remains 4.x/main-only because 3.x has no islands.

Verification:
- `npm run build`
- Focused navigation browser regressions: 2 passed
- FrontendAssets unit suite: 11 passed