### PR TITLE
[4.x] Only report missing component methods in debug mode

### DIFF
--- a/src/Exceptions/MethodNotFoundException.php
+++ b/src/Exceptions/MethodNotFoundException.php
@@ -12,4 +12,18 @@ class MethodNotFoundException extends \Exception
             "Unable to call component method. Public method [{$method}] not found on component"
         );
     }
+
+    public function report(): bool
+    {
+        return ! config('app.debug');
+    }
+
+    // In debug mode, let Laravel render the full error page.
+    // In production, return a generic 419 to avoid leaking details.
+    public function render($request)
+    {
+        if (config('app.debug')) return false;
+
+        return response('', 419);
+    }
 }

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -6,8 +6,10 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Stringable;
 use Livewire\Component;
+use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Form;
 use Livewire\Livewire;
+use Livewire\Mechanisms\HandleRequests\EndpointResolver;
 use Tests\TestComponent;
 
 class UnitTest extends \Tests\TestCase
@@ -266,6 +268,35 @@ class UnitTest extends \Tests\TestCase
         })
         ->call('refresh')
         ->assertSetStrict('refreshed', true);
+    }
+
+    public function test_invalid_call_method_name_returns_419_on_production()
+    {
+        config()->set('app.debug', false);
+
+        $component = Livewire::test(TestComponent::class);
+
+        $response = $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [
+                [
+                    'snapshot' => json_encode($component->snapshot),
+                    'updates' => [],
+                    'calls' => [
+                        ['method' => '|', 'params' => [], 'metadata' => []],
+                    ],
+                ],
+            ]]);
+
+        $response->assertStatus(419);
+    }
+
+    public function test_invalid_call_method_name_throws_method_not_found_on_debug_mode()
+    {
+        config()->set('app.debug', true);
+
+        $this->expectException(MethodNotFoundException::class);
+
+        Livewire::test(TestComponent::class)->call('missingAction');
     }
 }
 

--- a/src/Mechanisms/HandleComponents/UnitTest.php
+++ b/src/Mechanisms/HandleComponents/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Mechanisms\HandleComponents;
 
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Stringable;
@@ -270,7 +271,7 @@ class UnitTest extends \Tests\TestCase
         ->assertSetStrict('refreshed', true);
     }
 
-    public function test_invalid_call_method_name_returns_419_on_production()
+    public function test_invalid_call_method_name_returns_419_when_debug_is_disabled()
     {
         config()->set('app.debug', false);
 
@@ -290,13 +291,47 @@ class UnitTest extends \Tests\TestCase
         $response->assertStatus(419);
     }
 
-    public function test_invalid_call_method_name_throws_method_not_found_on_debug_mode()
+    public function test_method_not_found_exception_is_not_reported_when_debug_is_disabled()
+    {
+        config()->set('app.debug', false);
+
+        $reported = [];
+        app(ExceptionHandler::class)
+            ->reportable(function (MethodNotFoundException $e) use (&$reported) {
+                $reported[] = $e;
+
+                return false;
+            });
+
+        app(ExceptionHandler::class)->report(new MethodNotFoundException('invalidAction'));
+
+        $this->assertEmpty($reported);
+    }
+
+    public function test_invalid_call_method_name_throws_method_not_found_when_debug_is_enabled()
     {
         config()->set('app.debug', true);
 
         $this->expectException(MethodNotFoundException::class);
 
         Livewire::test(TestComponent::class)->call('missingAction');
+    }
+
+    public function test_method_not_found_exception_is_reported_when_debug_is_enabled()
+    {
+        config()->set('app.debug', true);
+
+        $reported = [];
+        app(ExceptionHandler::class)
+            ->reportable(function (MethodNotFoundException $e) use (&$reported) {
+                $reported[] = $e;
+
+                return false;
+            });
+
+        app(ExceptionHandler::class)->report(new MethodNotFoundException('invalidAction'));
+
+        $this->assertCount(1, $reported);
     }
 }
 


### PR DESCRIPTION
> [!NOTE]
> This is an alternative from https://github.com/livewire/livewire/pull/10689 but from exception handler. Also This PR doesnt take lazy component path.

## Summary

This PR prevents Livewire from reporting errors caused by requests for component methods that do not exist when the application is not running in debug mode.

Previously, when Livewire received a request targeting a missing component method—such as a scanner, bot, probe, or other automated request attempting to invoke arbitrary methods—the resulting exception could be reported even though it was caused by an invalid external request rather than an application error.

This can generate unnecessary noise in production error reporting and monitoring services.

This change limits reporting of these "method not found" errors to debug mode. In production, the invalid request continues to be handled appropriately, but the exception is no longer reported as an application error.

## Trade-off

This mirrors `CorruptComponentPayloadException`: in production, **all** `MethodNotFoundException`s become a quiet 419 and are not reported—not only scanner tokens like `"|"`.

**Upside**
- Stops scanner/fuzz noise (`method: "|"`, etc.) from filling error trackers as 500s
- Avoids leaking method names in production responses
- Same posture as other Livewire “invalid payload” paths

**Downside**
- Legitimate missing methods in production (typos, renames, stale tabs calling old actions) also become generic 419s with no tracker event
- Harder to diagnose production-only “action not found” issues; they look like session/page-expired rather than a missing method

**Mitigation**
- Debug (`app.debug = true`) still throws the full `MethodNotFoundException` with the method name
- Missing actions remain obvious during local/staging development

If we later need production visibility for real missing methods without reintroducing scanner noise, we can narrow quieting to implausible method tokens only (e.g. non-PHP-identifiers) and keep reportable 500s for names like `missingAction`.

Possibility fixes: https://github.com/livewire/livewire/issues/10688
