### PR TITLE
[4.x] Backport wire:navigate view transitions

### DIFF
--- a/docs/navigate.md
+++ b/docs/navigate.md
@@ -273,9 +273,106 @@ In addition to `wire:navigate`, you can manually call the `Livewire.navigate()` 
 <script>
     // ...
 
-    Livewire.navigate('/new/url')
+Livewire.navigate('/new/url')
 </script>
 ```
+
+## Animating page visits with view transitions
+
+By default, `wire:navigate` swaps in the new page instantly. Add `wire:transition.navigate` to an element to animate that region with the browser's [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API):
+
+```blade
+<main wire:transition.navigate>
+    <!-- ... -->
+</main>
+```
+
+The directive is element-scoped: only the marked `<main>` transitions. Siblings such as a sidebar or header update without animating. A transition runs when either the page being left or the page being entered contains a marked element, so clicks, programmatic navigation, and browser back and forward visits behave consistently.
+
+An unnamed directive is the page's primary transition region. Each page may contain one unnamed region. Give any additional regions unique names:
+
+```blade
+<main wire:transition.navigate>...</main>
+
+<aside wire:transition.navigate="secondary">...</aside>
+```
+
+### Keeping a sidebar still
+
+Because transitions are element-scoped, a persistent application shell needs no special transition CSS. Mark the changing content on both pages and leave the shell unmarked:
+
+```blade
+<body>
+    <aside>
+        <!-- This sidebar remains visually stationary... -->
+    </aside>
+
+    <main wire:transition.navigate="content">
+        {{ $slot }}
+    </main>
+</body>
+```
+
+Livewire temporarily disables the browser's root animation while element regions transition, preventing the unmarked sidebar from fading with the page.
+
+### Transitioning the full page
+
+To use the browser's native full-page transition, place the directive on the document element in your application layout:
+
+```blade
+<html wire:transition.navigate>
+    <!-- ... -->
+</html>
+```
+
+You may also place it on `<body>` to transition the complete body as a single element region.
+
+### Customizing the animation
+
+Put custom transition CSS in your application's shared `resources/css/app.css` file—the same stylesheet loaded by your layout using `@vite`. Keeping these styles in the shared stylesheet ensures they are present on both sides of every navigation.
+
+The unnamed region uses the transition name `livewire-navigate`. For example, this replaces its default animation with a short fade and rise:
+
+```css
+@keyframes navigate-out {
+    to { opacity: 0; transform: translateY(-0.5rem); }
+}
+
+@keyframes navigate-in {
+    from { opacity: 0; transform: translateY(0.5rem); }
+}
+
+html:active-view-transition-type(navigate)::view-transition-old(livewire-navigate) {
+    animation: navigate-out 150ms ease-in both;
+}
+
+html:active-view-transition-type(navigate)::view-transition-new(livewire-navigate) {
+    animation: navigate-in 200ms ease-out both;
+}
+```
+
+Navigation transitions carry the `navigate` transition type, keeping these rules separate from ordinary component `wire:transition` animations. Firefox supports the underlying transition but currently ignores transition types, so it uses the browser's default animation unless you also provide untyped fallback selectors.
+
+### Morphing elements between pages
+
+Give matching elements on both pages the same transition name to morph one into the other:
+
+```blade
+<!-- /posts -->
+<h2 wire:transition.navigate="post-{{ $post->id }}">{{ $post->title }}</h2>
+
+<!-- /posts/1 -->
+<h1 wire:transition.navigate="post-{{ $post->id }}">{{ $post->title }}</h1>
+```
+
+Livewire assigns the underlying `view-transition-name` immediately before the transition and clears it when the animation finishes. Named elements can be nested inside the primary region; the browser removes them from their parent's snapshot and transitions them independently.
+
+Ordinary `wire:transition` elements remain scoped to Livewire component updates. They are not named or animated by `wire:navigate` page transitions.
+
+> [!warning] Transition names must be unique per page
+> Like an `id` attribute, a transition name can only appear once per page. Include a unique identifier when rendering names in a loop.
+
+Browsers without View Transitions support, users who prefer reduced motion, and pages with an open dialog or popover fall back to an instant swap.
 
 ## Using with analytics software
 

--- a/docs/wire-transition.md
+++ b/docs/wire-transition.md
@@ -218,21 +218,32 @@ View Transitions are supported in Chrome 111+, Edge 111+, and Safari 18+. In bro
 
 [View browser support on caniuse.com →](https://caniuse.com/view-transitions)
 
+## Transitioning between page visits
+
+`wire:transition` animates elements during component updates. To animate elements between `wire:navigate` page visits instead, use the `.navigate` modifier:
+
+```blade
+<h2 wire:transition.navigate="post-{{ $post->id }}">{{ $post->title }}</h2>
+```
+
+The directive is element-scoped: only marked regions animate during the page visit, while unmarked layout elements remain stationary. An unnamed directive identifies one primary region; use explicit names for additional regions or shared elements. Read more in the [Navigate documentation](/docs/4.x/navigate#animating-page-visits-with-view-transitions).
+
 ## See also
 
 - **[wire:show](/docs/4.x/wire-show)** — Toggle visibility with CSS display
+- **[Navigate](/docs/4.x/navigate#animating-page-visits-with-view-transitions)** — Animate between page visits with `.navigate`
 - **[Loading States](/docs/4.x/loading-states)** — Show loading indicators during requests
 - **[Alpine Transitions](https://alpinejs.dev/directives/transition)** — For more complex animation needs
 
 ## Reference
 
-```blade
-wire:transition="name"
-```
+| Directive | Description |
+|-----------|-------------|
+| `wire:transition` | Animates an element during component updates using `match-element` |
+| `wire:transition="name"` | Animates a named element during component updates |
+| `wire:transition.navigate` | Animates the page's primary element region between visits |
+| `wire:transition.navigate="name"` | Animates a named region or shared element between visits |
 
-| Expression | Description |
-|------------|-------------|
-| (none) | Uses `match-element` as the view-transition-name |
-| `"name"` | Uses the provided string as the view-transition-name |
-
-This directive has no modifiers.
+| Modifier | Description |
+|----------|-------------|
+| `.navigate` | Transitions the element between page visits instead of component updates. Unnamed, it becomes the primary page region; named, it becomes an additional region or shared element. |

--- a/js/directives/wire-transition.js
+++ b/js/directives/wire-transition.js
@@ -1,6 +1,7 @@
 import { globalDirective } from "@/directives"
 
 let defaultName = 'match-element'
+let assignedTransitionNames = new WeakSet()
 
 // No-op — viewTransitionName is now set dynamically by transitionDomMutation()
 // to avoid creating permanent stacking contexts...
@@ -8,11 +9,25 @@ globalDirective('transition', ({ el, directive, cleanup }) => {
     //
 })
 
-function setTransitionNames(root, options = {}) {
-    root.querySelectorAll('[wire\\:transition]').forEach(el => {
+export function setTransitionNames(root, options = {}) {
+    let attribute = options.attribute ?? 'wire:transition'
+    let hasUsedDefaultName = false
+
+    elementsForAttribute(root, attribute, options.includeRoot).forEach(el => {
         if (el.style.viewTransitionName) return
 
-        let name = el.getAttribute('wire:transition')
+        let name = el.getAttribute(attribute)
+
+        if (! name && options.defaultName) {
+            if (hasUsedDefaultName) {
+                console.warn(`Livewire: Only one unnamed [${attribute}] element can be transitioned per page. Give additional elements unique names.`)
+
+                return
+            }
+
+            name = options.defaultName
+            hasUsedDefaultName = true
+        }
 
         // When the developer orchestrates a typed swap (e.g. #[Transition('forward')]),
         // unnamed wire:transition elements stay unnamed so they ride with the parent's
@@ -20,13 +35,79 @@ function setTransitionNames(root, options = {}) {
         if (! name && options.type) return
 
         el.style.viewTransitionName = name || defaultName
+        assignedTransitionNames.add(el)
     })
 }
 
-function clearTransitionNames(root) {
-    root.querySelectorAll('[wire\\:transition]').forEach(el => {
+export function clearTransitionNames(root, options = {}) {
+    let attribute = options.attribute ?? 'wire:transition'
+
+    elementsForAttribute(root, attribute, options.includeRoot).forEach(el => {
+        if (! assignedTransitionNames.has(el)) return
+
         el.style.viewTransitionName = ''
+        assignedTransitionNames.delete(el)
     })
+}
+
+function selectorForAttribute(attribute) {
+    return `[${attribute.replace(/[:.]/g, '\\$&')}]`
+}
+
+function elementsForAttribute(root, attribute, includeRoot = false) {
+    let selector = selectorForAttribute(attribute)
+    let elements = Array.from(root.querySelectorAll(selector))
+
+    if (includeRoot && root.matches?.(selector)) elements.unshift(root)
+
+    return elements
+}
+
+export function startViewTransition(update, options = {}) {
+    let transitionConfig = { update }
+
+    if (options.type) transitionConfig.types = [options.type]
+
+    try {
+        return document.startViewTransition(transitionConfig)
+    } catch (e) {
+        // Firefox supports the callback form but not typed transitions...
+        return document.startViewTransition(update)
+    }
+}
+
+export function skipTransitionWhenTopLayerOpens(transition) {
+    // Chromium rejects `ready` when skipTransition() is called. Consume that
+    // expected rejection so a deliberate policy skip is not reported as an error...
+    transition.ready.catch(() => {})
+
+    let onBeforeToggle = (event) => {
+        if (event.newState === 'open' && event.target.matches?.('dialog, [popover]')) {
+            transition.skipTransition()
+        }
+    }
+
+    document.addEventListener('beforetoggle', onBeforeToggle, true)
+
+    // Keep the attribute observer as a fallback for browsers that do not emit
+    // beforetoggle when a modal dialog is opened...
+    let observer = new MutationObserver(() => {
+        if (document.querySelector('dialog:modal')) {
+            transition.skipTransition()
+            observer.disconnect()
+        }
+    })
+
+    observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['open'],
+        subtree: true,
+    })
+
+    transition.finished.finally(() => {
+        observer.disconnect()
+        document.removeEventListener('beforetoggle', onBeforeToggle, true)
+    }).catch(() => {})
 }
 
 export async function transitionDomMutation(fromEl, toEl, callback, options = {}) {
@@ -94,71 +175,16 @@ export async function transitionDomMutation(fromEl, toEl, callback, options = {}
         setTransitionNames(fromEl, options)
     }
 
-    let transitionConfig = { update }
-
-    // Add transition types if provided...
-    if (options.type) {
-        transitionConfig.types = [options.type]
-    }
-
     let cleanup = () => {
         style.remove()
         clearTransitionNames(fromEl)
     }
 
-    // Watch for dialogs or popovers opening during the transition (e.g., via Alpine
-    // x-effect or a toast). ::view-transition pseudo-elements paint above the top
-    // layer, so the transition must be skipped before the browser paints a frame...
-    let skipOnTopLayer = (transition) => {
-        // Chromium rejects `ready` when skipTransition() is called. Consume that
-        // expected rejection so a deliberate policy skip is not reported as an error...
-        transition.ready.catch(() => {})
+    let transition = startViewTransition(update, { type: options.type })
 
-        let onBeforeToggle = (event) => {
-            if (event.newState === 'open' && event.target.matches?.('dialog, [popover]')) {
-                transition.skipTransition()
-            }
-        }
+    skipTransitionWhenTopLayerOpens(transition)
 
-        document.addEventListener('beforetoggle', onBeforeToggle, true)
+    transition.finished.finally(cleanup).catch(() => {})
 
-        // Keep the attribute observer as a fallback for browsers that do not emit
-        // beforetoggle when a modal dialog is opened...
-        let observer = new MutationObserver(() => {
-            if (document.querySelector('dialog:modal')) {
-                transition.skipTransition()
-                observer.disconnect()
-            }
-        })
-
-        observer.observe(document.documentElement, {
-            attributes: true,
-            attributeFilter: ['open'],
-            subtree: true,
-        })
-
-        transition.finished.finally(() => {
-            observer.disconnect()
-            document.removeEventListener('beforetoggle', onBeforeToggle, true)
-        }).catch(() => {})
-    }
-
-    try {
-        let transition = document.startViewTransition(transitionConfig)
-
-        skipOnTopLayer(transition)
-
-        transition.finished.finally(cleanup).catch(() => {})
-
-        await transition.updateCallbackDone
-    } catch (e) {
-        // Firefox 144+ supports View Transitions but only with a callback, not a config object (no transition types support)
-        let transition = document.startViewTransition(update)
-
-        skipOnTopLayer(transition)
-
-        transition.finished.finally(cleanup).catch(() => {})
-
-        await transition.updateCallbackDone
-    }
+    await transition.updateCallbackDone
 }

--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -6,6 +6,7 @@ import { restoreScrollPositionOrScrollToTop, storeScrollInformationInHtmlBeforeN
 import { isPersistedElement, putPersistantElementsBack, storePersistantElementsForLater } from "./persist"
 import { finishAndHideProgressBar, removeAnyLeftOverStaleProgressBars, showAndStartProgressBar } from "./bar"
 import { packUpPersistedPopovers, unPackPersistedPopovers } from "./popover"
+import { transitionPageSwap } from "./transition"
 import { swapCurrentPageWithNewHtml } from "./page"
 import { fetchHtml } from "./fetch"
 import { startNavigation } from "./navigation"
@@ -113,38 +114,40 @@ export default function (Alpine) {
             shouldPushToHistoryState && updateCurrentPageHtmlInHistoryStateForLaterBackButtonClicks()
 
             preventAlpineFromPickingUpDomChanges(Alpine, andAfterAllThis => {
-                enablePersist && storePersistantElementsForLater(persistedEl => {
-                    packUpPersistedTeleports(persistedEl)
-                    packUpPersistedPopovers(persistedEl)
-                })
-
-                if (shouldPushToHistoryState) {
-                    updateUrlAndStoreLatestHtmlForFutureBackButtons(html, finalDestination)
-                } else {
-                    replaceUrl(finalDestination, html)
-                }
-
-                swapCurrentPageWithNewHtml(html, (afterNewScriptsAreDoneLoading) => {
-                    removeAnyLeftOverStaleTeleportTargets(document.body)
-
-                    enablePersist && putPersistantElementsBack((persistedEl, newStub) => {
-                        unPackPersistedTeleports(persistedEl)
-                        unPackPersistedPopovers(persistedEl)
+                transitionPageSwap(html, () => {
+                    enablePersist && storePersistantElementsForLater(persistedEl => {
+                        packUpPersistedTeleports(persistedEl)
+                        packUpPersistedPopovers(persistedEl)
                     })
 
-                    !preserveScroll && restoreScrollPositionOrScrollToTop()
+                    if (shouldPushToHistoryState) {
+                        updateUrlAndStoreLatestHtmlForFutureBackButtons(html, finalDestination)
+                    } else {
+                        replaceUrl(finalDestination, html)
+                    }
 
-                    // Invoke any callbacks registered via onSwap during the navigating event
-                    swapCallbacks.forEach(callback => callback())
+                    swapCurrentPageWithNewHtml(html, (afterNewScriptsAreDoneLoading) => {
+                        removeAnyLeftOverStaleTeleportTargets(document.body)
 
-                    afterNewScriptsAreDoneLoading(() => {
-                        andAfterAllThis(() => {
-                            nowInitializeAlpineOnTheNewPage(Alpine)
-                            autofocusElementsWithTheAutofocusAttribute()
+                        enablePersist && putPersistantElementsBack((persistedEl, newStub) => {
+                            unPackPersistedTeleports(persistedEl)
+                            unPackPersistedPopovers(persistedEl)
+                        })
 
-                            fireEventForOtherLibrariesToHookInto('alpine:navigated')
-                            navigation.finish()
-                            showProgressBar && finishAndHideProgressBar()
+                        !preserveScroll && restoreScrollPositionOrScrollToTop()
+
+                        // Invoke any callbacks registered via onSwap during the navigating event
+                        swapCallbacks.forEach(callback => callback())
+
+                        afterNewScriptsAreDoneLoading(() => {
+                            andAfterAllThis(() => {
+                                nowInitializeAlpineOnTheNewPage(Alpine)
+                                autofocusElementsWithTheAutofocusAttribute()
+
+                                fireEventForOtherLibrariesToHookInto('alpine:navigated')
+                                navigation.finish()
+                                showProgressBar && finishAndHideProgressBar()
+                            })
                         })
                     })
                 })
@@ -216,32 +219,34 @@ export default function (Alpine) {
             updateCurrentPageHtmlInSnapshotCacheForLaterBackButtonClicks(currentPageKey, currentPageUrl)
 
             preventAlpineFromPickingUpDomChanges(Alpine, andAfterAllThis => {
-                enablePersist && storePersistantElementsForLater(persistedEl => {
-                    packUpPersistedTeleports(persistedEl)
-                    packUpPersistedPopovers(persistedEl)
-                })
-
-                swapCurrentPageWithNewHtml(html, () => {
-                    removeAnyLeftOverStaleProgressBars()
-
-                    removeAnyLeftOverStaleTeleportTargets(document.body)
-
-                    enablePersist && putPersistantElementsBack((persistedEl, newStub) => {
-                        unPackPersistedTeleports(persistedEl)
-                        unPackPersistedPopovers(persistedEl)
+                transitionPageSwap(html, () => {
+                    enablePersist && storePersistantElementsForLater(persistedEl => {
+                        packUpPersistedTeleports(persistedEl)
+                        packUpPersistedPopovers(persistedEl)
                     })
 
-                    restoreScrollPositionOrScrollToTop()
+                    swapCurrentPageWithNewHtml(html, () => {
+                        removeAnyLeftOverStaleProgressBars()
 
-                    // Invoke any callbacks registered via onSwap during the navigating event
-                    swapCallbacks.forEach(callback => callback())
+                        removeAnyLeftOverStaleTeleportTargets(document.body)
 
-                    andAfterAllThis(() => {
-                        nowInitializeAlpineOnTheNewPage(Alpine)
-                        autofocusElementsWithTheAutofocusAttribute()
+                        enablePersist && putPersistantElementsBack((persistedEl, newStub) => {
+                            unPackPersistedTeleports(persistedEl)
+                            unPackPersistedPopovers(persistedEl)
+                        })
 
-                        fireEventForOtherLibrariesToHookInto('alpine:navigated')
-                        navigation.finish()
+                        restoreScrollPositionOrScrollToTop()
+
+                        // Invoke any callbacks registered via onSwap during the navigating event
+                        swapCallbacks.forEach(callback => callback())
+
+                        andAfterAllThis(() => {
+                            nowInitializeAlpineOnTheNewPage(Alpine)
+                            autofocusElementsWithTheAutofocusAttribute()
+
+                            fireEventForOtherLibrariesToHookInto('alpine:navigated')
+                            navigation.finish()
+                        })
                     })
                 })
             })

--- a/js/plugins/navigate/transition.js
+++ b/js/plugins/navigate/transition.js
@@ -1,0 +1,90 @@
+import { clearTransitionNames, setTransitionNames, skipTransitionWhenTopLayerOpens, startViewTransition } from '@/directives/wire-transition'
+
+let type = 'navigate'
+let attribute = 'wire:transition.navigate'
+let navigateTransitionSelector = '[wire\\:transition\\.navigate]'
+let defaultName = 'livewire-navigate'
+
+export function transitionPageSwap(html, update) {
+    let newDocument = new DOMParser().parseFromString(html, 'text/html')
+    let currentDocumentTransitions = findNavigateTransitions(document)
+    let newDocumentTransitions = findNavigateTransitions(newDocument)
+
+    if (! currentDocumentTransitions.length && ! newDocumentTransitions.length) return update()
+
+    // Check if the View Transitions API is supported...
+    if (typeof document.startViewTransition !== 'function') return update()
+
+    // Respect users who prefer reduced motion...
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return update()
+
+    // Skip transitions behind an open top-layer element because the browser's
+    // transition snapshots would paint above it...
+    if (document.querySelector('dialog:modal, :popover-open')) return update()
+
+    let useRootTransition = document.documentElement.matches(navigateTransitionSelector)
+        || newDocument.documentElement.matches(navigateTransitionSelector)
+
+    // Element-scoped transitions leave the document root stationary. Marking
+    // <html> opts into the browser's full-page root transition instead...
+    let style = useRootTransition ? null : disableRootTransition()
+
+    setNavigateTransitionNames(document.body)
+
+    let updateAndNameNewPage = () => {
+        update()
+
+        setNavigateTransitionNames(document.body)
+    }
+
+    let viewTransition = startViewTransition(updateAndNameNewPage, { type })
+
+    skipTransitionWhenTopLayerOpens(viewTransition)
+
+    viewTransition.finished
+        .finally(() => {
+            style?.remove()
+            clearTransitionNames(document.body, { attribute, includeRoot: true })
+        })
+        .catch(() => {})
+}
+
+function findNavigateTransitions(subject) {
+    let root = subject.documentElement
+    let elements = Array.from(root.querySelectorAll(navigateTransitionSelector))
+
+    if (root.matches(navigateTransitionSelector)) elements.unshift(root)
+
+    return elements
+}
+
+function setNavigateTransitionNames(root) {
+    setTransitionNames(root, {
+        type,
+        attribute,
+        defaultName,
+        includeRoot: true,
+    })
+}
+
+function disableRootTransition() {
+    let style = document.createElement('style')
+
+    style.setAttribute('data-livewire-navigate-transition', '')
+
+    style.textContent = `
+        ::view-transition-old(root) {
+            animation: none !important;
+            opacity: 0 !important;
+        }
+
+        ::view-transition-new(root) {
+            animation: none !important;
+            opacity: 1 !important;
+        }
+    `
+
+    document.head.appendChild(style)
+
+    return style
+}

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -22,6 +22,11 @@ class BrowserTest extends \Tests\BrowserTestCase
 
             Livewire::component('query-page', QueryPage::class);
             Livewire::component('first-page', FirstPage::class);
+            Livewire::component('first-transition-page', FirstTransitionPage::class);
+            Livewire::component('second-transition-page', SecondTransitionPage::class);
+            Livewire::component('second-transition-opt-in-page', SecondTransitionOptInPage::class);
+            Livewire::component('first-animated-transition-page', FirstAnimatedTransitionPage::class);
+            Livewire::component('second-animated-transition-page', SecondAnimatedTransitionPage::class);
             Livewire::component('first-page-child', FirstPageChild::class);
             Livewire::component('first-page-with-link-outside', FirstPageWithLinkOutside::class);
             Livewire::component('second-page', SecondPage::class);
@@ -62,6 +67,11 @@ class BrowserTest extends \Tests\BrowserTestCase
 
                 return (new FirstPage)();
             })->middleware('web');
+            Route::get('/first-transition', fn () => (new FirstTransitionPage)())->middleware('web');
+            Route::get('/second-transition', fn () => (new SecondTransitionPage)())->middleware('web');
+            Route::get('/second-transition-opt-in', fn () => (new SecondTransitionOptInPage)())->middleware('web');
+            Route::get('/first-animated-transition', fn () => (new FirstAnimatedTransitionPage)())->middleware('web');
+            Route::get('/second-animated-transition', fn () => (new SecondAnimatedTransitionPage)())->middleware('web');
             Route::get('/first-outside', FirstPageWithLinkOutside::class)->middleware('web');
             Route::get('/redirect-to-second', fn () => redirect()->to('/second'));
             Route::get('/second', SecondPage::class)->middleware('web');
@@ -414,6 +424,150 @@ class BrowserTest extends \Tests\BrowserTestCase
                 ->waitFor('@link.to.second')
                 ->assertScript('return window._lw_dusk_test')
                 ->assertSee('On first');
+        });
+    }
+
+    public function test_wire_navigate_does_not_use_view_transitions_by_default()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/first-transition')
+                ->assertSee('On first transition page')
+                // Intercept document.startViewTransition to track if it gets called...
+                ->tap(fn ($b) => $b->script("
+                    window.__viewTransitionCount = 0;
+                    let orig = document.startViewTransition.bind(document);
+                    document.startViewTransition = function() {
+                        window.__viewTransitionCount++;
+                        return orig.apply(document, arguments);
+                    };
+                "))
+                ->waitForNavigate()->click('@link.plain')
+                ->assertSee('On second transition page')
+                ->assertScript('window.__viewTransitionCount', 0);
+        });
+    }
+
+    public function test_the_html_element_can_opt_into_a_full_page_transition()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/first-transition')
+                ->assertSee('On first transition page')
+                ->tap(fn ($b) => $b->script("
+                    window.__viewTransitionCount = 0;
+                    window.__rootTransitionWasDisabled = null;
+                    let orig = document.startViewTransition.bind(document);
+                    document.startViewTransition = function() {
+                        window.__viewTransitionCount++;
+                        window.__rootTransitionWasDisabled = !! document.querySelector('[data-livewire-navigate-transition]');
+                        return orig.apply(document, arguments);
+                    };
+
+                    document.documentElement.setAttribute('wire:transition.navigate', '');
+                "))
+                ->waitForNavigate()->click('@link.plain')
+                ->assertSee('On second transition page')
+                ->assertScript('window.__viewTransitionCount', 1)
+                // The document root keeps the browser's native full-page transition...
+                ->assertScript('window.__rootTransitionWasDisabled', false)
+                ->waitForNavigate()->back()
+                ->assertSee('On first transition page')
+                ->assertScript('window.__viewTransitionCount', 2);
+        });
+    }
+
+    public function test_the_body_element_can_be_the_transition_region()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/first-transition')
+                ->tap(fn ($b) => $b->script("
+                    window.__outgoingBodyTransitionName = null;
+                    window.__rootTransitionWasDisabled = null;
+                    let orig = document.startViewTransition.bind(document);
+                    document.startViewTransition = function() {
+                        window.__outgoingBodyTransitionName = document.body.style.viewTransitionName;
+                        window.__rootTransitionWasDisabled = !! document.querySelector('[data-livewire-navigate-transition]');
+                        return orig.apply(document, arguments);
+                    };
+
+                    document.body.setAttribute('wire:transition.navigate', '');
+                "))
+                ->waitForNavigate()->click('@link.plain')
+                ->assertSee('On second transition page')
+                ->assertScript('window.__outgoingBodyTransitionName', 'livewire-navigate')
+                ->assertScript('window.__rootTransitionWasDisabled', true);
+        });
+    }
+
+    public function test_a_page_can_opt_into_view_transitions_in_both_directions()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/first-transition')
+                ->tap(fn ($b) => $b->script("
+                    window.__viewTransitionCount = 0;
+                    let orig = document.startViewTransition.bind(document);
+                    document.startViewTransition = function() {
+                        window.__viewTransitionCount++;
+                        return orig.apply(document, arguments);
+                    };
+                "))
+                // The incoming page opts this navigation in...
+                ->waitForNavigate()->click('@link.opt-in')
+                ->assertSee('On opted-in transition page')
+                ->assertScript('window.__viewTransitionCount', 1)
+                // The outgoing page opts the cached back navigation in as well...
+                ->waitForNavigate()->back()
+                ->assertSee('On first transition page')
+                ->assertScript('window.__viewTransitionCount', 2);
+        });
+    }
+
+    public function test_named_elements_visibly_transition_between_pages()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/first-animated-transition')
+                ->click('@link.animated')
+                // Prove a transition is genuinely running, rather than merely counting API calls...
+                ->waitUntil("document.documentElement.matches(':active-view-transition')")
+                ->assertScript("document.documentElement.matches(':active-view-transition-type(navigate)')", true)
+                // The unnamed region gets the one implicit page-region name...
+                ->assertScript("document.querySelector('[dusk=navigate-region]').style.viewTransitionName", 'livewire-navigate')
+                ->assertScript("document.querySelector('[dusk=hero-detail]').style.viewTransitionName", 'hero')
+                // Ordinary component transitions and unmarked siblings stay separate...
+                ->assertScript("document.querySelector('[dusk=component-transition]').style.viewTransitionName", '')
+                ->assertScript("document.querySelector('[dusk=sidebar]').style.viewTransitionName", '')
+                ->assertScript("!! document.querySelector('style[data-livewire-navigate-transition]')", true)
+                ->waitUntil("! document.documentElement.matches(':active-view-transition')")
+                // Names don't leave permanent stacking contexts behind...
+                ->waitUntil("document.querySelector('[dusk=navigate-region]').style.viewTransitionName === ''")
+                ->waitUntil("document.querySelector('[dusk=hero-detail]').style.viewTransitionName === ''")
+                ->assertScript("!! document.querySelector('style[data-livewire-navigate-transition]')", false)
+                ->assertSee('On second animated page');
+        });
+    }
+
+    public function test_view_transitions_are_skipped_behind_an_open_dialog()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/first-animated-transition')
+                ->tap(fn ($b) => $b->script("
+                    window.__viewTransitionCount = 0;
+                    let orig = document.startViewTransition.bind(document);
+                    document.startViewTransition = function() {
+                        window.__viewTransitionCount++;
+                        return orig.apply(document, arguments);
+                    };
+
+                    document.querySelector('[dusk=transition-modal]').showModal();
+                    Livewire.navigate('/second-animated-transition');
+                "))
+                ->waitForText('On second animated page')
+                ->assertScript('window.__viewTransitionCount', 0);
         });
     }
 
@@ -1643,6 +1797,101 @@ class BrowserTest extends \Tests\BrowserTestCase
                 return app('livewire')->new($name)();
             })->middleware('web');
         }
+    }
+}
+
+class FirstTransitionPage extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <div>On first transition page</div>
+
+            <a href="/second-transition" wire:navigate dusk="link.plain">Plain link</a>
+            <a href="/second-transition-opt-in" wire:navigate dusk="link.opt-in">Opt-in page</a>
+        </div>
+        HTML;
+    }
+}
+
+class SecondTransitionPage extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <div>On second transition page</div>
+
+            <script type="application/json">{"note":"wire:transition.navigate is documentation, not an attribute"}</script>
+        </div>
+        HTML;
+    }
+}
+
+class SecondTransitionOptInPage extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        <div wire:transition.navigate>
+            <div>On opted-in transition page</div>
+        </div>
+        HTML;
+    }
+}
+
+class FirstAnimatedTransitionPage extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <aside dusk="sidebar">Stable sidebar</aside>
+
+            <main wire:transition.navigate dusk="navigate-region">
+                <div>On first animated page</div>
+
+                <style>
+                    ::view-transition-group(*) {
+                        animation-duration: 1.5s;
+                    }
+                </style>
+
+                <h2 wire:transition.navigate="hero" dusk="hero">Hero title</h2>
+                <div wire:transition="component-only" dusk="component-transition">Component-only transition</div>
+
+                <a href="/second-animated-transition" wire:navigate dusk="link.animated">Go to second animated page</a>
+
+                <dialog dusk="transition-modal">Modal</dialog>
+            </main>
+        </div>
+        HTML;
+    }
+}
+
+class SecondAnimatedTransitionPage extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        <div>
+            <aside dusk="sidebar">Stable sidebar</aside>
+
+            <main wire:transition.navigate dusk="navigate-region">
+                <div>On second animated page</div>
+
+                <style>
+                    ::view-transition-group(*) {
+                        animation-duration: 1.5s;
+                    }
+                </style>
+
+                <h1 wire:transition.navigate="hero" dusk="hero-detail">Hero title</h1>
+                <div wire:transition="component-only" dusk="component-transition">Component-only transition</div>
+            </main>
+        </div>
+        HTML;
     }
 }
 


### PR DESCRIPTION
Backports #10622 to `4.x`. Page visits can opt into native View Transitions with `wire:transition.navigate` on a content region or `<html>` for a full-page transition; named elements can morph between pages.

The original squash commit (`b1122c8a`) cherry-picks cleanly onto current `4.x`, including its documentation and browser tests. No compatibility changes were needed, and the resulting JavaScript matches `main`.

Validation:
- `npm run build`
- JavaScript tests: 110 passed, 1 skipped
- SupportNavigate and SupportTransitions browser tests: 77 passed, 443 assertions
- FrontendAssets unit tests: 20 passed, 35 assertions
- Populated Laravel/Flux demo in Chrome: observed an active content transition with a stationary sidebar, browser-back restoration, and a working component toggle

Compiled assets are built locally for verification and excluded from the commit, per repository policy.
