### PR TITLE
[4.x] Backport JSON session serialization support

### DIFF
--- a/src/Features/SupportSession/BaseSession.php
+++ b/src/Features/SupportSession/BaseSession.php
@@ -3,12 +3,16 @@
 namespace Livewire\Features\SupportSession;
 
 use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+use Livewire\Mechanisms\HandleSynths\CorruptPersistedValueException;
+use Livewire\Mechanisms\HandleSynths\PersistedValueCodec;
 use Illuminate\Support\Facades\Session;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class BaseSession extends LivewireAttribute
 {
+    protected $codec;
+
     function __construct(
         protected $key = null,
     ) {}
@@ -17,9 +21,23 @@ class BaseSession extends LivewireAttribute
     {
         if (! $this->exists()) return;
 
-        $fromSession = $this->read();
+        try {
+            $fromSession = $this->read();
+        } catch (CorruptPersistedValueException) {
+            Session::forget($this->key());
 
-        $this->setValue($fromSession);
+            return;
+        }
+
+        // A stored value can become unassignable after it was persisted: its
+        // type no longer matches the property (\TypeError), or it's a scalar
+        // backing a since-removed enum case (\ValueError from Enum::from()).
+        // Either way the stale value is forgotten and the default preserved.
+        try {
+            $this->setValue($fromSession);
+        } catch (\TypeError|\ValueError) {
+            Session::forget($this->key());
+        }
     }
 
     public function dehydrate($context)
@@ -34,12 +52,43 @@ class BaseSession extends LivewireAttribute
 
     protected function read()
     {
-        return Session::get($this->key());
+        // Always decode so changing session serializers doesn't strand values
+        // that Livewire encoded before the configuration changed.
+        $key = $this->key();
+
+        return $this->codec()->decodeFromStorage(
+            Session::get($key),
+            $this->component,
+            $this->getName(),
+            $key,
+        );
     }
 
     protected function write()
     {
-        Session::put($this->key(), $this->getValue());
+        $value = $this->getValue();
+        $key = $this->key();
+
+        if ($this->sessionIsJsonSerialized()) {
+            $value = $this->codec()->encodeForStorage(
+                $value,
+                $this->component,
+                $this->getName(),
+                $key,
+            );
+        }
+
+        Session::put($key, $value);
+    }
+
+    protected function sessionIsJsonSerialized()
+    {
+        return config('session.serialization', 'php') === 'json';
+    }
+
+    protected function codec()
+    {
+        return $this->codec ??= app(PersistedValueCodec::class);
     }
 
     protected function key()

--- a/src/Features/SupportSession/JsonSerializationBrowserTest.php
+++ b/src/Features/SupportSession/JsonSerializationBrowserTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Livewire\Features\SupportSession;
+
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Session;
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\BrowserTestCase;
+
+class JsonSerializationBrowserTest extends BrowserTestCase
+{
+    public static function tweakApplicationHook()
+    {
+        return function () {
+            config(['session.serialization' => 'json']);
+        };
+    }
+
+    public function test_collection_properties_survive_a_full_page_refresh()
+    {
+        Livewire::visit(new class extends Component {
+            #[Session]
+            public ?Collection $list = null;
+
+            public function mount(): void
+            {
+                $this->list ??= collect();
+            }
+
+            public function add(): void
+            {
+                $this->list->push($this->list->count() + 1);
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <span dusk="serialization">{{ config('session.serialization') }}</span>
+                    <button dusk="button" wire:click="add">Add</button>
+                    <span dusk="list">{{ $list->implode(', ') }}</span>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSeeIn('@serialization', 'json')
+            ->assertSeeIn('@list', '')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@list', '1')
+            ->refresh()
+            ->assertSeeIn('@list', '1')
+            ->waitForLivewire()->click('@button')
+            ->assertSeeIn('@list', '1, 2');
+    }
+}

--- a/src/Features/SupportSession/UnitTest.php
+++ b/src/Features/SupportSession/UnitTest.php
@@ -2,11 +2,19 @@
 
 namespace Livewire\Features\SupportSession;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Session as FacadesSession;
 use Livewire\Attributes\Session;
+use Livewire\Component;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+use Livewire\Mechanisms\HandleSynths\HandleSynths;
+use Livewire\Mechanisms\HandleSynths\PersistedValueCodec;
 use Tests\TestCase;
 use Livewire\Livewire;
 use Tests\TestComponent;
+use Sushi\Sushi;
 
 class UnitTest extends TestCase
 {
@@ -42,5 +50,429 @@ class UnitTest extends TestCase
         });
 
         $this->assertTrue(FacadesSession::has('baz.2'));
+    }
+
+    public function test_collection_properties_survive_json_session_serialization()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->call('add');
+
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->assertSet('list', fn ($list) => $list instanceof Collection && $list->all() === [1]);
+    }
+
+    public function test_synthesized_properties_survive_json_session_serialization()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        $date = Carbon::parse('2026-01-15 10:00:00');
+
+        Livewire::test(ComponentWithSynthesizedSessionProperties::class)
+            ->set('when', $date)
+            ->set('nested', ['list' => collect([1, 2]), 'when' => $date]);
+
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentWithSynthesizedSessionProperties::class)
+            ->assertSet('when', fn ($when) => $when instanceof Carbon && $when->equalTo($date))
+            ->assertSet('nested', fn ($nested) => $nested['list'] instanceof Collection
+                && $nested['list']->all() === [1, 2]
+                && $nested['when'] instanceof Carbon
+                && $nested['when']->equalTo($date));
+    }
+
+    public function test_custom_synthesized_properties_survive_json_session_serialization()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+        app(HandleSynths::class)->registerSynth(CustomSessionValueSynth::class);
+
+        Livewire::test(ComponentWithCustomSynthesizedSessionProperty::class);
+
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentWithCustomSynthesizedSessionProperty::class)
+            ->assertSet('value', fn ($value) => $value instanceof CustomSessionValue && $value->value === 'persisted');
+    }
+
+    public function test_model_properties_survive_json_session_serialization()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithSessionModel::class)
+            ->assertSet('article', fn ($article) => $article instanceof SessionArticle && $article->title === 'First');
+
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentWithSessionModel::class)
+            ->assertSet('article', fn ($article) => $article instanceof SessionArticle && $article->title === 'First');
+    }
+
+    public function test_php_sessions_continue_to_store_values_raw()
+    {
+        config(['session.serialization' => 'php']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->call('add');
+
+        $stored = session('collection');
+
+        $this->assertInstanceOf(Collection::class, $stored);
+        $this->assertSame([1], $stored->all());
+    }
+
+    public function test_json_sessions_continue_to_store_primitive_values_raw()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithPrimitiveSessionProperty::class)
+            ->set('count', 1);
+
+        $this->assertSame(1, session('primitive'));
+        $this->assertSame(['search' => '', 'tags' => [1, 2]], session('json-native'));
+    }
+
+    public function test_legacy_tuple_shaped_arrays_are_not_treated_as_synthetic_values()
+    {
+        $tuple = [['one', 'two'], ['s' => 'clctn', 'class' => Collection::class]];
+
+        FacadesSession::put('legacy-tuple', $tuple);
+
+        Livewire::test(ComponentWithRawSessionArray::class)
+            ->assertSet('value', $tuple);
+    }
+
+    public function test_session_envelopes_are_decoded_even_after_switching_to_php_serialization()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->call('add');
+
+        config(['session.serialization' => 'php']);
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->assertSet('list', fn ($list) => $list instanceof Collection && $list->all() === [1]);
+    }
+
+    public function test_client_authored_synth_envelopes_are_discarded_in_json_sessions()
+    {
+        $this->assertClientAuthoredSynthEnvelopeIsDiscarded('json');
+    }
+
+    public function test_client_authored_synth_envelopes_are_discarded_in_php_sessions()
+    {
+        $this->assertClientAuthoredSynthEnvelopeIsDiscarded('php');
+    }
+
+    public function test_unreadable_persisted_envelopes_are_discarded()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->call('add');
+
+        $stored = session('collection');
+        $stored[PersistedValueCodec::KEY]['version']++;
+
+        FacadesSession::put('collection', $stored);
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->assertSet('list', fn ($list) => $list instanceof Collection && $list->isEmpty());
+    }
+
+    public function test_components_can_share_an_explicit_session_key()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithSessionCollection::class)
+            ->call('add');
+
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentReadingSharedSessionCollection::class)
+            ->assertSet('items', fn ($items) => $items instanceof Collection && $items->all() === [1]);
+    }
+
+    public function test_values_for_synths_that_are_no_longer_registered_are_discarded()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        $encoded = app(PersistedValueCodec::class)->encodeForStorage(
+            new \Illuminate\Foundation\Auth\User,
+            new TestComponent,
+            'value',
+            'dangerous-value',
+        );
+
+        FacadesSession::put('dangerous-value', $encoded);
+
+        app()->instance(
+            \Livewire\Mechanisms\HandleSynths\HandleSynths::class,
+            new \Livewire\Mechanisms\HandleSynths\HandleSynths,
+        );
+
+        Livewire::test(ComponentWithDangerousSessionProperty::class)
+            ->assertSet('value', 'safe');
+    }
+
+    public function test_json_arrays_left_by_older_versions_are_discarded_from_typed_properties()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+        FacadesSession::put('stale-collection', [1, 2]);
+
+        Livewire::test(ComponentWithStaleSessionCollection::class)
+            ->assertSet('list', null);
+    }
+
+    public function test_stale_enum_backing_values_are_discarded_from_typed_properties()
+    {
+        config(['session.serialization' => 'json']);
+
+        app('session')->forgetDrivers();
+
+        // A scalar backing an enum case that no longer exists (a removed or
+        // renamed case, or a value written before the enum changed). Coercing
+        // it throws a ValueError that must be recovered from, not surfaced.
+        FacadesSession::put('stale-enum', 'archived');
+
+        Livewire::test(ComponentWithSessionEnum::class)
+            ->assertSet('status', null);
+    }
+
+    protected function assertClientAuthoredSynthEnvelopeIsDiscarded($serialization)
+    {
+        config(['session.serialization' => $serialization]);
+
+        app('session')->forgetDrivers();
+
+        Livewire::test(ComponentWithDangerousSessionProperty::class)
+            ->set('value', [
+                PersistedValueCodec::KEY => [
+                    'version' => PersistedValueCodec::VERSION,
+                    'value' => [null, [
+                        's' => 'mdl',
+                        'class' => \Illuminate\Foundation\Auth\User::class,
+                        'key' => 1,
+                    ]],
+                ],
+            ]);
+
+        session()->save();
+        session()->start();
+
+        Livewire::test(ComponentWithDangerousSessionProperty::class)
+            ->assertSet('value', 'safe');
+    }
+}
+
+class ComponentWithSessionCollection extends Component
+{
+    #[Session(key: 'collection')]
+    public ?Collection $list = null;
+
+    public function mount(): void
+    {
+        $this->list ??= collect();
+    }
+
+    public function add(): void
+    {
+        $this->list->push($this->list->count() + 1);
+    }
+
+    public function render()
+    {
+        return '<div>{{ $list->implode(", ") }}</div>';
+    }
+}
+
+class ComponentReadingSharedSessionCollection extends Component
+{
+    #[Session(key: 'collection')]
+    public ?Collection $items = null;
+
+    public function mount(): void
+    {
+        $this->items ??= collect();
+    }
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class ComponentWithSynthesizedSessionProperties extends Component
+{
+    #[Session]
+    public ?Carbon $when = null;
+
+    #[Session]
+    public array $nested = [];
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class ComponentWithCustomSynthesizedSessionProperty extends Component
+{
+    #[Session]
+    public ?CustomSessionValue $value = null;
+
+    public function mount()
+    {
+        $this->value ??= new CustomSessionValue('persisted');
+    }
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class ComponentWithSessionModel extends Component
+{
+    #[Session(key: 'article')]
+    public ?SessionArticle $article = null;
+
+    public function mount()
+    {
+        $this->article ??= SessionArticle::first();
+    }
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class SessionArticle extends Model
+{
+    use Sushi;
+
+    protected $rows = [
+        ['title' => 'First'],
+    ];
+}
+
+class CustomSessionValue
+{
+    public function __construct(public string $value) {}
+}
+
+class CustomSessionValueSynth extends Synth
+{
+    public static $key = 'session-value';
+
+    public static function match($target)
+    {
+        return $target instanceof CustomSessionValue;
+    }
+
+    public function dehydrate($target)
+    {
+        return [$target->value, []];
+    }
+
+    public function hydrate($value)
+    {
+        return new CustomSessionValue($value);
+    }
+}
+
+class ComponentWithPrimitiveSessionProperty extends Component
+{
+    #[Session(key: 'primitive')]
+    public int $count = 0;
+
+    #[Session(key: 'json-native')]
+    public array $filters = ['search' => '', 'tags' => [1, 2]];
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class ComponentWithRawSessionArray extends Component
+{
+    #[Session(key: 'legacy-tuple')]
+    public array $value = [];
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class ComponentWithDangerousSessionProperty extends Component
+{
+    #[Session(key: 'dangerous-value')]
+    public $value = 'safe';
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+class ComponentWithStaleSessionCollection extends Component
+{
+    #[Session(key: 'stale-collection')]
+    public ?Collection $list = null;
+
+    public function render()
+    {
+        return '<div></div>';
+    }
+}
+
+enum SessionStatus: string
+{
+    case Draft = 'draft';
+    case Published = 'published';
+}
+
+class ComponentWithSessionEnum extends Component
+{
+    #[Session(key: 'stale-enum')]
+    public ?SessionStatus $status = null;
+
+    public function render()
+    {
+        return '<div></div>';
     }
 }

--- a/src/Mechanisms/HandleSynths/CorruptPersistedValueException.php
+++ b/src/Mechanisms/HandleSynths/CorruptPersistedValueException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleSynths;
+
+class CorruptPersistedValueException extends \Exception
+{
+    public function __construct($previous = null)
+    {
+        parent::__construct('Livewire encountered corrupt persisted property data.', previous: $previous);
+    }
+}

--- a/src/Mechanisms/HandleSynths/PersistedValueCodec.php
+++ b/src/Mechanisms/HandleSynths/PersistedValueCodec.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleSynths;
+
+use Livewire\Drawer\Utils;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+
+class PersistedValueCodec
+{
+    const KEY = '__livewire_persisted';
+
+    const VERSION = 1;
+
+    public function __construct(protected HandleSynths $synths) {}
+
+    public function encodeForStorage($value, $component, $path, $key)
+    {
+        if (! $this->requiresSynthesis($value)) return $value;
+
+        $encoded = $this->synths->dehydrate(
+            $value,
+            new ComponentContext($component),
+            $path,
+        );
+
+        return [
+            static::KEY => [
+                'version' => static::VERSION,
+                'value' => $encoded,
+                'signature' => $this->signatureFor($encoded, $key),
+            ],
+        ];
+    }
+
+    public function decodeFromStorage($value, $component, $path, $key)
+    {
+        if (! $this->isEnvelope($value)) return $value;
+
+        $envelope = $value[static::KEY];
+
+        if (! $this->isValidEnvelope($envelope, $key)) {
+            throw new CorruptPersistedValueException;
+        }
+
+        try {
+            return $this->synths->hydrate(
+                $envelope['value'],
+                new ComponentContext($component),
+                $path,
+            );
+        } catch (\Throwable $e) {
+            throw new CorruptPersistedValueException($e);
+        }
+    }
+
+    protected function isEnvelope($value)
+    {
+        return is_array($value)
+            && count($value) === 1
+            && array_key_exists(static::KEY, $value);
+    }
+
+    protected function isValidEnvelope($envelope, $key)
+    {
+        if (! is_array($envelope) || count($envelope) !== 3) return false;
+
+        if (($envelope['version'] ?? null) !== static::VERSION) return false;
+
+        if (! array_key_exists('value', $envelope)) return false;
+
+        if (! Utils::isSyntheticTuple($envelope['value'])) return false;
+
+        if (! is_string($signature = $envelope['signature'] ?? null)) return false;
+
+        return hash_equals(
+            $this->signatureFor($envelope['value'], $key),
+            $signature,
+        );
+    }
+
+    protected function signatureFor($value, $key)
+    {
+        $payload = json_encode([
+            'type' => 'livewire-persisted-value',
+            'version' => static::VERSION,
+            'key' => $key,
+            'value' => $value,
+        ], JSON_THROW_ON_ERROR);
+
+        return hash_hmac('sha256', $payload, app('encrypter')->getKey());
+    }
+
+    protected function requiresSynthesis($value)
+    {
+        if (Utils::isAPrimitive($value)) return false;
+
+        if (! is_array($value)) return true;
+
+        foreach ($value as $child) {
+            if ($this->requiresSynthesis($child)) return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Mechanisms/HandleSynths/PersistedValueCodecUnitTest.php
+++ b/src/Mechanisms/HandleSynths/PersistedValueCodecUnitTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleSynths;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+use Tests\TestComponent;
+
+class PersistedValueCodecUnitTest extends \Tests\TestCase
+{
+    public function test_a_collection_round_trips_through_json_storage()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+
+        $encoded = $codec->encodeForStorage(collect([1, 2, 3]), $component, 'items', 'session.items');
+        $stored = json_decode(json_encode($encoded), true);
+        $decoded = $codec->decodeFromStorage($stored, $component, 'items', 'session.items');
+
+        $this->assertInstanceOf(Collection::class, $decoded);
+        $this->assertSame([1, 2, 3], $decoded->all());
+    }
+
+    public function test_json_safe_values_are_not_encoded()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $value = ['search' => '', 'tags' => [1, 2], 'enabled' => true];
+
+        $this->assertSame($value, $codec->encodeForStorage($value, $component, 'filters', 'session.filters'));
+        $this->assertSame($value, $codec->decodeFromStorage($value, $component, 'filters', 'session.filters'));
+    }
+
+    public function test_an_unsigned_envelope_is_never_hydrated()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $forged = [
+            PersistedValueCodec::KEY => [
+                'version' => PersistedValueCodec::VERSION,
+                'value' => [['secret'], ['s' => 'clctn', 'class' => Collection::class]],
+            ],
+        ];
+
+        $this->expectException(CorruptPersistedValueException::class);
+
+        $codec->decodeFromStorage($forged, $component, 'items', 'session.items');
+    }
+
+    public function test_nested_synthesized_values_round_trip_through_json_storage()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $date = Carbon::parse('2026-01-15 10:00:00');
+        $value = ['items' => collect([1, 2]), 'createdAt' => $date];
+
+        $encoded = $codec->encodeForStorage($value, $component, 'state', 'session.state');
+        $stored = json_decode(json_encode($encoded), true);
+        $decoded = $codec->decodeFromStorage($stored, $component, 'state', 'session.state');
+
+        $this->assertInstanceOf(Collection::class, $decoded['items']);
+        $this->assertSame([1, 2], $decoded['items']->all());
+        $this->assertInstanceOf(Carbon::class, $decoded['createdAt']);
+        $this->assertTrue($decoded['createdAt']->equalTo($date));
+    }
+
+    public function test_registered_custom_synths_round_trip_through_json_storage()
+    {
+        app(HandleSynths::class)->registerSynth(PersistedValueSynth::class);
+
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+
+        $encoded = $codec->encodeForStorage(new PersistedValue('stored'), $component, 'value', 'session.value');
+        $stored = json_decode(json_encode($encoded), true);
+        $decoded = $codec->decodeFromStorage($stored, $component, 'value', 'session.value');
+
+        $this->assertInstanceOf(PersistedValue::class, $decoded);
+        $this->assertSame('stored', $decoded->value);
+    }
+
+    public function test_bare_synth_tuples_are_not_decoded()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $tuple = [['one', 'two'], ['s' => 'clctn', 'class' => Collection::class]];
+
+        $this->assertSame($tuple, $codec->decodeFromStorage($tuple, $component, 'items', 'session.items'));
+    }
+
+    public function test_envelopes_with_sibling_application_data_are_not_decoded()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $encoded = $codec->encodeForStorage(collect([1, 2]), $component, 'items', 'session.items');
+        $withSiblingData = [...$encoded, 'application' => 'value'];
+
+        $this->assertSame($withSiblingData, $codec->decodeFromStorage($withSiblingData, $component, 'items', 'session.items'));
+    }
+
+    public function test_unsupported_envelope_versions_are_rejected()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $encoded = $codec->encodeForStorage(collect([1, 2]), $component, 'items', 'session.items');
+        $encoded[PersistedValueCodec::KEY]['version']++;
+
+        $this->expectException(CorruptPersistedValueException::class);
+
+        $codec->decodeFromStorage($encoded, $component, 'items', 'session.items');
+    }
+
+    public function test_tampered_envelopes_are_rejected_before_hydration()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $encoded = $codec->encodeForStorage(collect([1, 2]), $component, 'items', 'session.items');
+        $encoded[PersistedValueCodec::KEY]['value'][0][] = 3;
+
+        $this->expectException(CorruptPersistedValueException::class);
+
+        $codec->decodeFromStorage($encoded, $component, 'items', 'session.items');
+    }
+
+    public function test_signatures_are_bound_to_the_storage_key()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $component = new TestComponent;
+        $encoded = $codec->encodeForStorage(collect([1, 2]), $component, 'items', 'session.items');
+
+        $this->expectException(CorruptPersistedValueException::class);
+
+        $codec->decodeFromStorage($encoded, $component, 'items', 'session.other');
+    }
+
+    public function test_a_shared_storage_key_can_be_decoded_by_another_component_property()
+    {
+        $codec = app(PersistedValueCodec::class);
+        $encoded = $codec->encodeForStorage(collect([1, 2]), new TestComponent, 'items', 'shared');
+
+        $decoded = $codec->decodeFromStorage($encoded, new OtherTestComponent, 'renamed', 'shared');
+
+        $this->assertInstanceOf(Collection::class, $decoded);
+        $this->assertSame([1, 2], $decoded->all());
+    }
+
+    public function test_hydration_failures_are_reported_as_corrupt_persisted_values()
+    {
+        app(HandleSynths::class)->registerSynth(PersistedValueSynth::class);
+
+        $component = new TestComponent;
+        $encoded = app(PersistedValueCodec::class)
+            ->encodeForStorage(new PersistedValue('stored'), $component, 'value', 'session.value');
+        $codecWithoutCustomSynth = new PersistedValueCodec(new HandleSynths);
+
+        try {
+            $codecWithoutCustomSynth->decodeFromStorage($encoded, $component, 'value', 'session.value');
+        } catch (CorruptPersistedValueException $e) {
+            $this->assertStringContainsString('No synthesizer found', $e->getPrevious()->getMessage());
+
+            return;
+        }
+
+        $this->fail('The outdated persisted value was hydrated.');
+    }
+}
+
+class OtherTestComponent extends TestComponent
+{
+    //
+}
+
+class PersistedValue
+{
+    public function __construct(public string $value) {}
+}
+
+class PersistedValueSynth extends Synth
+{
+    public static $key = 'persisted-value';
+
+    public static function match($target)
+    {
+        return $target instanceof PersistedValue;
+    }
+
+    public function dehydrate($target)
+    {
+        return [$target->value, []];
+    }
+
+    public function hydrate($value)
+    {
+        return new PersistedValue($value);
+    }
+}


### PR DESCRIPTION
Backports #10630 and #10628 together to `4.x`. With JSON session serialization, typed `#[Session]` properties such as Collections become plain arrays after a full page refresh and fail assignment. This restores their types through Livewire's authenticated persisted-value codec, so update → refresh → update continues working.

Both original squash commits cherry-pick cleanly, with no compatibility changes. The codec and session implementation match `main`; original authorship is preserved. PHP-serialized sessions and JSON-native values retain their existing storage format.

Validation:
- Production asset build
- Full unit suite: 1,489 tests, 4,183 assertions; 13 skipped and 3 incomplete, no failures or errors
- SupportSession browser tests: 2 passed, 9 assertions
- Laravel 13 JSON-session demo in Chrome: Add → `1`, full refresh → HTTP 200 with `1`, Add → `1, 2`; no JavaScript errors
- Existing codec tests cover signature validation, storage-key scoping, nested/custom synthesized values, and corrupt-state handling

Compiled assets are excluded from the commits per repository policy.
