### PR TITLE
[4.x] Don't read uninitialized typed properties when expanding consolidated form object updates

### DIFF
--- a/src/Features/SupportLockedProperties/UnitTest.php
+++ b/src/Features/SupportLockedProperties/UnitTest.php
@@ -43,6 +43,20 @@ class UnitTest extends \Tests\TestCase
         ->set('foo.count', 2);
     }
 
+    function test_cant_update_uninitialized_typed_locked_property_with_an_array()
+    {
+        $this->expectException(CannotUpdateLockedPropertyException::class);
+        $this->expectExceptionMessage(
+            'Cannot update locked property: [group]'
+        );
+
+        Livewire::test(new class extends TestComponent {
+            #[BaseLocked]
+            public \stdClass $group;
+        })
+        ->set('group', ['count' => 1]);
+    }
+
     function test_can_update_locked_property_with_similar_name()
     {
         Livewire::test(new class extends TestComponent {

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -416,7 +416,7 @@ class HandleComponents extends Mechanism
         $expanded = [];
 
         foreach ($updates as $path => $value) {
-            if (is_array($value) && property_exists($component, $path) && $component->$path instanceof Form) {
+            if (is_array($value) && property_exists($component, $path) && ! Utils::propertyIsTypedAndUninitialized($component, $path) && $component->$path instanceof Form) {
                 foreach ($value as $key => $child) {
                     $expanded["{$path}.{$key}"] = $child;
                 }

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -416,7 +416,11 @@ class HandleComponents extends Mechanism
         $expanded = [];
 
         foreach ($updates as $path => $value) {
-            if (is_array($value) && property_exists($component, $path) && ! Utils::propertyIsTypedAndUninitialized($component, $path) && $component->$path instanceof Form) {
+            if (is_array($value)
+                && property_exists($component, $path)
+                && ! Utils::propertyIsTypedAndUninitialized($component, $path)
+                && $component->$path instanceof Form
+            ) {
                 foreach ($value as $key => $child) {
                     $expanded["{$path}.{$key}"] = $child;
                 }


### PR DESCRIPTION
A component with a typed public property that is never assigned dehydrates as `null`, so the property is still uninitialized on the next request. `expandConsolidatedFormObjectUpdates()` guards its `instanceof Form` read with `property_exists()`, which is true for a declared-but-uninitialized typed property, and the read itself throws.

That happens before `updateProperty()`, so no `update` hooks run and `#[Locked]` never gets a chance to throw. A tampered update on a locked property comes back as a 500 instead of the 419 the lock is meant to produce.

The pre-pass now skips properties that hold no value, using the same `Utils::propertyIsTypedAndUninitialized()` check `FormObjectSynth` already relies on. The update falls through to `updateProperty()` and the lock behaves as expected.

Fixes #10685
