### PR TITLE
Fix fragment scrolling after wire:navigate

### DIFF
--- a/js/plugins/navigate/scroll.js
+++ b/js/plugins/navigate/scroll.js
@@ -26,9 +26,34 @@ export function restoreScrollPositionOrScrollToTop() {
 
     queueMicrotask(() => {
         queueMicrotask(() => { // Double microtask here to make sure scrolling restoration is the LAST thing to happen. (Even after Alpine's x-init functions)...
+            let shouldScrollToFragment = ! document.body.hasAttribute('data-scroll-x')
+
             scroll(document.body)
 
             document.querySelectorAll(['[x-navigate\\:scroll]', '[wire\\:navigate\\:scroll]']).forEach(scroll)
+
+            if (shouldScrollToFragment) {
+                getFragmentTarget()?.scrollIntoView({ behavior: 'instant' })
+            }
         })
     })
+}
+
+function getFragmentTarget() {
+    let fragment = window.location.hash.substring(1)
+
+    if (! fragment) return
+
+    let target = document.getElementById(fragment)
+
+    if (target) return target
+
+    try {
+        fragment = decodeURIComponent(fragment)
+    } catch (e) {
+        // A malformed escape sequence can still be a valid element ID or name.
+    }
+
+    return document.getElementById(fragment)
+        || Array.from(document.getElementsByName(fragment)).find(el => el.tagName === 'A')
 }

--- a/src/Features/SupportNavigate/BrowserTest.php
+++ b/src/Features/SupportNavigate/BrowserTest.php
@@ -843,6 +843,60 @@ class BrowserTest extends \Tests\BrowserTestCase
         });
     }
 
+    public function test_navigate_scrolls_to_fragment_targets()
+    {
+        $this->browse(function ($browser) {
+            foreach (['comments', 'comments%3Areplies', '100%', 'legacy-comments'] as $index => $fragment) {
+                $browser
+                    ->visit('/first-scroll')
+                    ->waitForNavigate()->click('@link.to.fragment.'.$index)
+                    ->assertFragmentIs($fragment)
+                    ->assertInViewPort('@second-target');
+            }
+        });
+    }
+
+    public function test_navigate_with_an_unknown_fragment_scrolls_to_top()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first-scroll')
+                ->waitForNavigate()->click('@link.to.fragment.4')
+                ->assertFragmentIs('missing')
+                ->assertScript('window.scrollY', 0);
+        });
+    }
+
+    public function test_navigate_fragment_does_not_override_history_scroll_restoration()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first-scroll')
+                ->waitForNavigate()->click('@link.to.fragment.0')
+                ->assertInViewPort('@second-target');
+
+            $browser->script('window.scrollTo(0, 0)');
+
+            $browser
+                ->assertScript('window.scrollY', 0)
+                ->waitForNavigate()->back()
+                ->waitForNavigate()->forward()
+                ->assertFragmentIs('comments')
+                ->assertScript('window.scrollY', 0);
+        });
+    }
+
+    public function test_navigate_fragment_respects_preserve_scroll()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/first-scroll')
+                ->waitForNavigate()->click('@link.to.fragment.with.preserve.scroll')
+                ->assertFragmentIs('comments')
+                ->assertScript('window.scrollY', 0);
+        });
+    }
+
     public function test_navigate_scrolls_to_top_and_back_preserves_scroll()
     {
         $this->browse(function ($browser) {
@@ -2221,6 +2275,14 @@ class FirstScrollPage extends Component
         <div>
             <div>On first</div>
 
+            <div style="position: fixed; top: 0; right: 0;">
+                <a href="/second-scroll#comments" wire:navigate.preserve-scroll dusk="link.to.fragment.with.preserve.scroll">Preserve scroll</a>
+
+                @foreach (['comments', 'comments%3Areplies', '100%', 'legacy-comments', 'missing'] as $fragment)
+                    <a href="/second-scroll#{{ $fragment }}" wire:navigate dusk="link.to.fragment.{{ $loop->index }}">Go to fragment</a>
+                @endforeach
+            </div>
+
             <div style="height: 100vh;">spacer</div>
 
             <div dusk="first-target">below the fold</div>
@@ -2332,7 +2394,12 @@ class SecondScrollPage extends Component
 
             <div style="height: 100vh;">spacer</div>
 
-            <div dusk="second-target">below the fold</div>
+            <div id="comments" dusk="second-target">
+                <span id="comments:replies">Replies</span>
+                <span id="100%">Percentage</span>
+                <a name="legacy-comments">Legacy comments</a>
+                below the fold
+            </div>
 
             <div style="height: 100vh;">spacer</div>
         </div>


### PR DESCRIPTION
Navigating with `<a href="/posts#comments" wire:navigate>` updates the URL and replaces the page, but leaves the fragment target below the viewport. This change scrolls the target into view after the existing scroll restoration completes.

Fragment lookup supports element IDs, percent-encoded IDs, literal percent signs, and legacy named anchors. Missing targets retain the existing scroll-to-top behavior. Cached Back/Forward positions and explicit `preserve-scroll` continue to take precedence.

Validation:
- Confirmed the new browser regression fails against unmodified `4.x` and passes with the fix.
- Nine focused Dusk browser tests pass with 45 assertions, covering fragment scrolling, missing targets, history restoration, and existing link/programmatic scroll preservation. PHPUnit reports two deprecations.
- Rebuilt JavaScript assets for browser verification; generated bundles are excluded from the commit.

This branch contains only the fragment-scrolling fix and browser coverage. No separate discussion was created.
