### PR TITLE
[4.x] Quietly reject malformed requests while preserving application errors

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -385,3 +385,11 @@ This checksum is then used on the next network request to verify that the snapsh
 If Livewire finds a checksum mismatch, it will throw a `CorruptComponentPayloadException` and the request will fail.
 
 This protects against any form of malicious tampering that would otherwise result in granting users the ability to execute or modify unrelated code.
+
+## Malformed requests and error reporting
+
+When `app.debug` is `false`, Livewire rejects malformed snapshot structures, invalid lazy-load encodings, and invalid method-name syntax with a 404 or 419 response without reporting an application exception by default. Debug mode provides descriptive exceptions for these failures.
+
+Errors that may indicate a broken application still use Laravel's normal exception handling. For example, calling a valid-looking but nonexistent method such as `saveOrder` remains reportable. A `TypeError` inside an action, lifecycle hook, or render method produces a normal server error rather than a page-expired response.
+
+These checks validate Livewire's request format. Applications must still validate and authorize action parameters and public property updates.

--- a/src/Features/SupportLazyLoading/SupportLazyLoading.php
+++ b/src/Features/SupportLazyLoading/SupportLazyLoading.php
@@ -148,9 +148,7 @@ class SupportLazyLoading extends ComponentHook
         // Only applies while a lazy load is being resumed.
         if ($this->storeGet('isLazyLoadHydrating') !== true) return;
 
-        [ $encoded ] = $params;
-
-        $mountParams = $this->resurrectMountParams($encoded);
+        $mountParams = $this->resurrectMountParams($params[0] ?? null);
 
         $this->callMountLifecycleMethod($mountParams);
 
@@ -229,7 +227,11 @@ class SupportLazyLoading extends ComponentHook
     // Rebuild the captured mount params from the container snapshot.
     function resurrectMountParams($encoded)
     {
-        $snapshot = json_decode(base64_decode($encoded), associative: true);
+        $decoded = is_string($encoded) ? base64_decode($encoded, strict: true) : false;
+
+        if ($decoded === false) throw new CorruptComponentPayloadException;
+
+        $snapshot = json_decode($decoded, associative: true);
 
         $this->registerContainerComponent();
 

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -16,6 +16,39 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class UnitTest extends \Tests\TestCase
 {
+    public function test_typeerror_in_lazy_mount_is_still_reported()
+    {
+        config()->set('app.debug', false);
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        $component = Livewire::test(new #[Lazy] class extends Component {
+            public function mount() { strlen([]); }
+            public function placeholder() { return '<div>Loading...</div>'; }
+            public function render() { return '<div>Loaded</div>'; }
+        });
+
+        preg_match("/__lazyLoad\('([^']+)'\)/", html_entity_decode($component->html()), $matches);
+
+        $reported = [];
+
+        app(ExceptionHandler::class)->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+
+        $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [[
+                'snapshot' => json_encode($component->snapshot),
+                'updates' => [],
+                'calls' => [['method' => '__lazyLoad', 'params' => [$matches[1]]]],
+            ]]])
+            ->assertStatus(500);
+
+        $this->assertCount(1, $reported);
+        $this->assertInstanceOf(\TypeError::class, $reported[0]);
+    }
+
     #[DataProvider('invalidLazyLoadParams')]
     public function test_invalid_lazy_load_encoding_is_not_reported($params)
     {

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -16,6 +16,56 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class UnitTest extends \Tests\TestCase
 {
+    #[DataProvider('invalidLazyLoadParams')]
+    public function test_invalid_lazy_load_encoding_is_not_reported($params)
+    {
+        config()->set('app.debug', false);
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        $component = Livewire::test(BasicLazyComponent::class);
+        $reported = [];
+
+        app(ExceptionHandler::class)->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+
+        $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [[
+                'snapshot' => json_encode($component->snapshot),
+                'updates' => [],
+                'calls' => [['method' => '__lazyLoad', 'params' => $params]],
+            ]]])
+            ->assertStatus(419);
+
+        $this->assertEmpty($reported);
+    }
+
+    public static function invalidLazyLoadParams()
+    {
+        return [
+            'missing' => [[]],
+            'null' => [[null]],
+            'integer' => [[42]],
+            'array' => [[[]]],
+            'invalid base64' => [['|']],
+        ];
+    }
+
+    public function test_invalid_base64_characters_are_not_discarded_from_a_lazy_snapshot()
+    {
+        config()->set('app.debug', true);
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        $component = Livewire::test(BasicLazyComponent::class);
+        preg_match("/__lazyLoad\('([^']+)'\)/", html_entity_decode($component->html()), $matches);
+
+        $this->expectException(CorruptComponentPayloadException::class);
+
+        $component->call('__lazyLoad', $matches[1].'|');
+    }
+
     #[DataProvider('malformedSnapshots')]
     public function test_malformed_lazy_snapshot_is_not_reported($snapshot)
     {

--- a/src/Features/SupportLazyLoading/UnitTest.php
+++ b/src/Features/SupportLazyLoading/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Livewire\Features\SupportLazyLoading;
 
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Facades\Route;
 use Livewire\Attributes\Defer;
 use Livewire\Attributes\Layout;
@@ -10,9 +11,62 @@ use Livewire\Component;
 use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Livewire;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
+use Livewire\Mechanisms\HandleRequests\EndpointResolver;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UnitTest extends \Tests\TestCase
 {
+    #[DataProvider('malformedSnapshots')]
+    public function test_malformed_lazy_snapshot_is_not_reported($snapshot)
+    {
+        config()->set('app.debug', false);
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        $component = Livewire::test(BasicLazyComponent::class);
+        $reported = [];
+
+        app(ExceptionHandler::class)->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+
+        $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [[
+                'snapshot' => json_encode($component->snapshot),
+                'updates' => [],
+                'calls' => [['method' => '__lazyLoad', 'params' => [base64_encode($snapshot)]]],
+            ]]])
+            ->assertNotFound();
+
+        $this->assertEmpty($reported);
+    }
+
+    public static function malformedSnapshots()
+    {
+        return [
+            'invalid JSON' => ['{'],
+            'null' => ['null'],
+            'scalar' => ['42'],
+            'empty array' => ['[]'],
+            'empty object' => ['{}'],
+            'missing checksum' => ['{"data":[],"memo":{"id":"abc","name":"foo"}}'],
+            'non-string checksum' => ['{"data":[],"memo":{"id":"abc","name":"foo"},"checksum":[]}'],
+            'non-string name' => ['{"data":[],"memo":{"id":"abc","name":[]},"checksum":"hash"}'],
+        ];
+    }
+
+    public function test_malformed_lazy_snapshot_has_a_useful_error_in_debug_mode()
+    {
+        config()->set('app.debug', true);
+        SupportLazyLoading::$disableWhileTesting = false;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid Livewire snapshot structure');
+
+        Livewire::test(BasicLazyComponent::class)->call('__lazyLoad', base64_encode('{}'));
+    }
+
     public function test_can_lazy_load_component_with_custom_layout()
     {
         Livewire::component('page', PageWithCustomLayout::class);

--- a/src/Features/SupportTesting/RequestBroker.php
+++ b/src/Features/SupportTesting/RequestBroker.php
@@ -7,7 +7,6 @@ use Illuminate\Foundation\Testing\Concerns\MakesHttpRequests;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Debug\ExceptionHandler;
-use Livewire\Mechanisms\HandleRequests\HandleRequests;
 
 class RequestBroker
 {
@@ -29,9 +28,7 @@ class RequestBroker
         $this->withoutExceptionHandling([HttpException::class, AuthorizationException::class])->withoutMiddleware();
 
         try {
-            return app(HandleRequests::class)->temporarilyPropagateExceptions(
-                fn () => $callback($this),
-            );
+            return $callback($this);
         } finally {
             $this->app->instance(ExceptionHandler::class, $cachedHandler);
 

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -184,18 +184,6 @@ class HandleComponents extends Mechanism
 
     public function update($snapshot, $updates, $calls)
     {
-        if (! is_array($snapshot)
-            || ! is_array($snapshot['data'] ?? null)
-            || ! is_array($snapshot['memo'] ?? null)
-            || ! is_string($snapshot['checksum'] ?? null)
-            || ! is_string($snapshot['memo']['id'] ?? null)
-            || ! is_string($snapshot['memo']['name'] ?? null)
-        ) {
-            if (config('app.debug')) throw new \InvalidArgumentException('Invalid Livewire snapshot structure: expected [data], [memo], [checksum], [memo.id], and [memo.name].');
-
-            abort(404);
-        }
-
         foreach ($calls as $call) {
             if (! is_array($call)
                 || ! is_string($call['method'] ?? null)
@@ -207,11 +195,11 @@ class HandleComponents extends Mechanism
             }
         }
 
-        $data = $snapshot['data'];
-        $memo = $snapshot['memo'];
-
         if (config('app.debug')) $start = microtime(true);
         [ $component, $context ] = $this->fromSnapshot($snapshot);
+
+        $data = $snapshot['data'];
+        $memo = $snapshot['memo'];
 
         $this->pushOntoComponentStack($component);
 
@@ -245,6 +233,18 @@ class HandleComponents extends Mechanism
 
     public function fromSnapshot($snapshot)
     {
+        if (! is_array($snapshot)
+            || ! is_array($snapshot['data'] ?? null)
+            || ! is_array($snapshot['memo'] ?? null)
+            || ! is_string($snapshot['checksum'] ?? null)
+            || ! is_string($snapshot['memo']['id'] ?? null)
+            || ! is_string($snapshot['memo']['name'] ?? null)
+        ) {
+            if (config('app.debug')) throw new \InvalidArgumentException('Invalid Livewire snapshot structure: expected [data], [memo], [checksum], [memo.id], and [memo.name].');
+
+            abort(404);
+        }
+
         Checksum::verify($snapshot);
 
         trigger('snapshot-verified', $snapshot);

--- a/src/Mechanisms/HandleComponents/HandleComponents.php
+++ b/src/Mechanisms/HandleComponents/HandleComponents.php
@@ -188,10 +188,18 @@ class HandleComponents extends Mechanism
             if (! is_array($call)
                 || ! is_string($call['method'] ?? null)
                 || ! is_array($call['params'] ?? null)
+                || ! is_array($call['metadata'] ?? [])
             ) {
-                if (config('app.debug')) throw new \InvalidArgumentException('Invalid Livewire call structure: each call must contain [method] (string) and [params] (array).');
+                if (config('app.debug')) throw new \InvalidArgumentException('Invalid Livewire call structure: each call must contain [method] (string), [params] (array), and optional [metadata] (array).');
 
                 abort(404);
+            }
+
+            // Method names follow PHP's identifier syntax, with an optional "$" for magic actions.
+            if (! preg_match('/\A\$?[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*\z/', $call['method'])) {
+                if (config('app.debug')) throw new MethodNotFoundException($call['method']);
+
+                abort(419);
             }
         }
 

--- a/src/Mechanisms/HandleRequests/BrowserTest.php
+++ b/src/Mechanisms/HandleRequests/BrowserTest.php
@@ -12,6 +12,23 @@ class BrowserTest extends \Tests\BrowserTestCase
         return function () { config()->set('app.debug', false); };
     }
 
+    public function test_application_typeerror_shows_the_error_modal()
+    {
+        Livewire::visit(new class extends \Livewire\Component {
+            public function bug(): int { return 'not-an-int'; }
+
+            public function render() { return <<<'HTML'
+                <div>
+                    <button wire:click="bug" dusk="bug">Broken action</button>
+                </div>
+                HTML;
+            }
+        })
+            ->click('@bug')
+            ->waitFor('#livewire-error')
+            ->assertVisible('#livewire-error');
+    }
+
     public function test_invalid_method_name_shows_the_rejection_dialog()
     {
         Livewire::visit(new class extends \Livewire\Component {

--- a/src/Mechanisms/HandleRequests/BrowserTest.php
+++ b/src/Mechanisms/HandleRequests/BrowserTest.php
@@ -7,6 +7,28 @@ use Livewire\Livewire;
 
 class BrowserTest extends \Tests\BrowserTestCase
 {
+    public static function tweakApplicationHook()
+    {
+        return function () { config()->set('app.debug', false); };
+    }
+
+    public function test_invalid_method_name_shows_the_rejection_dialog()
+    {
+        Livewire::visit(new class extends \Livewire\Component {
+            public function render() { return <<<'HTML'
+                <div>
+                    <button x-on:click="$wire.$call('|')" dusk="invalid">Invalid call</button>
+                </div>
+                HTML;
+            }
+        })
+            ->click('@invalid')
+            ->waitForDialog()
+            ->assertDialogOpened("This page has expired.\nWould you like to refresh the page?")
+            ->dismissDialog()
+            ->assertMissing('#livewire-error');
+    }
+
     public function test_can_register_a_custom_update_endpoint()
     {
         Livewire::setUpdateRoute(function ($handle) {

--- a/src/Mechanisms/HandleRequests/HandleRequests.php
+++ b/src/Mechanisms/HandleRequests/HandleRequests.php
@@ -18,8 +18,6 @@ class HandleRequests extends Mechanism
 {
     protected $updateRoute;
 
-    protected $shouldPropagateExceptions = false;
-
     function boot()
     {
         // Register the default route immediately (before routes files load)
@@ -137,19 +135,6 @@ class HandleRequests extends Mechanism
         return $route->named('*livewire.update');
     }
 
-    function temporarilyPropagateExceptions($callback)
-    {
-        $cachedShouldPropagateExceptions = $this->shouldPropagateExceptions;
-
-        $this->shouldPropagateExceptions = true;
-
-        try {
-            return $callback();
-        } finally {
-            $this->shouldPropagateExceptions = $cachedShouldPropagateExceptions;
-        }
-    }
-
     function handleUpdate()
     {
         // When a custom update route is registered, reject requests that arrive
@@ -216,15 +201,7 @@ class HandleRequests extends Mechanism
                 continue;
             }
 
-            try {
-                [ $snapshot, $effects ] = app('livewire')->update($snapshot, $updates, $calls);
-            } catch (\TypeError $e) {
-                report($e);
-
-                if (config('app.debug') || $this->shouldPropagateExceptions) throw $e;
-
-                abort(419);
-            }
+            [ $snapshot, $effects ] = app('livewire')->update($snapshot, $updates, $calls);
 
             $componentResponses[] = [
                 'snapshot' => json_encode($snapshot, JSON_THROW_ON_ERROR),

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -72,14 +72,22 @@ class UnitTest extends TestCase
         // Disable debug mode to test production HTTP responses (404/419)...
         config()->set('app.debug', false);
 
-        $snapshot = json_encode(['data' => [], 'memo' => ['id' => 'abc', 'name' => 'foo'], 'checksum' => 'hash']);
+        $component = Livewire::test(new class extends TestComponent {});
+        $reported = [];
+
+        app(ExceptionHandler::class)->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
 
         $response = $this->withHeaders(['X-Livewire' => 'true'])
             ->postJson(EndpointResolver::updatePath(), ['components' => [
-                ['snapshot' => $snapshot, 'updates' => [], 'calls' => $calls],
+                ['snapshot' => json_encode($component->snapshot), 'updates' => [], 'calls' => $calls],
             ]]);
 
         $response->assertNotFound();
+        $this->assertEmpty($reported);
     }
 
     public static function malformedCalls()
@@ -89,7 +97,109 @@ class UnitTest extends TestCase
             'missing params' => [[['method' => 'doSomething']]],
             'non-string method' => [[['method' => 123, 'params' => []]]],
             'non-array params' => [[['method' => 'doSomething', 'params' => 'bad']]],
+            'non-array metadata' => [[['method' => '$refresh', 'params' => [], 'metadata' => 'bad']]],
         ];
+    }
+
+    #[DataProvider('invalidMethodNames')]
+    public function test_invalid_method_names_are_rejected_before_hydration($method): void
+    {
+        config()->set('app.debug', false);
+
+        $component = Livewire::test(new class extends TestComponent {});
+        $reported = [];
+        $hydrated = false;
+
+        app(ExceptionHandler::class)->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+
+        \Livewire\on('hydrate', function () use (&$hydrated) { $hydrated = true; });
+
+        $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [[
+                'snapshot' => json_encode($component->snapshot),
+                'updates' => [],
+                'calls' => [
+                    ['method' => '$refresh', 'params' => []],
+                    ['method' => $method, 'params' => []],
+                ],
+            ]]])
+            ->assertStatus(419);
+
+        $this->assertEmpty($reported);
+        $this->assertFalse($hydrated);
+    }
+
+    public static function invalidMethodNames()
+    {
+        return [
+            'punctuation' => ['|'],
+            'empty' => [''],
+            'leading digit' => ['1save'],
+            'trailing newline' => ["save\n"],
+            'null byte' => ["save\0"],
+        ];
+    }
+
+    public function test_invalid_method_name_remains_diagnostic_in_debug_mode(): void
+    {
+        config()->set('app.debug', true);
+
+        $this->expectException(\Livewire\Exceptions\MethodNotFoundException::class);
+
+        Livewire::test(new class extends TestComponent {})->call('|');
+    }
+
+    public function test_plausible_missing_method_is_still_reported(): void
+    {
+        config()->set('app.debug', false);
+
+        $component = Livewire::test(new class extends TestComponent {});
+        $reported = [];
+
+        app(ExceptionHandler::class)->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+
+        $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [[
+                'snapshot' => json_encode($component->snapshot),
+                'updates' => [],
+                'calls' => [['method' => 'missingAction', 'params' => []]],
+            ]]])
+            ->assertStatus(500);
+
+        $this->assertCount(1, $reported);
+        $this->assertInstanceOf(\Livewire\Exceptions\MethodNotFoundException::class, $reported[0]);
+    }
+
+    public function test_valid_calls_preserve_named_params_magic_actions_and_optional_metadata(): void
+    {
+        config()->set('app.debug', false);
+
+        $component = Livewire::test(new class extends TestComponent {
+            public $name;
+
+            public function enregistrer($name) { $this->name = $name; }
+        });
+
+        $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [[
+                'snapshot' => json_encode($component->snapshot),
+                'updates' => [],
+                'calls' => [
+                    ['method' => 'enregistrer', 'params' => ['name' => 'Taylor']],
+                    ['method' => '$refresh', 'params' => [], 'metadata' => null],
+                    ['method' => '$commit', 'params' => [], 'metadata' => []],
+                ],
+            ]]])
+            ->assertOk()
+            ->assertJsonPath('components.0.snapshot', fn ($snapshot) => json_decode($snapshot, true)['data']['name'] === 'Taylor');
     }
 
     public function test_bad_checksum_returns_419(): void

--- a/src/Mechanisms/HandleRequests/UnitTest.php
+++ b/src/Mechanisms/HandleRequests/UnitTest.php
@@ -332,9 +332,64 @@ class UnitTest extends TestCase
                 ],
             ]]);
 
-        $response->assertStatus(419);
-        $this->assertNotEmpty($reported, 'Legitimate TypeError from component method body should be reported.');
+        $response->assertStatus(500);
+        $this->assertCount(1, $reported, 'Legitimate TypeError from component method body should be reported once.');
         $this->assertInstanceOf(\TypeError::class, $reported[0]);
+    }
+
+    #[DataProvider('applicationTypeErrors')]
+    public function test_application_typeerrors_keep_normal_error_handling($phase): void
+    {
+        config()->set('app.debug', false);
+
+        $component = Livewire::test(new class extends TestComponent {
+            public $phase;
+            public $name = '';
+
+            public function mount($phase) { $this->phase = $phase; }
+            public function hydrate() { if ($this->phase === 'hydrate') $this->broken(); }
+            public function updatingName() { if ($this->phase === 'updating') $this->broken(); }
+            public function updatedName() { if ($this->phase === 'updated') $this->broken(); }
+            public function needsArray(array $items) {}
+            public function broken(): int { return 'not-an-int'; }
+
+            public function render()
+            {
+                if ($this->phase === 'render' && $this->name === 'changed') $this->broken();
+
+                return '<div></div>';
+            }
+        }, ['phase' => $phase]);
+
+        $reported = [];
+
+        app(ExceptionHandler::class)->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+
+        $this->withHeaders(['X-Livewire' => 'true'])
+            ->postJson(EndpointResolver::updatePath(), ['components' => [[
+                'snapshot' => json_encode($component->snapshot),
+                'updates' => ['name' => 'changed'],
+                'calls' => $phase === 'argument' ? [['method' => 'needsArray', 'params' => ['not-an-array']]] : [],
+            ]]])
+            ->assertStatus(500);
+
+        $this->assertCount(1, $reported);
+        $this->assertInstanceOf(\TypeError::class, $reported[0]);
+    }
+
+    public static function applicationTypeErrors()
+    {
+        return [
+            ['hydrate'],
+            ['updating'],
+            ['updated'],
+            ['render'],
+            ['argument'],
+        ];
     }
 
     public function test_valid_request_returns_200(): void


### PR DESCRIPTION
Malformed method calls and lazy-load payloads can produce reportable server errors. This change rejects those inputs quietly while preserving reports for plausible missing actions and failures in application code.

For example, a lazy-load parameter containing encoded `{}` now receives the same structural rejection as an ordinary malformed snapshot. A method named `|` receives a quiet 419. A missing `saveOrder` action remains reportable, and an application `TypeError` now gets Laravel's normal server-error response instead of a page-expired response.

This PR is intentionally split into four commits for review in order:

1. **`402a7eda` Validate snapshots at the shared hydration entry point.** Move the existing checks from `update()` into `fromSnapshot()` so lazy mount snapshots use them too. Preserve existing 404 responses and debug diagnostics.
2. **`6bfcd9b8` Reject invalid lazy-load encoding before decoding snapshots.** Check parameter type and decode base64 strictly. Use the existing corrupt-payload exception for encoding failures.
3. **`51b7afed` Reject malformed calls before the component lifecycle runs.** Validate method syntax and optional metadata during call preflight. Preserve named parameters, magic actions, and reportable missing methods.
4. **`11a45e49` Preserve normal error responses for application TypeErrors.** Remove the outer catch/report/419 conversion and its testing-only propagation switch. Keep the narrow property-assignment rejection. Document the policy and test both browser error responses.

Each step includes regression coverage. The policy is based on invalid protocol input, not caller identity. Application actions, argument binding, lifecycle hooks, rendering, and lazy mount failures continue through normal Laravel exception handling.

Validation:

- Full PHP unit suite: 1,525 tests, 4,258 assertions, no failures; 17 skipped and 3 incomplete.
- Chrome: all 3 request browser tests and 2 targeted lazy-loading browser tests passed.
- Standalone Laravel 12.69.2 app with debug disabled: verified updates, lazy mount parameters, malformed calls, wrong-type property updates, missing actions, and application errors. Its log contained only the two expected application errors.
- Package tests ran on PHP 8.4.6 / Laravel 12.3.0. Assets rebuilt locally; compiled assets are not included. Full browser and supported-version matrices remain for CI.

Fixes #10688. Related to #10689.
