### PR TITLE
Avoid fetching and swapping for same-page fragment navigation

### DIFF
--- a/js/plugins/navigate/history.js
+++ b/js/plugins/navigate/history.js
@@ -9,6 +9,7 @@ class Snapshot {
 
 let snapshotCache = {
     currentKey: null,
+    currentDocumentId: Math.random(),
     currentUrl: null,
     keys: [],
     lookup: {},
@@ -81,7 +82,8 @@ export function updateCurrentPageHtmlInSnapshotCacheForLaterBackButtonClicks(key
 
 export function whenTheBackOrForwardButtonIsClicked(
     registerFallback,
-    handleHtml
+    handleHtml,
+    handleFragment
 ) {
     let fallback
 
@@ -103,6 +105,19 @@ export function whenTheBackOrForwardButtonIsClicked(
 
         if (! alpine.snapshotIdx) return
 
+        // Fragment entries belong to the same live page. Let the browser restore
+        // their scroll position without reconstructing the page from a snapshot.
+        if (alpine.documentId && alpine.documentId === snapshotCache.currentDocumentId) {
+            let snapshot = snapshotCache.has(alpine.snapshotIdx) && snapshotCache.retrieve(alpine.snapshotIdx)
+
+            handleFragment(new URL(window.location.href), snapshot?.html, snapshotCache.currentUrl, snapshotCache.currentKey)
+
+            snapshotCache.currentKey = alpine.snapshotIdx
+            snapshotCache.currentUrl = new URL(window.location.href)
+
+            return
+        }
+
         if (snapshotCache.has(alpine.snapshotIdx)) {
             let snapshot = snapshotCache.retrieve(alpine.snapshotIdx)
 
@@ -110,9 +125,11 @@ export function whenTheBackOrForwardButtonIsClicked(
 
             snapshotCache.currentKey = alpine.snapshotIdx
             snapshotCache.currentUrl = snapshot.url
+            snapshotCache.currentDocumentId = alpine.documentId ?? Math.random()
         } else {
             snapshotCache.currentKey = null
             snapshotCache.currentUrl = null
+            snapshotCache.currentDocumentId = alpine.documentId ?? Math.random()
 
             fallback(alpine.url)
         }
@@ -126,15 +143,17 @@ export function updateUrlAndStoreLatestHtmlForFutureBackButtons(
     pushUrl(destination, html)
 }
 
-export function pushUrl(url, html) {
-    updateUrl('pushState', url, html)
+export function pushUrl(url, html, { sameDocument = false } = {}) {
+    updateUrl('pushState', url, html, { sameDocument })
 }
 
 export function replaceUrl(url, html) {
     updateUrl('replaceState', url, html)
 }
 
-function updateUrl(method, url, html) {
+function updateUrl(method, url, html, { sameDocument = false } = {}) {
+    if (method === 'pushState' && ! sameDocument) snapshotCache.currentDocumentId = Math.random()
+
     let key = url.toString() + '-' + Math.random()
 
     method === 'pushState'
@@ -150,7 +169,7 @@ function updateUrl(method, url, html) {
         }
     })
 
-    historyCoordinator[method](url, { snapshotIdx: key, url: url.toString() })
+    historyCoordinator[method](url, { snapshotIdx: key, url: url.toString(), documentId: snapshotCache.currentDocumentId })
 
     snapshotCache.currentKey = key
     snapshotCache.currentUrl = url

--- a/js/plugins/navigate/index.js
+++ b/js/plugins/navigate/index.js
@@ -1,6 +1,6 @@
-import { replaceUrl, updateCurrentPageHtmlInHistoryStateForLaterBackButtonClicks, updateCurrentPageHtmlInSnapshotCacheForLaterBackButtonClicks, updateUrlAndStoreLatestHtmlForFutureBackButtons, whenTheBackOrForwardButtonIsClicked } from "./history"
+import { pushUrl, replaceUrl, updateCurrentPageHtmlInHistoryStateForLaterBackButtonClicks, updateCurrentPageHtmlInSnapshotCacheForLaterBackButtonClicks, updateUrlAndStoreLatestHtmlForFutureBackButtons, whenTheBackOrForwardButtonIsClicked } from "./history"
 import { getPretchedHtmlOr, prefetchHtml, storeThePrefetchedHtmlForWhenALinkIsClicked } from "./prefetch"
-import { createUrlObjectFromString, extractDestinationFromLink, isSameOrigin, linkShouldBeHandledNatively, visitNatively, whenThisLinkIsHoveredFor, whenThisLinkIsPressed } from "./links"
+import { createUrlObjectFromString, extractDestinationFromLink, isSameOrigin, isSamePageFragment, linkShouldBeHandledNatively, visitNatively, whenThisLinkIsHoveredFor, whenThisLinkIsPressed } from "./links"
 import { isTeleportTarget, packUpPersistedTeleports, removeAnyLeftOverStaleTeleportTargets, unPackPersistedTeleports } from "./teleport"
 import { restoreScrollPositionOrScrollToTop, storeScrollInformationInHtmlBeforeNavigatingAway } from "./scroll"
 import { isPersistedElement, putPersistantElementsBack, storePersistantElementsForLater } from "./persist"
@@ -50,7 +50,7 @@ export default function (Alpine) {
         shouldPrefetchOnHover && whenThisLinkIsHoveredFor(el, 60, () => {
             let destination = extractDestinationFromLink(el)
 
-            if (linkShouldBeHandledNatively(el, destination)) return
+            if (linkShouldBeHandledNatively(el, destination) || isSamePageFragment(destination)) return
 
             prefetchHtml(destination, (html, finalDestination) => {
                 storeThePrefetchedHtmlForWhenALinkIsClicked(html, destination, finalDestination)
@@ -62,7 +62,7 @@ export default function (Alpine) {
         whenThisLinkIsPressed(el, (whenItIsReleased) => {
             let destination = extractDestinationFromLink(el)
 
-            prefetchHtml(destination, (html, finalDestination) => {
+            if (! isSamePageFragment(destination)) prefetchHtml(destination, (html, finalDestination) => {
                 storeThePrefetchedHtmlForWhenALinkIsClicked(html, destination, finalDestination)
             }, () => {
                 showProgressBar && finishAndHideProgressBar()
@@ -82,6 +82,24 @@ export default function (Alpine) {
 
     function navigateTo(destination, { preserveScroll = false, shouldPushToHistoryState = true }) {
         let navigation = startNavigation()
+
+        if (shouldPushToHistoryState && isSamePageFragment(destination)) {
+            navigation.ready()
+
+            storeScrollInformationInHtmlBeforeNavigatingAway()
+            updateCurrentPageHtmlInHistoryStateForLaterBackButtonClicks()
+
+            if (destination.href !== window.location.href) {
+                pushUrl(destination, document.documentElement.outerHTML, { sameDocument: true })
+            }
+
+            restoreScrollPositionOrScrollToTop({ scrollToFragment: ! preserveScroll })
+
+            fireEventForOtherLibrariesToHookInto('alpine:navigated')
+            navigation.finish()
+
+            return
+        }
 
         showProgressBar && showAndStartProgressBar()
 
@@ -250,6 +268,19 @@ export default function (Alpine) {
                     })
                 })
             })
+        },
+        (destination, snapshotHtml, currentPageUrl, currentPageKey) => {
+            let prevented = fireEventForOtherLibrariesToHookInto('alpine:navigate', {
+                url: destination, history: true, cached: true,
+            })
+
+            if (prevented) return
+
+            storeScrollInformationInHtmlBeforeNavigatingAway()
+            updateCurrentPageHtmlInSnapshotCacheForLaterBackButtonClicks(currentPageKey, currentPageUrl)
+            restoreScrollPositionOrScrollToTop({ snapshotHtml })
+
+            fireEventForOtherLibrariesToHookInto('alpine:navigated')
         },
     )
 

--- a/js/plugins/navigate/links.js
+++ b/js/plugins/navigate/links.js
@@ -87,6 +87,13 @@ export function isSameOrigin(destination) {
     return !! destination && destination.origin === window.location.origin
 }
 
+export function isSamePageFragment(destination) {
+    return isSameOrigin(destination)
+        && destination.pathname === window.location.pathname
+        && destination.search === window.location.search
+        && destination.href.includes('#')
+}
+
 export function visitNatively(destination) {
     window.location.href = destination.href
 }

--- a/js/plugins/navigate/scroll.js
+++ b/js/plugins/navigate/scroll.js
@@ -4,19 +4,30 @@ export function storeScrollInformationInHtmlBeforeNavigatingAway() {
     document.body.setAttribute('data-scroll-y', document.body.scrollTop)
 
     document.querySelectorAll(['[x-navigate\\:scroll]', '[wire\\:navigate\\:scroll]']).forEach(el => {
+        // Match saved scroll positions to live containers during fragment history visits.
+        if (! el.hasAttribute('data-scroll-id')) el.setAttribute('data-scroll-id', Math.random())
+
         el.setAttribute('data-scroll-x', el.scrollLeft)
         el.setAttribute('data-scroll-y', el.scrollTop)
     })
 }
 
-export function restoreScrollPositionOrScrollToTop() {
+export function restoreScrollPositionOrScrollToTop({ scrollToFragment = false, snapshotHtml = null } = {}) {
+    let savedElements = snapshotHtml
+        ? new DOMParser().parseFromString(snapshotHtml, 'text/html').querySelectorAll('[data-scroll-id]')
+        : []
+
+    let savedScroll = new Map(Array.from(savedElements, el => [el.getAttribute('data-scroll-id'), el]))
+
     let scroll = el => {
-        if (! el.hasAttribute('data-scroll-x')) {
+        let source = savedScroll.get(el.getAttribute('data-scroll-id')) || el
+
+        if (! source.hasAttribute('data-scroll-x')) {
             window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
         } else {
             el.scrollTo({
-                top: Number(el.getAttribute('data-scroll-y')),
-                left: Number(el.getAttribute('data-scroll-x')),
+                top: Number(source.getAttribute('data-scroll-y')),
+                left: Number(source.getAttribute('data-scroll-x')),
                 behavior: 'instant',
             })
             el.removeAttribute('data-scroll-x')
@@ -32,7 +43,9 @@ export function restoreScrollPositionOrScrollToTop() {
 
             document.querySelectorAll(['[x-navigate\\:scroll]', '[wire\\:navigate\\:scroll]']).forEach(scroll)
 
-            if (shouldScrollToFragment) {
+            if (scrollToFragment && ! window.location.hash) {
+                window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
+            } else if (shouldScrollToFragment || scrollToFragment) {
                 getFragmentTarget()?.scrollIntoView({ behavior: 'instant' })
             }
         })

--- a/src/Features/SupportNavigate/FragmentBrowserTest.php
+++ b/src/Features/SupportNavigate/FragmentBrowserTest.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace Livewire\Features\SupportNavigate;
+
+use Illuminate\Support\Facades\Route;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class FragmentBrowserTest extends \Tests\BrowserTestCase
+{
+    public static function tweakApplicationHook()
+    {
+        return function () {
+            Livewire::component('fragment-page', FragmentPage::class);
+            Route::get('/fragment', FragmentPage::class)->middleware('web');
+            Route::get('/fragment-other', FragmentPage::class)->middleware('web');
+        };
+    }
+
+    public function test_same_page_fragment_links_do_not_fetch_or_swap_the_page()
+    {
+        $this->browse(function ($browser) {
+            $browser->visit('/fragment')->click('@increment')->type('@draft', 'Unsaved draft');
+            $browser->script('window.fragmentRequests = 0; Livewire.hook("navigate.request", () => window.fragmentRequests++)');
+
+            $browser
+                ->waitForNoNavigatePrefetchRequest()->mouseover('@comments')
+                ->waitForNavigate()->click('@comments')
+                ->assertFragmentIs('comments')
+                ->assertInViewPort('@comments-target')
+                ->assertSeeIn('@count', '1')
+                ->assertInputValue('@draft', 'Unsaved draft')
+                ->assertScript('window.fragmentRequests', 0)
+                ->assertConsoleLogHasNoErrors();
+        });
+    }
+
+    public function test_fragment_history_keeps_the_live_page_and_restores_scroll()
+    {
+        $this->browse(function ($browser) {
+            $browser->visit('/fragment')->click('@increment');
+            $browser->script('window.fragmentRequests = 0; Livewire.hook("navigate.request", () => window.fragmentRequests++)');
+
+            $browser
+                ->waitForNavigate()->click('@comments')
+                ->assertInViewPort('@comments-target')
+                ->waitForNavigate()->click('@replies')
+                ->assertInViewPort('@replies-target')
+                ->waitForNavigate()->back()
+                ->assertFragmentIs('comments')
+                ->assertInViewPort('@comments-target')
+                ->assertSeeIn('@count', '1')
+                ->waitForNavigate()->back()
+                ->assertFragmentIs('')
+                ->assertScript('window.scrollY', 0)
+                ->assertSeeIn('@count', '1')
+                ->waitForNavigate()->forward()
+                ->assertFragmentIs('comments')
+                ->assertInViewPort('@comments-target')
+                ->assertSeeIn('@count', '1')
+                ->assertScript('window.fragmentRequests', 0);
+        });
+    }
+
+    public function test_fragment_history_works_after_visiting_another_page()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/fragment')
+                ->waitForNavigate()->click('@comments')
+                ->waitForNavigate()->click('@other')
+                ->assertPathIs('/fragment-other')
+                ->waitForNavigate()->back()
+                ->assertPathIs('/fragment')
+                ->assertFragmentIs('comments')
+                ->assertInViewPort('@comments-target')
+                ->click('@increment')
+                ->waitForNavigate()->back()
+                ->assertFragmentIs('')
+                ->assertSeeIn('@count', '1')
+                ->waitForNavigate()->forward()
+                ->assertFragmentIs('comments')
+                ->assertSeeIn('@count', '1')
+                ->waitForNavigate()->forward()
+                ->assertPathIs('/fragment-other');
+        });
+    }
+
+    public function test_programmatic_fragment_navigation_and_preserve_scroll()
+    {
+        $this->browse(function ($browser) {
+            $browser->visit('/fragment')->click('@increment');
+            $browser->script('window.fragmentRequests = 0; Livewire.hook("navigate.request", () => window.fragmentRequests++)');
+
+            $browser
+                ->waitForNavigate()->click('@preserve')
+                ->assertFragmentIs('comments')
+                ->assertScript('window.scrollY', 0)
+                ->waitForNavigate()->click('@programmatic-preserve')
+                ->assertFragmentIs('replies')
+                ->assertScript('window.scrollY', 0)
+                ->waitForNavigate()->click('@programmatic')
+                ->assertFragmentIs('replies')
+                ->assertInViewPort('@replies-target')
+                ->assertSeeIn('@count', '1')
+                ->assertScript('window.fragmentRequests', 0);
+        });
+    }
+
+    public function test_fragment_links_support_keyboard_activation_and_repeated_clicks()
+    {
+        $this->browse(function ($browser) {
+            $browser->visit('/fragment')->click('@increment');
+            $browser->script('window.fragmentRequests = 0; window.fragmentHistoryLength = history.length; Livewire.hook("navigate.request", () => window.fragmentRequests++)');
+
+            $browser
+                ->waitForNavigate()->keys('@comments', '{enter}')
+                ->assertFragmentIs('comments')
+                ->assertInViewPort('@comments-target');
+
+            $browser->script('window.scrollTo(0, 0)');
+
+            $browser
+                ->waitForNavigate()->click('@comments')
+                ->assertInViewPort('@comments-target')
+                ->assertScript('history.length === window.fragmentHistoryLength + 1', true)
+                ->assertSeeIn('@count', '1')
+                ->assertScript('window.fragmentRequests', 0);
+        });
+    }
+
+    public function test_empty_fragments_scroll_to_top_without_swapping()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/fragment')
+                ->click('@increment')
+                ->waitForNavigate()->click('@comments')
+                ->assertInViewPort('@comments-target')
+                ->waitForNavigate()->click('@top')
+                ->assertScript('window.scrollY', 0)
+                ->assertSeeIn('@count', '1');
+        });
+    }
+
+    public function test_fragment_navigation_is_cancellable_and_does_not_fire_swap_events()
+    {
+        $this->browse(function ($browser) {
+            $browser->visit('/fragment');
+            $browser->script(<<<'JS'
+                window.fragmentRequests = 0;
+                window.fragmentSwaps = 0;
+                Livewire.hook('navigate.request', () => window.fragmentRequests++);
+                document.addEventListener('livewire:navigating', () => window.fragmentSwaps++);
+                document.addEventListener('livewire:navigate', event => event.preventDefault(), { once: true });
+            JS);
+
+            $browser
+                ->click('@comments')
+                ->assertFragmentIs('')
+                ->assertScript('window.scrollY', 0)
+                ->waitForNavigate()->click('@comments')
+                ->assertFragmentIs('comments')
+                ->assertInViewPort('@comments-target')
+                ->assertScript('window.fragmentRequests', 0)
+                ->assertScript('window.fragmentSwaps', 0);
+        });
+    }
+
+    public function test_fragment_history_restores_marked_scroll_containers()
+    {
+        $this->browse(function ($browser) {
+            $browser->visit('/fragment');
+            $browser->script('document.getElementById("pane").scrollTop = 100');
+
+            $browser->waitForNavigate()->click('@comments');
+            $browser->script('document.getElementById("pane").scrollTop = 200');
+
+            $browser
+                ->waitForNavigate()->back()
+                ->assertScript('document.getElementById("pane").scrollTop', 100)
+                ->waitForNavigate()->forward()
+                ->assertScript('document.getElementById("pane").scrollTop', 200);
+        });
+    }
+
+    public function test_fragment_history_works_after_a_browser_refresh()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/fragment')
+                ->waitForNavigate()->click('@comments')
+                ->waitForNavigate()->click('@replies')
+                ->refresh()
+                ->waitForNavigate()->back()
+                ->assertFragmentIs('comments')
+                ->assertInViewPort('@comments-target')
+                ->click('@increment')
+                ->waitForNavigate()->back()
+                ->assertFragmentIs('')
+                ->assertSeeIn('@count', '1');
+        });
+    }
+
+    public function test_visiting_the_same_url_without_a_fragment_still_swaps_the_page()
+    {
+        $this->browse(function ($browser) {
+            $browser
+                ->visit('/fragment')
+                ->click('@increment')
+                ->waitForNavigate()->click('@reload')
+                ->assertSeeIn('@count', '0')
+                ->click('@increment')
+                ->click('@increment')
+                ->waitForNavigate()->back()
+                ->assertSeeIn('@count', '0');
+        });
+    }
+
+    public function test_a_query_string_change_still_fetches_and_swaps_the_page()
+    {
+        $this->browse(function ($browser) {
+            $browser->visit('/fragment')->click('@increment');
+            $browser->script('window.fragmentRequests = 0; Livewire.hook("navigate.request", () => window.fragmentRequests++)');
+
+            $browser
+                ->waitForNavigate()->click('@query')
+                ->assertQueryStringHas('page', '2')
+                ->assertFragmentIs('comments')
+                ->assertInViewPort('@comments-target')
+                ->assertSeeIn('@count', '0')
+                ->assertScript('window.fragmentRequests', 1);
+        });
+    }
+}
+
+class FragmentPage extends Component
+{
+    public function render()
+    {
+        return <<<'HTML'
+        <div x-data="{ count: 0 }">
+            <nav style="position: fixed; top: 0; right: 0;">
+                <button x-on:click="count++" dusk="increment">Increment</button>
+                <span x-text="count" dusk="count"></span>
+                <input dusk="draft">
+                <a href="#comments" wire:navigate.hover dusk="comments">Comments</a>
+                <a href="#" wire:navigate dusk="top">Top</a>
+                <a href="/fragment#replies" wire:navigate dusk="replies">Replies</a>
+                <a href="#comments" wire:navigate.preserve-scroll dusk="preserve">Preserve scroll</a>
+                <button x-on:click="Livewire.navigate('/fragment#replies', { preserveScroll: true })" dusk="programmatic-preserve">Programmatic preserve scroll</button>
+                <button x-on:click="Livewire.navigate('/fragment#replies')" dusk="programmatic">Programmatic</button>
+                <a href="/fragment?page=2#comments" wire:navigate dusk="query">Page two</a>
+                <a href="/fragment" wire:navigate dusk="reload">Reload</a>
+                <a href="/fragment-other" wire:navigate dusk="other">Other page</a>
+            </nav>
+            <div id="pane" wire:navigate:scroll style="position: fixed; left: 0; bottom: 0; height: 50px; width: 100px; overflow: auto;">
+                <div style="height: 500px;">Scrollable pane</div>
+            </div>
+            <div style="height: 200vh;"></div>
+            <div id="comments" dusk="comments-target">Comments</div>
+            <div style="height: 200vh;"></div>
+            <div id="replies" dusk="replies-target">Replies</div>
+            <div style="height: 200vh;"></div>
+        </div>
+        HTML;
+    }
+}


### PR DESCRIPTION
Clicking a `wire:navigate` link from `/posts` to `/posts#comments` currently fetches and replaces the page, resetting component state and unsaved input. Same-page fragment visits now update history and scroll while keeping the existing page alive. Hover and press prefetching are skipped too.

This is a follow-up to #10692 and is based on its branch so the diff contains only the same-page behavior. Merge #10692 first, then retarget this PR to `4.x`.

The shortcut requires the same origin, path, and query string. Different pages and query strings still use ordinary navigation. Clicking the same fragment again scrolls without adding another history entry; an empty fragment scrolls to the top. Both link and programmatic `preserveScroll` are respected.

Fragment history entries share a document ID, allowing Back/Forward to preserve live components while the browser restores viewport scrolling. Marked `wire:navigate:scroll` containers restore their saved positions without replacing their DOM. Cross-page history still uses the existing snapshot/fetch path.

Same-page visits retain the cancellable `livewire:navigate` and completion `livewire:navigated` events. They do not emit the page-swap event `livewire:navigating`.

Validation:
- Reproduced unwanted hover prefetching before the fix with a failing browser regression.
- 29 focused Dusk browser tests pass with 260 assertions, including 11 new tests for state/input preservation, hover, keyboard and programmatic navigation, repeated/empty fragments, cancellation, scroll preservation, nested scroll containers, query changes, page refresh, and history across other pages.
- Existing navigation lifecycle, snapshot-cache, refresh, error-page history, and fragment-scroll checks pass. PHPUnit reports two deprecations.
- Rebuilt JavaScript assets for browser verification. Generated bundles are excluded from the commit.
