### PR TITLE
[4.x] Quiet-abort malformed call probes with 419

### DIFF
--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -148,7 +148,16 @@ class SupportLazyLoading extends ComponentHook
         // Only applies while a lazy load is being resumed.
         if ($this->storeGet('isLazyLoadHydrating') !== true) return;
 
-        [ $encoded ] = $params;
+        $encoded = $params[0] ?? null;
+
+        // Probes send "|" / non-strings instead of a base64 snapshot. Quiet 419 outside debug.
+        if (! $this->lazyLoadParamLooksValid($encoded)) {
+            if (config('app.debug')) {
+                throw new CorruptComponentPayloadException;
+            }
+
+            abort(419);
+        }
 
         $mountParams = $this->resurrectMountParams($encoded);
 
@@ -229,7 +238,7 @@ class SupportLazyLoading extends ComponentHook
     // Rebuild the captured mount params from the container snapshot.
     function resurrectMountParams($encoded)
     {
-        $snapshot = json_decode(base64_decode($encoded), associative: true);
+        $snapshot = json_decode(base64_decode($encoded, strict: true), associative: true);
 
         $this->registerContainerComponent();
 
@@ -249,6 +258,21 @@ class SupportLazyLoading extends ComponentHook
         $hook->setComponent($this->component);
 
         $hook->mount($params);
+    }
+
+    protected function lazyLoadParamLooksValid(mixed $encoded): bool
+    {
+        if (! is_string($encoded) || $encoded === '') {
+            return false;
+        }
+
+        $decoded = base64_decode($encoded, strict: true);
+
+        if ($decoded === false) {
+            return false;
+        }
+
+        return is_array(json_decode($decoded, associative: true));
     }
 
     // A throwaway component used to carry mount params across the round-trip.

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -532,11 +532,25 @@ class HandleComponents extends Mechanism
         }
 
         $returns = [];
+
+        // Validate method names before any call bookkeeping — probes send "|", null, arrays, etc.
+        foreach ($calls as $call) {
+            $method = $call['method'] ?? null;
+
+            if (! $this->isValidComponentMethodName($method)) {
+                if (config('app.debug')) {
+                    throw new MethodNotFoundException(is_string($method) ? $method : get_debug_type($method));
+                }
+
+                abort(419);
+            }
+        }
+
         $shouldSkipRender = $this->shouldSkipRenderAfterCalls($root, $calls);
 
         foreach ($calls as $idx => $call) {
             $method = $call['method'];
-            $params = $call['params'];
+            $params = $call['params'] ?? [];
             $metadata = $call['metadata'] ?? [];
 
             $earlyReturnCalled = false;
@@ -596,6 +610,13 @@ class HandleComponents extends Mechanism
         }
 
         $componentContext->addEffect('returns', $returns);
+    }
+
+    protected function isValidComponentMethodName(mixed $method): bool
+    {
+        // PHP method name: letter/underscore/high-byte, then those plus digits.
+        return is_string($method)
+            && preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $method) === 1;
     }
 
     protected function shouldSkipRenderAfterCalls($root, $calls)

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -614,9 +614,10 @@ class HandleComponents extends Mechanism
 
     protected function isValidComponentMethodName(mixed $method): bool
     {
-        // PHP method name: letter/underscore/high-byte, then those plus digits.
+        // PHP method name, or Livewire magic actions like "$refresh" / "$set" / "$commit".
+        // Rejects probe junk like "|".
         return is_string($method)
-            && preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $method) === 1;
+            && preg_match('/^\$?[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $method) === 1;
     }
 
     protected function shouldSkipRenderAfterCalls($root, $calls)

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -239,6 +239,33 @@ class UnitTest extends TestCase
         })->call('missingAction');
     }
 
+    public function test_magic_dollar_call_methods_are_still_allowed(): void
+    {
+        config()->set('app.debug', false);
+
+        $testable = Livewire::test(new class extends TestComponent {
+            public $name = 'foo';
+
+            public function render()
+            {
+                return '<div>{{ $name }}</div>';
+            }
+        });
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                [
+                    'snapshot' => json_encode($testable->snapshot),
+                    'updates' => [],
+                    'calls' => [
+                        ['method' => '$refresh', 'params' => [], 'metadata' => []],
+                    ],
+                ],
+            ]]);
+
+        $response->assertOk();
+    }
+
     public function test_tampered_property_type_is_not_reported(): void
     {
         config()->set('app.debug', false);

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -171,6 +171,74 @@ class UnitTest extends TestCase
         $response->assertStatus(419);
     }
 
+    public function test_invalid_call_method_name_returns_419(): void
+    {
+        config()->set('app.debug', false);
+
+        $testable = Livewire::test(new class extends TestComponent {
+            public function render()
+            {
+                return '<div></div>';
+            }
+        });
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                [
+                    'snapshot' => json_encode($testable->snapshot),
+                    'updates' => [],
+                    'calls' => [
+                        ['method' => '|', 'params' => [], 'metadata' => []],
+                    ],
+                ],
+            ]]);
+
+        $response->assertStatus(419);
+    }
+
+    public function test_invalid_lazy_load_param_returns_419(): void
+    {
+        config()->set('app.debug', false);
+        \Livewire\Features\SupportLazyLoading\SupportLazyLoading::$disableWhileTesting = false;
+
+        $testable = Livewire::test(new #[\Livewire\Attributes\Lazy] class extends TestComponent {
+            public function placeholder()
+            {
+                return '<div>Loading...</div>';
+            }
+
+            public function render()
+            {
+                return '<div></div>';
+            }
+        });
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                [
+                    'snapshot' => json_encode($testable->snapshot),
+                    'updates' => [],
+                    'calls' => [
+                        ['method' => '__lazyLoad', 'params' => ['|'], 'metadata' => []],
+                    ],
+                ],
+            ]]);
+
+        $response->assertStatus(419);
+    }
+
+    public function test_valid_missing_call_method_still_throws_method_not_found(): void
+    {
+        $this->expectException(\Livewire\Exceptions\MethodNotFoundException::class);
+
+        Livewire::test(new class extends TestComponent {
+            public function render()
+            {
+                return '<div></div>';
+            }
+        })->call('missingAction');
+    }
+
     public function test_tampered_property_type_is_not_reported(): void
     {
         config()->set('app.debug', false);


### PR DESCRIPTION
## Summary

Malformed `components[].calls` from scanners currently produce reportable 500s:

- `method: "|"` (or other non-PHP-identifiers) → `MethodNotFoundException`
- `__lazyLoad` with params like `["|"]` instead of a base64 JSON snapshot → checksum / offset `ErrorException`

Livewire already quiet-`abort(419)`s scanner-injected **property** `TypeError`s outside debug. This applies the same posture to **calls**.

Valid PHP method names that simply do not exist on the component (e.g. `missingAction`) still throw `MethodNotFoundException`.

Fixes #10688

## Changes

- `HandleComponents::callMethods()`: reject non-string / non-identifier method names with `abort(419)` (rethrow as `MethodNotFoundException` when `app.debug`)
- `SupportLazyLoading`: validate `__lazyLoad` params[0] is a base64 JSON array snapshot before `resurrectMountParams()`; otherwise `abort(419)` (or `CorruptComponentPayloadException` in debug)
- Use strict `base64_decode` when resurrecting mount params

## Test plan

- [x] `vendor/bin/phpunit --testsuite Unit src/Mechanisms/HandleRequests/UnitTest.php`
- [x] `vendor/bin/phpunit --testsuite Unit src/Features/SupportLazyLoading/UnitTest.php`
- [ ] Confirm `|` method / bad `__lazyLoad` probes return 419 outside debug and are not reported