### PR TITLE
[4.x] Fixes an error when trying to read an uninitialized typed property

### DIFF
--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -416,7 +416,7 @@ class HandleComponents extends Mechanism
         $expanded = [];
 
         foreach ($updates as $path => $value) {
-            if (is_array($value) && property_exists($component, $path) && $component->$path instanceof Form) {
+            if (is_array($value) && isset($component->$path) && $component->$path instanceof Form) {
                 foreach ($value as $key => $child) {
                     $expanded["{$path}.{$key}"] = $child;
                 }

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -5,7 +5,9 @@ namespace Livewire\Mechanisms\HandleComponents;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Stringable;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
+use Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException;
 use Livewire\Form;
 use Livewire\Livewire;
 use Tests\TestComponent;
@@ -266,6 +268,22 @@ class UnitTest extends \Tests\TestCase
         })
         ->call('refresh')
         ->assertSetStrict('refreshed', true);
+    }
+
+    public function test_locked_uninitialized_typed_property_does_not_throw_uninitialized_property_error()
+    {
+        $this->expectException(CannotUpdateLockedPropertyException::class);
+
+        Livewire::test(new class extends Component {
+            #[Locked]
+            public \stdClass $group;
+
+            public function render()
+            {
+                return '<div></div>';
+            }
+        })
+            ->set('group', ['foo' => 'bar']);
     }
 }
 


### PR DESCRIPTION
## Summary

Fix an error when updating an uninitialized typed property.

`expandConsolidatedFormObjectUpdates()` uses `property_exists()` before checking whether a property is a `Form`. However, `property_exists()` also returns `true` for uninitialized typed properties. Accessing such a property throws a `Typed property ... must not be accessed before initialization` error.

```php
if (is_array($value) && property_exists($component, $path) && $component->$path instanceof Form) {}
```

## Solution

Use `isset()` to safely check that the property is initialized before evaluating the `Form` check. Same pattern with this PR https://github.com/livewire/livewire/pull/10554

This allows the update to continue through Livewire's normal property update flow, where attributes such as `#[Locked]` can correctly handle the update.

### Tests

* Add a regression test for an uninitialized typed property with `#[Locked]`.
* Verify that the update results in `CannotUpdateLockedPropertyException` instead of an uninitialized typed property error.

Fixes: https://github.com/livewire/livewire/issues/10685
