### PR TITLE
[4.x] Complete truncated component hook documentation

### DIFF
--- a/docs/component-hooks.md
+++ b/docs/component-hooks.md
@@ -144,4 +144,4 @@ class SupportCsvDownloads extends ComponentHook
 }
 ```
 
-You can 
+The callback returned from `call()` runs after the component method has finished. In this example, it can inspect each method's return value and handle `Csv` instances in one place.


### PR DESCRIPTION
## What

Completes the truncated sentence at the end of `docs/component-hooks.md` with a short explanation of the callback returned by `call()`.

## Why

The page currently ends mid-sentence at `You can`, leaving the practical example unfinished.

## Tests

Not run (documentation-only change).
