### PR TITLE
[4.x] Add [x-cloak="x-cloak"] CSS selector

### DIFF
--- a/src/Mechanisms/FrontendAssets/FrontendAssets.php
+++ b/src/Mechanisms/FrontendAssets/FrontendAssets.php
@@ -141,10 +141,12 @@ class FrontendAssets extends Mechanism
                 --livewire-progress-bar-color: {$progressBarColor};
             }
 
+            [x-cloak="x-cloak"],
             [x-cloak=""] {
                 display: none !important;
             }
 
+            [wire\:cloak="wire:cloak"],
             [wire\:cloak=""] {
                 display: none !important;
             }


### PR DESCRIPTION
## What does this PR do?

This PR fixes an edge case introduced by [[#10664](https://github.com/livewire/livewire/pull/10664)](https://github.com/livewire/livewire/pull/10664), which changed the default cloak selector to only target empty attributes.

Blade components render valueless attributes using the attribute name as their value:

```blade
<x-alert-unverified-email x-cloak />
```

becomes:

```html
x-cloak="x-cloak"
```

This PR updates the selectors to support both forms:

```css
[x-cloak="x-cloak"],
[x-cloak=""] {
    display: none !important;
}
```

The same fix is applied to `wire:cloak`.

Custom values such as `x-cloak="lg"` remain unaffected.