### PR TITLE
[4.x] Support `wire:navigate` with hash fragment

### DIFF
--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -2,7 +2,7 @@ import { replaceUrl, updateCurrentPageHtmlInHistoryStateForLaterBackButtonClicks
 import { getPretchedHtmlOr, prefetchHtml, storeThePrefetchedHtmlForWhenALinkIsClicked } from "./prefetch"
 import { createUrlObjectFromString, extractDestinationFromLink, isSameOrigin, linkShouldBeHandledNatively, visitNatively, whenThisLinkIsHoveredFor, whenThisLinkIsPressed } from "./links"
 import { isTeleportTarget, packUpPersistedTeleports, removeAnyLeftOverStaleTeleportTargets, unPackPersistedTeleports } from "./teleport"
-import { restoreScrollPositionOrScrollToTop, storeScrollInformationInHtmlBeforeNavigatingAway } from "./scroll"
+import { restoreScrollPositionOrScrollToHash, restoreScrollPositionOrScrollToTop, storeScrollInformationInHtmlBeforeNavigatingAway } from "./scroll"
 import { isPersistedElement, putPersistantElementsBack, storePersistantElementsForLater } from "./persist"
 import { finishAndHideProgressBar, removeAnyLeftOverStaleProgressBars, showAndStartProgressBar } from "./bar"
 import { packUpPersistedPopovers, unPackPersistedPopovers } from "./popover"
@@ -132,7 +132,7 @@ export default function (Alpine) {
                         unPackPersistedPopovers(persistedEl)
                     })
 
-                    !preserveScroll && restoreScrollPositionOrScrollToTop()
+                    restoreScrollPositionOrScrollToHash(finalDestination, preserveScroll)
 
                     // Invoke any callbacks registered via onSwap during the navigating event
                     swapCallbacks.forEach(callback => callback())

--- a/js/plugins/navigate/scroll.js
+++ b/js/plugins/navigate/scroll.js
@@ -32,3 +32,42 @@ export function restoreScrollPositionOrScrollToTop() {
         })
     })
 }
+
+export function restoreScrollPositionOrScrollToHash(destination, preserveScroll) {
+    if (destination.hash) {
+        queueMicrotask(() => {
+            queueMicrotask(() => {
+                let fragment = destination.hash.slice(1)
+                let element = document.getElementById(fragment)
+
+                if (! element) {
+                    try {
+                        let decodedFragment = decodeURIComponent(fragment)
+
+                        element = document.getElementById(decodedFragment)
+
+                        // Match the browser's fragment navigation behavior, including legacy named anchors.
+                        if (! element) {
+                            element = [...document.getElementsByTagName('a')]
+                                .find(el => el.getAttribute('name') === decodedFragment)
+                        }
+
+                        if (! element && decodedFragment.toLowerCase() === 'top') {
+                            window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
+
+                            return
+                        }
+                    } catch {
+                        // Ignore malformed percent-encoding.
+                    }
+                }
+
+                element?.scrollIntoView()
+            })
+        })
+
+        return
+    }
+
+    ! preserveScroll && restoreScrollPositionOrScrollToTop()
+}

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -1630,6 +1630,112 @@ class BrowserTest extends \Tests\BrowserTestCase
         });
     }
 
+    public function test_navigate_scrolls_to_hash()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first')
+                ->waitForNavigate()->click('@link.to.second.with.hash')
+                ->waitForText('On second')
+                ->assertFragmentIs('second-target')
+                ->assertInViewPort('#second-target');
+        });
+    }
+
+    public function test_navigate_to_missing_hash_scrolls_to_top()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first')
+                ->waitForNavigate()->click('@link.to.second.with.missing.hash')
+                ->waitForText('On second')
+                ->assertFragmentIs('does-not-exist')
+                ->assertSee('On second')
+                ->assertNotInViewPort('#second-target');
+        });
+    }
+
+    public function test_navigate_scrolls_to_hash_even_with_preserve_scroll()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first-scroll')
+                ->scrollTo('@first-target')
+                ->waitForNavigate()->click('@link.to.second.with.hash.preserve.scroll')
+                ->waitForText('On second')
+                ->assertFragmentIs('second-target')
+                ->assertInViewPort('#second-target');
+        });
+    }
+
+    public function test_navigate_to_hash_preserves_back_forward_scroll_behavior()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first-scroll')
+                ->waitForNavigate()->click('@link.to.second.with.hash')
+                ->waitForText('On second')
+                ->assertInViewPort('#second-target')
+                ->back()
+                ->waitForText('On first')
+                ->assertInViewPort('#first-target')
+                ->forward()
+                ->waitForText('On second')
+                ->assertInViewPort('#second-target');
+        });
+    }
+
+    public function test_navigate_scrolls_to_percent_encoded_hash()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/first')
+                ->waitForNavigate()->click('@link.to.encoded.hash')
+                ->waitForText('On second')
+                ->assertFragmentIs('second%20target')
+                ->tap(function (Browser $browser) {
+                    $browser->script(["
+                        window.__inViewPort = false
+                        const rect = document.getElementById('second target').getBoundingClientRect();
+
+                        window.__inViewPort = (
+                            rect.top >= 0 &&
+                            rect.left >= 0 &&
+                            rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+                            rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+                        );
+                    "]);
+                })
+                ->assertScript("window.__inViewPort", true);
+        });
+    }
+
+    public function test_navigate_scrolls_to_top_with_top_hash()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/first-scroll')
+                ->scrollTo('@first-target')
+                ->waitForNavigate()->click('@link.to.second.with.top.hash')
+                ->waitForText('On second')
+                ->assertFragmentIs('top')
+                ->assertScript('window.scrollY === 0')
+                ->assertNotInViewPort('#second-target');
+        });
+    }
+
+    public function test_navigate_scrolls_to_legacy_named_anchor()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit('/first')
+                ->waitForNavigate()->click('@link.to.second.with.named.hash')
+                ->waitForText('On second')
+                ->assertFragmentIs('named-target')
+                ->assertInViewPort('@named-target');
+        });
+    }
+
     protected function registerComponentTestRoutes($routes)
     {
         $registered = 0;
@@ -1683,6 +1789,12 @@ class FirstPage extends Component
 
             <a href="/first" wire:navigate wire:current.ignore dusk="link.to.first.wire.current.ignore">First (wire:current.ignore)</a>
             <a href="/second" wire:navigate wire:current.ignore dusk="link.to.second.wire.current.ignore">Second (wire:current.ignore)</a>
+
+            <a href="/second-scroll#second-target" wire:navigate dusk="link.to.second.with.hash">Go to second page with hash</a>
+            <a href="/second-scroll#does-not-exist" wire:navigate dusk="link.to.second.with.missing.hash">Go to second page with missing hash</a>
+            <a href="/second-scroll#second-target" wire:navigate.preserve-scroll dusk="link.to.second.with.hash.preserve.scroll">Go to second page with hash and preserve scroll</a>
+            <a href="/second-scroll#second%20target" wire:navigate dusk="link.to.encoded.hash">Go to second page with encoded hash</a>
+            <a href="/second-scroll#named-target" wire:navigate dusk="link.to.second.with.named.hash">Go to second page with named hash</a>
 
             @script
             <script>
@@ -1974,15 +2086,17 @@ class FirstScrollPage extends Component
 
             <div style="height: 100vh;">spacer</div>
 
-            <div dusk="first-target">below the fold</div>
+            <div id="first-target" dusk="first-target">below the fold</div>
 
             <a href="/second-scroll" wire:navigate.hover dusk="link.to.second">Go to second page</a>
-
-            <a href="/second-scroll" x-on:click="$event.preventDefault(); Livewire.navigate($el.href)"  dusk="link.to.second.using.javascript">Go to second page using javascript</a>
+            <a href="/second-scroll" x-on:click="$event.preventDefault(); Livewire.navigate($el.href)" dusk="link.to.second.using.javascript">Go to second page using javascript</a>
 
             <a href="/second-scroll" wire:navigate.hover.preserve-scroll dusk="link.to.second.with.preserve.scroll">Go to second page with preserve scroll</a>
+            <a href="/second-scroll" x-on:click="$event.preventDefault(); Livewire.navigate($el.href, { preserveScroll: true })" dusk="link.to.second.with.preserve.scroll.using.javascript">Go to second page with preserve scroll using javascript</a>
 
-            <a href="/second-scroll" x-on:click="$event.preventDefault(); Livewire.navigate($el.href, { preserveScroll: true })"  dusk="link.to.second.with.preserve.scroll.using.javascript">Go to second page with preserve scroll using javascript</a>
+            <a href="/second-scroll#second-target" wire:navigate dusk="link.to.second.with.hash">Go to second page with hash</a>
+            <a href="/second-scroll#second-target" wire:navigate.preserve-scroll dusk="link.to.second.with.hash.preserve.scroll">Go to second page with hash and preserve scroll</a>
+            <a href="/second-scroll#top" wire:navigate dusk="link.to.second.with.top.hash"> Go to second page with top hash</a>
 
             <div style="height: 100vh;">spacer</div>
         </div>
@@ -2083,7 +2197,9 @@ class SecondScrollPage extends Component
 
             <div style="height: 100vh;">spacer</div>
 
-            <div dusk="second-target">below the fold</div>
+            <div id="second-target" dusk="second-target">below the fold</div>
+            <div id="second target">encoded target</div>
+            <a name="named-target" dusk="named-target"></a>
 
             <div style="height: 100vh;">spacer</div>
         </div>


### PR DESCRIPTION
## Summary

Add support for URL fragments when using `wire:navigate`, so navigating to a URL with a hash scrolls to the corresponding element like a normal browser navigation.

## Problem

When `wire:navigate` navigates to a URL containing a fragment, Livewire replaces the page content but does not perform the browser's default fragment scrolling.

For example, navigating to:

```html
<a href="/posts#comments" wire:navigate>
    Comments
</a>
```

will update the URL to `/posts#comments`, but the page will remain at its current scroll position instead of scrolling to `#comments`.

Related discussion: https://github.com/livewire/livewire/discussions/8073

## Solution

Handle the fragment after the new page has been rendered:

1. Resolve the fragment target

   * Match elements by `id`
   * Support percent-encoded fragments
   * Support legacy `<a name="...">` anchors
   * Handle the special `#top` fragment
2. Scroll to the target when it exists
3. Fall back to the existing scroll-to-top behavior when there is no fragment
4. Let fragment navigation take precedence over `preserve-scroll`, matching normal browser navigation behavior

Back/forward navigation continues to use the existing scroll restoration behavior.

## Tests

* Navigate to an element using a URL fragment
* Navigate to a missing fragment
* Navigate using a percent-encoded fragment
* Navigate to `#top`
* Navigate to a legacy named anchor
* Navigate to a fragment with `preserve-scroll`
* Preserve fragment scroll position when navigating back and forward