### PR TITLE
[4.x] Keep failed requests fired without a caller from surfacing as unhandled promise rejections

### DIFF
--- a/js/$wire.js
+++ b/js/$wire.js
@@ -197,7 +197,7 @@ wireProperty('$js', (component) => {
     })
 })
 
-wireProperty('$set', (component) => async (property, value, live = true) => {
+wireProperty('$set', (component) => (property, value, live = true) => {
     dataSet(component.reactive, property, value)
 
     // If "live", send a request, queueing the property update to happen first
@@ -261,8 +261,8 @@ wireProperty('$interceptRequest', (component) => (actionNameOrCallback, maybeCal
 
 wireProperty('$errors', (component) => getErrorsObject(component))
 
-wireProperty('$call', (component) => async (method, ...params) => {
-    return await component.$wire[method](...params)
+wireProperty('$call', (component) => (method, ...params) => {
+    return component.$wire[method](...params)
 })
 
 wireProperty('$island', (component) => (name, options = {}) => {

--- a/js/evaluator.js
+++ b/js/evaluator.js
@@ -68,15 +68,7 @@ export function evaluateActionExpression(el, expression, options = {}) {
     let contextualExpression = contextualizeExpression(expression, el, ! isEvaluatingReactiveExpression())
 
     try {
-        let result = Alpine.evaluateRaw(el, contextualExpression, options)
-
-        // Silently catch Livewire request failures. These are handled by
-        // Livewire at the request level...
-        if (result instanceof Promise && result._livewireAction) {
-            result.catch(() => {})
-        }
-
-        return result
+        return Alpine.evaluateRaw(el, contextualExpression, options)
     } catch (error) {
         reportExpressionError(error, expression, el)
     }

--- a/js/features/supportListeners.js
+++ b/js/features/supportListeners.js
@@ -27,7 +27,7 @@ function registerListeners(component, listeners) {
                 setNextActionOrigin({ el: e.target })
             }
 
-            dispatchToComponent(component, name, e.detail)
+            component.$wire.call('__dispatch', name, e.detail || {})
         }
 
         window.addEventListener(name, handler)
@@ -46,30 +46,8 @@ function registerListeners(component, listeners) {
 
             if (e.__livewire) e.__livewire.receivedBy.push(component.id)
 
-            dispatchToComponent(component, name, e.detail)
+            component.$wire.call('__dispatch', name, e.detail || {})
         })
     })
-}
-
-// A dispatched event has no caller to hand a failed request to. The request
-// error handling (interceptors, the expired-page dialog, the error modal) has
-// already surfaced the failure, so don't let the rejected action promise escape
-// as an "Uncaught (in promise)" error on top of it...
-function dispatchToComponent(component, name, params) {
-    component.$wire.call('__dispatch', name, params || {}).catch(error => {
-        if (isRequestFailure(error)) return
-
-        throw error
-    })
-}
-
-// The value a request rejects its action promises with (see request/message.js)...
-function isRequestFailure(error) {
-    return error !== null
-        && typeof error === 'object'
-        && 'status' in error
-        && 'body' in error
-        && 'json' in error
-        && 'errors' in error
 }
 

--- a/js/features/supportListeners.js
+++ b/js/features/supportListeners.js
@@ -27,7 +27,7 @@ function registerListeners(component, listeners) {
                 setNextActionOrigin({ el: e.target })
             }
 
-            component.$wire.call('__dispatch', name, e.detail || {})
+            dispatchToComponent(component, name, e.detail)
         }
 
         window.addEventListener(name, handler)
@@ -46,8 +46,30 @@ function registerListeners(component, listeners) {
 
             if (e.__livewire) e.__livewire.receivedBy.push(component.id)
 
-            component.$wire.call('__dispatch', name, e.detail || {})
+            dispatchToComponent(component, name, e.detail)
         })
     })
+}
+
+// A dispatched event has no caller to hand a failed request to. The request
+// error handling (interceptors, the expired-page dialog, the error modal) has
+// already surfaced the failure, so don't let the rejected action promise escape
+// as an "Uncaught (in promise)" error on top of it...
+function dispatchToComponent(component, name, params) {
+    component.$wire.call('__dispatch', name, params || {}).catch(error => {
+        if (isRequestFailure(error)) return
+
+        throw error
+    })
+}
+
+// The value a request rejects its action promises with (see request/message.js)...
+function isRequestFailure(error) {
+    return error !== null
+        && typeof error === 'object'
+        && 'status' in error
+        && 'body' in error
+        && 'json' in error
+        && 'errors' in error
 }
 

--- a/js/request/action.js
+++ b/js/request/action.js
@@ -30,7 +30,11 @@ export default class Action {
             this.promiseResolution = { resolve, reject }
         })
 
-        this.promise._livewireAction = this
+        // Livewire surfaces failed requests itself (error modal, expired-page dialog,
+        // interceptors), so a caller that discards this promise shouldn't also get an
+        // "Uncaught (in promise)". This marks it handled without hiding the rejection
+        // from callers that await it...
+        this.promise.catch(() => {})
     }
 
     cancel() {

--- a/src/Features/SupportEvents/BrowserTest.php
+++ b/src/Features/SupportEvents/BrowserTest.php
@@ -611,4 +611,29 @@ class BrowserTest extends BrowserTestCase
             ->click('@button')
             ->waitForTextIn('@output', 'baz');
     }
+
+    public function test_a_failed_listener_request_does_not_leave_an_unhandled_promise_rejection()
+    {
+        Livewire::visit(new class extends Component {
+            #[On('foo')]
+            public function onFoo()
+            {
+                throw new \Exception('The listener failed.');
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button dusk="button" @click="$dispatch('foo')">Dispatch</button>
+                </div>
+                HTML;
+            }
+        })
+            ->tap(fn ($browser) => $browser->script('window.unhandledRejections = 0; window.addEventListener("unhandledrejection", () => window.unhandledRejections++)'))
+            ->click('@button')
+            ->waitFor('#livewire-error')
+            ->pause(250)
+            ->assertScript('window.unhandledRejections', 0);
+    }
 }

--- a/src/Mechanisms/HandleRequests/BrowserTest.php
+++ b/src/Mechanisms/HandleRequests/BrowserTest.php
@@ -3,6 +3,7 @@
 namespace Livewire\Mechanisms\HandleRequests;
 
 use Illuminate\Support\Facades\Route;
+use Livewire\Component;
 use Livewire\Livewire;
 
 class BrowserTest extends \Tests\BrowserTestCase
@@ -37,5 +38,61 @@ class BrowserTest extends \Tests\BrowserTestCase
         ->waitForLivewire()->click('@target')
         ->assertSeeIn('@output', 5)
         ;
+    }
+
+    public function test_failed_requests_fired_without_a_caller_do_not_leave_unhandled_promise_rejections()
+    {
+        Livewire::visit(new class extends Component {
+            public $value = '';
+
+            public function updatedValue()
+            {
+                throw new \Exception('The update failed.');
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <input dusk="input" wire:model.live="value">
+                    <button dusk="set" wire:click="$set('value', 'bar')">Set</button>
+                </div>
+                HTML;
+            }
+        })
+            ->tap(fn ($browser) => $browser->script('window.unhandledRejections = 0; window.addEventListener("unhandledrejection", () => window.unhandledRejections++)'))
+            ->type('@input', 'foo')
+            ->waitFor('#livewire-error')
+            ->tap(fn ($browser) => $browser->script("document.getElementById('livewire-error').close()"))
+            ->waitUntilMissing('#livewire-error')
+            ->click('@set')
+            ->waitFor('#livewire-error')
+            ->pause(250)
+            ->assertScript('window.unhandledRejections', 0);
+    }
+
+    public function test_a_failed_request_still_rejects_the_action_promise_for_callers_that_handle_it()
+    {
+        Livewire::visit(new class extends Component {
+            public function explode()
+            {
+                throw new \Exception('The action failed.');
+            }
+
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <button dusk="button" x-on:click="$wire.explode().catch(error => window.caught = error.status)">Explode</button>
+                </div>
+                HTML;
+            }
+        })
+            ->tap(fn ($browser) => $browser->script('window.unhandledRejections = 0; window.addEventListener("unhandledrejection", () => window.unhandledRejections++)'))
+            ->click('@button')
+            ->waitFor('#livewire-error')
+            ->pause(250)
+            ->assertScript('window.caught', 500)
+            ->assertScript('window.unhandledRejections', 0);
     }
 }


### PR DESCRIPTION
Livewire fires plenty of requests on its own behalf: `#[On]` listeners, `wire:model.live`, `wire:click="$set(...)"`, file uploads. None of them has a caller waiting on the action promise. When one of those requests fails (a 500 from a throwing handler, a 419 after a `release_token` change or session expiry, a 4xx from middleware), the action promise is rejected with `{ status, body, json, errors }` *after* Livewire has already surfaced the failure. Nobody owns that promise, so the browser reports:

```
Uncaught (in promise) {status: 419, body: '…', json: {…}, errors: null}
```

on top of the error modal or the "page has expired" dialog. Each one also fires `unhandledrejection`, which error trackers (Sentry, Bugsnag, in-house reporters) file as a page error. After a deployment that rotates the release token, a stale page produces one per listener or live input.

- Render a component with an `#[On('foo')]` listener, an `<input wire:model.live>`, or a `wire:click="$set(...)"`
- Make the request fail (throw in the handler, expire the session, rotate the release token)
- The Livewire error modal appears **and** the console shows `Uncaught (in promise) {status: …}`

```php
#[On('foo')]
public function onFoo()
{
    throw new \Exception('The listener failed.');
}
```

```html
<button @click="$dispatch('foo')">Dispatch</button>
```

## Findings

- Livewire already has a policy for this. `evaluateActionExpression()` in `js/evaluator.js` silently `.catch()`es any promise carrying the `_livewireAction` marker ("Silently catch Livewire request failures. These are handled by Livewire at the request level"). That covers `wire:click`, `wire:poll`, `wire:init` and `wire:intersect`.
- Every path that doesn't go through the evaluator leaks: `supportListeners.js` (`$wire.call('__dispatch', …)`), `wire-model.js` (`$wire.$commit()`), and `supportFileUploads.js` (`$wire.call('_startUpload', …)` and friends).
- Paths that *do* go through the evaluator still leak when the `$wire` method is an `async` wrapper, because the wrapper hands back a copy of the action promise without the marker. `$set` and `$call` are still `async`, so `wire:click="$set('open', true)"` and `wire:click="$toggle('open')"` leak today. #10428 fixed exactly this for `$refresh` and `$commit`.
- The action promise is only ever settled through `Action.resolvePromise()` / `Action.rejectPromise()`, and every rejection carries the same `{ status, body, json, errors }` shape, so there is nothing else for a shape check to distinguish.

## Potential solutions

- **Catch-and-rethrow shim in `supportListeners.js`** (this PR's first cut). Fixes listeners only, re-implements the `_livewireAction` policy as a structural `isRequestFailure()` check that has to track the rejection shape, and leaves `wire:model.live`, `$set`, `$toggle` and uploads producing the same noise.
- **`.catch(() => {})` at every internal call site.** Eight call sites today, and the next internal caller forgets it.
- **Mark the promise as handled where it is created.** One line in `Action`; the `_livewireAction` marker and the evaluator special case become redundant.

## Proposed solution

`Action` attaches a no-op rejection handler to its own promise when it is constructed. That marks the promise as handled, so a discarded one never becomes an `unhandledrejection`, while callers that `await` or `.catch()` it still receive the exact same rejection (attaching a handler doesn't change the promise's state or what other consumers see).

For that to cover everything, each `$wire` entry point has to hand back the action's own promise rather than an `async` wrapper's copy, so `$set` and `$call` drop their `async` the same way #10428 did for `$refresh` and `$commit`. With that in place the `_livewireAction` marker and the `if (result._livewireAction) result.catch(...)` branch in the evaluator are dead and removed, and `supportListeners.js` goes back to its original two lines.

Tests:

- `SupportEvents/BrowserTest`: a listener whose handler throws still shows the error modal and fires `unhandledrejection` zero times.
- `HandleRequests/BrowserTest`: the same for `wire:model.live` and `wire:click="$set(...)"` (fails on 4.x with 2 rejections), plus a test that `$wire.explode().catch(...)` still receives the rejection with `status: 500`, so callers that handle failures keep getting them.

---

One behaviour worth knowing about: a `#[Json]` method that is fired and forgotten (no `await`, no `.catch()`) and then fails is now silent, where before it logged `Uncaught (in promise) {status: 403, …}`. `#[Json]` methods are meant to be awaited, and this matches what `wire:click="jsonMethod"` already did, but it is the one place the console gets quieter without a modal taking its place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011y8NkAhu4j2vcTVy4fbrDw
