### PR TITLE
Sync 4.x fixes to main

### DIFF
--- a/docs/component-hooks.md
+++ b/docs/component-hooks.md
@@ -144,4 +144,4 @@ class SupportCsvDownloads extends ComponentHook
 }
 ```
 
-You can 
+The callback returned from `call()` runs after the component method has finished. In this example, it can inspect each method's return value and handle `Csv` instances in one place.

--- a/docs/nesting.md
+++ b/docs/nesting.md
@@ -429,6 +429,8 @@ You can apply these attributes in the child component using the `$attributes` va
 
 Attributes that match public property names are automatically passed as props and excluded from `$attributes`. Any remaining attributes like `class`, `id`, or `data-*` are available through `$attributes`.
 
+Only values that can be rendered as an HTML attribute are forwarded. Arrays and objects (other than `Htmlable` instances like `HtmlString`) are silently discarded rather than passed through `$attributes`.
+
 ## Islands vs nested components
 
 When building Livewire applications, you'll often face a choice: Should you create a nested child component or use an island? Both approaches allow you to isolate updates to specific regions, but they serve different purposes.

--- a/js/$wire.js
+++ b/js/$wire.js
@@ -1,6 +1,7 @@
 import { cancelUpload, removeUpload, uploadAction, uploadMultiple } from './features/supportFileUploads'
 import { dispatch, dispatchEl, dispatchRef, dispatchSelf, dispatchTo, listen } from '@/events'
 import { generateEntangleFunction } from '@/features/supportEntangle'
+import { generateWatchFunction } from '@/features/supportWatch'
 import { findComponentByEl } from '@/store'
 import { dataGet, dataSet, isEmpty } from '@/utils'
 import Alpine from 'alpinejs'
@@ -119,6 +120,8 @@ Alpine.magic('wire', (el, { cleanup }) => {
 
             if (['$entangle', 'entangle'].includes(property)) {
                 return generateEntangleFunction(component, cleanup)
+            } else if (['$watch', 'watch'].includes(property)) {
+                return generateWatchFunction(component, cleanup)
             }
 
             return component.$wire[property]
@@ -290,18 +293,7 @@ wireProperty('$toggle', (component) => (name, live = true) => {
 })
 
 wireProperty('$watch', (component) => (path, callback) => {
-    let getter = () => {
-        return dataGet(component.reactive, path)
-    }
-
-    let unwatch = Alpine.watch(getter, callback)
-
-    let removeCleanup = component.addCleanup(unwatch)
-
-    return () => {
-        removeCleanup()
-        unwatch()
-    }
+    return generateWatchFunction(component)(path, callback)
 })
 
 wireProperty('$effect', (component) => (callback) => {

--- a/js/features/supportListeners.js
+++ b/js/features/supportListeners.js
@@ -1,4 +1,5 @@
 import { on as hook } from '@/hooks'
+import { setNextActionOrigin } from '@/request'
 
 hook('effect', ({ component, effects }) => {
     let listeners = []
@@ -17,6 +18,14 @@ function registerListeners(component, listeners) {
             if (component.isLazy && ! component.hasBeenLazyLoaded) return
 
             if (e.__livewire) e.__livewire.receivedBy.push(component)
+
+            // Event listeners may live in a completely different component than
+            // the element that dispatched the event (for example, a global toast).
+            // Preserve that element as the action origin so it receives data-loading
+            // for the listener's request.
+            if (e.target instanceof Element) {
+                setNextActionOrigin({ el: e.target })
+            }
 
             component.$wire.call('__dispatch', name, e.detail || {})
         }
@@ -41,5 +50,4 @@ function registerListeners(component, listeners) {
         })
     })
 }
-
 

--- a/js/features/supportWatch.js
+++ b/js/features/supportWatch.js
@@ -1,0 +1,23 @@
+import { dataGet } from '@/utils'
+import Alpine from 'alpinejs'
+
+export function generateWatchFunction(component, cleanup) {
+    return (path, callback) => {
+        let getter = () => dataGet(component.reactive, path)
+
+        let unwatch = Alpine.watch(getter, callback)
+
+        if (cleanup) {
+            cleanup(unwatch)
+
+            return unwatch
+        }
+
+        let removeCleanup = component.addCleanup(unwatch)
+
+        return () => {
+            removeCleanup()
+            unwatch()
+        }
+    }
+}

--- a/js/plugins/navigate/persist.js
+++ b/js/plugins/navigate/persist.js
@@ -18,6 +18,7 @@ export function storePersistantElementsForLater(callback) {
 
 export function putPersistantElementsBack(callback) {
     let usedPersists = []
+    let putBacks = []
 
     document.querySelectorAll('[x-persist]').forEach(i => {
         let old = els[i.getAttribute('x-persist')]
@@ -29,12 +30,16 @@ export function putPersistantElementsBack(callback) {
 
         old._x_wasPersisted = true
 
-        callback(old, i)
-
         Alpine.mutateDom(() => {
             i.replaceWith(old)
         })
+
+        putBacks.push([old, i])
     })
+
+    // Wait until every persisted element is back on the page before running the
+    // callbacks, otherwise a teleport can't resolve a target inside one of them...
+    putBacks.forEach(([old, i]) => callback(old, i))
 
     Object.entries(els).forEach(([key, el]) => {
         if (usedPersists.includes(key)) return

--- a/js/plugins/navigate/teleport.js
+++ b/js/plugins/navigate/teleport.js
@@ -17,7 +17,7 @@ export function removeAnyLeftOverStaleTeleportTargets(body) {
 }
 
 export function unPackPersistedTeleports(persistedEl) {
-    // Before we put back any persisted elements, we're going to
+    // Now that the persisted elements are back on the page, we're going to
     // find any "x-teleports" and put their targets back on the page...
     Alpine.walk(persistedEl, (el, skip) => {
         if (! el._x_teleport) return;

--- a/js/request/interactions.js
+++ b/js/request/interactions.js
@@ -21,6 +21,12 @@ export function coordinateNetworkInteractions(messageBus) {
 
     // Handle modelable/reactive components...
     interceptPartition(({ message, compileRequest }) => {
+        // Island-only messages never trigger a full parent render on the server,
+        // so bound children can't receive fresh props from them. Bundling would
+        // only couple concurrent island requests together (stalling, for example,
+        // the second of two visible lazy island loads)...
+        if (! message.hasActionForComponent()) return
+
         let component = message.component
 
         let bundledMessages = []

--- a/src/Features/SupportDataLoading/BrowserTest.php
+++ b/src/Features/SupportDataLoading/BrowserTest.php
@@ -6,6 +6,43 @@ use Livewire\Livewire;
 
 class BrowserTest extends \Tests\BrowserTestCase
 {
+    public function test_data_loading_follows_an_event_origin_into_a_different_listener_component()
+    {
+        Livewire::visit([
+            new class extends \Livewire\Component {
+                public function render()
+                {
+                    return <<<'HTML'
+                    <div>
+                        <button x-on:click="$el.dispatchEvent(new CustomEvent('toast-action', { bubbles: true }))" dusk="toast-action">Retry</button>
+                        <livewire:receiver />
+                    </div>
+                    HTML;
+                }
+            },
+            'receiver' => new class extends \Livewire\Component {
+                #[\Livewire\Attributes\On('toast-action')]
+                public function handleToastAction()
+                {
+                    usleep(250 * 1000);
+                }
+
+                public function render()
+                {
+                    return '<div dusk="receiver">Receiver</div>';
+                }
+            },
+        ])
+        ->waitForLivewireToLoad()
+        ->assertAttributeMissing('@toast-action', 'data-loading')
+        ->click('@toast-action')
+        ->pause(10)
+        ->assertAttribute('@toast-action', 'data-loading', 'true')
+        ->pause(350)
+        ->assertAttributeMissing('@toast-action', 'data-loading')
+        ;
+    }
+
     public function test_data_loading_attribute_is_added_to_an_element_when_it_triggers_a_request()
     {
         Livewire::visit([

--- a/src/Features/SupportHtmlAttributeForwarding/HandlesHtmlAttributeForwarding.php
+++ b/src/Features/SupportHtmlAttributeForwarding/HandlesHtmlAttributeForwarding.php
@@ -2,6 +2,8 @@
 
 namespace Livewire\Features\SupportHtmlAttributeForwarding;
 
+use Illuminate\Contracts\Support\Htmlable;
+
 trait HandlesHtmlAttributeForwarding
 {
     protected array $htmlAttributes = [];
@@ -15,6 +17,11 @@ trait HandlesHtmlAttributeForwarding
 
     public function getHtmlAttributes(): array
     {
-        return $this->htmlAttributes;
+        // Structured values like arrays and objects can't be rendered as HTML
+        // attribute values, so only scalars and Htmlable objects are forwarded...
+        return array_filter(
+            $this->htmlAttributes,
+            fn ($value) => is_scalar($value) || is_null($value) || $value instanceof Htmlable
+        );
     }
 }

--- a/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
+++ b/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
@@ -2,9 +2,14 @@
 
 namespace Livewire\Features\SupportHtmlAttributeForwarding;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HtmlString;
 use Tests\TestCase;
 use Livewire\Livewire;
 use Livewire\Component;
+use Livewire\Attributes\Lazy;
+use Livewire\Features\SupportLazyLoading\SupportLazyLoading;
+use Sushi\Sushi;
 
 class UnitTest extends TestCase
 {
@@ -46,5 +51,191 @@ class UnitTest extends TestCase
         ->assertSeeHtml('id="error-alert"')
         ->assertSeeHtml('data-testid="my-alert"')
         ;
+    }
+
+    public function test_array_is_not_forwarded_as_html_attribute_to_component_placeholder()
+    {
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        Livewire::component('alert', LazyAlert::class);
+
+        $html = Livewire::mount('alert', [
+            'lazy' => true,
+            'pageFilters' => ['status' => 'active'],
+            'id' => 'error-alert',
+        ]);
+
+        $this->assertStringContainsString('id="error-alert"', $html);
+        $this->assertStringNotContainsString('pageFilters=', $html);
+    }
+
+    public function test_array_is_not_forwarded_as_html_attribute_to_component_render()
+    {
+        Livewire::component('alert', AlertWithAttributes::class);
+
+        $html = Livewire::mount('alert', [
+            'pageFilters' => ['status' => 'active'],
+            'id' => 'error-alert',
+        ]);
+
+        $this->assertStringContainsString('id="error-alert"', $html);
+        $this->assertStringNotContainsString('pageFilters=', $html);
+    }
+
+    public function test_array_is_not_forwarded_as_html_attribute_to_an_island()
+    {
+        Livewire::component('alert', AlertWithIslandAttributes::class);
+
+        $html = Livewire::mount('alert', [
+            'pageFilters' => ['status' => 'active'],
+            'id' => 'error-alert',
+        ]);
+
+        $this->assertStringContainsString('id="error-alert"', $html);
+        $this->assertStringNotContainsString('pageFilters=', $html);
+    }
+
+    public function test_eloquent_model_is_not_forwarded_as_html_attribute_to_component_placeholder()
+    {
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        Livewire::component('alert', LazyAlert::class);
+
+        $html = Livewire::mount('alert', [
+            'lazy' => true,
+            'record' => RecordModel::first(),
+            'id' => 'error-alert',
+        ]);
+
+        $this->assertStringContainsString('id="error-alert"', $html);
+        $this->assertStringNotContainsString('record=', $html);
+    }
+
+    public function test_eloquent_model_is_not_forwarded_as_html_attribute_to_component_render()
+    {
+        Livewire::component('alert', AlertWithAttributes::class);
+
+        $html = Livewire::mount('alert', [
+            'record' => RecordModel::first(),
+            'id' => 'error-alert',
+        ]);
+
+        $this->assertStringContainsString('id="error-alert"', $html);
+        $this->assertStringNotContainsString('record=', $html);
+    }
+
+    public function test_eloquent_model_is_not_forwarded_as_html_attribute_to_an_island()
+    {
+        Livewire::component('alert', AlertWithIslandAttributes::class);
+
+        $html = Livewire::mount('alert', [
+            'record' => RecordModel::first(),
+            'id' => 'error-alert',
+        ]);
+
+        $this->assertStringContainsString('id="error-alert"', $html);
+        $this->assertStringNotContainsString('record=', $html);
+    }
+
+    public function test_htmlable_objects_are_forwarded_as_html_attributes_to_component_placeholder()
+    {
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        Livewire::component('alert', LazyAlert::class);
+
+        $html = Livewire::mount('alert', [
+            'lazy' => true,
+            'id' => 'error-alert',
+            'title' => new HtmlString('Hello World'),
+        ]);
+
+        $this->assertStringContainsString('id="error-alert"', $html);
+        $this->assertStringContainsString('title="Hello World"', $html);
+    }
+
+    public function test_htmlable_objects_are_forwarded_as_html_attributes_to_component_render()
+    {
+        Livewire::component('alert', AlertWithAttributes::class);
+
+        $html = Livewire::mount('alert', [
+            'id' => 'error-alert',
+            'title' => new HtmlString('Hello World'),
+        ]);
+
+        $this->assertStringContainsString('id="error-alert"', $html);
+        $this->assertStringContainsString('title="Hello World"', $html);
+    }
+
+    public function test_htmlable_objects_are_forwarded_as_html_attributes_to_an_island()
+    {
+        Livewire::component('alert', AlertWithIslandAttributes::class);
+
+        $html = Livewire::mount('alert', [
+            'id' => 'error-alert',
+            'title' => new HtmlString('Hello World'),
+        ]);
+
+        $this->assertStringContainsString('id="error-alert"', $html);
+        $this->assertStringContainsString('title="Hello World"', $html);
+    }
+
+    public function test_arrays_and_objects_are_not_dehydrated_into_the_component_snapshot()
+    {
+        Livewire::component('alert', AlertWithAttributes::class);
+
+        $html = Livewire::mount('alert', [
+            'record' => RecordModel::first(),
+            'pageFilters' => ['status' => 'active'],
+            'id' => 'error-alert',
+        ]);
+
+        // Without filtering, these would be serialized into the wire:snapshot attribute...
+        $this->assertStringNotContainsString('first@example.com', $html);
+        $this->assertStringNotContainsString('pageFilters', $html);
+    }
+}
+
+class RecordModel extends Model
+{
+    use Sushi;
+
+    protected $rows = [
+        ['id' => 1, 'name' => 'First User', 'email' => 'first@example.com'],
+    ];
+}
+
+#[Lazy]
+class LazyAlert extends Component
+{
+    public function placeholder()
+    {
+        return '<div {{ $attributes }}>Loading...</div>';
+    }
+
+    public function render()
+    {
+        return '<div>Alert</div>';
+    }
+}
+
+class AlertWithAttributes extends Component
+{
+    public function render()
+    {
+        return '<div {{ $attributes }}>Alert</div>';
+    }
+}
+
+class AlertWithIslandAttributes extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            @island(name: 'content')
+                <div {{ $attributes }}>Island</div>
+            @endisland
+        </div>
+        HTML;
     }
 }

--- a/src/Features/SupportIslands/BrowserTest.php
+++ b/src/Features/SupportIslands/BrowserTest.php
@@ -1321,4 +1321,90 @@ class BrowserTest extends BrowserTestCase
             ->assertDontSee('ENDISLAND')
             ;
     }
+
+    public function test_visible_lazy_islands_with_a_reactive_nested_component_hydrate()
+    {
+        Livewire::visit([new class extends \Livewire\Component {
+            public bool $editing = false;
+
+            public function toggle()
+            {
+                $this->editing = ! $this->editing;
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    <button dusk="toggle" wire:click="toggle">Toggle Edit Mode</button>
+                    @island(name: 'one', lazy: true, always: true)
+                        @placeholder <div dusk="one-placeholder">Loading one</div> @endplaceholder
+                        <div dusk="one-mounted">One mounted</div>
+                    @endisland
+                    @island(name: 'two', lazy: true, always: true)
+                        @placeholder <div dusk="two-placeholder">Loading two</div> @endplaceholder
+                        <div dusk="two-mounted">Two mounted</div>
+                    @endisland
+                    <livewire:nested :$editing />
+                </div>
+                HTML;
+            }
+        }, 'nested' => new class extends \Livewire\Component {
+            #[\Livewire\Attributes\Reactive]
+            public $editing;
+            public function render() {
+                return <<<'HTML'
+                <div dusk="edit-mode">{{ $editing ? 'Yes' : 'No' }}</div>
+                HTML;
+            }
+        }])
+            ->waitFor('@one-mounted')
+            ->waitFor('@two-mounted')
+            ->assertNotPresent('@one-placeholder')
+            ->assertNotPresent('@two-placeholder')
+            ->assertSeeIn('@edit-mode', 'No')
+            ->waitForLivewire()->click('@toggle')
+            ->assertSeeIn('@edit-mode', 'Yes');
+    }
+
+    public function test_visible_lazy_islands_with_a_modelable_nested_component_hydrate()
+    {
+        Livewire::visit([new class extends \Livewire\Component {
+            public string $body = '';
+
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    <div dusk="content">{{ $body }}</div>
+                    @island(name: 'one', lazy: true, always: true)
+                        @placeholder <div dusk="one-placeholder">Loading one</div> @endplaceholder
+                        <div dusk="one-mounted">One mounted</div>
+                    @endisland
+                    @island(name: 'two', lazy: true, always: true)
+                        @placeholder <div dusk="two-placeholder">Loading two</div> @endplaceholder
+                        <div dusk="two-mounted">Two mounted</div>
+                    @endisland
+                    <livewire:nested wire:model.live="body" />
+                </div>
+                HTML;
+            }
+        }, 'nested' => new class extends \Livewire\Component {
+            #[\Livewire\Attributes\Modelable]
+            public $content;
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    <input dusk="input" wire:model="content" />
+                </div>
+                HTML;
+            }
+        }])
+            ->waitFor('@one-mounted')
+            ->waitFor('@two-mounted')
+            ->assertNotPresent('@one-placeholder')
+            ->assertNotPresent('@two-placeholder')
+            ->assertSeeNothingIn('@content')
+            ->assertSeeNothingIn('@input')
+            ->type('@input', 'livewire')
+            ->waitForTextIn('@content', 'livewire');
+    }
 }

--- a/src/Features/SupportIslands/SupportIslands.php
+++ b/src/Features/SupportIslands/SupportIslands.php
@@ -6,12 +6,19 @@ use Livewire\Features\SupportIslands\Compiler\IslandCompiler;
 use Illuminate\Support\Facades\Blade;
 use Livewire\ComponentHook;
 
+use function Livewire\before;
+
 class SupportIslands extends ComponentHook
 {
     public static function provide()
     {
         static::registerInlineIslandPrecompiler();
         static::registerIslandDirective();
+
+        // Flush implicit island renders before any dehydrate hook, so other hooks (e.g. assets) see their output...
+        before('dehydrate', function ($component) {
+            $component->renderImplicitIslandMorphs();
+        });
     }
 
     public static function registerIslandDirective()

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -5,6 +5,7 @@ namespace Livewire\Features\SupportIslands;
 use Tests\TestCase;
 use Livewire\Livewire;
 use Livewire\Features\SupportIslands\Compiler\IslandCompiler;
+use Livewire\Features\SupportScriptsAndAssets\SupportScriptsAndAssets;
 use Illuminate\Support\Facades\File;
 
 class UnitTest extends TestCase
@@ -738,5 +739,69 @@ class UnitTest extends TestCase
         $this->assertStringContainsString('wire:id="'.$appendedChildId.'" wire:name="island-child" wire:key="row-2"', $component->html());
         $this->assertStringNotContainsString('child 1', $component->html());
         $this->assertStringNotContainsString('child 2', $component->html());
+    }
+
+    public function test_assets_inside_an_implicitly_rendered_island_are_shipped()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    @island(defer: true)
+                        @placeholder <div>loading</div> @endplaceholder
+                        <div data-loaded>ready</div>
+                        @assets <script src="/x.js" data-x></script> @endassets
+                    @endisland
+                </div>
+                HTML;
+            }
+        });
+
+        $name = $component->instance()->getIslands()[0]['name'];
+
+        app('livewire')->update($component->snapshot, [], [
+            [
+                'method' => '__lazyLoadIsland',
+                'params' => [],
+                'path' => '',
+                'metadata' => [
+                    'island' => ['name' => $name, 'mode' => 'morph'],
+                ],
+            ],
+        ]);
+
+        $this->assertStringContainsString('/x.js', json_encode(SupportScriptsAndAssets::getAssets()));
+    }
+
+    public function test_assets_inside_an_explicitly_rendered_island_are_still_shipped()
+    {
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public function refresh()
+            {
+                $this->renderIsland('counter');
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    @island(defer: true, name: 'counter')
+                        @placeholder <div>loading</div> @endplaceholder
+                        <div data-loaded>ready</div>
+                        @assets <script src="/y.js" data-y></script> @endassets
+                    @endisland
+                </div>
+                HTML;
+            }
+        });
+
+        app('livewire')->update($component->snapshot, [], [
+            [
+                'method' => 'refresh',
+                'params' => [],
+                'path' => '',
+            ],
+        ]);
+
+        $this->assertStringContainsString('/y.js', json_encode(SupportScriptsAndAssets::getAssets()));
     }
 }

--- a/src/Features/SupportIslands/UnitTest.php
+++ b/src/Features/SupportIslands/UnitTest.php
@@ -677,4 +677,66 @@ class UnitTest extends TestCase
 
         File::deleteDirectory($compiledPath);
     }
+
+    public function test_children_mounted_during_an_island_render_are_kept_in_the_children_memo()
+    {
+        Livewire::component('island-child', new class extends \Livewire\Component {
+            public $number = 0;
+
+            public function render() {
+                return '<div>child {{ $number }}</div>';
+            }
+        });
+
+        $component = Livewire::test(new class extends \Livewire\Component {
+            public $from = 1;
+            public $to = 1;
+
+            public function loadMore()
+            {
+                $this->from = $this->to + 1;
+                $this->to++;
+            }
+
+            public function render() {
+                return <<<'HTML'
+                <div>
+                    @island(name: 'rows', always: true)
+                        @foreach (range($from, $to) as $number)
+                            <livewire:island-child :$number :wire:key="'row-'.$number" />
+                        @endforeach
+                    @endisland
+                </div>
+                HTML;
+            }
+        });
+
+        $this->assertSame(['row-1'], array_keys($component->snapshot['memo']['children']));
+
+        // Simulate an append-mode island render, like a "load more" button would...
+        $component->update(calls: [
+            [
+                'method' => 'loadMore',
+                'params' => [],
+                'path' => '',
+                'metadata' => [
+                    'island' => [
+                        'name' => 'rows',
+                        'mode' => 'append',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(['row-1', 'row-2'], array_keys($component->snapshot['memo']['children']));
+
+        $appendedChildId = $component->snapshot['memo']['children']['row-2'][1];
+
+        $component->call('$refresh');
+
+        // The appended child should come back as a stub, not mount again from scratch...
+        $this->assertStringContainsString('wire:id="'.$appendedChildId.'" wire:name="island-child" wire:key="row-2"', $component->html());
+        $this->assertStringNotContainsString('child 1', $component->html());
+        $this->assertStringNotContainsString('child 2', $component->html());
+    }
 }

--- a/src/Features/SupportLazyLoading/BrowserTest.php
+++ b/src/Features/SupportLazyLoading/BrowserTest.php
@@ -827,6 +827,46 @@ class BrowserTest extends BrowserTestCase
         ;
     }
 
+    public function test_conflicting_placeholder_node_does_not_break_watch_cleanup_or_leak_memory_on_lazy_component()
+    {
+        Livewire::visit([
+            new class extends Component {
+                public bool $childShown = false;
+
+                public function render() { return <<<HTML
+                <div>
+                    <button type="button" wire:click="\$toggle('childShown')">Toggle</button>
+
+                    @if (\$this->childShown)
+                        <livewire:child lazy />
+                    @endif
+                </div>
+                HTML; }
+            }, 'child' => new class extends Component {
+                public function placeholder() { return <<<HTML
+                    <div id="child">
+                        <div>Loading...</div>
+                        <div>Dummy placeholder</div>
+                    </div>
+                    HTML; }
+
+                public function render() { return <<<HTML
+                    <div id="child">
+                        <div x-data="{ init() { \$wire.\$watch('search', () => {}) } }">
+                            Children component
+                        </div>
+                    </div>
+                    HTML; }
+            }
+        ])
+        ->waitForText('Toggle')
+        ->click('button')
+        ->waitForText('Children component')
+        ->click('button')
+        ->waitUntilMissing('#child')
+        ->assertConsoleLogHasNoErrors()
+        ->assertScript("window.Livewire.all().some(c => c.name === 'child')", false);
+    }
 }
 
 class Page extends Component {

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -264,6 +264,122 @@ class BrowserTest extends \Tests\BrowserTestCase
         ;
     }
 
+    public function test_navigate_works_with_teleports_targeting_inside_a_persist()
+    {
+        $this->registerComponentTestRoutes([
+            '/second' => new class extends Component {
+                public function render(){ return <<<'HTML'
+                    <div>
+                        <div>
+                            On second page
+                        </div>
+
+                        @persist('header')
+                            <div>Placeholder</div>
+                        @endpersist
+                    </div>
+                HTML; }
+            },
+        ]);
+
+        Livewire::visit(new class extends Component {
+            public function render(){
+                return <<<'HTML'
+                    <div>
+                        <div>
+                            On first page
+                        </div>
+
+                        @persist('header')
+                            <div x-data="{ outerScopeCount: 0 }">
+                                <div id="labels"></div>
+
+                                <template x-teleport="#labels">
+                                    <div>
+                                        <span x-text="outerScopeCount" dusk="target"></span>
+                                        <button x-on:click="outerScopeCount++" dusk="button">inc</button>
+                                    </div>
+                                </template>
+                            </div>
+                        @endpersist
+
+                        <a href="/second" wire:navigate dusk="link">Go to second page</a>
+                    </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@target', '0')
+        ->click('@button')
+        ->assertSeeIn('@target', '1')
+        ->click('@link')
+        ->waitForText('On second page')
+        ->assertSeeIn('@target', '1')
+        ->click('@button')
+        ->assertSeeIn('@target', '2')
+        ;
+    }
+
+    public function test_navigate_works_with_teleports_targeting_inside_another_persist()
+    {
+        $this->registerComponentTestRoutes([
+            '/second' => new class extends Component {
+                public function render(){ return <<<'HTML'
+                    <div>
+                        <div>
+                            On second page
+                        </div>
+
+                        @persist('header')
+                            <div>Placeholder</div>
+                        @endpersist
+
+                        @persist('sidebar')
+                            <div>Placeholder</div>
+                        @endpersist
+                    </div>
+                HTML; }
+            },
+        ]);
+
+        Livewire::visit(new class extends Component {
+            public function render(){
+                return <<<'HTML'
+                    <div>
+                        <div>
+                            On first page
+                        </div>
+
+                        @persist('header')
+                            <div x-data="{ outerScopeCount: 0 }">
+                                <template x-teleport="#labels">
+                                    <div>
+                                        <span x-text="outerScopeCount" dusk="target"></span>
+                                        <button x-on:click="outerScopeCount++" dusk="button">inc</button>
+                                    </div>
+                                </template>
+                            </div>
+                        @endpersist
+
+                        @persist('sidebar')
+                            <div id="labels"></div>
+                        @endpersist
+
+                        <a href="/second" wire:navigate dusk="link">Go to second page</a>
+                    </div>
+                HTML;
+            }
+        })
+        ->assertSeeIn('@target', '0')
+        ->click('@button')
+        ->assertSeeIn('@target', '1')
+        ->click('@link')
+        ->waitForText('On second page')
+        ->assertSeeIn('@target', '1')
+        ->click('@button')
+        ->assertSeeIn('@target', '2')
+        ;
+    }
+
     public function test_can_configure_progress_bar()
     {
         $this->browse(function ($browser) {

--- a/src/Features/SupportNestingComponents/SupportNestingComponents.php
+++ b/src/Features/SupportNestingComponents/SupportNestingComponents.php
@@ -112,7 +112,7 @@ class SupportNestingComponents extends ComponentHook
 
     function keepRenderedChildren()
     {
-        $this->storeSet('children', $this->storeGet('previousChildren'));
+        $this->storeSet('children', array_replace($this->storeGet('previousChildren', []), $this->getChildren()));
     }
 
     static function setParametersToMatchingProperties($component, $params)

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -141,11 +141,11 @@ class FrontendAssets extends Mechanism
                 --livewire-progress-bar-color: {$progressBarColor};
             }
 
-            [x-cloak] {
+            [x-cloak=""] {
                 display: none !important;
             }
 
-            [wire\:cloak] {
+            [wire\:cloak=""] {
                 display: none !important;
             }
 

--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -141,10 +141,12 @@ class FrontendAssets extends Mechanism
                 --livewire-progress-bar-color: {$progressBarColor};
             }
 
+            [x-cloak="x-cloak"],
             [x-cloak=""] {
                 display: none !important;
             }
 
+            [wire\:cloak="wire:cloak"],
             [wire\:cloak=""] {
                 display: none !important;
             }


### PR DESCRIPTION
Selectively carry the ten post-v4.4.3 fixes from 4.x into main. This avoids a wholesale branch merge while preserving the eligible fixes for browser-event origins, HTML attribute forwarding, lazy islands, persisted teleports, watcher cleanup, island-mounted children, island assets, custom `x-cloak` variants, and component-hook documentation, and Blade-rendered cloak attribute values.

Source PRs: #10648, #10649, #10650, #10653, #10656, #10659, #10664, #10666, #10674, #10675

Verification:
- `npm run test:run`: 164 passed, 1 skipped
- `npm run build`
- HTML forwarding/island unit coverage: 36 passed before refresh; refreshed SupportIslands suite: 27 passed
- Original focused browser regressions: 6 passed
- Refreshed islands/assets browser suites: 53 passed
- FrontendAssets suite: 16 passed