### PR TITLE
[4.x] Prevent malformed synthesized values from throwing before property type handling

### DIFF
--- a/src/Mechanisms/HandleComponents/Synthesizers/CarbonSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/CarbonSynth.php
@@ -41,11 +41,15 @@ class CarbonSynth extends Synth {
     static function hydrateFromType($type, $value) {
         if ($value === '' || $value === null) return null;
 
+        if (! is_string($value)) return $value;
+
         return new $type($value);
     }
 
     function hydrate($value, $meta) {
         if ($value === '' || $value === null) return null;
+
+        if (! is_string($value)) return $value;
 
         $type = $meta['type'] ?? null;
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/EnumSynth.php
@@ -16,6 +16,8 @@ class EnumSynth extends Synth {
     static function hydrateFromType($type, $value) {
         if ($value === null || $value === '') return null;
 
+        if (! is_int($value) && ! is_string($value)) return $value;
+
         return $type::from($value);
     }
 
@@ -28,6 +30,8 @@ class EnumSynth extends Synth {
 
     function hydrate($value, $meta) {
         if ($value === null || $value === '') return null;
+
+        if (! is_int($value) && ! is_string($value)) return $value;
 
         $class = $meta['class'] ?? null;
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/StringableSynth.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/StringableSynth.php
@@ -16,6 +16,8 @@ class StringableSynth extends Synth {
     }
 
     function hydrate($value) {
+        if (! is_string($value)) return $value;
+
         return str($value);
     }
 }

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
@@ -79,6 +79,28 @@ class CarbonSynthUnitTest extends \Tests\TestCase
         $testable->updateProperty('date', 'Bad Date');
     }
 
+    public function test_malformed_carbon_update_throws_type_error()
+    {
+        config()->set('app.debug', true);
+
+        $this->expectException(\TypeError::class);
+
+        Livewire::test(ComponentWithNullablePublicCarbonCaster::class)
+            ->set('date', [])
+            ->assertOk();
+    }
+
+    public function test_malformed_synthesized_carbon_update_throws_type_error()
+    {
+        config()->set('app.debug', true);
+
+        $this->expectException(\TypeError::class);
+
+        Livewire::test(ComponentWithInitializedCarbonCaster::class)
+            ->set('date', [])
+            ->assertOk();
+    }
+
     public function test_malformed_carbon_update_returns_419()
     {
         config()->set('app.debug', false);

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
@@ -79,7 +79,7 @@ class CarbonSynthUnitTest extends \Tests\TestCase
         $testable->updateProperty('date', 'Bad Date');
     }
 
-    public function test_malformed_carbon_update_throws_type_error_on_debug_mode()
+    public function test_malformed_carbon_update_throws_type_error_when_debug_enabled()
     {
         config()->set('app.debug', true);
 
@@ -90,7 +90,7 @@ class CarbonSynthUnitTest extends \Tests\TestCase
             ->assertOk();
     }
 
-    public function test_malformed_synthesized_carbon_update_throws_type_error_on_debug_mode()
+    public function test_malformed_synthesized_carbon_update_throws_type_error_when_debug_enabled()
     {
         config()->set('app.debug', true);
 
@@ -101,7 +101,7 @@ class CarbonSynthUnitTest extends \Tests\TestCase
             ->assertOk();
     }
 
-    public function test_malformed_carbon_update_returns_419_on_production()
+    public function test_malformed_carbon_update_returns_419_when_debug_disabled()
     {
         config()->set('app.debug', false);
 
@@ -110,7 +110,7 @@ class CarbonSynthUnitTest extends \Tests\TestCase
             ->assertStatus(419);
     }
 
-    public function test_malformed_synthesized_carbon_update_returns_419_on_production()
+    public function test_malformed_synthesized_carbon_update_returns_419_when_debug_disabled()
     {
         config()->set('app.debug', false);
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
@@ -78,6 +78,34 @@ class CarbonSynthUnitTest extends \Tests\TestCase
         $this->expectException(\Exception::class);
         $testable->updateProperty('date', 'Bad Date');
     }
+
+    public function test_malformed_carbon_update_returns_419()
+    {
+        config()->set('app.debug', false);
+
+        Livewire::test(ComponentWithNullablePublicCarbonCaster::class)
+            ->set('date', [])
+            ->assertStatus(419);
+    }
+
+    public function test_malformed_synthesized_carbon_update_returns_419()
+    {
+        config()->set('app.debug', false);
+
+        Livewire::test(ComponentWithInitializedCarbonCaster::class)
+            ->set('date', [])
+            ->assertStatus(419);
+    }
+}
+
+class ComponentWithInitializedCarbonCaster extends TestComponent
+{
+    public Carbon $date;
+
+    public function mount()
+    {
+        $this->date = Carbon::parse('2026-01-01');
+    }
 }
 
 class ComponentWithPublicCarbonCaster extends TestComponent

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/CarbonSynthUnitTest.php
@@ -79,7 +79,7 @@ class CarbonSynthUnitTest extends \Tests\TestCase
         $testable->updateProperty('date', 'Bad Date');
     }
 
-    public function test_malformed_carbon_update_throws_type_error()
+    public function test_malformed_carbon_update_throws_type_error_on_debug_mode()
     {
         config()->set('app.debug', true);
 
@@ -90,7 +90,7 @@ class CarbonSynthUnitTest extends \Tests\TestCase
             ->assertOk();
     }
 
-    public function test_malformed_synthesized_carbon_update_throws_type_error()
+    public function test_malformed_synthesized_carbon_update_throws_type_error_on_debug_mode()
     {
         config()->set('app.debug', true);
 
@@ -101,7 +101,7 @@ class CarbonSynthUnitTest extends \Tests\TestCase
             ->assertOk();
     }
 
-    public function test_malformed_carbon_update_returns_419()
+    public function test_malformed_carbon_update_returns_419_on_production()
     {
         config()->set('app.debug', false);
 
@@ -110,7 +110,7 @@ class CarbonSynthUnitTest extends \Tests\TestCase
             ->assertStatus(419);
     }
 
-    public function test_malformed_synthesized_carbon_update_returns_419()
+    public function test_malformed_synthesized_carbon_update_returns_419_on_production()
     {
         config()->set('app.debug', false);
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -62,7 +62,7 @@ class EnumUnitTest extends \Tests\TestCase
         ;
     }
 
-    public function test_malformed_enum_property_update_throws_type_error_on_debug_mode()
+    public function test_malformed_enum_property_update_throws_type_error_when_debug_enabled()
     {
         config()->set('app.debug', true);
 
@@ -73,7 +73,7 @@ class EnumUnitTest extends \Tests\TestCase
             ->assertOk();
     }
 
-    public function test_malformed_synthesized_enum_update_throws_type_error_on_debug_mode()
+    public function test_malformed_synthesized_enum_update_throws_type_error_when_debug_enabled()
     {
         config()->set('app.debug', true);
 
@@ -84,7 +84,7 @@ class EnumUnitTest extends \Tests\TestCase
             ->assertOk();
     }
 
-    public function test_malformed_enum_property_update_returns_419_on_production()
+    public function test_malformed_enum_property_update_returns_419_when_debug_disabled()
     {
         config()->set('app.debug', false);
 
@@ -93,7 +93,7 @@ class EnumUnitTest extends \Tests\TestCase
             ->assertStatus(419);
     }
 
-    public function test_malformed_synthesized_enum_update_returns_419_on_production()
+    public function test_malformed_synthesized_enum_update_returns_419_when_debug_disabled()
     {
         config()->set('app.debug', false);
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -62,7 +62,7 @@ class EnumUnitTest extends \Tests\TestCase
         ;
     }
 
-    public function test_malformed_enum_property_update_throws_type_error()
+    public function test_malformed_enum_property_update_throws_type_error_on_debug_mode()
     {
         config()->set('app.debug', true);
 
@@ -73,7 +73,7 @@ class EnumUnitTest extends \Tests\TestCase
             ->assertOk();
     }
 
-    public function test_malformed_synthesized_enum_update_throws_type_error()
+    public function test_malformed_synthesized_enum_update_throws_type_error_on_debug_mode()
     {
         config()->set('app.debug', true);
 
@@ -84,7 +84,7 @@ class EnumUnitTest extends \Tests\TestCase
             ->assertOk();
     }
 
-    public function test_malformed_enum_property_update_returns_419()
+    public function test_malformed_enum_property_update_returns_419_on_production()
     {
         config()->set('app.debug', false);
 
@@ -93,7 +93,7 @@ class EnumUnitTest extends \Tests\TestCase
             ->assertStatus(419);
     }
 
-    public function test_malformed_synthesized_enum_update_returns_419()
+    public function test_malformed_synthesized_enum_update_returns_419_on_production()
     {
         config()->set('app.debug', false);
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -62,6 +62,28 @@ class EnumUnitTest extends \Tests\TestCase
         ;
     }
 
+    public function test_malformed_enum_property_update_throws_type_error()
+    {
+        config()->set('app.debug', true);
+
+        $this->expectException(\TypeError::class);
+
+        Livewire::test(ComponentWithNullablePublicEnumCaster::class)
+            ->set('status', [])
+            ->assertOk();
+    }
+
+    public function test_malformed_synthesized_enum_update_throws_type_error()
+    {
+        config()->set('app.debug', true);
+
+        $this->expectException(\TypeError::class);
+
+        Livewire::test(ComponentWithInitializedPublicEnumCaster::class)
+            ->set('status', [])
+            ->assertOk();
+    }
+
     public function test_malformed_enum_property_update_returns_419()
     {
         config()->set('app.debug', false);

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/EnumUnitTest.php
@@ -61,6 +61,24 @@ class EnumUnitTest extends \Tests\TestCase
             ->assertSet('list', [])
         ;
     }
+
+    public function test_malformed_enum_property_update_returns_419()
+    {
+        config()->set('app.debug', false);
+
+        Livewire::test(ComponentWithNullablePublicEnumCaster::class)
+            ->set('status', [])
+            ->assertStatus(419);
+    }
+
+    public function test_malformed_synthesized_enum_update_returns_419()
+    {
+        config()->set('app.debug', false);
+
+        Livewire::test(ComponentWithInitializedPublicEnumCaster::class)
+            ->set('status', [])
+            ->assertStatus(419);
+    }
 }
 
 enum TestingEnum: string
@@ -128,5 +146,15 @@ class ComponentWithValidatedEnum extends TestComponent
         if (!($this->enum instanceof ValidatedEnum)) {
             throw new \Exception('The type of Enum has been changed.');
         }
+    }
+}
+
+class ComponentWithInitializedPublicEnumCaster extends TestComponent
+{
+    public TestingEnum $status;
+
+    public function mount()
+    {
+        $this->status = TestingEnum::TEST;
     }
 }

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/StringableSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/StringableSynthUnitTest.php
@@ -6,7 +6,7 @@ use Livewire\Livewire;
 
 class StringableSynthUnitTest extends \Tests\TestCase
 {
-    public function test_malformed_stringable_update_throws_type_error_on_debug_mode()
+    public function test_malformed_stringable_update_throws_type_error_when_debug_enabled()
     {
         config()->set('app.debug', true);
 
@@ -24,7 +24,7 @@ class StringableSynthUnitTest extends \Tests\TestCase
             ->assertOk();
     }
 
-    public function test_malformed_stringable_update_returns_419_on_production()
+    public function test_malformed_stringable_update_returns_419_when_debug_disabled()
     {
         config()->set('app.debug', false);
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/StringableSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/StringableSynthUnitTest.php
@@ -6,6 +6,24 @@ use Livewire\Livewire;
 
 class StringableSynthUnitTest extends \Tests\TestCase
 {
+    public function test_malformed_stringable_update_throws_type_error()
+    {
+        config()->set('app.debug', true);
+
+        $this->expectException(\TypeError::class);
+
+        Livewire::test(new class extends \Tests\TestComponent {
+            public \Illuminate\Support\Stringable $value;
+
+            public function mount()
+            {
+                $this->value = str('hello');
+            }
+        })
+            ->set('value', [])
+            ->assertOk();
+    }
+
     public function test_malformed_stringable_update_returns_419()
     {
         config()->set('app.debug', false);

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/StringableSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/StringableSynthUnitTest.php
@@ -6,7 +6,7 @@ use Livewire\Livewire;
 
 class StringableSynthUnitTest extends \Tests\TestCase
 {
-    public function test_malformed_stringable_update_throws_type_error()
+    public function test_malformed_stringable_update_throws_type_error_on_debug_mode()
     {
         config()->set('app.debug', true);
 
@@ -24,7 +24,7 @@ class StringableSynthUnitTest extends \Tests\TestCase
             ->assertOk();
     }
 
-    public function test_malformed_stringable_update_returns_419()
+    public function test_malformed_stringable_update_returns_419_on_production()
     {
         config()->set('app.debug', false);
 

--- a/src/Mechanisms/HandleComponents/Synthesizers/Tests/StringableSynthUnitTest.php
+++ b/src/Mechanisms/HandleComponents/Synthesizers/Tests/StringableSynthUnitTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Livewire\Mechanisms\HandleComponents\Synthesizers\Tests;
+
+use Livewire\Livewire;
+
+class StringableSynthUnitTest extends \Tests\TestCase
+{
+    public function test_malformed_stringable_update_returns_419()
+    {
+        config()->set('app.debug', false);
+
+        Livewire::test(new class extends \Tests\TestComponent {
+            public \Illuminate\Support\Stringable $value;
+
+            public function mount()
+            {
+                $this->value = str('hello');
+            }
+        })
+            ->set('value', [])
+            ->assertStatus(419);
+    }
+}


### PR DESCRIPTION
## Summary

Fix malformed property updates causing certain synthesizers to throw while hydrating values before Livewire reaches its existing typed-property error handling.

This affects:

- `EnumSynth`
- `CarbonSynth`
- `StringableSynth`

These synthesizers know the expected shape of their dehydrated values. When an incoming value does not match that shape, it is passed through unchanged instead of being given to an object constructor or conversion method that would throw.

This allows the invalid value to reach Livewire's existing property assignment path, where invalid typed-property assignments are handled consistently.

Array-shaped synthesizers remains protected by `ArrayShapeSynthesizerInterface`

## Problem

A malformed property update can currently throw inside a synthesizer.

For example:

```text
update property
    ↓
EnumSynth::hydrate()
    ↓
Enum::from([])
    ↓
TypeError
```
Similarly, malformed values can be passed to constructors or conversion helpers in `CarbonSynth` and `StringableSynth`.

Because these exceptions occur during synthesizer hydration, they happen before Livewire's existing typed-property error handling can process the invalid value.

## Solution

**EnumSynth**

`BackedEnum::from()` only accepts `string` and `int` values.

Both hydration paths are guarded:
- `hydrate()`
- `hydrateFromType()`

Malformed values are returned unchanged instead of calling `::from()` with an unsupported value.

**CarbonSynth**

Carbon's dehydrated representation is a date/time string.

Both hydration paths are guarded:
- `hydrate()`
- `hydrateFromType()`

Non-string values are returned unchanged instead of being passed to the `Carbon`/`DateTime` constructor.

**StringableSynth**

`StringableSynth` dehydrates values to strings.

Non-string values are returned unchanged instead of being passed to `str()` during hydration.

This allows malformed values to continue to Livewire's existing property assignment and typed-property error handling.

Fixes: https://github.com/livewire/livewire/issues/10683