### PR TITLE
[4.x] Preserve non-HTML attribute for blade props

### DIFF
--- a/src/Features/SupportHtmlAttributeForwarding/HandlesHtmlAttributeForwarding.php
+++ b/src/Features/SupportHtmlAttributeForwarding/HandlesHtmlAttributeForwarding.php
@@ -24,4 +24,9 @@ trait HandlesHtmlAttributeForwarding
             fn ($value) => is_scalar($value) || is_null($value) || $value instanceof Htmlable
         );
     }
+
+    public function getNonHtmlAttributes(): array
+    {
+        return array_diff_key($this->htmlAttributes, $this->getHtmlAttributes());
+    }
 }

--- a/src/Features/SupportHtmlAttributeForwarding/SupportHtmlAttributeForwarding.php
+++ b/src/Features/SupportHtmlAttributeForwarding/SupportHtmlAttributeForwarding.php
@@ -9,23 +9,17 @@ class SupportHtmlAttributeForwarding extends ComponentHook
 {
     public function render($view, $properties)
     {
-        $attributes = $this->component->getHtmlAttributes();
-
-        $view->with(['attributes' => new ComponentAttributeBag($attributes)]);
+        $this->forwardAttributesToView($view);
     }
 
     public function renderIsland($name, $view, $properties)
     {
-        $attributes = $this->component->getHtmlAttributes();
-
-        $view->with(['attributes' => new ComponentAttributeBag($attributes)]);
+        $this->forwardAttributesToView($view);
     }
 
     public function renderPlaceholder($view, $properties)
     {
-        $attributes = $this->component->getHtmlAttributes();
-
-        $view->with(['attributes' => new ComponentAttributeBag($attributes)]);
+        $this->forwardAttributesToView($view);
     }
 
     function hydrate($memo)
@@ -44,5 +38,14 @@ class SupportHtmlAttributeForwarding extends ComponentHook
         if (! empty($attributes)) {
             $context->addMemo('attributes', $attributes);
         }
+    }
+
+    protected function forwardAttributesToView($view)
+    {
+        $attributes = $this->component->getHtmlAttributes();
+
+        $view->with($this->component->getNonHtmlAttributes());
+
+        $view->with(['attributes' => new ComponentAttributeBag($attributes)]);
     }
 }

--- a/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
+++ b/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
@@ -250,6 +250,22 @@ class UnitTest extends TestCase
         $this->assertStringContainsString('id="rows-component"', $html);
         $this->assertStringNotContainsString('rows="', $html);
     }
+
+    public function test_non_html_attributes_are_available_as_blade_props_in_placeholder()
+    {
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        Livewire::component('alert', LazyAlertWithProps::class);
+
+        $html = Livewire::mount('alert', [
+            'lazy' => true,
+            'rows' => [
+                ['id' => 1, 'name' => 'Alice'],
+            ],
+        ]);
+
+        $this->assertStringContainsString('Alice', $html);
+    }
 }
 
 class RecordModel extends Model
@@ -322,5 +338,23 @@ class AlertWithPropsWithoutDefault extends Component
             {{ $rows[0]['name'] }}
         </div>
         HTML;
+    }
+}
+
+#[Lazy]
+class LazyAlertWithProps extends Component
+{
+    public function placeholder()
+    {
+        return <<<'HTML'
+        @props(['rows'])
+
+        <div>{{ $rows[0]['name'] }}</div>
+        HTML;
+    }
+
+    public function render()
+    {
+        return '<div>Alert</div>';
     }
 }

--- a/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
+++ b/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
@@ -203,10 +203,13 @@ class UnitTest extends TestCase
                 ['id' => 1, 'name' => 'Alice'],
                 ['id' => 2, 'name' => 'Bob'],
             ],
+            'id' => 'rows-component',
         ]);
 
         $this->assertStringContainsString('Alice', $html);
         $this->assertStringContainsString('Bob', $html);
+        $this->assertStringContainsString('id="rows-component"', $html);
+        $this->assertStringNotContainsString('rows=', $html);
     }
 
     public function test_non_html_attributes_are_available_as_blade_props_without_default()
@@ -217,22 +220,12 @@ class UnitTest extends TestCase
             'rows' => [
                 ['id' => 1, 'name' => 'Alice'],
             ],
+            'id' => 'rows-component',
         ]);
 
         $this->assertStringContainsString('Alice', $html);
-    }
-
-    public function test_non_html_attributes_are_not_forwarded_as_html_attributes()
-    {
-        Livewire::component('alert', AlertWithProps::class);
-
-        $html = Livewire::mount('alert', [
-            'rows' => [
-                ['id' => 1, 'name' => 'Alice'],
-            ],
-        ]);
-
-        $this->assertStringNotContainsString('rows="', $html);
+        $this->assertStringContainsString('id="rows-component"', $html);
+        $this->assertStringNotContainsString('rows=', $html);
     }
 
     public function test_html_attributes_are_forwarded_while_non_html_attributes_are_available_as_blade_props()
@@ -262,9 +255,12 @@ class UnitTest extends TestCase
             'rows' => [
                 ['id' => 1, 'name' => 'Alice'],
             ],
+            'id' => 'rows-component',
         ]);
 
         $this->assertStringContainsString('Alice', $html);
+        $this->assertStringContainsString('id="rows-component"', $html);
+        $this->assertStringNotContainsString('rows=', $html);
     }
 
     public function test_eloquent_model_are_available_as_blade_props_without_being_dehydrated()
@@ -273,9 +269,11 @@ class UnitTest extends TestCase
 
         $html = Livewire::mount('alert', [
             'record' => RecordModel::first(),
+            'id' => 'rows-component',
         ]);
 
         $this->assertStringContainsString('First User', $html);
+        $this->assertStringContainsString('id="rows-component"', $html);
         $this->assertStringNotContainsString('first@example.com', $html);
     }
 }
@@ -346,7 +344,7 @@ class AlertWithPropsWithoutDefault extends Component
     {
         return <<<'HTML'
         @props(['rows'])
-        <div>
+        <div {{ $attributes }}>
             {{ $rows[0]['name'] }}
         </div>
         HTML;
@@ -360,8 +358,7 @@ class LazyAlertWithProps extends Component
     {
         return <<<'HTML'
         @props(['rows'])
-
-        <div>{{ $rows[0]['name'] }}</div>
+        <div {{ $attributes }}>{{ $rows[0]['name'] }}</div>
         HTML;
     }
 
@@ -377,7 +374,7 @@ class AlertWithRecordProps extends Component
     {
         return <<<'HTML'
         @props(['record'])
-        <div>{{ $record->name }}</div>
+        <div {{ $attributes }}>{{ $record->name }}</div>
         HTML;
     }
 }

--- a/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
+++ b/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
@@ -193,6 +193,63 @@ class UnitTest extends TestCase
         $this->assertStringNotContainsString('first@example.com', $html);
         $this->assertStringNotContainsString('pageFilters', $html);
     }
+
+    public function test_non_html_attributes_are_available_as_blade_props()
+    {
+        Livewire::component('alert', AlertWithProps::class);
+
+        $html = Livewire::mount('alert', [
+            'rows' => [
+                ['id' => 1, 'name' => 'Alice'],
+                ['id' => 2, 'name' => 'Bob'],
+            ],
+        ]);
+
+        $this->assertStringContainsString('Alice', $html);
+        $this->assertStringContainsString('Bob', $html);
+    }
+
+    public function test_non_html_attributes_are_available_as_blade_props_without_default()
+    {
+        Livewire::component('alert', AlertWithPropsWithoutDefault::class);
+
+        $html = Livewire::mount('alert', [
+            'rows' => [
+                ['id' => 1, 'name' => 'Alice'],
+            ],
+        ]);
+
+        $this->assertStringContainsString('Alice', $html);
+    }
+
+    public function test_non_html_attributes_are_not_forwarded_as_html_attributes()
+    {
+        Livewire::component('alert', AlertWithProps::class);
+
+        $html = Livewire::mount('alert', [
+            'rows' => [
+                ['id' => 1, 'name' => 'Alice'],
+            ],
+        ]);
+
+        $this->assertStringNotContainsString('rows="', $html);
+    }
+
+    public function test_html_attributes_are_forwarded_while_non_html_attributes_are_available_as_blade_props()
+    {
+        Livewire::component('alert', AlertWithProps::class);
+
+        $html = Livewire::mount('alert', [
+            'rows' => [
+                ['id' => 1, 'name' => 'Alice'],
+            ],
+            'id' => 'rows-component',
+        ]);
+
+        $this->assertStringContainsString('Alice', $html);
+        $this->assertStringContainsString('id="rows-component"', $html);
+        $this->assertStringNotContainsString('rows="', $html);
+    }
 }
 
 class RecordModel extends Model
@@ -235,6 +292,34 @@ class AlertWithIslandAttributes extends Component
             @island(name: 'content')
                 <div {{ $attributes }}>Island</div>
             @endisland
+        </div>
+        HTML;
+    }
+}
+
+class AlertWithProps extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        @props(['rows' => []])
+        <ul {{ $attributes }}>
+            @foreach ($rows as $row)
+                <li wire:key="{{ $row['id'] }}">{{ $row['name'] }}</li>
+            @endforeach
+        </ul>
+        HTML;
+    }
+}
+
+class AlertWithPropsWithoutDefault extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        @props(['rows'])
+        <div>
+            {{ $rows[0]['name'] }}
         </div>
         HTML;
     }

--- a/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
+++ b/src/Features/SupportHtmlAttributeForwarding/UnitTest.php
@@ -194,7 +194,7 @@ class UnitTest extends TestCase
         $this->assertStringNotContainsString('pageFilters', $html);
     }
 
-    public function test_non_html_attributes_are_available_as_blade_props()
+    public function test_non_html_attributes_are_available_to_blade_props()
     {
         Livewire::component('alert', AlertWithProps::class);
 
@@ -265,6 +265,18 @@ class UnitTest extends TestCase
         ]);
 
         $this->assertStringContainsString('Alice', $html);
+    }
+
+    public function test_eloquent_model_are_available_as_blade_props_without_being_dehydrated()
+    {
+        Livewire::component('alert', AlertWithRecordProps::class);
+
+        $html = Livewire::mount('alert', [
+            'record' => RecordModel::first(),
+        ]);
+
+        $this->assertStringContainsString('First User', $html);
+        $this->assertStringNotContainsString('first@example.com', $html);
     }
 }
 
@@ -356,5 +368,16 @@ class LazyAlertWithProps extends Component
     public function render()
     {
         return '<div>Alert</div>';
+    }
+}
+
+class AlertWithRecordProps extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        @props(['record'])
+        <div>{{ $record->name }}</div>
+        HTML;
     }
 }


### PR DESCRIPTION
## Summary

Fix a regression where array and object values passed to a Livewire component could no longer be used with Blade's `@props` directive.

## Problem

Values passed to a component that weren't defined as component properties were being treated as HTML attributes.

After a recent fix (https://github.com/livewire/livewire/pull/10649) to prevent arrays and objects from being rendered as HTML attributes, those values were also no longer available to `@props`.

For example:

```blade
@props(['rows' => []])

@foreach ($rows as $row)
    ...
@endforeach
```

If `rows` was passed from the parent, the component would incorrectly receive the default empty array instead of the provided rows.

## Solution

Non-HTML values are now still available to the component view, so they can be used with `@props`.

At the same time, they are not rendered as HTML attributes.

Regular HTML attributes such as `id` and `class` continue to work as before.

## Tests

Added coverage for:

* Using non-HTML values with `@props`
* Using `@props` without a default value
* Ensuring non-HTML values are not rendered as HTML attributes
* Ensuring regular HTML attributes continue to be forwarded correctly

Fixes: https://github.com/livewire/livewire/issues/10680