### PR TITLE
Update Alpine 3.17.2 lockfile on main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,18 @@
             "name": "laravel-livewire",
             "license": "MIT",
             "dependencies": {
-                "@alpinejs/anchor": "^3.17.1",
-                "@alpinejs/collapse": "^3.17.1",
-                "@alpinejs/csp": "^3.17.1",
-                "@alpinejs/focus": "^3.17.1",
-                "@alpinejs/intersect": "^3.17.1",
-                "@alpinejs/mask": "^3.17.1",
-                "@alpinejs/morph": "^3.17.1",
-                "@alpinejs/persist": "^3.17.1",
-                "@alpinejs/resize": "^3.17.1",
-                "@alpinejs/sort": "^3.17.1",
+                "@alpinejs/anchor": "^3.17.2",
+                "@alpinejs/collapse": "^3.17.2",
+                "@alpinejs/csp": "^3.17.2",
+                "@alpinejs/focus": "^3.17.2",
+                "@alpinejs/intersect": "^3.17.2",
+                "@alpinejs/mask": "^3.17.2",
+                "@alpinejs/morph": "^3.17.2",
+                "@alpinejs/persist": "^3.17.2",
+                "@alpinejs/resize": "^3.17.2",
+                "@alpinejs/sort": "^3.17.2",
                 "@vue/reactivity": "^3.2.45",
-                "alpinejs": "^3.17.1",
+                "alpinejs": "^3.17.2",
                 "nprogress": "^0.2.0"
             },
             "devDependencies": {
@@ -29,33 +29,33 @@
             }
         },
         "node_modules/@alpinejs/anchor": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.17.1.tgz",
-            "integrity": "sha512-x6mVH3CAUKLMMh1jEgJ7pWi9DzKEgTq6pK391wN1MvSLndjr0RYOyfCakS1Y6SqHZbTyRtwfp3zG3ECoFYILKw==",
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/anchor/-/anchor-3.17.2.tgz",
+            "integrity": "sha512-b4I/HwzG6o1L1hOcuGSxDuFUVJH4MgKWC+xr5fxWvUNeqqsTyB0ioqhfcqoA0vvIFnm9eLhGuwiKt4FymZis0A==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.5.3"
             }
         },
         "node_modules/@alpinejs/collapse": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.17.1.tgz",
-            "integrity": "sha512-ygf0kJ2I+1TgBUjS+V1Dx2KlT/y/AatyfavzL7b2T3qrPx7WRGI4yxvFB0h6J5OZVO08dhtDTVk/Z1GIC6ME/w==",
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.17.2.tgz",
+            "integrity": "sha512-OugjrAUGXkg8Msmitgf3rXFyoSYXchN00LPQYC2zDjaTcuRaVXXseBZcCU7DZ7b6cyZzCvYbIYngbaaEzvEfuw==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/csp": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.17.1.tgz",
-            "integrity": "sha512-HDrY0ZxvJWSmeUYqtHVSsitaqy1es3VDCNodPpdQRX4nHhHiRoeib+rOzRFFStFRD/6x0KmQzJVJ4FCLAI/DUQ==",
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.17.2.tgz",
+            "integrity": "sha512-jJXIzBaplTu1xVuhtNXEYDQDbQrdVJbXHYSVeF22fz4Vzm+g0X2XMb4pY1ywEpYLsFRx7ZcBE5gMyyuJpKPfHg==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.5.40"
             }
         },
         "node_modules/@alpinejs/focus": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.17.1.tgz",
-            "integrity": "sha512-23+9xUfPMhuqIm6xeqLQmQTBjNY/yHtJ5np05WrFZLdKXOXCLktpAE7ZAgmPoD/s7F2banEiJzTSFDO6GnWUIg==",
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.17.2.tgz",
+            "integrity": "sha512-ZYER+iuYu9IHT2ihAaP04alQLzLzH5nEMmFwVDe7Yu6bzeub+yJISYjR2hH+DlQTcmAZc7xnFMb6zscCVI091Q==",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^8.0.0",
@@ -63,39 +63,39 @@
             }
         },
         "node_modules/@alpinejs/intersect": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.17.1.tgz",
-            "integrity": "sha512-60UZyk6BNGocHgEvKxBfgqPXq9Y1tuQ363/FjdlXc1eNI8Q0arelStWLhEyd0u8JJp7FTr50S/CmaYXMijTQYQ==",
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.17.2.tgz",
+            "integrity": "sha512-q4AJZDk7l/q7PaLeacMmdCfCCtgU3Qve9QTt4t6+A0z8F3YU2xqku08O9N7IENwiPKxlWseqXWWSlr97FSyZ9w==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/mask": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.17.1.tgz",
-            "integrity": "sha512-EK/6nkVdO0kyLM/xYag6oJ2jEbQevEfsdRdjUnwJnzCcLLulUpTLo0JVRBml9XBobM614pVOEMzdbXPPI0wB9w==",
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/mask/-/mask-3.17.2.tgz",
+            "integrity": "sha512-o2ht803nXshsYyNFvR4cUg/9XijF9eqwN8FFEVJUxriVJRS5jWDVADjijHcjQuVKGJYmzdnUMSLBPv48F8In9Q==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/morph": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.17.1.tgz",
-            "integrity": "sha512-RVafJn9fsF1mrxbQniSgTyneV4ybEFPgBGsjwpxko1g0WPdctTewgnxxO86gy5VztpjNvpjRW1bcpq39WtMt8w==",
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/morph/-/morph-3.17.2.tgz",
+            "integrity": "sha512-9O+m1ChwU3JNFsTY7WDAOdG3qPYmE5zJp+2XWX/ymc57S9ifmmx0RCnRR/14CPEqTc/cdpUIOlnAGBg0NAGHpw==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/persist": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.17.1.tgz",
-            "integrity": "sha512-PN/93FIWakZYY4zB/VGDlFtx2LOoa318huflgLMo2jsk+pkjLlDkX1qmuUFh5xhI7Uj3vSvU1Eu1WIA3TN3PTA==",
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.17.2.tgz",
+            "integrity": "sha512-BN8v27efELn2IgWjFoY0IkUmT1JOt3gUwEIb+2rjCU875E6VDbc6n0d29l9giITRgqyugm00H/xB1kcPVrQlcQ==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/resize": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.17.1.tgz",
-            "integrity": "sha512-TyHYMY6DQBh9P/hOFH3KGLE7ilyfR3u3qsYtJfpsE6Fq8eKobkjudahmhHmdiGurohx8YaVbWBNilDcnAjLOTw==",
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/resize/-/resize-3.17.2.tgz",
+            "integrity": "sha512-6v/LECG5pHMh/5iAY/PSPilZZtgt6kVmbpTTyLScmusIt1wyGqbX/wLXJnJwnr40Swb3B4ZImEBK9r1+GDlC8g==",
             "license": "MIT"
         },
         "node_modules/@alpinejs/sort": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.17.1.tgz",
-            "integrity": "sha512-Q6qF00WI4cQAZdIxPgbsHnxZIiIv4T1kfSPyEy2QB/SLhLdISuIjzTBa3TQAe1P45BkRtNk5Y8fQuDZuKhN/6w==",
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/sort/-/sort-3.17.2.tgz",
+            "integrity": "sha512-72v63zuFkepgO2nwi8wNrD1z6pAY3S+d+lCwSZ9Q39hkIFISxPXKffEh3qtTu7Dzlc98EYLz4kVS/pxp3mdw5g==",
             "license": "MIT",
             "dependencies": {
                 "sortablejs": "^1.15.2"
@@ -1266,9 +1266,9 @@
             }
         },
         "node_modules/alpinejs": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.17.1.tgz",
-            "integrity": "sha512-HDUhA9juSA/pNYZ5FAAlW4qNsdeVORFSVONEIu0hVasqCOqLitf15R9tCr5GBCV0ZxiZW2Qx6BYdMSF7iGLT/Q==",
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.17.2.tgz",
+            "integrity": "sha512-xbnG3LlnmFkiNO49C+qhqjEDqOdB0snKqvT48ZVp8TakpZOpsoQbc/jAxpptQRjZi7c9rLeCfvwQ/XOSirIZFQ==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.5.40"


### PR DESCRIPTION
Updates `package-lock.json` to match the Alpine 3.17.2 constraints already merged in #10671.

This fixes the exact-head `npm ci` failure on main.